### PR TITLE
[Parse/Syntax] Simplify how the final SourceFileSyntax root is formed

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1215,6 +1215,8 @@ public:
 
   bool shouldBuildSyntaxTree() const;
 
+  bool canBeParsedInFull() const;
+
   syntax::SourceFileSyntax getSyntaxRoot() const;
   void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
   bool hasSyntaxRoot() const;

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -363,7 +363,7 @@ public:
   /// This function will be called during the destroying of a root syntax
   /// parsing context. However, we can explicitly call this function to get
   /// the syntax tree before closing the root context.
-  void finalizeRoot();
+  RC<RawSyntax> finalizeRoot();
 
   /// Make a missing node corresponding to the given token kind and text, and
   /// push this node into the context. The synthesized node can help

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -121,6 +121,14 @@ namespace swift {
                            PersistentParserState *PersistentState = nullptr,
                            DelayedParsingCallbacks *DelayedParseCB = nullptr);
 
+  /// Parse a single buffer into the given source file, until the full source
+  /// contents are parsed.
+  ///
+  /// \return true if the parser found code with side effects.
+  bool parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
+                             PersistentParserState *PersistentState = nullptr,
+                             DelayedParsingCallbacks *DelayedParseCB = nullptr);
+
   /// Finish the parsing by going over the nodes that were delayed
   /// during the first parsing pass.
   void performDelayedParsing(DeclContext *DC,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1561,11 +1561,15 @@ bool SourceFile::shouldCollectToken() const {
 }
 
 bool SourceFile::shouldBuildSyntaxTree() const {
+  return canBeParsedInFull() && SyntaxInfo->Enable;
+}
+
+bool SourceFile::canBeParsedInFull() const {
   switch (Kind) {
   case SourceFileKind::Library:
   case SourceFileKind::Main:
   case SourceFileKind::Interface:
-    return SyntaxInfo->Enable;
+    return true;
   case SourceFileKind::REPL:
   case SourceFileKind::SIL:
     return false;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1056,13 +1056,7 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
         SourceFileKind::Library, SourceFile::ImplicitModuleImportKind::None,
         BufferID);
 
-    bool Done;
-    do {
-      // Parser may stop at some erroneous constructions like #else, #endif
-      // or '}' in some cases, continue parsing until we are done
-      parseIntoSourceFile(*NextInput, BufferID, &Done, nullptr,
-                          &PersistentState, nullptr);
-    } while (!Done);
+    parseIntoSourceFileFull(*NextInput, BufferID, &PersistentState);
   }
 
   // Now parse the main file.
@@ -1071,11 +1065,8 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
         MainModule->getMainSourceFile(Invocation.getSourceFileKind());
     MainFile.SyntaxParsingCache = Invocation.getMainFileSyntaxParsingCache();
 
-    bool Done;
-    do {
-      parseIntoSourceFile(MainFile, MainFile.getBufferID().getValue(), &Done,
-                          nullptr, &PersistentState, nullptr);
-    } while (!Done);
+    parseIntoSourceFileFull(MainFile, MainFile.getBufferID().getValue(),
+                            &PersistentState);
   }
 
   assert(Context->LoadedModules.size() == 1 &&

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2383,8 +2383,12 @@ static void diagnoseOperatorFixityAttributes(Parser &P,
 static unsigned skipUntilMatchingRBrace(Parser &P, bool &HasPoundDirective,
                                         SyntaxParsingContext *&SyntaxContext) {
   HasPoundDirective = false;
+  bool isRootCtx = SyntaxContext->isRoot();
   SyntaxParsingContext BlockItemListContext(SyntaxContext,
                                             SyntaxKind::CodeBlockItemList);
+  if (isRootCtx) {
+    BlockItemListContext.setTransparent();
+  }
   SyntaxParsingContext BlockItemContext(SyntaxContext,
                                         SyntaxKind::CodeBlockItem);
   SyntaxParsingContext BodyContext(SyntaxContext, SyntaxKind::TokenList);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -266,8 +266,12 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
 ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                                      BraceItemListKind Kind,
                                      BraceItemListKind ConditionalBlockKind) {
+  bool isRootCtx = SyntaxContext->isRoot();
   SyntaxParsingContext ItemListContext(SyntaxContext,
                                        SyntaxKind::CodeBlockItemList);
+  if (isRootCtx) {
+    ItemListContext.setTransparent();
+  }
 
   bool IsTopLevel = (Kind == BraceItemListKind::TopLevelCode) ||
                     (Kind == BraceItemListKind::TopLevelLibrary);

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -1,9 +1,9 @@
 {
-  "id": 18,
+  "id": 17,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 17,
+      "id": 16,
       "kind": "CodeBlockItemList",
       "layout": [
         {
@@ -204,7 +204,7 @@
       "presence": "Present"
     },
     {
-      "id": 16,
+      "id": 15,
       "tokenKind": {
         "kind": "eof",
         "text": ""

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -1,9 +1,9 @@
 {
-  "id": 40,
+  "id": 39,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 39,
+      "id": 38,
       "kind": "CodeBlockItemList",
       "layout": [
         {
@@ -426,7 +426,7 @@
       "presence": "Present"
     },
     {
-      "id": 38,
+      "id": 37,
       "tokenKind": {
         "kind": "eof",
         "text": ""

--- a/test/incrParse/Outputs/extend-identifier-at-eof.json
+++ b/test/incrParse/Outputs/extend-identifier-at-eof.json
@@ -1,9 +1,9 @@
 {
-  "id": 39,
+  "id": 37,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 38,
+      "id": 36,
       "kind": "CodeBlockItemList",
       "layout": [
         {
@@ -11,23 +11,23 @@
           "omitted": true
         },
         {
-          "id": 35,
+          "id": 34,
           "kind": "CodeBlockItem",
           "layout": [
             {
-              "id": 34,
+              "id": 33,
               "kind": "SequenceExpr",
               "layout": [
                 {
-                  "id": 33,
+                  "id": 32,
                   "kind": "ExprList",
                   "layout": [
                     {
-                      "id": 28,
+                      "id": 27,
                       "kind": "DiscardAssignmentExpr",
                       "layout": [
                         {
-                          "id": 27,
+                          "id": 26,
                           "tokenKind": {
                             "kind": "kw__"
                           },
@@ -65,11 +65,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 30,
+                      "id": 29,
                       "kind": "AssignmentExpr",
                       "layout": [
                         {
-                          "id": 29,
+                          "id": 28,
                           "tokenKind": {
                             "kind": "equal"
                           },
@@ -86,11 +86,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 32,
+                      "id": 31,
                       "kind": "IdentifierExpr",
                       "layout": [
                         {
-                          "id": 31,
+                          "id": 30,
                           "tokenKind": {
                             "kind": "identifier",
                             "text": "xx"
@@ -118,7 +118,7 @@
       "presence": "Present"
     },
     {
-      "id": 37,
+      "id": 35,
       "tokenKind": {
         "kind": "eof",
         "text": ""

--- a/test/incrParse/Outputs/incrementalTransfer.json
+++ b/test/incrParse/Outputs/incrementalTransfer.json
@@ -1,9 +1,9 @@
 {
-  "id": 82,
+  "id": 80,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 81,
+      "id": 79,
       "kind": "CodeBlockItemList",
       "layout": [
         {
@@ -11,17 +11,17 @@
           "omitted": true
         },
         {
-          "id": 78,
+          "id": 77,
           "kind": "CodeBlockItem",
           "layout": [
             {
-              "id": 77,
+              "id": 76,
               "kind": "FunctionDecl",
               "layout": [
                 null,
                 null,
                 {
-                  "id": 55,
+                  "id": 54,
                   "tokenKind": {
                     "kind": "kw_func"
                   },
@@ -40,7 +40,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 56,
+                  "id": 55,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "bar"
@@ -51,15 +51,15 @@
                 },
                 null,
                 {
-                  "id": 61,
+                  "id": 60,
                   "kind": "FunctionSignature",
                   "layout": [
                     {
-                      "id": 60,
+                      "id": 59,
                       "kind": "ParameterClause",
                       "layout": [
                         {
-                          "id": 57,
+                          "id": 56,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -68,13 +68,13 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 58,
+                          "id": 57,
                           "kind": "FunctionParameterList",
                           "layout": [],
                           "presence": "Present"
                         },
                         {
-                          "id": 59,
+                          "id": 58,
                           "tokenKind": {
                             "kind": "r_paren"
                           },
@@ -97,11 +97,11 @@
                 },
                 null,
                 {
-                  "id": 76,
+                  "id": 75,
                   "kind": "CodeBlock",
                   "layout": [
                     {
-                      "id": 62,
+                      "id": 61,
                       "tokenKind": {
                         "kind": "l_brace"
                       },
@@ -110,21 +110,21 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 74,
+                      "id": 73,
                       "kind": "CodeBlockItemList",
                       "layout": [
                         {
-                          "id": 73,
+                          "id": 72,
                           "kind": "CodeBlockItem",
                           "layout": [
                             {
-                              "id": 72,
+                              "id": 71,
                               "kind": "VariableDecl",
                               "layout": [
                                 null,
                                 null,
                                 {
-                                  "id": 63,
+                                  "id": 62,
                                   "tokenKind": {
                                     "kind": "kw_let"
                                   },
@@ -147,19 +147,19 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 71,
+                                  "id": 70,
                                   "kind": "PatternBindingList",
                                   "layout": [
                                     {
-                                      "id": 70,
+                                      "id": 69,
                                       "kind": "PatternBinding",
                                       "layout": [
                                         {
-                                          "id": 65,
+                                          "id": 64,
                                           "kind": "IdentifierPattern",
                                           "layout": [
                                             {
-                                              "id": 64,
+                                              "id": 63,
                                               "tokenKind": {
                                                 "kind": "identifier",
                                                 "text": "x"
@@ -178,11 +178,11 @@
                                         },
                                         null,
                                         {
-                                          "id": 69,
+                                          "id": 68,
                                           "kind": "InitializerClause",
                                           "layout": [
                                             {
-                                              "id": 66,
+                                              "id": 65,
                                               "tokenKind": {
                                                 "kind": "equal"
                                               },
@@ -196,11 +196,11 @@
                                               "presence": "Present"
                                             },
                                             {
-                                              "id": 68,
+                                              "id": 67,
                                               "kind": "StringLiteralExpr",
                                               "layout": [
                                                 {
-                                                  "id": 67,
+                                                  "id": 66,
                                                   "tokenKind": {
                                                     "kind": "string_literal",
                                                     "text": "\"hello world\""
@@ -239,7 +239,7 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 75,
+                      "id": 74,
                       "tokenKind": {
                         "kind": "r_brace"
                       },
@@ -271,7 +271,7 @@
       "presence": "Present"
     },
     {
-      "id": 80,
+      "id": 78,
       "tokenKind": {
         "kind": "eof",
         "text": ""


### PR DESCRIPTION
Instead of creating multiple CodeBlockItemList nodes, that need to get merged and discarded later on, do this:

* Ensure for libSyntax parsing that we parse the whole file
* Create top-level CodeBlockItem nodes that we just directly wrap with a single CodeBlockItemList node at the end

The importance of this change will become more obvious later on when we'll decouple syntax parsing from the formation of libSyntax tree nodes.