### PR TITLE
[5.0][stdlib] Support throwing yields in all _modify accessors

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -794,8 +794,8 @@ extension Dictionary {
       }
     }
     _modify {
+      defer { _fixLifetime(self) }
       yield &_variant[key]
-      _fixLifetime(self)
     }
   }
 }
@@ -898,8 +898,8 @@ extension Dictionary {
         native._insert(at: bucket, key: key, value: value)
       }
       let address = native._values + bucket.offset
+      defer { _fixLifetime(self) }
       yield &address.pointee
-      _fixLifetime(self)
     }
   }
 
@@ -1272,14 +1272,10 @@ extension Dictionary {
       return Values(_dictionary: self)
     }
     _modify {
-      var values: Values
-      do {
-        var temp = _Variant(dummy: ())
-        swap(&temp, &_variant)
-        values = Values(_variant: temp)
-      }
+      var values = Values(_variant: _Variant(dummy: ()))
+      swap(&values._variant, &_variant)
+      defer { self._variant = values._variant }
       yield &values
-      self._variant = values._variant
     }
   }
 
@@ -1462,8 +1458,8 @@ extension Dictionary {
         let native = _variant.ensureUniqueNative()
         let bucket = native.validatedBucket(for: position)
         let address = native._values + bucket.offset
+        defer { _fixLifetime(self) }
         yield &address.pointee
-        _fixLifetime(self)
       }
     }
 
@@ -1846,8 +1842,8 @@ extension Dictionary.Index {
       }
       let dummy = _HashTable.Index(bucket: _HashTable.Bucket(offset: 0), age: 0)
       _variant = .native(dummy)
+      defer { _variant = .cocoa(cocoa) }
       yield &cocoa
