### PR TITLE
Sort overloads in suggestPotentialOverloads()

### DIFF
--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -933,8 +933,7 @@ operator=(const CalleeCandidateInfo &CCI) {
 /// arguments, emit a diagnostic indicating any partially matching overloads.
 void CalleeCandidateInfo::
 suggestPotentialOverloads(SourceLoc loc, bool isResult) {
-  std::string suggestionText = "";
-  std::set<std::string> dupes;
+  std::set<std::string> sorted;
   
   // FIXME2: For (T,T) & (Self, Self), emit this as two candidates, one using
   // the LHS and one using the RHS type for T's.
@@ -947,18 +946,20 @@ suggestPotentialOverloads(SourceLoc loc, bool isResult) {
     // If we've already seen this (e.g. decls overridden on the result type),
     // ignore this one.
     auto name = isResult ? type->getString() : getTypeListString(type);
-    if (!dupes.insert(name).second)
-      continue;
-    
+    sorted.insert(name);
+  }
+
+  if (sorted.empty())
+    return;
+
+  std::string suggestionText = "";
+  for (auto name : sorted) {
     if (!suggestionText.empty())
       suggestionText += ", ";
     suggestionText += name;
   }
-  
-  if (suggestionText.empty())
-    return;
-  
-  if (dupes.size() == 1) {
+
+  if (sorted.size() == 1) {
     CS.TC.diagnose(loc, diag::suggest_expected_match, isResult, suggestionText);
   } else {
     CS.TC.diagnose(loc, diag::suggest_partial_overloads, isResult, declName,

--- a/test/ClangImporter/objc_diags.swift
+++ b/test/ClangImporter/objc_diags.swift
@@ -4,5 +4,5 @@ import ObjectiveC
 
 func instanceMethod(_ b: B) {
   b.method(1, 2.5) // expected-error {{argument labels '(_:, _:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'method' exist with these partially matching parameter lists: (Int32, with: Float), (Int32, withFloat: Float), (Int32, onExtB: Double), (Int32, with: Double), (Int32, withDouble: Double), (Int32, onExtA: Double), (Int32, onCat1: Double)}}
+  // expected-note @-1 {{overloads for 'method' exist with these partially matching parameter lists: (Int32, onCat1: Double), (Int32, onExtA: Double), (Int32, onExtB: Double), (Int32, with: Double), (Int32, with: Float), (Int32, withDouble: Double), (Int32, withFloat: Float)}}
 }

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -24,7 +24,7 @@ func testInstanceTypeFactoryMethodInherited() {
   _ = NSObjectFactorySub(double: 314159)
   _ = NSObjectFactorySub(float: 314159) // expected-error{{incorrect argument label in call (have 'float:', expected 'integer:')}}
   let a = NSObjectFactorySub(buildingWidgets: ()) // expected-error{{argument labels '(buildingWidgets:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'NSObjectFactorySub' exist with these partially matching parameter lists: (integer: Int), (double: Double)}}
+  // expected-note @-1 {{overloads for 'NSObjectFactorySub' exist with these partially matching parameter lists: (double: Double), (integer: Int)}}
   _ = a
 }
 
@@ -77,7 +77,7 @@ func testNSErrorFactoryMethod(_ path: String) throws {
 
 func testNonInstanceTypeFactoryMethod(_ s: String) {
   _ = NSObjectFactory(string: s) // expected-error{{argument labels '(string:)' do not match any available overloads}}
-  // expected-note @-1 {{(integer: Int), (double: Double), (float: Float)}}
+  // expected-note @-1 {{(double: Double), (float: Float), (integer: Int)}}
 }
 
 func testUseOfFactoryMethod(_ queen: Bee) {

--- a/test/ClangImporter/objc_implicit_with.swift
+++ b/test/ClangImporter/objc_implicit_with.swift
@@ -35,7 +35,7 @@ func testInstanceTypeFactoryMethodInherited() {
   _ = NSObjectFactorySub(double: 314159)
   _ = NSObjectFactorySub(float: 314159) // expected-error{{incorrect argument label in call (have 'float:', expected 'integer:')}}
   let a = NSObjectFactorySub(buildingWidgets: ()) // expected-error{{argument labels '(buildingWidgets:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'NSObjectFactorySub' exist with these partially matching parameter lists: (integer: Int), (double: Double)}}
+  // expected-note @-1 {{overloads for 'NSObjectFactorySub' exist with these partially matching parameter lists: (double: Double), (integer: Int)}}
   _ = a
 }
 
@@ -45,7 +45,7 @@ func testNSErrorFactoryMethod(_ path: String) throws {
 
 func testNonInstanceTypeFactoryMethod(_ s: String) {
   _ = NSObjectFactory(string: s) // expected-error{{argument labels '(string:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'NSObjectFactory' exist with these partially matching parameter lists: (integer: Int), (double: Double), (float: Float)}}
+  // expected-note @-1 {{overloads for 'NSObjectFactory' exist with these partially matching parameter lists: (double: Double), (float: Float), (integer: Int)}}
 }
 
 func testUseOfFactoryMethod(_ queen: Bee) {

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -269,7 +269,7 @@ func rdar19831698() {
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
   var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[Any]'}}
-  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Array<Element>, Array<Element>), (Self, Other), (Other, Self)}}
+  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Array<Element>, Array<Element>), (Other, Self), (Self, Other)}}
   var v75 = true + "str" // expected-error {{binary operator '+' cannot be applied to operands of type 'Bool' and 'String'}} expected-note {{expected an argument list of type '(String, String)'}}
 }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -356,7 +356,7 @@ func f19997471(_ x: Int) {}
 func someGeneric19997471<T>(_ x: T) {
   takeVoidVoidFn {
     f19997471(x) // expected-error {{cannot invoke 'f19997471' with an argument list of type '(T)'}}
-    // expected-note @-1 {{overloads for 'f19997471' exist with these partially matching parameter lists: (String), (Int)}}
+    // expected-note @-1 {{overloads for 'f19997471' exist with these partially matching parameter lists: (Int), (String)}}
   }
 }
 
@@ -747,7 +747,7 @@ takesTwoInOut { _ in } // expected-error {{contextual closure type '(Int, inout 
 func f20371273() {
   let x: [Int] = [1, 2, 3, 4]
   let y: UInt = 4
-  _ = x.filter { ($0 + y)  > 42 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (UInt, UInt), (Int, Int)}}
+  _ = x.filter { ($0 + y)  > 42 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UInt, UInt)}}
 }
 
 // rdar://problem/42337247

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -94,10 +94,10 @@ _ = b as! Derived
 Int(i) // expected-warning{{unused}}
 _ = i as Int
 Z(z) // expected-error{{cannot invoke initializer for type 'Z' with an argument list of type '(Z)'}}
