### PR TITLE
[WIP][Sema][stdlib] Remove _getBuiltinLogicValue

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -175,7 +175,6 @@ IDENTIFIER(appendInterpolation)
 IDENTIFIER_WITH_NAME(dollarInterpolation, "$interpolation")
 IDENTIFIER(arrayLiteral)
 IDENTIFIER(dictionaryLiteral)
-IDENTIFIER_(getBuiltinLogicValue)
 IDENTIFIER(className)
 
 IDENTIFIER_(ErrorType)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3316,15 +3316,12 @@ namespace {
         // Strip off 'Bool' to 'Builtin.Int1' conversion. Otherwise, we'll have
         // to handle multiple ways of type-checking.
         if (expr->isImplicit()) {
-          if (auto call = dyn_cast<CallExpr>(expr)) {
-            if (auto DSCE = dyn_cast<DotSyntaxCallExpr>(call->getFn())) {
-              auto RefD = DSCE->getFn()->getReferencedDecl().getDecl();
-              if (RefD->getBaseName() == TC.Context.Id_getBuiltinLogicValue &&
-                  RefD->getDeclContext()->getSelfNominalTypeDecl() ==
-                      TC.Context.getBoolDecl()) {
-                expr = DSCE->getBase();
-                continue;
-              }
+          if (auto mfe = dyn_cast<MemberRefExpr>(expr)) {
+            auto member = mfe->getMember().getDecl();
+            if (member->getBaseName() == TC.Context.Id_value_ &&
+                member->getDeclContext() == TC.Context.getBoolDecl()) {
+              expr = mfe->getBase();
+              continue;
             }
           }
         }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -646,8 +646,7 @@ public:
   /// \param locator Locator used to describe the location of this expression.
   ///
   /// \returns the expression converted to a logic value (Builtin i1).
-  Expr *convertBooleanTypeToBuiltinI1(Expr *expr,
-                                      ConstraintLocator *locator) const;
+  Expr *getBoolValue(Expr *expr, ConstraintLocator *locator) const;
 
   /// Convert the given optional-producing expression to a Bool
   /// indicating whether the optional has a value.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2758,8 +2758,7 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
       auto &cs = solution.getConstraintSystem();
 
       auto converted =
-        solution.convertBooleanTypeToBuiltinI1(expr,
-                                             cs.getConstraintLocator(OrigExpr));
+        solution.getBoolValue(expr, cs.getConstraintLocator(OrigExpr));
       cs.setExprTypes(converted);
       return converted;
     }

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -62,8 +62,8 @@
 /// have a consistent type interface.
 @_fixed_layout
 public struct Bool {
-  @usableFromInline
-  internal var _value: Builtin.Int1
+  
+  public var _value: Builtin.Int1
 
   /// Creates an instance initialized to `false`.
   ///
@@ -167,15 +167,6 @@ extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLitera
   @_transparent
   public init(booleanLiteral value: Bool) {
     self = value
-  }
-}
-
-extension Bool {
-  // This is a magic entry point known to the compiler.
-  @_transparent
-  public // COMPILER_INTRINSIC
-  func _getBuiltinLogicValue() -> Builtin.Int1 {
-    return _value
   }
 }
 

--- a/test/DebugInfo/patternmatching.swift
+++ b/test/DebugInfo/patternmatching.swift
@@ -14,7 +14,7 @@ func classifyPoint2(_ p: (Double, Double)) {
 
 switch p {
     case (let x, let y) where
-      // CHECK:   call {{.*}}double {{.*}}return_same{{.*}}, !dbg ![[LOC1:.*]]
+      // CHECK: fcmp oeq double {{.*}}, {{.*}}, !dbg ![[LOC1:.*]]
       // CHECK: br {{.*}}, label {{.*}}, label {{.*}}, !dbg ![[LOC1]]
       // CHECK: call{{.*}}markUsed{{.*}}, !dbg ![[LOC3:.*]]
       // CHECK: ![[LOC1]] = !DILocation(line: [[@LINE+1]],

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -416,7 +416,7 @@ struct Sentinel2 {}
 // CHECK-DAG: - !private ["s33ExpressibleByUnicodeScalarLiteralP", ""]
 // CHECK-DAG: - !private ["Sx", "Stride"]
 // CHECK-DAG: - !private ["Sa", "reduce"]
-// CHECK-DAG: - !private ["Sb", "_getBuiltinLogicValue"]
+// CHECK-DAG: - !private ["Sb", "_value"]
 // CHECK-DAG: - ["Sb", "InnerToBool"]
 // CHECK-DAG: - !private ["4main17OtherFileIntArrayV", "deinit"]
 // CHECK-DAG: - !private ["4main18OtherFileOuterTypeV", "InnerType"]

--- a/test/PCMacro/else.swift
+++ b/test/PCMacro/else.swift
@@ -21,8 +21,8 @@ if (a) {
 
 // CHECK: [8:1-8:14] pc before
 // CHECK-NEXT: [8:1-8:14] pc after
-// CHECK-NEXT: [9:1-9:7] pc before
-// CHECK-NEXT: [9:1-9:7] pc after
+// CHECK-NEXT: [9:1-9:6] pc before
+// CHECK-NEXT: [9:1-9:6] pc after
 // CHECK-NEXT: [11:3-11:7] pc before
 // CHECK-NEXT: [11:3-11:7] pc after
 // CHECK-NEXT: [12:3-12:4] pc before

--- a/test/PCMacro/if.swift
+++ b/test/PCMacro/if.swift
@@ -21,7 +21,7 @@ if (a) {
 
 // CHECK: [8:1-8:13] pc before
 // CHECK-NEXT: [8:1-8:13] pc after
-// CHECK-NEXT: [9:1-9:7] pc before
-// CHECK-NEXT: [9:1-9:7] pc after
+// CHECK-NEXT: [9:1-9:6] pc before
+// CHECK-NEXT: [9:1-9:6] pc after
 // CHECK-NEXT: [10:3-10:4] pc before
 // CHECK-NEXT: [10:3-10:4] pc after

--- a/test/Parse/if_expr.swift
+++ b/test/Parse/if_expr.swift
@@ -3,13 +3,13 @@
 // CHECK: (func_decl{{.*}}"r13756261(_:_:)"
 func r13756261(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (call_expr
+  // CHECK:   (member_ref_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
+  // CHECK:     (member_ref_expr
   // CHECK:     (declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
+  // CHECK:       (member_ref_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   return (x) ? y : (x) ? y : (x) ? y : y
@@ -18,13 +18,13 @@ func r13756261(_ x: Bool, _ y: Int) -> Int {
 // CHECK: (func_decl{{.*}}"r13756221(_:_:)"
 func r13756221(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (call_expr
+  // CHECK:   (member_ref_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
+  // CHECK:     (member_ref_expr
   // CHECK:     (declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
+  // CHECK:       (member_ref_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   return (x) ? y
@@ -36,11 +36,11 @@ func r13756221(_ x: Bool, _ y: Int) -> Int {
 // CHECK: (func_decl{{.*}}"telescoping_if(_:_:)"
 func telescoping_if(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (call_expr
+  // CHECK:   (member_ref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
+  // CHECK:     (member_ref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
+  // CHECK:       (member_ref_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   // CHECK:     (declref_expr
@@ -91,11 +91,11 @@ func prec_below(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (if_expr
-  // CHECK:         (call_expr
+  // CHECK:         (member_ref_expr
   // CHECK:         (binary_expr
   // CHECK:         (declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
+  // CHECK:       (member_ref_expr
   // CHECK:       (binary_expr
   // CHECK:       (declref_expr
   // CHECK:   (declref_expr
@@ -109,14 +109,14 @@ func prec_equal(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // CHECK: (binary_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
+  // CHECK:     (member_ref_expr
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (if_expr
-  // CHECK:         (call_expr
+  // CHECK:         (member_ref_expr
   // CHECK:         (binary_expr
   // CHECK:           (declref_expr
   // CHECK:           (declref_expr

--- a/test/Profiler/coverage_label.swift
+++ b/test/Profiler/coverage_label.swift
@@ -11,7 +11,7 @@ func foo() { // CHECK-DAG: [[@LINE]]:12 -> [[@LINE+19]]:2 : 0
   }
 
   label2: do { // CHECK-DAG: [[@LINE]]:14 -> [[@LINE+7]]:4 : 0
-    x += 3         // CHECK-DAG: [[@LINE+1]]:11 -> [[@LINE+1]]:17 : 0
+    x += 3         // CHECK-DAG: [[@LINE+1]]:11 -> [[@LINE+1]]:16 : 0
     while (true) { // CHECK-DAG: [[@LINE]]:18 -> [[@LINE+3]]:6 : 1
       x += 4
       break label2 // Note: This exit affects the condition counter expr @ L15.

--- a/test/Profiler/coverage_toplevel.swift
+++ b/test/Profiler/coverage_toplevel.swift
@@ -10,7 +10,7 @@ func f1() {}
 var i : Int32 = 0
 
 // CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+2]]:1
-// CHECK:  [[@LINE+1]]:7 -> [[@LINE+1]]:15 : (0 + 1)
+// CHECK:  [[@LINE+1]]:7 -> [[@LINE+1]]:11 : (0 + 1)
 while (i < 10) {
   i += 1
 }

--- a/test/Profiler/coverage_while.swift
+++ b/test/Profiler/coverage_while.swift
@@ -16,24 +16,24 @@ func eoo() {
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_while.foo
 func foo() -> Int32 {
   var x : Int32 = 0
-  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:17 : (0 + 1)
+  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:13 : (0 + 1)
   while (x < 10) {
     x += 1
   }
 
-  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:22 : (0 + 2)
+  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:19 : (0 + 2)
   while ((x - 1) > 0) {
     x -= 1
     if (x % 2 == 0) { continue }
   }
 
-  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:18 : ((0 + 4) - 5)
+  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:13 : ((0 + 4) - 5)
   while (x < 100) {
     x += 1
     if (x == 10) { break }
   }
 
-  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:18 : ((0 + 6) - 9)
+  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:13 : ((0 + 6) - 9)
   while (x < 100) {
     x += 1
     while (true) { break }
@@ -45,10 +45,10 @@ func foo() -> Int32 {
   // CHECK: [[@LINE+1]]:10 -> [[@LINE+4]]:4 : 10
   repeat {
     x -= 1
-    // CHECK: [[@LINE+1]]:11 -> [[@LINE+1]]:16 : 10
+    // CHECK: [[@LINE+1]]:11 -> [[@LINE+1]]:14 : 10
   } while x > 0
 
-  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:18 : ((0 + 11) - 12)
+  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:13 : ((0 + 11) - 12)
   while (x < 100) {
     if (x == 40) { // CHECK: [[@LINE]]:18 -> [[@LINE+2]]:6 : 12
       return x
@@ -57,7 +57,7 @@ func foo() -> Int32 {
   }
 
   var y : Int32? = 2
-  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:15 : ((0 + 13) - 12)
+  // CHECK: [[@LINE+1]]:9 -> [[@LINE+1]]:12 : ((0 + 13) - 12)
   while x > 30, let _ = y {
     y = nil
   }
@@ -76,21 +76,21 @@ func goo() {
 
   repeat { // CHECK-DAG: [[@LINE]]:10 -> [[@LINE+2]]:4 : [[RWS1:[0-9]+]]
     x += 1
-  } while x < 10 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:17 : [[RWS1]]
+  } while x < 10 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:14 : [[RWS1]]
 
   repeat { // CHECK-DAG: [[@LINE]]:10 -> [[@LINE+5]]:4 : [[RWS2:[0-9]+]]
     x += 1
     if (x % 2 == 0) { // CHECK-DAG: [[@LINE]]:21 -> [[@LINE+2]]:6 : [[CONT1:[0-9]+]]
       continue
     } // CHECK-DAG: [[@LINE]]:6 -> [[@LINE+1]]:4 : ([[RWS2]] - [[CONT1]])
-  } while x < 20 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:17 : [[RWS2]]
+  } while x < 20 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:14 : [[RWS2]]
 
   repeat { // CHECK-DAG: [[@LINE]]:10 -> [[@LINE+5]]:4 : [[RWS3:[0-9]+]]
     x += 1
     if (x % 2 == 0) { // CHECK-DAG: [[@LINE]]:21 -> [[@LINE+2]]:6 : [[BRK1:[0-9]+]]
       break
     } // CHECK-DAG: [[@LINE]]:6 -> [[@LINE+1]]:4 : ([[RWS3]] - [[BRK1]])
-  } while x < 30 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:17 : ([[RWS3]] - [[BRK1]])
+  } while x < 30 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:14 : ([[RWS3]] - [[BRK1]])
 
   repeat { // CHECK-DAG: [[@LINE]]:10 -> [[@LINE+10]]:4 : [[RWS4:[0-9]+]]
     x += 1
@@ -102,7 +102,7 @@ func goo() {
       break
     } // CHECK-DAG: [[@LINE]]:6 -> [[@LINE+2]]:4 : (([[RWS4]] - [[CONT2]]) - [[BRK2]])
     x += 1
-  } while x < 40 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:17 : ([[RWS4]] - [[BRK2]])
+  } while x < 40 // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:14 : ([[RWS4]] - [[BRK2]])
 
   repeat { // CHECK-DAG: [[@LINE]]:10 -> [[@LINE+1]]:4 : [[RWS5:[0-9]+]]
   } while false // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:16 : [[RWS5]]

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -444,7 +444,7 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
     : z
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBA]]
   // CHECK:   [[A:%[0-9]+]] = load [trivial] [[READ]]
-  // CHECK:   [[ACOND:%[0-9]+]] = apply {{.*}}([[A]])
+  // CHECK:   [[ACOND:%[0-9]+]] = struct_extract [[A]] : $Bool, #Bool._value
   // CHECK:   cond_br [[ACOND]], [[IF_A:bb[0-9]+]], [[ELSE_A:bb[0-9]+]]
   // CHECK: [[IF_A]]:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
@@ -453,7 +453,7 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   // CHECK: [[ELSE_A]]:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBB]]
   // CHECK:   [[B:%[0-9]+]] = load [trivial] [[READ]]
-  // CHECK:   [[BCOND:%[0-9]+]] = apply {{.*}}([[B]])
+  // CHECK:   [[BCOND:%[0-9]+]] = struct_extract [[B]] : $Bool, #Bool._value 
   // CHECK:   cond_br [[BCOND]], [[IF_B:bb[0-9]+]], [[ELSE_B:bb[0-9]+]]
   // CHECK: [[IF_B]]:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -247,7 +247,7 @@ func if_multi_where() {
   // CHECK:   br [[DONE]]
 
   // CHECK: [[CHECK_WHERE]]([[B:%[0-9]+]] : @owned $String):
-  // CHECK:   function_ref Swift.Bool._getBuiltinLogicValue() -> Builtin.Int1
+  // CHECK:   struct_extract {{.*}} : $Bool, #Bool._value
   // CHECK:   cond_br {{.*}}, [[IF_BODY:bb[0-9]+]], [[IF_EXIT3:bb[0-9]+]]
   if let a = foo(), var b = bar(), a == b {
     // CHECK: [[IF_BODY]]:
@@ -274,8 +274,7 @@ func if_leading_boolean(_ a : Int) {
   // CHECK: debug_value %0 : $Int, let, name "a"
   // CHECK: [[EQRESULT:%[0-9]+]] = apply {{.*}}(%0, %0{{.*}}) : $@convention({{.*}}) (Int, Int{{.*}}) -> Bool
 
-  // CHECK:      [[FN:%.*]] = function_ref {{.*}}
-  // CHECK-NEXT: [[EQRESULTI1:%[0-9]+]] = apply [[FN:%.*]]([[EQRESULT]]) : $@convention(method) (Bool) -> Builtin.Int1
+  // CHECK:      [[EQRESULTI1:%[0-9]+]] = struct_extract [[EQRESULT]] : $Bool, #Bool._value
   // CHECK-NEXT: cond_br [[EQRESULTI1]], [[CHECKFOO:bb[0-9]+]], [[ELSE:bb[0-9]+]]
 
   // Call Foo and test for the optional being present.

--- a/test/SILGen/opaque_ownership.swift
+++ b/test/SILGen/opaque_ownership.swift
@@ -62,7 +62,7 @@ infix operator  == : ComparisonPrecedence
 infix operator  ~= : ComparisonPrecedence
 
 public struct Bool {
-  var _value: Builtin.Int1
+  public var _value: Builtin.Int1
 
   public init() {
     let zero: Int64 = 0
@@ -73,12 +73,6 @@ public struct Bool {
 
   public init(_ value: Bool) {
     self = value
-  }
-}
-
-extension Bool {
-  public func _getBuiltinLogicValue() -> Builtin.Int1 {
-    return _value
   }
 }
 

--- a/test/SILGen/pound_assert.swift
+++ b/test/SILGen/pound_assert.swift
@@ -3,19 +3,17 @@
 // CHECK-LABEL: sil hidden @$s12pound_assert15noCustomMessage{{[_0-9a-zA-Z]*}}
 func noCustomMessage() {
   #assert(true)
-  // CHECK: [[GET_LOGIC_VALUE:%.*]] = function_ref {{.*}}_getBuiltinLogicValue
-  // CHECK-NEXT: [[LOGIC_VALUE:%.*]] = apply [[GET_LOGIC_VALUE]]
+  // CHECK: [[BOOL_VALUE:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
   // CHECK-NEXT: [[MESSAGE:%.*]] = string_literal utf8 ""
-  // CHECK-NEXT: builtin "poundAssert"([[LOGIC_VALUE]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer)
+  // CHECK-NEXT: builtin "poundAssert"([[BOOL_VALUE]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer)
 }
 // CHECK: } // end sil function '$s12pound_assert15noCustomMessage{{[_0-9a-zA-Z]*}}'
 
 // CHECK-LABEL: sil hidden @$s12pound_assert13customMessage{{[_0-9a-zA-Z]*}}
 func customMessage() {
   #assert(true, "custom message")
-  // CHECK: [[GET_LOGIC_VALUE:%.*]] = function_ref {{.*}}_getBuiltinLogicValue
-  // CHECK-NEXT: [[LOGIC_VALUE:%.*]] = apply [[GET_LOGIC_VALUE]]
+  // CHECK: [[BOOL_VALUE:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
   // CHECK-NEXT: [[MESSAGE:%.*]] = string_literal utf8 "custom message"
-  // CHECK-NEXT: builtin "poundAssert"([[LOGIC_VALUE]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer)
+  // CHECK-NEXT: builtin "poundAssert"([[BOOL_VALUE]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer)
 }
 // CHECK: } // end sil function '$s12pound_assert13customMessage{{[_0-9a-zA-Z]*}}'

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -335,7 +335,7 @@ func testStringForEachStmt() {
   // CHECK-LABEL: sil hidden @$s13sil_locations21testStringForEachStmtyyF
   // CHECK: br {{.*}} line:[[@LINE-8]]:3
   // CHECK: switch_enum {{.*}} line:[[@LINE-9]]:3
-  // CHECK: cond_br {{.*}} line:[[@LINE-8]]:8
+  // CHECK: cond_br {{.*}} line:[[@LINE-8]]:10
   // Break branch:
   // CHECK: br {{.*}} line:[[@LINE-9]]:7
   // Looping back branch:
@@ -388,9 +388,9 @@ func testRepeatWhile() {
   
   // CHECK-LABEL: sil hidden @$s13sil_locations15testRepeatWhileyyF
   // CHECK: br {{.*}} line:[[@LINE-6]]:3
-  // CHECK: cond_br {{.*}} line:[[@LINE-5]]:11
+  // CHECK: cond_br {{.*}} line:[[@LINE-5]]:14
   // Loop back branch:
-  // CHECK: br {{.*}} line:[[@LINE-7]]:11  
+  // CHECK: br {{.*}} line:[[@LINE-7]]:14
 }
 
 
@@ -408,9 +408,9 @@ func testWhile() {
   // CHECK-LABEL: sil hidden @$s13sil_locations9testWhileyyF
   // CHECK: br {{.*}} line:[[@LINE-9]]:3
   // While loop conditional branch:
-  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:9
+  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:11
   // If stmt condition branch:
-  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:8
+  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:10
   // Break branch:
   // CHECK: br {{.*}} line:[[@LINE-12]]:7
   // Looping back branch:

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -323,9 +323,8 @@ label3:
 func test_if_break(_ a : Bool) {
   // CHECK: br [[LOOP:bb[0-9]+]]
   // CHECK: [[LOOP]]:
-  // CHECK: function_ref @$sSb21_getBuiltinLogicValue{{[_0-9a-zA-Z]*}}F
-  // CHECK-NEXT: apply
-  // CHECK-NEXT: cond_br {{.*}}, [[LOOPTRUE:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+  // CHECK: [[WHILE_CONDITION:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
+  // CHECK-NEXT: cond_br [[WHILE_CONDITION]], [[LOOPTRUE:bb[0-9]+]], [[EXIT:bb[0-9]+]]
   while a {
     if a {
       foo()
@@ -335,9 +334,8 @@ func test_if_break(_ a : Bool) {
   }
 
   // CHECK: [[LOOPTRUE]]:
-  // CHECK: function_ref @$sSb21_getBuiltinLogicValue{{[_0-9a-zA-Z]*}}F
-  // CHECK-NEXT: apply
-  // CHECK-NEXT: cond_br {{.*}}, [[IFTRUE:bb[0-9]+]], [[IFFALSE:bb[0-9]+]]
+  // CHECK: [[IF_CONDITION:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
+  // CHECK-NEXT: cond_br [[IF_CONDITION]], [[IFTRUE:bb[0-9]+]], [[IFFALSE:bb[0-9]+]]
 
   // [[IFTRUE]]:
   // CHECK: function_ref statements.foo
@@ -473,7 +471,7 @@ func defer_test2(_ cond : Bool) {
   callee3()
   
 // test the condition.
-// CHECK:  [[CONDTRUE:%.*]] = apply {{.*}}(%0)
+// CHECK:  [[CONDTRUE:%.*]] = struct_extract %0 : $Bool, #Bool._value
 // CHECK: cond_br [[CONDTRUE]], [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
   while cond {
 // CHECK: [[BODY]]:

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -437,9 +437,6 @@ bb14(%48 : $Int32):
 }
 
 
-sil [transparent] [serialized] @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@convention(method) (Bool) -> Builtin.Int1
-
-
 sil [serialized] @_TZFsoi3eeeFTGSqPs9AnyObject__GSqPS____Sb : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
 
 

--- a/test/SILOptimizer/recursive_func.sil
+++ b/test/SILOptimizer/recursive_func.sil
@@ -33,52 +33,47 @@ sil @REC_recursive : $@convention(method) (Int, @guaranteed REC) -> () {
 bb0(%0 : $Int, %1 : $REC):
   debug_value %0 : $Int, let, name "a" // id: %2
   debug_value %1 : $REC, let, name "self" // id: %3
-  // function_ref Swift.Bool._getBuiltinLogicValue (Swift.Bool)() -> Builtin.Int1
-  %4 = function_ref @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@convention(method) (Bool) -> Builtin.Int1 // user: %11
   // function_ref Swift.>= @infix (Swift.Int, Swift.Int) -> Swift.Bool
-  %5 = function_ref @_TFsoi2geFTSiSi_Sb : $@convention(thin) (Int, Int) -> Bool // user: %10
+  %4 = function_ref @_TFsoi2geFTSiSi_Sb : $@convention(thin) (Int, Int) -> Bool // user: %9
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.IntLiteral) -> Swift.Int
-  %6 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %9
-  %7 = metatype $@thin Int.Type                   // user: %9
-  %8 = integer_literal $Builtin.IntLiteral, 2        // user: %9
-  %9 = apply %6(%8, %7) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %10
-  %10 = apply %5(%0, %9) : $@convention(thin) (Int, Int) -> Bool // user: %11
-  %11 = apply %4(%10) : $@convention(method) (Bool) -> Builtin.Int1 // user: %12
-  cond_br %11, bb1, bb2                           // id: %12
+  %5 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %8
+  %6 = metatype $@thin Int.Type                   // user: %8
+  %7 = integer_literal $Builtin.IntLiteral, 2        // user: %8
+  %8 = apply %5(%7, %6) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %9
+  %9 = apply %4(%0, %8) : $@convention(thin) (Int, Int) -> Bool // user: %10
+  %10 = struct_extract %9 : $Bool, #Bool._value // user: %11
+  cond_br %10, bb1, bb2                           // id: %11
 
 bb1:                                              // Preds: bb0
-  strong_retain %1 : $REC                         // id: %13
-  %14 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %21
+  strong_retain %1 : $REC                         // id: %12
+  %13 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %20
   // function_ref Swift.- @infix (Swift.Int, Swift.Int) -> Swift.Int
-  %15 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %20
+  %14 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %19
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.IntLiteral) -> Swift.Int
-  %16 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %19
-  %17 = metatype $@thin Int.Type                  // user: %19
-  %18 = integer_literal $Builtin.IntLiteral, 2       // user: %19
-  %19 = apply %16(%18, %17) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %20
-  %20 = apply %15(%0, %19) : $@convention(thin) (Int, Int) -> Int // user: %21
-  %21 = apply %14(%20, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
-  strong_retain %1 : $REC                         // id: %22
-  %23 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %30
+  %15 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %18
+  %16 = metatype $@thin Int.Type                  // user: %18
+  %17 = integer_literal $Builtin.IntLiteral, 2       // user: %18
+  %18 = apply %15(%17, %16) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %19
+  %19 = apply %14(%0, %18) : $@convention(thin) (Int, Int) -> Int // user: %20
+  %20 = apply %13(%19, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
+  strong_retain %1 : $REC                         // id: %21
+  %22 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %29
   // function_ref Swift.- @infix (Swift.Int, Swift.Int) -> Swift.Int
-  %24 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %29
+  %23 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %28
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.IntLiteral) -> Swift.Int
-  %25 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %28
-  %26 = metatype $@thin Int.Type                  // user: %28
-  %27 = integer_literal $Builtin.IntLiteral, 1       // user: %28
-  %28 = apply %25(%27, %26) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %29
-  %29 = apply %24(%0, %28) : $@convention(thin) (Int, Int) -> Int // user: %30
-  %30 = apply %23(%29, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
-  br bb2                                          // id: %31
+  %24 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %27
+  %25 = metatype $@thin Int.Type                  // user: %27
+  %26 = integer_literal $Builtin.IntLiteral, 1       // user: %27
+  %27 = apply %24(%26, %25) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %28
+  %28 = apply %23(%0, %27) : $@convention(thin) (Int, Int) -> Int // user: %29
+  %29 = apply %22(%28, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
+  br bb2                                          // id: %30
 
 bb2:                                              // Preds: bb0 bb1
-  strong_release %1 : $REC                        // id: %32
-  %33 = tuple ()                                  // user: %34
-  return %33 : $()                                // id: %34
+  strong_release %1 : $REC                        // id: %31
+  %32 = tuple ()                                  // user: %33
+  return %32 : $()                                // id: %33
 }
-
-// Swift.Bool._getBuiltinLogicValue (Swift.Bool)() -> Builtin.Int1
-sil [transparent] @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@convention(method) (Bool) -> Builtin.Int1
 
 // Swift.>= @infix (Swift.Int, Swift.Int) -> Swift.Bool
 sil [transparent] @_TFsoi2geFTSiSi_Sb : $@convention(thin) (Int, Int) -> Bool

--- a/test/SILOptimizer/recursive_single.sil
+++ b/test/SILOptimizer/recursive_single.sil
@@ -35,41 +35,36 @@ sil @_TFC6single3REC9recursivefS0_FSiT_ : $@convention(method) (Int, @guaranteed
 bb0(%0 : $Int, %1 : $REC):
   debug_value %0 : $Int, let, name "a" // id: %2
   debug_value %1 : $REC, let, name "self" // id: %3
-  // function_ref Swift.Bool._getBuiltinLogicValue (Swift.Bool)() -> Builtin.Int1
-  %4 = function_ref @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@convention(method) (Bool) -> Builtin.Int1 // user: %11
   // function_ref Swift.>= @infix (Swift.Int, Swift.Int) -> Swift.Bool
-  %5 = function_ref @_TFsoi2geFTSiSi_Sb : $@convention(thin) (Int, Int) -> Bool // user: %10
+  %4 = function_ref @_TFsoi2geFTSiSi_Sb : $@convention(thin) (Int, Int) -> Bool // user: %9
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.IntLiteral) -> Swift.Int
-  %6 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %9
-  %7 = metatype $@thin Int.Type                   // user: %9
-  %8 = integer_literal $Builtin.IntLiteral, 2        // user: %9
-  %9 = apply %6(%8, %7) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %10
-  %10 = apply %5(%0, %9) : $@convention(thin) (Int, Int) -> Bool // user: %11
-  %11 = apply %4(%10) : $@convention(method) (Bool) -> Builtin.Int1 // user: %12
-  cond_br %11, bb1, bb2                           // id: %12
+  %5 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %8
+  %6 = metatype $@thin Int.Type                   // user: %8
+  %7 = integer_literal $Builtin.IntLiteral, 2        // user: %8
+  %8 = apply %5(%7, %6) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %9
+  %9 = apply %4(%0, %8) : $@convention(thin) (Int, Int) -> Bool // user: %10
+  %10 = struct_extract %9 : $Bool, #Bool._value
+  cond_br %10, bb1, bb2                           // id: %11
 
 bb1:                                              // Preds: bb0
-  strong_retain %1 : $REC                         // id: %13
-  %14 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %21
+  strong_retain %1 : $REC                         // id: %12
+  %13 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %20
   // function_ref Swift.- @infix (Swift.Int, Swift.Int) -> Swift.Int
-  %15 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %20
+  %14 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %19
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.IntLiteral) -> Swift.Int
-  %16 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %19
-  %17 = metatype $@thin Int.Type                  // user: %19
-  %18 = integer_literal $Builtin.IntLiteral, 2       // user: %19
-  %19 = apply %16(%18, %17) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %20
-  %20 = apply %15(%0, %19) : $@convention(thin) (Int, Int) -> Int // user: %21
-  %21 = apply %14(%20, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
-  br bb2                                          // id: %22
+  %15 = function_ref @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBI_Si : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %18
+  %16 = metatype $@thin Int.Type                  // user: %18
+  %17 = integer_literal $Builtin.IntLiteral, 2       // user: %18
+  %18 = apply %15(%17, %16) : $@convention(thin) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %19
+  %19 = apply %14(%0, %18) : $@convention(thin) (Int, Int) -> Int // user: %20
+  %20 = apply %13(%19, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
+  br bb2                                          // id: %21
 
 bb2:                                              // Preds: bb0 bb1
-  strong_release %1 : $REC                        // id: %23
-  %24 = tuple ()                                  // user: %25
-  return %24 : $()                                // id: %25
+  strong_release %1 : $REC                        // id: %22
+  %23 = tuple ()                                  // user: %24
+  return %23 : $()                                // id: %24
 }
-
-// Swift.Bool._getBuiltinLogicValue (Swift.Bool)() -> Builtin.Int1
-sil [transparent] @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@convention(method) (Bool) -> Builtin.Int1
 
 // Swift.>= @infix (Swift.Int, Swift.Int) -> Swift.Bool
 sil [transparent] @_TFsoi2geFTSiSi_Sb : $@convention(thin) (Int, Int) -> Bool


### PR DESCRIPTION
This removes the `_getBuiltinLogicValue()` intrinsic function from `Bool` and instead accesses the `Bool._value` property directly. Currently the property is internal, but I noticed that the integer and floating point types backing value is public, so I thought it might be better to access the property than keep this function in the stdlib API.

I labeled this WIP because there are at least 5 known tests failing that I can't seem to reason about:
- `SILGen/opaque_ownership.swift`
- `refactoring/CollaseNestedIf`
- `refactoring/ConvertToTernaryExpr`
- `refactoring/ExpandTernaryExpr`
- `stmt/statements.swift`

One thing I've noticed in the bottom 4 is that any boolean stmt condition is cutting off the last expression in refactoring/fixits. E.g. instead of `where 1 != 100`, the fixit suggests: `where 1 !=`. Which is slightly confusing as my change doesn't touch refactoring/fixits. 😕 

cc: @slavapestov and some standard library folk: @airspeedswift 