### PR TITLE
[Test] Re-enabled stdlib/ErrorBridgedStatic.

### DIFF
--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -7,7 +7,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: static_stdlib
-// REQUIRES: rdar42789939
 
 import StdlibUnittest
 


### PR DESCRIPTION
This test appears to have been fixed by
https://github.com/apple/swift/pull/21107. Fixes rdar://problem/42789939.
