### PR TITLE
Runtime: Fix metatype to mangling of function with single tuple-typed argument [5.0]

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1767,9 +1767,8 @@ void ASTMangler::appendFunctionInputType(
     const auto &param = params.front();
     auto type = param.getPlainType();
 
-    // If this is just a single parenthesized type,
-    // to save space in the mangled name, let's encode
-    // it as a single type dropping sugar.
+    // If the sole unlabeled parameter has a non-tuple type, encode
+    // the parameter list as a single type.
     if (!param.hasLabel() && !param.isVariadic() &&
         !isa<TupleType>(type.getPointer())) {
       appendTypeListElement(Identifier(), type, param.getParameterFlags());

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -495,14 +495,21 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     NodePointer totalInput = nullptr;
     switch (inputs.size()) {
     case 1: {
-      auto &singleParam = inputs.front();
+      auto singleParam = inputs.front();
+
+      // If the sole unlabeled parameter has a non-tuple type, encode
+      // the parameter list as a single type.
       if (!singleParam.second) {
-        totalInput = singleParam.first;
-        break;
+        auto singleType = singleParam.first;
+        if (singleType->getKind() == Node::Kind::Type)
+          singleType = singleType->getFirstChild();
+        if (singleType->getKind() != Node::Kind::Tuple) {
+          totalInput = singleParam.first;
+          break;
+        }
       }
 
-      // If single parameter has a variadic marker it
-      // requires a tuple wrapper.
+      // Otherwise it requires a tuple wrapper.
       LLVM_FALLTHROUGH;
     }
 

--- a/test/RemoteAST/structural_types.swift
+++ b/test/RemoteAST/structural_types.swift
@@ -37,6 +37,14 @@ typealias Fn8 = (String, Int, Double, Float) -> ()
 printType(Fn8.self)
 // CHECK: found type: (String, Int, Double, Float) -> ()
 
+typealias Fn9 = ((Int, Float)) -> ()
+printType(Fn9.self)
+// CHECK: found type: ((Int, Float)) -> ()
+
+typealias Fn10 = (Int...) -> ()
+printType(Fn10.self)
+// CHECK: found type: (Int...) -> ()
+
 typealias Tuple1 = (Int, Float, Int)
 printType(Tuple1.self)
 // CHECK: found type: (Int, Float, Int)

--- a/test/stdlib/TypeName.swift
+++ b/test/stdlib/TypeName.swift
@@ -59,11 +59,17 @@ TypeNameTests.test("Prints") {
   typealias F = () -> ()
   typealias F2 = () -> () -> ()
   typealias F3 = (() -> ()) -> ()
+  typealias F4 = (Int, Float) -> ()
+  typealias F5 = ((Int, Float)) -> ()
+  typealias F6 = (Int...) -> ()
 
   expectEqual("() -> ()", _typeName(F.self))
   expectEqual("() -> () -> ()", _typeName(F2.self))
   expectEqual("(() -> ()) -> ()", _typeName(F3.self))
   expectEqual("() -> ()", _typeName((() -> ()).self))
+  expectEqual("(Swift.Int, Swift.Float) -> ()", _typeName(F4.self))
+  expectEqual("((Swift.Int, Swift.Float)) -> ()", _typeName(F5.self))
+  expectEqual("(Swift.Int...) -> ()", _typeName(F6.self))
 
   expectEqual("(main.P) -> main.P2 & main.P3",
     _typeName(((P) -> P2 & P3).self))


### PR DESCRIPTION
This fixes converting a metatype to a readable string when the metatype is for a function type with a single tuple type argument.

Unfortunately the mangling for function types was never properly updated for the new post-SE-0110 representation, so there's a hack in ASTMangler. Preserve the hack on the runtime side.

Fixes https://bugs.swift.org/browse/SR-8235, rdar://problem/42134697.