### PR TITLE
Adopt bulk Dictionary creation in bridging

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSDictionary.swift
+++ b/stdlib/public/Darwin/Foundation/NSDictionary.swift
@@ -61,6 +61,140 @@ extension Dictionary : _ObjectiveCBridgeable {
                          to: NSDictionary.self)
   }
 
+  /***
+  Precondition: `buffer` points to a region of memory bound to `AnyObject`,
+    with a capacity large enough to fit at least `index`+1 elements of type `T`
+  
+  _bridgeInitialize rebinds the `index`th `T` of `buffer` to `T`,
+    and initializes it to `value`
+
+  Note: *not* the `index`th element of `buffer`, since T and AnyObject may be
+  different sizes. e.g. if T is String (2 words) then given a buffer like so:
+
+  [object:AnyObject, object:AnyObject, uninitialized, uninitialized]
+
+  `_bridgeInitialize(1, of: buffer, to: buffer[1] as! T)` will leave it as:
+
+  [object:AnyObject, object:AnyObject, string:String]
+
+  and `_bridgeInitialize(0, of: buffer, to: buffer[0] as! T)` will then leave:
+
+  [string:String, string:String]
+
+  Doing this in reverse order as shown above is required if T and AnyObject are
+  different sizes. Here's what we get if instead of 1, 0 we did 0, 1:
+
+  [object:AnyObject, object:AnyObject, uninitialized, uninitialized]
+  [string:String, uninitialized, uninitialized]
+  <segfault trying to treat the second word of 'string' as an AnyObject>
+
+  Note: if you have retained any of the objects in `buffer`, you must release
+  them separately, _bridgeInitialize will overwrite them without releasing them
+  */
+  @inline(__always)
+  private static func _bridgeInitialize<T>(index:Int,
+    of buffer: UnsafePointer<AnyObject>, to value: T) {
+    let typedBase = UnsafeMutableRawPointer(mutating:
+                      buffer).assumingMemoryBound(to: T.self)
+    let rawTarget = UnsafeMutableRawPointer(mutating: typedBase + index)
+    rawTarget.initializeMemory(as: T.self, repeating: value, count: 1)
+  }
+
+  @inline(__always)
+  private static func _verbatimForceBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) {
+    //doesn't have to iterate in reverse because sizeof(T) == sizeof(AnyObject)
+    for i in 0..<count {
+      _bridgeInitialize(index: i, of: buffer, to: buffer[i] as! T)
+    }
+  }
+
+  @inline(__always)
+  private static func _verbatimBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to type: T.Type
+  ) -> Int {
+    var numUninitialized = count
+    while numUninitialized > 0 {
+      guard let bridged = buffer[numUninitialized - 1] as? T else {
+        return numUninitialized
+      }
+      numUninitialized -= 1
+      _bridgeInitialize(index: numUninitialized, of: buffer, to: bridged)
+    }
+    return numUninitialized
+  }
+
+  @inline(__always)
+  private static func _nonVerbatimForceBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) {
+    for i in (0..<count).reversed() {
+      let bridged = Swift._forceBridgeFromObjectiveC(buffer[i], T.self)
+      _bridgeInitialize(index: i, of: buffer, to: bridged)
+    }
+  }
+  
+  @inline(__always)
+  private static func _nonVerbatimBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) -> Int {
+    var numUninitialized = count
+    while numUninitialized > 0 {
+      guard let bridged = Swift._conditionallyBridgeFromObjectiveC(
+        buffer[numUninitialized - 1], T.self)
+        else {
+        return numUninitialized
+      }
+      numUninitialized -= 1
+      _bridgeInitialize(index: numUninitialized, of: buffer, to: bridged)
+    }
+    return numUninitialized
+  }
+
+  @inline(__always)
+  private static func _forceBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) {
+    if _isBridgedVerbatimToObjectiveC(T.self) {
+      _verbatimForceBridge(buffer, count: count, to: T.self)
+    } else {
+      _nonVerbatimForceBridge(buffer, count: count, to: T.self)
+    }
+  }
+  
+  @inline(__always)
+  private static func _conditionallyBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) -> Bool {
+    let numUninitialized:Int
+    if _isBridgedVerbatimToObjectiveC(T.self) {
+      numUninitialized = _verbatimBridge(buffer, count: count, to: T.self)
+    } else {
+      numUninitialized = _nonVerbatimBridge(buffer, count: count, to: T.self)
+    }
+    if numUninitialized == 0 {
+      return true
+    }
+    let numInitialized = count - numUninitialized
+    (UnsafeMutableRawPointer(mutating: buffer).assumingMemoryBound(to:
+      T.self) + numUninitialized).deinitialize(count: numInitialized)
+    return false
+  }
+
+  @_specialize(where Key == String, Value == Any)
   public static func _forceBridgeFromObjectiveC(
     _ d: NSDictionary,
     result: inout Dictionary?
@@ -73,53 +207,120 @@ extension Dictionary : _ObjectiveCBridgeable {
 
     if _isBridgedVerbatimToObjectiveC(Key.self) &&
        _isBridgedVerbatimToObjectiveC(Value.self) {
+      //Lazily type-checked on access
       result = [Key : Value](_cocoaDictionary: d)
       return
     }
 
-    if Key.self == String.self {
+    let keyStride = MemoryLayout<Key>.stride
+    let valueStride = MemoryLayout<Value>.stride
+    let objectStride = MemoryLayout<AnyObject>.stride
+
+    //If Key or Value are smaller than AnyObject, a Dictionary with N elements
+    //doesn't have large enough backing stores to hold the objects to be bridged
+    //For now we just handle that case the slow way.
+    if keyStride < objectStride || valueStride < objectStride {
+      var builder = _DictionaryBuilder<Key, Value>(count: d.count)
+      d.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
+        let anyObjectKey = anyKey as AnyObject
+        let anyObjectValue = anyValue as AnyObject
+        builder.add(
+            key: Swift._forceBridgeFromObjectiveC(anyObjectKey, Key.self),
+            value: Swift._forceBridgeFromObjectiveC(anyObjectValue, Value.self))
+      })
+      result = builder.take()
+    } else {
+      defer { _fixLifetime(d) }
+    
+      let numElems = d.count
+      
       // String and NSString have different concepts of equality, so
       // string-keyed NSDictionaries may generate key collisions when bridged
       // over to Swift. See rdar://problem/35995647
-      var dict = Dictionary(minimumCapacity: d.count)
-      d.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
-        let key = Swift._forceBridgeFromObjectiveC(
-          anyKey as AnyObject, Key.self)
-        let value = Swift._forceBridgeFromObjectiveC(
-          anyValue as AnyObject, Value.self)
-        // FIXME: Log a warning if `dict` already had a value for `key`
-        dict[key] = value
-      })
-      result = dict
-      return
+      let handleDuplicates = (Key.self == String.self)
+      
+      result = Dictionary(_unsafeUninitializedCapacity: numElems,
+        allowingDuplicates: handleDuplicates) { (keys, vals, outCount) in
+        
+        let objectKeys = UnsafeMutableRawPointer(mutating:
+          keys.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+        let objectVals = UnsafeMutableRawPointer(mutating:
+          vals.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+
+        //This initializes the first N AnyObjects of the Dictionary buffers.
+        //Any unused buffer space is left uninitialized
+        //This is fixed up in-place as we bridge elements, by _bridgeInitialize
+        __NSDictionaryGetObjects(d, objectVals, objectKeys, numElems)
+
+        _forceBridge(objectKeys, count: numElems, to: Key.self)
+        _forceBridge(objectVals, count: numElems, to: Value.self)
+        
+        outCount = numElems
+      }
     }
-
-    // `Dictionary<Key, Value>` where either `Key` or `Value` is a value type
-    // may not be backed by an NSDictionary.
-    var builder = _DictionaryBuilder<Key, Value>(count: d.count)
-    d.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
-      let anyObjectKey = anyKey as AnyObject
-      let anyObjectValue = anyValue as AnyObject
-      builder.add(
-          key: Swift._forceBridgeFromObjectiveC(anyObjectKey, Key.self),
-          value: Swift._forceBridgeFromObjectiveC(anyObjectValue, Value.self))
-    })
-    result = builder.take()
   }
