### PR TITLE
Added runtime fixes required by some modules

### DIFF
--- a/stdlib/public/Python/PythonLibrary+Symbols.swift
+++ b/stdlib/public/Python/PythonLibrary+Symbols.swift
@@ -50,6 +50,9 @@ let PyImport_ImportModule: @convention(c) (
 let PyEval_GetBuiltins: @convention(c) () -> PyObjectPointer =
   PythonLibrary.loadSymbol(name: "PyEval_GetBuiltins")
 
+let PyRun_SimpleString: @convention(c) (PyCCharPointer) -> Void =
+    PythonLibrary.loadSymbol(name: "PyRun_SimpleString")
+
 let PyErr_Occurred: @convention(c) () -> PyObjectPointer? =
   PythonLibrary.loadSymbol(name: "PyErr_Occurred")
 


### PR DESCRIPTION
- Sets the `sys.args` property with [""] (the same as the Python interpreter). Some modules (like `argparse`: https://github.com/python/cpython/blob/master/Lib/argparse.py#L1638) expect at least one element in the list.
- Fixes the `sys.executable` value in Darwin for Python 3, where by default it returns the current executable path instead of the Python interpreter path. Some modules expect this to use it in subprocesses: `subprocess.call([sys.executable, "-m", "module_name"])`.
