### PR TITLE
[5.0] Don't duplicate basic blocks ending in dynamic_method_br

### DIFF
--- a/lib/SIL/LoopInfo.cpp
+++ b/lib/SIL/LoopInfo.cpp
@@ -98,6 +98,9 @@ bool SILLoop::canDuplicate(SILInstruction *I) const {
   if (isa<BeginAccessInst>(I))
     return false;
 
+  if (isa<DynamicMethodBranchInst>(I))
+    return false;
+
   assert(I->isTriviallyDuplicatable() &&
     "Code here must match isTriviallyDuplicatable in SILInstruction");
   return true;

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1182,6 +1182,11 @@ bool SILInstruction::isTriviallyDuplicatable() const {
   if (isa<BeginApplyInst>(this))
     return false;
 
+  // dynamic_method_br is not duplicatable because IRGen does not support phi
+  // nodes of objc_method type.
+  if (isa<DynamicMethodBranchInst>(this))
+    return false;
+
   // If you add more cases here, you should also update SILLoop:canDuplicate.
 
   return true;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4046,6 +4046,13 @@ public:
     require(!(isa<MethodInst>(branchArg) &&
               cast<MethodInst>(branchArg)->getMember().isForeign),
         "branch argument cannot be a witness_method or an objc method_inst");
+    require(!(branchArg->getType().is<SILFunctionType>() &&
+              branchArg->getType()
+                      .castTo<SILFunctionType>()
+                      ->getExtInfo()
+                      .getRepresentation() ==
+                  SILFunctionTypeRepresentation::ObjCMethod),
+            "branch argument cannot be a objective-c method");
     return branchArg->getType() == bbArg->getType();
   }
 

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -3147,3 +3147,46 @@ bb6:
   %rv = tuple ()
   return %rv : $()
 }
+
+class X {
+  @objc func f() { }
+}
+
+sil @external_g : $@convention(thin) () -> ()
+
+// Don't tail duplicate dynamic_method_br. IRGen cannot handle phi nodes of
+// objc_methods.
+// CHECK-LABEL: sil @dont_tail_duplicate_dynamic_method_br
+// CHECK: dynamic_method_br
+// CHECK-NOT: dynamic_method_br
+// CHECK: return
+sil @dont_tail_duplicate_dynamic_method_br : $@convention(thin) (@owned Builtin.UnknownObject, Builtin.Int1) -> () {
+bb0(%x : $Builtin.UnknownObject, %b : $Builtin.Int1):
+  cond_br %b, bb1, bb2
+
+bb1:
+  %f = function_ref @external_f : $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) () -> ()
+  strong_retain %x : $Builtin.UnknownObject
+  br bb3(%x : $Builtin.UnknownObject)
+
+bb2:
+  %g = function_ref @external_g : $@convention(thin) () -> ()
+  apply %g() : $@convention(thin) () -> ()
+  strong_retain %x : $Builtin.UnknownObject
+  br bb3(%x : $Builtin.UnknownObject)
+
+bb3(%y: $Builtin.UnknownObject):
+  strong_release %y : $Builtin.UnknownObject
+  dynamic_method_br %x : $Builtin.UnknownObject, #X.f!1.foreign, bb4, bb5
+
+bb4(%m : $@convention(objc_method) (Builtin.UnknownObject) -> ()):
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %r = tuple()
+  return %r : $()
+}


### PR DESCRIPTION
IRGen does not support objc methods thunks.

* No ABI impact
* Fixes a compiler crash

rdar://46531828