### PR TITLE
Use @unknown default in a switch over SCNGeometryPrimitiveType

### DIFF
--- a/stdlib/public/Darwin/SceneKit/SceneKit.swift.gyb
+++ b/stdlib/public/Darwin/SceneKit/SceneKit.swift.gyb
@@ -164,6 +164,8 @@ extension SCNGeometryElement {
       primitiveCount = indexCount
     case .polygon:
       fatalError("Expected constant number of indices per primitive")
+    @unknown default:
+      fatalError("Unexpected primitive type")
     }
     self.init(
       data: Data(bytes: indices, count: indexCount * MemoryLayout<IndexType>.stride),


### PR DESCRIPTION
To future-proof the switch statement.

<rdar://problem/39029889>