### PR TITLE
SILCombine: peephole to propagate resilient enum cases

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -193,7 +193,8 @@ removeInstructions(ArrayRef<SILInstruction*> UsersToRemove) {
 
 /// Returns false if Inst is an instruction that would require us to keep the
 /// alloc_ref alive.
-static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts) {
+static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts,
+                              bool onlyAcceptTrivialStores) {
   if (isa<SetDeallocatingInst>(Inst) || isa<FixLifetimeInst>(Inst))
     return true;
 
@@ -203,6 +204,24 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts) {
       // dealloc_partial_ref invokes releases implicitly
       isa<DeallocPartialRefInst>(Inst))
     return acceptRefCountInsts;
+
+  if (isa<InjectEnumAddrInst>(Inst))
+    return true;
+
+  // We know that the destructor has no side effects so we can remove the
+  // deallocation instruction too.
+  if (isa<DeallocationInst>(Inst) || isa<AllocationInst>(Inst))
+    return true;
+
+  // Much like deallocation, destroy addr is safe.
+  if (isa<DestroyAddrInst>(Inst))
+    return true;
+
+  // The only store instructions which is guaranteed to store a trivial value
+  // is an inject_enum_addr witout a payload (i.e. without init_enum_data_addr).
+  // There can also be a 'store [trivial]', but we don't handle that yet.
+  if (onlyAcceptTrivialStores)
+    return false;
 
   // If we see a store here, we have already checked that we are storing into
   // the pointer before we added it to the worklist, so we can skip it.
@@ -215,15 +234,6 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts) {
       !isa<TermInst>(Inst))
     return true;
 
-  // We know that the destructor has no side effects so we can remove the
-  // deallocation instruction too.
-  if (isa<DeallocationInst>(Inst))
-    return true;
-
-  // Much like deallocation, destroy addr is safe.
-  if (isa<DestroyAddrInst>(Inst))
-    return true;
-
   // Otherwise we do not know how to handle this instruction. Be conservative
   // and don't zap it.
   return false;
