### PR TITLE
[5.0] [Constraint solver] De-prioritize SIMD operators.

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -491,6 +491,9 @@ bool DisjunctionStep::shouldStopAt(const DisjunctionChoice &choice) const {
 }
 
 bool swift::isSIMDOperator(ValueDecl *value) {
+  if (!value)
+    return false;
+
   auto func = dyn_cast<FuncDecl>(value);
   if (!func)
     return false;
@@ -556,10 +559,8 @@ bool DisjunctionStep::shortCircuitDisjunctionAt(
   // If we have an operator from the SIMDOperators module, and the prior
   // choice was not from the SIMDOperators module, we're done.
   if (currentChoice->getKind() == ConstraintKind::BindOverload &&
-      currentChoice->getOverloadChoice().isDecl() &&
       isSIMDOperator(currentChoice->getOverloadChoice().getDecl()) &&
       lastSuccessfulChoice->getKind() == ConstraintKind::BindOverload &&
-      lastSuccessfulChoice->getOverloadChoice().isDecl() &&
       !isSIMDOperator(lastSuccessfulChoice->getOverloadChoice().getDecl()) &&
       !ctx.LangOpts.SolverEnableOperatorDesignatedTypes) {
     return true;

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -490,6 +490,24 @@ bool DisjunctionStep::shouldStopAt(const DisjunctionChoice &choice) const {
           shortCircuitDisjunctionAt(choice, lastChoice));
 }
 
+bool swift::isSIMDOperator(ValueDecl *value) {
+  auto func = dyn_cast<FuncDecl>(value);
+  if (!func)
+    return false;
+
+  if (!func->isOperator())
+    return false;
+
+  auto nominal = func->getDeclContext()->getSelfNominalTypeDecl();
+  if (!nominal)
+    return false;
+
+  if (nominal->getName().empty())
+    return false;
+
+  return nominal->getName().str().startswith_lower("simd");
+}
+
 bool DisjunctionStep::shortCircuitDisjunctionAt(
     Constraint *currentChoice, Constraint *lastSuccessfulChoice) const {
   auto &ctx = CS.getASTContext();
@@ -534,6 +552,18 @@ bool DisjunctionStep::shortCircuitDisjunctionAt(
   // Implicit conversions are better than checked casts.
   if (currentChoice->getKind() == ConstraintKind::CheckedCast)
     return true;
+
+  // If we have an operator from the SIMDOperators module, and the prior
+  // choice was not from the SIMDOperators module, we're done.
+  if (currentChoice->getKind() == ConstraintKind::BindOverload &&
+      currentChoice->getOverloadChoice().isDecl() &&
+      isSIMDOperator(currentChoice->getOverloadChoice().getDecl()) &&
+      lastSuccessfulChoice->getKind() == ConstraintKind::BindOverload &&
+      lastSuccessfulChoice->getOverloadChoice().isDecl() &&
+      !isSIMDOperator(lastSuccessfulChoice->getOverloadChoice().getDecl()) &&
+      !ctx.LangOpts.SolverEnableOperatorDesignatedTypes) {
+    return true;
+  }
 
   return false;
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1459,7 +1459,7 @@ static ArrayRef<OverloadChoice> partitionSIMDOperators(
   // Check whether we have any SIMD operators.
   bool foundSIMDOperator = false;
   for (const auto &choice : choices) {
-    if (choice.isDecl() && isSIMDOperator(choice.getDecl())) {
+    if (isSIMDOperator(choice.getDecl())) {
       foundSIMDOperator = true;
       break;
     }
@@ -1471,8 +1471,7 @@ static ArrayRef<OverloadChoice> partitionSIMDOperators(
   scratch.assign(choices.begin(), choices.end());
   std::stable_partition(scratch.begin(), scratch.end(),
                         [](const OverloadChoice &choice) {
-                          return !choice.isDecl() ||
-                                 !isSIMDOperator(choice.getDecl());
+                          return !isSIMDOperator(choice.getDecl());
                         });
 
   return scratch;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3830,6 +3830,9 @@ bool exprNeedsParensOutsideFollowingOperator(
     TypeChecker &TC, DeclContext *DC, Expr *expr, Expr *rootExpr,
     PrecedenceGroupDecl *followingPG);
 
+/// Determine whether this is a SIMD operator.
+bool isSIMDOperator(ValueDecl *value);
+
 } // end namespace swift
 
 #endif // LLVM_SWIFT_SEMA_CONSTRAINT_SYSTEM_H

--- a/validation-test/Sema/type_checker_perf/fast/rdar46541800.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46541800.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 
 import simd

--- a/validation-test/Sema/type_checker_perf/fast/rdar46541800.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46541800.swift
@@ -1,0 +1,62 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -solver-enable-operator-designated-types
+// REQUIRES: OS=macosx
+
+import simd
+import CoreGraphics
+import Foundation
+
+class SomeView {
+  func layoutSubviews() {
+    let descriptionTextViewFrame = CGRect.zero
+    let availableBounds = CGRect()
+    let descriptionLabelProperties = SomeView.descriptionTextViewLabelProperties()
+    let textSize = descriptionTextView.sizeThatFits(availableBounds.size)
+    let textInset = descriptionTextView.textInset(forBounds: CGRect(origin: .zero, size: textSize))
+    let descriptionTextBaselineOffset: CGFloat = CGFloat()
+    let displayScale: CGFloat = CGFloat()
+    let _ = (descriptionTextViewFrame.height 
+             + (-descriptionTextView.lastBaselineOffsetFromBottom - textInset.bottom + descriptionLabelProperties.lastBaselineOffsetFromBottom)
+            + (-descriptionTextView.firstBaselineOffsetFromTop - textInset.top + descriptionTextBaselineOffset).ceilingValue(scale: displayScale)
+            )
+  }
+
+  static func descriptionTextViewLabelProperties() -> FontDescriptorBaselineProperties {
+      fatalError()
+  }
+  
+  lazy var descriptionTextView: SomeOtherView = SomeOtherView()
+}
+
+class SomeOtherView {
+  init() { }
+  func sizeThatFits(_ size: CGSize) -> CGSize { return size }
+}
+
+
+struct FontDescriptorBaselineProperties {
+ //   let fontDescriptor: MPUFontDescriptor
+    let defaultFirstBaselineOffsetFromTop: CGFloat
+    let defaultLastBaselineOffsetFromBottom: CGFloat
+    var firstBaselineOffsetFromTop: CGFloat { fatalError() }    
+    var lastBaselineOffsetFromBottom: CGFloat {
+        fatalError()
+    }
+}
+
+struct EdgeInsets {
+  var top: CGFloat
+  var bottom: CGFloat
+}
+
+extension SomeOtherView {
+    func textInset(forBounds bounds: CGRect) -> EdgeInsets { fatalError() }
+    var firstBaselineOffsetFromTop: CGFloat { fatalError() }    
+    var lastBaselineOffsetFromBottom: CGFloat {
+        fatalError()
+    }
+}
+
+extension CGFloat {
+    public func ceilingValue(scale: CGFloat) -> CGFloat { fatalError() }
+}


### PR DESCRIPTION
The new SIMD proposal introduced a number of new operators, the presence of
which causes more "expression too complex" failures. Route around the
problem by de-prioritizing those operators, visiting them only if no
other operator could be chosen. This should limit the type checker
performance cost of said operators to only those expressions that need
them OR that already failed to type-check.

Fixes rdar://problem/46541800.