-// expected-note @-1 {{overloads for 'Z' exist with these partially matching parameter lists: (UnicodeScalar), (String)}}
+// expected-note @-1 {{overloads for 'Z' exist with these partially matching parameter lists: (String), (UnicodeScalar)}}
 
 Z.init(z)  // expected-error {{cannot invoke 'Z.Type.init' with an argument list of type '(Z)'}}
-// expected-note @-1 {{overloads for 'Z.Type.init' exist with these partially matching parameter lists: (UnicodeScalar), (String)}}
+// expected-note @-1 {{overloads for 'Z.Type.init' exist with these partially matching parameter lists: (String), (UnicodeScalar)}}
 
 
 _ = z as Z

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -659,7 +659,7 @@ example21890157.property = "confusing"  // expected-error {{value of optional ty
 struct UnaryOp {}
 
 _ = -UnaryOp() // expected-error {{unary operator '-' cannot be applied to an operand of type 'UnaryOp'}}
-// expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists: (Float), (Double)}}
+// expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists: (Double), (Float), (Float80)}}
 
 
 // <rdar://problem/23433271> Swift compiler segfault in failure diagnosis
@@ -708,10 +708,10 @@ if AssocTest.one(1) == AssocTest.one(1) {} // expected-error{{binary operator '=
 func r24251022() {
   var a = 1
   var b: UInt32 = 2
-  _ = a + b // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (UInt32, UInt32), (Int, Int)}}
+  _ = a + b // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UInt32, UInt32)}}
   a += a + // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+' exist with these partially matching parameter lists:}}
     b
-  a += b  // expected-error {{binary operator '+=' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+=' exist with these partially matching parameter lists: (inout UInt32, UInt32), (inout Int, Int)}}
+  a += b  // expected-error {{binary operator '+=' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+=' exist with these partially matching parameter lists: (inout Int, Int), (inout UInt32, UInt32)}}
 }
 
 func overloadSetResultType(_ a : Int, b : Int) -> Int {
@@ -1005,15 +1005,15 @@ func SR_6272_d() {
   let x: Float = 1.0
 
   // expected-error@+2 {{binary operator '+' cannot be applied to operands of type 'SR_6272_D' and 'Float'}} {{none}}
-  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (SR_6272_D, Int), (Float, Float)}}
+  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (Float, Float), (SR_6272_D, Int)}}
   let _: Float = SR_6272_D(integerLiteral: 42) + x
 
   // expected-error@+2 {{binary operator '+' cannot be applied to operands of type 'SR_6272_D' and 'Double'}} {{none}}
