### PR TITLE
[WIP][stdlib] Dictionary: Add unsafe bulk-loading initializer

### DIFF
--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -42,3 +42,85 @@ struct _DictionaryBuilder<Key: Hashable, Value> {
     return Dictionary(_native: _target)
   }
 }
+
+extension Dictionary {
+  /// Creates a new dictionary with the specified capacity, then calls the given
+  /// closure to initialize its contents.
+  ///
+  /// Foundation uses this initializer to bridge the contents of an NSDictionary
+  /// instance without allocating a pair of intermediary buffers.  Pass the
+  /// required capacity and a closure that can intialize the dictionary's
+  /// elements. The closure must return `c`, the number of initialized elements
+  /// in both buffers, such that the elements in the range `0..<c` are
+  /// initialized and the elements in the range `c..<capacity` are
+  /// uninitialized. The resulting dictionary has a `count` equal to `c`.
+  ///
+  /// The closure must not add any duplicate keys to the keys buffer.  The
+  /// buffers passed to the closure are only valid for the duration of the call.
+  /// After the closure returns, this initializer moves all initialized elements
+  /// into their correct buckets.
+  ///
+  /// - Parameters:
+  ///   - capacity: The capacity of the new dictionary.
+  ///   - body: A closure that can initialize the dictionary's elements. This
+  ///     closure must return the count of the initialized elements, starting at
+  ///     the beginning of the buffer.
+  @inlinable
+  public // SPI(Foundation)
+  init(
+    _unsafeUninitializedCapacity capacity: Int,
+    initializingWith initializer: (
+      _ keys: UnsafeMutableBufferPointer<Key>,
+      _ values: UnsafeMutableBufferPointer<Value>,
+      _ initializedCount: inout Int
+    ) -> Void
+  ) {
+    let native = _NativeDictionary<Key, Value>(capacity: capacity)
+    let keys = UnsafeMutableBufferPointer<Key>(
+      start: native._keys,
+      count: capacity)
+    let values = UnsafeMutableBufferPointer<Value>(
+      start: native._values,
+      count: capacity)
+    var count = 0
+    initializer(keys, values, &count)
+    _precondition(count >= 0 && count <= capacity)
+
+    // Hash elements into the correct buckets.
+    var bucket = _HashTable.Bucket(offset: 0)
+    while bucket.offset < count {
+      if native.hashTable._isOccupied(bucket) {
+        // We've moved an element here in a previous iteration.
+        bucket.offset += 1
+        continue
+      }
+      let hashValue = native.hashValue(for: native._keys[bucket.offset])
+      let target: _HashTable.Bucket
+      if _isDebugAssertConfiguration() {
+        let (b, found) = native.find(
+          native._keys[bucket.offset],
+          hashValue: hashValue)
+        guard !found else {
+          _preconditionFailure("Duplicate keys found")
+        }
+        native.hashTable.insert(b)
+        target = b
+      } else {
+        target = native.hashTable.insertNew(hashValue: hashValue)
+      }
+      if target < bucket || target.offset >= count {
+        // Target bucket is uninitialized
+        native.moveEntry(from: bucket, to: target)
+        bucket.offset += 1
+      } else if target == bucket {
+        // Already in place
+        bucket.offset += 1
+      } else {
+        // Swap into place, then try again with the swapped-in value.
+        native.swapEntry(target, with: bucket)
+      }
+    }
+    native._storage._count = count
+    self = Dictionary(_native: native)
+  }
+}

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -53,15 +53,21 @@ extension Dictionary {
   /// elements. The closure must return `c`, the number of initialized elements
   /// in both buffers, such that the elements in the range `0..<c` are
   /// initialized and the elements in the range `c..<capacity` are
-  /// uninitialized. The resulting dictionary has a `count` equal to `c`.
+  /// uninitialized.
   ///
-  /// The closure must not add any duplicate keys to the keys buffer.  The
-  /// buffers passed to the closure are only valid for the duration of the call.
-  /// After the closure returns, this initializer moves all initialized elements
-  /// into their correct buckets.
+  /// The resulting dictionary has a `count` less than or equal to `c`. The
+  /// actual count is less iff some of the initialized keys were duplicates.
+  /// (This cannot happen if `allowingDuplicates` is false.)
+  ///
+  /// The buffers passed to the closure are only valid for the duration of the
+  /// call.  After the closure returns, this initializer moves all initialized
+  /// elements into their correct buckets.
   ///
   /// - Parameters:
   ///   - capacity: The capacity of the new dictionary.
+  ///   - allowingDuplicates: If false, then the caller guarantees that all keys
+  ///     are unique. This promise isn't verified -- if it turns out to be
+  ///     false, then the resulting dictionary won't be valid.
   ///   - body: A closure that can initialize the dictionary's elements. This
   ///     closure must return the count of the initialized elements, starting at
   ///     the beginning of the buffer.
@@ -108,8 +114,8 @@ extension _NativeDictionary {
     //
     // - We have some number of unprocessed elements at the start of the
     //   key/value buffers -- buckets up to and including `bucket`. Everything
-    //   this region is either unprocessed or in use. There are no uninitialized
-    //   entries in it.
+    //   in this region is either unprocessed or in use. There are no
+    //   uninitialized entries in it.
     //
     // - Everything after `bucket` is either uninitialized or in use. This
     //   region works exactly like regular dictionary storage.

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -140,10 +140,9 @@ extension _NativeDictionary {
         if found {
           _internalInvariant(b != bucket)
           _precondition(allowingDuplicates, "Duplicate keys found")
-          // Discard existing entry, then move the current entry in place of it.
-          uncheckedDestroy(at: b)
+          // Discard duplicate entry.
+          uncheckedDestroy(at: bucket)
           _storage._count -= 1
-          moveEntry(from: bucket, to: b)
           bucket.offset -= 1
           continue
         }

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -106,7 +106,7 @@ extension _NativeDictionary {
       UnsafeMutableBufferPointer(start: _keys, count: capacity),
       UnsafeMutableBufferPointer(start: _values, count: capacity),
       &initializedCount)
-    _precondition(count >= 0 && count <= capacity)
+    _precondition(initializedCount >= 0 && initializedCount <= capacity)
     _storage._count = initializedCount
 
     // Hash initialized elements and move each of them into their correct

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -127,7 +127,6 @@ extension _HashTable {
     @inlinable
     @inline(__always)
     internal init(offset: Int) {
-      _internalInvariant(offset >= 0)
       self.offset = offset
     }
 

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -137,7 +137,7 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedDestroy(at bucket: Bucket) {
     defer { _fixLifetime(self) }
-    _internalInvariant(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isValid(bucket))
     (_keys + bucket.offset).deinitialize(count: 1)
     (_values + bucket.offset).deinitialize(count: 1)
   }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -619,10 +619,21 @@ extension _NativeDictionary: _HashTableDelegate {
   @inlinable
   @inline(__always)
   internal func moveEntry(from source: Bucket, to target: Bucket) {
+    _internalInvariant(hashTable.isValid(source))
+    _internalInvariant(hashTable.isValid(target))
     (_keys + target.offset)
       .moveInitialize(from: _keys + source.offset, count: 1)
     (_values + target.offset)
       .moveInitialize(from: _values + source.offset, count: 1)
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func swapEntry(_ left: Bucket, with right: Bucket) {
+    _internalInvariant(hashTable.isValid(left))
+    _internalInvariant(hashTable.isValid(right))
+    swap(&_keys[left.offset], &_keys[right.offset])
+    swap(&_values[left.offset], &_values[right.offset])
   }
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5595,6 +5595,7 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Nonunique") {
       },
       uniquingKeysWith: { a, b in a })
 
+    expectEqual(d1.count, d2.count)
     for i in 0 ..< c / 2 {
       expectEqual(TestEquatableValueTy(i), d1[TestKeyTy(i)])
     }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5547,6 +5547,32 @@ DictionaryTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
   d.remove(at: i)
 }
 
+DictionaryTestSuite.test("BulkLoadingInitializer") {
+  for c in [0, 1, 2, 3, 5, 10, 25, 150] {
+    let d1 = Dictionary<TestKeyTy, TestEquatableValueTy>(
+      _unsafeUninitializedCapacity: c
+    ) { keys, values, count in
+      let k = keys.baseAddress!
+      let v = values.baseAddress!
+      for i in 0 ..< c {
+        (k + i).initialize(to: TestKeyTy(i))
+        (v + i).initialize(to: TestEquatableValueTy(i))
+        count += 1
+      }
+    }
+
+    let d2 = Dictionary(
+      uniqueKeysWithValues: (0..<c).map {
+        (TestKeyTy($0), TestEquatableValueTy($0))
+      })
+
+    for i in 0 ..< c {
+      expectEqual(TestEquatableValueTy(i), d1[TestKeyTy(i)])
+    }
+    expectEqual(d1, d2)
+  }
+}
+
 DictionaryTestSuite.setUp {
 #if _runtime(_ObjC)
   // Exercise ARC's autoreleased return value optimization in Foundation.


### PR DESCRIPTION
This in an experimental Dictionary initializer that is designed to work better with `-[NSDictionary getObjects:andKeys:count:]`. This is primarily useful during bridging.

(Interface inspired by @natecook1000's [Array initializer proposal](https://forums.swift.org/t/array-initializer-with-access-to-uninitialized-buffer/13689).)
