### PR TITLE
Bugfix to allow importing numpy again.

### DIFF
--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -191,7 +191,9 @@ private extension PythonLibrary {
   
   static func loadPythonLibrary(at path: String) -> UnsafeMutableRawPointer? {
     log("Trying to load library at '\(path)'...")
-    let pythonLibraryHandle = dlopen(path, RTLD_LAZY)
+    // Must be RTLD_GLOBAL because subsequent .so files from the imported python
+    // modules may depend on this .so file.
+    let pythonLibraryHandle = dlopen(path, RTLD_LAZY | RTLD_GLOBAL)
     
     if pythonLibraryHandle != nil {
       log("Library at '\(path)' was sucessfully loaded.")


### PR DESCRIPTION
Imported python modules (like numpy) would not be able to find the symbols that had been moved from static linkage to dynamic linkage. This CL properly exports those symbols again.

Broken in: #20674