### PR TITLE
Exclude/fix certain tests for swift-evolve

### DIFF
--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -1,2 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil -Ounchecked | %target-sil-opt -assume-parsing-unqualified-ownership-sil
+
+// FIXME: Fails if the positions of the two Collection subscript requirements
+// are reversed. rdar://problem/46650834
+// UNSUPPORTED: swift_evolve
+
 var W = [UInt32](repeating: 0, count: 16)

--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil -Ounchecked | %target-sil-opt -assume-parsing-unqualified-ownership-sil
 
-// FIXME: Fails if the positions of the two Collection subscript requirements
-// are reversed. rdar://problem/46650834
-// UNSUPPORTED: swift_evolve
+// Fails if the positions of the two Collection subscript requirements are
+// reversed. rdar://problem/46650834
+// XFAIL: swift_evolve
 
 var W = [UInt32](repeating: 0, count: 16)

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -1,4 +1,6 @@
 // REQUIRES: objc_interop
+
+// SourceKit is expected to produce documentation in source order.
 // UNSUPPORTED: swift_evolve
 
 // FIXME: the test output we're comparing to is specific to macOS.

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -1,4 +1,5 @@
 // REQUIRES: objc_interop
+// UNSUPPORTED: swift_evolve
 
 // FIXME: the test output we're comparing to is specific to macOS.
 // REQUIRES-ANY: OS=macosx

--- a/test/SourceKit/InterfaceGen/gen_stdlib.swift
+++ b/test/SourceKit/InterfaceGen/gen_stdlib.swift
@@ -8,17 +8,17 @@ var x: Int
 
 // Just check a small part, mainly to make sure we can print the interface of the stdlib.
 // CHECK-STDLIB-NOT: extension _SwiftNSOperatingSystemVersion
-// CHECK-STDLIB: struct Int : FixedWidthInteger, SignedInteger {
-// CHECK-STDLIB:   static var bitWidth: Int { get }
-// CHECK-STDLIB:   var nonzeroBitCount: Int { get }
+// CHECK-STDLIB-LABEL: struct Int : FixedWidthInteger, SignedInteger {
+// CHECK-STDLIB-DAG:   static var bitWidth: Int { get }
+// CHECK-STDLIB-DAG:   var nonzeroBitCount: Int { get }
 // CHECK-STDLIB: }
 
 // Check that extensions of nested decls are showing up.
 // CHECK-STDLIB-LABEL: extension String.Index {
-// CHECK-STDLIB: func samePosition(in utf8: String.UTF8View) -> String.UTF8View.Index?
-// CHECK-STDLIB: func samePosition(in characters: String) -> String.Index?
-// CHECK-STDLIB: func samePosition(in unicodeScalars: String.UnicodeScalarView) -> String.UnicodeScalarIndex?
-// CHECK-STDLIB-NEXT: }
+// CHECK-STDLIB-DAG: func samePosition(in utf8: String.UTF8View) -> String.UTF8View.Index?
+// CHECK-STDLIB-DAG: func samePosition(in characters: String) -> String.Index?
+// CHECK-STDLIB-DAG: func samePosition(in unicodeScalars: String.UnicodeScalarView) -> String.UnicodeScalarIndex?
+// CHECK-STDLIB: }
 
 // CHECK-MUTATING-ATTR: mutating func
 

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -13,3 +13,8 @@
 // RUN: diff -u %S/Outputs/cake.json %t.dump.json
 // RUN: %api-digester -deserialize-sdk --input-paths %S/Outputs/cake-abi.json -o %t.dump.json
 // RUN: diff -u %S/Outputs/cake-abi.json %t.dump.json
+
+// The input JSON files need to be modified when standard library declarations
+// are reordered. This is expected behavior and we simply shouldn't run the test
+// when automatically evolving the standard library.
+// UNSUPPORTED: swift_evolve

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -6,3 +6,6 @@
 // RUN: %clang -E -P -x c %S/Outputs/stability-stdlib-abi.swift.expected -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-stdlib-abi.swift.expected
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-abi.swift.expected %t.tmp/changes.txt.tmp
+
+// FIXME: rdar://problem/46617463, rdar://problem/46618883
+// UNSUPPORTED: swift_evolve

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -7,5 +7,8 @@
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-abi.swift.expected %t.tmp/changes.txt.tmp
 
-// FIXME: rdar://problem/46617463, rdar://problem/46618883
-// UNSUPPORTED: swift_evolve
+// The digester hasn't learned that we've stopped baking non-stored class member
+// order into the ABI. rdar://problem/46617463
+// The digester can incorrectly register a generic signature change when
+// declarations are shuffled. rdar://problem/46618883
+// XFAIL: swift_evolve

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -540,6 +540,9 @@ elif swift_test_subset == 'only_stress':
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_subset)
 
+if lit_config.params.get('swift_evolve', None) is not None:
+    config.available_features.add("swift_evolve")
+
 # Enable benchmark testing when the binary is found (has fully qualified path).
 if config.benchmark_o != 'Benchmark_O':
     config.available_features.add('benchmark')

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -540,7 +540,7 @@ elif swift_test_subset == 'only_stress':
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_subset)
 
-if lit_config.params.get('swift_evolve', None) is not None:
+if 'swift_evolve' in lit_config.params:
     config.available_features.add("swift_evolve")
 
 # Enable benchmark testing when the binary is found (has fully qualified path).


### PR DESCRIPTION
This pull request adds a swift_evolve feature to our lit configuration and marks several tests as unsupported with it.

swift-evolve is a tool currently in development which automatically modifies source code in ways that should be source- and ABI-compatible; we will be using it to test resilience. Currently it simply shuffles declarations. The tests I'm marking as unsupported in this pull request either intentionally depend on the order of declarations, or expose bugs in our tools that we've filed but haven't fixed.

This PR also fixes one more order-dependent test in SourceKit.

Part of rdar://problem/44426013.