### PR TITLE
[stdlib][SR-2239] Refactor AAPCS64 variable argument list support.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -322,9 +322,19 @@ getSwiftStdlibType(const clang::TypedefNameDecl *D,
     break;
 
   case MappedCTypeKind::VaList:
-   if (ClangTypeSize != ClangCtx.getTypeSize(ClangCtx.VoidPtrTy)) {
-      if (ClangCtx.getTargetInfo().getBuiltinVaListKind() !=
-          clang::TargetInfo::AArch64ABIBuiltinVaList)
+    switch (ClangCtx.getTargetInfo().getBuiltinVaListKind()) {
+      case clang::TargetInfo::CharPtrBuiltinVaList:
+      case clang::TargetInfo::VoidPtrBuiltinVaList:
+      case clang::TargetInfo::PowerABIBuiltinVaList:
+      case clang::TargetInfo::AAPCSABIBuiltinVaList:
+        assert(ClangCtx.getTypeSize(ClangCtx.VoidPtrTy) == ClangTypeSize &&
+               "expected va_list type to be sizeof(void *)");
+        break;
+      case clang::TargetInfo::AArch64ABIBuiltinVaList:
+        break;
+      case clang::TargetInfo::PNaClABIBuiltinVaList:
+      case clang::TargetInfo::SystemZBuiltinVaList:
+      case clang::TargetInfo::X86_64ABIBuiltinVaList:
         return std::make_pair(Type(), "");
     }
     break;

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -219,15 +219,15 @@ extension UInt {
 }
 
 /// A wrapper around a C `va_list` pointer.
-#if arch(arm64) && os(Linux)
+#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 @_fixed_layout
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance
-  internal var value: (__stack: UnsafeMutablePointer<Int>?,
-                       __gr_top: UnsafeMutablePointer<Int>?,
-                       __vr_top: UnsafeMutablePointer<Int>?,
-                       __gr_off: Int32,
-                       __vr_off: Int32)
+  internal var _value: (__stack: UnsafeMutablePointer<Int>?,
+                        __gr_top: UnsafeMutablePointer<Int>?,
+                        __vr_top: UnsafeMutablePointer<Int>?,
+                        __gr_off: Int32,
+                        __vr_off: Int32)
 
   @inlinable // unsafe-performance
   public // @testable
@@ -236,7 +236,17 @@ public struct CVaListPointer {
        __vr_top: UnsafeMutablePointer<Int>?,
        __gr_off: Int32,
        __vr_off: Int32) {
-    value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
+    _value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
+  }
+}
+
+extension CVaListPointer : CustomDebugStringConvertible {
+  public var debugDescription: String {
+    return "(\(_value.__stack.debugDescription), " +
+           "\(_value.__gr_top.debugDescription), " +
+           "\(_value.__vr_top.debugDescription), " +
+           "\(_value.__gr_off), " +
+           "\(_value.__vr_off))"
   }
 }
 

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -91,7 +91,7 @@ internal let _countGPRegisters = 16
 @usableFromInline
 internal let _registerSaveWords = _countGPRegisters
 
-#elseif arch(arm64) && os(Linux)
+#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 // ARM Procedure Call Standard for aarch64. (IHI0055B)
 // The va_list type may refer to any parameter in a parameter list may be in one
 // of three memory locations depending on its type and position in the argument
@@ -408,7 +408,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
-  
+
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
   @inlinable // FIXME(sil-serialize-all)
@@ -419,7 +419,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
 }
 #endif
 
