### PR TITLE
Sema: Source compatibility fix for extensions of type aliases [5.0]

### DIFF
--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -209,3 +209,17 @@ extension A.B {
 extension A.B.D {
   func g() { }
 }
+
+// rdar://problem/43955962
+struct OldGeneric<T> {}
+typealias NewGeneric<T> = OldGeneric<T>
+
+extension NewGeneric {
+  static func oldMember() -> OldGeneric {
+    return OldGeneric()
+  }
+
+  static func newMember() -> NewGeneric {
+    return NewGeneric()
+  }
+}

--- a/validation-test/compiler_crashers_fixed/28815-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers_fixed/28815-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -6,5 +6,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
+
+// XFAIL: *
+
 extension CountableRange{{}{}protocol P{typealias a:A{}func 丏
 protocol A:CountableRange


### PR DESCRIPTION
Referring to a generic type without arguments inside the definition
of the type itself or an extension thereof is a shorthand for
forwarding the arguments from context:

```
struct Generic<T> {}

extension Generic {
  func makeOne() -> Generic  // same as -> Generic<T>
}
```

However this didn't work if the type was replaced by a typealias:

```
struct OldGeneric<T> {}
typealias Generic<T> = OldGeneric<T>

extension Generic {
  func makeOne() -> OldGeneric  // OK
  func makeOne() -> Generic  // error
}
```

Add a hack for making this work so that we better cope with the
renaming of DictionaryLiteral to KeyValuePairs in Swift 5.0.

Fixes <rdar://problem/43955962>.