-  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (SR_6272_D, Int), (Double, Double)}}
+  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (Double, Double), (SR_6272_D, Int)}}
   let _: Float = SR_6272_D(integerLiteral: 42) + 42.0
 
   // expected-error@+2 {{binary operator '+' cannot be applied to operands of type 'SR_6272_D' and 'Float'}} {{none}}
-  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (SR_6272_D, Int), (Float, Float)}}
+  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (Float, Float), (SR_6272_D, Int)}}
   let _: Float = SR_6272_D(integerLiteral: 42) + x + 1.0
 }
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -131,7 +131,7 @@ func overloaded_identity(_ b : Float) -> Float {}
 
 func test_contextual_result_1() {
   return overloaded_identity()  // expected-error {{cannot invoke 'overloaded_identity' with no arguments}}
-  // expected-note @-1 {{overloads for 'overloaded_identity' exist with these partially matching parameter lists: (Int), (Float)}}
+  // expected-note @-1 {{overloads for 'overloaded_identity' exist with these partially matching parameter lists: (Float), (Int)}}
 }
 
 func test_contextual_result_2() {

--- a/test/Constraints/super_constructor.swift
+++ b/test/Constraints/super_constructor.swift
@@ -21,7 +21,7 @@ class D : B {
 
   init(g:Int) {
     super.init("aoeu") // expected-error{{argument labels '(_:)' do not match any available overloads}}
-    // expected-note @-1 {{overloads for 'B.init' exist with these partially matching parameter lists: (x: Int), (a: UnicodeScalar), (b: UnicodeScalar), (z: Float)}}
+    // expected-note @-1 {{overloads for 'B.init' exist with these partially matching parameter lists: (a: UnicodeScalar), (b: UnicodeScalar), (x: Int), (z: Float)}}
   }
 
   init(h:Int) {

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -153,7 +153,7 @@ func gcd_23700031<T>(_ a: T, b: T) {
   var a = a
   var b = b
   (a, b) = (b, a % b)  // expected-error {{binary operator '%' cannot be applied to two 'T' operands}}
-  // expected-note @-1 {{overloads for '%' exist with these partially matching parameter lists: (UInt8, UInt8), (Int8, Int8), (UInt16, UInt16), (Int16, Int16), (UInt32, UInt32), (Int32, Int32), (UInt64, UInt64), (Int64, Int64), (UInt, UInt), (Int, Int)}}
+  // expected-note @-1 {{overloads for '%' exist with these partially matching parameter lists: (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
 }
 
 // <rdar://problem/24210190>

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -68,7 +68,7 @@ class Z0 {
     // expected-note @+2 {{delegation occurs here}}
 
     self.init(5, 5) // expected-error{{cannot invoke 'Z0.init' with an argument list of type '(Int, Int)'}}
-    // expected-note @-1 {{overloads for 'Z0.init' exist with these partially matching parameter lists: (), (value: Int), (value: Double)}}
+    // expected-note @-1 {{overloads for 'Z0.init' exist with these partially matching parameter lists: (), (value: Double), (value: Int)}}
   }
 
   init(value: Int) { /* ... */ }
@@ -78,7 +78,7 @@ class Z0 {
 struct Z1 {
   init() {
     self.init(5, 5) // expected-error{{cannot invoke 'Z1.init' with an argument list of type '(Int, Int)'}}
-  // expected-note @-1 {{overloads for 'Z1.init' exist with these partially matching parameter lists: (), (value: Int), (value: Double)}}
+  // expected-note @-1 {{overloads for 'Z1.init' exist with these partially matching parameter lists: (), (value: Double), (value: Int)}}
   }
 
   init(value: Int) { /* ... */ }
@@ -91,7 +91,7 @@ enum Z2 {
 
   init() {
     self.init(5, 5) // expected-error{{cannot invoke 'Z2.init' with an argument list of type '(Int, Int)'}}
-    // expected-note @-1 {{overloads for 'Z2.init' exist with these partially matching parameter lists: (), (value: Int), (value: Double)}}
+    // expected-note @-1 {{overloads for 'Z2.init' exist with these partially matching parameter lists: (), (value: Double), (value: Int)}}
   }
 
   init(value: Int) { /* ... */ }
@@ -314,12 +314,12 @@ func foo<T: C>(_ x: T, y: T.Type) where T: P {
 class TestOverloadSets {
   convenience init() {
     self.init(5, 5) // expected-error{{cannot invoke 'TestOverloadSets.init' with an argument list of type '(Int, Int)'}}
-    // expected-note @-1 {{overloads for 'TestOverloadSets.init' exist with these partially matching parameter lists: (), (a: Z0), (value: Int), (value: Double)}}
+    // expected-note @-1 {{overloads for 'TestOverloadSets.init' exist with these partially matching parameter lists: (), (a: Z0), (value: Double), (value: Int)}}
   }
   
   convenience init(a : Z0) {
     self.init(42 as Int8) // expected-error{{argument labels '(_:)' do not match any available overloads}}
-    // expected-note @-1 {{overloads for 'TestOverloadSets.init' exist with these partially matching parameter lists: (a: Z0), (value: Int), (value: Double)}}
+    // expected-note @-1 {{overloads for 'TestOverloadSets.init' exist with these partially matching parameter lists: (a: Z0), (value: Double), (value: Int)}}
   }
   
   init(value: Int) { /* ... */ }

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -104,11 +104,11 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeRawBufferPointer(start: rp, count: 1)
   _ = UnsafeMutableRawBufferPointer(mrbp)
   _ = UnsafeRawBufferPointer(mrbp)
-  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeRawBufferPointer)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
+  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeRawBufferPointer)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableBufferPointer<T>), (UnsafeMutableRawBufferPointer)}}
   _ = UnsafeRawBufferPointer(rbp)
   _ = UnsafeMutableRawBufferPointer(mbpi)
   _ = UnsafeRawBufferPointer(mbpi)
-  _ = UnsafeMutableRawBufferPointer(bpi) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeBufferPointer<Int>)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
+  _ = UnsafeMutableRawBufferPointer(bpi) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeBufferPointer<Int>)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableBufferPointer<T>), (UnsafeMutableRawBufferPointer)}}
   _ = UnsafeRawBufferPointer(bpi)
   _ = UnsafeMutableRawBufferPointer(start: omrp, count: 1)
   _ = UnsafeRawBufferPointer(start: omrp, count: 1)

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -20,7 +20,7 @@ var d4 : () -> Int = { d2 }  // expected-error{{function produces expected type 
 
 var e0 : [Int]
 e0[] // expected-error {{cannot subscript a value of type '[Int]' with an index of type '()'}}
