### PR TITLE
stdlib: Make _typeByName Foundation SPI reject symbolic references.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -84,12 +84,16 @@ public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
-    return  _getTypeByMangledName(nameUTF8.baseAddress!,
-                                  UInt(nameUTF8.endIndex),
-                                  genericEnvironment: nil,
-                                  genericArguments: nil)
+    return  _getTypeByMangledNameUntrusted(nameUTF8.baseAddress!,
+                                  UInt(nameUTF8.endIndex))
   }
 }
+
+@_silgen_name("swift_stdlib_getTypeByMangledNameUntrusted")
+internal func _getTypeByMangledNameUntrusted(
+  _ name: UnsafePointer<UInt8>,
+  _ nameLength: UInt)
+  -> Any.Type?
 
 @_silgen_name("swift_getTypeByMangledNameInEnvironment")
 internal func _getTypeByMangledName(

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1301,6 +1301,23 @@ swift_getTypeByMangledNameInContext(
   return swift_checkMetadataState(MetadataState::Complete, metadata).Value;
 }
 
+/// Demangle a mangled name, but don't allow symbolic references.
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+const Metadata *_Nullable
+swift_stdlib_getTypeByMangledNameUntrusted(const char *typeNameStart,
+                                           size_t typeNameLength) {
+  llvm::StringRef typeName(typeNameStart, typeNameLength);
+  for (char c : typeName) {
+    if (c >= '\x01' && c <= '\x1F')
+      return nullptr;
+  }
+  
+  auto metadata = swift_getTypeByMangledName(typeName, {}, {});
+  if (!metadata) return nullptr;
+
+  return swift_checkMetadataState(MetadataState::Complete, metadata).Value;
+}
+
 #if SWIFT_OBJC_INTEROP
 
 // Return the ObjC class for the given type name.


### PR DESCRIPTION
It's used for recovering type metadata from deserialized mangled names, which should never have symbolic
references in them.