### PR TITLE
[5.0] [Sema] Diagnose internal(set) from @inlinable functions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4106,27 +4106,33 @@ ERROR(usable_from_inline_attr_in_protocol,none,
   "a default argument value|" \
   "a property initializer in a '@_fixed_layout' type}"
 
+#define DECL_OR_ACCESSOR "%select{%0|%0 for}"
+
 ERROR(local_type_in_inlinable_function,
       none, "type %0 cannot be nested inside " FRAGILE_FUNC_KIND "1",
       (DeclName, unsigned))
 
 ERROR(resilience_decl_unavailable,
-      none, "%0 %1 is %select{private|fileprivate|internal|%error|%error}2 and "
+      none, DECL_OR_ACCESSOR "4 %1 is %select{private|fileprivate|internal|%error|%error}2 and "
       "cannot be referenced from " FRAGILE_FUNC_KIND "3",
-      (DescriptiveDeclKind, DeclName, AccessLevel, unsigned))
+      (DescriptiveDeclKind, DeclName, AccessLevel, unsigned, bool))
 
 WARNING(resilience_decl_unavailable_warn,
-        none, "%0 %1 is %select{private|fileprivate|internal|%error|%error}2 and "
+        none, DECL_OR_ACCESSOR "4 %1 is %select{private|fileprivate|internal|%error|%error}2 and "
         "should not be referenced from " FRAGILE_FUNC_KIND "3",
-        (DescriptiveDeclKind, DeclName, AccessLevel, unsigned))
+        (DescriptiveDeclKind, DeclName, AccessLevel, unsigned, bool))
 
 #undef FRAGILE_FUNC_KIND
 
 NOTE(resilience_decl_declared_here_public,
-     none, "%0 %1 is not public", (DescriptiveDeclKind, DeclName))
+     none, DECL_OR_ACCESSOR "2 %1 is not public",
+     (DescriptiveDeclKind, DeclName, bool))
 
 NOTE(resilience_decl_declared_here,
-     none, "%0 %1 is not '@usableFromInline' or public", (DescriptiveDeclKind, DeclName))
+     none, DECL_OR_ACCESSOR "2 %1 is not '@usableFromInline' or public",
+     (DescriptiveDeclKind, DeclName, bool))
+
+#undef DECL_OR_ACCESSOR
 
 ERROR(class_designated_init_inlinable_resilient,none,
       "initializer for class %0 is "

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2411,8 +2411,7 @@ bool ValueDecl::isUsableFromInline() const {
       return true;
 
   if (auto *containingProto = dyn_cast<ProtocolDecl>(getDeclContext())) {
-    if (isProtocolRequirement() &&
-        containingProto->getAttrs().hasAttribute<UsableFromInlineAttr>())
+    if (containingProto->getAttrs().hasAttribute<UsableFromInlineAttr>())
       return true;
   }
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -134,21 +134,37 @@ bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
+  auto diagName = D->getFullName();
+  bool isAccessor = false;
+
+  // Swift 4.2 did not check accessor accessiblity.
+  if (auto accessor = dyn_cast<AccessorDecl>(D)) {
+    isAccessor = true;
+
+    if (!Context.isSwiftVersionAtLeast(5))
+      downgradeToWarning = DowngradeToWarning::Yes;
+
+    // For accessors, diagnose with the name of the storage instead of the
+    // implicit '_'.
+    diagName = accessor->getStorage()->getFullName();
+  }
+
   auto diagID = diag::resilience_decl_unavailable;
   if (downgradeToWarning == DowngradeToWarning::Yes)
     diagID = diag::resilience_decl_unavailable_warn;
 
   diagnose(loc, diagID,
-           D->getDescriptiveKind(), D->getFullName(),
+           D->getDescriptiveKind(), diagName,
            D->getFormalAccessScope().accessLevelForDiagnostics(),
-           static_cast<unsigned>(Kind));
+           static_cast<unsigned>(Kind),
+           isAccessor);
 
   if (TreatUsableFromInlineAsPublic) {
     diagnose(D, diag::resilience_decl_declared_here,
-             D->getDescriptiveKind(), D->getFullName());
+             D->getDescriptiveKind(), diagName, isAccessor);
   } else {
     diagnose(D, diag::resilience_decl_declared_here_public,
-             D->getDescriptiveKind(), D->getFullName());
+             D->getDescriptiveKind(), diagName, isAccessor);
   }
 
   return (downgradeToWarning == DowngradeToWarning::No);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1355,12 +1355,12 @@ void TypeChecker::diagnosePotentialUnavailability(
 }
 
 void TypeChecker::diagnosePotentialAccessorUnavailability(
-    AccessorDecl *Accessor, SourceRange ReferenceRange,
+    const AccessorDecl *Accessor, SourceRange ReferenceRange,
     const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
     bool ForInout) {
   assert(Accessor->isGetterOrSetter());
 
-  AbstractStorageDecl *ASD = Accessor->getStorage();
+  const AbstractStorageDecl *ASD = Accessor->getStorage();
   DeclName Name = ASD->getFullName();
 
   auto &diag = ForInout ? diag::availability_inout_accessor_only_version_newer
@@ -2355,7 +2355,8 @@ public:
   bool diagAvailability(const ValueDecl *D, SourceRange R,
                         const ApplyExpr *call = nullptr,
                         bool AllowPotentiallyUnavailableProtocol = false,
-                        bool SignalOnPotentialUnavailability = true);
+                        bool SignalOnPotentialUnavailability = true,
+                        bool ForInout = false);
 
 private:
   bool diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
