### PR TITLE
Runtime: Make getTypeByMangledNameIn(Context|Environment) a public entry point.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -91,7 +91,7 @@ func _typeByName(_ name: String) -> Any.Type? {
   }
 }
 
-@_silgen_name("swift_stdlib_getTypeByMangledName")
+@_silgen_name("swift_getTypeByMangledNameInEnvironment")
 internal func _getTypeByMangledName(
   _ name: UnsafePointer<UInt8>,
   _ nameLength: UInt,

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -245,7 +245,7 @@ public:
     const bool sourceIsMetadata;
 
     union {
-      const Metadata *base;
+      const TargetContextDescriptor<InProcess> *baseContext;
       const TargetGenericEnvironment<InProcess> *environment;
     };
 
@@ -293,9 +293,16 @@ public:
   public:
     /// Produce substitutions entirely from the given metadata.
     explicit SubstGenericParametersFromMetadata(const Metadata *base)
-      : sourceIsMetadata(true), base(base),
+      : sourceIsMetadata(true), baseContext(base->getTypeContextDescriptor()),
         genericArgs(base ? (const void * const *)base->getGenericArgs()
                          : nullptr) { }
+    
+    /// Produce substitutions from the given instantiation arguments for the
+    /// given context.
+    explicit SubstGenericParametersFromMetadata(const ContextDescriptor *base,
+                                                const void * const *args)
+      : sourceIsMetadata(true), baseContext(base), genericArgs(args)
+    {}
 
     /// Produce substitutions from the given instantiation arguments for the
     /// given generic environment.


### PR DESCRIPTION
This can be used by compiler-generated code as a size optimization for metadata access, using a
mangled name instead of possibly many open-coded metadata calls. It can also allow reflection
libraries outside of the standard library to turn type reference strings into in-process metadata
pointers in a robust way. rdar://problem/46451849