### PR TITLE
build: fix cross-compiled installation of libdispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -898,14 +898,20 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
   if(CMAKE_C_COMPILER_ID STREQUAL Clang AND
      CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.8
      OR LLVM_USE_SANITIZER)
-   set(SWIFT_LIBDISPATCH_C_COMPILER ${CMAKE_C_COMPILER})
-   set(SWIFT_LIBDISPATCH_CXX_COMPILER ${CMAKE_CXX_COMPILER})
- elseif(${CMAKE_SYSTEM_NAME} STREQUAL ${CMAKE_HOST_SYSTEM_NAME})
-   set(SWIFT_LIBDISPATCH_C_COMPILER ${PATH_TO_CLANG_BUILD}/bin/clang)
-   set(SWIFT_LIBDISPATCH_CXX_COMPILER ${PATH_TO_CLANG_BUILD}/bin/clang++)
- else()
-   message(SEND_ERROR "libdispatch requires a newer clang compiler (${CMAKE_C_COMPILER_VERSION} < 3.9)")
- endif()
+    set(SWIFT_LIBDISPATCH_C_COMPILER ${CMAKE_C_COMPILER})
+    set(SWIFT_LIBDISPATCH_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+  elseif(${CMAKE_SYSTEM_NAME} STREQUAL ${CMAKE_HOST_SYSTEM_NAME})
+    set(SWIFT_LIBDISPATCH_C_COMPILER ${PATH_TO_CLANG_BUILD}/bin/clang)
+    set(SWIFT_LIBDISPATCH_CXX_COMPILER ${PATH_TO_CLANG_BUILD}/bin/clang++)
+  else()
+    message(SEND_ERROR "libdispatch requires a newer clang compiler (${CMAKE_C_COMPILER_VERSION} < 3.9)")
+  endif()
+
+  if(SWIFT_HOST_VARIANT_SDK STREQUAL Windows)
+    set(SOURCEKIT_LIBDISPATCH_RUNTIME_DIR bin)
+  else()
+    set(SOURCEKIT_LIBDISPATCH_RUNTIME_DIR lib)
+  endif()
 
   include(ExternalProject)
   ExternalProject_Add(libdispatch
@@ -923,6 +929,7 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
                         -DCMAKE_LINKER=${CMAKE_LINKER}
                         -DCMAKE_RANLIB=${CMAKE_RANLIB}
                         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                        -DBUILD_SHARED_LIBS=YES
                         -DENABLE_SWIFT=NO
                         -DENABLE_TESTING=NO
                       INSTALL_COMMAND
@@ -933,9 +940,9 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
                       STEP_TARGETS
                         install
                       BUILD_BYPRODUCTS
-                        <INSTALL_DIR>/lib/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                        <INSTALL_DIR>/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
                         <INSTALL_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}dispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
-                        <INSTALL_DIR>/lib/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
+                        <INSTALL_DIR>/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
                         <INSTALL_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}BlocksRuntime${CMAKE_IMPORT_LIBRARY_SUFFIX}
                       BUILD_ALWAYS
                         1)
@@ -951,7 +958,7 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
   set_target_properties(dispatch
                         PROPERTIES
                           IMPORTED_LOCATION
-                            ${install_dir}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                            ${install_dir}/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
                           IMPORTED_IMPLIB
                             ${install_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}dispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
                           INTERFACE_INCLUDE_DIRECTORIES
@@ -961,7 +968,7 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
   set_target_properties(BlocksRuntime
                         PROPERTIES
                           IMPORTED_LOCATION
-                            ${install_dir}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
+                            ${install_dir}/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
                           IMPORTED_IMPLIB
                             ${install_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}BlocksRuntime${CMAKE_IMPORT_LIBRARY_SUFFIX}
                           INTERFACE_INCLUDE_DIRECTORIES


### PR DESCRIPTION
When building SourceKit for non-Darwin targets, we build libdispatch.  The
installation of libdispatch changes based on the target system name.  Ensure
that we pass along the CMAKE_SYSTEM_NAME and that we get the location for the
shared libraries correct.  Explicitly set `BUILD_SHARED_LIBS` to `YES` rather
than relying on the implicit behaviour.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
