### PR TITLE
test: add and use prefix substitutions for libraries

### DIFF
--- a/test/IRGen/vtable_symbol_linkage.swift
+++ b/test/IRGen/vtable_symbol_linkage.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule.%target-dylib-extension
-// RUN: %target-build-swift -I %t %s %t/BaseModule.%target-dylib-extension -o %t/a.out
+// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule%{target-shared-library-suffix}
+// RUN: %target-build-swift -I %t %s %t/BaseModule%{target-shared-library-suffix} -o %t/a.out
 
-// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule.%target-dylib-extension -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience
-// RUN: %target-build-swift -I %t %s %t/BaseModule.%target-dylib-extension -o %t/a.out -Xfrontend -enable-class-resilience
+// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule%{target-shared-library-suffix} -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience
+// RUN: %target-build-swift -I %t %s %t/BaseModule%{target-shared-library-suffix} -o %t/a.out -Xfrontend -enable-class-resilience
 
 // Check if the program can be linked without undefined symbol errors.
 

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/libresilient_class%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/libresilient_class%{target-shared-library-suffix}
 
 
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/libresilient_class.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/libresilient_class%{target-shared-library-suffix}
 
 
 // REQUIRES: executable_test

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(fixed_layout_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(fixed_layout_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -lfixed_layout_class -o %t/main -Xfrontend -enable-class-resilience -Xlinker -rpath -Xlinker %t
@@ -14,13 +14,13 @@
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_class) %t/%target-library-name(fixed_layout_class)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct_wmo)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class_wmo)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_class_wmo)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(fixed_layout_class_wmo)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(fixed_layout_class_wmo)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -lfixed_layout_class_wmo -Xfrontend -enable-class-resilience -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,32 +1,32 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/libresilient_class.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libfixed_layout_class.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/libfixed_layout_class.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -lfixed_layout_class -o %t/main -Xfrontend -enable-class-resilience -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension %t/libfixed_layout_class.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix} %t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_class_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libfixed_layout_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/libfixed_layout_class_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -lfixed_layout_class_wmo -Xfrontend -enable-class-resilience -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_class_wmo.%target-dylib-extension %t/libfixed_layout_class_wmo.%target-dylib-extension
+// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,32 +1,32 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(fixed_layout_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -lfixed_layout_class -o %t/main -Xfrontend -enable-class-resilience -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix} %t/%{target-shared-library-prefix}fixed_layout_class%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_class) %t/%target-library-name(fixed_layout_class)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_class_wmo)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(fixed_layout_class_wmo)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -lfixed_layout_class_wmo -Xfrontend -enable-class-resilience -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_class_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}fixed_layout_class_wmo%{target-shared-library-suffix}
+// RUN: %target-run %t/main2 %t/%target-library-name(resilient_struct_wmo) %t/%target-library-name(resilient_class_wmo) %t/%target-library-name(fixed_layout_class_wmo)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libBasic.%target-dylib-extension) %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
-// RUN: %target-build-swift-dylib(%t/libWithAssoc.%target-dylib-extension) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
-// RUN: %target-build-swift-dylib(%t/libSubclass.%target-dylib-extension) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Basic%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}WithAssoc%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Subclass%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
 // RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc -lSubclass %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
-// RUN: %target-run %t/conditional_conformances_modules %t/libBasic.%target-dylib-extension %t/libWithAssoc.%target-dylib-extension %t/libSubclass.%target-dylib-extension
+// RUN: %target-run %t/conditional_conformances_modules %t/%{target-shared-library-prefix}Basic%{target-shared-library-suffix} %t/%{target-shared-library-prefix}WithAssoc%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Subclass%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 // FIXME: seems to fail on 32-bit simulator?

--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}WithAssoc%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Subclass%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
 // RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc -lSubclass %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
-// RUN: %target-run %t/conditional_conformances_modules %t/%{target-shared-library-prefix}Basic%{target-shared-library-suffix} %t/%{target-shared-library-prefix}WithAssoc%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Subclass%{target-shared-library-suffix}
+// RUN: %target-run %t/conditional_conformances_modules %t/%target-library-name(Basic) %t/%target-library-name(WithAssoc) %t/%target-library-name(Subclass)
 
 // REQUIRES: executable_test
 // FIXME: seems to fail on 32-bit simulator?

--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Basic%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}WithAssoc%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Subclass%{target-shared-library-suffix}) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Basic)) %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%target-library-name(WithAssoc)) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Subclass)) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
 // RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc -lSubclass %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/conditional_conformances_modules %t/%target-library-name(Basic) %t/%target-library-name(WithAssoc) %t/%target-library-name(Subclass)
 

--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -1,50 +1,50 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libModule1.%target-dylib-extension) -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/libModule2.%target-dylib-extension) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
-// RUN: %target-run %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
 
 // Now the same in optimized mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libModule1.%target-dylib-extension) -O -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/libModule2.%target-dylib-extension) -O -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
