### PR TITLE
[5.0] Cherry-pick parseable interface generation improvements

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -278,7 +278,8 @@ def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the Clang module cache path">;
 
-def module_name : Separate<["-"], "module-name">, Flags<[FrontendOption, ParseableInterfaceOption]>,
+def module_name : Separate<["-"], "module-name">,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Name of the module to build">;
 def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
@@ -464,17 +465,20 @@ def Xlinker : Separate<["-"], "Xlinker">,
 
 def O_Group : OptionGroup<"<optimization level options>">;
 
-def Onone : Flag<["-"], "Onone">, Group<O_Group>, Flags<[FrontendOption]>,
+def Onone : Flag<["-"], "Onone">, Group<O_Group>,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Compile without any optimization">;
-def O : Flag<["-"], "O">, Group<O_Group>, Flags<[FrontendOption]>,
+def O : Flag<["-"], "O">, Group<O_Group>,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Compile with optimizations">;
-def Osize : Flag<["-"], "Osize">, Group<O_Group>, Flags<[FrontendOption]>,
+def Osize : Flag<["-"], "Osize">, Group<O_Group>,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Compile with optimizations and target small code size">;
 def Ounchecked : Flag<["-"], "Ounchecked">, Group<O_Group>,
-  Flags<[FrontendOption]>,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Compile with optimizations and remove runtime safety checks">;
 def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
-  Flags<[HelpHidden, FrontendOption]>,
+  Flags<[HelpHidden, FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Compile with optimizations appropriate for a playground">;
 
 def RemoveRuntimeAsserts : Flag<["-"], "remove-runtime-asserts">,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 468; // Last change: SelfProtocolConformance
+const uint16_t SWIFTMODULE_VERSION_MINOR = 469; // @_hasStorage
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -591,11 +591,13 @@ class PrintAST : public ASTVisitor<PrintAST> {
       return;
 
     printAccess(D->getFormalAccess());
+    bool shouldSkipSetterAccess =
+      llvm::is_contained(Options.ExcludeAttrList, DAK_SetterAccess);
 
     if (auto storageDecl = dyn_cast<AbstractStorageDecl>(D)) {
       if (auto setter = storageDecl->getSetter()) {
         AccessLevel setterAccess = setter->getFormalAccess();
-        if (setterAccess != D->getFormalAccess())
+        if (setterAccess != D->getFormalAccess() && !shouldSkipSetterAccess)
           printAccess(setterAccess, "(set)");
       }
     }
@@ -865,6 +867,10 @@ static bool hasNonMutatingSetter(const AbstractStorageDecl *ASD) {
   return setter && setter->isExplicitNonMutating();
 }
 
+static bool hasLessAccessibleSetter(const AbstractStorageDecl *ASD) {
+  return ASD->getSetterFormalAccess() < ASD->getFormalAccess();
+}
+
 void PrintAST::printAttributes(const Decl *D) {
   if (Options.SkipAttributes)
     return;
@@ -880,11 +886,20 @@ void PrintAST::printAttributes(const Decl *D) {
       Options.ExcludeAttrList.push_back(DAK_Final);
     }
 
-    // Don't print @_hasInitialValue if we're printing an initializer
-    // expression.
     if (auto vd = dyn_cast<VarDecl>(D)) {
+      // Don't print @_hasInitialValue if we're printing an initializer
+      // expression.
       if (vd->isInitExposedToClients())
         Options.ExcludeAttrList.push_back(DAK_HasInitialValue);
+
+      if (!Options.PrintForSIL) {
+        // Don't print @_hasStorage if the value is simply stored, or the
+        // decl is resilient.
+        if (vd->isResilient() ||
+            (vd->getImplInfo().isSimpleStored() &&
+             !hasLessAccessibleSetter(vd)))
+          Options.ExcludeAttrList.push_back(DAK_HasStorage);
+      }
     }
 
     // Don't print any contextual decl modifiers.
@@ -1610,18 +1625,27 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
   if (isa<VarDecl>(ASD) && !Options.PrintPropertyAccessors)
     return;
 
-  // Never print anything for stored properties.
-  if (ASD->getAllAccessors().empty())
-    return;
-
   auto impl = ASD->getImplInfo();
 
-  // Treat StoredWithTrivialAccessors the same as Stored unless
-  // we're printing for SIL, in which case we want to distinguish it
-  // from a pure stored property.
+  // Don't print accessors for trivially stored properties...
   if (impl.isSimpleStored()) {
+    // ...unless we're printing for SIL, which expects a { get set? } on
+    //    trivial properties
     if (Options.PrintForSIL) {
       Printer << " { get " << (impl.supportsMutation() ? "set }" : "}");
+    }
+    // ...or you're private/internal(set), at which point we'll print
+    //    @_hasStorage var x: T { get }
+    else if (ASD->isSettable(nullptr) && hasLessAccessibleSetter(ASD)) {
+      Printer << " {";
+      {
+        IndentRAII indentMore(*this);
+        indent();
+        Printer.printNewline();
+        Printer << "get";
+        Printer.printNewline();
+      }
+      Printer << "}";
     }
     return;
   }
@@ -1759,12 +1783,8 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
       llvm_unreachable("simply-stored variable should have been filtered out");
     case WriteImplKind::StoredWithObservers:
     case WriteImplKind::InheritedWithObservers: {
-      bool skippedWillSet = PrintAccessor(ASD->getWillSetFunc());
-      bool skippedDidSet = PrintAccessor(ASD->getDidSetFunc());
-      if (skippedDidSet && skippedWillSet) {
-        PrintAccessor(ASD->getGetter());
-        PrintAccessor(ASD->getSetter());
-      }
+      PrintAccessor(ASD->getGetter());
+      PrintAccessor(ASD->getSetter());
       break;
     }
     case WriteImplKind::Set:
@@ -2088,6 +2108,12 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
       SmallString<128> scratch;
       Printer << " = " << entry.getInitStringRepresentation(scratch);
     }
+
+    // HACK: If we're just printing a single pattern and it has accessors,
+    //       print the accessors here.
+    if (decl->getNumPatternEntries() == 1) {
+      printAccessors(vd);
+    }
   }
 }
 
