### PR TITLE
Add frontend mode -build-module-from-parseable-interface

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -126,6 +126,9 @@ public:
     EmitModuleOnly, ///< Emit module only
     MergeModules,   ///< Merge modules only
 
+    /// Build from a swiftinterface, as close to `import` as possible
+    BuildModuleFromParseableInterface,
+
     EmitSIBGen, ///< Emit serialized AST + raw SIL
     EmitSIB,    ///< Emit serialized AST + canonical SIL
 

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -69,10 +69,13 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
 
   std::string CacheDir;
 
-  void
-  configureSubInvocationAndOutputPaths(CompilerInvocation &SubInvocation,
-                                       Identifier ModuleName, StringRef InPath,
-                                       llvm::SmallString<128> &OutPath);
+  /// Wire up the SubInvocation's InputsAndOutputs to contain both input and
+  /// output filenames.
+  ///
+  /// This is a method rather than a helper function in the implementation file
+  /// because it accesses non-public bits of FrontendInputsAndOutputs.
+  static void configureSubInvocationInputsAndOutputs(
+    CompilerInvocation &SubInvocation, StringRef InPath, StringRef OutPath);
 
   std::error_code
   openModuleFiles(AccessPathElem ModuleID, StringRef DirName,

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -92,6 +92,17 @@ public:
     return std::unique_ptr<ParseableInterfaceModuleLoader>(
         new ParseableInterfaceModuleLoader(ctx, cacheDir, tracker, loadMode));
   }
+
+  /// Unconditionally build \p InPath (a swiftinterface file) to \p OutPath (as
+  /// a swiftmodule file).
+  ///
+  /// A simplified version of the core logic in #openModuleFiles, mostly for
+  /// testing purposes.
+  static bool buildSwiftModuleFromSwiftInterface(ASTContext &Ctx,
+                                                 StringRef CacheDir,
+                                                 StringRef ModuleName,
+                                                 StringRef InPath,
+                                                 StringRef OutPath);
 };
 
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -513,6 +513,11 @@ def dump_interface_hash : Flag<["-"], "dump-interface-hash">,
    HelpText<"Parse input file(s) and dump interface token hash(es)">,
    ModeOpt;
 
+def build_module_from_parseable_interface :
+  Flag<["-"], "build-module-from-parseable-interface">,
+  HelpText<"Treat the (single) input as a swiftinterface and produce a module">,
+  ModeOpt;
+
 def enable_resilience_bypass : Flag<["-"], "enable-resilience-bypass">,
    HelpText<"Completely bypass resilience when accessing types in resilient frameworks">;
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -370,6 +370,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::REPL;
   if (Opt.matches(OPT_interpret))
     return FrontendOptions::ActionType::Immediate;
+  if (Opt.matches(OPT_build_module_from_parseable_interface))
+    return FrontendOptions::ActionType::BuildModuleFromParseableInterface;
 
   llvm_unreachable("Unhandled mode option");
 }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -48,6 +48,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::EmitSIB:
   case ActionType::EmitModuleOnly:
   case ActionType::MergeModules:
+  case ActionType::BuildModuleFromParseableInterface:
     return true;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -83,6 +84,7 @@ bool FrontendOptions::isActionImmediate(ActionType action) {
   case ActionType::EmitSIB:
   case ActionType::EmitModuleOnly:
   case ActionType::MergeModules:
+  case ActionType::BuildModuleFromParseableInterface:
     return false;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -170,6 +172,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
 
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
+  case ActionType::BuildModuleFromParseableInterface:
     return TY_SwiftModuleFile;
 
   case ActionType::Immediate:
@@ -207,6 +210,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -242,6 +246,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -277,6 +282,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -309,6 +315,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -347,6 +354,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -379,15 +387,16 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
-  case ActionType::EmitImportedModules:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -427,6 +436,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitObject:
   case ActionType::EmitImportedModules:
   case ActionType::MergeModules:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::DumpTypeInfo:
     return true;
 
@@ -446,6 +456,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::EmitSIB:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
+  case ActionType::BuildModuleFromParseableInterface:
   case ActionType::EmitBC:
   case ActionType::EmitObject:
   case ActionType::Immediate:
@@ -488,6 +499,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
+  case ActionType::BuildModuleFromParseableInterface:
     return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -559,6 +559,17 @@ static bool precompileBridgingHeader(CompilerInvocation &Invocation,
           .InputsAndOutputs.getSingleOutputFilename());
 }
 
+static bool buildModuleFromParseableInterface(CompilerInvocation &Invocation,
+                                              CompilerInstance &Instance) {
+  const auto &InputsAndOutputs =
+      Invocation.getFrontendOptions().InputsAndOutputs;
+  assert(InputsAndOutputs.hasSingleInput());
+  StringRef InputPath = InputsAndOutputs.getFilenameOfFirstInput();
+  return ParseableInterfaceModuleLoader::buildSwiftModuleFromSwiftInterface(
+      Instance.getASTContext(), Invocation.getClangModuleCachePath(),
+      Invocation.getModuleName(), InputPath, Invocation.getOutputFilename());
+}
+
 static bool compileLLVMIR(CompilerInvocation &Invocation,
                           CompilerInstance &Instance,
                           UnifiedStatsReporter *Stats) {
@@ -922,6 +933,9 @@ static bool performCompile(CompilerInstance &Instance,
   // avoid touching any other inputs and just parse, emit and exit.
   if (Action == FrontendOptions::ActionType::EmitPCH)
     return precompileBridgingHeader(Invocation, Instance);
+
+  if (Action == FrontendOptions::ActionType::BuildModuleFromParseableInterface)
+    return buildModuleFromParseableInterface(Invocation, Instance);
 
   if (Invocation.getInputKind() == InputFileKind::LLVM)
     return compileLLVMIR(Invocation, Instance, Stats);

--- a/test/ParseableInterface/ParseStdlib.swiftinterface
+++ b/test/ParseableInterface/ParseStdlib.swiftinterface
@@ -1,0 +1,12 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib
+
+// Note that the "-parse-stdlib" is picked up from the module flags. It should
+// not be written in any of the invocations below.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -o %t/ParseStdlib.swiftmodule %s
+// RUN: %target-swift-ide-test -print-module -module-to-print ParseStdlib -I %t -source-filename x -print-interface | %FileCheck %s
+
+// CHECK: func test(_: Int42)
+public func test(_: Builtin.Int42) {}

--- a/test/ParseableInterface/SmokeTest.swiftinterface
+++ b/test/ParseableInterface/SmokeTest.swiftinterface
@@ -1,4 +1,4 @@
-// swift-tools-version: 4.0
+// swift-interface-format-version: 1.0
 // swift-module-flags: 
 
 // Make sure parse-only works...
@@ -6,7 +6,7 @@
 
 // ...and then make sure parse-and-typecheck-and-serialize works.
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/SmokeTest.swiftmodule %s
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -o %t/SmokeTest.swiftmodule %s
 // RUN: %target-swift-ide-test -print-module -module-to-print SmokeTest -I %t -source-filename x -print-interface > %t/SmokeTest.txt
 // RUN: %FileCheck %s < %t/SmokeTest.txt
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t/SmokeTest.txt


### PR DESCRIPTION
Makes it easier to test the caching behavior, and may also be useful for "prebuilding" swiftinterfaces in the future, or having the Driver kick off a bunch of separate builds as proper tasks.