### PR TITLE
[DNM] Intentionally expose some symbols we think should not be

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -21,7 +21,7 @@ internal typealias _CocoaString = AnyObject
 // variables, allowing the core stdlib to remain decoupled from
 // Foundation.
 
-@usableFromInline // @testable
+@inlinable @inline(__always) // @testable
 @_effects(releasenone)
 internal func _stdlib_binary_CFStringCreateCopy(
   _ source: _CocoaString

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -12,12 +12,14 @@
 
 import SwiftShims
 
+@usableFromInline
 internal enum _Normalization {
 
   // ICU's NFC unorm2 instance
   //
   // TODO(String performance): Should we cache one on TLS? Is this an expensive
   // call?
+  @usableFromInline
   internal static var _nfcNormalizer: OpaquePointer = {
     var err = __swift_stdlib_U_ZERO_ERROR
     let normalizer = __swift_stdlib_unorm2_getNFCInstance(&err)
@@ -47,10 +49,13 @@ extension Unicode.Scalar {
   // produce new sub-segments.
 
   // Whether this scalar value always has a normalization boundary before it.
-  @inline(__always) // common fast-path
+  @inline(__always) @inlinable // common fast-path
   internal var _hasNormalizationBoundaryBefore: Bool {
     // Fast-path: All scalars up through U+02FF are NFC and have boundaries
     // before them
+    
+    
+    
     if self.value < 0x300 { return true }
 
     _internalInvariant(Int32(exactly: self.value) != nil, "top bit shouldn't be set")

--- a/test/stdlib/NoFoundation.swift
+++ b/test/stdlib/NoFoundation.swift
@@ -37,3 +37,4 @@ import Dispatch
 if #available(OSX 10.10, iOS 8.0, *) {
 	print(DispatchQueue.global(qos: .default))
 }
+


### PR DESCRIPTION
We discussed what the rules are for what the stdlib should and should not be able to expose, and here's what we've come up with:

* Things defined in the standard library proper, in Swift: Yes
* Anything in a manually generated list with format TBD: Yes
* Anything the compiler itself generates calls to (e.g. swift_retain): Yes
* Everything else in SwiftShims: No
* Anything not listed above: No, but also I haven't found a way to get anything else to compile, so I'm not sure how this could be a problem

The very small changes here intentionally inline a call to a CF shim and a call to an ICU shim that should not be. This should cause the checker we've discussed, once it exists, to flag _swift_stdlib_CFStringCreateCopy and __swift_stdlib_unorm2_hasBoundaryBefore as not acceptable to be in inlined code. Note that symbols *other* than those two showing up as failures does not necessarily mean a checker is doing the wrong thing; it could also be finding real failures we didn't know about, or things we should put on the manual ok-list.

The existing tests already contain uses of static inline SwiftShims functions. These will all need to be listed, e.g. _swift_stdlib_strlen_unsigned, _swift_stdlib_memcmp, and so on.