### PR TITLE
[Key paths] Map Hashable conformances for subscript indexes out of context

### DIFF
--- a/test/IRGen/keypath_subscript.swift
+++ b/test/IRGen/keypath_subscript.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// rdar://problem/46632723
+public struct Foo<T>: Hashable { }
+
+public struct Bar<U, V> {
+  public subscript<W> (foo: W) -> Int {
+    return 0
+  }
+
+  // CHECK-LABEL: define {{.*}} @"$s17keypath_subscript3FooVyqd__Gr0__lTh"
+  // CHECK: call swiftcc %swift.metadata_response @"$s17keypath_subscript3FooVMa"
+  public func blah<W>(_: W) -> AnyKeyPath {
+    return \Bar<U, V>.[Foo<W>()] as AnyKeyPath
+  }
+}
+


### PR DESCRIPTION
SILGen et al were expecting interface types, so make sure that's how we
record them. Fixes rdar://problem/46632723.
