### PR TITLE
LoopUnroll: handle more variations of the comparison builtin

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -99,27 +99,42 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
     return None;
 
   // Match an add 1 recurrence.
-  SILPhiArgument *RecArg;
-  IntegerLiteralInst *End;
-  SILValue RecNext;
+
+  auto *Cmp = dyn_cast<BuiltinInst>(CondBr->getCondition());
+  if (!Cmp)
+    return None;
 
   unsigned Adjust = 0;
+  SILBasicBlock *Exit = CondBr->getTrueBB();
 
-  if (!match(CondBr->getCondition(),
-             m_BuiltinInst(BuiltinValueKind::ICMP_EQ, m_SILValue(RecNext),
-                           m_IntegerLiteralInst(End))) &&
-      !match(CondBr->getCondition(),
-             m_BuiltinInst(BuiltinValueKind::ICMP_SGE, m_SILValue(RecNext),
-                           m_IntegerLiteralInst(End)))) {
-    if (!match(CondBr->getCondition(),
-               m_BuiltinInst(BuiltinValueKind::ICMP_SGT, m_SILValue(RecNext),
-                             m_IntegerLiteralInst(End))))
-      return None;
-    // Otherwise, we have a greater than comparison.
-    else
+  switch (Cmp->getBuiltinInfo().ID) {
+    case BuiltinValueKind::ICMP_EQ:
+    case BuiltinValueKind::ICMP_SGE:
+      break;
+    case BuiltinValueKind::ICMP_SGT:
       Adjust = 1;
+      break;
+    case BuiltinValueKind::ICMP_SLE:
+      Exit = CondBr->getFalseBB();
+      Adjust = 1;
+      break;
+    case BuiltinValueKind::ICMP_NE:
+    case BuiltinValueKind::ICMP_SLT:
+      Exit = CondBr->getFalseBB();
+      break;
+    default:
+      return None;
   }
 
+  if (Loop->contains(Exit))
+    return None;
+
+  auto *End = dyn_cast<IntegerLiteralInst>(Cmp->getArguments()[1]);
+  if (!End)
+    return None;
+
+  SILValue RecNext = Cmp->getArguments()[0];
+  SILPhiArgument *RecArg;
   if (!match(RecNext,
              m_TupleExtractInst(m_ApplyInst(BuiltinValueKind::SAddOver,
                                             m_SILPhiArgument(RecArg), m_One()),
@@ -194,7 +209,7 @@ static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount) {
 /// iterations header or if this is the last iteration remove the backedge to
 /// the header.
 static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
-                               unsigned LastLoopIter, SILBasicBlock *OrigHeader,
+                               unsigned LastLoopIter, SILBasicBlock *CurrentHeader,
                                SILBasicBlock *NextIterationsHeader) {
 
   auto *CurrentTerminator = Latch->getTerminator();
@@ -245,22 +260,25 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
   // On the last iteration change the conditional exit to an unconditional
   // one.
   if (CurLoopIter == LastLoopIter) {
-    if (CondBr->getTrueBB() != OrigHeader)
-      SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getTrueBB(),
-                                      CondBr->getTrueArgs());
-    else
+    if (CondBr->getTrueBB() == CurrentHeader) {
       SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getFalseBB(),
                                       CondBr->getFalseArgs());
+    } else {
+      assert(CondBr->getFalseBB() == CurrentHeader);
+      SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getTrueBB(),
+                                      CondBr->getTrueArgs());
+    }
     CondBr->eraseFromParent();
     return;
   }
 
   // Otherwise, branch to the next iteration's header.
-  if (CondBr->getTrueBB() == OrigHeader) {
+  if (CondBr->getTrueBB() == CurrentHeader) {
     SILBuilder(CondBr).createCondBranch(
         CondBr->getLoc(), CondBr->getCondition(), NextIterationsHeader,
         CondBr->getTrueArgs(), CondBr->getFalseBB(), CondBr->getFalseArgs());
   } else {
+    assert(CondBr->getFalseBB() == CurrentHeader);
     SILBuilder(CondBr).createCondBranch(
         CondBr->getLoc(), CondBr->getCondition(), CondBr->getTrueBB(),
         CondBr->getTrueArgs(), NextIterationsHeader, CondBr->getFalseArgs());
@@ -401,11 +419,11 @@ static bool tryToUnrollLoop(SILLoop *Loop) {
        ++Iteration) {
     auto *CurrentLatch = Latches[Iteration];
     auto LastIteration = End - 1;
-    auto *OriginalHeader = Headers[0];
+    auto *CurrentHeader = Headers[Iteration];
     auto *NextIterationsHeader =
         Iteration == LastIteration ? nullptr : Headers[Iteration + 1];
 
-    redirectTerminator(CurrentLatch, Iteration, LastIteration, OriginalHeader,
+    redirectTerminator(CurrentLatch, Iteration, LastIteration, CurrentHeader,
                        NextIterationsHeader);
   }
 

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -143,6 +143,155 @@ bb3:
  return %8 : $()
 }
 
+// CHECK-LABEL: sil @loop_unroll_5
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb4
+// CHECK-NEXT: }
+
+sil @loop_unroll_5 : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 0
+ %1 = integer_literal $Builtin.Int64, 1
+ %2 = integer_literal $Builtin.Int64, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ br bb1(%0 : $Builtin.Int64)
+
+bb1(%4 : $Builtin.Int64):
+  %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
+  %7 = builtin "cmp_slt_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %7, bb2, bb3
+
+bb2:
+  br bb1(%6 : $Builtin.Int64)
+
+bb3:
+ %8 = tuple()
+ return %8 : $()
+}
+
+// CHECK-LABEL: sil @loop_unroll_6
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb4
+// CHECK-NEXT: }
+
+sil @loop_unroll_6 : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 0
+ %1 = integer_literal $Builtin.Int64, 1
+ %2 = integer_literal $Builtin.Int64, 1
+ %3 = integer_literal $Builtin.Int1, 1
+ br bb1(%0 : $Builtin.Int64)
+
+bb1(%4 : $Builtin.Int64):
+  %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
+  %7 = builtin "cmp_sle_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %7, bb2, bb3
+
+bb2:
+  br bb1(%6 : $Builtin.Int64)
+
+bb3:
+ %8 = tuple()
+ return %8 : $()
+}
+
+// CHECK-LABEL: sil @loop_unroll_7
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb4
+// CHECK-NEXT: }
+
+sil @loop_unroll_7 : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 0
+ %1 = integer_literal $Builtin.Int64, 1
+ %2 = integer_literal $Builtin.Int64, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ br bb1(%0 : $Builtin.Int64)
+
+bb1(%4 : $Builtin.Int64):
+  %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
+  %7 = builtin "cmp_ne_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %7, bb2, bb3
+
+bb2:
+  br bb1(%6 : $Builtin.Int64)
+
+bb3:
+ %8 = tuple()
+ return %8 : $()
+}
+
+// CHECK-LABEL: sil @unroll_with_exit_block_arg_1
+// CHECK: bb1({{.*}}):
+// CHECK:   cond_br {{.*}}, bb3{{.*}}, bb2({{.*}})
+// CHECK: bb2({{.*}}):
+// CHECK:   return
+// CHECK: bb3({{.*}}):
+// CHECK:   cond_br {{.*}}, bb4{{.*}}, bb2({{.*}})
+// CHECK: bb4({{.*}}):
+// CHECK:   br bb2({{.*}})
+// CHECK: }
+sil @unroll_with_exit_block_arg_1 : $@convention(thin) () -> () {
+bb0:
+  %27 = integer_literal $Builtin.Int64, 1
+  %28 = integer_literal $Builtin.Int64, 4
+  %56 = integer_literal $Builtin.Int1, -1
+  br bb4(%27 : $Builtin.Int64, %28 : $Builtin.Int64)
+
+bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
+  %60 = builtin "sadd_with_overflow_Int64"(%58 : $Builtin.Int64, %27 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %61 = tuple_extract %60 : $(Builtin.Int64, Builtin.Int1), 0
+  %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
+  %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %70, bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64), bb6(%61 : $Builtin.Int64)
+
+bb6(%72 : $Builtin.Int64):
+  %401 = tuple ()
+  return %401 : $()
+}
+
+// CHECK-LABEL: sil @unroll_with_exit_block_arg_2
+// CHECK: bb1({{.*}}):
+// CHECK:   cond_br {{.*}}, bb2, bb3({{.*}})
+// CHECK: bb2:
+// CHECK:   br bb4{{.*}}
+// CHECK: bb3({{.*}}):
+// CHECK:   return
+// CHECK: bb4({{.*}}):
+// CHECK:   cond_br {{.*}}, bb5, bb3({{.*}})
+// CHECK: bb5:
+// CHECK:   br bb6{{.*}}
+// CHECK: bb6({{.*}}):
+// CHECK:   br bb3({{.*}})
+// CHECK: }
+sil @unroll_with_exit_block_arg_2 : $@convention(thin) () -> () {
+bb0:
+  %27 = integer_literal $Builtin.Int64, 1
+  %28 = integer_literal $Builtin.Int64, 4
+  %56 = integer_literal $Builtin.Int1, -1
+  br bb4(%27 : $Builtin.Int64, %28 : $Builtin.Int64)
+
+bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
+  %60 = builtin "sadd_with_overflow_Int64"(%58 : $Builtin.Int64, %27 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %61 = tuple_extract %60 : $(Builtin.Int64, Builtin.Int1), 0
+  %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
+  %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %70, bb5, bb6(%61 : $Builtin.Int64)
+
+bb5:
+  br bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64)
+
+bb6(%72 : $Builtin.Int64):
+  %401 = tuple ()
+  return %401 : $()
+}
+
+
 class B {}
 
 // CHECK-LABEL: sil @unroll_with_stack_allocation


### PR DESCRIPTION
Handle !=, <, <= in addition to ==, >, >=.

This enables loop unrolling if the loop is written as 'while i < e { }'.

rdar://problem/46606173
