### PR TITLE
[5.0] build: always process `include`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -912,8 +912,9 @@ endif()
 # https://bugs.swift.org/browse/SR-5975
 add_subdirectory(stdlib)
 
+add_subdirectory(include)
+
 if(SWIFT_INCLUDE_TOOLS)
-  add_subdirectory(include)
   add_subdirectory(lib)
   
   # Always include this after including stdlib/!


### PR DESCRIPTION
The `include` subdirectory now generates a header which is used for the
runtime as well, making this directory a need irrespective of whether
the tools are being built or not.  This repairs the build of just the
runtime without the tools.