### PR TITLE
[runtime] Some follow-up for the addition of 'swift/Runtime/CMakeConfig.h'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1024,6 +1024,8 @@ if(SWIFT_INCLUDE_TOOLS)
   # Refer to the large comment above the add_subdirectory(stdlib) call.
   # https://bugs.swift.org/browse/SR-5975
   add_subdirectory(tools)
+elseif(SWIFT_BUILD_STDLIB)
+  add_subdirectory(include/swift/Runtime)
 endif()
 
 add_subdirectory(utils)

--- a/include/swift/Runtime/CMakeConfig.h.in
+++ b/include/swift/Runtime/CMakeConfig.h.in
@@ -2,6 +2,7 @@
 // See https://cmake.org/cmake/help/v3.0/command/configure_file.html.
 
 #ifndef SWIFT_RUNTIME_CMAKECONFIG_H
+#define SWIFT_RUNTIME_CMAKECONFIG_H
 
 #cmakedefine01 SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
 


### PR DESCRIPTION
* Complete the guard macro for the CMakeConfig.h header
* Fix the 'SWIFT_INCLUDE_TOOLS=NO' 'SWIFT_BUILD_STDLIB=YES' build

This is follow-up from https://github.com/apple/swift/pull/21114