@@ -2319,7 +2345,6 @@ void PrintAST::visitProtocolDecl(ProtocolDecl *decl) {
                        Options.BracketOptions.shouldCloseNominal(decl));
   }
 }
-
 static bool isStructOrClassContext(DeclContext *dc) {
   auto *nominal = dc->getSelfNominalTypeDecl();
   if (nominal == nullptr)

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -629,6 +629,9 @@ public:
       return;
     }
 
+    if (!isPublicOrUsableFromInline(nominal))
+      return;
+
     map[nominal].recordProtocols(directlyInherited);
 
     // Recurse to find any nested types.
@@ -647,6 +650,9 @@ public:
       return;
 
     const NominalTypeDecl *nominal = extension->getExtendedNominal();
+    if (!isPublicOrUsableFromInline(nominal))
+      return;
+
     map[nominal].recordConditionalConformances(extension->getInherited());
     // No recursion here because extensions are never nested.
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4804,6 +4804,72 @@ static void diagnoseAndIgnoreObservers(Parser &P,
   }
 }
 
+/// Gets the storage info of the provided storage decl if it has the
+/// @_hasStorage attribute and it's not in SIL mode.
+///
+/// In this case, we say the decl is:
+///
+/// Read:
+///   - Stored, always
+/// Write:
+///   - Stored, if the decl is a 'var'.
+///   - StoredWithObservers, if the decl has a setter
+///     - This indicates that the original decl had a 'didSet' and/or 'willSet'
+///   - InheritedWithObservers, if the decl has a setter and is an overridde.
+///   - Immutable, if the decl is a 'let' or it does not have a setter.
+/// ReadWrite:
+///   - Stored, if the decl has no accessors listed.
+///   - Immutable, if the decl is a 'let' or it does not have a setter.
+///   - MaterializeToTemporary, if the decl has a setter.
+static StorageImplInfo classifyWithHasStorageAttr(
+  Parser::ParsedAccessors &accessors, ASTContext &ctx,
+  AbstractStorageDecl *storage, const DeclAttributes &attrs) {
+
+  // Determines if the storage is immutable, either by declaring itself as a
+  // `let` or by omitting a setter.
+  auto isImmutable = [&]() {
+    if (auto varDecl = dyn_cast<VarDecl>(storage))
+      return varDecl->isImmutable();
+    if (accessors.Set == nullptr) return true;
+    return false;
+  };
+
+  // Determines if the storage had a private setter, i.e. it's not a 'let' and
+  // it had a setter.
+  auto isPrivateSet = [&]() {
+    if (auto varDecl = dyn_cast<VarDecl>(storage))
+      return !varDecl->isImmutable() && accessors.Set == nullptr;
+    return false;
+  };
+
+  // Default to stored writes.
+  WriteImplKind writeImpl = WriteImplKind::Stored;
+  ReadWriteImplKind readWriteImpl = ReadWriteImplKind::Stored;
+
+  if (accessors.Get && accessors.Set) {
+    // If we see `@_hasStorage var x: T { get set }`, then our property has
+    // willSet/didSet observers.
+    writeImpl = attrs.hasAttribute<OverrideAttr>() ?
+      WriteImplKind::InheritedWithObservers :
+      WriteImplKind::StoredWithObservers;
+    readWriteImpl = ReadWriteImplKind::MaterializeToTemporary;
+  } else if (isImmutable()) {
+    writeImpl = WriteImplKind::Immutable;
+    readWriteImpl = ReadWriteImplKind::Immutable;
+  }
+
+  if (isPrivateSet()) {
+    // If we saw a 'var' with no setter, that means it was
+    // private/internal(set). Honor that with a synthesized attribute.
+    storage->getAttrs().add(
+      new (ctx) SetterAccessAttr(
+        SourceLoc(), SourceLoc(), AccessLevel::Private, /*implicit: */true));
+  }
+
+  // Always force Stored reads if @_hasStorage is present.
+  return StorageImplInfo(ReadImplKind::Stored, writeImpl, readWriteImpl);
+}
+
 StorageImplInfo
 Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
                                   bool invalid, ParseDeclOptions flags,
@@ -4962,10 +5028,26 @@ Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
     readWriteImpl = ReadWriteImplKind::Immutable;
   }
 
