### PR TITLE
[benchmark] Re-enable Benchmark_Driver.test-sh

### DIFF
--- a/test/benchmark/Benchmark_Driver.test-sh
+++ b/test/benchmark/Benchmark_Driver.test-sh
@@ -1,5 +1,3 @@
-// REQUIRES: rdar_46565291
-
 // REQUIRES: OS=macosx
 // REQUIRES: benchmark
 // REQUIRES: CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
Follow-up to #21150, which resolves [SR-9442](https://bugs.swift.org/browse/SR-9442).