### PR TITLE
[ConstraintSystem] Erase `InOutExpr` from member base

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1190,20 +1190,6 @@ ConstraintSystem::getTypeOfMemberReference(
   // Figure out the instance type used for the base.
   Type baseObjTy = getFixedTypeRecursive(baseTy, /*wantRValue=*/true);
 
-  ParameterTypeFlags baseFlags;
-  // FIXME(diagnostics): `InOutType` could appear here as a result
-  // of successful re-typecheck of the one of the sub-expressions e.g.
-  // `let _: Int = { (s: inout S) in s.bar() }`. On the first
-  // attempt to type-check whole expression `s.bar()` - is going
-  // to have a base which points directly to declaration of `S`.
-  // But when diagnostics attempts to type-check `s.bar()` standalone
-  // its base would be tranformed into `InOutExpr -> DeclRefExr`,
-  // and `InOutType` is going to be recorded in constraint system.
-  if (auto objType = baseObjTy->getInOutObjectType()) {
-    baseObjTy = objType;
-    baseFlags = baseFlags.withInOut(true);
-  }
-
   bool isInstance = true;
   if (auto baseMeta = baseObjTy->getAs<AnyMetatypeType>()) {
     baseObjTy = baseMeta->getInstanceType();
@@ -1215,7 +1201,7 @@ ConstraintSystem::getTypeOfMemberReference(
     return getTypeOfReference(value, functionRefKind, locator, useDC, base);
   }
 
-  FunctionType::Param baseObjParam(baseObjTy, Identifier(), baseFlags);
+  FunctionType::Param baseObjParam(baseObjTy);
 
   // Don't open existentials when accessing typealias members of
   // protocols.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -984,6 +984,27 @@ namespace {
           CallArgs.insert(arg);
       }
 
+      // FIXME(diagnostics): `InOutType` could appear here as a result
+      // of successful re-typecheck of the one of the sub-expressions e.g.
+      // `let _: Int = { (s: inout S) in s.bar() }`. On the first
+      // attempt to type-check whole expression `s.bar()` - is going
+      // to have a base which points directly to declaration of `S`.
+      // But when diagnostics attempts to type-check `s.bar()` standalone
+      // its base would be tranformed into `InOutExpr -> DeclRefExr`,
+      // and `InOutType` is going to be recorded in constraint system.
+      if (!expr->isImplicit()) {
+        if (isa<MemberRefExpr>(expr) || isa<DynamicMemberRefExpr>(expr)) {
+          auto *LE = cast<LookupExpr>(expr);
+          if (auto *IOE = dyn_cast<InOutExpr>(LE->getBase()))
+            LE->setBase(IOE->getSubExpr());
+        }
+
+        if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(expr)) {
+          if (auto *IOE = dyn_cast<InOutExpr>(DSCE->getBase()))
+            DSCE->setBase(IOE->getSubExpr());
+        }
+      }
+
       // Local function used to finish up processing before returning. Every
       // return site should call through here.
       auto finish = [&](bool recursive, Expr *expr) {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -208,3 +208,19 @@ func ??= <T>(lhs: inout T?, rhs: T?) {}
 var c: Int = 0
 c ??= 5 // expected-error{{binary operator '??=' cannot be applied to two 'Int' operands}}
 // expected-note@-1{{expected an argument list of type '(inout T?, T?)'}}
+
+func rdar46459603() {
+  enum E {
+  case foo(value: String)
+  }
+
+  let e = E.foo(value: "String")
+  var arr = ["key": e]
+
+  _ = arr.values == [e]
+  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'Dictionary<String, E>.Values' and '[E]'}}
+  // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
+  _ = [arr.values] == [[e]]
+  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '[Dictionary<String, E>.Values]' and '[[E]]'}}
+  // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
+}


### PR DESCRIPTION
Diagnostics could introduce type-checked expressions into AST during
it's bottom up re-typechecking in attempt to find a problem.

To minimize number of AST permutations solver has to handle
let's just strip away implicit `InOutExpr` introduced by previous
successful type-checks, which is not really important anyway.

Resolves: rdar://problem/46459603

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