-// RUN: %target-run %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
 
 // Now the same in size mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libModule1.%target-dylib-extension) -Osize -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/libModule2.%target-dylib-extension) -Osize -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -Osize -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -Osize -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -Osize -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
-// RUN: %target-run %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
 
 // Now the same in optimized wholemodule mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libModule1.%target-dylib-extension) -O -wmo -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/libModule2.%target-dylib-extension) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -wmo -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -wmo -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
-// RUN: %target-run %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
 
 // Test the -enable-implicit-dynamic flag.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libModule1.%target-dylib-extension) -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
-// RUN: %target-build-swift-dylib(%t/libModule2.%target-dylib-extension) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
-// RUN: %target-run %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
 
 // Test the -enable-implicit-dynamic flag in optimized wholemodule mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libModule1.%target-dylib-extension) -O -wmo -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
-// RUN: %target-build-swift-dylib(%t/libModule2.%target-dylib-extension) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -wmo -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -wmo -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
-// RUN: %target-run %t/main %t/libModule1.%target-dylib-extension %t/libModule2.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
 
 
 // REQUIRES: executable_test

--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -2,32 +2,32 @@
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Now the same in optimized mode.
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Now the same in size mode.
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -Osize -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -Osize -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -Osize -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Now the same in optimized wholemodule mode.
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -wmo -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -wmo -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Test the -enable-implicit-dynamic flag.
 
@@ -35,16 +35,16 @@
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Test the -enable-implicit-dynamic flag in optimized wholemodule mode.
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -wmo -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -wmo -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix} %t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 
 // REQUIRES: executable_test

--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -1,30 +1,30 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Now the same in optimized mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -O -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -O -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Now the same in size mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -Osize -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -Osize -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -Osize -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -Osize -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -Osize -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Now the same in optimized wholemodule mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -wmo -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -O -wmo -DMODULE -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -wmo -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
@@ -32,16 +32,16 @@
 // Test the -enable-implicit-dynamic flag.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // Test the -enable-implicit-dynamic flag in optimized wholemodule mode.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module1%{target-shared-library-suffix}) -O -wmo -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}Module2%{target-shared-library-suffix}) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -O -wmo -DMODULENODYNAMIC -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift -Xfrontend -enable-implicit-dynamic
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -O -wmo -I%t -L%t -lModule1 -Xlinker -rpath -Xlinker %t -DMODULE2 -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_module.swift
 // RUN: %target-build-swift -O -wmo -I%t -L%t -lModule1 -DMAIN -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)

--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -1,17 +1,17 @@
 // First build without chaining.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(A)) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(B)) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(C)) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
 // RUN: %target-build-swift -I%t -L%t -lA -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
 // RUN: %target-run %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
 
 // Now build with chaining enabled.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
+// RUN: %target-build-swift-dylib(%t/%target-library-name(A)) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(B)) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
+// RUN: %target-build-swift-dylib(%t/%target-library-name(C)) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
 // RUN: %target-build-swift -I%t -L%t -lA -DCHAINING -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
 // RUN: %target-codesign %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
 // RUN: %target-run %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)

--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -1,20 +1,20 @@
 // First build without chaining.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libA.%target-dylib-extension) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
-// RUN: %target-build-swift-dylib(%t/libB.%target-dylib-extension) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
-// RUN: %target-build-swift-dylib(%t/libC.%target-dylib-extension) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
 // RUN: %target-build-swift -I%t -L%t -lA -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension
-// RUN: %target-run %t/main %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
 
 // Now build with chaining enabled.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libA.%target-dylib-extension) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
-// RUN: %target-build-swift-dylib(%t/libB.%target-dylib-extension) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
-// RUN: %target-build-swift-dylib(%t/libC.%target-dylib-extension) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) -module-name A -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_A.swift
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
 // RUN: %target-build-swift -I%t -L%t -lA -DCHAINING -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension
-// RUN: %target-run %t/main %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -4,8 +4,8 @@
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift
 // RUN: %target-build-swift -I%t -L%t -lA -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
+// RUN: %target-run %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
 
 // Now build with chaining enabled.
 // RUN: %empty-directory(%t)
@@ -13,8 +13,8 @@
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name B -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) -I%t -L%t -lA -Xlinker -rpath -Xlinker %t -module-name C -emit-module -emit-module-path %t -swift-version 5 %S/Inputs/dynamic_replacement_chaining_B.swift -Xfrontend -enable-dynamic-replacement-chaining
 // RUN: %target-build-swift -I%t -L%t -lA -DCHAINING -o %t/main -Xlinker -rpath -Xlinker %t %s -swift-version 5
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
+// RUN: %target-run %t/main %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -1,26 +1,26 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_enum)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_enum)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_enum_wmo)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_enum_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}
+// RUN: %target-run %t/main2 %t/%target-library-name(resilient_struct_wmo) %t/%target-library-name(resilient_enum_wmo)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -1,26 +1,26 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_enum.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/libresilient_enum.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_enum.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_enum_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_enum_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_enum_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_enum_wmo.%target-dylib-extension
+// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_enum%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_enum)) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_enum)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main -Xlinker -rpath -Xlinker %t
@@ -11,10 +11,10 @@
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_enum)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_enum_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_enum_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_enum_wmo)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_enum_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t

