### PR TITLE
[5.0][Stdlib] Rename AnyKeyPath's ObjC name and _VaListBuilder to avoid conflicts with older stdlibs.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -338,7 +338,7 @@ DECL_ATTR(_implements, Implements,
   NotSerialized, 67)
 DECL_ATTR(_objcRuntimeName, ObjCRuntimeName,
   OnClass |
-  UserInaccessible | RejectByParser |
+  UserInaccessible |
   NotSerialized, 68)
 SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,
   OnClass | LongAttribute | RejectByParser |

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1327,6 +1327,9 @@ ERROR(alignment_must_be_positive_integer,none,
 ERROR(swift_native_objc_runtime_base_must_be_identifier,none,
       "@_swift_native_objc_runtime_base class name must be an identifier", ())
 
+ERROR(objc_runtime_name_must_be_identifier,none,
+      "@_objcRuntimeName name must be an identifier", ())
+
 ERROR(attr_only_at_non_local_scope, none,
       "attribute '%0' can only be used in a non-local scope", (StringRef))
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -29,8 +29,9 @@ internal func _abstract(
 /// A type-erased key path, from any root type to any resulting value
 /// type. NOTE: older runtimes had Swift.AnyKeyPath as the ObjC name.
 /// The two must coexist, so it was renamed. The old name must not be
-/// used in the new runtime.
-@objc(_SwiftAnyKeyPath)
+/// used in the new runtime. _TtCs11_AnyKeyPath is the mangled name for
+/// Swift._AnyKeyPath.
+@_objcRuntimeName(_TtCs11_AnyKeyPath)
 public class AnyKeyPath: Hashable, _AppendKeyPath {
   /// The root type for this key path.
   @inlinable

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -26,7 +26,11 @@ internal func _abstract(
 
 // MARK: Type-erased abstract base classes
 
-/// A type-erased key path, from any root type to any resulting value type.
+/// A type-erased key path, from any root type to any resulting value
+/// type. NOTE: older runtimes had Swift.AnyKeyPath as the ObjC name.
+/// The two must coexist, so it was renamed. The old name must not be
+/// used in the new runtime.
+@objc(_SwiftAnyKeyPath)
 public class AnyKeyPath: Hashable, _AppendKeyPath {
   /// The root type for this key path.
   @inlinable

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -127,7 +127,7 @@ internal typealias _VAInt  = Int32
 @inlinable // c-abi
 public func withVaList<R>(_ args: [CVarArg],
   _ body: (CVaListPointer) -> R) -> R {
-  let builder = _VaListBuilder()
+  let builder = __VaListBuilder()
   for a in args {
     builder.append(a)
   }
@@ -137,7 +137,7 @@ public func withVaList<R>(_ args: [CVarArg],
 /// Invoke `body` with a C `va_list` argument derived from `builder`.
 @inlinable // c-abi
 internal func _withVaList<R>(
-  _ builder: _VaListBuilder,
+  _ builder: __VaListBuilder,
   _ body: (CVaListPointer) -> R
 ) -> R {
   let result = body(builder.va_list())
@@ -168,7 +168,7 @@ internal func _withVaList<R>(
 ///   `va_list` argument.
 @inlinable // c-abi
 public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
-  let builder = _VaListBuilder()
+  let builder = __VaListBuilder()
   for a in args {
     builder.append(a)
   }
@@ -406,9 +406,12 @@ extension Float80 : CVarArg, _CVarArgAligned {
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
+// NOTE: older runtimes called this _VaListBuilder. The two must
+// coexist, so it was renamed. The old name must not be used in the new
+// runtime.
 @_fixed_layout
 @usableFromInline // c-abi
-final internal class _VaListBuilder {
+final internal class __VaListBuilder {
   @_fixed_layout // c-abi
   @usableFromInline
   internal struct Header {
@@ -503,9 +506,12 @@ final internal class _VaListBuilder {
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
+// NOTE: older runtimes called this _VaListBuilder. The two must
+// coexist, so it was renamed. The old name must not be used in the new
+// runtime.
 @_fixed_layout
 @usableFromInline // c-abi
-final internal class _VaListBuilder {
+final internal class __VaListBuilder {
 
   @inlinable // c-abi
   internal init() {}
@@ -533,16 +539,16 @@ final internal class _VaListBuilder {
   }
 
   // NB: This function *cannot* be @inlinable because it expects to project
-  // and escape the physical storage of `_VaListBuilder.alignedStorageForEmptyVaLists`.
+  // and escape the physical storage of `__VaListBuilder.alignedStorageForEmptyVaLists`.
   // Marking it inlinable will cause it to resiliently use accessors to
-  // project `_VaListBuilder.alignedStorageForEmptyVaLists` as a computed
+  // project `__VaListBuilder.alignedStorageForEmptyVaLists` as a computed
   // property.
   @usableFromInline // c-abi
   internal func va_list() -> CVaListPointer {
     // Use Builtin.addressof to emphasize that we are deliberately escaping this
     // pointer and assuming it is safe to do so.
     let emptyAddr = UnsafeMutablePointer<Int>(
-      Builtin.addressof(&_VaListBuilder.alignedStorageForEmptyVaLists))
+      Builtin.addressof(&__VaListBuilder.alignedStorageForEmptyVaLists))
     return CVaListPointer(_fromUnsafeMutablePointer: storage ?? emptyAddr)
   }
 

--- a/test/IRGen/objc_runtime_name_attr.swift
+++ b/test/IRGen/objc_runtime_name_attr.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+//import Foundation
+
+class NormalEverydayClass {}
+// CHECK: @"$s22objc_runtime_name_attr19NormalEverydayClassCMm" = hidden global %objc_class
+// CHECK: @_DATA__TtC22objc_runtime_name_attr19NormalEverydayClass = private constant
+
+
+@_objcRuntimeName(RenamedClass)
+class ThisWillBeRenamed {}
+// CHECK: @"$s22objc_runtime_name_attr17ThisWillBeRenamedCMm" = hidden global %objc_class
+// CHECK: @_DATA_RenamedClass = private constant
+


### PR DESCRIPTION
Cherry-pick #21127 to `swift-5.0-branch`.

rdar://problem/46546165