### PR TITLE
Fix two crash-on-invalid involving extensions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1761,6 +1761,8 @@ public:
     return getValidationState() > ValidationState::CheckingWithValidSignature;
   }
 
+  void createGenericParamsIfMissing(NominalTypeDecl *nominal);
+
   bool hasDefaultAccessLevel() const {
     return Bits.ExtensionDecl.DefaultAndMaxAccessLevel != 0;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1422,13 +1422,10 @@ public:
                        Requirements.back().getSourceRange().End);
   }
 
-  /// Retrieve the depth of this generic parameter list.
-  unsigned getDepth() const {
-    unsigned depth = 0;
-    for (auto gp = getOuterParameters(); gp; gp = gp->getOuterParameters())
-      ++depth;
-    return depth;
-  }
+  unsigned getDepth() const;
+
+  /// Configure the depth of the generic parameters in this list.
+  void configureGenericParamDepth();
 
   /// Create a copy of the generic parameter list and all of its generic
   /// parameter declarations. The copied generic parameters are re-parented

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1056,6 +1056,113 @@ AccessLevel ExtensionDecl::getMaxAccessLevel() const {
     {AccessLevel::Private, AccessLevel::Private}).second;
 }
 
+/// Clone the given generic parameters in the given list. We don't need any
+/// of the requirements, because they will be inferred.
+static GenericParamList *cloneGenericParams(ASTContext &ctx,
+                                            DeclContext *dc,
+                                            GenericParamList *fromParams) {
+  // Clone generic parameters.
+  SmallVector<GenericTypeParamDecl *, 2> toGenericParams;
+  for (auto fromGP : *fromParams) {
+    // Create the new generic parameter.
+    auto toGP = new (ctx) GenericTypeParamDecl(dc, fromGP->getName(),
+                                               SourceLoc(),
+                                               fromGP->getDepth(),
+                                               fromGP->getIndex());
+    toGP->setImplicit(true);
+
+    // Record new generic parameter.
+    toGenericParams.push_back(toGP);
+  }
+
+  auto toParams = GenericParamList::create(ctx, SourceLoc(), toGenericParams,
+                                           SourceLoc());
+
+  auto outerParams = fromParams->getOuterParameters();
+  if (outerParams != nullptr)
+    outerParams = cloneGenericParams(ctx, dc, outerParams);
+  toParams->setOuterParameters(outerParams);
+
+  return toParams;
+}
+
+/// Ensure that the outer generic parameters of the given generic
+/// context have been configured.
+static void configureOuterGenericParams(const GenericContext *dc) {
+  auto genericParams = dc->getGenericParams();
+
+  // If we already configured the outer parameters, we're done.
+  if (genericParams && genericParams->getOuterParameters())
+    return;
+
+  DeclContext *outerDC = dc->getParent();
+  while (!outerDC->isModuleScopeContext()) {
+    if (auto outerDecl = outerDC->getAsDecl()) {
+      if (auto outerGenericDC = outerDecl->getAsGenericContext()) {
+        if (genericParams)
+          genericParams->setOuterParameters(outerGenericDC->getGenericParams());
+
+        configureOuterGenericParams(outerGenericDC);
+        return;
+      }
+    }
+
+    outerDC = outerDC->getParent();
+  }
+}
+
+void ExtensionDecl::createGenericParamsIfMissing(NominalTypeDecl *nominal) {
+  if (getGenericParams())
+    return;
+
+  // Hack to force generic parameter lists of protocols to be created if the
+  // nominal is an (invalid) nested type of a protocol.
+  DeclContext *outerDC = nominal;
+  while (!outerDC->isModuleScopeContext()) {
+    if (auto *proto = dyn_cast<ProtocolDecl>(outerDC))
+      proto->createGenericParamsIfMissing();
+
+    outerDC = outerDC->getParent();
+  }
+
+  configureOuterGenericParams(nominal);
+
+  if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
+    // For a protocol extension, build the generic parameter list directly
+    // since we want it to have an inheritance clause.
+    setGenericParams(proto->createGenericParams(this));
+  } else if (auto genericParams = nominal->getGenericParamsOfContext()) {
+    // Clone the generic parameter list of a generic type.
+    setGenericParams(
+        cloneGenericParams(getASTContext(), this, genericParams));
+  }
+
+  // Set the depth of every generic parameter.
+  auto *genericParams = getGenericParams();
+  for (auto *outerParams = genericParams;
+       outerParams != nullptr;
+       outerParams = outerParams->getOuterParameters())
+    outerParams->configureGenericParamDepth();
+
+  // If we have a trailing where clause, deal with it now.
+  // For now, trailing where clauses are only permitted on protocol extensions.
+  if (auto trailingWhereClause = getTrailingWhereClause()) {
+    if (genericParams) {
+      // Merge the trailing where clause into the generic parameter list.
+      // FIXME: Long-term, we'd like clients to deal with the trailing where
+      // clause explicitly, but for now it's far more direct to represent
+      // the trailing where clause as part of the requirements.
+      genericParams->addTrailingWhereClause(
+        getASTContext(),
+        trailingWhereClause->getWhereLoc(),
+        trailingWhereClause->getRequirements());
+    }
+
+    // If there's no generic parameter list, the where clause is diagnosed
+    // in typeCheckDecl().
+  }
+}
+
 PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        SourceLoc VarLoc,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -687,6 +687,21 @@ void GenericParamList::addTrailingWhereClause(
   Requirements = newRequirements;
 }
 