--- a/test/Interpreter/fractal.swift
+++ b/test/Interpreter/fractal.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -o %t/libcomplex.%target-dylib-extension -emit-module %S/complex.swift -module-link-name complex
+// RUN: %target-build-swift -emit-library -o %t/%{target-shared-library-prefix}complex%{target-shared-library-suffix} -emit-module %S/complex.swift -module-link-name complex
 // RUN: %target-jit-run %s -I %t -L %t | %FileCheck %s
 
 // RUN: grep -v import %s > %t/main.swift

--- a/test/Interpreter/fractal.swift
+++ b/test/Interpreter/fractal.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -o %t/%{target-shared-library-prefix}complex%{target-shared-library-suffix} -emit-module %S/complex.swift -module-link-name complex
+// RUN: %target-build-swift -emit-library -o %t/%target-library-name(complex) -emit-module %S/complex.swift -module-link-name complex
 // RUN: %target-jit-run %s -I %t -L %t | %FileCheck %s
 
 // RUN: grep -v import %s > %t/main.swift

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -1,26 +1,26 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_global.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/libresilient_global.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_global -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_global.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_global_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_global_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_global_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_global_wmo.%target-dylib-extension
+// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -1,26 +1,26 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_global)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_global -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_global)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_global_wmo)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_global_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}
+// RUN: %target-run %t/main2 %t/%target-library-name(resilient_struct_wmo) %t/%target-library-name(resilient_global_wmo)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_global%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_global)) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_global)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_global -o %t/main -Xlinker -rpath -Xlinker %t
@@ -11,10 +11,10 @@
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_global)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_global_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_global_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_global_wmo)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_global_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t

--- a/test/Interpreter/mandelbrot.swift
+++ b/test/Interpreter/mandelbrot.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -o %t/libcomplex.%target-dylib-extension -emit-module %S/complex.swift -module-link-name complex
+// RUN: %target-build-swift -emit-library -o %t/%{target-shared-library-prefix}complex%{target-shared-library-suffix} -emit-module %S/complex.swift -module-link-name complex
 // RUN: %target-jit-run %s -I %t -L %t | %FileCheck %s
 
 // RUN: grep -v import %s > %t/main.swift

--- a/test/Interpreter/mandelbrot.swift
+++ b/test/Interpreter/mandelbrot.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -o %t/%{target-shared-library-prefix}complex%{target-shared-library-suffix} -emit-module %S/complex.swift -module-link-name complex
+// RUN: %target-build-swift -emit-library -o %t/%target-library-name(complex) -emit-module %S/complex.swift -module-link-name complex
 // RUN: %target-jit-run %s -I %t -L %t | %FileCheck %s
 
 // RUN: grep -v import %s > %t/main.swift

--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main -Xlinker -rpath -Xlinker %t

--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct)
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/Interpreter/protocol_resilience.swift
+++ b/test/Interpreter/protocol_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_protocol)) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol
 // RUN: %target-codesign %t/%target-library-name(resilient_protocol)
 
 // RUN: %target-build-swift %s -lresilient_protocol -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
@@ -8,7 +8,7 @@
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_protocol)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_protocol_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_protocol_wmo)
 
 // RUN: %target-build-swift %s -lresilient_protocol_wmo -I %t -L %t -o %t/main2 -Xlinker -rpath -Xlinker %t

--- a/test/Interpreter/protocol_resilience.swift
+++ b/test/Interpreter/protocol_resilience.swift
@@ -1,20 +1,20 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_protocol)
 
 // RUN: %target-build-swift %s -lresilient_protocol -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_protocol)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_protocol_wmo)
 
 // RUN: %target-build-swift %s -lresilient_protocol_wmo -I %t -L %t -o %t/main2 -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}
+// RUN: %target-run %t/main2 %t/%target-library-name(resilient_protocol_wmo)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/protocol_resilience.swift
+++ b/test/Interpreter/protocol_resilience.swift
@@ -1,20 +1,20 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_protocol.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol
-// RUN: %target-codesign %t/libresilient_protocol.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -lresilient_protocol -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_protocol.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_protocol%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_protocol_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_protocol_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -lresilient_protocol_wmo -I %t -L %t -o %t/main2 -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/libresilient_protocol_wmo.%target-dylib-extension
+// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_protocol_wmo%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/resilient_metadata_cycles.swift
+++ b/test/Interpreter/resilient_metadata_cycles.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/libresilient_class.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/resilient_metadata_cycles.swift
+++ b/test/Interpreter/resilient_metadata_cycles.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t

