### PR TITLE
[benchmark] Fix lit test for Benchmark_Driver

### DIFF
--- a/test/benchmark/Benchmark_Driver.test-sh
+++ b/test/benchmark/Benchmark_Driver.test-sh
@@ -11,6 +11,6 @@
 // RUNJUSTONCE-LABEL: Ackermann
 // RUNJUSTONCE-NOT: Ackermann
 
-// RUN: %Benchmark_Driver check 1 \
+// RUN: %Benchmark_Driver check 1 --verbose \
 // RUN:                 | %FileCheck %s --check-prefix DOCTORCHECK
 // DOCTORCHECK: Ackermann


### PR DESCRIPTION
Resolves [SR-9442](https://bugs.swift.org/browse/SR-9442).

Test expects to see `Ackermann` in the output, but if the check passes without any issues, which it now should, the test failed.

The fix was to add `--verbose` flag, to always see `Ackermann` in the DEBUG output, as the point of this integration test is just to see the python script doesn't crash when invoking the driver.