### PR TITLE
Accessor synthesis cleanup (NFC)

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5892,21 +5892,24 @@ ObjCSelector DestructorDecl::getObjCSelector() const {
 
 SourceRange FuncDecl::getSourceRange() const {
   SourceLoc StartLoc = getStartLoc();
-  if (StartLoc.isInvalid() ||
-      getBodyKind() == BodyKind::Synthesize)
+
+  if (StartLoc.isInvalid())
     return SourceRange();
 
   if (getBodyKind() == BodyKind::Unparsed ||
       getBodyKind() == BodyKind::Skipped)
     return { StartLoc, BodyRange.End };
 
-  if (auto *B = getBody()) {
+  if (auto *B = getBody(/*canSynthesize=*/false)) {
     if (!B->isImplicit())
       return { StartLoc, B->getEndLoc() };
   }
 
   if (isa<AccessorDecl>(this))
     return StartLoc;
+
+  if (getBodyKind() == BodyKind::Synthesize)
+    return SourceRange();
 
   auto TrailingWhereClauseSourceRange = getGenericTrailingWhereClauseSourceRange();
   if (TrailingWhereClauseSourceRange.isValid())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -427,11 +427,7 @@ createModifyCoroutinePrototype(AbstractStorageDecl *storage,
 }
 
 /// Build an expression that evaluates the specified parameter list as a tuple
-/// or paren expr, suitable for use in an applyexpr.
-///
-/// NOTE: This returns null if a varargs parameter exists in the list, as it
-/// cannot be forwarded correctly yet.
-///
+/// or paren expr, suitable for use in an apply expr.
 static Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
                                          ASTContext &ctx) {
   SmallVector<Identifier, 4> labels;
@@ -2209,7 +2205,7 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       // "computed" in the current AST state.
       if (var->isImplicit() || var->isStatic())
         continue;
-      tc.validateDecl(var);
+
       if (!var->hasStorage() && !var->getAttrs().hasAttribute<LazyAttr>())
         continue;
 
@@ -2221,6 +2217,7 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       
       accessLevel = std::min(accessLevel, var->getFormalAccess());
 
+      tc.validateDecl(var);
       auto varInterfaceType = var->getValueInterfaceType();
 
       // If var is a lazy property, its value is provided for the underlying
@@ -2528,7 +2525,6 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
     auto paramTy = decl->getInterfaceType();
     auto substTy = paramTy.subst(subMap);
     decl->setInterfaceType(substTy);
-    decl->setType(GenericEnvironment::mapTypeIntoContext(genericEnv, substTy));
   }
 
   // Create the initializer declaration, inheriting the name,

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -203,10 +203,10 @@ static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
   getter->setImplicit();
 
   // If we're stealing the 'self' from a lazy initializer, set it now.
-  if (selfDecl) {
+  // Note that we don't re-parent the 'self' declaration to be part of
+  // the getter until we synthesize the body of the getter later.
+  if (selfDecl)
     *getter->getImplicitSelfDeclStorage() = selfDecl;
-    selfDecl->setDeclContext(getter);
-  }
 
   // We need to install the generic environment here because:
   // 1) validating the getter will change the implicit self decl's DC to it,
@@ -1292,6 +1292,7 @@ static void synthesizeLazyGetterBody(AbstractFunctionDecl *fn, void *context) {
 
   // Recontextualize any closure declcontexts nested in the initializer to
   // realize that they are in the getter function.
+  Get->getImplicitSelfDecl()->setDeclContext(Get);
   InitValue->walk(RecontextualizeClosures(Get));
 
   // Wrap the initializer in a LazyInitializerExpr to avoid problems with

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -36,30 +36,6 @@ using namespace swift;
 
 const bool IsImplicit = true;
 
-static  SynthesizedFunction::Kind
-getSynthKindForAccessorKind(AccessorKind kind) {
-  switch (kind) {
-  case AccessorKind::Read:
-    return SynthesizedFunction::ReadCoroutine;
-
-  case AccessorKind::Modify:
-    return SynthesizedFunction::ModifyCoroutine;
-
-  case AccessorKind::Get:
-    return SynthesizedFunction::Getter;
-
-  case AccessorKind::Set:
-    return SynthesizedFunction::Setter;
-
-#define OPAQUE_ACCESSOR(ID, KEYWORD)
-#define ACCESSOR(ID) \
-  case AccessorKind::ID:
-#include "swift/AST/AccessorKinds.def"
-    llvm_unreachable("unexpected synthesized accessor");
-  }
-  llvm_unreachable("bad kind");
-}
-
 /// Should a particular accessor for the given storage be synthesized
 /// on-demand, or is it always defined eagerly in the file that declared
 /// the storage?
@@ -111,8 +87,8 @@ static VarDecl *getFirstParamDecl(FuncDecl *fn) {
 static ParamDecl *buildArgument(SourceLoc loc, DeclContext *DC,
                                 StringRef name,
                                 Type interfaceType,
-                                VarDecl::Specifier specifier) {
-  auto &context = DC->getASTContext();
+                                VarDecl::Specifier specifier,
+                                ASTContext &context) {
   auto *param = new (context) ParamDecl(specifier, SourceLoc(), SourceLoc(),
                                         Identifier(), loc,
                                         context.getIdentifier(name),
@@ -129,8 +105,8 @@ static ParamDecl *buildArgument(SourceLoc loc, DeclContext *DC,
 ///   forwarding pattern.
 static ParameterList *
 buildIndexForwardingParamList(AbstractStorageDecl *storage,
-                              ArrayRef<ParamDecl*> prefix) {
-  auto &context = storage->getASTContext();
+                              ArrayRef<ParamDecl*> prefix,
+                              ASTContext &context) {
   auto subscript = dyn_cast<SubscriptDecl>(storage);
 
   // Fast path: if this isn't a subscript, just use whatever we have.
@@ -179,8 +155,8 @@ static GenericParamList *createAccessorGenericParams(
   return nullptr;
 }
 
-static AccessorDecl *createGetterPrototype(TypeChecker &TC,
-                                           AbstractStorageDecl *storage) {
+static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
+                                           ASTContext &ctx) {
   assert(!storage->getGetter());
 
   SourceLoc loc = storage->getLoc();
@@ -205,7 +181,7 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
   GenericParamList *genericParams = createAccessorGenericParams(storage);
 
   // Add an index-forwarding clause.
-  auto *getterParams = buildIndexForwardingParamList(storage, {});
+  auto *getterParams = buildIndexForwardingParamList(storage, {}, ctx);
 
   SourceLoc staticLoc;
   if (auto var = dyn_cast<VarDecl>(storage)) {
@@ -216,7 +192,7 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
   auto storageInterfaceType = storage->getValueInterfaceType();
 
   auto getter = AccessorDecl::create(
-      TC.Context, loc, /*AccessorKeywordLoc*/ loc,
+      ctx, loc, /*AccessorKeywordLoc*/ loc,
       AccessorKind::Get, storage,
       staticLoc, StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
@@ -259,8 +235,8 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
   return getter;
 }
 
-static AccessorDecl *createSetterPrototype(TypeChecker &TC,
-                                           AbstractStorageDecl *storage,
+static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
+                                           ASTContext &ctx,
                                            AccessorDecl *getter = nullptr) {
   assert(!storage->getSetter());
   assert(storage->supportsMutation());
@@ -276,12 +252,12 @@ static AccessorDecl *createSetterPrototype(TypeChecker &TC,
   auto storageInterfaceType = storage->getValueInterfaceType();
   auto valueDecl = buildArgument(storage->getLoc(), storage->getDeclContext(),
                                  "value", storageInterfaceType,
-                                 VarDecl::Specifier::Default);
-  auto *params = buildIndexForwardingParamList(storage, valueDecl);
+                                 VarDecl::Specifier::Default, ctx);
+  auto *params = buildIndexForwardingParamList(storage, valueDecl, ctx);
 
-  Type setterRetTy = TupleType::getEmpty(TC.Context);
+  Type setterRetTy = TupleType::getEmpty(ctx);
   auto setter = AccessorDecl::create(
-      TC.Context, loc, /*AccessorKeywordLoc*/ SourceLoc(),
+      ctx, loc, /*AccessorKeywordLoc*/ SourceLoc(),
       AccessorKind::Set, storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
@@ -318,7 +294,7 @@ static AccessorDecl *createSetterPrototype(TypeChecker &TC,
 /// If the storage is for a global stored property or a stored property of a
 /// resilient type, we are synthesizing accessors to present a resilient
 /// interface to the storage and they should not be transparent.
-static void maybeMarkTransparent(TypeChecker &TC, AccessorDecl *accessor) {
+static void maybeMarkTransparent(AccessorDecl *accessor, ASTContext &ctx) {
   auto *DC = accessor->getDeclContext();
   auto *nominalDecl = DC->getSelfNominalTypeDecl();
 
@@ -353,29 +329,15 @@ static void maybeMarkTransparent(TypeChecker &TC, AccessorDecl *accessor) {
   if (accessor->hasForcedStaticDispatch())
     return;
 
-  accessor->getAttrs().add(new (TC.Context) TransparentAttr(IsImplicit));
-}
-
-template <class... Args>
-static void triggerSynthesis(TypeChecker &TC, FuncDecl *fn, Args... args) {
-  if (fn->hasBody()) return;
-
-  auto synthesisRecord = SynthesizedFunction(fn, args...);
-  TC.FunctionsToSynthesize.insert({ fn, synthesisRecord });
-}
-
-static void finishSynthesis(TypeChecker &TC, FuncDecl *fn) {  
-  TC.Context.addSynthesizedDecl(fn);
-  TC.DeclsToFinalize.insert(fn);
+  accessor->getAttrs().add(new (ctx) TransparentAttr(IsImplicit));
 }
 
 static AccessorDecl *
-createCoroutineAccessorPrototype(TypeChecker &TC,
-                                 AbstractStorageDecl *storage,
-                                 AccessorKind kind) {
+createCoroutineAccessorPrototype(AbstractStorageDecl *storage,
+                                 AccessorKind kind,
+                                ASTContext &ctx) {
   assert(kind == AccessorKind::Read || kind == AccessorKind::Modify);
 
-  auto &ctx = TC.Context;
   SourceLoc loc = storage->getLoc();
 
   bool isStatic = storage->isStatic();
@@ -386,7 +348,7 @@ createCoroutineAccessorPrototype(TypeChecker &TC,
   auto dc = storage->getDeclContext();
 
   // The forwarding index parameters.
-  auto *params = buildIndexForwardingParamList(storage, {});
+  auto *params = buildIndexForwardingParamList(storage, {}, ctx);
 
   // Coroutine accessors always return ().
   Type retTy = TupleType::getEmpty(ctx);
@@ -431,7 +393,7 @@ createCoroutineAccessorPrototype(TypeChecker &TC,
     }
   }
 
-  maybeMarkTransparent(TC, accessor);
+  maybeMarkTransparent(accessor, ctx);
 
   AvailabilityInference::applyInferredAvailableAttrs(accessor,
                                                      asAvailableAs, ctx);
@@ -453,13 +415,15 @@ createCoroutineAccessorPrototype(TypeChecker &TC,
 }
 
 static AccessorDecl *
-createReadCoroutinePrototype(TypeChecker &tc, AbstractStorageDecl *storage) {
-  return createCoroutineAccessorPrototype(tc, storage, AccessorKind::Read);
+createReadCoroutinePrototype(AbstractStorageDecl *storage,
+                             ASTContext &ctx) {
+  return createCoroutineAccessorPrototype(storage, AccessorKind::Read, ctx);
 }
 
 static AccessorDecl *
-createModifyCoroutinePrototype(TypeChecker &tc, AbstractStorageDecl *storage) {
-  return createCoroutineAccessorPrototype(tc, storage, AccessorKind::Modify);
+createModifyCoroutinePrototype(AbstractStorageDecl *storage,
+                               ASTContext &ctx) {
+  return createCoroutineAccessorPrototype(storage, AccessorKind::Modify, ctx);
 }
 
 /// Build an expression that evaluates the specified parameter list as a tuple
@@ -541,13 +505,13 @@ enum class SelfAccessorKind {
 
 static Expr *buildSelfReference(VarDecl *selfDecl,
                                 SelfAccessorKind selfAccessorKind,
-                                TypeChecker &TC) {
+                                ASTContext &ctx) {
   switch (selfAccessorKind) {
   case SelfAccessorKind::Peer:
-    return new (TC.Context) DeclRefExpr(selfDecl, DeclNameLoc(), IsImplicit);
+    return new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(), IsImplicit);
 
   case SelfAccessorKind::Super:
-    return new (TC.Context) SuperRefExpr(selfDecl, SourceLoc(), IsImplicit);
+    return new (ctx) SuperRefExpr(selfDecl, SourceLoc(), IsImplicit);
   }
   llvm_unreachable("bad self access kind");
 }
@@ -570,9 +534,7 @@ namespace {
 static Expr *buildStorageReference(AccessorDecl *accessor,
                                    AbstractStorageDecl *storage,
                                    TargetImpl target,
-                                   TypeChecker &TC) {
-  ASTContext &ctx = TC.Context;
-
+                                   ASTContext &ctx) {
   AccessSemantics semantics;
   SelfAccessorKind selfAccessKind;
   switch (target) {
@@ -615,7 +577,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   }
 
   Expr *selfDRE =
-    buildSelfReference(selfDecl, selfAccessKind, TC);
+    buildSelfReference(selfDecl, selfAccessKind, ctx);
 
   if (auto subscript = dyn_cast<SubscriptDecl>(storage)) {
     Expr *indices = buildSubscriptIndexReference(ctx, accessor);
@@ -629,18 +591,18 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
 
 /// Load the value of VD.  If VD is an @override of another value, we call the
 /// superclass getter.  Otherwise, we do a direct load of the value.
-static Expr *createPropertyLoadOrCallSuperclassGetter(AccessorDecl *accessor,
-                                              AbstractStorageDecl *storage,
-                                              TargetImpl target,
-                                                      TypeChecker &TC) {
-  return buildStorageReference(accessor, storage, target, TC);
+static Expr *
+createPropertyLoadOrCallSuperclassGetter(AccessorDecl *accessor,
+                                         AbstractStorageDecl *storage,
+                                         TargetImpl target,
+                                         ASTContext &ctx) {
+  return buildStorageReference(accessor, storage, target, ctx);
 }
 
 /// Look up the NSCopying protocol from the Foundation module, if present.
 /// Otherwise return null.
-static ProtocolDecl *getNSCopyingProtocol(TypeChecker &TC,
+static ProtocolDecl *getNSCopyingProtocol(ASTContext &ctx,
                                           DeclContext *DC) {
-  ASTContext &ctx = TC.Context;
   auto foundation = ctx.getLoadedModule(ctx.Id_Foundation);
   if (!foundation)
     return nullptr;
@@ -657,10 +619,13 @@ static ProtocolDecl *getNSCopyingProtocol(TypeChecker &TC,
   return dyn_cast<ProtocolDecl>(results.front());
 }
 
-static bool checkConformanceToNSCopying(TypeChecker &TC, VarDecl *var,
+static bool checkConformanceToNSCopying(ASTContext &ctx, VarDecl *var,
                                         Type type) {
   auto dc = var->getDeclContext();
-  auto proto = getNSCopyingProtocol(TC, dc);
+  auto proto = getNSCopyingProtocol(ctx, dc);
+
+  // FIXME: Remove this usage of TypeChecker
+  auto &TC = *(TypeChecker *) ctx.getLazyResolver();
   if (!proto || !TC.conformsToProtocol(type, proto, dc, None)) {
     TC.diagnose(var->getLoc(), diag::nscopying_doesnt_conform);
     return true;
@@ -680,7 +645,7 @@ static std::pair<Type, bool> getUnderlyingTypeOfVariable(VarDecl *var) {
 
 bool TypeChecker::checkConformanceToNSCopying(VarDecl *var) {
   Type type = getUnderlyingTypeOfVariable(var).first;
-  return ::checkConformanceToNSCopying(*this, var, type);
+  return ::checkConformanceToNSCopying(Context, var, type);
 }
 
 /// Synthesize the code to store 'Val' to 'VD', given that VD has an @NSCopying
@@ -688,9 +653,7 @@ bool TypeChecker::checkConformanceToNSCopying(VarDecl *var) {
 /// just need to generate something like "self.property = val.copy(zone: nil)"
 /// here.  This does some type checking to validate that the call will succeed.
 static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
-                                        TypeChecker &TC) {
-  auto &Ctx = TC.Context;
-
+                                        ASTContext &Ctx) {
   // We support @NSCopying on class types (which conform to NSCopying),
   // protocols which conform, and option types thereof.
   auto underlyingTypeAndIsOptional = getUnderlyingTypeOfVariable(VD);
@@ -699,7 +662,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
 
   // The element type must conform to NSCopying.  If not, emit an error and just
   // recovery by synthesizing without the copy call.
-  if (checkConformanceToNSCopying(TC, VD, underlyingType)) {
+  if (checkConformanceToNSCopying(Ctx, VD, underlyingType)) {
     return Val;
   }
 
@@ -748,27 +711,28 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
 ///
 /// If the property is an override, we call the superclass setter.
 /// Otherwise, we do a direct store of the value.
-static void createPropertyStoreOrCallSuperclassSetter(AccessorDecl *accessor,
-                                                      Expr *value,
+static
+void createPropertyStoreOrCallSuperclassSetter(AccessorDecl *accessor,
+                                               Expr *value,
                                                AbstractStorageDecl *storage,
                                                TargetImpl target,
                                                SmallVectorImpl<ASTNode> &body,
-                                                      TypeChecker &TC) {
+                                               ASTContext &ctx) {
   // If the storage is an @NSCopying property, then we store the
   // result of a copyWithZone call on the value, not the value itself.
   if (auto property = dyn_cast<VarDecl>(storage)) {
     if (property->getAttrs().hasAttribute<NSCopyingAttr>())
-      value = synthesizeCopyWithZoneCall(value, property, TC);
+      value = synthesizeCopyWithZoneCall(value, property, ctx);
   }
 
   // Create:
   //   (assign (decl_ref_expr(VD)), decl_ref_expr(value))
   // or:
   //   (assign (member_ref_expr(decl_ref_expr(self), VD)), decl_ref_expr(value))
-  Expr *dest = buildStorageReference(accessor, storage, target, TC);
+  Expr *dest = buildStorageReference(accessor, storage, target, ctx);
 
-  body.push_back(new (TC.Context) AssignExpr(dest, SourceLoc(), value,
-                                             IsImplicit));
+  body.push_back(new (ctx) AssignExpr(dest, SourceLoc(), value,
+                                      IsImplicit));
 }
 
 LLVM_ATTRIBUTE_UNUSED
@@ -781,67 +745,66 @@ static bool isSynthesizedComputedProperty(AbstractStorageDecl *storage) {
 /// which is not an override of a base class property, it performs a direct
 /// storage load.  For an override of a base member property, it chains up to
 /// super.
-static void synthesizeTrivialGetterBody(TypeChecker &TC, AccessorDecl *getter,
-                                        TargetImpl target) {
+static void synthesizeTrivialGetterBody(AccessorDecl *getter,
+                                        TargetImpl target,
+                                        ASTContext &ctx) {
   auto storage = getter->getStorage();
   assert(!storage->getAttrs().hasAttribute<LazyAttr>() &&
          !storage->getAttrs().hasAttribute<NSManagedAttr>());
 
-  auto &ctx = TC.Context;
   SourceLoc loc = storage->getLoc();
 
   Expr *result =
-    createPropertyLoadOrCallSuperclassGetter(getter, storage, target, TC);
+    createPropertyLoadOrCallSuperclassGetter(getter, storage, target, ctx);
   ASTNode returnStmt = new (ctx) ReturnStmt(SourceLoc(), result, IsImplicit);
 
   getter->setBody(BraceStmt::create(ctx, loc, returnStmt, loc, true));
 
-  finishSynthesis(TC, getter);
-
-  maybeMarkTransparent(TC, getter);
+  maybeMarkTransparent(getter, ctx);
 }
 
 /// Synthesize the body of a getter which just directly accesses the
 /// underlying storage.
-static void synthesizeTrivialGetterBody(TypeChecker &TC, AccessorDecl *getter) {
+static void synthesizeTrivialGetterBody(AccessorDecl *getter,
+                                        ASTContext &ctx) {
   assert(getter->getStorage()->hasStorage());
-  synthesizeTrivialGetterBody(TC, getter, TargetImpl::Storage);
+  synthesizeTrivialGetterBody(getter, TargetImpl::Storage, ctx);
 }
 
 /// Synthesize the body of a getter which just delegates to its superclass
 /// implementation.
-static void synthesizeInheritedGetterBody(TypeChecker &TC,
-                                          AccessorDecl *getter) {
+static void synthesizeInheritedGetterBody(AccessorDecl *getter,
+                                          ASTContext &ctx) {
   // This should call the superclass getter.
-  synthesizeTrivialGetterBody(TC, getter, TargetImpl::Super);
+  synthesizeTrivialGetterBody(getter, TargetImpl::Super, ctx);
 }
 
 /// Synthesize the body of a getter which just delegates to an addressor.
-static void synthesizeAddressedGetterBody(TypeChecker &TC,
-                                          AccessorDecl *getter) {
+static void synthesizeAddressedGetterBody(AccessorDecl *getter,
+                                          ASTContext &ctx) {
   assert(getter->getStorage()->getAddressor());
 
   // This should call the addressor.
-  synthesizeTrivialGetterBody(TC, getter, TargetImpl::Implementation);
+  synthesizeTrivialGetterBody(getter, TargetImpl::Implementation, ctx);
 }
 
 /// Synthesize the body of a getter which just delegates to a read
 /// coroutine accessor.
-static void synthesizeReadCoroutineGetterBody(TypeChecker &TC,
-                                              AccessorDecl *getter) {
+static void synthesizeReadCoroutineGetterBody(AccessorDecl *getter,
+                                              ASTContext &ctx) {
   assert(getter->getStorage()->getReadCoroutine());
 
   // This should call the read coroutine.
-  synthesizeTrivialGetterBody(TC, getter, TargetImpl::Implementation);
+  synthesizeTrivialGetterBody(getter, TargetImpl::Implementation, ctx);
 }
 
 /// Synthesize the body of a setter which just stores to the given storage
 /// declaration (which doesn't have to be the storage for the setter).
-static void synthesizeTrivialSetterBodyWithStorage(TypeChecker &TC,
-                                                   AccessorDecl *setter,
-                                                   TargetImpl target,
-                                           AbstractStorageDecl *storageToUse) {
-  auto &ctx = TC.Context;
+static void
+synthesizeTrivialSetterBodyWithStorage(AccessorDecl *setter,
+                                       TargetImpl target,
+                                       AbstractStorageDecl *storageToUse,
+                                       ASTContext &ctx) {
   SourceLoc loc = setter->getStorage()->getLoc();
 
   VarDecl *valueParamDecl = getFirstParamDecl(setter);
@@ -849,24 +812,24 @@ static void synthesizeTrivialSetterBodyWithStorage(TypeChecker &TC,
   auto *valueDRE =
     new (ctx) DeclRefExpr(valueParamDecl, DeclNameLoc(), IsImplicit);
   SmallVector<ASTNode, 1> setterBody;
+
   createPropertyStoreOrCallSuperclassSetter(setter, valueDRE, storageToUse,
-                                            target, setterBody, TC);
+                                            target, setterBody, ctx);
   setter->setBody(BraceStmt::create(ctx, loc, setterBody, loc, true));
 
-  finishSynthesis(TC, setter);
-
-  maybeMarkTransparent(TC, setter);
+  maybeMarkTransparent(setter, ctx);
 }
 
-static void synthesizeTrivialSetterBody(TypeChecker &TC, AccessorDecl *setter) {
+static void synthesizeTrivialSetterBody(AccessorDecl *setter,
+                                        ASTContext &ctx) {
   auto storage = setter->getStorage();
   assert(!isSynthesizedComputedProperty(storage));
-  synthesizeTrivialSetterBodyWithStorage(TC, setter, TargetImpl::Storage,
-                                         storage);
+  synthesizeTrivialSetterBodyWithStorage(setter, TargetImpl::Storage,
+                                         storage, ctx);
 }
 
-static void synthesizeCoroutineAccessorBody(TypeChecker &TC,
-                                            AccessorDecl *accessor) {
+static void synthesizeCoroutineAccessorBody(AccessorDecl *accessor,
+                                            ASTContext &ctx) {
   assert(accessor->isCoroutine());
 
   auto storage = accessor->getStorage();
@@ -878,86 +841,88 @@ static void synthesizeCoroutineAccessorBody(TypeChecker &TC,
   SmallVector<ASTNode, 1> body;
 
   // Build a reference to the storage.
-  Expr *ref = buildStorageReference(accessor, storage, target, TC);
+  Expr *ref = buildStorageReference(accessor, storage, target, ctx);
 
   // Wrap it with an `&` marker if this is a modify.
   if (accessor->getAccessorKind() == AccessorKind::Modify) {
-    ref = new (TC.Context) InOutExpr(SourceLoc(), ref, Type(), true);
+    ref = new (ctx) InOutExpr(SourceLoc(), ref, Type(), true);
   }
 
   // Yield it.
-  YieldStmt *yield = YieldStmt::create(TC.Context, loc, loc, ref, loc, true);
+  YieldStmt *yield = YieldStmt::create(ctx, loc, loc, ref, loc, true);
   body.push_back(yield);
 
-  accessor->setBody(BraceStmt::create(TC.Context, loc, body, loc, true));
+  accessor->setBody(BraceStmt::create(ctx, loc, body, loc, true));
 
-  finishSynthesis(TC, accessor);
-  maybeMarkTransparent(TC, accessor);
+  maybeMarkTransparent(accessor, ctx);
 }
 
 /// Synthesize the body of a read coroutine.
-static void synthesizeReadCoroutineBody(TypeChecker &TC, AccessorDecl *read) {
+static void synthesizeReadCoroutineBody(AccessorDecl *read,
+                                        ASTContext &ctx) {
   assert(read->getStorage()->getReadImpl() != ReadImplKind::Read);
-  synthesizeCoroutineAccessorBody(TC, read);
+  synthesizeCoroutineAccessorBody(read, ctx);
 }
 
 /// Synthesize the body of a modify coroutine.
-static void synthesizeModifyCoroutineBody(TypeChecker &TC,
-                                          AccessorDecl *modify) {
+static void synthesizeModifyCoroutineBody(AccessorDecl *modify,
+                                          ASTContext &ctx) {
 #ifndef NDEBUG
   auto impl = modify->getStorage()->getReadWriteImpl();
   assert(impl != ReadWriteImplKind::Modify &&
          impl != ReadWriteImplKind::Immutable);
 #endif
-  synthesizeCoroutineAccessorBody(TC, modify);
+  synthesizeCoroutineAccessorBody(modify, ctx);
 }
 
-static void addGetterToStorage(TypeChecker &TC, AbstractStorageDecl *storage) {
-  auto getter = createGetterPrototype(TC, storage);
+static void addGetterToStorage(AbstractStorageDecl *storage,
+                               ASTContext &ctx) {
+  auto getter = createGetterPrototype(storage, ctx);
 
   // Install the prototype.
   storage->setSynthesizedGetter(getter);
 }
 
-static void addSetterToStorage(TypeChecker &TC, AbstractStorageDecl *storage) {
-  auto setter = createSetterPrototype(TC, storage);
+static void addSetterToStorage(AbstractStorageDecl *storage,
+                               ASTContext &ctx) {
+  auto setter = createSetterPrototype(storage, ctx);
 
   // Install the prototype.
   storage->setSynthesizedSetter(setter);
 }
 
-static void addReadCoroutineToStorage(TypeChecker &TC,
-                                      AbstractStorageDecl *storage) {
-  auto read = createReadCoroutinePrototype(TC, storage);
+static void addReadCoroutineToStorage(AbstractStorageDecl *storage,
+                                      ASTContext &ctx) {
+  auto read = createReadCoroutinePrototype(storage, ctx);
 
   // Install the prototype.
   storage->setSynthesizedReadCoroutine(read);
 }
 
-static void addModifyCoroutineToStorage(TypeChecker &TC,
-                                        AbstractStorageDecl *storage) {
-  auto modify = createModifyCoroutinePrototype(TC, storage);
+static void addModifyCoroutineToStorage(AbstractStorageDecl *storage,
+                                        ASTContext &ctx) {
+  auto modify = createModifyCoroutinePrototype(storage, ctx);
 
   // Install the prototype.
   storage->setSynthesizedModifyCoroutine(modify);
 }
 
 
-static void addOpaqueAccessorToStorage(TypeChecker &TC,
-                                       AbstractStorageDecl *storage,
-                                       AccessorKind kind) {
+static void addOpaqueAccessorToStorage(AbstractStorageDecl *storage,
+                                       AccessorKind kind,
+                                       ASTContext &ctx) {
   switch (kind) {
   case AccessorKind::Get:
-    return addGetterToStorage(TC, storage);
+    return addGetterToStorage(storage, ctx);
 
   case AccessorKind::Set:
-    return addSetterToStorage(TC, storage);
+    return addSetterToStorage(storage, ctx);
 
   case AccessorKind::Read:
-    return addReadCoroutineToStorage(TC, storage);
+    return addReadCoroutineToStorage(storage, ctx);
 
   case AccessorKind::Modify:
-    return addModifyCoroutineToStorage(TC, storage);
+    return addModifyCoroutineToStorage(storage, ctx);
 
 #define OPAQUE_ACCESSOR(ID, KEYWORD)
 #define ACCESSOR(ID) \
@@ -967,8 +932,8 @@ static void addOpaqueAccessorToStorage(TypeChecker &TC,
   }
 }
 
-static void addExpectedOpaqueAccessorsToStorage(TypeChecker &TC,
-                                                AbstractStorageDecl *storage) {
+static void addExpectedOpaqueAccessorsToStorage(AbstractStorageDecl *storage,
+                                                ASTContext &ctx) {
   // Nameless vars from interface files should not have any accessors.
   // TODO: Replace this check with a broader check that all storage decls
   //       from interface files have all their accessors up front.
@@ -979,15 +944,15 @@ static void addExpectedOpaqueAccessorsToStorage(TypeChecker &TC,
     if (storage->getAccessor(kind))
       return;
 
-    addOpaqueAccessorToStorage(TC, storage, kind);
+    addOpaqueAccessorToStorage(storage, kind, ctx);
   });
 }
 
 /// Add trivial accessors to a Stored or Addressed property.
 static void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
-                                         TypeChecker &TC) {
+                                         ASTContext &ctx) {
   assert(!isSynthesizedComputedProperty(storage));
-  addExpectedOpaqueAccessorsToStorage(TC, storage);
+  addExpectedOpaqueAccessorsToStorage(storage, ctx);
 }
 
 static StorageImplInfo getProtocolStorageImpl(AbstractStorageDecl *storage) {
@@ -1002,32 +967,32 @@ static StorageImplInfo getProtocolStorageImpl(AbstractStorageDecl *storage) {
 
 /// Given a storage declaration in a protocol, set it up with the right
 /// StorageImpl and add the right set of opaque accessors.
-static void setProtocolStorageImpl(TypeChecker &TC,
-                                   AbstractStorageDecl *storage) {
-  addExpectedOpaqueAccessorsToStorage(TC, storage);
+static void setProtocolStorageImpl(AbstractStorageDecl *storage,
+                                   ASTContext &ctx) {
+  addExpectedOpaqueAccessorsToStorage(storage, ctx);
 
   storage->overwriteImplInfo(getProtocolStorageImpl(storage));
 }
 
 /// Synthesize the body of a setter which just delegates to a mutable
 /// addressor.
-static void synthesizeMutableAddressSetterBody(TypeChecker &TC,
-                                               AccessorDecl *setter) {
+static void synthesizeMutableAddressSetterBody(AccessorDecl *setter,
+                                               ASTContext &ctx) {
   // This should call the mutable addressor.
-  synthesizeTrivialSetterBodyWithStorage(TC, setter, TargetImpl::Implementation,
-                                         setter->getStorage());
+  synthesizeTrivialSetterBodyWithStorage(setter, TargetImpl::Implementation,
+                                         setter->getStorage(), ctx);
 }
 
 /// Synthesize the body of a setter which just delegates to a modify
 /// coroutine accessor.
-static void synthesizeModifyCoroutineSetterBody(TypeChecker &TC,
-                                                AccessorDecl *setter) {
+static void synthesizeModifyCoroutineSetterBody(AccessorDecl *setter,
+                                                ASTContext &ctx) {
   // This should call the modify coroutine.
-  synthesizeTrivialSetterBodyWithStorage(TC, setter, TargetImpl::Implementation,
-                                         setter->getStorage());
+  synthesizeTrivialSetterBodyWithStorage(setter, TargetImpl::Implementation,
+                                         setter->getStorage(), ctx);
 }
 
-static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
+static void convertNSManagedStoredVarToComputed(VarDecl *VD, ASTContext &ctx) {
   // If it's not still stored, just bail out.
   if (!VD->getImplInfo().isSimpleStored())
     return;
@@ -1041,19 +1006,21 @@ static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
 
   // Create the getter.
   if (!VD->getGetter()) {
-    addGetterToStorage(TC, VD);
+    addGetterToStorage(VD, ctx);
   }
 
   // Create the setter.
   if (!VD->getSetter()) {
-    addSetterToStorage(TC, VD);
+    addSetterToStorage(VD, ctx);
   }
 
   // Okay, we have both a getter and setter; overwrite the impl info.
   VD->overwriteImplInfo(StorageImplInfo::getMutableComputed());
 
-  addExpectedOpaqueAccessorsToStorage(TC, VD);
+  addExpectedOpaqueAccessorsToStorage(VD, ctx);
 }
+
+void synthesizeAccessorBody(AbstractFunctionDecl *fn, void *);
 
 /// The specified AbstractStorageDecl was just found to satisfy a
 /// protocol property requirement.  Ensure that it has the full
@@ -1069,20 +1036,22 @@ void TypeChecker::synthesizeWitnessAccessorsForStorage(
       return;
 
     // Otherwise, synthesize it.
-    addOpaqueAccessorToStorage(*this, storage, kind);
+    addOpaqueAccessorToStorage(storage, kind, Context);
 
     // Flag that we've added an accessor.
     addedAccessor = true;
 
     // Trigger synthesize of the accessor body if it's created on-demand.
     if (isOnDemandAccessor(storage, kind)) {
-      auto synthKind = getSynthKindForAccessorKind(kind);
-      triggerSynthesis(*this, storage->getAccessor(kind), synthKind);
+      auto *accessor = storage->getAccessor(kind);
+      assert(!accessor->hasBody());
+      accessor->setBodySynthesizer(&synthesizeAccessorBody);
 
       // Make sure SILGen emits the accessor; on-demand accessors have shared
       // linkage, and if its defined in a different translation unit from the
       // conformance we cannot simply generate an external declaration.
-      Context.addExternalDecl(storage->getAccessor(kind));
+      Context.addExternalDecl(accessor);
+      DeclsToFinalize.insert(accessor);
     }
   });
 
@@ -1095,11 +1064,11 @@ void TypeChecker::synthesizeWitnessAccessorsForStorage(
 
 /// Given a VarDecl with a willSet: and/or didSet: specifier, synthesize the
 /// setter which calls them.
-static void synthesizeObservedSetterBody(TypeChecker &TC, AccessorDecl *Set,
-                                         TargetImpl target) {
+static void synthesizeObservedSetterBody(AccessorDecl *Set,
+                                         TargetImpl target,
+                                         ASTContext &Ctx) {
   auto VD = cast<VarDecl>(Set->getStorage());
 
-  auto &Ctx = VD->getASTContext();
   SourceLoc Loc = VD->getLoc();
 
   // We have to be paranoid about the accessors already having bodies
@@ -1121,7 +1090,7 @@ static void synthesizeObservedSetterBody(TypeChecker &TC, AccessorDecl *Set,
   VarDecl *OldValue = nullptr;
   if (VD->getDidSetFunc()) {
     Expr *OldValueExpr
-      = createPropertyLoadOrCallSuperclassGetter(Set, VD, target, TC);
+      = createPropertyLoadOrCallSuperclassGetter(Set, VD, target, Ctx);
 
     OldValue = new (Ctx) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                                  /*IsCaptureList*/false, SourceLoc(),
@@ -1156,7 +1125,7 @@ static void synthesizeObservedSetterBody(TypeChecker &TC, AccessorDecl *Set,
   // Create an assignment into the storage or call to superclass setter.
   auto *ValueDRE = new (Ctx) DeclRefExpr(ValueDecl, DeclNameLoc(), true);
   createPropertyStoreOrCallSuperclassSetter(Set, ValueDRE, VD, target,
-                                            SetterBody, TC);
+                                            SetterBody, Ctx);
 
   // Create:
   //   (call_expr (dot_syntax_call_expr (decl_ref_expr(didSet)),
@@ -1178,18 +1147,16 @@ static void synthesizeObservedSetterBody(TypeChecker &TC, AccessorDecl *Set,
   }
 
   Set->setBody(BraceStmt::create(Ctx, Loc, SetterBody, Loc, true));
-
-  finishSynthesis(TC, Set);
 }
 
-static void synthesizeStoredWithObserversSetterBody(TypeChecker &TC,
-                                                    AccessorDecl *setter) {
-  synthesizeObservedSetterBody(TC, setter, TargetImpl::Storage);
+static void synthesizeStoredWithObserversSetterBody(AccessorDecl *setter,
+                                                    ASTContext &ctx) {
+  synthesizeObservedSetterBody(setter, TargetImpl::Storage, ctx);
 }
 
-static void synthesizeInheritedWithObserversSetterBody(TypeChecker &TC,
-                                                       AccessorDecl *setter) {
-  synthesizeObservedSetterBody(TC, setter, TargetImpl::Super);
+static void synthesizeInheritedWithObserversSetterBody(AccessorDecl *setter,
+                                                      ASTContext &ctx) {
+  synthesizeObservedSetterBody(setter, TargetImpl::Super, ctx);
 }
 
 namespace {
@@ -1236,12 +1203,21 @@ namespace {
 
 /// Synthesize the getter for a lazy property with the specified storage
 /// vardecl.
-static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
-                                     VarDecl *Storage) {
-  auto &Ctx = TC.Context;
+static void synthesizeLazyGetterBody(AbstractFunctionDecl *fn, void *context) {
+  auto &Ctx = fn->getASTContext();
+
+  // FIXME: Remove TypeChecker dependencies below.
+  auto &TC = *(TypeChecker *) Ctx.getLazyResolver();
+
+  // The stored property backing the lazy var.
+  AccessorDecl *Get = cast<AccessorDecl>(fn);
+  VarDecl *Storage = (VarDecl *) context;
 
   // The lazy var itself.
   auto VD = cast<VarDecl>(Get->getStorage());
+
+  if (Get->isInvalid() || Ctx.hadError())
+    return;
 
   // The getter checks the optional, storing the initial value in if nil.  The
   // specific pattern we generate is:
@@ -1265,7 +1241,7 @@ static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
   auto *Tmp1PBDPattern = new (Ctx) NamedPattern(Tmp1VD, /*implicit*/true);
   auto *Tmp1Init =
     createPropertyLoadOrCallSuperclassGetter(Get, Storage,
-                                             TargetImpl::Storage, TC);
+                                             TargetImpl::Storage, Ctx);
   auto *Tmp1PBD = PatternBindingDecl::createImplicit(
       Ctx, StaticSpellingKind::None, Tmp1PBDPattern, Tmp1Init, Get);
   Body.push_back(Tmp1PBD);
@@ -1340,7 +1316,7 @@ static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
   auto Tmp2DRE = new (Ctx) DeclRefExpr(Tmp2VD, DeclNameLoc(), /*Implicit*/true,
                                        AccessSemantics::DirectToStorage);
   createPropertyStoreOrCallSuperclassSetter(Get, Tmp2DRE, Storage,
-                                            TargetImpl::Storage, Body, TC);
+                                            TargetImpl::Storage, Body, Ctx);
 
   // Return tmp2.
   Tmp2DRE = new (Ctx) DeclRefExpr(Tmp2VD, DeclNameLoc(), /*Implicit*/true,
@@ -1350,14 +1326,18 @@ static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
 
   Get->setBody(BraceStmt::create(Ctx, VD->getLoc(), Body, VD->getLoc(),
                                  /*implicit*/true));
-
-  finishSynthesis(TC, Get);
 }
 
-static void synthesizeLazySetterBody(TypeChecker &TC, AccessorDecl *setter,
-                                     VarDecl *underlyingStorage) {
-  synthesizeTrivialSetterBodyWithStorage(TC, setter, TargetImpl::Storage,
-                                         underlyingStorage);
+static void synthesizeLazySetterBody(AbstractFunctionDecl *fn, void *context) {
+  auto *setter = cast<AccessorDecl>(fn);
+  auto *underlyingStorage = (VarDecl *) context;
+  auto &ctx = setter->getASTContext();
+
+  if (setter->isInvalid() || ctx.hadError())
+    return;
+
+  synthesizeTrivialSetterBodyWithStorage(setter, TargetImpl::Storage,
+                                         underlyingStorage, ctx);
 }
 
 void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
@@ -1486,7 +1466,7 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
   
   // Add accessors to the storage, since we'll need them to satisfy the
   // conformance requirements.
-  addTrivialAccessorsToStorage(Storage, *this);
+  addTrivialAccessorsToStorage(Storage, Context);
 
   // FIXME: Hack to eliminate spurious diagnostics.
   if (BehaviorStorage->isStatic() != Storage->isStatic()) return;
@@ -1776,10 +1756,8 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
 
   // Now that we've got the storage squared away, enqueue the getter and
   // setter to be synthesized.
-  triggerSynthesis(*this, VD->getGetter(),
-                   SynthesizedFunction::LazyGetter, Storage);
-  triggerSynthesis(*this, VD->getSetter(),
-                   SynthesizedFunction::LazySetter, Storage);
+  VD->getGetter()->setBodySynthesizer(&synthesizeLazyGetterBody, Storage);
+  VD->getSetter()->setBodySynthesizer(&synthesizeLazySetterBody, Storage);
 
   // Mark the vardecl to be final, implicit, and private.  In a class, this
   // prevents it from being dynamically dispatched.  Note that we do this after
@@ -1844,7 +1822,10 @@ void swift::triggerAccessorSynthesis(TypeChecker &TC,
     if (!accessor)
       return;
 
-    triggerSynthesis(TC, accessor, getSynthKindForAccessorKind(kind));
+    accessor->setBodySynthesizer(&synthesizeAccessorBody);
+
+    TC.Context.addSynthesizedDecl(accessor);
+    TC.DeclsToFinalize.insert(accessor);
   });
 }
 
@@ -1874,7 +1855,7 @@ static void maybeAddAccessorsToBehaviorStorage(TypeChecker &TC, VarDecl *var) {
     AccessorDecl *getter;
     AccessorDecl *setter = nullptr;
     if (valueProp && valueProp->getGetter()) {
-      getter = createGetterPrototype(TC, var);
+      getter = createGetterPrototype(var, TC.Context);
       // The getter is mutating if the behavior implementation is, unless
       // we're in a class or non-instance context.
       if (mightBeMutating && valueProp->isGetterMutating())
@@ -1884,7 +1865,7 @@ static void maybeAddAccessorsToBehaviorStorage(TypeChecker &TC, VarDecl *var) {
 
       // Make a setter if the behavior property has one.
       if (valueProp->getSetter()) {
-        setter = createSetterPrototype(TC, var, getter);
+        setter = createSetterPrototype(var, TC.Context, getter);
         if (mightBeMutating && valueProp->isSetterMutating())
           setter->setSelfAccessKind(SelfAccessKind::Mutating);
         // TODO: max of property and implementation setter visibility?
@@ -1894,9 +1875,9 @@ static void maybeAddAccessorsToBehaviorStorage(TypeChecker &TC, VarDecl *var) {
       // Even if we couldn't find a value property, still make up a stub
       // getter and setter, so that subsequent diagnostics make sense for a
       // computed-ish property.
-      getter = createGetterPrototype(TC, var);
+      getter = createGetterPrototype(var, TC.Context);
       getter->setAccess(var->getFormalAccess());
-      setter = createSetterPrototype(TC, var, getter);
+      setter = createSetterPrototype(var, TC.Context, getter);
       setter->setSelfAccessKind(SelfAccessKind::NonMutating);
       setter->setAccess(var->getFormalAccess());
     }
@@ -1993,22 +1974,22 @@ static void maybeAddAccessorsToBehaviorStorage(TypeChecker &TC, VarDecl *var) {
   return makeBehaviorAccessors();
 }
 
-static void maybeAddAccessorsToLazyVariable(TypeChecker &TC, VarDecl *var) {
+static void maybeAddAccessorsToLazyVariable(VarDecl *var, ASTContext &ctx) {
   // If there are already accessors, something is invalid; bail out.
   if (!var->getImplInfo().isSimpleStored())
     return;
 
   if (!var->getGetter()) {
-    addGetterToStorage(TC, var);
+    addGetterToStorage(var, ctx);
   }
 
   if (!var->getSetter()) {
-    addSetterToStorage(TC, var);
+    addSetterToStorage(var, ctx);
   }
 
   var->overwriteImplInfo(StorageImplInfo::getMutableComputed());
 
-  addExpectedOpaqueAccessorsToStorage(TC, var);
+  addExpectedOpaqueAccessorsToStorage(var, ctx);
 }
 
 /// Try to add the appropriate accessors required a storage declaration.
@@ -2027,7 +2008,7 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
 
   // Lazy properties require special handling.
   if (storage->getAttrs().hasAttribute<LazyAttr>()) {
-    maybeAddAccessorsToLazyVariable(TC, cast<VarDecl>(storage));
+    maybeAddAccessorsToLazyVariable(cast<VarDecl>(storage), TC.Context);
     return;
   }
 
@@ -2044,7 +2025,7 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
   if (!dc->isTypeContext()) {
     // dynamic globals need accessors.
     if (dc->isModuleScopeContext() && storage->isNativeDynamic()) {
-      addTrivialAccessorsToStorage(storage, TC);
+      addTrivialAccessorsToStorage(storage, TC.Context);
       return;
     }
     // Fixed-layout global variables don't get accessors.
@@ -2074,14 +2055,14 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
       }
     }
 
-    setProtocolStorageImpl(TC, storage);
+    setProtocolStorageImpl(storage, TC.Context);
     return;
 
   // NSManaged properties on classes require special handling.
   } else if (dc->getSelfClassDecl()) {
     auto var = dyn_cast<VarDecl>(storage);
     if (var && var->getAttrs().hasAttribute<NSManagedAttr>()) {
-      convertNSManagedStoredVarToComputed(var, TC);
+      convertNSManagedStoredVarToComputed(var, TC.Context);
       return;
     }
 
@@ -2096,98 +2077,101 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
   if (auto sourceFile = dc->getParentSourceFile())
     if (sourceFile->Kind == SourceFileKind::SIL) {
       if (storage->getGetter()) {
-        addExpectedOpaqueAccessorsToStorage(TC, storage);
+        addExpectedOpaqueAccessorsToStorage(storage, TC.Context);
       }
       return;
     }
 
   // Everything else gets mandatory accessors.
-  addTrivialAccessorsToStorage(storage, TC);
+  addTrivialAccessorsToStorage(storage, TC.Context);
 }
 
-static void synthesizeGetterBody(TypeChecker &TC, AccessorDecl *getter) {
+static void synthesizeGetterBody(AccessorDecl *getter,
+                                 ASTContext &ctx) {
   if (getter->hasForcedStaticDispatch()) {
-    synthesizeTrivialGetterBody(TC, getter, TargetImpl::Ordinary);
+    synthesizeTrivialGetterBody(getter, TargetImpl::Ordinary, ctx);
     return;
   }
 
   switch (getter->getStorage()->getReadImpl()) {
   case ReadImplKind::Stored:
-    synthesizeTrivialGetterBody(TC, getter);
+    synthesizeTrivialGetterBody(getter, ctx);
     return;
 
   case ReadImplKind::Get:
     llvm_unreachable("synthesizing getter that already exists?");
 
   case ReadImplKind::Inherited:
-    synthesizeInheritedGetterBody(TC, getter);
+    synthesizeInheritedGetterBody(getter, ctx);
     return;
 
   case ReadImplKind::Address:
-    synthesizeAddressedGetterBody(TC, getter);
+    synthesizeAddressedGetterBody(getter, ctx);
     return;
 
   case ReadImplKind::Read:
-    synthesizeReadCoroutineGetterBody(TC, getter);
+    synthesizeReadCoroutineGetterBody(getter, ctx);
     return;
   }
   llvm_unreachable("bad ReadImplKind");
 }
 
-static void synthesizeSetterBody(TypeChecker &TC, AccessorDecl *setter) {
+static void synthesizeSetterBody(AccessorDecl *setter,
+                                 ASTContext &ctx) {
   switch (setter->getStorage()->getWriteImpl()) {
   case WriteImplKind::Immutable:
     llvm_unreachable("synthesizing setter from immutable storage");
 
   case WriteImplKind::Stored:
-    return synthesizeTrivialSetterBody(TC, setter);
+    return synthesizeTrivialSetterBody(setter, ctx);
 
   case WriteImplKind::StoredWithObservers:
-    return synthesizeStoredWithObserversSetterBody(TC, setter);
+    return synthesizeStoredWithObserversSetterBody(setter, ctx);
 
   case WriteImplKind::InheritedWithObservers:
-    return synthesizeInheritedWithObserversSetterBody(TC, setter);
+    return synthesizeInheritedWithObserversSetterBody(setter, ctx);
 
   case WriteImplKind::Set:
     llvm_unreachable("synthesizing setter for unknown reason?");  
 
   case WriteImplKind::MutableAddress:
-    return synthesizeMutableAddressSetterBody(TC, setter);
+    return synthesizeMutableAddressSetterBody(setter, ctx);
 
   case WriteImplKind::Modify:
-    synthesizeModifyCoroutineSetterBody(TC, setter);
-    return;
+    return synthesizeModifyCoroutineSetterBody(setter, ctx);
   }
   llvm_unreachable("bad ReadImplKind");
 }
+ 
+void synthesizeAccessorBody(AbstractFunctionDecl *fn, void *) {
+  auto *accessor = cast<AccessorDecl>(fn);
+  auto &ctx = accessor->getASTContext();
 
-void TypeChecker::synthesizeFunctionBody(SynthesizedFunction fn) {
-  switch (fn.getKind()) {
-  case SynthesizedFunction::Getter:
-    synthesizeGetterBody(*this, cast<AccessorDecl>(fn.getDecl()));
+  if (accessor->isInvalid() || ctx.hadError())
     return;
 
-  case SynthesizedFunction::Setter:
-    synthesizeSetterBody(*this, cast<AccessorDecl>(fn.getDecl()));
+  switch (accessor->getAccessorKind()) {
+  case AccessorKind::Get:
+    synthesizeGetterBody(accessor, ctx);
     return;
 
-  case SynthesizedFunction::ReadCoroutine:
-    synthesizeReadCoroutineBody(*this, cast<AccessorDecl>(fn.getDecl()));
+  case AccessorKind::Set:
+    synthesizeSetterBody(accessor, ctx);
     return;
 
-  case SynthesizedFunction::ModifyCoroutine:
-    synthesizeModifyCoroutineBody(*this, cast<AccessorDecl>(fn.getDecl()));
+  case AccessorKind::Read:
+    synthesizeReadCoroutineBody(accessor, ctx);
     return;
 
-  case SynthesizedFunction::LazyGetter:
-    synthesizeLazyGetterBody(*this, cast<AccessorDecl>(fn.getDecl()),
-                             fn.getLazyTargetVariable());
+  case AccessorKind::Modify:
+    synthesizeModifyCoroutineBody(accessor, ctx);
     return;
 
-  case SynthesizedFunction::LazySetter:
-    synthesizeLazySetterBody(*this, cast<AccessorDecl>(fn.getDecl()),
-                             fn.getLazyTargetVariable());
-    return;
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
+  case AccessorKind::Address:
+  case AccessorKind::MutableAddress:
+    break;
   }
   llvm_unreachable("bad synthesized function kind");
 }

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -42,59 +42,6 @@ class TypeChecker;
 
 class ObjCReason;
 
-/// A function which needs to have its body synthesized.
-///
-/// This class exists in expectation that someone will need to add more
-/// information to it.
-class SynthesizedFunction {
-public:
-  enum Kind {
-    Getter,
-    Setter,
-    ReadCoroutine,
-    ModifyCoroutine,
-    LazyGetter,
-    LazySetter,
-  };
-
-private:
-  FuncDecl *Fn;
-  Kind K;
-
-  using Members = ExternalUnionMembers<void, VarDecl*>;
-  static Members::Index getIndexForKind(Kind kind) {
-    switch (kind) {
-    case Kind::Getter:
-    case Kind::Setter:
-    case Kind::ReadCoroutine:
-    case Kind::ModifyCoroutine:
-      return Members::indexOf<void>();
-    case Kind::LazyGetter:
-    case Kind::LazySetter:
-      return Members::indexOf<VarDecl*>();
-    }
-    llvm_unreachable("bad kind");
-  };
-  ExternalUnion<Kind, Members, getIndexForKind> Extra;
-  static_assert(decltype(Extra)::union_is_trivially_copyable,
-                "expected all members to be trivial");
-
-public:
-  SynthesizedFunction(FuncDecl *fn, Kind kind) : Fn(fn), K(kind) {
-    assert(getIndexForKind(kind) == Members::indexOf<void>() &&
-           "this storage kind requires extra data");
-  }
-
-  SynthesizedFunction(FuncDecl *fn, Kind kind, VarDecl *var) : Fn(fn), K(kind) {
-    Extra.emplace<VarDecl*>(K, var);
-  }
-
-  FuncDecl *getDecl() const { return Fn; }
-  Kind getKind() const { return K; }
-
-  VarDecl *getLazyTargetVariable() const { return Extra.get<VarDecl*>(K); }
-};
-
 // These are implemented in TypeCheckDecl.cpp.
 void makeFinal(ASTContext &ctx, ValueDecl *D);
 

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -39,7 +39,7 @@ static bool canDeriveConformance(NominalTypeDecl *type) {
 }
 
 /// Derive the implementation of allCases for a "simple" no-payload enum.
-void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl) {
+void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl, void *) {
   auto *parentDC = funcDecl->getDeclContext();
   auto *parentEnum = parentDC->getSelfEnumDecl();
   auto enumTy = parentDC->getDeclaredTypeInContext();

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -512,7 +512,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
 /// Synthesizes the body for `func encode(to encoder: Encoder) throws`.
 ///
 /// \param encodeDecl The function decl whose body to synthesize.
-static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
+static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -749,7 +749,7 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
 /// Synthesizes the body for `init(from decoder: Decoder) throws`.
 ///
 /// \param initDecl The function decl whose body to synthesize.
-static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
+static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -1024,7 +1024,7 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
                               /*GenericParams=*/nullptr, conformanceDC);
   initDecl->setImplicit();
   initDecl->setSynthesized();
-  initDecl->setBodySynthesizer(deriveBodyDecodable_init);
+  initDecl->setBodySynthesizer(&deriveBodyDecodable_init);
 
   // This constructor should be marked as `required` for non-final classes.
   if (classDecl && !classDecl->getAttrs().hasAttribute<FinalAttr>()) {

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -29,7 +29,7 @@ using namespace swift;
 /// Sets the body of the given function to `return nil`.
 ///
 /// \param funcDecl The function whose body to set.
-static void deriveNilReturn(AbstractFunctionDecl *funcDecl) {
+static void deriveNilReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto *parentDC = funcDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
@@ -43,7 +43,7 @@ static void deriveNilReturn(AbstractFunctionDecl *funcDecl) {
 /// Sets the body of the given function to `return self.rawValue`.
 ///
 /// \param funcDecl The function whose body to set.
-static void deriveRawValueReturn(AbstractFunctionDecl *funcDecl) {
+static void deriveRawValueReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto *parentDC = funcDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
@@ -62,7 +62,7 @@ static void deriveRawValueReturn(AbstractFunctionDecl *funcDecl) {
 /// the parameter of the given constructor.
 ///
 /// \param initDecl The constructor whose body to set.
-static void deriveRawValueInit(AbstractFunctionDecl *initDecl) {
+static void deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
   auto *parentDC = initDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
@@ -190,7 +190,7 @@ static ValueDecl *deriveProperty(DerivedConformance &derived, Type type,
 ///
 /// \param strValDecl The function whose body to set.
 static void
-deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl) {
+deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
   // enum SomeEnum {
   //   case A, B, C
   //   @derived var stringValue: String {
@@ -255,7 +255,7 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl) {
 ///
 /// \param initDecl The function whose body to set.
 static void
-deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl) {
+deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
   // enum SomeEnum {
   //   case A, B, C
   //   @derived init?(stringValue: String) {
@@ -279,7 +279,7 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl) {
 
   auto elements = enumDecl->getAllElements();
   if (elements.empty() /* empty enum */) {
-    deriveNilReturn(initDecl);
+    deriveNilReturn(initDecl, nullptr);
     return;
   }
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -303,7 +303,7 @@ static GuardStmt *returnIfNotEqualGuard(ASTContext &C,
 }
 
 static void
-deriveBodyEquatable_enum_uninhabited_eq(AbstractFunctionDecl *eqDecl) {
+deriveBodyEquatable_enum_uninhabited_eq(AbstractFunctionDecl *eqDecl, void *) {
   auto parentDC = eqDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
@@ -334,7 +334,8 @@ deriveBodyEquatable_enum_uninhabited_eq(AbstractFunctionDecl *eqDecl) {
 /// values. This generates code that converts each value to its integer ordinal
 /// and compares them, which produces an optimal single icmp instruction.
 static void
-deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl) {
+deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
+                                               void *) {
   auto parentDC = eqDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
@@ -389,7 +390,8 @@ deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl) {
 /// Derive the body for an '==' operator for an enum where at least one of the
 /// cases has associated values.
 static void
-deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl) {
+deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
+                                                void *) {
   auto parentDC = eqDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
@@ -503,7 +505,8 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl) {
 }
 
 /// Derive the body for an '==' operator for a struct.
-static void deriveBodyEquatable_struct_eq(AbstractFunctionDecl *eqDecl) {
+static void deriveBodyEquatable_struct_eq(AbstractFunctionDecl *eqDecl,
+                                          void *) {
   auto parentDC = eqDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
@@ -554,7 +557,7 @@ static void deriveBodyEquatable_struct_eq(AbstractFunctionDecl *eqDecl) {
 /// Derive an '==' operator implementation for an enum or a struct.
 static ValueDecl *
 deriveEquatable_eq(DerivedConformance &derived,
-                   void (*bodySynthesizer)(AbstractFunctionDecl *)) {
+                   void (*bodySynthesizer)(AbstractFunctionDecl *, void *)) {
   // enum SomeEnum<T...> {
   //   case A, B(Int), C(String, Int)
   //
@@ -731,7 +734,8 @@ static CallExpr *createHasherCombineCall(ASTContext &C,
 
 static FuncDecl *
 deriveHashable_hashInto(DerivedConformance &derived,
-                        void (*bodySynthesizer)(AbstractFunctionDecl *)) {
+                        void (*bodySynthesizer)(AbstractFunctionDecl *,
+                                                void *)) {
   // @derived func hash(into hasher: inout Hasher)
 
   ASTContext &C = derived.TC.Context;
@@ -792,7 +796,7 @@ deriveHashable_hashInto(DerivedConformance &derived,
 /// Derive the body for the hash(into:) method when hashValue has a
 /// user-supplied implementation.
 static void
-deriveBodyHashable_compat_hashInto(AbstractFunctionDecl *hashIntoDecl) {
+deriveBodyHashable_compat_hashInto(AbstractFunctionDecl *hashIntoDecl, void *) {
   // func hash(into hasher: inout Hasher) {
   //   hasher.combine(self.hashValue)
   // }
@@ -817,8 +821,7 @@ deriveBodyHashable_compat_hashInto(AbstractFunctionDecl *hashIntoDecl) {
 /// value.
 static void
 deriveBodyHashable_enum_rawValue_hashInto(
-  AbstractFunctionDecl *hashIntoDecl
-) {
+  AbstractFunctionDecl *hashIntoDecl, void *) {
   // enum SomeEnum: Int {
   //   case A, B, C
   //   @derived func hash(into hasher: inout Hasher) {
@@ -846,8 +849,7 @@ deriveBodyHashable_enum_rawValue_hashInto(
 /// values.
 static void
 deriveBodyHashable_enum_noAssociatedValues_hashInto(
-  AbstractFunctionDecl *hashIntoDecl
-) {
+  AbstractFunctionDecl *hashIntoDecl, void *) {
   // enum SomeEnum {
   //   case A, B, C
   //   @derived func hash(into hasher: inout Hasher) {
@@ -888,8 +890,7 @@ deriveBodyHashable_enum_noAssociatedValues_hashInto(
 /// values.
 static void
 deriveBodyHashable_enum_hasAssociatedValues_hashInto(
-  AbstractFunctionDecl *hashIntoDecl
-) {
+  AbstractFunctionDecl *hashIntoDecl, void *) {
   // enum SomeEnumWithAssociatedValues {
   //   case A, B(Int), C(String, Int)
   //   @derived func hash(into hasher: inout Hasher) {
@@ -977,7 +978,7 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
 
 /// Derive the body for the 'hash(into:)' method for a struct.
 static void
-deriveBodyHashable_struct_hashInto(AbstractFunctionDecl *hashIntoDecl) {
+deriveBodyHashable_struct_hashInto(AbstractFunctionDecl *hashIntoDecl, void *) {
   // struct SomeStruct {
   //   var x: Int
   //   var y: String
@@ -1019,7 +1020,7 @@ deriveBodyHashable_struct_hashInto(AbstractFunctionDecl *hashIntoDecl) {
 
 /// Derive the body for the 'hashValue' getter.
 static void
-deriveBodyHashable_hashValue(AbstractFunctionDecl *hashValueDecl) {
+deriveBodyHashable_hashValue(AbstractFunctionDecl *hashValueDecl, void *) {
   auto parentDC = hashValueDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
@@ -1194,7 +1195,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         return nullptr;
 
       if (auto ED = dyn_cast<EnumDecl>(Nominal)) {
-        void (*bodySynthesizer)(AbstractFunctionDecl *);
+        void (*bodySynthesizer)(AbstractFunctionDecl *, void *);
         if (ED->isObjC())
           bodySynthesizer = deriveBodyHashable_enum_rawValue_hashInto;
         else if (ED->hasOnlyCasesWithoutAssociatedValues())

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -26,7 +26,7 @@
 using namespace swift;
 
 static void deriveBodyBridgedNSError_enum_nsErrorDomain(
-              AbstractFunctionDecl *domainDecl) {
+              AbstractFunctionDecl *domainDecl, void *) {
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -59,7 +59,8 @@ static Type deriveRawRepresentable_Raw(DerivedConformance &derived) {
   return derived.getConformanceContext()->mapTypeIntoContext(rawInterfaceType);
 }
 
-static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
+static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl,
+                                           void *) {
   // enum SomeEnum : SomeType {
   //   case A = 111, B = 222
   //   @derived
@@ -188,7 +189,7 @@ static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
 }
 
 static void
-deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
+deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   // enum SomeEnum : SomeType {
   //   case A = 111, B = 222
   //   @derived

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -283,15 +283,14 @@ public:
         // recontextualized into it, so treat it as if it's already there.
         if (auto init = dyn_cast<PatternBindingInitializer>(TmpDC)) {
           if (auto lazyVar = init->getInitializedLazyVar()) {
-            // Referring to the 'self' parameter is fine.
-            if (D == init->getImplicitSelfDecl())
-              return { false, DRE };
-
-            // Otherwise, act as if we're in the getter.
-            auto getter = lazyVar->getGetter();
-            assert(getter && "lazy variable without getter");
-            TmpDC = getter;
-            continue;
+            // If we have a getter with a body, we're already re-parented
+            // everything so pretend we're inside the getter.
+            if (auto getter = lazyVar->getGetter()) {
+              if (getter->getBody(/*canSynthesize=*/false)) {
+                TmpDC = getter;
+                continue;
+              }
+            }
           }
         }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1008,13 +1008,7 @@ static void validatePatternBindingEntry(TypeChecker &tc,
   // If the pattern didn't get a type or if it contains an unbound generic type,
   // we'll need to check the initializer.
   if (!pattern->hasType() || pattern->getType()->hasUnboundGenericType()) {
-    // We used to not apply the solution to lazy bindings here, but that's
-    // unnecessary: the code for building lazy getters already has to handle
-    // initializers which have had solutions applied, and not applying the
-    // solution blocks other diagnostics if we decide not to synthesize the
-    // getter.
-    bool skipApplyingSolution = false;
-    if (tc.typeCheckPatternBinding(binding, entryNumber, skipApplyingSolution))
+    if (tc.typeCheckPatternBinding(binding, entryNumber))
       return;
   }
 
@@ -2644,7 +2638,7 @@ public:
           // If we got a default initializer, install it and re-type-check it
           // to make sure it is properly coerced to the pattern type.
           PBD->setInit(i, defaultInit);
-          TC.typeCheckPatternBinding(PBD, i, /*skipApplyingSolution*/false);
+          TC.typeCheckPatternBinding(PBD, i);
         }
       }
     }
@@ -2733,7 +2727,7 @@ public:
     // If the initializers in the PBD aren't checked yet, do so now.
     for (unsigned i = 0, e = PBD->getNumPatternEntries(); i != e; ++i) {
       if (!PBD->isInitializerChecked(i) && PBD->getInit(i))
-        TC.typeCheckPatternBinding(PBD, i, /*skipApplyingSolution*/false);
+        TC.typeCheckPatternBinding(PBD, i);
     }
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -554,7 +554,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
   TC.DelayedCircularityChecks.clear();
 
   // Compute captures for functions and closures we visited.
-  for (AnyFunctionRef closure : TC.ClosuresWithUncomputedCaptures) {
+  for (auto *closure : TC.ClosuresWithUncomputedCaptures) {
     TC.computeCaptures(closure);
   }
   TC.ClosuresWithUncomputedCaptures.clear();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -453,17 +453,6 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
       TC.typeCheckAbstractFunctionBody(AFD);
     }
 
-    // Synthesize any necessary function bodies.
-    // FIXME: If we're not planning to run SILGen, this is wasted effort.
-    while (!TC.FunctionsToSynthesize.empty()) {
-      auto function = TC.FunctionsToSynthesize.back().second;
-      TC.FunctionsToSynthesize.pop_back();
-      if (function.getDecl()->isInvalid() || TC.Context.hadError())
-        continue;
-
-      TC.synthesizeFunctionBody(function);
-    }
-
     // Type check external definitions.
     for (unsigned n = TC.Context.ExternalDefinitions.size();
          currentExternalDef != n;
@@ -539,7 +528,6 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
   } while (currentFunctionIdx < TC.definedFunctions.size() ||
            currentExternalDef < TC.Context.ExternalDefinitions.size() ||
            currentSynthesizedDecl < SF.SynthesizedDecls.size() ||
-           !TC.FunctionsToSynthesize.empty() ||
            TC.NextDeclToFinalize < TC.DeclsToFinalize.size() ||
            !TC.ConformanceContexts.empty() ||
            !TC.DelayedRequirementSignatures.empty() ||

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -557,7 +557,7 @@ public:
 
   /// A list of closures for the most recently type-checked function, which we
   /// will need to compute captures for.
-  std::vector<AnyFunctionRef> ClosuresWithUncomputedCaptures;
+  std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
 
   /// Local functions that have been captured before their definitions.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -257,15 +257,12 @@ enum class TypeCheckExprFlags {
   /// and so we should not visit bodies of non-single expression closures.
   SkipMultiStmtClosures = 0x40,
 
-  /// If set, don't apply a solution.
-  SkipApplyingSolution = 0x100,
-
   /// This is an inout yield.
-  IsInOutYield = 0x200,
+  IsInOutYield = 0x100,
 
-  /// If set, a conversion constraint should be specfied so that the result of
+  /// If set, a conversion constraint should be specified so that the result of
   /// the expression is an optional type.
-  ExpressionTypeMustBeOptional = 0x400,
+  ExpressionTypeMustBeOptional = 0x200,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;
@@ -1535,10 +1532,8 @@ public:
 
   
   /// Type-check an initialized variable pattern declaration.
-  bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC,
-                        bool skipApplyingSolution);
-  bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
-                               bool skipApplyingSolution);
+  bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC);
+  bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber);
 
   /// Type-check a for-each loop's pattern binding and sequence together.
   bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -44,7 +44,6 @@ class TypeResolution;
 class TypeResolutionOptions;
 class TypoCorrectionResults;
 class ExprPattern;
-class SynthesizedFunction;
 enum class TypeResolutionStage : uint8_t;
 
 namespace constraints {
@@ -544,9 +543,6 @@ public:
   /// Track the index of the next declaration that needs to be finalized,
   /// from the \c DeclsToFinalize set.
   unsigned NextDeclToFinalize = 0;
-
-  /// The list of functions that need to have their bodies synthesized.
-  llvm::MapVector<FuncDecl*, SynthesizedFunction> FunctionsToSynthesize;
 
   /// The list of protocols that need their requirement signatures computed,
   /// because they were first validated by validateDeclForNameLookup(),
@@ -1272,8 +1268,6 @@ public:
   /// complement of accessors.
   void synthesizeWitnessAccessorsForStorage(AbstractStorageDecl *requirement,
                                             AbstractStorageDecl *storage);
-
-  void synthesizeFunctionBody(SynthesizedFunction fn);
 
   /// Provide storage and accessor implementations for the given property,
   /// which must be lazy.

--- a/test/multifile/Inputs/external_lazy_property.swift
+++ b/test/multifile/Inputs/external_lazy_property.swift
@@ -1,3 +1,12 @@
 public struct Test1 {
-    lazy var property: String = "help"
+  lazy var property: String = "help"
+}
+
+public class Test2 {
+  var x = 0
+  var y = 1
+
+  lazy var property = {
+    return [self.x, self.y]
+  }()
 }

--- a/test/multifile/lazy.swift
+++ b/test/multifile/lazy.swift
@@ -1,6 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil -verify -primary-file %s %S/Inputs/external_lazy_property.swift
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s -primary-file %S/Inputs/external_lazy_property.swift
 
 // rdar://45712204
 func test1(s: Test1) {
-  s.property // expected-error {{cannot use mutating getter on immutable value: 's' is a 'let' constant}}
+  _ = s.property // expected-error {{cannot use mutating getter on immutable value: 's' is a 'let' constant}}
+}
+
+func test2(s: Test2) {
+  _ = s.property
 }


### PR DESCRIPTION
We had two mechanisms for lazily synthesizing a function body. Now there is only one. I'm going to use this in the ClangImporter for a few things later.