+unsigned GenericParamList::getDepth() const {
+  unsigned depth = 0;
+  for (auto gpList = getOuterParameters();
+       gpList != nullptr;
+       gpList = gpList->getOuterParameters())
+    ++depth;
+  return depth;
+}
+
+void GenericParamList::configureGenericParamDepth() {
+  unsigned depth = getDepth();
+  for (auto param : *this)
+    param->setDepth(depth);
+}
+
 TrailingWhereClause::TrailingWhereClause(
                        SourceLoc whereLoc,
                        ArrayRef<RequirementRepr> requirements)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2963,6 +2963,17 @@ public:
         if (enumDecl->hasRawType())
           checkEnumRawValues(TC, enumDecl);
       }
+
+      // Only generic and protocol types are permitted to have
+      // trailing where clauses.
+      if (auto trailingWhereClause = ED->getTrailingWhereClause()) {
+        if (!ED->getGenericParams() &&
+            !ED->isInvalid()) {
+          ED->diagnose(diag::extension_nongeneric_trailing_where,
+                       nominal->getFullName())
+          .highlight(trailingWhereClause->getSourceRange());
+        }
+      }
     }
 
     if (auto genericParams = ED->getGenericParams())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4554,17 +4554,6 @@ static Type formExtensionInterfaceType(TypeChecker &tc, ExtensionDecl *ext,
   return resultType;
 }
 
-/// Visit the given generic parameter lists from the outermost to the innermost,
-/// calling the visitor function for each list.
-static void visitOuterToInner(
-                      GenericParamList *genericParams,
-                      llvm::function_ref<void(GenericParamList *)> visitor) {
-  if (auto outerGenericParams = genericParams->getOuterParameters())
-    visitOuterToInner(outerGenericParams, visitor);
-
-  visitor(genericParams);
-}
-
 /// Check the generic parameters of an extension, recursively handling all of
 /// the parameter lists within the extension.
 static std::pair<GenericEnvironment *, Type>
@@ -4577,12 +4566,6 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   Type extInterfaceType =
     formExtensionInterfaceType(tc, ext, type, genericParams,
                                mustInferRequirements);
