### PR TITLE
NFC: Simplify code by using Triple.getOSAndEnvironmentName

### DIFF
--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -226,9 +226,8 @@ static std::string adjustClangTriple(StringRef TripleStr) {
     }
     break;
   }
-  OS << '-' << Triple.getVendorName() << '-' << Triple.getOSName();
-  if (Triple.hasEnvironment())
-    OS << '-' << Triple.getEnvironmentName();
+  OS << '-' << Triple.getVendorName() << '-' <<
+      Triple.getOSAndEnvironmentName();
   OS.flush();
   return Result;
 }


### PR DESCRIPTION
This avoids the need to check if the environment component is set.