### PR TITLE
[5.0] KeyPath: Allow existing context descriptors to be used as generic environment.

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1305,17 +1305,10 @@ void IRGenModule::emitSILProperty(SILProperty *prop) {
                        {},
                        hasSubscriptIndices);
   
-  auto size = fields.getNextOffsetFromGlobal();
-  
   auto var = cast<llvm::GlobalVariable>(
     getAddrOfPropertyDescriptor(prop->getDecl(),
                                 fields.finishAndCreateFuture()));
   var->setConstant(true);
   var->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-  // A simple stored component descriptor can fit in four bytes. Anything else
-  // needs pointer alignment.
-  if (size <= Size(4))
-    var->setAlignment(4);
-  else
-    var->setAlignment(getPointerAlignment().getValue());
+  var->setAlignment(4);
 }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -96,9 +96,17 @@ internal func _getTypeByMangledNameUntrusted(
   -> Any.Type?
 
 @_silgen_name("swift_getTypeByMangledNameInEnvironment")
-internal func _getTypeByMangledName(
+public func _getTypeByMangledNameInEnvironment(
   _ name: UnsafePointer<UInt8>,
   _ nameLength: UInt,
   genericEnvironment: UnsafeRawPointer?,
+  genericArguments: UnsafeRawPointer?)
+  -> Any.Type?
+
+@_silgen_name("swift_getTypeByMangledNameInContext")
+public func _getTypeByMangledNameInContext(
+  _ name: UnsafePointer<UInt8>,
+  _ nameLength: UInt,
+  genericContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type?


### PR DESCRIPTION
If a key path literal appears in a generic context with an existing context descriptor, this will allow us to
save some code size by not having to emit a separate GenericEnvironment descriptor. rdar://problem/46633593

This is an additive ABI change. It is not necessary for convergence.