-  // Allow the _hasStorage attribute to override all the accessors we parsed
+  // Allow the @_hasStorage attribute to override all the accessors we parsed
   // when making the final classification.
   if (attrs.hasAttribute<HasStorageAttr>()) {
-    return StorageImplInfo::getSimpleStored(StorageIsMutable_t(Set != nullptr));
+    // The SIL rules for @_hasStorage are slightly different from the non-SIL
+    // rules. In SIL mode, @_hasStorage marks that the type is simply stored,
+    // and the only thing that determines mutability is the existence of the
+    // setter.
+    //
+    // FIXME: SIL should not be special cased here. The behavior should be
+    //        consistent between SIL and non-SIL.
+    //        The strategy here should be to keep track of all opaque accessors
+    //        along with enough information to access the storage trivially
+    //        if allowed. This could be a representational change to
+    //        StorageImplInfo such that it keeps a bitset of listed accessors
+    //        and dynamically determines the access strategy from that.
+    if (P.isInSILMode())
+      return StorageImplInfo::getSimpleStored(
+        StorageIsMutable_t(Set != nullptr));
+
+    return classifyWithHasStorageAttr(*this, P.Context, storage, attrs);
   }
 
   return StorageImplInfo(readImpl, writeImpl, readWriteImpl);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -85,6 +85,7 @@ public:
   IGNORED_ATTR(FixedLayout)
   IGNORED_ATTR(ForbidSerializingReference)
   IGNORED_ATTR(Frozen)
+  IGNORED_ATTR(HasStorage)
   IGNORED_ATTR(Implements)
   IGNORED_ATTR(ImplicitlyUnwrappedOptional)
   IGNORED_ATTR(Infix)
@@ -285,7 +286,6 @@ public:
   void visitAccessControlAttr(AccessControlAttr *attr);
   void visitSetterAccessAttr(SetterAccessAttr *attr);
   bool visitAbstractAccessControlAttr(AbstractAccessControlAttr *attr);
-  void visitHasStorageAttr(HasStorageAttr *attr);
   void visitObjCMembersAttr(ObjCMembersAttr *attr);
 };
 } // end anonymous namespace
@@ -426,16 +426,6 @@ void AttributeEarlyChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
     diagnoseAndRemoveAttr(attr, diag::invalid_ibinspectable,
                                  attr->getAttrName());
-}
-
-void AttributeEarlyChecker::visitHasStorageAttr(HasStorageAttr *attr) {
-  auto *VD = cast<VarDecl>(D);
-  if (VD->getDeclContext()->getSelfClassDecl())
-    return;
-  auto nominalDecl = VD->getDeclContext()->getSelfNominalTypeDecl();
-  if (nominalDecl && isa<StructDecl>(nominalDecl))
-    return;
-  diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute_simple);
 }
 
 static Optional<Diag<bool,Type>>

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4048,6 +4048,10 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     auto *VD = cast<VarDecl>(D);
     auto *PBD = VD->getParentPatternBinding();
 
+    // Add the '@_hasStorage' attribute if this property is stored.
+    if (VD->hasStorage() && !VD->getAttrs().hasAttribute<HasStorageAttr>())
+      VD->getAttrs().add(new (Context) HasStorageAttr(/*isImplicit=*/true));
+
     // Note that we need to handle the fact that some VarDecls don't
     // have a PatternBindingDecl, for example the iterator in a
     // 'for ... in ...' loop.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1205,6 +1205,7 @@ namespace  {
     UNINTERESTING_ATTR(Convenience)
     UNINTERESTING_ATTR(Semantics)
     UNINTERESTING_ATTR(SetterAccess)
+    UNINTERESTING_ATTR(HasStorage)
     UNINTERESTING_ATTR(UIApplicationMain)
     UNINTERESTING_ATTR(UsableFromInline)
     UNINTERESTING_ATTR(ObjCNonLazyRealization)
