### PR TITLE
[stdlib][5.0] Remove Strideable ClosedRange operator

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -338,38 +338,6 @@ extension Comparable {
   }
 }
 
-extension Strideable where Stride: SignedInteger {  
-  /// Returns a countable closed range that contains both of its bounds.
-  ///
-  /// Use the closed range operator (`...`) to create a closed range of any type
-  /// that conforms to the `Strideable` protocol with an associated signed
-  /// integer `Stride` type, such as any of the standard library's integer
-  /// types. This example creates a `ClosedRange<Int>` from zero up to,
-  /// and including, nine.
-  ///
-  ///     let singleDigits = 0...9
-  ///     print(singleDigits.contains(9))
-  ///     // Prints "true"
-  ///
-  /// You can use sequence or collection methods on the `singleDigits` range.
-  ///
-  ///     print(singleDigits.count)
-  ///     // Prints "10"
-  ///     print(singleDigits.last)
-  ///     // Prints "9"
-  ///
-  /// - Parameters:)`.
-  ///   - minimum: The lower bound for the range.
-  ///   - maximum: The upper bound for the range.
-  @_transparent
-  public static func ... (minimum: Self, maximum: Self) -> ClosedRange<Self> {
-    // FIXME: swift-3-indexing-model: tests for traps.
-    _precondition(
-      minimum <= maximum, "Can't form Range with upperBound < lowerBound")
-    return ClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
-  }
-}
-
 extension ClosedRange: Equatable {
   /// Returns a Boolean value indicating whether two ranges are equal.
   ///

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -600,3 +600,5 @@ Var String.Index._utf16Index has been removed (deprecated)
 
 Func MutableCollection.withContiguousMutableStorageIfAvailable(_:) has been added as a protocol requirement
 Func Sequence.withContiguousStorageIfAvailable(_:) has been added as a protocol requirement
+
+Func Strideable....(_:_:) has been removed

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -216,3 +216,5 @@ Func Sequence.reduce(into:_:) has parameter 0 changing from Default to Owned
 
 Func MutableCollection.withContiguousMutableStorageIfAvailable(_:) has been added as a protocol requirement
 Func Sequence.withContiguousStorageIfAvailable(_:) has been added as a protocol requirement
+
+Func Strideable....(_:_:) has been removed


### PR DESCRIPTION
Cherry pick of #20665. Redundant operator missed in original conditional conformance sweep.