### PR TITLE
[stdlib] Remove Interval.swift from GroupInfo.json

### DIFF
--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -197,7 +197,6 @@
     "Bitset.swift"
   ],
   "Misc": [
-    "Interval.swift",
     "ErrorType.swift",
     "InputStream.swift",
     "LifetimeManager.swift",


### PR DESCRIPTION
Interval.swift.gyb was deleted when implementing SE-0065.

(See also: apple/swift@f493b54e448dbc92a52c9c6b512a1ac1020bdc47)