### PR TITLE
[ConstraintSystem] Attempt global operators earlier.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1857,6 +1857,9 @@ void ConstraintSystem::partitionDisjunction(
 
   partitionForDesignatedTypes(Choices, forEachChoice, appendPartition);
 
+  // Add all the things defined at global scope.
+  appendPartition(globalScope);
+
   SmallVector<unsigned, 4> everythingElse;
   // Gather the remaining options.
   forEachChoice(Choices, [&](unsigned index, Constraint *constraint) -> bool {
@@ -1866,7 +1869,6 @@ void ConstraintSystem::partitionDisjunction(
   appendPartition(everythingElse);
 
   // Now create the remaining partitions from what we previously collected.
-  appendPartition(globalScope);
   appendPartition(unavailable);
   appendPartition(disabled);
 


### PR DESCRIPTION
When -Xfrontend -solver-enable-operator-designated-types is enabled,
attempt operators defined outside of types before attempting operators
defined within (non-designated) types.

This helps fix some source compatability problems that arise from
attempting some of the operators defined for Optional (e.g. we
would sometimes typecheck successfully with the operator for Optional
and then inject values into Optionals and skip attempting
globally defined operators that also match).

The old behavior resulted in failures in SourceKit and SIL Optimizer
tests when enabling designated types by default in our test suite.
