### PR TITLE
[AutoDiff] Add `Builtin.autodiffGet(JVP|VJP)` for extracting AD associated functions

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -953,9 +953,6 @@ public:
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Determine whether the given type is differentiable.
-  bool isDifferentiable(CanType type, ModuleDecl *module);
-
   /// Compute the tangent space of this manifold, if the given type represents a
   /// differentiable manifold.
   Optional<TangentSpace> getTangentSpace(CanType type, ModuleDecl *module);

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -111,8 +111,9 @@ class AutoDiffParameterIndices {
 
   unsigned getNumNonSelfParameters() const;
 
-  AutoDiffParameterIndices(unsigned numIndices, bool isMethodFlag)
-      : indices(numIndices), isMethodFlag(isMethodFlag) {}
+  AutoDiffParameterIndices(unsigned numIndices, bool isMethodFlag,
+                           bool setAllParams = false)
+      : indices(numIndices, setAllParams), isMethodFlag(isMethodFlag) {}
 
   AutoDiffParameterIndices(llvm::SmallBitVector indices, bool isMethodFlag)
       : indices(indices), isMethodFlag(isMethodFlag) {}
@@ -122,7 +123,8 @@ public:
   /// given `functionType`. `isMethod` specifies whether to treat the function
   /// as a method.
   static AutoDiffParameterIndices *
-  create(ASTContext &C, AnyFunctionType *functionType, bool isMethod);
+  create(ASTContext &C, AnyFunctionType *functionType, bool isMethod,
+         bool setAllParams = false);
 
   bool isMethod() const { return isMethodFlag; }
 

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -375,6 +375,14 @@ BUILTIN_SIL_OPERATION(AllocWithTailElems, "allocWithTailElems", Special)
 /// Projects the first tail-allocated element of type E from a class C.
 BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 
+// SWIFT_ENABLE_TENSORFLOW
+/// autodifGetJVP has type <T: Differentiable, R: Differentiable>
+///     ((T) -> R) -> (T) -> (R, (T.TangentVector) -> R.TangentVector).
+BUILTIN_SIL_OPERATION(AutoDiffGetJVP, "autodiffGetJVP", Special)
+/// autodifGetVJP has type <T: Differentiable, R: Differentiable>
+///     ((T) -> R) -> (T) -> (R, (R.CotangentVector) -> T.CotangentVector).
+BUILTIN_SIL_OPERATION(AutoDiffGetVJP, "autodiffGetVJP", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3120,6 +3120,10 @@ public:
   ///
   /// Pass `selfUncurried = true` when the function type is for a method whose
   /// self parameter has been uncurried as in (A, B, C, Self) -> R.
+  ///
+  /// \note The original function type (`self`) need not be `@autodiff`, and the
+  /// resulting function will preserve all `ExtInfo` of the original function,
+  /// including `@autodiff`.
   AnyFunctionType *getAutoDiffAssociatedFunctionType(
       const AutoDiffParameterIndices &indices, unsigned resultIndex,
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5188,10 +5188,6 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-bool ASTContext::isDifferentiable(CanType type, ModuleDecl *module) {
-  return getTangentSpace(type, module).hasValue();
-}
-
 Optional<TangentSpace> ASTContext::getTangentSpace(CanType type,
                                                    ModuleDecl *module) {
   auto lookup = getImpl().TangentSpaces.find(type);

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -110,7 +110,7 @@ static AnyFunctionType *unwrapSelfParameter(AnyFunctionType *functionType,
 /// as a method.
 AutoDiffParameterIndices *
 AutoDiffParameterIndices::create(ASTContext &C, AnyFunctionType *functionType,
-                                 bool isMethod) {
+                                 bool isMethod, bool setAllParams) {
   // TODO(SR-9290): Note that the AutoDiffParameterIndices' destructor never
   // gets called, which causes a small memory leak in the case that the
   // SmallBitVector decides to allocate some heap space.
@@ -119,7 +119,8 @@ AutoDiffParameterIndices::create(ASTContext &C, AnyFunctionType *functionType,
   unsigned paramCount =
       unwrapSelfParameter(functionType, isMethod)->getNumParams() +
       (isMethod ? 1 : 0);
-  return ::new (mem) AutoDiffParameterIndices(paramCount, isMethod);
+  return
+      ::new (mem) AutoDiffParameterIndices(paramCount, isMethod, setAllParams);
 }
 
 /// Allocates and initializes an `AutoDiffParameterIndices` corresponding to

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1041,6 +1041,32 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
   return ManagedValue::forUnmanaged(val);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+/// Specialized emitter for Builtin.addressOfBorrow.
+static ManagedValue emitBuiltinAutoDiffGetJVP(SILGenFunction &SGF,
+                                              SILLocation loc,
+                                              SubstitutionMap substitutions,
+                                              Expr *argument,
+                                              SGFContext C) {
+  auto argVal = SGF.emitRValue(argument);
+  auto jvp = SGF.getBuilder().createAutoDiffFunctionExtract(
+      loc, AutoDiffFunctionExtractee::JVP, /*differentiationOrder*/ 1,
+      std::move(argVal).forwardAsSingleValue(SGF, loc));
+  return SGF.emitManagedRValueWithCleanup(jvp);
+}
+
+static ManagedValue emitBuiltinAutoDiffGetVJP(SILGenFunction &SGF,
+                                              SILLocation loc,
+                                              SubstitutionMap substitutions,
+                                              Expr *argument,
+                                              SGFContext C) {
+  auto argVal = SGF.emitRValue(argument);
+  auto vjp = SGF.getBuilder().createAutoDiffFunctionExtract(
+      loc, AutoDiffFunctionExtractee::VJP, /*differentiationOrder*/ 1,
+      std::move(argVal).forwardAsSingleValue(SGF, loc));
+  return SGF.emitManagedRValueWithCleanup(vjp);
+}
+
 Optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5733,9 +5733,6 @@ RValue RValueEmitter::visitAutoDiffFunctionExpr(AutoDiffFunctionExpr *E,
 RValue RValueEmitter::visitAutoDiffFunctionExtractOriginalExpr(
     AutoDiffFunctionExtractOriginalExpr *E, SGFContext C) {
   auto diffFunc = SGF.emitRValueAsSingleValue(E->getSubExpr());
-  llvm::outs() << "Difffunc subexpr type = " << E->getSubExpr()->getType() << '\n';
-  llvm::outs() << "Difffunc = " << diffFunc.getValue() << '\n';
-  llvm::outs().flush();
   auto *orig = SGF.B.createAutoDiffFunctionExtractOriginal(
       E, diffFunc.forward(SGF));
   return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(orig));

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2381,16 +2381,6 @@ bool TypeResolver::resolveASTFunctionTypeParams(
           nondiff = true;
       }
     }
-    // If the outer function is differentiable, arguments that are not marked as
-    // `@nondiff` must be differentiable
-    if (isDifferentiable && !nondiff &&
-        !Context.isDifferentiable(ty->getCanonicalType(),
-                                  DC->getParentModule())) {
-      diagnose(eltTypeRepr->getLoc(),
-               diag::autodiff_attr_argument_not_differentiable)
-          .highlight(eltTypeRepr->getSourceRange())
-          .fixItInsert(eltTypeRepr->getLoc(), "@nondiff ");
-    }
 
     // SWIFT_ENABLE_TENSORFLOW
     ParameterTypeFlags paramFlags =
@@ -2469,16 +2459,6 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
   case AnyFunctionType::Representation::Swift:
     break;
   }
-  
-  // SWIFT_ENABLE_TENSORFLOW
-  // If the function is marked as `@autodiff`, the result must be a
-  // differentiable type.
-  if (extInfo.isDifferentiable() &&
-      !Context.isDifferentiable(outputTy->getCanonicalType(),
-                                DC->getParentModule()))
-    diagnose(repr->getResultTypeRepr()->getLoc(),
-             diag::autodiff_attr_result_not_differentiable)
-        .highlight(repr->getResultTypeRepr()->getSourceRange());
 
   return fnTy;
 }

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -30,6 +30,6 @@ func apply() {
 // CHECK-SIL-LABEL: @{{.*}}apply{{.*}}
 // CHECK-SIL:       [[ORIG:%.*]] = function_ref @{{.*}}thin{{.*}} : $@convention(thin) (Float) -> Float
 // CHECK-SIL-NEXT:  [[ORIG_THICK:%.*]] = thin_to_thick_function [[ORIG]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
-// CHECK-SIL-NEXT:  [[DIFFED:%.*]] = autodiff_function [wrt 0] [order 1] %1 : $@callee_guaranteed (Float) -> Float
+// CHECK-SIL-NEXT:  [[DIFFED:%.*]] = autodiff_function [wrt 0] [order 1] [[ORIG_THICK]] : $@callee_guaranteed (Float) -> Float
 // CHECK-SIL:   destroy_value [[DIFFED]] : $@autodiff @callee_guaranteed (Float) -> Float
 

--- a/test/AutoDiff/core_builtins.swift
+++ b/test/AutoDiff/core_builtins.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -parse-stdlib -typecheck -verify %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck -check-prefix=CHECK-SIL %s
+
+import Swift
+
+func evaldiff<T: Differentiable, U: Differentiable>(_ f: @autodiff (T) -> U, _ x: T) {
+  let jvp: (T) -> (U, (T.TangentVector) -> U.TangentVector) = Builtin.autodiffGetJVP(f)
+  let vjp: (T) -> (U, (U.CotangentVector) -> T.CotangentVector) = Builtin.autodiffGetVJP(f)
+  _ = jvp(x)
+  _ = vjp(x)
+}
+
+// CHECK-SIL-LABEL: @{{.*}}evaldiff{{.*}}
+// CHECK-SIL: bb0([[DIFFED:%.*]] : @trivial $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U, [[X:%.*]] : @trivial $*T):
+// CHECK-SIL:   [[JVP:%.*]] = autodiff_function_extract [jvp] [order 1] [[DIFFED]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
+// CHECK-SIL:   [[VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
+// CHECK-SIL:   apply [[JVP]]({{%.*}}, [[X]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed T.TangentVector) -> @out U.TangentVector)
+// CHECK-SIL:   apply [[VJP]]({{%.*}}, [[X]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed U.CotangentVector) -> @out T.CotangentVector)

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -30,8 +30,11 @@ let _: @autodiff(forward, order: 0) (Float) -> Float
 //
 
 struct NonDiffType { var x: Int }
-// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+// FIXME: Properly type-check parameters and the result's differentiability
+// xpected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
 let _: @autodiff (NonDiffType) -> Float
+// xpected-error @+1 {{result is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+let _: @autodiff (Float) -> NonDiffType
 
 //
 // Argument selection (@nondiff)


### PR DESCRIPTION
Add `Builtin.autodiffGetJVP` and `Builtin.autodiffGetVJP` builtins, which correspond to `autodiff_function_extract [jvp]` and `autodiff_function_extract [vjp]`, respectively.

* Extend `BuiltinGenericSignatureBuilder` so that clients are able to add conformance constraints via `BuiltinGenericSignatureBuilder::addConformanceRequirement`.

* Add `getAutoDiffGetAssociatedFunction` in `Builtins.cpp`, which builds an AD builtin decl for a given arity, a differentiation order, and a throwing flag. Today, `Builtin.autodiffGet(JVP|VJP)` is only for extracting first-order derivatives of unary `@autodiff` functions. In the future, we could determine the arity/order/throwing-ness from suffixes to `Builtin.autodiffGet(JVP|VJP)`, e.g. `Builtin.autodiffGetJVP_Arity2_Order2_Throwing`.

    ```swift
    func foo<T: Differentiable, U: Differentiable>(_ f: @autodiff (T) -> U) {
      let jvp: (T) -> (U, (T.TangentVector) -> U.TangentVector) = Builtin.autodiffGetJVP(f)
      let vjp: (T) -> (U, (U.CotangentVector) -> T.CotangentVector) = Builtin.autodiffGetVJP(f)
    }
    ```

* Remove `makeBoundGeneric` in `Builtins.cpp` that I wrote earlier because we've merged `makeBoundGenericType` from upstream.

* Improve `AutoDiffParameterIndices` to include a `setAllParams` argument which makes it easy to create an `AutoDiffParameterIndices` whose all indices are set.

* In `TypeResolver::resolveASTFunctionTypeParams` and `TypeResolver::resolveASTFunctionType`, the checks for `Differentiable`-conformances of `T` and `U` in `@autodiff (T) -> U` is not correct when `T` and `U` are not backed by type decls. They are removed, and [SR-9448](https://bugs.swift.org/browse/SR-9448) tracking a proper fix.

* Remove `ASTContext::isDifferentiable` because its implementation is incorrect: It does not handle the case where the input type is a generic type parameter.