### PR TITLE
[5.0] IRGen: Drop the witness table pointer in visitThickToObjCMetaty…

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4700,6 +4700,8 @@ void IRGenSILFunction::visitThinToThickFunctionInst(
 void IRGenSILFunction::visitThickToObjCMetatypeInst(ThickToObjCMetatypeInst *i){
   Explosion from = getLoweredExplosion(i->getOperand());
   llvm::Value *swiftMeta = from.claimNext();
+  // Claim any conformances.
+  (void)from.claimAll();
   CanType instanceType(i->getType().castTo<AnyMetatypeType>().getInstanceType());
   Explosion to;
   llvm::Value *classPtr =

--- a/test/IRGen/metatype.sil
+++ b/test/IRGen/metatype.sil
@@ -75,3 +75,18 @@ bb0(%0 : $AnyObject):
   %1 = existential_metatype $@objc_metatype AnyObject.Type, %0 : $AnyObject
   return %1 : $@objc_metatype AnyObject.Type
 }
+
+
+public protocol ClassProto : AnyObject {
+  var other: ClassProto? { get }
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @drop_witness_table(%swift.type*, i8**)
+// CHECK:  call %objc_class* @swift_getObjCClassFromMetadata(%swift.type* %0)
+// CHECK:  ret void
+sil @drop_witness_table : $@convention(thin) (@thick ClassProto.Type) -> () {
+bb0(%0 : $@thick ClassProto.Type):
+  %1 = thick_to_objc_metatype %0 : $@thick ClassProto.Type to $@objc_metatype ClassProto.Type
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
…peInst

* Should have no effect in an non-assert build
* No ABI impact

Otherwise, we will assert in an assert build of the compiler.

rdar://46563206