### PR TITLE
[5.0][CSDiagnostics] Fix requirement source lookup to support member refer…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -119,6 +119,10 @@ ValueDecl *RequirementFailure::getDeclRef() const {
     ConstraintLocatorBuilder subscript(locator);
     locator = cs.getConstraintLocator(
         subscript.withPathElement(PathEltKind::SubscriptMember));
+  } else if (isa<MemberRefExpr>(anchor)) {
+    ConstraintLocatorBuilder memberRef(locator);
+    locator =
+        cs.getConstraintLocator(memberRef.withPathElement(PathEltKind::Member));
   }
 
   auto overload = getOverloadChoiceIfAvailable(locator);


### PR DESCRIPTION
…ences

Fuzzing found a problem related to re-typecheck introducing
`MemberRefExpr` into AST with failing requirements which
are then diagnosed via fixes, quite unlikely case to be
found in the wild.

(cherry picked from commit 03d283171cf7caa784e68bfd974e44b980e78d4a)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
