### PR TITLE
Fix a hole in access control checking for var/let

### DIFF
--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4.2
 
 public protocol PublicProto {
   func publicReq()
@@ -799,3 +800,7 @@ private extension ClassWithProperties {
     set {}
   }
 }
+
+public var inferredType = PrivateStruct() // expected-error {{variable cannot be declared public because its type 'PrivateStruct' uses a private type}}
+public var inferredGenericParameters: Optional = PrivateStruct() // expected-warning {{variable should not be declared public because its type uses a private type}}
+public var explicitType: Optional<PrivateStruct> = PrivateStruct() // expected-error {{variable cannot be declared public because its type uses a private type}}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -807,3 +807,7 @@ private extension ClassWithProperties {
     set {}
   }
 }
+
+public var inferredType = PrivateStruct() // expected-error {{variable cannot be declared public because its type 'PrivateStruct' uses a private type}}
+public var inferredGenericParameters: Optional = PrivateStruct() // expected-error {{variable cannot be declared public because its type uses a private type}}
+public var explicitType: Optional<PrivateStruct> = PrivateStruct() // expected-error {{variable cannot be declared public because its type uses a private type}}


### PR DESCRIPTION
Previously if a declaration had both a Type and a TypeRepr available, we would only check the access of the TypeRepr. However, this is incomplete when the type is partially inferred, as in

```swift
public var inferredGenericParameters: Optional = PrivateStruct()
```

The new algorithm is to the Type first, then:
- if the Type is okay, move on to check the TypeRepr
- if the Type is not okay and we're in pre-Swift-5 mode, check the TypeRepr, and if *that's* okay downgrade the whole thing to a warning.

Unfortunately, we can't *just* check the Type in the "good" case, because we don't always properly preserve sugar when going from a TypeRepr that represents a typealias to the corresponding Type, and we want to be able to fix those cases in the future. So we have to check both.