### PR TITLE
[test] Tweak Driver/subcommands.swift not to actually run anything

### DIFF
--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -1,32 +1,25 @@
 // Check that 'swift' and 'swift repl' invoke the REPL.
-//
-// REQUIRES: swift_interpreter
-//
+
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir/usr/bin
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t.dir/usr/bin/swift)
 
 // RUN: %t.dir/usr/bin/swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
 // RUN: %t.dir/usr/bin/swift repl -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
-//
+
 // CHECK-SWIFT-INVOKES-REPL: {{.*}}/swift -frontend -repl
 
 
-// Check that 'swift -', 'swift t.swift', and 'swift /path/to/file' invoke the interpreter
-// (for shebang line use). We have to run these since we can't get the driver to
-// dump what it is doing and test the argv[1] processing.
-//
 // RUN: %empty-directory(%t.dir)
 // RUN: %empty-directory(%t.dir/subpath)
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/stdin
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/t.swift
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/subpath/build
-// RUN: cd %t.dir && %swift_driver_plain - < %t.dir/stdin -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-STDIN-INVOKES-INTERPRETER %s
-// CHECK-SWIFT-STDIN-INVOKES-INTERPRETER: exec: <stdin>
-// RUN: cd %t.dir && %swift_driver_plain t.swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-SUFFIX-INVOKES-INTERPRETER %s
-// CHECK-SWIFT-SUFFIX-INVOKES-INTERPRETER: exec: t.swift
-// RUN: cd %t.dir && %swift_driver_plain subpath/build -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-PATH-INVOKES-INTERPRETER %s
-// CHECK-SWIFT-PATH-INVOKES-INTERPRETER: exec: subpath/build
+// RUN: cd %t.dir && %swift_driver_plain -### - < %t.dir/stdin 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-INTERPRETER %s
+// RUN: cd %t.dir && %swift_driver_plain -### t.swift 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-INTERPRETER %s
+// RUN: cd %t.dir && %swift_driver_plain -### subpath/build 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-INTERPRETER %s
+
+// CHECK-SWIFT-INVOKES-INTERPRETER: {{.*}}/swift -frontend -interpret
 
 
 // Check that 'swift foo' invokes 'swift-foo'.


### PR DESCRIPTION
Whoever touched this test last didn't know the rule for arguments passed to the interpreter: if they're after the file to interpret, they're treated as arguments to the script rather than the compiler.