-
-  // Prepare all of the generic parameter lists for generic signature
-  // validation.
-  visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
-    tc.prepareGenericParamList(gpList, ext);
-  });
 
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](GenericSignatureBuilder &builder) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4481,6 +4481,9 @@ static Type formExtensionInterfaceType(TypeChecker &tc, ExtensionDecl *ext,
                                        Type type,
                                        GenericParamList *genericParams,
                                        bool &mustInferRequirements) {
+  if (type->is<ErrorType>())
+    return type;
+
   // Find the nominal type declaration and its parent type.
   Type parentType;
   GenericTypeDecl *genericDecl;
@@ -4602,30 +4605,22 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   return { env, extInterfaceType };
 }
 
-void TypeChecker::validateExtension(ExtensionDecl *ext) {
-  // If we're currently validating, or have already validated this extension,
-  // there's nothing more to do now.
-  if (ext->hasValidationStarted())
-    return;
-
-  DeclValidationRAII IBV(ext);
-
-  auto dc = ext->getDeclContext();
-
+static void validateExtendedType(ExtensionDecl *ext, TypeChecker &tc) {
   // If we didn't parse a type, fill in an error type and bail out.
   if (!ext->getExtendedTypeLoc().getTypeRepr()) {
     ext->setInvalid();
-    ext->getExtendedTypeLoc().setInvalidType(Context);
+    ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;
   }
 
   // Validate the extended type.
   TypeResolutionOptions options(TypeResolverContext::ExtensionBinding);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
-  if (validateType(ext->getExtendedTypeLoc(),
-                   TypeResolution::forInterface(dc), options)) {
+  if (tc.validateType(ext->getExtendedTypeLoc(),
+                      TypeResolution::forInterface(ext->getDeclContext()),
+                      options)) {
     ext->setInvalid();
-    ext->getExtendedTypeLoc().setInvalidType(Context);
+    ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;
   }
 
@@ -4646,38 +4641,47 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
 
   // Cannot extend a metatype.
   if (extendedType->is<AnyMetatypeType>()) {
-    diagnose(ext->getLoc(), diag::extension_metatype, extendedType)
+    tc.diagnose(ext->getLoc(), diag::extension_metatype, extendedType)
       .highlight(ext->getExtendedTypeLoc().getSourceRange());
     ext->setInvalid();
-    ext->getExtendedTypeLoc().setInvalidType(Context);
+    ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;
   }
 
   // Cannot extend a bound generic type.
   if (extendedType->isSpecialized()) {
-    diagnose(ext->getLoc(), diag::extension_specialization,
+    tc.diagnose(ext->getLoc(), diag::extension_specialization,
              extendedType->getAnyNominal()->getName())
       .highlight(ext->getExtendedTypeLoc().getSourceRange());
     ext->setInvalid();
-    ext->getExtendedTypeLoc().setInvalidType(Context);
+    ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;
   }
-
-  auto *nominal = extendedType->getAnyNominal();
 
   // Cannot extend function types, tuple types, etc.
-  if (nominal == nullptr) {
-    diagnose(ext->getLoc(), diag::non_nominal_extension, extendedType)
+  if (!extendedType->getAnyNominal()) {
+    tc.diagnose(ext->getLoc(), diag::non_nominal_extension, extendedType)
       .highlight(ext->getExtendedTypeLoc().getSourceRange());
     ext->setInvalid();
-    ext->getExtendedTypeLoc().setInvalidType(Context);
+    ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;
   }
+}
+
+void TypeChecker::validateExtension(ExtensionDecl *ext) {
+  // If we're currently validating, or have already validated this extension,
+  // there's nothing more to do now.
+  if (ext->hasValidationStarted())
+    return;
+
+  DeclValidationRAII IBV(ext);
+
+  validateExtendedType(ext, *this);
 
   // Extensions nested inside other declarations are invalid and we
   // do not bind them.
-  if (!isa<SourceFile>(dc))
-    return;
+  if (!isa<SourceFile>(ext->getDeclContext()))
+     return;
 
   // If this is not bound to any decls at this point, this extension is in
   // inactive coditional compilation block. It's not safe to typecheck this
@@ -4686,26 +4690,25 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   if (!ext->alreadyBoundToNominal())
     return;
 
-  // Validate the nominal type declaration being extended.
-  validateDecl(nominal);
+  if (auto *nominal = ext->getExtendedNominal()) {
+    // Validate the nominal type declaration being extended.
+    validateDecl(nominal);
 
-  if (nominal->getGenericParamsOfContext()) {
-    auto genericParams = ext->getGenericParams();
-    assert(genericParams && "bindExtensionDecl didn't set generic params?");
+    if (nominal->getGenericParamsOfContext()) {
+      auto genericParams = ext->getGenericParams();
+      assert(genericParams && "bindExtensionDecl didn't set generic params?");
 
-    // Check generic parameters.
-    GenericEnvironment *env;
-    std::tie(env, extendedType) = checkExtensionGenericParams(
-        *this, ext, ext->getExtendedType(),
-        genericParams);
+      // Check generic parameters.
+      GenericEnvironment *env;
+      Type extendedType = ext->getExtendedType();
+      std::tie(env, extendedType) = checkExtensionGenericParams(
+          *this, ext, extendedType,
+          genericParams);
 
-    ext->getExtendedTypeLoc().setType(extendedType);
-    ext->setGenericEnvironment(env);
-    return;
+      ext->getExtendedTypeLoc().setType(extendedType);
+      ext->setGenericEnvironment(env);
+    }
   }
-
-  assert(extendedType->is<NominalType>());
-  assert(!nominal->isGenericContext());
 }
 
 /// Build a default initializer string for the given pattern.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -502,11 +502,13 @@ static void checkInheritanceClause(
 /// Check the inheritance clauses generic parameters along with any
 /// requirements stored within the generic parameter list.
 static void checkGenericParams(GenericParamList *genericParams,
-                               DeclContext *owningDC) {
+                               DeclContext *owningDC,
+                               TypeChecker &tc) {
   if (!genericParams)
     return;
 
   for (auto gp : *genericParams) {
+    tc.checkDeclAttributesEarly(gp);
     checkInheritanceClause(gp);
   }
 
@@ -645,7 +647,7 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
 
   for (unsigned i = 0, e = nestedList.size(); i < e; i++) {
     auto genericParams = nestedList.rbegin()[i];
-    prepareGenericParamList(genericParams, DC);
+    genericParams->configureGenericParamDepth();
 
     parentEnv = checkGenericEnvironment(genericParams, DC, parentSig,
                                         /*allowConcreteGenericParams=*/true,
@@ -2379,7 +2381,7 @@ public:
 
     if (!SD->isInvalid()) {
       TC.checkReferencedGenericParams(SD);
-      checkGenericParams(SD->getGenericParams(), SD);
+      checkGenericParams(SD->getGenericParams(), SD, TC);
       TC.checkProtocolSelfRequirements(SD);
     }
 
@@ -2488,7 +2490,7 @@ public:
 
     checkUnsupportedNestedType(ED);
     TC.validateDecl(ED);
-    checkGenericParams(ED->getGenericParams(), ED);
+    checkGenericParams(ED->getGenericParams(), ED, TC);
 
     {
       // Check for circular inheritance of the raw type.
@@ -2525,7 +2527,7 @@ public:
     checkUnsupportedNestedType(SD);
 
     TC.validateDecl(SD);
-    checkGenericParams(SD->getGenericParams(), SD);
+    checkGenericParams(SD->getGenericParams(), SD, TC);
 
     TC.addImplicitConstructors(SD);
 
@@ -2653,7 +2655,7 @@ public:
 
     TC.validateDecl(CD);
     TC.requestSuperclassLayout(CD);
-    checkGenericParams(CD->getGenericParams(), CD);
+    checkGenericParams(CD->getGenericParams(), CD, TC);
 
     {
       // Check for circular inheritance.
@@ -2898,7 +2900,7 @@ public:
     TC.validateDecl(FD);
 
     if (!FD->isInvalid()) {
-      checkGenericParams(FD->getGenericParams(), FD);
+      checkGenericParams(FD->getGenericParams(), FD, TC);
       TC.checkReferencedGenericParams(FD);
       TC.checkProtocolSelfRequirements(FD);
     }
@@ -2976,8 +2978,7 @@ public:
       }
     }
 
-    if (auto genericParams = ED->getGenericParams())
-      checkGenericParams(genericParams, ED);
+    checkGenericParams(ED->getGenericParams(), ED, TC);
 
     validateAttributes(TC, ED);
 
@@ -3025,7 +3026,7 @@ public:
     TC.validateDecl(CD);
 
     if (!CD->isInvalid()) {
-      checkGenericParams(CD->getGenericParams(), CD);
+      checkGenericParams(CD->getGenericParams(), CD, TC);
       TC.checkReferencedGenericParams(CD);
       TC.checkProtocolSelfRequirements(CD);
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -144,14 +144,6 @@ TypeChecker::gatherGenericParamBindingsText(
   return result.str().str();
 }
 
-void
-TypeChecker::prepareGenericParamList(GenericParamList *gp,
-                                     DeclContext *dc) {
-  gp->configureGenericParamDepth();
-  for (auto paramDecl : *gp)
-    checkDeclAttributesEarly(paramDecl);
-}
-
 /// Add the generic parameter types from the given list to the vector.
 static void addGenericParamTypes(GenericParamList *gpList,
                                  SmallVectorImpl<GenericTypeParamType *> &params) {
@@ -472,7 +464,7 @@ computeGenericFuncSignature(TypeChecker &tc, AbstractFunctionDecl *func) {
   // Do some initial configuration of the generic parameter lists that's
   // required in all cases.
   gp->setOuterParameters(dc->getGenericParamsOfContext());
-  tc.prepareGenericParamList(gp, func);
+  gp->configureGenericParamDepth();
 
   // Accessors can always use the generic context of their storage
   // declarations.  This is a compile-time optimization since it lets us
@@ -608,7 +600,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
   GenericSignature *sig;
   if (auto *gp = subscript->getGenericParams()) {
     gp->setOuterParameters(dc->getGenericParamsOfContext());
-    prepareGenericParamList(gp, subscript);
+    gp->configureGenericParamDepth();
 
     // Create the generic signature builder.
     GenericSignatureBuilder builder(Context);
@@ -775,8 +767,7 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
   }
 
   gp->setOuterParameters(dc->getGenericParamsOfContext());
-
-  prepareGenericParamList(gp, typeDecl);
+  gp->configureGenericParamDepth();
 
   // For a protocol, compute the requirement signature first. It will be used
   // by clients of the protocol.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -147,11 +147,9 @@ TypeChecker::gatherGenericParamBindingsText(
 void
 TypeChecker::prepareGenericParamList(GenericParamList *gp,
                                      DeclContext *dc) {
-  unsigned depth = gp->getDepth();
-  for (auto paramDecl : *gp) {
+  gp->configureGenericParamDepth();
+  for (auto paramDecl : *gp)
     checkDeclAttributesEarly(paramDecl);
-    paramDecl->setDepth(depth);
-  }
 }
 
 /// Add the generic parameter types from the given list to the vector.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -348,14 +348,7 @@ static void bindExtensionToNominal(ExtensionDecl *ext,
   // If we have a trailing where clause, deal with it now.
   // For now, trailing where clauses are only permitted on protocol extensions.
   if (auto trailingWhereClause = ext->getTrailingWhereClause()) {
-    if (!genericParams) {
-      // Only generic and protocol types are permitted to have
-      // trailing where clauses.
-      ext->diagnose(diag::extension_nongeneric_trailing_where,
-                    nominal->getFullName())
-        .highlight(trailingWhereClause->getSourceRange());
-      ext->setTrailingWhereClause(nullptr);
-    } else {
+    if (genericParams) {
       // Merge the trailing where clause into the generic parameter list.
       // FIXME: Long-term, we'd like clients to deal with the trailing where
       // clause explicitly, but for now it's far more direct to represent
@@ -365,6 +358,9 @@ static void bindExtensionToNominal(ExtensionDecl *ext,
         trailingWhereClause->getWhereLoc(),
         trailingWhereClause->getRequirements());
     }
+
+    // If there's no generic parameter list, the where clause is diagnosed
+    // in typeCheckDecl().
   }
 
   nominal->addExtension(ext);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -255,114 +255,13 @@ Type TypeChecker::lookupBoolType(const DeclContext *dc) {
   return *boolType;
 }
 
-/// Clone the given generic parameters in the given list. We don't need any
-/// of the requirements, because they will be inferred.
-static GenericParamList *cloneGenericParams(ASTContext &ctx,
-                                            DeclContext *dc,
-                                            GenericParamList *fromParams) {
-  // Clone generic parameters.
-  SmallVector<GenericTypeParamDecl *, 2> toGenericParams;
-  for (auto fromGP : *fromParams) {
-    // Create the new generic parameter.
-    auto toGP = new (ctx) GenericTypeParamDecl(dc, fromGP->getName(),
-                                               SourceLoc(),
-                                               fromGP->getDepth(),
-                                               fromGP->getIndex());
-    toGP->setImplicit(true);
-
-    // Record new generic parameter.
-    toGenericParams.push_back(toGP);
-  }
-
-  auto toParams = GenericParamList::create(ctx, SourceLoc(), toGenericParams,
-                                           SourceLoc());
-
-  auto outerParams = fromParams->getOuterParameters();
-  if (outerParams != nullptr)
-    outerParams = cloneGenericParams(ctx, dc, outerParams);
-  toParams->setOuterParameters(outerParams);
-
-  return toParams;
-}
-
-/// Ensure that the outer generic parameters of the given generic
-/// context have been configured.
-static void configureOuterGenericParams(const GenericContext *dc) {
-  auto genericParams = dc->getGenericParams();
-
-  // If we already configured the outer parameters, we're done.
-  if (genericParams && genericParams->getOuterParameters())
-    return;
-
-  DeclContext *outerDC = dc->getParent();
-  while (!outerDC->isModuleScopeContext()) {
-    if (auto outerDecl = outerDC->getAsDecl()) {
-      if (auto outerGenericDC = outerDecl->getAsGenericContext()) {
-        if (genericParams)
-          genericParams->setOuterParameters(outerGenericDC->getGenericParams());
-
-        configureOuterGenericParams(outerGenericDC);
-        return;
-      }
-    }
-
-    outerDC = outerDC->getParent();
-  }
-}
-
 /// Bind the given extension to the given nominal type.
 static void bindExtensionToNominal(ExtensionDecl *ext,
                                    NominalTypeDecl *nominal) {
   if (ext->alreadyBoundToNominal())
     return;
 
-  // Hack to force generic parameter lists of protocols to be created if the
-  // nominal is an (invalid) nested type of a protocol.
-  DeclContext *outerDC = nominal;
-  while (!outerDC->isModuleScopeContext()) {
-    if (auto *proto = dyn_cast<ProtocolDecl>(outerDC))
-      proto->createGenericParamsIfMissing();
-
-    outerDC = outerDC->getParent();
-  }
-
-  configureOuterGenericParams(nominal);
-
-  if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
-    // For a protocol extension, build the generic parameter list directly
-    // since we want it to have an inheritance clause.
-    ext->setGenericParams(proto->createGenericParams(ext));
-  } else if (auto genericParams = nominal->getGenericParamsOfContext()) {
-    // Clone the generic parameter list of a generic type.
-    ext->setGenericParams(
-        cloneGenericParams(ext->getASTContext(), ext, genericParams));
-  }
-
-  // Set the depth of every generic parameter.
-  auto *genericParams = ext->getGenericParams();
-  for (auto *outerParams = genericParams;
-       outerParams != nullptr;
-       outerParams = outerParams->getOuterParameters())
-    outerParams->configureGenericParamDepth();
-
-  // If we have a trailing where clause, deal with it now.
-  // For now, trailing where clauses are only permitted on protocol extensions.
-  if (auto trailingWhereClause = ext->getTrailingWhereClause()) {
-    if (genericParams) {
-      // Merge the trailing where clause into the generic parameter list.
-      // FIXME: Long-term, we'd like clients to deal with the trailing where
-      // clause explicitly, but for now it's far more direct to represent
-      // the trailing where clause as part of the requirements.
-      genericParams->addTrailingWhereClause(
-        ext->getASTContext(),
-        trailingWhereClause->getWhereLoc(),
-        trailingWhereClause->getRequirements());
-    }
-
-    // If there's no generic parameter list, the where clause is diagnosed
-    // in typeCheckDecl().
-  }
-
+  ext->createGenericParamsIfMissing(nominal);
   nominal->addExtension(ext);
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1129,10 +1129,6 @@ public:
   /// Infer default value witnesses for all requirements in the given protocol.
   void inferDefaultWitnesses(ProtocolDecl *proto);
 
-  /// Perform semantic checks on the given generic parameter list.
-  void prepareGenericParamList(GenericParamList *genericParams,
-                               DeclContext *dc);
-
   /// Compute the generic signature, generic environment and interface type
   /// of a generic function.
   void validateGenericFuncSignature(AbstractFunctionDecl *func);

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -18,7 +18,15 @@ extension Double : P2 {
   typealias AssocType = Double
 }
 
-extension X<Int, Double, String> { } // expected-error{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
+extension X<Int, Double, String> {
+// expected-error@-1{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
+  let x = 0
+  // expected-error@-1 {{extensions must not contain stored properties}}
+  static let x = 0
+  // expected-error@-1 {{static stored properties not supported in generic types}}
+  func f() -> Int {}
+  class C<T> {}
+}
 
 typealias GGG = X<Int, Double, String>
 

--- a/validation-test/compiler_crashers_2_fixed/0185-sr9017.swift
+++ b/validation-test/compiler_crashers_2_fixed/0185-sr9017.swift
@@ -1,0 +1,8 @@
+// RUN: not %target-swift-frontend -emit-ir %s
+
+public final class Action<Input, Error: Swift.Error> {
+
+extension Action {
+
+public enum ActionError<Error: Swift.Error>: Swift.Error {
+  case disabled


### PR DESCRIPTION
A perennial problem with the declaration checker is that we have it bail out early or skip some checks entirely on an invalid declaration, which means the invalid declaration does not satisfy all the invariants we expect. Later on, we type check something else that references the invalid declaration, and crash because of the broken invariant.

This PR fixes some issues with extensions:

- If an extension's extended declaration was resolved (getExtendedNominal()) but the extended type has a problem (getExtendedType()), we did not build the extension's generic signature. This means that DeclContext::isGenericContext() could return true (because the extension had a generic parameter list) but DeclContext::getGenericSignatureOfContext() could return null (because we skipped building the signature). This was rdar://problem/46604393.

- If an extension was (incorrectly) nested inside of another declaration, which can happen if a user accidentally omits a closing brace for instance, we skipped binding the extension altogether, because binding only walks top-level declarations when looking for extensions. So the extension did not get a generic parameter list. However we still would set the extension's extended type to a generic type, which again caused problems. This was https://bugs.swift.org/browse/SR-9017.

The total line change in this PR is a tad big, but to make it easier to review, look at the patches separately. All of them are small, except for the second-to-last one which moves code from Sema to AST without actually changing it.