@@ -2511,32 +2512,13 @@ private:
   void diagAccessorAvailability(AccessorDecl *D, SourceRange ReferenceRange,
                                 const DeclContext *ReferenceDC,
                                 bool ForInout) const {
-    if (!D) {
+    if (diagnoseDeclAvailability(D, TC,
+                                 const_cast<DeclContext*>(ReferenceDC),
+                                 ReferenceRange,
+                                 /*AllowPotentiallyUnavailableProtocol*/false,
+                                 /*SignalOnPotentialUnavailability*/false,
+                                 ForInout))
       return;
-    }
-
-    // If the property/subscript is unconditionally unavailable, don't bother
-    // with any of the rest of this.
-    if (AvailableAttr::isUnavailable(D->getStorage()))
-      return;
-
-    if (diagnoseExplicitUnavailability(D, ReferenceRange, ReferenceDC,
-                                       /*call*/nullptr)) {
-      return;
-    }
-
-    // Make sure not to diagnose an accessor's deprecation if we already
-    // complained about the property/subscript.
-    if (!TypeChecker::getDeprecated(D->getStorage()))
-      TC.diagnoseIfDeprecated(ReferenceRange, ReferenceDC, D, /*call*/nullptr);
-
-    auto MaybeUnavail = TC.checkDeclarationAvailability(D, ReferenceRange.Start,
-                                                        DC);
-    if (MaybeUnavail.hasValue()) {
-      TC.diagnosePotentialAccessorUnavailability(D, ReferenceRange, ReferenceDC,
-                                                 MaybeUnavail.getValue(),
-                                                 ForInout);
-    }
   }
 };
 } // end anonymous namespace
@@ -2546,7 +2528,8 @@ private:
 bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
                                           const ApplyExpr *call,
                                           bool AllowPotentiallyUnavailableProtocol,
-                                          bool SignalOnPotentialUnavailability) {
+                                          bool SignalOnPotentialUnavailability,
+                                          bool ForInout) {
   if (!D)
     return false;
 
@@ -2555,6 +2538,16 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
       return true;
     if (call && diagnoseMemoryLayoutMigration(D, R, attr, call))
       return true;
+  }
+
+  // Keep track if this is an accessor.
+  auto accessor = dyn_cast<AccessorDecl>(D);
+
+  if (accessor) {
+    // If the property/subscript is unconditionally unavailable, don't bother
+    // with any of the rest of this.
+    if (AvailableAttr::isUnavailable(accessor->getStorage()))
+      return false;
   }
 
   if (FragileKind)
@@ -2566,8 +2559,14 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
   if (diagnoseExplicitUnavailability(D, R, DC, call))
     return true;
 
+  // Make sure not to diagnose an accessor's deprecation if we already
+  // complained about the property/subscript.
+  bool isAccessorWithDeprecatedStorage =
+    accessor && TypeChecker::getDeprecated(accessor->getStorage());
+
   // Diagnose for deprecation
-  TC.diagnoseIfDeprecated(R, DC, D, call);
+  if (!isAccessorWithDeprecatedStorage)
+    TC.diagnoseIfDeprecated(R, DC, D, call);
 
   if (AllowPotentiallyUnavailableProtocol && isa<ProtocolDecl>(D))
     return false;
@@ -2575,7 +2574,13 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
   // Diagnose (and possibly signal) for potential unavailability
   auto maybeUnavail = TC.checkDeclarationAvailability(D, R.Start, DC);
   if (maybeUnavail.hasValue()) {
-    TC.diagnosePotentialUnavailability(D, R, DC, maybeUnavail.getValue());
+    if (accessor) {
+      TC.diagnosePotentialAccessorUnavailability(accessor, R, DC,
+                                                 maybeUnavail.getValue(),
+                                                 ForInout);
+    } else {
+      TC.diagnosePotentialUnavailability(D, R, DC, maybeUnavail.getValue());
+    }
     if (SignalOnPotentialUnavailability)
       return true;
   }
@@ -2751,10 +2756,12 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *Decl,
                                      DeclContext *DC,
                                      SourceRange R,
                                      bool AllowPotentiallyUnavailableProtocol,
