### PR TITLE
[5.0] IRGen: Fix building a closure that captures a struct containing…

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1435,11 +1435,8 @@ void irgen::emitFunctionPartialApplication(
     if (isIndirectFormalParameter(*singleRefcountedConvention))
       ctx = IGF.Builder.CreateLoad(ctx, IGF.IGM.getPointerAlignment());
     // We might get a struct containing a pointer e.g type <{ %AClass* }>
-    if (!ctx->getType()->isPointerTy())
-      ctx = IGF.coerceValue(ctx, IGF.IGM.RefCountedPtrTy,
-                            IGF.IGM.DataLayout);
-    else
-      ctx = IGF.Builder.CreateBitCast(ctx, IGF.IGM.RefCountedPtrTy);
+    if (ctx->getType() != IGF.IGM.RefCountedPtrTy)
+      ctx = IGF.coerceValue(ctx, IGF.IGM.RefCountedPtrTy, IGF.IGM.DataLayout);
     out.add(ctx);
     return;
   }

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1434,7 +1434,12 @@ void irgen::emitFunctionPartialApplication(
     llvm::Value *ctx = args.claimNext();
     if (isIndirectFormalParameter(*singleRefcountedConvention))
       ctx = IGF.Builder.CreateLoad(ctx, IGF.IGM.getPointerAlignment());
-    ctx = IGF.Builder.CreateBitCast(ctx, IGF.IGM.RefCountedPtrTy);
+    // We might get a struct containing a pointer e.g type <{ %AClass* }>
+    if (!ctx->getType()->isPointerTy())
+      ctx = IGF.coerceValue(ctx, IGF.IGM.RefCountedPtrTy,
+                            IGF.IGM.DataLayout);
+    else
+      ctx = IGF.Builder.CreateBitCast(ctx, IGF.IGM.RefCountedPtrTy);
     out.add(ctx);
     return;
   }

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -524,3 +524,28 @@ bb2(%r : $()):
 bb3(%v : $()):
   return %v : $()
 }
+
+struct A1 {
+    let b: () -> ()
+}
+
+struct A2<T>  {
+    let a: T
+}
+
+class  A3 {}
+
+sil @amethod : $@convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+
+sil @repo : $@convention(thin) (@in_guaranteed A2<A3>) -> @owned @callee_guaranteed () -> (@owned A1, @error Error) {
+bb0(%0 : $*A2<A3>):
+  %1 = load %0 : $*A2<A3>
+  %2 = alloc_stack $A2<A3>
+  store %1 to %2 : $*A2<A3>
+  %4 = function_ref @amethod : $@convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+  %5 = partial_apply [callee_guaranteed] %4(%2) : $@convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+  dealloc_stack %2 : $*A2<A3>
+  return %5 : $@callee_guaranteed () -> (@owned A1, @error Error)
+}
+
+sil_vtable A3 {}


### PR DESCRIPTION
… a reference using an indirect convention

A <{ %AClass*}> value cannot be bitcasted to a swift.refcounted*.

* No ABI impact
* Fixes a compiler crash

rdar://46538967