### PR TITLE
Add traceback to exception descriptions when available.

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -220,9 +220,9 @@ extension PythonError : CustomStringConvertible {
       if let t = t {
         let traceback = Python.import("traceback")
         exceptionDescription += """
-        \nTraceback:
-        \(PythonObject("").join(traceback.format_tb(t)))
-        """
+          \nTraceback:
+          \(PythonObject("").join(traceback.format_tb(t)))
+          """
       }
       return exceptionDescription
     case .invalidCall(let e):
@@ -246,12 +246,9 @@ private func throwPythonErrorIfPresent() throws {
   PyErr_Fetch(&type, &value, &traceback)
 
   // The value for the exception may not be set but the type always should be.
-  let r = PythonObject(owning: value ?? type!)
-  var t: PythonObject?
-  if let traceback = traceback {
-    t = PythonObject(owning: traceback)
-  }
-  throw PythonError.exception(r, traceback: t)
+  let resultObject = PythonObject(owning: value ?? type!)
+  let tracebackObject = traceback.flatMap { PythonObject(owning: $0) }
+  throw PythonError.exception(resultObject, traceback: tracebackObject)
 }
 
 /// A `PythonObject` wrapper that enables throwing method calls.

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -140,7 +140,7 @@ PythonRuntimeTestSuite.test("RangeIteration") {
 }
 
 PythonRuntimeTestSuite.test("Errors") {
-  expectThrows(PythonError.exception("division by zero"), {
+  expectThrows(PythonError.exception("division by zero", traceback: nil), {
     try PythonObject(1).__truediv__.throwing.dynamicallyCall(withArguments: 0)
     // `expectThrows` does not fail if no error is thrown.
     fatalError("No error was thrown.")


### PR DESCRIPTION
Added traceback to exception descriptions when available:

```
$ swift
Welcome to Apple Swift version 5.0-dev (LLVM 06a544889f, Clang 4710b9d3d7, Swift a8a8bdc4da).
Type :help for assistance.
  1> import Python
  2> let os = Python.import("os") 
  3> os.path.join(23) 
Fatal error: 'try!' expression unexpectedly raised an error: Python exception: expected str, bytes or os.PathLike object, not int  
Traceback:
    File "/usr/local/Frameworks/Python.framework/Versions/3.7/lib/python3.7/posixpath.py", line 80, in join
    a = os.fspath(a)
: file /Users/pvieito/Documents/Developer/PythonKit/PythonKit/Python.swift, line 607
```