### PR TITLE
test: guard Float80 on Windows

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -8,7 +8,7 @@
 import Swift
 import StdlibUnittest
 
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 
 struct Float80Bits : Equatable, CustomStringConvertible {
   var signAndExponent: UInt16
@@ -58,7 +58,7 @@ extension Float80 {
 %   ('Float80', 'Float80Bits')
 % ]:
 %   if FloatTy == 'Float80':
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 %   end
 func expectBitwiseEqual(
   _ expected: ${FloatTy}, _ actual: ${FloatTy},
@@ -605,7 +605,7 @@ FloatingPoint.test("${Self}.nextUp, .nextDown/nan") {
 }
 %end
 
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 
 FloatingPoint.test("Float80/ExpressibleByIntegerLiteral") {
   expectEqual(positiveOne(),  1.0 as Float80)
@@ -825,7 +825,7 @@ FloatingPoint.test("${FloatSelf}/{Comparable,Hashable,Equatable}") {
 % end
 
 % for Self in ['Float32', 'Float64', 'Float80']:
-#if ${'arch(i386) || arch(x86_64)' if Self == 'Float80' else 'true'}
+#if ${'!os(Windows) && (arch(i386) || arch(x86_64))' if Self == 'Float80' else 'true'}
 FloatingPoint.test("${Self}/Strideable") {
   // FIXME: the test data could probably be better chosen here, to
   // exercise more cases.  Note: NaNs (and possibly Infs) are singular
@@ -1018,7 +1018,7 @@ FloatingPoint.test("Float64/Literals") {
   }
 }
 
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 
 FloatingPoint.test("Float80/Literals") {
   do {
@@ -1156,7 +1156,7 @@ FloatingPoint.test("Float64/quietNaN") {
   }
 }
 
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 
 FloatingPoint.test("Float80/quietNaN") {
   do {
@@ -1251,7 +1251,7 @@ FloatingPoint.test("Float64/signalingNaN") {
 
 #endif
 
-#if arch(x86_64)
+#if !os(Windows) && arch(x86_64)
 
 FloatingPoint.test("Float80/signalingNaN") {
   do {


### PR DESCRIPTION
Windows does not support fp80 even on x86.  Adjust the test conditions
accordingly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
