### PR TITLE
test: invoke python scripts with the interpreter

### DIFF
--- a/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
@@ -20,40 +20,40 @@
 //
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
-// RUN: %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
+// RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
 // RUN: %target-swift-frontend -I %t -emit-parseable-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-parseable-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
 // Actual test: add an inlinable func with an unused var to LeafModule.swiftinterface (which should emit a warning); check we do get a rebuild, but no warning.
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: echo "@inlinable func foo() { var x = 10 }" >>%t/LeafModule.swiftinterface
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/LeafModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/warn.txt 2>&1
-// RUN: %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // "check warn.txt exists and is empty"
 // RUN: test -e %t/warn.txt -a ! -s %t/warn.txt
 //
 //
 // Next test: make LeafModule.swiftinterface import NotAModule (which should emit an error); check we do not get a rebuild, do get an error.
 //
-// RUN: %S/Inputs/make-old.py %t/modulecache/*.swiftmodule %t/*.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/*.swiftmodule %t/*.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: echo "import NotAModule" >>%t/LeafModule.swiftinterface
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/LeafModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: not %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err.txt 2>&1
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR <%t/err.txt
 // CHECK-ERROR: LeafModule.swiftinterface:6:8: error: no such module 'NotAModule'
 // CHECK-ERROR: OtherModule.swiftinterface:4:8: error: no such module 'LeafModule'
@@ -61,10 +61,10 @@
 //
 // Next test: same as above, but with a .dia file
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: not %target-swift-frontend -I %t -module-cache-path %t/modulecache -serialize-diagnostics -serialize-diagnostics-path %t/err.dia -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: c-index-test -read-diagnostics %t/err.dia 2>&1 | %FileCheck %s -check-prefix=CHECK-ERROR
 
 import OtherModule

--- a/test/ParseableInterface/ModuleCache/module-cache-intermediate-hash-change-rebuilds-only-intermediate.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-intermediate-hash-change-rebuilds-only-intermediate.swift
@@ -18,25 +18,25 @@
 //
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
-// RUN: %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
+// RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
 // RUN: %target-swift-frontend -I %t -emit-parseable-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-parseable-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
 // Actual test: Change a byte in OtherModule.swiftinterface, check we only rebuild its cached module.
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: sed -e 's/OtherFunc2/OtterFunc2/' -i.prev %t/OtherModule.swiftinterface
-// RUN: %S/Inputs/make-old.py %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/OtherModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/LeafModule-*.swiftmodule
 
 import OtherModule
 

--- a/test/ParseableInterface/ModuleCache/module-cache-intermediate-size-change-rebuilds-only-intermediate.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-intermediate-size-change-rebuilds-only-intermediate.swift
@@ -17,26 +17,26 @@
 //
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
-// RUN: %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
+// RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
 // RUN: %target-swift-frontend -I %t -emit-parseable-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-parseable-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
 // Actual test: make OtherModule.swiftinterface change size without changing mtime, check we only rebuild its cached module.
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: echo "// size change" >>%t/OtherModule.swiftinterface
-// RUN: %S/Inputs/make-old.py %t/OtherModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/LeafModule-*.swiftmodule
 
 import OtherModule
 

--- a/test/ParseableInterface/ModuleCache/module-cache-leaf-hash-change-rebuilds-all.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-leaf-hash-change-rebuilds-all.swift
@@ -29,13 +29,13 @@
 //
 // Actual test: Change a byte in LeafModule.swiftinterface, check both cached modules get rebuilt.
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: sed -e 's/LeafFunc2/LoafFunc2/' -i.prev %t/LeafModule.swiftinterface
 // RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 
 import OtherModule
 

--- a/test/ParseableInterface/ModuleCache/module-cache-leaf-size-change-rebuilds-all.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-leaf-size-change-rebuilds-all.swift
@@ -17,25 +17,25 @@
 //
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
-// RUN: %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
+// RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
 // RUN: %target-swift-frontend -I %t -emit-parseable-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-parseable-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
 // Actual test: make LeafModule.swiftinterface change size without changing mtime, check both cached modules get rebuilt.
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: echo "// size change" >>%t/LeafModule.swiftinterface
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/LeafModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 
 import OtherModule
 

--- a/test/ParseableInterface/ModuleCache/module-cache-no-rebuild.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-no-rebuild.swift
@@ -17,23 +17,23 @@
 //
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
-// RUN: %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
+// RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
 // RUN: %target-swift-frontend -I %t -emit-parseable-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-parseable-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
-// RUN: %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
 // Actual test: rebuild output, check no intermediates gets rebuilt.
 //
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
-// RUN: %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
-// RUN: %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
+// RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 
 import OtherModule
 


### PR DESCRIPTION
Ensure that we explicitly provide the path to the interpreter when
running the python scripts during the tests.  This is needed to have the
tests work on Windows which does not honour the shebang in the file.  It
also ensures that we use the correct interpreter for the tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
