### PR TITLE
[5.0] Fix a hole in access control checking for var/let

### DIFF
--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4.2
 
 public protocol PublicProto {
   func publicReq()
@@ -799,3 +800,7 @@ private extension ClassWithProperties {
     set {}
   }
 }
+
+public var inferredType = PrivateStruct() // expected-error {{variable cannot be declared public because its type 'PrivateStruct' uses a private type}}
+public var inferredGenericParameters: Optional = PrivateStruct() // expected-warning {{variable should not be declared public because its type uses a private type}}
+public var explicitType: Optional<PrivateStruct> = PrivateStruct() // expected-error {{variable cannot be declared public because its type uses a private type}}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -807,3 +807,7 @@ private extension ClassWithProperties {
     set {}
   }
 }
+
+public var inferredType = PrivateStruct() // expected-error {{variable cannot be declared public because its type 'PrivateStruct' uses a private type}}
+public var inferredGenericParameters: Optional = PrivateStruct() // expected-error {{variable cannot be declared public because its type uses a private type}}
+public var explicitType: Optional<PrivateStruct> = PrivateStruct() // expected-error {{variable cannot be declared public because its type uses a private type}}


### PR DESCRIPTION
- **Explanation**: Previously, our access control logic would always prefer checking a type-as-written (TypeRepr) over the actual Type used for a declaration. Almost all of the time this is good enough, but there's a hole when generic arguments get inferred:

        public var inferredGenericParameters: Optional = PrivateStruct()

    Fix this hole by first checking the Type and then also checking the TypeRepr. The diagnostic is downgraded to a warning in pre-Swift-5.0 modes. (This is not the first access control fix in Swift 5 with this behavior.)

- **Scope**: Does a little more work when checking access control of declarations everywhere, but only changes behavior for inferred generic arguments like the example above.

- **Issue**: rdar://problem/46596085

- **Risk**: Medium-low. Very few projects are already compiling in Swift 5 mode, and they have to be using this specific pattern to have a problem.

- **Testing**: Passed regression tests and the source compat suite.

- **Reviewed by**: @slavapestov  