-  // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: (Int), (Range<Int>),}}
+  // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: ((UnboundedRange_) -> ()), (Int), (R), (Range<Int>), (Range<Self.Index>)}}
 
 var f0 : [Float]
 var f1 : [(Int,Int)]

--- a/validation-test/compiler_crashers_2_fixed/0146-rdar38309176.swift
+++ b/validation-test/compiler_crashers_2_fixed/0146-rdar38309176.swift
@@ -5,5 +5,5 @@ func foo(_ msg: Double) {}
 
 func rdar38309176(_ errors: inout [String]) {
   foo("error: \(errors[0])") // expected-error {{cannot invoke 'foo' with an argument list of type '(String)'}}
-  // expected-note@-1 {{overloads for 'foo' exist with these partially matching parameter lists: (Int), (Double)}}
+  // expected-note@-1 {{overloads for 'foo' exist with these partially matching parameter lists: (Double), (Int)}}
 }

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -36,7 +36,7 @@ func test_truncatingBitPatternAPIIsStableAcrossPlatforms() {
   _ = UInt16(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   _ = UInt32(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   UInt64(truncatingBitPattern: UInt(0)) // expected-error {{incorrect argument label in call (have 'truncatingBitPattern:', expected '_truncatingBits:')}}
-  UInt(truncatingBitPattern: UInt(0)) // expected-error {{cannot invoke initializer for type 'UInt' with an argument list of type '(truncatingBitPattern: UInt)'}} expected-note {{overloads for 'UInt' exist with these partially matching parameter lists: (truncatingBitPattern: UInt64), (truncatingBitPattern: Int64)}}
+  UInt(truncatingBitPattern: UInt(0)) // expected-error {{cannot invoke initializer for type 'UInt' with an argument list of type '(truncatingBitPattern: UInt)'}} expected-note {{overloads for 'UInt' exist with these partially matching parameter lists: (truncatingBitPattern: Int64), (truncatingBitPattern: UInt64)}}
 
   _ = Int8(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   _ = Int16(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}


### PR DESCRIPTION
When the compiler fails to find an overload with suitable parameter or return types, it often attaches a note listing the available overloads so that users can find the one they meant to use. The overloads are currently ordered in a way that depends on the order they were declared, so swift-evolve would sometimes cause tests involving these diagnostics to fail.

This change emits the list in a textually-sorted order instead. The names were already being sorted as they were inserted into a std::set, so this shouldn’t significantly slow down the diagnostic.