@@ -233,7 +243,7 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts) {
 /// zapping it completely.
 static bool
 hasUnremovableUsers(SILInstruction *AllocRef, UserList &Users,
-                    bool acceptRefCountInsts) {
+                    bool acceptRefCountInsts, bool onlyAcceptTrivialStores) {
   SmallVector<SILInstruction *, 16> Worklist;
   Worklist.push_back(AllocRef);
 
@@ -252,7 +262,7 @@ hasUnremovableUsers(SILInstruction *AllocRef, UserList &Users,
     }
 
     // If we can't zap this instruction... bail...
-    if (!canZapInstruction(I, acceptRefCountInsts)) {
+    if (!canZapInstruction(I, acceptRefCountInsts, onlyAcceptTrivialStores)) {
       LLVM_DEBUG(llvm::dbgs() << "        Found instruction we can't zap...\n");
       return true;
     }
@@ -701,7 +711,8 @@ bool DeadObjectElimination::processAllocRef(AllocRefInst *ARI) {
   // escape, then we can completely remove the use graph of this alloc_ref.
   UserList UsersToRemove;
   if (hasUnremovableUsers(ARI, UsersToRemove,
-                          /*acceptRefCountInsts=*/ !HasSideEffects)) {
+                          /*acceptRefCountInsts=*/ !HasSideEffects,
+                          /*onlyAcceptTrivialStores*/false)) {
     LLVM_DEBUG(llvm::dbgs() << "    Found a use that cannot be zapped...\n");
     return false;
   }
@@ -716,12 +727,11 @@ bool DeadObjectElimination::processAllocRef(AllocRefInst *ARI) {
 }
 
 bool DeadObjectElimination::processAllocStack(AllocStackInst *ASI) {
-  // Trivial types don't have destructors. Let's try to zap this AllocStackInst.
-  if (!ASI->getElementType().isTrivial(ASI->getModule()))
-    return false;
-
+  // Trivial types don't have destructors.
+  bool isTrivialType = ASI->getElementType().isTrivial(ASI->getModule());
   UserList UsersToRemove;
-  if (hasUnremovableUsers(ASI, UsersToRemove, /*acceptRefCountInsts=*/ true)) {
+  if (hasUnremovableUsers(ASI, UsersToRemove, /*acceptRefCountInsts=*/ true,
+      /*onlyAcceptTrivialStores*/!isTrivialType)) {
     LLVM_DEBUG(llvm::dbgs() << "    Found a use that cannot be zapped...\n");
     return false;
   }

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -325,8 +325,9 @@ sil @non_trivial_destructor_objc_destructor : $@convention(thin) () -> () {
 }
 
 // CHECK-LABEL: sil @non_trivial_destructor_on_stack : $@convention(thin) () -> () {
-// CHECK: alloc_stack
-// CHECK: return
+// CHECK:      bb0:
+// CHECK-NEXT:   %0 = tuple ()
+// CHECK-NEXT:   return %0
 sil @non_trivial_destructor_on_stack : $@convention(thin) () -> () {
   %0 = alloc_stack $NonTrivialDestructor
   dealloc_stack %0 : $*NonTrivialDestructor
@@ -358,3 +359,18 @@ sil @trivial_destructor_may_trap : $@convention(thin) () -> () {
   %4 = tuple()
   return %4 : $()
 }
+
+// CHECK-LABEL: sil @remove_dead_enum_stackloc
+// CHECK:      bb0:
+// CHECK-NEXT:   %0 = tuple ()
+// CHECK-NEXT:   return %0
+sil @remove_dead_enum_stackloc : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $FloatingPointRoundingRule
+  inject_enum_addr %0 : $*FloatingPointRoundingRule, #FloatingPointRoundingRule.toNearestOrEven!enumelt
+  destroy_addr %0 : $*FloatingPointRoundingRule
+  dealloc_stack %0 : $*FloatingPointRoundingRule
+  %1 = tuple ()
+  return %1 : $()
+}
+

--- a/test/SILOptimizer/fp_rounding.swift
+++ b/test/SILOptimizer/fp_rounding.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-sil  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib,CPU=x86_64
+
+// This is an end-to-end test to ensure that the optimizer can propagate
+// resilient enum cases (FloatingPointRoundingRule) and produces optimal
+// code for Float.rounded().
+
+// CHECK-LABEL: sil @{{.*}}propagate_roundingmode
+// CHECK:      bb0:
+// CHECK-NEXT:   %0 = integer_literal {{.*}}, 0
+// CHECK-NEXT:   %1 = struct $Int (%0 {{.*}})
+// CHECK-NEXT:   return %1
+public func propagate_roundingmode() -> Int {
+  let rm = FloatingPointRoundingRule.toNearestOrEven
+  switch rm {
+    case .toNearestOrAwayFromZero:
+      return 1
+    default:
+      return 0
+  }
+}
+
+// CHECK-LABEL: sil @{{.*}}round_floating_point
+// CHECK: bb0({{.*}}):
+// CHECK:   [[R:%[0-9]+]] = builtin "int_round{{.*}}"
+// CHECK:   [[F:%[0-9]+]] = struct $Float ([[R]]
+// CHECK:   return [[F]]
+public func round_floating_point(_ x: Float) -> Float {
+  return x.rounded()
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2106,6 +2106,36 @@ bb3:
   return %2 : $()
 }
 
+// CHECK-LABEL: sil @resilient_enum_case_propagation
+// CHECK: bb0:
+// CHECK:   br bb2
+// CHECK: bb1:
+// CHECK:   return
+sil @resilient_enum_case_propagation : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = alloc_stack $FloatingPointRoundingRule
+  inject_enum_addr %0 : $*FloatingPointRoundingRule, #FloatingPointRoundingRule.toNearestOrEven!enumelt
+  %2 = alloc_stack $FloatingPointRoundingRule
+  copy_addr %0 to [initialization] %2 : $*FloatingPointRoundingRule
+  destroy_addr %0 : $*FloatingPointRoundingRule
+  switch_enum_addr %2 : $*FloatingPointRoundingRule, case #FloatingPointRoundingRule.toNearestOrAwayFromZero!enumelt: bb1, default bb2
+
+bb1:
+  %6 = integer_literal $Builtin.Int64, 1
+  br bb3(%6 : $Builtin.Int64)
+
+bb2:
+  destroy_addr %2 : $*FloatingPointRoundingRule
+  %9 = integer_literal $Builtin.Int64, 0
+  br bb3(%9 : $Builtin.Int64)
+
+bb3(%11 : $Builtin.Int64):
+  dealloc_stack %2 : $*FloatingPointRoundingRule
+  dealloc_stack %0 : $*FloatingPointRoundingRule
+  return %11 : $Builtin.Int64
+}
+
+
 @objc(XX) protocol XX {
 }
 

--- a/validation-test/Evolution/test_backward_deploy_enum.swift
+++ b/validation-test/Evolution/test_backward_deploy_enum.swift
@@ -5,7 +5,7 @@ import StdlibUnittest
 import backward_deploy_enum
 
 // <rdar://problem/46438568>
-// XFAIL: *
+// REQUIRES: rdar46438568
 
 var BackwardDeployEnumTest = TestSuite("BackwardDeployEnum")
 


### PR DESCRIPTION
Basically the pattern to optimize is:
    inject_enum_addr %stackloc, #SomeCase
    switch_enum_addr %stackloc ...
    
This works even if the enum is resilient or not a loadable type (e.g. an enum with a not loadable payload) and the case does not have a payload. As long as we don't have opaque values in SIL we need this peephole to optimize the pattern.
This change fixes the code generation for Float.rounded().
    
rdar://problem/46353885
