### PR TITLE
[ParseableInterface] Don't print @_hasInitialValue for resilient variables

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -889,8 +889,8 @@ void PrintAST::printAttributes(const Decl *D) {
 
     if (auto vd = dyn_cast<VarDecl>(D)) {
       // Don't print @_hasInitialValue if we're printing an initializer
-      // expression.
-      if (vd->isInitExposedToClients())
+      // expression or if the storage is resilient.
+      if (vd->isInitExposedToClients() || vd->isResilient())
         Options.ExcludeAttrList.push_back(DAK_HasInitialValue);
 
       if (!Options.PrintForSIL) {

--- a/test/ParseableInterface/fixed-layout-property-initializers.swift
+++ b/test/ParseableInterface/fixed-layout-property-initializers.swift
@@ -1,37 +1,38 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t.swiftinterface
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix NONRESILIENT --check-prefix COMMON < %t.swiftinterface
 
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-resilience %s
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t-resilient.swiftinterface
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix RESILIENT --check-prefix COMMON < %t-resilient.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix NONRESILIENT --check-prefix COMMON
 
 // RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix RESILIENT --check-prefix COMMON
 
-// CHECK: @_fixed_layout public struct MyStruct {
+// COMMON: @_fixed_layout public struct MyStruct {
 @_fixed_layout
 public struct MyStruct {
-  // CHECK: public var publicVar: [[BOOL:(Swift\.)?Bool]] = false
+  // COMMON: public var publicVar: [[BOOL:(Swift\.)?Bool]] = false
   public var publicVar: Bool = false
 
-  // CHECK: internal var internalVar: ([[BOOL]], [[BOOL]]) = (false, true)
+  // COMMON: internal var internalVar: ([[BOOL]], [[BOOL]]) = (false, true)
   internal var internalVar: (Bool, Bool) = (false, true)
 
-  // CHECK: private var privateVar: [[BOOL]] = Bool(4 < 10)
+  // COMMON: private var privateVar: [[BOOL]] = Bool(4 < 10)
   private var privateVar: Bool = Bool(4 < 10)
 
-  // CHECK: @usableFromInline
-  // CHECK-NEXT: internal var ufiVar: [[BOOL]] = true
+  // COMMON: @usableFromInline
+  // COMMON-NEXT: internal var ufiVar: [[BOOL]] = true
   @usableFromInline internal var ufiVar: Bool = true
 
-  // CHECK: public var multiVar1: [[BOOL]] = Bool(false), (multiVar2, multiVar3): ([[BOOL]], [[BOOL]]) = (true, 3 == 0)
+  // COMMON: public var multiVar1: [[BOOL]] = Bool(false), (multiVar2, multiVar3): ([[BOOL]], [[BOOL]]) = (true, 3 == 0)
   public var multiVar1: Bool = Bool(false), (multiVar2, multiVar3): (Bool, Bool) = (true, 3 == 0)
 
-  // CHECK: @_hasInitialValue public static var staticVar: [[BOOL]]
+  // NONRESILIENT: @_hasInitialValue public static var staticVar: [[BOOL]]
+  // RESILIENT: {{^}}  public static var staticVar: [[BOOL]]
   public static var staticVar: Bool = Bool(true && false)
 
   // FROMSOURCE: @inlinable internal init() {}
@@ -39,23 +40,24 @@ public struct MyStruct {
   @inlinable init() {}
 }
 
-// CHECK: @_fixed_layout public class MyClass {
+// COMMON: @_fixed_layout public class MyClass {
 @_fixed_layout
 public class MyClass {
-  // CHECK: public var publicVar: [[BOOL]] = false
+  // COMMON: public var publicVar: [[BOOL]] = false
   public var publicVar: Bool = false
 
-  // CHECK: internal var internalVar: [[BOOL]] = false
+  // COMMON: internal var internalVar: [[BOOL]] = false
   internal var internalVar: Bool = false
 
-  // CHECK: private var privateVar: {{(Swift\.)?}}UInt8 = UInt8(2)
+  // COMMON: private var privateVar: {{(Swift\.)?}}UInt8 = UInt8(2)
   private var privateVar: UInt8 = UInt8(2)
 
-  // CHECK: @usableFromInline
-  // CHECK-NEXT: internal var ufiVar: [[BOOL]] = true
+  // COMMON: @usableFromInline
+  // COMMON-NEXT: internal var ufiVar: [[BOOL]] = true
   @usableFromInline internal var ufiVar: Bool = true
 
-  // CHECK: @_hasInitialValue public static var staticVar: [[BOOL]]
+  // NONRESILIENT: @_hasInitialValue public static var staticVar: [[BOOL]]
+  // RESILIENT: {{^}}  public static var staticVar: [[BOOL]]
   public static var staticVar: Bool = Bool(true && false)
 
   // FROMSOURCE: @inlinable internal init() {}
@@ -63,5 +65,6 @@ public class MyClass {
   @inlinable init() {}
 }
 
-// CHECK: @_hasInitialValue public var topLevelVar: [[BOOL]]
+// NONRESILIENT: @_hasInitialValue public var topLevelVar: [[BOOL]]
+// RESILIENT: {{^}}public var topLevelVar: [[BOOL]]
 public var topLevelVar: Bool = Bool(false && !true)

--- a/test/ParseableInterface/stored-properties.swift
+++ b/test/ParseableInterface/stored-properties.swift
@@ -53,7 +53,7 @@ public struct HasStoredProperties {
   private var privateVar: Bool
 
   // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: [[INT]] {
-  // RESILIENT: {{^}}  @_hasInitialValue public var storedWithObserversInitialValue: [[INT]] {
+  // RESILIENT: {{^}}  public var storedWithObserversInitialValue: [[INT]] {
   // COMMON-NEXT: get
   // COMMON-NEXT: set
   // COMMON-NEXT: }


### PR DESCRIPTION
Came up during review of #21269, and should not be merged until that's merged and the test in it can be fixed.