### PR TITLE
Fixes comment for binaryString example snippet in FixedWidthInteger

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1829,7 +1829,7 @@ extension BinaryInteger {
 ///     // Prints "0b11001001"
 ///
 /// The `binaryString` implementation uses the static `bitWidth` property and
-/// the right shift operator (`<<`), both of which are available to any type
+/// the right shift operator (`>>`), both of which are available to any type
 /// that conforms to the `FixedWidthInteger` protocol.
 ///
 /// The next example declares a generic `squared` function, which accepts an


### PR DESCRIPTION
<!-- What's in this pull request? -->
Comment inside of FixedWidthInteger has example snippet for property binaryString. Code is correct. But following comment mentions left shift operation actually meaning right shift one. That's a typo I guess.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
n/a

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->