-      _variant = .cocoa(cocoa)
     }
   }
 #endif

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -794,44 +794,7 @@ extension Dictionary {
       }
     }
     _modify {
-      // FIXME: This code should be moved to _variant, with Dictionary.subscript
-      // yielding `&_variant[key]`.
-
-      let (bucket, found) = _variant.mutatingFind(key)
-
-      // FIXME: Mark this entry as being modified in hash table metadata
-      // so that lldb can recognize it's not valid.
-
-      // Move the old value (if any) out of storage, wrapping it into an
-      // optional before yielding it.
-      let native = _variant.asNative
-      if found {
-        var value: Value? = (native._values + bucket.offset).move()
-        yield &value
-        if let value = value {
-          // **Mutation**
-          //
-          // Initialize storage to new value.
-          (native._values + bucket.offset).initialize(to: value)
-        } else {
-          // **Removal**
-          //
-          // We've already deinitialized the value; deinitialize the key too and
-          // register the removal.
-          (native._keys + bucket.offset).deinitialize(count: 1)
-          native._delete(at: bucket)
-        }
-      } else {
-        var value: Value? = nil
-        yield &value
-        if let value = value {
-          // **Insertion**
-          //
-          // Insert the new entry at the correct place.  Note that
-          // `mutatingFind` already ensured that we have enough capacity.
-          native._insert(at: bucket, key: key, value: value)
-        }
-      }
+      yield &_variant[key]
       _fixLifetime(self)
     }
   }

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -279,6 +279,31 @@ extension Dictionary._Variant: _DictionaryBuffer {
 }
 
 extension Dictionary._Variant {
+  @inlinable
+  internal subscript(key: Key) -> Value? {
+    @inline(__always)
+    get {
+      return lookup(key)
+    }
+    @inline(__always)
+    _modify {
+#if _runtime(_ObjC)
+      guard isNative else {
+        let cocoa = asCocoa
+        var native = _NativeDictionary<Key, Value>(
+          cocoa, capacity: cocoa.count + 1)
+        self = .init(native: native)
+        yield &native[key, isUnique: true]
+        return
+      }
+#endif
+      let isUnique = isUniquelyReferenced()
+      yield &asNative[key, isUnique: isUnique]
+    }
+  }
+}
+
+extension Dictionary._Variant {
   /// Same as find(_:), except assume a corresponding key/value pair will be
   /// inserted if it doesn't already exist, and mutated if it does exist. When
   /// this function returns, the storage is guaranteed to be native, uniquely

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -95,8 +95,8 @@ extension Dictionary._Variant {
     _modify {
       var native = _NativeDictionary<Key, Value>(object.unflaggedNativeInstance)
       self = .init(dummy: ())
+      defer { object = .init(native: native._storage) }
       yield &native
-      object = .init(native: native._storage)
     }
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1367,8 +1367,8 @@ extension Set.Index {
       }
       let dummy = _HashTable.Index(bucket: _HashTable.Bucket(offset: 0), age: 0)
       _variant = .native(dummy)
+      defer { _variant = .cocoa(cocoa) }
       yield &cocoa
-      _variant = .cocoa(cocoa)
     }
   }
 #endif

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -92,8 +92,12 @@ extension Set._Variant {
     _modify {
       var native = _NativeSet<Element>(object.unflaggedNativeInstance)
       self = .init(dummy: ())
+      defer {
+        // This is in a defer block because yield might throw, and we need to
+        // preserve Set's storage invariants when that happens.
+        object = .init(native: native._storage)
+      }
       yield &native
-      object = .init(native: native._storage)
     }
   }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -29,6 +29,8 @@ extension Dictionary {
 // Check that the generic parameters are called 'Key' and 'Value'.
 protocol TestProtocol1 {}
 
+struct TestError: Error {}
+
 extension Dictionary where Key : TestProtocol1, Value : TestProtocol1 {
   var _keyValueAreTestProtocol1: Bool {
     fatalError("not implemented")
@@ -145,6 +147,14 @@ func getCOWSlowEquatableDictionary()
   return d
 }
 
+func expectUnique<T: AnyObject>(_ v: inout T) {
+  expectTrue(isKnownUniquelyReferenced(&v))
+}
+
+func expectUnique<T: AnyObject>(_ v: inout T?) {
+  guard v != nil else { return }
+  expectTrue(isKnownUniquelyReferenced(&v))
+}
 
 DictionaryTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
   var d = getCOWFastDictionary()
@@ -335,6 +345,10 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate")
   }
 }
 
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKey.Uniqueness") {
+  var d = getCOWSlowEquatableDictionary()
+  expectUnique(&d[TestKeyTy(20)])
+}
 
 DictionaryTestSuite.test("COW.Fast.UpdateValueForKeyDoesNotReallocate") {
   do {
@@ -855,6 +869,71 @@ DictionaryTestSuite.test("COW.Fast.DefaultedSubscriptDoesNotCopyValue") {
   }
 }
 
+DictionaryTestSuite.test("COW.Slow.DefaultedSubscript.Uniqueness") {
+  var d = getCOWSlowEquatableDictionary()
+
+  expectUnique(&d[TestKeyTy(20), default: TestEquatableValueTy(0)])
+  expectUnique(&d[TestKeyTy(40), default: TestEquatableValueTy(0)])
+}
+
+func bumpValue(_ value: inout TestEquatableValueTy) {
+  value = TestEquatableValueTy(value.value + 1)
+}
+
+func bumpValueAndThrow(_ value: inout TestEquatableValueTy) throws {
+  value = TestEquatableValueTy(value.value + 1)
+  throw TestError()
+}
+
+DictionaryTestSuite.test("COW.Slow.DefaultedSubscript.Insertion.modify") {
+  var d = getCOWSlowEquatableDictionary()
+
+  bumpValue(&d[TestKeyTy(40), default: TestEquatableValueTy(1040)])
+  expectEqual(TestEquatableValueTy(1041), d[TestKeyTy(40)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.DefaultedSubscript.Mutation.modify") {
+  var d = getCOWSlowEquatableDictionary()
+
+  bumpValue(&d[TestKeyTy(10), default: TestEquatableValueTy(2000)])
+  expectEqual(TestEquatableValueTy(1011), d[TestKeyTy(10)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.DefaultedSubscript.Insertion.modifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+
+  do {
+    try bumpValueAndThrow(
+      &d[TestKeyTy(40), default: TestEquatableValueTy(1040)])
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+  expectEqual(TestEquatableValueTy(1041), d[TestKeyTy(40)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.DefaultedSubscript.Mutation.modifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+
+  do {
+    try bumpValueAndThrow(
+      &d[TestKeyTy(10), default: TestEquatableValueTy(2000)])
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+  expectEqual(TestEquatableValueTy(1011), d[TestKeyTy(10)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+
 DictionaryTestSuite.test("COW.Fast.IndexForKeyDoesNotReallocate") {
   let d = getCOWFastDictionary()
   let identity1 = d._rawIdentifier()
@@ -1351,7 +1430,7 @@ DictionaryTestSuite.test("COW.Slow.EqualityTestDoesNotReallocate") {
 // Keys and Values collection tests.
 //===---
 
-DictionaryTestSuite.test("COW.Fast.ValuesAccessDoesNotReallocate") {
+DictionaryTestSuite.test("COW.Fast.Values.AccessDoesNotReallocate") {
   var d1 = getCOWFastDictionary()
   let identity1 = d1._rawIdentifier()
   
@@ -1380,7 +1459,61 @@ DictionaryTestSuite.test("COW.Fast.ValuesAccessDoesNotReallocate") {
   { $0 == $1 }
 }
 
-DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
+DictionaryTestSuite.test("COW.Slow.Values.Modify") {
+  var d1 = getCOWSlowEquatableDictionary()
+  var d2: [TestKeyTy: TestEquatableValueTy] = [
+    TestKeyTy(40): TestEquatableValueTy(1040),
+    TestKeyTy(50): TestEquatableValueTy(1050),
+    TestKeyTy(60): TestEquatableValueTy(1060),
+  ]
+  d1.values = d2.values
+  expectEqual(d1, d2)
+  expectNil(d1[TestKeyTy(10)])
+  expectNil(d1[TestKeyTy(20)])
+  expectNil(d1[TestKeyTy(30)])
+  expectEqual(TestEquatableValueTy(1040), d1[TestKeyTy(40)])
+  expectEqual(TestEquatableValueTy(1050), d1[TestKeyTy(50)])
+  expectEqual(TestEquatableValueTy(1060), d1[TestKeyTy(60)])
+}
+
+@inline(never)
+func replaceValuesThenThrow<K: Hashable, V>(
+  _ v: inout Dictionary<K, V>.Values,
+  with v2: Dictionary<K, V>.Values
+) throws {
+  v = v2
+  throw TestError()
+}
+
+DictionaryTestSuite.test("COW.Slow.Values.ModifyThrow") {
+  var d1 = getCOWSlowEquatableDictionary()
+  var d2: [TestKeyTy: TestEquatableValueTy] = [
+    TestKeyTy(40): TestEquatableValueTy(1040),
+    TestKeyTy(50): TestEquatableValueTy(1050),
+    TestKeyTy(60): TestEquatableValueTy(1060),
+  ]
+  do {
+    try replaceValuesThenThrow(&d1.values, with: d2.values)
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+  expectEqual(d1, d2)
+  expectNil(d1[TestKeyTy(10)])
+  expectNil(d1[TestKeyTy(20)])
+  expectNil(d1[TestKeyTy(30)])
+  expectEqual(TestEquatableValueTy(1040), d1[TestKeyTy(40)])
+  expectEqual(TestEquatableValueTy(1050), d1[TestKeyTy(50)])
+  expectEqual(TestEquatableValueTy(1060), d1[TestKeyTy(60)])
+}
+
+DictionaryTestSuite.test("COW.Slow.Values.Uniqueness") {
+  var d = getCOWSlowEquatableDictionary()
+  let i = d.index(forKey: TestKeyTy(20))!
+  expectUnique(&d.values[i])
+}
+
+DictionaryTestSuite.test("COW.Fast.Keys.AccessDoesNotReallocate") {
   let d1 = getCOWFastDictionary()
   let identity1 = d1._rawIdentifier()
   
@@ -1436,7 +1569,7 @@ DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
   }
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Insertion") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Insertion") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(40)] = TestEquatableValueTy(1040)
@@ -1445,7 +1578,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Insertion") {
   // Note: Leak tests are done in tearDown.
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Mutation") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Mutation") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(10)] = TestEquatableValueTy(2010)
@@ -1454,7 +1587,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Mutation") {
   // Note: Leak tests are done in tearDown.
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Removal") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Removal") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(10)] = nil
@@ -1463,7 +1596,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Removal") {
   // Note: Leak tests are done in tearDown.
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Noop") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Noop") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(40)] = nil
@@ -1479,12 +1612,24 @@ extension Optional {
   }
 
   @inline(never)
+  mutating func setWrappedThenThrow(to value: Wrapped) throws {
+    self = .some(value)
+    throw TestError()
+  }
+
+  @inline(never)
   mutating func clear() {
     self = .none
   }
+
+  @inline(never)
+  mutating func clearThenThrow() throws {
+    self = .none
+    throw TestError()
+  }
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Insertion_modify") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Insertion.modify") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(40)].setWrapped(to: TestEquatableValueTy(1040))
@@ -1493,7 +1638,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Insertion_modify") {
   // Note: Leak tests are done in tearDown.
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Mutation_modify") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Mutation.modify") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(10)].setWrapped(to: TestEquatableValueTy(2010))
@@ -1502,7 +1647,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Mutation_modify") {
   // Note: Leak tests are done in tearDown.
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Removal_modify") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Removal.modify") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(10)].clear()
@@ -1511,10 +1656,70 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Removal_modify") {
   // Note: Leak tests are done in tearDown.
 }
 
-DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys_Noop_modify") {
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Noop.modify") {
   var d = getCOWSlowEquatableDictionary()
 
   d[TestKeyTy(40)].clear()
+  expectNil(d[TestKeyTy(40)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Insertion.modifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+
+  do {
+    try d[TestKeyTy(40)].setWrappedThenThrow(to: TestEquatableValueTy(1040))
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+
+  expectEqual(TestEquatableValueTy(1040), d[TestKeyTy(40)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Mutation.modifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+
+  do {
+    try d[TestKeyTy(10)].setWrappedThenThrow(to: TestEquatableValueTy(2010))
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+
+  expectEqual(TestEquatableValueTy(2010), d[TestKeyTy(10)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Removal.modifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+
+  do {
+    try d[TestKeyTy(10)].clearThenThrow()
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+
+  expectNil(d[TestKeyTy(10)])
+
+  // Note: Leak tests are done in tearDown.
+}
+
+DictionaryTestSuite.test("COW.Slow.SubscriptWithKeys.Noop.modifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+
+  do {
+    try d[TestKeyTy(40)].clearThenThrow()
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+
   expectNil(d[TestKeyTy(40)])
 
   // Note: Leak tests are done in tearDown.
@@ -4896,7 +5101,216 @@ DictionaryTestSuite.test("Values.MutationDoesNotInvalidateIndices") {
 }
 #endif
 
+DictionaryTestSuite.test("Values.Subscript.Uniqueness") {
+  var d = getCOWSlowEquatableDictionary()
+  let i = d.index(forKey: TestKeyTy(20))!
+  expectUnique(&d.values[i])
+}
 
+DictionaryTestSuite.test("Values.Subscript.Modify") {
+  var d = getCOWSlowEquatableDictionary()
+  let i = d.index(forKey: TestKeyTy(20))!
+  bumpValue(&d.values[i])
+  expectEqual(TestEquatableValueTy(1021), d[TestKeyTy(20)])
+}
+
+DictionaryTestSuite.test("Values.Subscript.ModifyThrow") {
+  var d = getCOWSlowEquatableDictionary()
+  let i = d.index(forKey: TestKeyTy(20))!
+  do {
+    try bumpValueAndThrow(&d.values[i])
+    expectTrue(false, "Did not throw")
+  } catch {
+    expectTrue(error is TestError)
+  }
+  expectEqual(TestEquatableValueTy(1021), d[TestKeyTy(20)])
+}
+
+DictionaryTestSuite.test("RemoveAt.InvalidatesIndices") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  let j = d.index(forKey: 10)!
+
+  d.remove(at: j)
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("RemoveValueForKey.InvalidatesIndices") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+
+  d.removeValue(forKey: 10)
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("ResizeOnInsertion.InvalidatesIndices") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  for i in 0 ..< (d.capacity - d.count) {
+    d[100 + i] = 100 + i
+  }
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d[0] = 0
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("ResizeOnUpdate.InvalidatesIndices") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  for i in 0 ..< (d.capacity - d.count) {
+    d.updateValue(100 + i, forKey: 100 + i)
+  }
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.updateValue(0, forKey: 0)
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("RemoveAll.InvalidatesIndices") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.removeAll(keepingCapacity: true)
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("ReserveCapacity.InvalidatesIndices") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.reserveCapacity(0)
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.reserveCapacity(d.capacity)
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.reserveCapacity(d.capacity * 10)
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("IndexValidation.Subscript.Getter.AcrossInstances") {
+  // The mutation count may happen to be the same across any two dictionaries.
+  // The probability of this is low, but it could happen -- so check a bunch of
+  // these cases at once; a trap will definitely occur at least once.
+  let dicts = (0 ..< 10).map { _ in getCOWFastDictionary() }
+  let indices = dicts.map { $0.index(forKey: 20)! }
+  let d = getCOWFastDictionary()
+
+  expectCrashLater()
+  for i in indices {
+    _ = d[i]
+  }
+  _fixLifetime(dicts)
+}
+
+DictionaryTestSuite.test("IndexValidation.Subscript.Getter.AfterRemoval") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.removeValue(forKey: 10)
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("IndexValidation.Subscript.Getter.AfterGrow") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  let identifier = d._rawIdentifier()
+  expectEqual(d[i], (key: 20, value: 1020))
+  for i in 0 ..< (d.capacity - d.count) {
+    d[100 + i] = 100 + i
+  }
+  expectEqual(d._rawIdentifier(), identifier)
+  expectEqual(d.count, d.capacity)
+
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d[0] = 0
+  expectNotEqual(d._rawIdentifier(), identifier)
+
+  expectCrashLater()
+  _ = d[i]
+}
+
+DictionaryTestSuite.test("IndexValidation.KeysSubscript.Getter.AfterRemoval") {
+  var d = getCOWFastDictionary()
+  let i = d.keys.firstIndex(of: 20)!
+  expectEqual(d.keys[i], 20)
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.removeValue(forKey: 10)
+  expectCrashLater()
+  _ = d.keys[i]
+}
+
+DictionaryTestSuite.test("IndexValidation.KeysSubscript.Getter.AfterGrow") {
+  var d = getCOWFastDictionary()
+  let i = d.keys.firstIndex(of: 20)!
+  let identifier = d._rawIdentifier()
+  expectEqual(d.keys[i], 20)
+  expectEqual(d[i], (key: 20, value: 1020))
+  for i in 0 ..< (d.capacity - d.count) {
+    d[100 + i] = 100 + i
+  }
+  expectEqual(d._rawIdentifier(), identifier)
+  expectEqual(d.count, d.capacity)
+
+  expectEqual(d.keys[i], 20)
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d[0] = 0
+  expectNotEqual(d._rawIdentifier(), identifier)
+
+  expectCrashLater()
+  _ = d.keys[i]
+}
+
+DictionaryTestSuite.test("IndexValidation.ValuesSubscript.Getter.AfterRemoval") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  expectEqual(d.values[i], 1020)
+  expectEqual(d[i], (key: 20, value: 1020))
+
+  d.removeValue(forKey: 10)
+  expectCrashLater()
+  _ = d.values[i]
+}
+
+DictionaryTestSuite.test("IndexValidation.ValuesSubscript.Getter.AfterGrow") {
+  var d = getCOWFastDictionary()
+  let i = d.index(forKey: 20)!
+  let identifier = d._rawIdentifier()
+  expectEqual(d.values[i], 1020)
+  expectEqual(d[i], (key: 20, value: 1020))
+  for i in 0 ..< (d.capacity - d.count) {
+    d[100 + i] = 100 + i
+  }
+  expectEqual(d._rawIdentifier(), identifier)
+  expectEqual(d.count, d.capacity)
+
+  expectEqual(d.values[i], 1020)
+  expectEqual(d[i], (key: 20, value: 1020))
+}
 
 DictionaryTestSuite.setUp {
 #if _runtime(_ObjC)


### PR DESCRIPTION
This cherry picks the following PRs to the 5.0 branch:

https://github.com/apple/swift/pull/20918 -- [stdlib] Refactor Dictionary.subscript._modify for better layering 
https://github.com/apple/swift/pull/21045 -- [stdlib] Dictionary: Support throwing yields in _modify accessors

(The first one isn't strictly necessary, but including it prevented a conflict and lets the two branches remain in sync.)

rdar://problem/46489668