--- a/test/Interpreter/resilient_metadata_cycles.swift
+++ b/test/Interpreter/resilient_metadata_cycles.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix} %t/%{target-shared-library-prefix}resilient_class%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_class)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
@@ -8,7 +8,7 @@
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
 // RUN: %target-build-swift %s -lresilient_struct_wmo -I %t -L %t -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -1,20 +1,20 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -lresilient_struct_wmo -I %t -L %t -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/libresilient_struct_wmo.%target-dylib-extension
+// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -1,20 +1,20 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resilient_struct%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
 // RUN: %target-build-swift %s -lresilient_struct_wmo -I %t -L %t -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main
 // RUN: %target-codesign %t/main2
 
-// RUN: %target-run %t/main2 %t/%{target-shared-library-prefix}resilient_struct_wmo%{target-shared-library-suffix}
+// RUN: %target-run %t/main2 %t/%target-library-name(resilient_struct_wmo)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
+++ b/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v1.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resil)) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v1.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
 // RUN: %target-codesign %t/%target-library-name(resil)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresil -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v2.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resil)) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v2.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
 // RUN: %target-codesign %t/%target-library-name(resil)
 
 // RUN: %target-run %t/main %t/%target-library-name(resil)

--- a/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
+++ b/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresil.%target-dylib-extension) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v1.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
-// RUN: %target-codesign %t/libresil.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v1.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}
 
 // RUN: %target-build-swift %s -L %t -I %t -lresil -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
-// RUN: %target-build-swift-dylib(%t/libresil.%target-dylib-extension) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v2.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
-// RUN: %target-codesign %t/libresil.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v2.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
+// RUN: %target-codesign %t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}
 
-// RUN: %target-run %t/main %t/libresil.%target-dylib-extension
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
+++ b/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v1.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resil)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresil -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}) -Xfrontend -enable-resilience %S/Inputs/resilient_generic_struct_v2.swift -emit-module -emit-module-path %t/resil.swiftmodule -module-name resil
-// RUN: %target-codesign %t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(resil)
 
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}resil%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resil)
 
 // REQUIRES: executable_test
 

--- a/test/ParseableInterface/linking-to-module.swift
+++ b/test/ParseableInterface/linking-to-module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-parseable-module-interface -o %t/libcoreTestModuleKitUtilsTool.%target-dylib-extension
+// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-parseable-module-interface -o %t/%{target-shared-library-prefix}coreTestModuleKitUtilsTool%{target-shared-library-suffix}
 // RUN: %target-swift-frontend -emit-ir -I %t -L %t -enable-parseable-module-interface %s | %FileCheck %s
 
 import TestModule

--- a/test/ParseableInterface/linking-to-module.swift
+++ b/test/ParseableInterface/linking-to-module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-parseable-module-interface -o %t/%{target-shared-library-prefix}coreTestModuleKitUtilsTool%{target-shared-library-suffix}
+// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-parseable-module-interface -o %t/%target-library-name(coreTestModuleKitUtilsTool)
 // RUN: %target-swift-frontend -emit-ir -I %t -L %t -enable-parseable-module-interface %s | %FileCheck %s
 
 import TestModule

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors.%target-dylib-extension | %FileCheck %s
+// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -1,8 +1,8 @@
 
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors.%target-dylib-extension | %FileCheck %s
+// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,7 +1,7 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,7 +1,7 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
-// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,7 +1,7 @@
 // REQUIRES: asan_runtime
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
-// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,7 +1,7 @@
 // REQUIRES: asan_runtime
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/libTypesToReflect.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} -I %S/Inputs
-// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
+// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // ... now, test single-frontend mode with multi-threaded LLVM emission:
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} -I %S/Inputs -whole-module-optimization -num-threads 2
-// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
+// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs -whole-module-optimization -num-threads 2
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // CHECK-32: FIELDS:
 // CHECK-32: =======

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension -I %S/Inputs
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
+// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} -I %S/Inputs
+// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // ... now, test single-frontend mode with multi-threaded LLVM emission:
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension -I %S/Inputs -whole-module-optimization -num-threads 2
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
+// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} -I %S/Inputs -whole-module-optimization -num-threads 2
+// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // CHECK-32: FIELDS:
 // CHECK-32: =======

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
-// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+// RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 // REQUIRES: objc_interop
 
 // Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+// RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 // REQUIRES: objc_interop
 
 // Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,7 +1,7 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
-// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} -binary-filename %platform-module-dir/%{target-shared-library-prefix}swiftCore%{target-shared-library-suffix} -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) -binary-filename %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 12TypeLowering11BasicStructV
 // CHECK-64:      (struct TypeLowering.BasicStruct)

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,7 +1,7 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension -binary-filename %platform-module-dir/libswiftCore.%target-dylib-extension -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/%{target-shared-library-prefix}TypesToReflect%{target-shared-library-suffix} -binary-filename %platform-module-dir/%{target-shared-library-prefix}swiftCore%{target-shared-library-suffix} -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 12TypeLowering11BasicStructV
 // CHECK-64:      (struct TypeLowering.BasicStruct)

--- a/test/TBD/all-in-one.swift
+++ b/test/TBD/all-in-one.swift
@@ -6,7 +6,7 @@
 // RUN: %gyb %S/subclass.swift.gyb > %t/subclass.swift
 
 // RUN: %target-build-swift %S/Inputs/extension_types.swift -module-name ExtensionTypes -emit-module -emit-module-path %t/ExtensionTypes.swiftmodule
-// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/subclass_super.%target-dylib-extension -Xfrontend -enable-resilience
+// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/subclass_super%{target-shared-library-suffix} -Xfrontend -enable-resilience
 
 // RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h  -Xfrontend -disable-objc-attr-requires-foundation-module
 // RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo

--- a/test/TBD/subclass.swift.gyb
+++ b/test/TBD/subclass.swift.gyb
@@ -14,7 +14,7 @@
 
 // Other-module superclass is not resilient:
 // RUN: %empty-directory(%t/super)
-// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/super/subclass_super.%target-dylib-extension
+// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/super/subclass_super%{target-shared-library-suffix}
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %t/main.swift -I %t/super
 // RUN: %target-swift-frontend -enable-resilience -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %t/main.swift -I %t/super
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %t/main.swift -I %t/super -enable-testing
@@ -27,7 +27,7 @@
 
 // Other-module superclass is resilient:
 // RUN: %empty-directory(%t/super)
-// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/super/subclass_super.%target-dylib-extension -Xfrontend -enable-resilience
+// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/super/subclass_super%{target-shared-library-suffix} -Xfrontend -enable-resilience
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %t/main.swift -I %t/super
 // RUN: %target-swift-frontend -enable-resilience -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %t/main.swift -I %t/super
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %t/main.swift -I %t/super -enable-testing

--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'client()' >%t/main.swift
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix}) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
+// RUN: %target-build-swift-dylib(%t/%target-library-name(AttrImplFP)) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift -L %t -Xlinker -rpath -Xlinker %t -lAttrImplFP
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/%target-library-name(AttrImplFP)

--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'client()' >%t/main.swift
-// RUN: %target-build-swift-dylib(%t/libAttrImplFP.%target-dylib-extension) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix}) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift -L %t -Xlinker -rpath -Xlinker %t -lAttrImplFP
 // RUN: %target-codesign %t/a.out
-// RUN: %target-codesign %t/libAttrImplFP.%target-dylib-extension
-// RUN: %target-run %t/a.out %t/libAttrImplFP.%target-dylib-extension | %FileCheck %s
+// RUN: %target-codesign %t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix}
+// RUN: %target-run %t/a.out %t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix} | %FileCheck %s
 // REQUIRES: executable_test
 
 // This test just checks that the lookup-table entries for @_implements are

--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -3,8 +3,8 @@
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix}) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift -L %t -Xlinker -rpath -Xlinker %t -lAttrImplFP
 // RUN: %target-codesign %t/a.out
-// RUN: %target-codesign %t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix}
-// RUN: %target-run %t/a.out %t/%{target-shared-library-prefix}AttrImplFP%{target-shared-library-suffix} | %FileCheck %s
+// RUN: %target-codesign %t/%target-library-name(AttrImplFP)
+// RUN: %target-run %t/a.out %t/%target-library-name(AttrImplFP) | %FileCheck %s
 // REQUIRES: executable_test
 
 // This test just checks that the lookup-table entries for @_implements are

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -622,7 +622,8 @@ def use_interpreter_for_simple_runs():
 if run_vendor == 'apple':
     config.available_features.add('objc_interop')
     config.target_object_format = "macho"
-    config.target_dylib_extension = "dylib"
+    config.target_shared_library_prefix = 'lib'
+    config.target_shared_library_suffix = ".dylib"
     config.target_codesign = "codesign -f -s -"
     config.target_runtime = "objc"
 
@@ -791,7 +792,8 @@ if run_vendor == 'apple':
 elif run_os in ['windows-msvc']:
     lit_config.note('Testing Windows ' + config.variant_triple)
     config.target_object_format = 'coff'
-    config.target_dylib_extension = 'dll'
+    config.target_shared_library_prefix = ''
+    config.target_shared_library_suffix = '.dll'
     config.target_sdk_name = 'windows'
     config.target_runtime = 'native'
 
