### PR TITLE
[5.0][Runtime] Fix incorrect cast in NonFixedExistentialMetatypeBox::Container::getNumWitnessTables.

### DIFF
--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -624,7 +624,7 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedExistentialMetatypeBox
     ExistentialMetatypeContainer Header;
 
     static unsigned getNumWitnessTables(const Metadata *self) {
-      auto castSelf = static_cast<const ExistentialTypeMetadata*>(self); 
+      auto castSelf = static_cast<const ExistentialMetatypeMetadata*>(self); 
       return castSelf->Flags.getNumWitnessTables();
     }
 

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -666,6 +666,18 @@ Reflection.test("ObjectIdentifier/CustomDebugStringConvertible") {
 
 }
 
+class C: Q1 & Codable { }
+
+Reflection.test("multiprotocolTypes") {
+  // [SR-8158]: Printing type(of: Codable & Protocol type ) EXC_BAD_ACCESS
+  // This use of String(reflecting:) exercises a previously incorrect cast in
+  // NonFixedExistentialMetatypeBox::Container::getNumWitnessTables.
+  let obj: Q1 & Codable = C()
+  let t = type(of: obj)
+  let x = String(reflecting: t)
+  expectEqual("a.C", x)
+}
+
 
 var BitTwiddlingTestSuite = TestSuite("BitTwiddling")
 


### PR DESCRIPTION
Cherry-pick #21119 for swift-5.0-branch.

The incorrect cast led to absurd values for getNumWitnessTables which then caused crashes (or worse?) down the line.

SR-8158 rdar://problem/41725205