### PR TITLE
add SILDeclRef modifier for autodiff functions

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -316,6 +316,14 @@ struct SILAutoDiffIndices {
                [&s](unsigned p) { s << p; }, [&s]{ s << ' '; });
     s << "))";
   }
+
+  std::string mangle() const {
+    std::string result = "src_" + llvm::utostr(source) + "_wrt_";
+    interleave(parameters.set_bits(),
+               [&](unsigned idx) { result += llvm::utostr(idx); },
+               [&] { result += '_'; });
+    return result;
+  }
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -483,6 +483,9 @@ ERROR(expected_sil_value_ownership_kind,none,
       "expected value ownership kind in SIL code", ())
 ERROR(expected_sil_colon,none,
       "expected ':' before %0", (StringRef))
+// SWIFT_ENABLE_TENSORFLOW
+ERROR(malformed_autodiff_parameter_indices,none,
+      "malformed autodiff parameter indices", ())
 
 // SIL Values
 ERROR(sil_value_redefinition,none,

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -343,6 +343,23 @@ void SILDeclRef::print(raw_ostream &OS) const {
 
   if (isDirectReference)
     OS << ((isDot || uncurryLevel != 0) ? '.' : '!')  << "direct";
+
+  // SWIFT_ENABLE_TENSORFLOW
+  if (autoDiffAssociatedFunctionIdentifier) {
+    auto *autoDiffFuncId = autoDiffAssociatedFunctionIdentifier;
+    OS << ((isDot || uncurryLevel != 0 || isForeign || isDirectReference)
+               ? '.' : '!');
+    switch (autoDiffFuncId->getKind()) {
+    case AutoDiffAssociatedFunctionKind::JVP:
+      OS << "jvp.";
+      break;
+    case AutoDiffAssociatedFunctionKind::VJP:
+      OS << "vjp.";
+      break;
+    }
+    OS << autoDiffFuncId->getDifferentiationOrder() << "."
+       << autoDiffFuncId->getParameterIndices()->getString();
+  }
 }
 
 void SILDeclRef::dump() const {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -170,6 +170,18 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
     addSymbol(SILDeclRef(AFD).asForeign());
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  // The AutoDiff pass creates an order-1 VJP for every function with a
+  // @differentiable attribute.
+  if (auto *DA = AFD->getAttrs().getAttribute<DifferentiableAttr>()) {
+    auto *id = AutoDiffAssociatedFunctionIdentifier::get(
+        AutoDiffAssociatedFunctionKind::VJP,
+        /*differentiationOrder*/ 1,
+        DA->getCheckedParameterIndices(),
+        AFD->getASTContext());
+    addSymbol(SILDeclRef(AFD).asAutoDiffAssociatedFunction(id));
+  }
+
   auto publicDefaultArgGenerators = SwiftModule->isTestingEnabled();
   if (!publicDefaultArgGenerators)
     return;

--- a/test/AutoDiff/sildeclref_parse.sil
+++ b/test/AutoDiff/sildeclref_parse.sil
@@ -1,0 +1,30 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=sildeclref_parse | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=sildeclref_parse | %FileCheck %s
+
+import Swift
+
+protocol Proto {
+  @differentiable(reverse)
+  func f(_ x: Float, _ y: Float) -> Float
+}
+
+// CHECK-LABEL: sil hidden @generic
+sil hidden @generic : $@convention(thin) <T where T : Proto> (@in T) -> () {
+bb0(%0 : $*T):
+  // CHECK: witness_method $T, #Proto.f!1
+  %1 = witness_method $T, #Proto.f!1 : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Proto.f!1.jvp.1.SSS
+  %2 = witness_method $T, #Proto.f!1.jvp.1.SSS : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Proto.f!1.jvp.1.UUS
+  %3 = witness_method $T, #Proto.f!1.jvp.1.UUS : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Proto.f!1.vjp.1.SSS
+  %4 = witness_method $T, #Proto.f!1.vjp.1.SSS : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Proto.f!1.vjp.1.UUS
+  %5 = witness_method $T, #Proto.f!1.vjp.1.UUS : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  %6 = tuple ()
+  return %6 : $()
+}

--- a/test/AutoDiff/tbdgen.swift
+++ b/test/AutoDiff/tbdgen.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -enable-testing
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -enable-testing -O
+
+// TODO: These tests are disabled because the primal value struct makes the TBDGen be different before/after SILGen.
+// UN: %empty-directory(%t)
+// UN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// UN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// UN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
+@differentiable(reverse) public func publicDiffable(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: (.0)) public func publicDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+
+@differentiable(reverse) internal func internalDiffable(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: (.0)) internal func internalDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+
+@differentiable(reverse) private func privateDiffable(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: (.0)) private func privateDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -33,13 +33,3 @@ private func privateWithDefault(_: Int = 0) {}
 
 @_silgen_name("silgen_internalNoArgs") internal func internalNoArgsSilgenNameDecl()
 @_silgen_name("silgen_internalSomeArgs") internal func internalSomeArgsSilgenNameDecl(_: Int, x: Int)
-
-// SWIFT_ENABLE_TENSORFLOW
-@differentiable(reverse) public func publicDiffable(_ x: Float, _ y: Float) -> Float { return x }
-@differentiable(reverse, wrt: (.0)) public func publicDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
-
-@differentiable(reverse) internal func internalDiffable(_ x: Float, _ y: Float) -> Float { return x }
-@differentiable(reverse, wrt: (.0)) internal func internalDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
-
-@differentiable(reverse) private func privateDiffable(_ x: Float, _ y: Float) -> Float { return x }
-@differentiable(reverse, wrt: (.0)) private func privateDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -36,10 +36,10 @@ private func privateWithDefault(_: Int = 0) {}
 
 // SWIFT_ENABLE_TENSORFLOW
 @differentiable(reverse) public func publicDiffable(_ x: Float, _ y: Float) -> Float { return x }
-@differentiable(reverse, wrt: .0) public func publicDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: (.0)) public func publicDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
 
 @differentiable(reverse) internal func internalDiffable(_ x: Float, _ y: Float) -> Float { return x }
-@differentiable(reverse, wrt: .0) internal func internalDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: (.0)) internal func internalDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
 
 @differentiable(reverse) private func privateDiffable(_ x: Float, _ y: Float) -> Float { return x }
