### PR TITLE
[5.0] Runtime: Make getTypeByMangledName a public entry point.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -91,7 +91,7 @@ func _typeByName(_ name: String) -> Any.Type? {
   }
 }
 
-@_silgen_name("swift_stdlib_getTypeByMangledName")
+@_silgen_name("swift_getTypeByMangledName")
 internal func _getTypeByMangledName(
   _ name: UnsafePointer<UInt8>,
   _ nameLength: UInt,

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -151,7 +151,7 @@ OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , swift::,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
                         (demangler, node, substGenericParam, substWitnessTable))
-OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , swift::,
+OVERRIDE_METADATALOOKUP(getTypeByMangledNameInternal, TypeInfo, , swift::,
                         (StringRef typeName,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2644,7 +2644,7 @@ swift::swift_initClassMetadata(ClassMetadata *self,
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
     const Metadata *superclass =
-      swift_getTypeByMangledName(superclassName, substitutions, substitutions);
+      swift_getTypeByMangledNameInternal(superclassName, substitutions, substitutions);
     if (!superclass) {
       fatalError(0,
                  "failed to demangle superclass of %s from mangled name '%s'\n",
@@ -2734,7 +2734,7 @@ swift::swift_updateClassMetadata(ClassMetadata *self,
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
     const Metadata *superclass =
-      swift_getTypeByMangledName(superclassName, substitutions, substitutions);
+      swift_getTypeByMangledNameInternal(superclassName, substitutions, substitutions);
     if (!superclass) {
       fatalError(0,
                  "failed to demangle superclass of %s from mangled name '%s'\n",
@@ -4252,7 +4252,7 @@ swift_getAssociatedTypeWitnessSlowImpl(
     // The protocol's Self is the only generic parameter that can occur in the
     // type.
     assocTypeMetadata =
-      swift_getTypeByMangledName(mangledName,
+      swift_getTypeByMangledNameInternal(mangledName,
         [conformingType](unsigned depth, unsigned index) -> const Metadata * {
           if (depth == 0 && index == 0)
             return conformingType;
@@ -4279,7 +4279,7 @@ swift_getAssociatedTypeWitnessSlowImpl(
     auto originalConformingType = findConformingSuperclass(conformingType,
                                                            conformance);
     SubstGenericParametersFromMetadata substitutions(originalConformingType);
-    assocTypeMetadata = swift_getTypeByMangledName(mangledName, substitutions,
+    assocTypeMetadata = swift_getTypeByMangledNameInternal(mangledName, substitutions,
                                                    substitutions);
   }
 
@@ -5024,7 +5024,7 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
   
   auto mangledName = Demangle::mangleNode(node);
   auto result =
-    swift_getTypeByMangledName(
+    swift_getTypeByMangledNameInternal(
                           mangledName,
                           [](unsigned, unsigned){ return nullptr; },
                           [](const Metadata *, unsigned) { return nullptr; });

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -327,7 +327,7 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
-  TypeInfo swift_getTypeByMangledName(
+  TypeInfo swift_getTypeByMangledNameInternal(
                                StringRef typeName,
                                SubstGenericParameterFn substGenericParam,
                                SubstDependentWitnessTableFn substWitnessTable);

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -635,7 +635,7 @@ bool swift::_checkGenericRequirements(
 
     // Resolve the subject generic parameter.
     const Metadata *subjectType =
-      swift_getTypeByMangledName(req.getParam(), substGenericParam,
+      swift_getTypeByMangledNameInternal(req.getParam(), substGenericParam,
                                  substWitnessTable);
     if (!subjectType)
       return true;
@@ -660,7 +660,7 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::SameType: {
       // Demangle the second type under the given substitutions.
       auto otherType =
-        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
+        swift_getTypeByMangledNameInternal(req.getMangledTypeName(), substGenericParam,
                                    substWitnessTable);
       if (!otherType) return true;
 
@@ -687,7 +687,7 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::BaseClass: {
       // Demangle the base type under the given substitutions.
       auto baseType =
-        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
+        swift_getTypeByMangledNameInternal(req.getMangledTypeName(), substGenericParam,
                                    substWitnessTable);
       if (!baseType) return true;
 

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -336,7 +336,7 @@ getFieldAt(const Metadata *base, unsigned index) {
   auto typeName = field.getMangledTypeName(0);
 
   SubstGenericParametersFromMetadata substitutions(base);
-  auto typeInfo = swift_getTypeByMangledName(typeName, substitutions,
+  auto typeInfo = swift_getTypeByMangledNameInternal(typeName, substitutions,
                                              substitutions);
 
   // Complete the type metadata before returning it to the caller.

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -181,7 +181,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledNode) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledName) {
-  auto Result = swift_getTypeByMangledName("", nullptr, nullptr);
+  auto Result = swift_getTypeByMangledNameInternal("", nullptr, nullptr);
   ASSERT_EQ((const Metadata *)Result, nullptr);
 }
 


### PR DESCRIPTION
This can be used by compiler-generated code as a size optimization for metadata access, using a
mangled name instead of possibly many open-coded metadata calls. It can also allow reflection
libraries outside of the standard library to turn type reference strings into in-process metadata
pointers in a robust way. rdar://problem/46451849

This is an additive ABI change. It is not necessary for convergence.