-
+  
+  @_specialize(where Key == String, Value == Any)
   public static func _conditionallyBridgeFromObjectiveC(
     _ x: NSDictionary,
     result: inout Dictionary?
   ) -> Bool {
-    let anyDict = x as [NSObject : AnyObject]
-    if _isBridgedVerbatimToObjectiveC(Key.self) &&
-       _isBridgedVerbatimToObjectiveC(Value.self) {
-      result = Swift._dictionaryDownCastConditional(anyDict)
+
+    if let native = [Key : Value]._bridgeFromObjectiveCAdoptingNativeStorageOf(
+        x as AnyObject) {
+      result = native
+      return true
+    }
+
+    let keyStride = MemoryLayout<Key>.stride
+    let valueStride = MemoryLayout<Value>.stride
+    let objectStride = MemoryLayout<AnyObject>.stride
+
+    //If Key or Value are smaller than AnyObject, a Dictionary with N elements
+    //doesn't have large enough backing stores to hold the objects to be bridged
+    //For now we just handle that case the slow way.
+    if keyStride < objectStride || valueStride < objectStride {
+      result = x as [NSObject : AnyObject] as? Dictionary
       return result != nil
     }
 
-    result = anyDict as? Dictionary
-    return result != nil
+    defer { _fixLifetime(x) }
+    
+    let numElems = x.count
+    var success = true
+    
+    // String and NSString have different concepts of equality, so
+    // string-keyed NSDictionaries may generate key collisions when bridged
+    // over to Swift. See rdar://problem/35995647
+    let handleDuplicates = (Key.self == String.self)
+    
+    let tmpResult = Dictionary(_unsafeUninitializedCapacity: numElems,
+      allowingDuplicates: handleDuplicates) { (keys, vals, outCount) in
+      
+      let objectKeys = UnsafeMutableRawPointer(mutating:
+        keys.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+      let objectVals = UnsafeMutableRawPointer(mutating:
+        vals.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+
+      //This initializes the first N AnyObjects of the Dictionary buffers.
+      //Any unused buffer space is left uninitialized
+      //This is fixed up in-place as we bridge elements, by _bridgeInitialize
+      __NSDictionaryGetObjects(x, objectVals, objectKeys, numElems)
+
+      success = _conditionallyBridge(objectKeys, count: numElems, to: Key.self)
+      if success {
+        success = _conditionallyBridge(objectVals,
+                                       count: numElems, to: Value.self)
+        if !success {
+          (UnsafeMutableRawPointer(mutating: objectKeys).assumingMemoryBound(to:
+            Key.self)).deinitialize(count: numElems)
+        }
+      }
+      outCount = success ? numElems : 0
+    }
+    
+    result = success ? tmpResult : nil
+    return success
   }
 
   @_effects(readonly)

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -42,3 +42,85 @@ struct _DictionaryBuilder<Key: Hashable, Value> {
     return Dictionary(_native: _target)
   }
 }
+
+extension Dictionary {
+  /// Creates a new dictionary with the specified capacity, then calls the given
+  /// closure to initialize its contents.
+  ///
+  /// Foundation uses this initializer to bridge the contents of an NSDictionary
+  /// instance without allocating a pair of intermediary buffers.  Pass the
+  /// required capacity and a closure that can intialize the dictionary's
+  /// elements. The closure must return `c`, the number of initialized elements
+  /// in both buffers, such that the elements in the range `0..<c` are
+  /// initialized and the elements in the range `c..<capacity` are
+  /// uninitialized. The resulting dictionary has a `count` equal to `c`.
+  ///
+  /// The closure must not add any duplicate keys to the keys buffer.  The
+  /// buffers passed to the closure are only valid for the duration of the call.
+  /// After the closure returns, this initializer moves all initialized elements
+  /// into their correct buckets.
+  ///
+  /// - Parameters:
+  ///   - capacity: The capacity of the new dictionary.
+  ///   - body: A closure that can initialize the dictionary's elements. This
+  ///     closure must return the count of the initialized elements, starting at
+  ///     the beginning of the buffer.
+  @inlinable
+  public // SPI(Foundation)
+  init(
+    _unsafeUninitializedCapacity capacity: Int,
+    initializingWith initializer: (
+      _ keys: UnsafeMutableBufferPointer<Key>,
+      _ values: UnsafeMutableBufferPointer<Value>,
+      _ initializedCount: inout Int
+    ) -> Void
+  ) {
+    let native = _NativeDictionary<Key, Value>(capacity: capacity)
+    let keys = UnsafeMutableBufferPointer<Key>(
+      start: native._keys,
+      count: capacity)
+    let values = UnsafeMutableBufferPointer<Value>(
+      start: native._values,
+      count: capacity)
+    var count = 0
+    initializer(keys, values, &count)
+    _precondition(count >= 0 && count <= capacity)
+
+    // Hash elements into the correct buckets.
+    var bucket = _HashTable.Bucket(offset: 0)
+    while bucket.offset < count {
+      if native.hashTable._isOccupied(bucket) {
+        // We've moved an element here in a previous iteration.
+        bucket.offset += 1
+        continue
+      }
+      let hashValue = native.hashValue(for: native._keys[bucket.offset])
+      let target: _HashTable.Bucket
+      if _isDebugAssertConfiguration() {
+        let (b, found) = native.find(
+          native._keys[bucket.offset],
+          hashValue: hashValue)
+        guard !found else {
+          _preconditionFailure("Duplicate keys found")
+        }
+        native.hashTable.insert(b)
+        target = b
+      } else {
+        target = native.hashTable.insertNew(hashValue: hashValue)
+      }
+      if target < bucket || target.offset >= count {
+        // Target bucket is uninitialized
+        native.moveEntry(from: bucket, to: target)
+        bucket.offset += 1
+      } else if target == bucket {
+        // Already in place
+        bucket.offset += 1
+      } else {
+        // Swap into place, then try again with the swapped-in value.
+        native.swapEntry(target, with: bucket)
+      }
+    }
+    native._storage._count = count
+    self = Dictionary(_native: native)
+  }
+}

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -53,15 +53,21 @@ extension Dictionary {
   /// elements. The closure must return `c`, the number of initialized elements
   /// in both buffers, such that the elements in the range `0..<c` are
   /// initialized and the elements in the range `c..<capacity` are
-  /// uninitialized. The resulting dictionary has a `count` equal to `c`.
+  /// uninitialized.
   ///
-  /// The closure must not add any duplicate keys to the keys buffer.  The
-  /// buffers passed to the closure are only valid for the duration of the call.
-  /// After the closure returns, this initializer moves all initialized elements
-  /// into their correct buckets.
+  /// The resulting dictionary has a `count` less than or equal to `c`. The
+  /// actual count is less iff some of the initialized keys were duplicates.
+  /// (This cannot happen if `allowingDuplicates` is false.)
+  ///
+  /// The buffers passed to the closure are only valid for the duration of the
+  /// call.  After the closure returns, this initializer moves all initialized
+  /// elements into their correct buckets.
   ///
   /// - Parameters:
   ///   - capacity: The capacity of the new dictionary.
+  ///   - allowingDuplicates: If false, then the caller guarantees that all keys
+  ///     are unique. This promise isn't verified -- if it turns out to be
+  ///     false, then the resulting dictionary won't be valid.
   ///   - body: A closure that can initialize the dictionary's elements. This
   ///     closure must return the count of the initialized elements, starting at
   ///     the beginning of the buffer.
@@ -108,8 +114,8 @@ extension _NativeDictionary {
     //
     // - We have some number of unprocessed elements at the start of the
     //   key/value buffers -- buckets up to and including `bucket`. Everything
-    //   this region is either unprocessed or in use. There are no uninitialized
-    //   entries in it.
+    //   in this region is either unprocessed or in use. There are no
+    //   uninitialized entries in it.
     //
     // - Everything after `bucket` is either uninitialized or in use. This
     //   region works exactly like regular dictionary storage.

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -140,10 +140,9 @@ extension _NativeDictionary {
         if found {
           _internalInvariant(b != bucket)
           _precondition(allowingDuplicates, "Duplicate keys found")
-          // Discard existing entry, then move the current entry in place of it.
-          uncheckedDestroy(at: b)
+          // Discard duplicate entry.
+          uncheckedDestroy(at: bucket)
           _storage._count -= 1
-          moveEntry(from: bucket, to: b)
           bucket.offset -= 1
           continue
         }

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -127,7 +127,6 @@ extension _HashTable {
     @inlinable
     @inline(__always)
     internal init(offset: Int) {
-      _internalInvariant(offset >= 0)
       self.offset = offset
     }
 

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -137,7 +137,7 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedDestroy(at bucket: Bucket) {
     defer { _fixLifetime(self) }
-    _internalInvariant(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isValid(bucket))
     (_keys + bucket.offset).deinitialize(count: 1)
     (_values + bucket.offset).deinitialize(count: 1)
   }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -620,10 +620,21 @@ extension _NativeDictionary: _HashTableDelegate {
   @inlinable
   @inline(__always)
   internal func moveEntry(from source: Bucket, to target: Bucket) {
+    _internalInvariant(hashTable.isValid(source))
+    _internalInvariant(hashTable.isValid(target))
     (_keys + target.offset)
       .moveInitialize(from: _keys + source.offset, count: 1)
     (_values + target.offset)
       .moveInitialize(from: _values + source.offset, count: 1)
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func swapEntry(_ left: Bucket, with right: Bucket) {
+    _internalInvariant(hashTable.isValid(left))
+    _internalInvariant(hashTable.isValid(right))
+    swap(&_keys[left.offset], &_keys[right.offset])
+    swap(&_values[left.offset], &_values[right.offset])
   }
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5739,6 +5739,7 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Nonunique") {
       },
       uniquingKeysWith: { a, b in a })
 
+    expectEqual(d1.count, d2.count)
     for i in 0 ..< c / 2 {
       expectEqual(TestEquatableValueTy(i), d1[TestKeyTy(i)])
     }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -2383,6 +2383,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.ImmutableDictionaryIsRetained
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableDictionaryIsCopied") {
+  //some bridged NSDictionary operations on non-standard NSDictionary subclasses
+  //autorelease keys and values. Make sure the leak checker isn't confused
+  autoreleasepool {
   let nsd: NSDictionary = CustomImmutableNSDictionary(_privateInit: ())
 
   CustomImmutableNSDictionary.timesCopyWithZoneWasCalled = 0
@@ -2406,6 +2409,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableDictionaryIsCopie
   _fixLifetime(nsd)
   _fixLifetime(d)
   _fixLifetime(bridgedBack)
+  }
 }
 
 
@@ -3243,9 +3247,9 @@ autoreleasepoolIfUnoptimizedReturnAutoreleased {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_ParallelArray") {
-autoreleasepoolIfUnoptimizedReturnAutoreleased {
-  // Add an autorelease pool because ParallelArrayDictionary autoreleases
-  // values in objectForKey.
+  //some bridged NSDictionary operations on non-standard NSDictionary subclasses
+  //autorelease keys and values. Make sure the leak checker isn't confused
+autoreleasepool {
 
   let d = getParallelArrayBridgedNonverbatimDictionary()
   let identity1 = d._rawIdentifier()

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5691,10 +5691,11 @@ DictionaryTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
   d.remove(at: i)
 }
 
-DictionaryTestSuite.test("BulkLoadingInitializer") {
+DictionaryTestSuite.test("BulkLoadingInitializer.Unique") {
   for c in [0, 1, 2, 3, 5, 10, 25, 150] {
     let d1 = Dictionary<TestKeyTy, TestEquatableValueTy>(
-      _unsafeUninitializedCapacity: c
+      _unsafeUninitializedCapacity: c,
+      allowingDuplicates: false
     ) { keys, values, count in
       let k = keys.baseAddress!
       let v = values.baseAddress!
@@ -5713,7 +5714,35 @@ DictionaryTestSuite.test("BulkLoadingInitializer") {
     for i in 0 ..< c {
       expectEqual(TestEquatableValueTy(i), d1[TestKeyTy(i)])
     }
-    expectEqual(d1, d2)
+    expectEqual(d2, d1)
+  }
+}
+
+DictionaryTestSuite.test("BulkLoadingInitializer.Nonunique") {
+  for c in [0, 1, 2, 3, 5, 10, 25, 150] {
+    let d1 = Dictionary<TestKeyTy, TestEquatableValueTy>(
+      _unsafeUninitializedCapacity: c,
+      allowingDuplicates: true
+    ) { keys, values, count in
+      let k = keys.baseAddress!
+      let v = values.baseAddress!
+      for i in 0 ..< c {
+        (k + i).initialize(to: TestKeyTy(i / 2))
+        (v + i).initialize(to: TestEquatableValueTy(i / 2))
+        count += 1
+      }
+    }
+
+    let d2 = Dictionary(
+      (0 ..< c).map {
+        (TestKeyTy($0 / 2), TestEquatableValueTy($0 / 2))
+      },
+      uniquingKeysWith: { a, b in a })
+
+    for i in 0 ..< c / 2 {
+      expectEqual(TestEquatableValueTy(i), d1[TestKeyTy(i)])
+    }
+    expectEqual(d2, d1)
   }
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5691,6 +5691,32 @@ DictionaryTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
   d.remove(at: i)
 }
 
+DictionaryTestSuite.test("BulkLoadingInitializer") {
+  for c in [0, 1, 2, 3, 5, 10, 25, 150] {
+    let d1 = Dictionary<TestKeyTy, TestEquatableValueTy>(
+      _unsafeUninitializedCapacity: c
+    ) { keys, values, count in
+      let k = keys.baseAddress!
+      let v = values.baseAddress!
+      for i in 0 ..< c {
+        (k + i).initialize(to: TestKeyTy(i))
+        (v + i).initialize(to: TestEquatableValueTy(i))
+        count += 1
+      }
+    }
+
+    let d2 = Dictionary(
+      uniqueKeysWithValues: (0..<c).map {
+        (TestKeyTy($0), TestEquatableValueTy($0))
+      })
+
+    for i in 0 ..< c {
+      expectEqual(TestEquatableValueTy(i), d1[TestKeyTy(i)])
+    }
+    expectEqual(d1, d2)
+  }
+}
+
 DictionaryTestSuite.setUp {
 #if _runtime(_ObjC)
   // Exercise ARC's autoreleased return value optimization in Foundation.


### PR DESCRIPTION
Karoy's new Dictionary initializer gives us access to the uninitialized backing buffers, which we can bulk-copy the contents of the NSDictionary into.