### PR TITLE
[5.0][Foundation] Update hashing for bridged NSError protocols

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -409,12 +409,6 @@ extension _BridgedNSError where Self.RawValue: FixedWidthInteger {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_code)
   }
-
-  public var hashValue: Int { return _code }
-
-  public func _rawHashValue(seed: Int) -> Int {
-    return _code._rawHashValue(seed: seed)
-  }
 }
 
 /// Describes a bridged error that stores the underlying NSError, so
@@ -491,14 +485,6 @@ public extension _BridgedStoredNSError {
 extension _BridgedStoredNSError {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_nsError)
-  }
-
-  public var hashValue: Int {
-    return _nsError.hash
-  }
-
-  public func _rawHashValue(seed: Int) -> Int {
-    return _nsError._rawHashValue(seed: seed)
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -406,7 +406,15 @@ extension _BridgedNSError where Self.RawValue: FixedWidthInteger {
     self.init(rawValue: RawValue(_bridgedNSError.code))
   }
 
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_code)
+  }
+
   public var hashValue: Int { return _code }
+
+  public func _rawHashValue(seed: Int) -> Int {
+    return _code._rawHashValue(seed: seed)
+  }
 }
 
 /// Describes a bridged error that stores the underlying NSError, so
@@ -480,9 +488,17 @@ public extension _BridgedStoredNSError {
 }
 
 /// Implementation of Hashable for all _BridgedStoredNSErrors.
-public extension _BridgedStoredNSError {
-  var hashValue: Int {
-    return _nsError.hashValue
+extension _BridgedStoredNSError {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_nsError)
+  }
+
+  public var hashValue: Int {
+    return _nsError.hash
+  }
+
+  public func _rawHashValue(seed: Int) -> Int {
+    return _nsError._rawHashValue(seed: seed)
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -570,10 +570,6 @@ public struct CocoaError : _BridgedStoredNSError {
     public init(rawValue: Int) {
       self.rawValue = rawValue
     }
-    
-    public var hashValue: Int {
-      return self.rawValue
-    }
   }
 }
 
@@ -1800,10 +1796,6 @@ public struct URLError : _BridgedStoredNSError {
 
     public init(rawValue: Int) {
       self.rawValue = rawValue
-    }
-
-    public var hashValue: Int {
-      return self.rawValue
     }
   }
 }


### PR DESCRIPTION
(Cherry-picked from #21056, reviewed by @jrose-apple and @DougGregor)

Protocols that wish to provide a default implementation of hashing should do so by providing a `hash(into:)` implementation. `hashValue` has been deprecated as a `Hashable` requirement in SE-0206. 

Protocol extensions that only implement hashValue force `hashValue`-based synthesis on conforming types by default, which will probably produce deprecation warnings soon.

Add missing Hashable requirements to `_BridgedNSError` and `_BridgedStoredNSError`.

It is important to add these extensions now, since the presence/absence of defaulted Hashable requirements can cause [ABI headaches](https://github.com/apple/swift/pull/20705) down the road for conforming types, and these protocols are ~~used by ClangImporter~~ involved in automatic conformance synthesis.

rdar://problem/46496484