### PR TITLE
Revert "[TypeRecontruction] Remove handling of InOutTypes."

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1913,6 +1913,18 @@ static void VisitNodeTypeAlias(
   }
 }
 
+static void VisitNodeInOut(
+    ASTContext *ast,
+    Demangle::NodePointer cur_node, VisitNodeResult &result) {
+  VisitNodeResult type_result;
+  VisitNode(ast, cur_node->getFirstChild(), type_result);
+  if (type_result._types.size() == 1 && type_result._types[0]) {
+    result._types.push_back(InOutType::get(type_result._types[0]));
+  } else {
+    result._error = "couldn't resolve referent type";
+  }
+}
+
 static void VisitNodeExistentialMetatype(ASTContext *ast,
                                          Demangle::NodePointer cur_node,
                                          VisitNodeResult &result) {
@@ -2110,6 +2122,9 @@ static void VisitNodeTupleElement(
 
   auto tupleType = tuple_type_result._types.front();
   auto typeFlags = ParameterTypeFlags();
+  typeFlags = typeFlags.withInOut(tupleType->is<InOutType>());
+  if (auto *inOutTy = tupleType->getAs<InOutType>())
+    tupleType = inOutTy->getObjectType();
   Identifier idName =
       tuple_name.empty() ? Identifier() : ast->getIdentifier(tuple_name);
   result._tuple_type_element = TupleTypeElt(tupleType, idName, typeFlags);
@@ -2348,6 +2363,10 @@ static void VisitNode(
   case Demangle::Node::Kind::Setter:
   case Demangle::Node::Kind::WillSet: // out of order on purpose
     VisitNodeSetterGetter(ast, node, result);
+    break;
+
+  case Demangle::Node::Kind::InOut:
+    VisitNodeInOut(ast, node, result);
     break;
 
   case Demangle::Node::Kind::ExistentialMetatype:

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -3,6 +3,7 @@ $SytD ---> ()
 $Ss5Int32VD ---> Int32
 $S4blah4mainyyF8PatatinoL_VMa ---> Can't resolve type of $S4blah4mainyyF8PatatinoL_VMa
 $Ss10CollectionP7Element ---> Can't resolve type of $Ss10CollectionP7Element
+$Ss15ContiguousArrayV9formIndex5afterySiz_tFSS_Tg5 ---> (inout Int) -> ()
 $S12TypeReconstr8PatatinoaySiGD ---> Patatino<Int>
 $S7ElementQzD ---> τ_0_0.Element
 $S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6UInt64Vvp ---> UInt64


### PR DESCRIPTION
This reverts commit 751550be1a8e556d3cedfbb51c81c762a6d50b20.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
