### PR TITLE
Sema: Source compatibility fix for extensions of type aliases

### DIFF
--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -210,3 +210,16 @@ extension A.B.D {
   func g() { }
 }
 
+// rdar://problem/43955962
+struct OldGeneric<T> {}
+typealias NewGeneric<T> = OldGeneric<T>
+
+extension NewGeneric {
+  static func oldMember() -> OldGeneric {
+    return OldGeneric()
+  }
+
+  static func newMember() -> NewGeneric {
+    return NewGeneric()
+  }
+}


### PR DESCRIPTION
Referring to a generic type without arguments inside the definition
of the type itself or an extension thereof is a shorthand for
forwarding the arguments from context:

```
struct Generic<T> {}

extension Generic {
  func makeOne() -> Generic  // same as -> Generic<T>
}
```

However this didn't work if the type was replaced by a typealias:

```
struct OldGeneric<T> {}
typealias Generic<T> = OldGeneric<T>

extension Generic {
  func makeOne() -> OldGeneric  // OK
  func makeOne() -> Generic  // error
}
```

Add a hack for making this work so that we better cope with the
renaming of DictionaryLiteral to KeyValuePairs in Swift 5.0.

Fixes <rdar://problem/43955962>.