@@ -848,22 +850,26 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     if run_os == 'windows-cygnus':
       lit_config.note("Testing Cygwin " + config.variant_triple)
       config.target_object_format = "coff"
-      config.target_dylib_extension = "dll"
+      config.target_shared_library_prefix = 'lib'
+      config.target_shared_library_suffix = ".dll"
       config.target_sdk_name = "cygwin"
     elif run_os == 'windows-gnu':
       lit_config.note("Testing MinGW " + config.variant_triple)
       config.target_object_format = "coff"
-      config.target_dylib_extension = "dll"
+      config.target_shared_library_prefix = 'lib'
+      config.target_shared_library_suffix = ".dll"
       config.target_sdk_name = "mingw"
     elif run_os == 'freebsd':
       lit_config.note("Testing FreeBSD " + config.variant_triple)
       config.target_object_format = "elf"
-      config.target_dylib_extension = "so"
+      config.target_shared_library_prefix = 'lib'
+      config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "freebsd"
     else:
       lit_config.note("Testing Linux " + config.variant_triple)
       config.target_object_format = "elf"
-      config.target_dylib_extension = "so"
+      config.target_shared_library_prefix = 'lib'
+      config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "linux"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
@@ -907,7 +913,8 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
 elif run_os == 'linux-androideabi':
     lit_config.note("Testing Android " + config.variant_triple)
     config.target_object_format = "elf"
-    config.target_dylib_extension = "so"
+    config.target_shared_library_prefix = 'lib'
+    config.target_shared_library_suffix = ".so"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_sdk_name = "android"
@@ -1021,7 +1028,7 @@ if (not getattr(config, 'target_run', None) and
 
         def upload_dylibs(dylib_dir):
             glob_pattern = os.path.join(dylib_dir,
-                                        '*.' + config.target_dylib_extension)
+                                        '*' + config.target_shared_library_suffix)
             libs = glob.glob(glob_pattern)
             upload_files(libs, dylib_dir, 'stdlib/')
 
@@ -1208,10 +1215,11 @@ if swift_execution_tests_extra_flags:
 
 config.target_resilience_test = (
      '%s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S --s %%s '
-     '--lib-prefix "%s" --lib-suffix ".%s" --target-codesign "%s" '
+     '--lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
      '--additional-compile-flags "%s"'
-     % (config.rth, config.target_build_swift, config.target_run, 'lib',
-        config.target_dylib_extension, config.target_codesign,
+     % (config.rth, config.target_build_swift, config.target_run,
+        config.target_shared_library_prefix,
+        config.target_shared_library_suffix, config.target_codesign,
         rth_flags))
 
 # FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
@@ -1320,7 +1328,8 @@ config.substitutions.append(('%target-swiftmodule-name', run_cpu + '.swiftmodule
 config.substitutions.append(('%target-swiftdoc-name', run_cpu + '.swiftdoc'))
 
 config.substitutions.append(('%target-object-format', config.target_object_format))
-config.substitutions.append(('%target-dylib-extension', config.target_dylib_extension))
+config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))
+config.substitutions.append(('%{target-shared-library-suffix}', config.target_shared_library_suffix))
 
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1330,9 +1330,9 @@ config.substitutions.append(('%target-swiftdoc-name', run_cpu + '.swiftdoc'))
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))
 config.substitutions.append(('%{target-shared-library-suffix}', config.target_shared_library_suffix))
-config.substitutions.append(('%target-library-name\(([^)]+)\)',
-                             SubstituteCaptures(r'%s\1%s' % (config.target_shared_library_prefix,
-                                                             config.target_shared_library_suffix))))
+config.substitutions.insert(0, ('%target-library-name\(([^)]+)\)',
+                                SubstituteCaptures(r'%s\1%s' % (config.target_shared_library_prefix,
+                                                                config.target_shared_library_suffix))))
 
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1330,6 +1330,9 @@ config.substitutions.append(('%target-swiftdoc-name', run_cpu + '.swiftdoc'))
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))
 config.substitutions.append(('%{target-shared-library-suffix}', config.target_shared_library_suffix))
+config.substitutions.append(('%target-library-name\(([^)]+)\)',
+                             SubstituteCaptures(r'%s\1%s' % (config.target_shared_library_prefix,
+                                                             config.target_shared_library_suffix))))
 
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 

--- a/test/multifile/default-arguments/two-modules/main.swift
+++ b/test/multifile/default-arguments/two-modules/main.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/onone %t/wmo
-// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/onone/library.%target-dylib-extension -swift-version 4
-// RUN: %target-build-swift %S/main.swift %t/onone/library.%target-dylib-extension -I %t/onone/ -o %t/onone/main -swift-version 4
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/onone/library%{target-shared-library-suffix} -swift-version 4
+// RUN: %target-build-swift %S/main.swift %t/onone/library%{target-shared-library-suffix} -I %t/onone/ -o %t/onone/main -swift-version 4
 
-// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/wmo/library.%target-dylib-extension -swift-version 4
-// RUN: %target-build-swift %S/main.swift %t/wmo/library.%target-dylib-extension -I %t/wmo/ -o %t/wmo/main -swift-version 4
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/wmo/library%{target-shared-library-suffix} -swift-version 4
+// RUN: %target-build-swift %S/main.swift %t/wmo/library%{target-shared-library-suffix} -I %t/wmo/ -o %t/wmo/main -swift-version 4
 
 import library
 

--- a/test/multifile/extensions/two-modules/main.swift
+++ b/test/multifile/extensions/two-modules/main.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/onone %t/wmo
-// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library.%target-dylib-extension
-// RUN: %target-build-swift %S/main.swift %t/onone/library.%target-dylib-extension -I %t/onone/ -o %t/onone/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library%{target-shared-library-suffix}
+// RUN: %target-build-swift %S/main.swift %t/onone/library%{target-shared-library-suffix} -I %t/onone/ -o %t/onone/main
 
-// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library.%target-dylib-extension
-// RUN: %target-build-swift %S/main.swift %t/wmo/library.%target-dylib-extension -I %t/wmo/ -o %t/wmo/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library%{target-shared-library-suffix}
+// RUN: %target-build-swift %S/main.swift %t/wmo/library%{target-shared-library-suffix} -I %t/wmo/ -o %t/wmo/main
 
 import library
 

--- a/test/multifile/imported-conformance/option-set/main.swift
+++ b/test/multifile/imported-conformance/option-set/main.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %empty-directory(%t/linker)
-// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/library.swift -o %t/linker/%{target-shared-library-prefix}library%{target-shared-library-suffix} -emit-module-path %t/linker/library.swiftmodule -module-name library
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/library.swift -o %t/linker/%target-library-name(library) -emit-module-path %t/linker/library.swiftmodule -module-name library
 // RUN: %target-build-swift %S/main.swift -I %t/linker/ -L %t/linker/ -llibrary -o %t/linker/main
 
 // REQUIRES: objc_interop

--- a/test/multifile/imported-conformance/option-set/main.swift
+++ b/test/multifile/imported-conformance/option-set/main.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %empty-directory(%t/linker)
-// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/library.swift -o %t/linker/liblibrary.%target-dylib-extension -emit-module-path %t/linker/library.swiftmodule -module-name library
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/library.swift -o %t/linker/%{target-shared-library-prefix}library%{target-shared-library-suffix} -emit-module-path %t/linker/library.swiftmodule -module-name library
 // RUN: %target-build-swift %S/main.swift -I %t/linker/ -L %t/linker/ -llibrary -o %t/linker/main
 
 // REQUIRES: objc_interop

--- a/test/multifile/multiconformanceimpls/main.swift
+++ b/test/multifile/multiconformanceimpls/main.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) %S/Inputs/A.swift -emit-module -emit-module-path %t/A.swiftmodule -module-name A
-// RUN: %target-codesign %t/%{target-shared-library-prefix}A%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(A)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) %S/Inputs/B.swift -emit-module -emit-module-path %t/B.swiftmodule -module-name B -I%t -L%t -lA
-// RUN: %target-codesign %t/%{target-shared-library-prefix}B%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(B)
 // RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) %S/Inputs/C.swift -emit-module -emit-module-path %t/C.swiftmodule -module-name C -I%t -L%t -lA
