### PR TITLE
build: use `target_link_libraries` for DWARImporter

### DIFF
--- a/lib/DWARFImporter/CMakeLists.txt
+++ b/lib/DWARFImporter/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_swift_host_library(swiftDWARFImporter STATIC
-  DWARFImporter.cpp
-  LINK_LIBRARIES
+  DWARFImporter.cpp)
+target_link_libraries(swiftDWARFImporter PRIVATE
     swiftAST
     swiftParse
 )
-
-#add_dependencies(swiftDWARFImporter )


### PR DESCRIPTION
Use `target_link_libraries` for the linked libraries like the other host
libraries.  This is setup for migrating the host libraries and
executables to the LLVM build infrastructure and matches what the rest
of the host tools and libraries do.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