-                                     bool SignalOnPotentialUnavailability)
+                                     bool SignalOnPotentialUnavailability,
+                                     bool ForInout)
 {
   AvailabilityWalker AW(TC, DC);
   return AW.diagAvailability(Decl, R, nullptr,
                              AllowPotentiallyUnavailableProtocol,
-                             SignalOnPotentialUnavailability);
+                             SignalOnPotentialUnavailability,
+                             ForInout);
 }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -41,7 +41,8 @@ bool diagnoseDeclAvailability(const ValueDecl *Decl,
                               DeclContext *DC,
                               SourceRange R,
                               bool AllowPotentiallyUnavailableProtocol,
-                              bool SignalOnPotentialUnavailability);
+                              bool SignalOnPotentialUnavailability,
+                              bool ForInout);
 
 void diagnoseUnavailableOverride(ValueDecl *override,
                                  const ValueDecl *base,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1515,7 +1515,8 @@ static bool diagnoseAvailability(IdentTypeRepr *IdType,
       TypeChecker &tc = static_cast<TypeChecker &>(*ctx.getLazyResolver());
       if (diagnoseDeclAvailability(typeDecl, tc, DC, comp->getIdLoc(),
                                    AllowPotentiallyUnavailableProtocol,
-                                   /*SignalOnPotentialUnavailability*/false)) {
+                                   /*SignalOnPotentialUnavailability*/false,
+                                   /*ForInout*/false)) {
         return true;
       }
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2077,7 +2077,7 @@ public:
   /// Emits a diagnostic for a reference to a storage accessor that is
   /// potentially unavailable.
   void diagnosePotentialAccessorUnavailability(
-      AccessorDecl *Accessor, SourceRange ReferenceRange,
+      const AccessorDecl *Accessor, SourceRange ReferenceRange,
       const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
       bool ForInout);
 

--- a/test/Compatibility/attr_inlinable_swift42.swift
+++ b/test/Compatibility/attr_inlinable_swift42.swift
@@ -17,6 +17,14 @@ enum InternalEnum {
   case persimmon(String)
 }
 
+public struct HasInternalSetProperty {
+  public internal(set) var x: Int // expected-note {{setter for 'x' is not '@usableFromInline' or public}}
+
+  @inlinable public mutating func setsX() {
+    x = 10 // expected-warning {{setter for 'x' is internal and should not be referenced from an '@inlinable' function}}
+  }
+}
+
 @usableFromInline protocol P {
   typealias T = Int
 }

--- a/test/Compatibility/attr_inlinable_swift42.swift
+++ b/test/Compatibility/attr_inlinable_swift42.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4.2
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-resilience -enable-testing
+
+enum InternalEnum {
+  // expected-note@-1 {{type declared here}}
+  case apple
+  case orange
+}
+
+@usableFromInline enum VersionedEnum {
+  case apple
+  case orange
+  case pear(InternalEnum)
+  // expected-warning@-1 {{type of enum case in '@usableFromInline' enum should be '@usableFromInline' or public}}
+  case persimmon(String)
+}
+

--- a/test/Compatibility/attr_inlinable_swift42.swift
+++ b/test/Compatibility/attr_inlinable_swift42.swift
@@ -17,3 +17,12 @@ enum InternalEnum {
   case persimmon(String)
 }
 
+@usableFromInline protocol P {
+  typealias T = Int
+}
+
+extension P {
+  @inlinable func f() {
+    _ = T.self // typealiases were not checked in Swift 4.2, but P.T inherits @usableFromInline in Swift 4.2 mode
+  }
+}

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -248,3 +248,13 @@ public struct KeypathStruct {
     // expected-error@-1 {{property 'x' is internal and cannot be referenced from an '@inlinable' function}}
   }
 }
+@usableFromInline protocol P {
+  typealias T = Int
+}
+
+extension P {
+  @inlinable func f() {
+    _ = T.self // ok, typealias inherits @usableFromInline from P
+  }
+}
+

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4.2
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-testing
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-resilience
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-resilience -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience -enable-testing
 @inlinable struct TestInlinableStruct {}
 // expected-error@-1 {{'@inlinable' attribute cannot be applied to this declaration}}
 
@@ -157,7 +157,7 @@ enum InternalEnum {
   case apple
   case orange
   case pear(InternalEnum)
-  // expected-warning@-1 {{type of enum case in '@usableFromInline' enum should be '@usableFromInline' or public}}
+  // expected-error@-1 {{type of enum case in '@usableFromInline' enum must be '@usableFromInline' or public}}
   case persimmon(String)
 }
 

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -248,6 +248,15 @@ public struct KeypathStruct {
     // expected-error@-1 {{property 'x' is internal and cannot be referenced from an '@inlinable' function}}
   }
 }
+
+public struct HasInternalSetProperty {
+  public internal(set) var x: Int // expected-note {{setter for 'x' is not '@usableFromInline' or public}}
+
+  @inlinable public mutating func setsX() {
+    x = 10 // expected-error {{setter for 'x' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+}
+
 @usableFromInline protocol P {
   typealias T = Int
 }


### PR DESCRIPTION
This patch mainly consolidates the functions used to check accessors vs.
other decls, and makes sure we check setter access as well as regular
decl access.

rdar://45217648