-#if arch(x86_64) || arch(s390x)
+#if arch(x86_64) || arch(s390x) || (arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows)))
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
@@ -429,6 +429,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
 @_fixed_layout
 @usableFromInline // c-abi
 final internal class __VaListBuilder {
+  #if arch(x86_64) || arch(s390x)
   @_fixed_layout // c-abi
   @usableFromInline
   internal struct Header {
@@ -445,15 +446,19 @@ final internal class __VaListBuilder {
     @usableFromInline // c-abi
     internal var reg_save_area: UnsafeMutablePointer<Int>?
   }
+  #endif
 
   @usableFromInline // c-abi
   internal var gpRegistersUsed = 0
   @usableFromInline // c-abi
   internal var fpRegistersUsed = 0
 
+  #if arch(x86_64) || arch(s390x)
   @usableFromInline // c-abi
   final  // Property must be final since it is used by Builtin.addressof.
   internal var header = Header()
+  #endif
+
   @usableFromInline // c-abi
   internal var storage: ContiguousArray<Int>
 
@@ -470,12 +475,16 @@ final internal class __VaListBuilder {
   internal func append(_ arg: CVarArg) {
     var encoded = arg._cVarArgEncoding
 
-#if arch(x86_64)
+#if arch(x86_64) || arch(arm64)
     let isDouble = arg is _CVarArgPassedAsDouble
 
     if isDouble && fpRegistersUsed < _countFPRegisters {
-      var startIndex = _countGPRegisters
-           + (fpRegistersUsed * _fpRegisterWords)
+      #if arch(arm64)
+        var startIndex = fpRegistersUsed * _fpRegisterWords
+      #else
+        var startIndex = _countGPRegisters
+             + (fpRegistersUsed * _fpRegisterWords)
+      #endif
       for w in encoded {
         storage[startIndex] = w
         startIndex += 1
@@ -485,7 +494,12 @@ final internal class __VaListBuilder {
     else if encoded.count == 1
       && !isDouble
       && gpRegistersUsed < _countGPRegisters {
-      storage[gpRegistersUsed] = encoded[0]
+      #if arch(arm64)
+        let startIndex = ( _fpRegisterWords * _countFPRegisters) + gpRegistersUsed
+      #else
+        let startIndex = gpRegistersUsed
+      #endif
+      storage[startIndex] = encoded[0]
       gpRegistersUsed += 1
     }
     else {
@@ -510,139 +524,24 @@ final internal class __VaListBuilder {
 
   @inlinable // c-abi
   internal func va_list() -> CVaListPointer {
-    header.reg_save_area = storage._baseAddress
-    header.overflow_arg_area
-      = storage._baseAddress + _registerSaveWords
-    return CVaListPointer(
-             _fromUnsafeMutablePointer: UnsafeMutableRawPointer(
-               Builtin.addressof(&self.header)))
+    #if arch(x86_64) || arch(s390x)
+      header.reg_save_area = storage._baseAddress
+      header.overflow_arg_area
+        = storage._baseAddress + _registerSaveWords
+      return CVaListPointer(
+               _fromUnsafeMutablePointer: UnsafeMutableRawPointer(
+                 Builtin.addressof(&self.header)))
+    #elseif arch(arm64)
+      let vr_top = storage._baseAddress + (_fpRegisterWords * _countFPRegisters)
+      let gr_top = vr_top + _countGPRegisters
+
+      return CVaListPointer(__stack: gr_top,
+                            __gr_top: gr_top,
+                            __vr_top: vr_top,
+                            __gr_off: -64,
+                            __vr_off: -128)
+    #endif
   }
-}
-#elseif arch(arm64) && os(Linux)
-
-// NOTE: older runtimes called this _VaListBuilder. The two must
-// coexist, so it was renamed. The old name must not be used in the new
-// runtime.
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
-final internal class __VaListBuilder {
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal init() {
-    // Prepare the register save area.
-    allocated = _registerSaveWords
-    storage = allocStorage(wordCount: allocated)
-    // Append stack arguments after register save area.
-    count = allocated
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  deinit {
-    if let allocatedStorage = storage {
-      deallocStorage(wordCount: allocated, storage: allocatedStorage)
-    }
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal func append(_ arg: CVarArg) {
-    var encoded = arg._cVarArgEncoding
-
-    if arg is _CVarArgPassedAsDouble
-      && fpRegistersUsed < _countFPRegisters {
-      var startIndex = (fpRegistersUsed * _fpRegisterWords)
-      for w in encoded {
-        storage[startIndex] = w
-        startIndex += 1
-      }
-      fpRegistersUsed += 1
-    } else if encoded.count == 1
-      && !(arg is _CVarArgPassedAsDouble)
-      && gpRegistersUsed < _countGPRegisters {
-      var startIndex = ( _fpRegisterWords * _countFPRegisters) + gpRegistersUsed
-      storage[startIndex] = encoded[0]
-      gpRegistersUsed += 1
-    } else {
-      // Arguments in stack slot.
-      appendWords(encoded)
-    }
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal func va_list() -> CVaListPointer {
-    let vr_top = storage + (_fpRegisterWords * _countFPRegisters)
-    let gr_top = vr_top + _countGPRegisters
-
-    return CVaListPointer(__stack: gr_top, __gr_top: gr_top,
-                          __vr_top: vr_top, __gr_off: -64, __vr_off: -128)
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal func appendWords(_ words: [Int]) {
-    let newCount = count + words.count
-    if newCount > allocated {
-      let oldAllocated = allocated
-      let oldStorage = storage
-      let oldCount = count
-
-      allocated = max(newCount, allocated * 2)
-      let newStorage = allocStorage(wordCount: allocated)
-      storage = newStorage
-      // Count is updated below.
-      if let allocatedOldStorage = oldStorage {
-        newStorage.moveInitialize(from: allocatedOldStorage, count: oldCount)
-        deallocStorage(wordCount: oldAllocated, storage: allocatedOldStorage)
-      }
-    }
-
-    let allocatedStorage = storage!
-    for word in words {
-      allocatedStorage[count] = word
-      count += 1
-    }
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal func rawSizeAndAlignment(
-    _ wordCount: Int
-  ) -> (Builtin.Word, Builtin.Word) {
-    return ((wordCount * MemoryLayout<Int>.stride)._builtinWordValue,
-      requiredAlignmentInBytes._builtinWordValue)
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal func allocStorage(wordCount: Int) -> UnsafeMutablePointer<Int> {
-    let (rawSize, rawAlignment) = rawSizeAndAlignment(wordCount)
-    let rawStorage = Builtin.allocRaw(rawSize, rawAlignment)
-    return UnsafeMutablePointer<Int>(rawStorage)
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal func deallocStorage(
-    wordCount: Int, storage: UnsafeMutablePointer<Int>
-  ) {
-    let (rawSize, rawAlignment) = rawSizeAndAlignment(wordCount)
-    Builtin.deallocRaw(storage._rawValue, rawSize, rawAlignment)
-  }
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal let requiredAlignmentInBytes = MemoryLayout<Double>.alignment
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal var count = 0
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal var allocated = 0
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal var storage: UnsafeMutablePointer<Int>!
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal var gpRegistersUsed = 0
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal var fpRegistersUsed = 0
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal var overflowWordsUsed = 0
 }
 
 #else


### PR DESCRIPTION
This refactoring uses large portions of the already existing code for
x86_64 and s390 to implement AAPCS64 __VaListBuilder. The parts where
each implementation differ are the x86_64 header, and the order of the
general and vector registers.

The changes also addresses many of the request from the reviewers in
 #20862 which were not addressed originally, like the reuse of the
already existing code, and the generalizations for the code to be useful
for platforms different than Linux (Android, for example).

Some of the previous reviewers concerns were not addressed. Below are my explanations.

@compnerd:

- `_fpRegisterWords` should not be `MemoryLayout<Double>.size / MemoryLayout<Int>.size`, because the size of `Double` is just 8 bytes, while the vector registers seems to be 16 bytes wide.
- About using the same indexing than x86_64 (“Should this not be offset by gpRegistersUsed like L554?”), I tried, but I couldn’t make it work. However the organization VR, then GR, and then stack seems to pass the tests, which seems pretty complete (there’s at least an example than goes beyond the 8 register limit which starts using the stack).
- I keep using literal `-64` and `-128`. If you want me to add the math is fine, but I think the real math according to the standard is confussing in this case (`MemoryLayout<Double>.size * _countFPRegisters` was also incorrect for the reason above).

@rjmccall:

- I didn’t implement the `@_va_list_kind` you were proposing, but I’m not against it. I think, however, that it is of limited utility (it will only be used here, and probably nowhere else). If you still think it is a good idea, can I implement it as a follow up?

@futurejones: I hope you don’t mind I’m modifying the code and adopting the feedback from the previous PR. The code is generally useful to more platforms than Linux, so it will be a pity not to use it. My only intention is to have a better support for all the platforms with a cleaner code.