-// RUN: %target-codesign %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
+// RUN: %target-codesign %t/%target-library-name(C)
 // RUN: %target-build-swift %s -I %t -o %t/a.out -L %t -Xlinker -rpath -Xlinker %t -lA -lB -lC
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix} |  %FileCheck %s
+// RUN: %target-run %t/a.out %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C) |  %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/multifile/multiconformanceimpls/main.swift
+++ b/test/multifile/multiconformanceimpls/main.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libA.%target-dylib-extension) %S/Inputs/A.swift -emit-module -emit-module-path %t/A.swiftmodule -module-name A
-// RUN: %target-codesign %t/libA.%target-dylib-extension
-// RUN: %target-build-swift-dylib(%t/libB.%target-dylib-extension) %S/Inputs/B.swift -emit-module -emit-module-path %t/B.swiftmodule -module-name B -I%t -L%t -lA
-// RUN: %target-codesign %t/libB.%target-dylib-extension
-// RUN: %target-build-swift-dylib(%t/libC.%target-dylib-extension) %S/Inputs/C.swift -emit-module -emit-module-path %t/C.swiftmodule -module-name C -I%t -L%t -lA
-// RUN: %target-codesign %t/libC.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) %S/Inputs/A.swift -emit-module -emit-module-path %t/A.swiftmodule -module-name A
+// RUN: %target-codesign %t/%{target-shared-library-prefix}A%{target-shared-library-suffix}
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) %S/Inputs/B.swift -emit-module -emit-module-path %t/B.swiftmodule -module-name B -I%t -L%t -lA
+// RUN: %target-codesign %t/%{target-shared-library-prefix}B%{target-shared-library-suffix}
+// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) %S/Inputs/C.swift -emit-module -emit-module-path %t/C.swiftmodule -module-name C -I%t -L%t -lA
+// RUN: %target-codesign %t/%{target-shared-library-prefix}C%{target-shared-library-suffix}
 // RUN: %target-build-swift %s -I %t -o %t/a.out -L %t -Xlinker -rpath -Xlinker %t -lA -lB -lC
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension |  %FileCheck %s
+// RUN: %target-run %t/a.out %t/%{target-shared-library-prefix}A%{target-shared-library-suffix} %t/%{target-shared-library-prefix}B%{target-shared-library-suffix} %t/%{target-shared-library-prefix}C%{target-shared-library-suffix} |  %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/multifile/synthesized-accessors/two-modules/main.swift
+++ b/test/multifile/synthesized-accessors/two-modules/main.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/onone %t/wmo
-// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library.%target-dylib-extension
-// RUN: %target-build-swift %S/main.swift %t/onone/library.%target-dylib-extension -I %t/onone/ -o %t/onone/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library%{target-shared-library-suffix}
+// RUN: %target-build-swift %S/main.swift %t/onone/library%{target-shared-library-suffix} -I %t/onone/ -o %t/onone/main
 
-// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library.%target-dylib-extension
-// RUN: %target-build-swift %S/main.swift %t/wmo/library.%target-dylib-extension -I %t/wmo/ -o %t/wmo/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library%{target-shared-library-suffix}
+// RUN: %target-build-swift %S/main.swift %t/wmo/library%{target-shared-library-suffix} -I %t/wmo/ -o %t/wmo/main
 
 import library
 

--- a/validation-test/Evolution/test_keypaths.swift.gyb
+++ b/validation-test/Evolution/test_keypaths.swift.gyb
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t/rth)
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %s > %t/test_keypaths.swift
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %S/Inputs/keypaths.swift.gyb > %t/Inputs/keypaths.swift
-// RUN: %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix ".%target-dylib-extension" --target-codesign "%target-codesign" --no-symbol-diff
+// RUN: %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix "%{target-shared-library-suffix}" --target-codesign "%target-codesign" --no-symbol-diff
 
 // REQUIRES: executable_test
 

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -3,8 +3,8 @@
 // RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-first.swift -emit-library -emit-module -module-name first -Xlinker -install_name -Xlinker '@executable_path/libfirst.dylib')
 // RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-second.swift -emit-library -emit-module -module-name second -Xlinker -install_name -Xlinker '@executable_path/libsecond.dylib')
 // RUN: %target-build-swift -I %t -L %t -lfirst -lsecond %s -o %t/main
-// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}first%{target-shared-library-suffix} %t/%{target-shared-library-prefix}second%{target-shared-library-suffix}
-// RUN: %target-run %t/main %t/%{target-shared-library-prefix}first%{target-shared-library-suffix} %t/%{target-shared-library-prefix}second%{target-shared-library-suffix}
+// RUN: %target-codesign %t/main %t/%target-library-name(first) %t/%target-library-name(second)
+// RUN: %target-run %t/main %t/%target-library-name(first) %t/%target-library-name(second)
 
 // REQUIRES: executable_test
 

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -3,8 +3,8 @@
 // RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-first.swift -emit-library -emit-module -module-name first -Xlinker -install_name -Xlinker '@executable_path/libfirst.dylib')
 // RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-second.swift -emit-library -emit-module -module-name second -Xlinker -install_name -Xlinker '@executable_path/libsecond.dylib')
 // RUN: %target-build-swift -I %t -L %t -lfirst -lsecond %s -o %t/main
-// RUN: %target-codesign %t/main %t/libfirst.%target-dylib-extension %t/libsecond.%target-dylib-extension
-// RUN: %target-run %t/main %t/libfirst.%target-dylib-extension %t/libsecond.%target-dylib-extension
+// RUN: %target-codesign %t/main %t/%{target-shared-library-prefix}first%{target-shared-library-suffix} %t/%{target-shared-library-prefix}second%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%{target-shared-library-prefix}first%{target-shared-library-suffix} %t/%{target-shared-library-prefix}second%{target-shared-library-suffix}
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
The naming convention is different on Windows than on Unix-like
environments.  In order to follow the convention we need to substitute
the prefix and the suffix.  Take the opportunity to rename the
`target-dylib-extension` to the CMake-like variable
`target-shared-library-suffix` and introduce
`target-shared-library-prefix`.  This helps linking the test suite
binaries on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
