### PR TITLE
[AutoDiff] Define differential operators in stdlib!

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -953,9 +953,6 @@ public:
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Determine whether the given type is differentiable.
-  bool isDifferentiable(CanType type, ModuleDecl *module);
-
   /// Compute the tangent space of this manifold, if the given type represents a
   /// differentiable manifold.
   Optional<TangentSpace> getTangentSpace(CanType type, ModuleDecl *module);

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -111,8 +111,9 @@ class AutoDiffParameterIndices {
 
   unsigned getNumNonSelfParameters() const;
 
-  AutoDiffParameterIndices(unsigned numIndices, bool isMethodFlag)
-      : indices(numIndices), isMethodFlag(isMethodFlag) {}
+  AutoDiffParameterIndices(unsigned numIndices, bool isMethodFlag,
+                           bool setAllParams = false)
+      : indices(numIndices, setAllParams), isMethodFlag(isMethodFlag) {}
 
   AutoDiffParameterIndices(llvm::SmallBitVector indices, bool isMethodFlag)
       : indices(indices), isMethodFlag(isMethodFlag) {}
@@ -122,7 +123,8 @@ public:
   /// given `functionType`. `isMethod` specifies whether to treat the function
   /// as a method.
   static AutoDiffParameterIndices *
-  create(ASTContext &C, AnyFunctionType *functionType, bool isMethod);
+  create(ASTContext &C, AnyFunctionType *functionType, bool isMethod,
+         bool setAllParams = false);
 
   bool isMethod() const { return isMethodFlag; }
 

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -375,6 +375,14 @@ BUILTIN_SIL_OPERATION(AllocWithTailElems, "allocWithTailElems", Special)
 /// Projects the first tail-allocated element of type E from a class C.
 BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 
+// SWIFT_ENABLE_TENSORFLOW
+/// autodifGetJVP has type <T: Differentiable, R: Differentiable>
+///     ((T) -> R) -> (T) -> (R, (T.TangentVector) -> R.TangentVector).
+BUILTIN_SIL_OPERATION(AutoDiffGetJVP, "autodiffGetJVP", Special)
+/// autodifGetVJP has type <T: Differentiable, R: Differentiable>
+///     ((T) -> R) -> (T) -> (R, (R.CotangentVector) -> T.CotangentVector).
+BUILTIN_SIL_OPERATION(AutoDiffGetVJP, "autodiffGetVJP", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -376,10 +376,10 @@ BUILTIN_SIL_OPERATION(AllocWithTailElems, "allocWithTailElems", Special)
 BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 
 // SWIFT_ENABLE_TENSORFLOW
-/// autodifGetJVP has type <T: Differentiable, R: Differentiable>
+/// autodiffGetJVP has type <T: Differentiable, R: Differentiable>
 ///     ((T) -> R) -> (T) -> (R, (T.TangentVector) -> R.TangentVector).
 BUILTIN_SIL_OPERATION(AutoDiffGetJVP, "autodiffGetJVP", Special)
-/// autodifGetVJP has type <T: Differentiable, R: Differentiable>
+/// autodiffGetVJP has type <T: Differentiable, R: Differentiable>
 ///     ((T) -> R) -> (T) -> (R, (R.CotangentVector) -> T.CotangentVector).
 BUILTIN_SIL_OPERATION(AutoDiffGetVJP, "autodiffGetVJP", Special)
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3120,6 +3120,10 @@ public:
   ///
   /// Pass `selfUncurried = true` when the function type is for a method whose
   /// self parameter has been uncurried as in (A, B, C, Self) -> R.
+  ///
+  /// \note The original function type (`self`) need not be `@autodiff`, and the
+  /// resulting function will preserve all `ExtInfo` of the original function,
+  /// including `@autodiff`.
   AnyFunctionType *getAutoDiffAssociatedFunctionType(
       const AutoDiffParameterIndices &indices, unsigned resultIndex,
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7655,6 +7655,7 @@ public:
     } rawValue;
     Extractee() = default;
     Extractee(innerty rawValue) : rawValue(rawValue) {}
+    Extractee(uint8_t rawValue) : Extractee((innerty)rawValue) {}
     explicit Extractee(StringRef name);
     operator innerty() const { return rawValue; }
   };

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7648,14 +7648,14 @@ class AutoDiffFunctionExtractInst :
                            SingleValueInstruction> {
 public:
   struct Extractee {
-    enum innerty : uint8_t {
+    enum innerty : unsigned {
       Original = 0,
       JVP = 1,
       VJP = 2
     } rawValue;
     Extractee() = default;
     Extractee(innerty rawValue) : rawValue(rawValue) {}
-    Extractee(uint8_t rawValue) : Extractee((innerty)rawValue) {}
+    Extractee(unsigned rawValue) : Extractee((innerty)rawValue) {}
     explicit Extractee(StringRef name);
     operator innerty() const { return rawValue; }
   };

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 457; // Last change: add jvp and vjp to sil differentiable attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 458; // Last change: serialize autodiff_function and autodiff_function_extract
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5188,10 +5188,6 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-bool ASTContext::isDifferentiable(CanType type, ModuleDecl *module) {
-  return getTangentSpace(type, module).hasValue();
-}
-
 Optional<TangentSpace> ASTContext::getTangentSpace(CanType type,
                                                    ModuleDecl *module) {
   auto lookup = getImpl().TangentSpaces.find(type);

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -110,7 +110,7 @@ static AnyFunctionType *unwrapSelfParameter(AnyFunctionType *functionType,
 /// as a method.
 AutoDiffParameterIndices *
 AutoDiffParameterIndices::create(ASTContext &C, AnyFunctionType *functionType,
-                                 bool isMethod) {
+                                 bool isMethod, bool setAllParams) {
   // TODO(SR-9290): Note that the AutoDiffParameterIndices' destructor never
   // gets called, which causes a small memory leak in the case that the
   // SmallBitVector decides to allocate some heap space.
@@ -119,7 +119,8 @@ AutoDiffParameterIndices::create(ASTContext &C, AnyFunctionType *functionType,
   unsigned paramCount =
       unwrapSelfParameter(functionType, isMethod)->getNumParams() +
       (isMethod ? 1 : 0);
-  return ::new (mem) AutoDiffParameterIndices(paramCount, isMethod);
+  return
+      ::new (mem) AutoDiffParameterIndices(paramCount, isMethod, setAllParams);
 }
 
 /// Allocates and initializes an `AutoDiffParameterIndices` corresponding to

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1055,8 +1055,7 @@ static ValueDecl *getAutoDiffGetAssociatedFunction(
     [=, &Ts](BuiltinGenericSignatureBuilder &builder) -> Type {
       FunctionType::ExtInfo ext;
       auto extInfo = FunctionType::ExtInfo()
-          .withDifferentiability(FunctionTypeDifferentiability::Bidirectional)
-          .withNoEscape();
+          .withDifferentiability(FunctionTypeDifferentiability::Bidirectional);
       if (isThrowing)
         extInfo = extInfo.withThrows();
       SmallVector<FunctionType::Param, 2> params;

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -45,6 +45,8 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::DestructureTupleInst:
   // SWIFT_ENABLE_TENSORFLOW
   case SILNodeKind::GradientInst:
+  case SILNodeKind::AutoDiffFunctionInst:
+  case SILNodeKind::AutoDiffFunctionExtractInst:
     return true;
   default:
     return false;

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1041,6 +1041,32 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
   return ManagedValue::forUnmanaged(val);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+/// Specialized emitter for Builtin.addressOfBorrow.
+static ManagedValue emitBuiltinAutoDiffGetJVP(SILGenFunction &SGF,
+                                              SILLocation loc,
+                                              SubstitutionMap substitutions,
+                                              Expr *argument,
+                                              SGFContext C) {
+  auto argVal = SGF.emitRValue(argument);
+  auto jvp = SGF.getBuilder().createAutoDiffFunctionExtract(
+      loc, AutoDiffFunctionExtractee::JVP, /*differentiationOrder*/ 1,
+      std::move(argVal).forwardAsSingleValue(SGF, loc));
+  return SGF.emitManagedRValueWithCleanup(jvp);
+}
+
+static ManagedValue emitBuiltinAutoDiffGetVJP(SILGenFunction &SGF,
+                                              SILLocation loc,
+                                              SubstitutionMap substitutions,
+                                              Expr *argument,
+                                              SGFContext C) {
+  auto argVal = SGF.emitRValue(argument);
+  auto vjp = SGF.getBuilder().createAutoDiffFunctionExtract(
+      loc, AutoDiffFunctionExtractee::VJP, /*differentiationOrder*/ 1,
+      std::move(argVal).forwardAsSingleValue(SGF, loc));
+  return SGF.emitManagedRValueWithCleanup(vjp);
+}
+
 Optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5733,9 +5733,6 @@ RValue RValueEmitter::visitAutoDiffFunctionExpr(AutoDiffFunctionExpr *E,
 RValue RValueEmitter::visitAutoDiffFunctionExtractOriginalExpr(
     AutoDiffFunctionExtractOriginalExpr *E, SGFContext C) {
   auto diffFunc = SGF.emitRValueAsSingleValue(E->getSubExpr());
-  llvm::outs() << "Difffunc subexpr type = " << E->getSubExpr()->getType() << '\n';
-  llvm::outs() << "Difffunc = " << diffFunc.getValue() << '\n';
-  llvm::outs().flush();
   auto *orig = SGF.B.createAutoDiffFunctionExtractOriginal(
       E, diffFunc.forward(SGF));
   return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(orig));

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2381,16 +2381,6 @@ bool TypeResolver::resolveASTFunctionTypeParams(
           nondiff = true;
       }
     }
-    // If the outer function is differentiable, arguments that are not marked as
-    // `@nondiff` must be differentiable
-    if (isDifferentiable && !nondiff &&
-        !Context.isDifferentiable(ty->getCanonicalType(),
-                                  DC->getParentModule())) {
-      diagnose(eltTypeRepr->getLoc(),
-               diag::autodiff_attr_argument_not_differentiable)
-          .highlight(eltTypeRepr->getSourceRange())
-          .fixItInsert(eltTypeRepr->getLoc(), "@nondiff ");
-    }
 
     // SWIFT_ENABLE_TENSORFLOW
     ParameterTypeFlags paramFlags =
@@ -2469,16 +2459,6 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
   case AnyFunctionType::Representation::Swift:
     break;
   }
-  
-  // SWIFT_ENABLE_TENSORFLOW
-  // If the function is marked as `@autodiff`, the result must be a
-  // differentiable type.
-  if (extInfo.isDifferentiable() &&
-      !Context.isDifferentiable(outputTy->getCanonicalType(),
-                                DC->getParentModule()))
-    diagnose(repr->getResultTypeRepr()->getLoc(),
-             diag::autodiff_attr_result_not_differentiable)
-        .highlight(repr->getResultTypeRepr()->getSourceRange());
 
   return fnTy;
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -972,7 +972,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   Builder.setInsertionPoint(BB);
   Builder.setCurrentDebugScope(Fn->getDebugScope());
   unsigned RawOpCode = 0, TyCategory = 0, TyCategory2 = 0, TyCategory3 = 0,
-           Attr = 0, NumSubs = 0, NumConformances = 0, IsNonThrowingApply = 0;
+           // SWIFT_ENABLE_TENSORFLOW
+           Attr = 0, Attr2 = 0, NumSubs = 0, NumConformances = 0,
+           IsNonThrowingApply = 0;
   // SWIFT_ENABLE_TENSORFLOW
   unsigned NumArguments = 0;
   unsigned GradResultIndex = 0;
@@ -1086,6 +1088,16 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     SILInstGradientLayout::readRecord(scratch, Attr, TyID, TyCategory, ValID,
                                       GradResultIndex, ListOfValues);
     RawOpCode = (unsigned)SILInstructionKind::GradientInst;
+    break;
+  case SIL_INST_AUTODIFF_FUNCTION:
+    SILInstAutoDiffFunctionLayout::readRecord(scratch, /*order*/ Attr,
+                                              NumArguments, ListOfValues);
+    break;
+  case SIL_INST_AUTODIFF_FUNCTION_EXTRACT:
+    SILInstAutoDiffFunctionExtractLayout::readRecord(scratch, ValID,
+                                                     TyID, TyCategory,
+                                                     /*extractee*/ Attr,
+                                                     /*order*/ Attr2);
     break;
   case SIL_INST_NO_OPERAND:
     SILInstNoOperandLayout::readRecord(scratch, RawOpCode);
@@ -1488,10 +1500,29 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     break;
   }
   case SILInstructionKind::AutoDiffFunctionInst: {
-    llvm_unreachable("FIXME: Unhandled");
+    llvm::SmallBitVector paramIndices(ListOfValues.size() - NumArguments);
+    for (unsigned i : range(paramIndices.size()))
+      paramIndices[i] = (bool)ListOfValues[i];
+    SmallVector<SILValue, 4> operands;
+    for (auto i = paramIndices.size(); i < NumArguments; i += 3) {
+      auto astTy = MF->getType(ListOfValues[i+1]);
+      auto silTy = getSILType(astTy, (SILValueCategory)ListOfValues[i+2]);
+      operands.push_back(getLocalValue(ListOfValues[i], silTy));
+    }
+    ResultVal = Builder.createAutoDiffFunction(Loc, paramIndices,
+        /*differentiationOrder*/ Attr, operands[0],
+        ArrayRef<SILValue>(operands).drop_front());
+    break;
   }
   case SILInstructionKind::AutoDiffFunctionExtractInst: {
-    llvm_unreachable("FIXME: unhandled");
+    auto astTy = MF->getType(TyID);
+    auto silTy = getSILType(astTy, SILValueCategory::Object);
+    auto val = getLocalValue(ValID, silTy);
+    AutoDiffFunctionExtractee extractee(Attr);
+    auto order = Attr2;
+    ResultVal =
+        Builder.createAutoDiffFunctionExtract(Loc, extractee, order, val);
+    break;
   }
   case SILInstructionKind::GraphOperationInst: {
     // TODO(SR-8848): Deserialize attributes.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1091,13 +1091,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     break;
   case SIL_INST_AUTODIFF_FUNCTION:
     SILInstAutoDiffFunctionLayout::readRecord(scratch, /*order*/ Attr,
-                                              NumArguments, ListOfValues);
+                                              /*numParams*/ Attr2, NumArguments,
+                                              ListOfValues);
+    RawOpCode = (unsigned)SILInstructionKind::AutoDiffFunctionInst;
     break;
   case SIL_INST_AUTODIFF_FUNCTION_EXTRACT:
-    SILInstAutoDiffFunctionExtractLayout::readRecord(scratch, ValID,
-                                                     TyID, TyCategory,
-                                                     /*extractee*/ Attr,
+    SILInstAutoDiffFunctionExtractLayout::readRecord(scratch, TyID, TyCategory,
+                                                     ValID, /*extractee*/ Attr,
                                                      /*order*/ Attr2);
+    RawOpCode = (unsigned)SILInstructionKind::AutoDiffFunctionExtractInst;
     break;
   case SIL_INST_NO_OPERAND:
     SILInstNoOperandLayout::readRecord(scratch, RawOpCode);
@@ -1500,16 +1502,19 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     break;
   }
   case SILInstructionKind::AutoDiffFunctionInst: {
-    llvm::SmallBitVector paramIndices(ListOfValues.size() - NumArguments);
-    for (unsigned i : range(paramIndices.size()))
-      paramIndices[i] = (bool)ListOfValues[i];
+    auto numParamIndices = ListOfValues.size() - NumArguments * 3;
+    auto paramIndices = ListOfValues.take_front(numParamIndices);
+    auto numParams = Attr2;
+    llvm::SmallBitVector paramIndicesBitVec(numParams);
+    for (unsigned idx : paramIndices)
+      paramIndicesBitVec.set(idx);
     SmallVector<SILValue, 4> operands;
-    for (auto i = paramIndices.size(); i < NumArguments; i += 3) {
-      auto astTy = MF->getType(ListOfValues[i+1]);
-      auto silTy = getSILType(astTy, (SILValueCategory)ListOfValues[i+2]);
-      operands.push_back(getLocalValue(ListOfValues[i], silTy));
+    for (auto i = numParamIndices; i < NumArguments * 3; i += 3) {
+      auto astTy = MF->getType(ListOfValues[i]);
+      auto silTy = getSILType(astTy, (SILValueCategory)ListOfValues[i+1]);
+      operands.push_back(getLocalValue(ListOfValues[i+2], silTy));
     }
-    ResultVal = Builder.createAutoDiffFunction(Loc, paramIndices,
+    ResultVal = Builder.createAutoDiffFunction(Loc, paramIndicesBitVec,
         /*differentiationOrder*/ Attr, operands[0],
         ArrayRef<SILValue>(operands).drop_front());
     break;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -175,6 +175,8 @@ namespace sil_block {
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
     SIL_INST_GRAPH_OPERATION,
     SIL_INST_GRADIENT,
+    SIL_INST_AUTODIFF_FUNCTION,
+    SIL_INST_AUTODIFF_FUNCTION_EXTRACT,
 
     // We also share these layouts from the decls block. Their enumerators must
     // not overlap with ours.
@@ -427,6 +429,22 @@ namespace sil_block {
     ValueIDField,
     BCFixed<32>,        // result index
     BCArray<BCFixed<1>> // parameter indices
+  >;
+
+  using SILInstAutoDiffFunctionLayout = BCRecordLayout<
+    SIL_INST_AUTODIFF_FUNCTION,
+    BCVBR<8>,             // differentiation order
+    BCVBR<8>,             // number of operands
+    BCArray<ValueIDField> // operands
+  >;
+
+  using SILInstAutoDiffFunctionExtractLayout = BCRecordLayout<
+    SIL_INST_AUTODIFF_FUNCTION_EXTRACT,
+    ValueIDField,
+    TypeIDField,
+    SILTypeCategoryField,
+    BCFixed<2>, // extractee
+    BCVBR<8>    // order
   >;
 
   // SIL instructions with one type. (alloc_stack)

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -295,7 +295,7 @@ namespace sil_block {
                      BCFixed<3>,  // side effect info.
                      BCVBR<8>,    // number of specialize attributes
                      // SWIFT_ENABLE_TENSORFLOW
-                     BCVBR<8>,    // number of reverse differentiable attributes
+                     BCVBR<8>,    // number of differentiable attributes
                      BCFixed<1>,  // has qualified ownership
                      BCFixed<1>,  // must be weakly referenced
                      TypeIDField, // SILFunctionType
@@ -434,15 +434,16 @@ namespace sil_block {
   using SILInstAutoDiffFunctionLayout = BCRecordLayout<
     SIL_INST_AUTODIFF_FUNCTION,
     BCVBR<8>,             // differentiation order
+    BCVBR<8>,             // number of function parameters
     BCVBR<8>,             // number of operands
-    BCArray<ValueIDField> // operands
+    BCArray<ValueIDField> // parameter indices and operands
   >;
 
   using SILInstAutoDiffFunctionExtractLayout = BCRecordLayout<
     SIL_INST_AUTODIFF_FUNCTION_EXTRACT,
-    ValueIDField,
     TypeIDField,
     SILTypeCategoryField,
+    ValueIDField,
     BCFixed<2>, // extractee
     BCVBR<8>    // order
   >;

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -94,6 +94,7 @@ public extension Differentiable where TangentVector == CotangentVector {
 // Differential Operators
 //===----------------------------------------------------------------------===//
 
+/*
 @inlinable
 public func valueWithDifferential<T, R>(
   at x: T, in f: @escaping @autodiff (T) -> R
@@ -147,6 +148,7 @@ public func gradient<T, R>(
         R.CotangentVector == R {
   return { x in gradient(at: x, in: f) }
 }
+ */
 
 //===----------------------------------------------------------------------===//
 // Builtins

--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -1,5 +1,10 @@
 // RUN: %target-sil-opt %s | %FileCheck %s
 
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name autodiff_function
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name autodiff_function
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name autodiff_function | %FileCheck %s
+
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -30,6 +30,6 @@ func apply() {
 // CHECK-SIL-LABEL: @{{.*}}apply{{.*}}
 // CHECK-SIL:       [[ORIG:%.*]] = function_ref @{{.*}}thin{{.*}} : $@convention(thin) (Float) -> Float
 // CHECK-SIL-NEXT:  [[ORIG_THICK:%.*]] = thin_to_thick_function [[ORIG]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
-// CHECK-SIL-NEXT:  [[DIFFED:%.*]] = autodiff_function [wrt 0] [order 1] %1 : $@callee_guaranteed (Float) -> Float
+// CHECK-SIL-NEXT:  [[DIFFED:%.*]] = autodiff_function [wrt 0] [order 1] [[ORIG_THICK]] : $@callee_guaranteed (Float) -> Float
 // CHECK-SIL:   destroy_value [[DIFFED]] : $@autodiff @callee_guaranteed (Float) -> Float
 

--- a/test/AutoDiff/core_builtins.swift
+++ b/test/AutoDiff/core_builtins.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -parse-stdlib -typecheck -verify %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck -check-prefix=CHECK-SIL %s
+
+import Swift
+
+func evaldiff<T: Differentiable, U: Differentiable>(_ f: @autodiff (T) -> U, _ x: T) {
+  let jvp: (T) -> (U, (T.TangentVector) -> U.TangentVector) = Builtin.autodiffGetJVP(f)
+  let vjp: (T) -> (U, (U.CotangentVector) -> T.CotangentVector) = Builtin.autodiffGetVJP(f)
+  _ = jvp(x)
+  _ = vjp(x)
+}
+
+// CHECK-SIL-LABEL: @{{.*}}evaldiff{{.*}}
+// CHECK-SIL: bb0([[DIFFED:%.*]] : @trivial $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U, [[X:%.*]] : @trivial $*T):
+// CHECK-SIL:   [[JVP:%.*]] = autodiff_function_extract [jvp] [order 1] [[DIFFED]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
+// CHECK-SIL:   [[VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
+// CHECK-SIL:   apply [[JVP]]({{%.*}}, [[X]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed T.TangentVector) -> @out U.TangentVector)
+// CHECK-SIL:   apply [[VJP]]({{%.*}}, [[X]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed U.CotangentVector) -> @out T.CotangentVector)

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -30,8 +30,11 @@ let _: @autodiff(forward, order: 0) (Float) -> Float
 //
 
 struct NonDiffType { var x: Int }
-// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+// FIXME: Properly type-check parameters and the result's differentiability
+// xpected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
 let _: @autodiff (NonDiffType) -> Float
+// xpected-error @+1 {{result is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+let _: @autodiff (Float) -> NonDiffType
 
 //
 // Argument selection (@nondiff)

--- a/test/AutoDiff/differential_operators.swift
+++ b/test/AutoDiff/differential_operators.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
+
+import Swift
+
+@inlinable
+public func valueWithDifferential<T, R>(
+  at x: T, in f: @escaping @autodiff (T) -> R
+) -> (value: R, differential: (T.TangentVector) -> R.TangentVector)
+  where T : Differentiable, R : Differentiable {
+  return Builtin.autodiffGetJVP(f)(x)
+}
+
+@inlinable
+public func valueWithPullback<T, R>(
+  at x: T, in f: @escaping @autodiff (T) -> R
+) -> (value: R, pullback: (R.CotangentVector) -> T.CotangentVector)
+  where T : Differentiable, R : Differentiable {
+  return Builtin.autodiffGetVJP(f)(x)
+}


### PR DESCRIPTION
(following #21144)

* Serialize `autodiff_function` and `autodiff_function_extract`. This is required for serializing differential operators.

* Define differential operators in stdlib. Generalized differentiability is almost there!

The next step is to make AD fill in JVP and VJP in `autodiff_function` instructions.