### PR TITLE
AST: Rework @objcMembers inheritance to not depend on validation order [5.0]

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -524,7 +524,7 @@ protected:
     NumRequirementsInSignature : 16
   );
 
-  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+2+1+2+1+3+1+1,
+  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+2+1+2+1+3+1+1+1+1,
     /// Whether this class requires all of its instance variables to
     /// have in-class initializers.
     RequiresStoredPropertyInits : 1,
@@ -547,6 +547,10 @@ protected:
 
     /// Whether the class has @objc ancestry.
     ObjCKind : 3,
+
+    /// Whether this class has @objc members.
+    HasObjCMembersComputed : 1,
+    HasObjCMembers : 1,
 
     HasMissingDesignatedInitializers : 1,
     HasMissingVTableEntries : 1
@@ -3574,6 +3578,8 @@ class ClassDecl final : public NominalTypeDecl {
   friend class SuperclassTypeRequest;
   friend class TypeChecker;
 
+  bool hasObjCMembersSlow();
+
 public:
   ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
             MutableArrayRef<TypeLoc> Inherited,
@@ -3732,10 +3738,19 @@ public:
     Bits.ClassDecl.InheritsSuperclassInits = true;
   }
 
-  /// Figure out if this class has any @objc ancestors, in which case it should
-  /// have implicitly @objc members. Note that a class with generic ancestry
-  /// might have implicitly @objc members, but will never itself be @objc.
+  /// Returns if this class has any @objc ancestors, or if it is directly
+  /// visible to Objective-C. The latter is a stronger condition which is only
+  /// true if the class does not have any generic ancestry.
   ObjCClassKind checkObjCAncestry() const;
+
+  /// Returns if the class has implicitly @objc members. This is true if any
+  /// ancestor class has the @objcMembers attribute.
+  bool hasObjCMembers() const {
+    if (Bits.ClassDecl.HasObjCMembersComputed)
+      return Bits.ClassDecl.HasObjCMembers;
+
+    return const_cast<ClassDecl *>(this)->hasObjCMembersSlow();
+  }
 
   /// The type of metaclass to use for a class.
   enum class MetaclassKind : uint8_t {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3315,6 +3315,8 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
   Bits.ClassDecl.RawForeignKind = 0;
   Bits.ClassDecl.HasDestructorDecl = 0;
   Bits.ClassDecl.ObjCKind = 0;
+  Bits.ClassDecl.HasObjCMembersComputed = 0;
+  Bits.ClassDecl.HasObjCMembers = 0;
   Bits.ClassDecl.HasMissingDesignatedInitializers = 0;
   Bits.ClassDecl.HasMissingVTableEntries = 0;
 }
@@ -3475,6 +3477,20 @@ ObjCClassKind ClassDecl::checkObjCAncestry() const {
   const_cast<ClassDecl *>(this)->Bits.ClassDecl.ObjCKind
     = unsigned(kind) + 1;
   return kind;
+}
+
+bool ClassDecl::hasObjCMembersSlow() {
+  // Don't attempt to calculate this again.
+  Bits.ClassDecl.HasObjCMembersComputed = true;
+
+  bool result = false;
+  if (getAttrs().hasAttribute<ObjCMembersAttr>())
+    result = true;
+  else if (auto *superclassDecl = getSuperclassDecl())
+    result = superclassDecl->hasObjCMembers();
+
+  Bits.ClassDecl.HasObjCMembers = result;
+  return result;
 }
 
 ClassDecl::MetaclassKind ClassDecl::getMetaclassKind() const {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7416,13 +7416,9 @@ void ClangImporter::Implementation::importAttributes(
       return;
     }
 
-    // Map Clang's swift_objc_members attribute to @objcMembers. Also handle
-    // inheritance of @objcMembers by looking at the superclass.
-    if (ID->hasAttr<clang::SwiftObjCMembersAttr>() ||
-        (isa<ClassDecl>(MappedDecl) &&
-         cast<ClassDecl>(MappedDecl)->hasSuperclass() &&
-         cast<ClassDecl>(MappedDecl)->getSuperclassDecl()
-           ->getAttrs().hasAttribute<ObjCMembersAttr>())) {
+    // Map Clang's swift_objc_members attribute to @objcMembers.
+    if (ID->hasAttr<clang::SwiftObjCMembersAttr>() &&
+        isa<ClassDecl>(MappedDecl)) {
       if (!MappedDecl->getAttrs().hasAttribute<ObjCMembersAttr>()) {
         auto attr = new (C) ObjCMembersAttr(/*IsImplicit=*/true);
         MappedDecl->getAttrs().add(attr);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3957,14 +3957,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
           (CD->hasSuperclass() &&
            CD->getSuperclassDecl()->requiresStoredPropertyInits()))
         CD->setRequiresStoredPropertyInits(true);
-
-      // Inherit @objcMembers.
-      if (auto superclass = CD->getSuperclassDecl()) {
-        if (superclass->getAttrs().hasAttribute<ObjCMembersAttr>() &&
-            !CD->getAttrs().hasAttribute<ObjCMembersAttr>()) {
-          CD->getAttrs().add(new (Context) ObjCMembersAttr(/*IsImplicit=*/true));
-        }
-      }
     }
 
     if (auto *ED = dyn_cast<EnumDecl>(nominal)) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -988,7 +988,7 @@ static bool isMemberOfObjCMembersClass(const ValueDecl *VD) {
   auto classDecl = VD->getDeclContext()->getSelfClassDecl();
   if (!classDecl) return false;
 
-  return classDecl->getAttrs().hasAttribute<ObjCMembersAttr>();
+  return classDecl->hasObjCMembers();
 }
 
 // A class is @objc if it does not have generic ancestry, and it either has

--- a/test/attr/Inputs/attr_objcMembers_other.swift
+++ b/test/attr/Inputs/attr_objcMembers_other.swift
@@ -1,0 +1,3 @@
+@objcMembers class BaseClassWithObjCMembers {}
+
+class OtherClassWithObjCMembers : BaseClassWithObjCMembers {}

--- a/test/attr/attr_objcMembers.swift
+++ b/test/attr/attr_objcMembers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s %S/Inputs/attr_objcMembers_other.swift
 // REQUIRES: objc_interop
 
 import Foundation
@@ -24,12 +24,17 @@ extension SubClassOfSomeClassWithObjCMembers {
   func wibble() { }
 }
 
+class SubClassOfOtherClassWithObjCMembers : OtherClassWithObjCMembers {
+  func quux() { }
+}
+
 // @objc should be inferred for everything referenced here.
 func selectorTest() {
   _ = #selector(SomeClassWithObjCMembers.foo)
   _ = #selector(getter: SomeClassWithObjCMembers.bar)
   _ = #selector(SubClassOfSomeClassWithObjCMembers.baz)
   _ = #selector(SubClassOfSomeClassWithObjCMembers.wibble)
+  _ = #selector(SubClassOfOtherClassWithObjCMembers.quux)
 }
 
 @nonobjc extension SomeClassWithObjCMembers {


### PR DESCRIPTION
Sema would directly check for the presence of the @objcMembers attribute,
and inherit it from the immediate superclass in validateDecl().

We don't want validateDecl() to have side effects like this and this was
already a problem, because it would not inherit the attribute transitively
in some cases.

Instead, add a ClassDecl::hasObjCMembers() method that walks over all
ancestors and caches the result.

<rdar://problem/46420252>