### PR TITLE
build: always process `include`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1016,8 +1016,9 @@ endif()
 # https://bugs.swift.org/browse/SR-5975
 add_subdirectory(stdlib)
 
+add_subdirectory(include)
+
 if(SWIFT_INCLUDE_TOOLS)
-  add_subdirectory(include)
   add_subdirectory(lib)
   
   # Always include this after including stdlib/!


### PR DESCRIPTION
The `include` subdirectory now generates a header which is used for the
runtime as well, making this directory a need irrespective of whether
the tools are being built or not.  This repairs the build of just the
runtime without the tools.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