-@differentiable(reverse, wrt: .0) private func privateDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: (.0)) private func privateDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -33,3 +33,13 @@ private func privateWithDefault(_: Int = 0) {}
 
 @_silgen_name("silgen_internalNoArgs") internal func internalNoArgsSilgenNameDecl()
 @_silgen_name("silgen_internalSomeArgs") internal func internalSomeArgsSilgenNameDecl(_: Int, x: Int)
+
+// SWIFT_ENABLE_TENSORFLOW
+@differentiable(reverse) public func publicDiffable(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: .0) public func publicDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+
+@differentiable(reverse) internal func internalDiffable(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: .0) internal func internalDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }
+
+@differentiable(reverse) private func privateDiffable(_ x: Float, _ y: Float) -> Float { return x }
+@differentiable(reverse, wrt: .0) private func privateDiffableWRT(_ x: Float, _ y: Float) -> Float { return x }


### PR DESCRIPTION
Adds a new field to SILDeclRef that modifies it to refer to an autodiff function that is associated with the original one. Adds printing/parsing for it. Uses the SILDeclRef to TBDGen a public symbol that the AD pass creates.

I want to remove the "autodiff" witness table entries and replace them with normal method witness table entries that use this SILDeclRef, but I will do that in a subsequent PR.

@slavapestov, @rjmccall: This is based on some discussion that I had with @rjmccall on Friday. There's a difference: I made a new field that "modifies" the meaning of the rest of the SILDeclRef, rather than a new kind of SILDeclRef. After having played with it a bit, it seems most natural to do it this way. (It's sort of a derivation path idea, I think?) I will probably merge this quite quickly to unblock some autodiff stuff that we are working on, but we can continue the discussion and I'll eventually come back and modify things to whatever we eventually come up with.