@@ -1224,7 +1225,6 @@ namespace  {
     UNINTERESTING_ATTR(SynthesizedProtocol)
     UNINTERESTING_ATTR(RequiresStoredPropertyInits)
     UNINTERESTING_ATTR(Transparent)
-    UNINTERESTING_ATTR(HasStorage)
     UNINTERESTING_ATTR(Testable)
 
     UNINTERESTING_ATTR(WarnUnqualifiedAccess)

--- a/test/ParseableInterface/access-filter.swift
+++ b/test/ParseableInterface/access-filter.swift
@@ -109,7 +109,9 @@ extension UFIProto {
 
 // CHECK: extension PublicStruct {{[{]$}}
 extension PublicStruct {
-  // CHECK: public private(set) static var secretlySettable: Int{{$}}
+  // CHECK: @_hasInitialValue public static var secretlySettable: Int {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
   public private(set) static var secretlySettable: Int = 0
 } // CHECK: {{^[}]$}}
 

--- a/test/ParseableInterface/conformances.swift
+++ b/test/ParseableInterface/conformances.swift
@@ -167,6 +167,7 @@ extension MultiGeneric: PublicProto where U: PrivateProto {}
 // CHECK: public struct MultiGeneric<T, U, V> {
 // CHECK-END: extension conformances.MultiGeneric : PublicProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 
+
 internal struct InternalImpl_BAD: PrivateSubProto {}
 internal struct InternalImplConstrained_BAD<T> {}
 extension InternalImplConstrained_BAD: PublicProto where T: PublicProto {}
@@ -180,6 +181,13 @@ public struct WrapperForInternal {
 }
 extension WrapperForInternal.InternalImplConstrained_BAD: PublicProto where T: PublicProto {}
 extension WrapperForInternal.InternalImplConstrained2_BAD: PublicProto where T: PrivateProto {}
+
+
+internal protocol ExtraHashable: Hashable {}
+extension Bool: ExtraHashable {}
+
+// NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Hashable
+// NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Equatable
 
 
 // CHECK-END: @usableFromInline

--- a/test/ParseableInterface/conformances.swift
+++ b/test/ParseableInterface/conformances.swift
@@ -3,6 +3,8 @@
 // RUN: %FileCheck -check-prefix CHECK-END %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 
+// NEGATIVE-NOT: BAD
+
 // CHECK-LABEL: public protocol SimpleProto {
 public protocol SimpleProto {
   // CHECK: associatedtype Element
@@ -164,6 +166,20 @@ extension MultiGeneric: PublicProto where U: PrivateProto {}
 
 // CHECK: public struct MultiGeneric<T, U, V> {
 // CHECK-END: extension conformances.MultiGeneric : PublicProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+
+internal struct InternalImpl_BAD: PrivateSubProto {}
+internal struct InternalImplConstrained_BAD<T> {}
+extension InternalImplConstrained_BAD: PublicProto where T: PublicProto {}
+internal struct InternalImplConstrained2_BAD<T> {}
+extension InternalImplConstrained2_BAD: PublicProto where T: PrivateProto {}
+
+public struct WrapperForInternal {
+  internal struct InternalImpl_BAD: PrivateSubProto {}
+  internal struct InternalImplConstrained_BAD<T> {}
+  internal struct InternalImplConstrained2_BAD<T> {}
+}
+extension WrapperForInternal.InternalImplConstrained_BAD: PublicProto where T: PublicProto {}
+extension WrapperForInternal.InternalImplConstrained2_BAD: PublicProto where T: PrivateProto {}
 
 
 // CHECK-END: @usableFromInline

--- a/test/ParseableInterface/option-preservation.swift
+++ b/test/ParseableInterface/option-preservation.swift
@@ -1,18 +1,21 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-resilience -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null
+// RUN: %target-swift-frontend -enable-resilience -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null -Onone
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
-// CHECK-SWIFTINTERFACE: {{swift-module-flags:.* -enable-resilience}}
+// CHECK-SWIFTINTERFACE: swift-module-flags:
+// CHECK-SWIFTINTERFACE-SAME: -enable-resilience
+// CHECK-SWIFTINTERFACE-SAME: -Onone
 
 // Make sure flags show up when filelists are enabled
 
-// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation 2>&1
+// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation -Ounchecked 2>&1
 // RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
 
 // CHECK-FILELIST-INTERFACE: swift-module-flags:
 // CHECK-FILELIST-INTERFACE-SAME: -target
 // CHECK-FILELIST-INTERFACE-SAME: -module-link-name fooCore
+// CHECK-FILELIST-INTERFACE-SAME: -Ounchecked
 // CHECK-FILELIST-INTERFACE-SAME: -module-name foo
 
 public func foo() { }

--- a/test/ParseableInterface/stored-properties-client.swift
+++ b/test/ParseableInterface/stored-properties-client.swift
@@ -1,0 +1,143 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %S/stored-properties.swift -module-name StoredProperties -emit-parseable-module-interface-path %t/StoredProperties.swiftinterface
+// RUN: %target-swift-frontend -emit-ir %s -I %t -enable-parseable-module-interface | %FileCheck %s -check-prefix CHECK -check-prefix COMMON
+
+// RUN: %target-swift-frontend -typecheck %S/stored-properties.swift -enable-resilience -module-name StoredProperties -emit-parseable-module-interface-path %t/StoredProperties.swiftinterface
+// RUN: %target-swift-frontend -emit-ir %s -I %t -enable-parseable-module-interface | %FileCheck %s -check-prefix RESILIENT -check-prefix COMMON
+
+import StoredProperties
+
+/// This test makes sure clients of a parseable interface see correct type
+/// layout and use the right access patterns in the presence of a
+/// .swiftinterface file, in both resilient and non-resilient cases.
+
+// COMMON: %[[BAGOFVARIABLES:T16StoredProperties14BagOfVariablesV]] = type <{ %TSi, %TSb, [{{(3|7)}} x i8], %TSi }>
+
+// This type is non-@_fixed_layout, so it becomes opaque in a resilient module
+// CHECK: %[[HASSTOREDPROPERTIES:T16StoredProperties03HasaB0V]] = type <{ %TSi, %TSi, %TSb, [{{(3|7)}} x i8], %TSi, %TSb }>
+// RESILIENT: %[[HASSTOREDPROPERTIES:swift.opaque]] = type opaque
+
+// COMMON: %[[HASSTOREDPROPERTIESFIXEDLAYOUT:T16StoredProperties03HasaB11FixedLayoutV]] = type <{ %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]] }>
+
+// These are here just to make sure the compiler doesn't optimize away accesses.
+// They're overloaded instead of generic so we avoid generic dispatch.
+
+@inline(never)
+func _blackHole(_ value: Int) {}
+
+@inline(never)
+func _blackHole(_ value: Bool) {}
+
+@inline(never)
+func _blackHole(_ value: BagOfVariables) {}
+
+/// In the following code, getting and setting is split because otherwise
+/// the resulting IR is ordered differently.
+
+/// Test that we call the correct accessors in a resilient module, and that
+/// we use trivial storage accesses in a non-resilient module.
+
+func testGetting() {
+  // CHECK: %[[VALUE:.*]] = alloca %[[HASSTOREDPROPERTIES]]
+  // CHECK: call swiftcc void @"$s16StoredProperties03HasaB0VACycfC"(%[[HASSTOREDPROPERTIES]]* {{.*}} %[[VALUE]])
+  // RESILIENT: %[[VALUE:.*]] = alloca i8, [[WORD:i[0-9]+]] %size
+  // RESILIENT: %[[VALUECAST:.*]] = bitcast i8* %value to %[[HASSTOREDPROPERTIES]]*
+  // RESILIENT: call swiftcc void @"$s16StoredProperties03HasaB0VACycfC"(%[[HASSTOREDPROPERTIES]]* noalias nocapture sret %[[VALUECAST]])
+  var value = HasStoredProperties()
+
+  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 1
+  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 2
+
+  // These are accessed in declaration order so the IR is emitted in the same
+  // order.
+
+  // COMMON: call swiftcc [[WORD:i[0-9]+]] @"$s16StoredProperties03HasaB0V14computedGetterSivg"
+  _blackHole(value.computedGetter)
+
+  // COMMON: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V14computedGetSetSivg"
+  _blackHole(value.computedGetSet)
+
+  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 0
+  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 4
+
+  // RESILIENT: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V06simpleA9ImmutableSivg"
+  _blackHole(value.simpleStoredImmutable)
+
+  // RESILIENT: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V06simpleA7MutableSivg"
+  _blackHole(value.simpleStoredMutable)
+
+  // RESILIENT: call swiftcc i1 @"$s16StoredProperties03HasaB0V19storedWithObserversSbvg"
+  _blackHole(value.storedWithObservers)
+
+  // RESILIENT: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V16storedPrivateSetSivg"
+  _blackHole(value.storedPrivateSet)
+}
+
+func testSetting() {
+  // CHECK: call swiftcc void @"$s16StoredProperties03HasaB0VACycfC"(%[[HASSTOREDPROPERTIES]]* {{.*}})
+  // RESILIENT: call swiftcc %swift.metadata_response @"$s16StoredProperties03HasaB0VMa"([[WORD]] 0)
+  // RESILIENT: %[[VALUEALLOC:.*]] = alloca i8, [[WORD]] %size
+  // RESILIENT: bitcast i8* %[[VALUEALLOC]] to %[[HASSTOREDPROPERTIES]]*
+  var value = HasStoredProperties()
+
+  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB0V19storedWithObserversSbvs"(i1 false, %[[HASSTOREDPROPERTIES]]* {{.*}})
+  value.storedWithObservers = false
+
+  // COMMON-NEXT: call swiftcc void @"$s16StoredProperties03HasaB0V14computedGetSetSivs"([[WORD]] 4, %[[HASSTOREDPROPERTIES]]* {{.*}})
+  value.computedGetSet = 4
+
+  // CHECK: %[[MUTABLE_PTR:.*]] = getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* {{.*}}, i32 0, i32 1
+  // CHECK: %[[MUTABLE_INT_PTR:.*]] = getelementptr inbounds %TSi, %TSi* %[[MUTABLE_PTR]], i32 0, i32 0
+  // CHECK: store [[WORD]] 4, [[WORD]]* %[[MUTABLE_INT_PTR]]
+  // RESILIENT: call swiftcc void @"$s16StoredProperties03HasaB0V06simpleA7MutableSivs"([[WORD]] 4, %[[HASSTOREDPROPERTIES]]* {{.*}})
+  value.simpleStoredMutable = 4
+}
+
+testGetting()
+testSetting()
+
+/// Test that we always use trivial access patterns for @_fixed_layout types
+/// in resilient or non-resilient modules.
+
+func testFixedLayoutGetting() {
+  // COMMON: %[[VALUEALLOCA:.*]] = alloca %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]
+  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB11FixedLayoutVACycfC"(%[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* {{.*}} %[[VALUEALLOCA]])
+  var value = HasStoredPropertiesFixedLayout()
+
+  // These next two tests just make sure we don't use resilient access patterns
+  // for these fixed_layout structs.
+
+  // COMMON: getelementptr inbounds %[[HASSTOREDPROPERTIESFIXEDLAYOUT]], %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* %[[VALUEALLOCA]], i32 0, i32 0
+  // COMMON: getelementptr inbounds %[[HASSTOREDPROPERTIESFIXEDLAYOUT]], %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* %[[VALUEALLOCA]], i32 0, i32 1
+
+  // COMMON: call swiftcc void @"$s4main10_blackHoleyy16StoredProperties14BagOfVariablesVF"([[WORD]] %{{.*}}, i1 %{{.*}}, [[WORD]] %{{.*}})
+  _blackHole(value.simpleStoredMutable)
+
+  // COMMON: call swiftcc void @"$s4main10_blackHoleyy16StoredProperties14BagOfVariablesVF"([[WORD]] %{{.*}}, i1 %{{.*}}, [[WORD]] %{{.*}})
+  _blackHole(value.storedWithObservers)
+}
+
+func testFixedLayoutSetting() {
+  // COMMON: %[[VALUEALLOCA:.*]] = alloca %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]
+  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB11FixedLayoutVACycfC"(%[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* {{.*}} %[[VALUEALLOCA]])
+  var value = HasStoredPropertiesFixedLayout()
+
+  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB11FixedLayoutV19storedWithObserversAA14BagOfVariablesVvs"
+  value.storedWithObservers = BagOfVariables()
+
+  // COMMON: %[[PROP:.*]] = getelementptr inbounds %[[HASSTOREDPROPERTIESFIXEDLAYOUT]], %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* %value, i32 0, i32 0
+  // COMMON: %[[PROPA:.*]] = getelementptr inbounds %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]]* %[[PROP]], i32 0, i32 0
+  // COMMON: %[[PROPAVAL:.*]] = getelementptr inbounds %TSi, %TSi* %[[PROPA]], i32 0, i32 0
+  // COMMON: store [[WORD]] {{.*}} %[[PROPAVAL]]
+  // COMMON: %[[PROPB:.*]] = getelementptr inbounds %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]]* %[[PROP]], i32 0, i32 1
+  // COMMON: %[[PROPBVAL:.*]] = getelementptr inbounds %TSb, %TSb* %[[PROPB]], i32 0, i32 0
+  // COMMON: store i1 {{.*}} %[[PROPBVAL]]
+  // COMMON: %[[PROPC:.*]] = getelementptr inbounds %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]]* %[[PROP]], i32 0, i32 3
+  // COMMON: %[[PROPCVAL:.*]] = getelementptr inbounds %TSi, %TSi* %[[PROPC]], i32 0, i32 0
+  // COMMON: store [[WORD]] {{.*}} %[[PROPCVAL]]
+  value.simpleStoredMutable = BagOfVariables()
+}
+
+testFixedLayoutGetting()
+testFixedLayoutSetting()

--- a/test/ParseableInterface/stored-properties.swift
+++ b/test/ParseableInterface/stored-properties.swift
@@ -1,0 +1,104 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
+// RUN: %FileCheck %s < %t.swiftinterface --check-prefix CHECK --check-prefix COMMON
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-resilience %s
+// RUN: %FileCheck %s < %t-resilient.swiftinterface --check-prefix RESILIENT --check-prefix COMMON
+
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix CHECK --check-prefix COMMON
+
+// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix RESILIENT --check-prefix COMMON
+
+// COMMON: public struct HasStoredProperties {
+public struct HasStoredProperties {
+  // COMMON: public var computedGetter: [[INT:.*Int]] {
+  // COMMON-NEXT: get
+  // COMMON-NEXT: }
+  public var computedGetter: Int { return 3 }
+
+  // COMMON: public var computedGetSet: [[INT]] {
+  // COMMON-NEXT: get
+  // COMMON-NEXT: set
+  // COMMON-NEXT: }
+  public var computedGetSet: Int {
+    get { return 3 }
+    set {}
+  }
+
+  // COMMON: public let simpleStoredImmutable: [[INT]]{{$}}
+  public let simpleStoredImmutable: Int
+
+  // COMMON: public var simpleStoredMutable: [[INT]]{{$}}
+  public var simpleStoredMutable: Int
+
+  // CHECK: @_hasStorage public var storedWithObservers: [[BOOL:.*Bool]] {
+  // RESILIENT: {{^}}  public var storedWithObservers: [[BOOL:.*Bool]] {
+  // COMMON-NEXT: get
+  // COMMON-NEXT: set
+  // COMMON-NEXT: }
+  public var storedWithObservers: Bool {
+    willSet {}
+  }
+
+  // CHECK: @_hasStorage public var storedPrivateSet: [[INT]] {
+  // RESILIENT: {{^}}  public var storedPrivateSet: [[INT]] {
+  // COMMON-NEXT: get
+  // COMMON-NEXT: }
+  public private(set) var storedPrivateSet: Int
+
+  // CHECK: private var _: [[BOOL]]
+  private var privateVar: Bool
+
+  // COMMON: public init(){{$}}
+  public init() {
+    self.simpleStoredImmutable = 0
+    self.simpleStoredMutable = 0
+    self.storedPrivateSet = 0
+    self.storedWithObservers = false
+    self.privateVar = false
+  }
+
+// COMMON: }
+}
+
+// COMMON: @_fixed_layout public struct BagOfVariables {
+@_fixed_layout
+public struct BagOfVariables {
+  // COMMON: public let a: [[INT]] = 0
+  public let a: Int = 0
+
+  // COMMON: public var b: [[BOOL]] = false
+  public var b: Bool = false
+
+  // COMMON: public var c: [[INT]] = 0
+  public var c: Int = 0
+
+  // COMMON: public init()
+  public init() {}
+
+// COMMON: }
+}
+
+// COMMON: @_fixed_layout public struct HasStoredPropertiesFixedLayout {
+@_fixed_layout
+public struct HasStoredPropertiesFixedLayout {
+  // COMMON: public var simpleStoredMutable: [[BAGOFVARIABLES:.*BagOfVariables]]
+  public var simpleStoredMutable: BagOfVariables
+
+  // COMMON: @_hasStorage public var storedWithObservers: [[BAGOFVARIABLES]] {
+  // COMMON-NEXT: get
+  // COMMON-NEXT: set
+  // COMMON-NEXT: }
+  public var storedWithObservers: BagOfVariables {
+    didSet {}
+  }
+
+  // COMMON: public init(){{$}}
+  public init() {
+    self.simpleStoredMutable = BagOfVariables()
+    self.storedWithObservers = BagOfVariables()
+  }
+}

--- a/test/SIL/Parser/final.swift
+++ b/test/SIL/Parser/final.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
 
 // CHECK: final class Rect
-// CHECK: @_hasStorage @_hasInitialValue final var orgx: Double
+// CHECK: @_hasInitialValue @_hasStorage final var orgx: Double
 final class Rect {
   var orgx = 0.0
 }

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -340,7 +340,7 @@ class C {
 
 // CHECK-LABEL: @readIdentifiedClass
 // CHECK: [read] Class %0 = argument of bb0 : $C
-// CHECK: Field: @_hasStorage var property: Int
+// CHECK: Field: var property: Int
 sil @readIdentifiedClass : $@convention(thin) (@guaranteed C) -> Int {
 bb0(%0 : $C):
   %1 = ref_element_addr %0 : $C, #C.property
@@ -352,7 +352,7 @@ bb0(%0 : $C):
 
 // CHECK-LABEL: @writeIdentifiedClass
 // CHECK: [modify] Class %0 = argument of bb0 : $C
-// CHECK: Field: @_hasStorage var property: Int
+// CHECK: Field: var property: Int
 sil @writeIdentifiedClass : $@convention(thin) (@guaranteed C, Int) -> () {
 bb0(%0 : $C, %1 : $Int):
   %2 = ref_element_addr %0 : $C, #C.property
@@ -365,7 +365,7 @@ bb0(%0 : $C, %1 : $Int):
 
 // CHECK-LABEL: @readWriteIdentifiedClass
 // CHECK: [modify] Class   %1 = alloc_ref $C
-// CHECK: Field: @_hasStorage var property: Int
+// CHECK: Field: var property: Int
 sil @readWriteIdentifiedClass : $@convention(thin) (Int) -> (Int) {
 bb0(%0 : $Int):
   %1 = alloc_ref $C
@@ -380,7 +380,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: @readIdentifiedNestedClass
 // CHECK: [read] Class %0 = argument of bb0 : $C
-// CHECK: Field: @_hasStorage var property: Int
+// CHECK: Field: var property: Int
 sil @readIdentifiedNestedClass : $@convention(thin) (@guaranteed C) -> Int {
 bb0(%0 : $C):
   %1 = ref_element_addr %0 : $C, #C.property
@@ -394,7 +394,7 @@ bb0(%0 : $C):
 
 // CHECK-LABEL: @writeIdentifiedNestedClass
 // CHECK: [modify] Class %0 = argument of bb0 : $C
-// CHECK: Field: @_hasStorage var property: Int
+// CHECK: Field: var property: Int
 sil @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> () {
 bb0(%0 : $C, %1 : $Int):
   %2 = ref_element_addr %0 : $C, #C.property
@@ -409,7 +409,7 @@ bb0(%0 : $C, %1 : $Int):
 
 // CHECK-LABEL: @readWriteIdentifiedNestedClass
 // CHECK: [modify] Class   %1 = alloc_ref $C
-// CHECK: Field: @_hasStorage var property: Int
+// CHECK: Field: var property: Int
 sil @readWriteIdentifiedNestedClass : $@convention(thin) (Int) -> (Int) {
 bb0(%0 : $Int):
   %1 = alloc_ref $C
@@ -541,7 +541,7 @@ bb0(%0 : $*Int, %1 : $*Int):
 // Test directly recursive argument access.
 // CHECK-LABEL: @readRecursiveArgument
 // CHECK:   [read] Class %0 = argument of bb0 : $C
-// CHECK:   Field: @_hasStorage var property: Int
+// CHECK:   Field: var property: Int
 sil @readRecursiveArgument : $@convention(thin) (@guaranteed C, Int) -> Int {
 bb0(%0 : $C, %1 : $Int):
   %propaddr = ref_element_addr %0 : $C, #C.property
@@ -556,7 +556,7 @@ bb0(%0 : $C, %1 : $Int):
 // Test a class argument access from an optional caller value.
 // CHECK-LABEL: @readOptionalArgumentInCallee
 // CHECK:   [read] Class   %1 = unchecked_enum_data %0 : $Optional<C>, #Optional.some!enumelt.1
-// CHECK:   Field: @_hasStorage var property: Int
+// CHECK:   Field: var property: Int
 sil @readOptionalArgumentInCallee : $@convention(thin) (@guaranteed Optional<C>) -> Int {
 bb0(%0 : $Optional<C>):
   %c = unchecked_enum_data %0 : $Optional<C>, #Optional.some!enumelt.1
@@ -567,7 +567,7 @@ bb0(%0 : $Optional<C>):
 
 // CHECK-LABEL: @readOptionalArgumentInCalleeHelper
 // CHECK:   [read] Class %0 = argument of bb0 : $C
-// CHECK:   Field: @_hasStorage var property: Int
+// CHECK:   Field: var property: Int
 sil private @readOptionalArgumentInCalleeHelper : $@convention(thin) (@guaranteed C) -> Int {
 bb0(%0 : $C):
   %propaddr = ref_element_addr %0 : $C, #C.property

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -292,7 +292,8 @@
           "moduleName": "cake",
           "declAttributes": [
             "HasInitialValue",
-            "ReferenceOwnership"
+            "ReferenceOwnership",
+            "HasStorage"
           ],
           "fixedbinaryorder": 0,
           "ownership": 1,
@@ -359,7 +360,8 @@
           "moduleName": "cake",
           "declAttributes": [
             "HasInitialValue",
-            "ReferenceOwnership"
+            "ReferenceOwnership",
+            "HasStorage"
           ],
           "fixedbinaryorder": 1,
           "ownership": 2,
@@ -685,7 +687,8 @@
           "usr": "s:4cake17fixedLayoutStructV1aSivp",
           "moduleName": "cake",
           "declAttributes": [
-            "HasInitialValue"
+            "HasInitialValue",
+            "HasStorage"
           ],
           "fixedbinaryorder": 0,
           "hasStorage": true
@@ -728,7 +731,8 @@
           "moduleName": "cake",
           "isInternal": true,
           "declAttributes": [
-            "HasInitialValue"
+            "HasInitialValue",
+            "HasStorage"
           ],
           "fixedbinaryorder": 1,
           "hasStorage": true,
@@ -773,7 +777,8 @@
           "moduleName": "cake",
           "isInternal": true,
           "declAttributes": [
-            "HasInitialValue"
+            "HasInitialValue",
+            "HasStorage"
           ],
           "fixedbinaryorder": 2,
           "hasStorage": true
@@ -815,7 +820,8 @@
           "moduleName": "cake",
           "declAttributes": [
             "HasInitialValue",
-            "Available"
+            "Available",
+            "HasStorage"
           ],
           "fixedbinaryorder": 3,
           "isLet": true,
@@ -1077,7 +1083,8 @@
       "usr": "s:4cake9GlobalVarSivp",
       "moduleName": "cake",
       "declAttributes": [
-        "HasInitialValue"
+        "HasInitialValue",
+        "HasStorage"
       ],
       "isLet": true,
       "hasStorage": true
@@ -1135,7 +1142,8 @@
           "moduleName": "cake",
           "isInternal": true,
           "declAttributes": [
-            "HasInitialValue"
+            "HasInitialValue",
+            "HasStorage"
           ],
           "fixedbinaryorder": 0,
           "hasStorage": true

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -335,7 +335,8 @@
           "moduleName": "cake",
           "declAttributes": [
             "HasInitialValue",
-            "ReferenceOwnership"
+            "ReferenceOwnership",
+            "HasStorage"
           ],
           "ownership": 1,
           "hasStorage": true
@@ -401,7 +402,8 @@
           "moduleName": "cake",
           "declAttributes": [
             "HasInitialValue",
-            "ReferenceOwnership"
+            "ReferenceOwnership",
+            "HasStorage"
           ],
           "ownership": 2,
           "hasStorage": true
@@ -749,7 +751,8 @@
           "usr": "s:4cake17fixedLayoutStructV1aSivp",
           "moduleName": "cake",
           "declAttributes": [
-            "HasInitialValue"
+            "HasInitialValue",
+            "HasStorage"
           ],
           "hasStorage": true
         }
@@ -1026,7 +1029,8 @@
       "usr": "s:4cake9GlobalVarSivp",
       "moduleName": "cake",
       "declAttributes": [
-        "HasInitialValue"
+        "HasInitialValue",
+        "HasStorage"
       ],
       "isLet": true,
       "hasStorage": true

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -839,19 +839,19 @@ class infer_instanceVar1 {
   }
 
   var observingAccessorsVar1: Int {
-  // CHECK: @objc var observingAccessorsVar1: Int {
+  // CHECK: @_hasStorage @objc var observingAccessorsVar1: Int {
     willSet {}
-    // CHECK-NEXT: {{^}} willSet {}
+    // CHECK-NEXT: {{^}} @objc get
     didSet {}
-    // CHECK-NEXT: {{^}} didSet {}
+    // CHECK-NEXT: {{^}} @objc set
   }
 
   @objc var observingAccessorsVar1_: Int {
-  // CHECK: {{^}} @objc var observingAccessorsVar1_: Int {
+  // CHECK: {{^}} @objc @_hasStorage var observingAccessorsVar1_: Int {
     willSet {}
-    // CHECK-NEXT: {{^}} willSet {}
+    // CHECK-NEXT: {{^}} @objc get
     didSet {}
-    // CHECK-NEXT: {{^}} didSet {}
+    // CHECK-NEXT: {{^}} @objc set
   }
 
 
@@ -1709,14 +1709,20 @@ class HasNSManaged {
 
   @NSManaged
   var goodManaged: Class_ObjC1
-  // CHECK-LABEL: {{^}}  @objc @NSManaged dynamic var goodManaged: Class_ObjC1
+  // CHECK-LABEL: {{^}}  @objc @NSManaged @_hasStorage dynamic var goodManaged: Class_ObjC1 {
+  // CHECK-NEXT: {{^}} @objc get
+  // CHECK-NEXT: {{^}} @objc set
+  // CHECK-NEXT: {{^}} }
 
   @NSManaged
   var badManaged: PlainStruct
   // expected-error@-1 {{property cannot be marked @NSManaged because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
   // expected-error@-3{{'dynamic' property 'badManaged' must also be '@objc'}}
-  // CHECK-LABEL: {{^}}  @NSManaged var badManaged: PlainStruct
+  // CHECK-LABEL: {{^}}  @NSManaged @_hasStorage var badManaged: PlainStruct {
+  // CHECK-NEXT: {{^}} get
+  // CHECK-NEXT: {{^}} set
+  // CHECK-NEXT: {{^}} }
 }
 
 //===---

--- a/test/attr/hasInitialValue.swift
+++ b/test/attr/hasInitialValue.swift
@@ -12,7 +12,7 @@ class C {
     // CHECK: {{^}}  @_implicitly_unwrapped_optional @_hasInitialValue var iuo: Int!
     var iuo: Int!
 
-    // CHECK: {{^}}  lazy var lazyIsntARealInit: Int
+    // CHECK: {{^}}  @_hasStorage lazy var lazyIsntARealInit: Int
     lazy var lazyIsntARealInit: Int = 0
 
     init() {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -688,6 +688,7 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
     case DAK_HasInitialValue:
+    case DAK_HasStorage:
       return None;
     default:
       break;


### PR DESCRIPTION
- **Explanation**: Cherry-picks of #20250, #20656, #20657, and part of #20936 to bring 5.0's generation of swiftinterface files up to par with master. This will allow generating swiftinterfaces from projects using the Swift 5.0 compiler without having to build with a custom toolchain, which is important because we still don't have module stability *yet.*

    Note that there are still known issues in this generation logic (for example, we get `lazy var` wrong in non-resilient structs).

- **Scope**: The changes here are mostly to AST printing, and around the use of an attribute that users can't type (`_hasStorage`).

- **Issue**: rdar://problem/43812188, mainly

- **Risk**: Low, due to the limited scope. (AST printing isn't used for anything but diagnostics during a normal compile. The places where this affects generated interfaces are beneficial.)

- **Testing**: Added compiler regression tests. On master, we also try to read in the generated swiftinterfaces, but 5.0 doesn't have the support for that.

- **Reviewed by**: @harlanhaskins and I reviewed each other's changes here. 