### PR TITLE
differentiate witness methods

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -355,7 +355,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
                                 getExtInfo(),
                                 getCoroutineKind(), getCalleeConvention(),
                                 getParameters(), getYields(), jvpResults,
-                                getOptionalErrorResult(), ctx);
+                                getOptionalErrorResult(), ctx,
+                                getWitnessMethodConformanceOrNone());
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
     SmallVector<SILParameterInfo, 8> cotangentParams;
@@ -387,7 +388,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
                                 getExtInfo(),
                                 getCoroutineKind(), getCalleeConvention(),
                                 getParameters(), getYields(), vjpResults,
-                                getOptionalErrorResult(), ctx);
+                                getOptionalErrorResult(), ctx,
+                                getWitnessMethodConformanceOrNone());
   }
   }
 }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1261,33 +1261,30 @@ public:
     require(origTy, "The original function must have a function type");
     require(!origTy->isDifferentiable(),
             "The original function must not be @autodiff");
-    // TODO: Temporarily disabled this check because witness thunks generate
-    // `autodiff_function` instructions without associated functions, and the AD
-    // pass does not yet fill in the associated functions.
-    // if (F.getModule().getStage() == SILStage::Canonical ||
-    //     adfi->hasAssociatedFunctions()) {
-    //   for (auto order : range(1, adfi->getDifferentiationOrder() + 1)) {
-    //     auto pair = adfi->getAssociatedFunctionPair(order);
-    //     auto jvpType = pair.first->getType().getAs<SILFunctionType>();
-    //     require(jvpType, "The JVP function must have a function type");
-    //     require(!jvpType->isDifferentiable(),
-    //             "The JVP function must not be @autodiff");
-    //     auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
-    //         adfi->getParameterIndices(), /*resultIndex*/ 0, order,
-    //         AutoDiffAssociatedFunctionKind::JVP, F.getModule(),
-    //         LookUpConformanceInModule(F.getModule().getSwiftModule()));
-    //     require(expectedJVPType == jvpType, "Unexpected JVP function type");
-    //     auto vjpType = pair.second->getType().getAs<SILFunctionType>();
-    //     require(vjpType, "The VJP function must have a function type");
-    //     require(!vjpType->isDifferentiable(),
-    //             "The VJP function must not be @autodiff");
-    //     auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
-    //         adfi->getParameterIndices(), /*resultIndex*/ 0, order,
-    //         AutoDiffAssociatedFunctionKind::VJP, F.getModule(),
-    //         LookUpConformanceInModule(F.getModule().getSwiftModule()));
-    //     require(expectedVJPType == vjpType, "Unexpected VJP function type");
-    //   }
-    // }
+    if (F.getModule().getStage() == SILStage::Canonical ||
+        adfi->hasAssociatedFunctions()) {
+      for (auto order : range(1, adfi->getDifferentiationOrder() + 1)) {
+        auto pair = adfi->getAssociatedFunctionPair(order);
+        auto jvpType = pair.first->getType().getAs<SILFunctionType>();
+        require(jvpType, "The JVP function must have a function type");
+        require(!jvpType->isDifferentiable(),
+                "The JVP function must not be @autodiff");
+        auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
+            adfi->getParameterIndices(), /*resultIndex*/ 0, order,
+            AutoDiffAssociatedFunctionKind::JVP, F.getModule(),
+            LookUpConformanceInModule(F.getModule().getSwiftModule()));
+        require(expectedJVPType == jvpType, "Unexpected JVP function type");
+        auto vjpType = pair.second->getType().getAs<SILFunctionType>();
+        require(vjpType, "The VJP function must have a function type");
+        require(!vjpType->isDifferentiable(),
+                "The VJP function must not be @autodiff");
+        auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
+            adfi->getParameterIndices(), /*resultIndex*/ 0, order,
+            AutoDiffAssociatedFunctionKind::VJP, F.getModule(),
+            LookUpConformanceInModule(F.getModule().getSwiftModule()));
+        require(expectedVJPType == vjpType, "Unexpected VJP function type");
+      }
+    }
   }
   
   void checkAutoDiffFunctionExtractInst(AutoDiffFunctionExtractInst *adfei) {

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -676,6 +676,12 @@ enum class FunctionSynthesisState {
   Done
 };
 
+/// Stores information about `apply` instructions that `PrimalGen` calculates.
+struct ApplyInfo {
+  /// The differentiation indices that are used to differentiate this apply.
+  SILAutoDiffIndices indices;
+};
+
 /// A differentiation task, specifying the original function and the
 /// `[differentiable]` attribute on the function. PrimalGen and AdjointGen
 /// will synthesize the primal and the adjoint for this task, filling the primal
@@ -711,7 +717,15 @@ private:
   /// differentiation tasks, if it's active. This is filled during primal
   /// synthesis, so that adjoint synthesis does not need to recompute the
   /// original function and differentiation indices.
+  ///
+  /// Note: This is only used when `!DifferentiationUseVJP`.
   DenseMap<ApplyInst *, DifferentiationTask *> associatedTasks;
+
+  /// Mapping from original `apply` instructions to their corresponding
+  /// `ApplyInfo`s.
+  ///
+  /// Note: This is only used when `DifferentiationUseVJP`.
+  DenseMap<ApplyInst *, ApplyInfo> applyInfos;
 
   /// Cache for associated functions.
   SILFunction *primal = nullptr;
@@ -803,6 +817,10 @@ public:
 
   DenseMap<ApplyInst *, DifferentiationTask *> &getAssociatedTasks() {
     return associatedTasks;
+  }
+
+  DenseMap<ApplyInst *, ApplyInfo> &getApplyInfos() {
+    return applyInfos;
   }
 
   bool isEqual(const DifferentiationTask &other) const {
@@ -1652,6 +1670,77 @@ reapplyFunctionConversion(SILValue newFunc, SILValue oldFunc,
   llvm_unreachable("Unhandled function convertion instruction");
 }
 
+/// Emits a reference to a VJP corresponding to `original`, differentiated with
+/// `indices`. On failure, returns a null `SILValue`.
+///
+/// Creates new differentiation tasks, if necessary, using `invoker` as the
+/// invoker. Calls `taskCallback` for all newly-created tasks (but may also call
+/// `taskCallback` for already-existing tasks), so that the caller can make sure
+/// that the task actually gets executed.
+static SILValue emitVJPReference(
+    ADContext &context, SILBuilder &builder, SILAutoDiffIndices indices,
+    SILValue original, DifferentiationInvoker invoker,
+    std::function<void(DifferentiationTask *)> taskCallback) {
+  if (auto *originalFRI = findReferenceToVisibleFunction(original)) {
+    auto loc = originalFRI->getLoc();
+    auto *originalFn = originalFRI->getReferencedFunction();
+    auto *task = context.lookUpOrRegisterDifferentiationTask(originalFn,
+                                                             indices, invoker);
+    taskCallback(task);
+    auto *vjpRef = builder.createFunctionRef(loc, task->getVJP());
+    return reapplyFunctionConversion(vjpRef, originalFRI, original, builder,
+                                     loc);
+  }
+  if (auto *witnessMethod = dyn_cast<WitnessMethodInst>(original)) {
+    auto loc = witnessMethod->getLoc();
+    auto requirement = witnessMethod->getMember();
+    auto *requirementDecl = requirement.getDecl();
+    auto *diffAttr =
+        requirementDecl->getAttrs().getAttribute<DifferentiableAttr>();
+    if (!diffAttr) {
+      // TODO: If we move diagnostics into this function, then we can tell the
+      // user that differentiation failed because the requirement is not
+      // differentiable.
+      return SILValue();
+    }
+
+    // Check that the requirement indices are the same as the desired indices.
+    auto *requirementParameterIndices = diffAttr->getCheckedParameterIndices();
+    auto loweredRequirementIndices = requirementParameterIndices->getLowered(
+        requirementDecl->getInterfaceType()->castTo<AnyFunctionType>(),
+        /*isMethod*/ true);
+    SILAutoDiffIndices requirementIndices(/*source*/ 0, loweredRequirementIndices);
+
+    // TODO:
+    // If we desire a superset of the available indices, then we should emit a
+    // diagnostic that the requirement can't be differentiated as much as we
+    // want.
+    // If we desire a subset of the available indices, then we should
+    // automatically convert the VJP to a VJP with the desired indices.
+    assert(requirementIndices == indices &&
+           "FIXME: handle the case where the requirement indices are "
+           "different from the desired indices.");
+
+    auto originalType = cast<SILFunctionType>(original->getType().getASTType());
+    auto vjpType = originalType->getAutoDiffAssociatedFunctionType(
+        requirementIndices.parameters, requirementIndices.source,
+        /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::VJP,
+        builder.getModule(),
+        LookUpConformanceInModule(builder.getModule().getSwiftModule()));
+
+    // Emit a witness_method instruction pointing at the VJP.
+    auto *autoDiffFuncId = AutoDiffAssociatedFunctionIdentifier::get(
+        AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
+        requirementParameterIndices, context.getASTContext());
+    return builder.createWitnessMethod(
+        loc, witnessMethod->getLookupType(), witnessMethod->getConformance(),
+        requirement.asAutoDiffAssociatedFunction(autoDiffFuncId),
+        SILType::getPrimitiveObjectType(vjpType));
+  }
+
+  return SILValue();
+}
+
 /// Create a builtin floating point value. The specified type must be a builtin
 /// float type.
 static SILValue createBuiltinFPScalar(intmax_t scalar, CanType type,
@@ -2482,41 +2571,23 @@ public:
 
     // Form expected indices by assuming there's only one result.
     SILAutoDiffIndices indices(activeResultIndices.front(), activeParamIndices);
+    getDifferentiationTask()->getApplyInfos().insert({ai, {indices}});
 
-    // Retrieve the original function being called.
-    auto calleeOrigin = ai->getCalleeOrigin();
-    auto *calleeOriginFnRef = dyn_cast<FunctionRefInst>(calleeOrigin);
-    // If callee does not trace back to a `function_ref`, it is an opaque
-    // function. Emit a "not differentiable" diagnostic here.
-    // FIXME: Handle `partial_apply`, `witness_method`.
-    if (!calleeOriginFnRef) {
+    auto vjp = emitVJPReference(
+        context, builder, indices, getMappedValue(ai->getCallee()),
+        /*invoker*/ {ai, synthesis.task},
+        [&](DifferentiationTask *newTask) {
+           primalGen.lookUpPrimalAndMaybeScheduleSynthesis(newTask);
+        });
+    if (!vjp) {
       context.emitNondifferentiabilityError(ai, synthesis.task);
       errorOccurred = true;
       return;
     }
 
-    // Find or register a differentiation task for this function.
-    auto *newTask = context.lookUpOrRegisterDifferentiationTask(
-        calleeOriginFnRef->getReferencedFunction(), indices,
-        /*invoker*/ {ai, synthesis.task});
-
-    // Store this task so that AdjointGen can use it.
-    getDifferentiationTask()->getAssociatedTasks().insert({ai, newTask});
-
-    // If the task is newly created, then we need to schedule a synthesis item
-    // for the primal.
-    primalGen.lookUpPrimalAndMaybeScheduleSynthesis(newTask);
-
-    auto *vjpFn = newTask->getVJP();
-    assert(vjpFn);
-    auto *vjp = builder.createFunctionRef(ai->getCallee().getLoc(), vjpFn);
-
-    // TODO: The `visitApplyInstWithoutVJP` reapplies function conversions here,
-    // but all the tests seem to pass without doing that here. Investigate.
-
     // Call the VJP using the original parameters.
     SmallVector<SILValue, 8> newArgs;
-    auto vjpFnTy = vjpFn->getLoweredFunctionType();
+    auto vjpFnTy = cast<SILFunctionType>(vjp->getType().getASTType());
     auto numVJPParams = vjpFnTy->getNumParameters();
     assert(vjpFnTy->getNumIndirectFormalResults() == 0 &&
            "FIXME: handle vjp with indirect results");
@@ -3478,18 +3549,17 @@ public:
     auto &builder = getBuilder();
     auto loc = remapLocation(ai->getLoc());
 
-    // Look for the task that differentiates the callee.
-    auto &assocTasks = getDifferentiationTask()->getAssociatedTasks();
-    auto assocTaskLookUp = assocTasks.find(ai);
-    // If no task was found, then this task doesn't need to be differentiated.
-    if (assocTaskLookUp == assocTasks.end()) {
+    auto &applyInfos = getDifferentiationTask()->getApplyInfos();
+    auto applyInfoLookUp = applyInfos.find(ai);
+    // If no ApplyInfo was found, then this task doesn't need to be differentiated.
+    if (applyInfoLookUp == applyInfos.end()) {
       // Must not be active.
       assert(
           !activityInfo.isActive(ai, getDifferentiationTask()->getIndices()));
       return;
     }
-    auto *otherTask = assocTaskLookUp->getSecond();
-    auto origTy = otherTask->getOriginal()->getLoweredFunctionType();
+    auto applyInfo = applyInfoLookUp->getSecond();
+    auto origTy = cast<SILFunctionType>(ai->getCallee()->getType().getASTType());
     SILFunctionConventions origConvs(origTy, getModule());
 
     // Get the pullback.
@@ -3552,11 +3622,11 @@ public:
     // self parameter.
     auto selfParamIndex = originalParams.size() - 1;
     if (ai->hasSelfArgument() &&
-        otherTask->getIndices().isWrtParameter(selfParamIndex))
+        applyInfo.indices.isWrtParameter(selfParamIndex))
       addAdjointValue(ai->getArgument(origNumIndRes + selfParamIndex),
                       AdjointValue::getMaterialized(*allResultsIt++));
     // Set adjoints for the remaining non-self original parameters.
-    for (unsigned i : otherTask->getIndices().parameters.set_bits()) {
+    for (unsigned i : applyInfo.indices.parameters.set_bits()) {
       // Do not set the adjoint of the original self parameter because we
       // already added it at the beginning.
       if (ai->hasSelfArgument() && i == selfParamIndex)
@@ -5038,43 +5108,28 @@ bool Differentiation::processAutoDiffFunctionInst(AutoDiffFunctionInst *adfi,
                                                   ADContext &context) {
   SILFunction *parent = adfi->getFunction();
   auto origFnOperand = adfi->getOriginalFunction();
-  // If it traces back to a `function_ref`, differentiate that.
-  if (auto *originalFRI = findReferenceToVisibleFunction(origFnOperand)) {
-    auto *original = originalFRI->getReferencedFunction();
-    // TODO: Find syntax-level AD invoker from `adfi`.
-    auto *task = context.lookUpOrRegisterDifferentiationTask(
-        original, SILAutoDiffIndices(0, adfi->getParameterIndices()),
-        DifferentiationInvoker(adfi));
-    // Expand the `autodiff_function` instruction by adding the JVP and VJP
-    // functions.
-    SILBuilder builder(adfi);
-    auto loc = parent->getLocation();
-    auto *vjp = task->getVJP();
-    auto *vjpRef = builder.createFunctionRef(loc, vjp);
-    auto finalVJP = reapplyFunctionConversion(
-        vjpRef, originalFRI, origFnOperand, builder, loc);
-    SILValue finalJVP;
-    // TODO: Implement "forward-mode differentiation" to get JVP. Currently it's
-    // just an undef because we won't use it.
-    {
-      auto origFnTy = origFnOperand->getType().getAs<SILFunctionType>();
-      auto jvpType = origFnTy->getAutoDiffAssociatedFunctionType(
-          adfi->getParameterIndices(), /*resultIndex*/ 0,
-          /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP,
-          *getModule(),
-          /*lookupConformance*/
-              LookUpConformanceInModule(getModule()->getSwiftModule()));
-      finalJVP = SILUndef::get(SILType::getPrimitiveObjectType(jvpType),
-                             getModule());
-    }
-    auto *newADFI = builder.createAutoDiffFunction(
-        loc, adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
-        origFnOperand, {finalJVP, finalVJP});
-    adfi->replaceAllUsesWith(newADFI);
-    adfi->eraseFromParent();
+  SILBuilder builder(adfi);
+
+  SILValue finalJVP;
+  // TODO: Implement "forward-mode differentiation" to get JVP. Currently it's
+  // just an undef because we won't use it.
+  {
+    auto origFnTy = origFnOperand->getType().getAs<SILFunctionType>();
+    auto jvpType = origFnTy->getAutoDiffAssociatedFunctionType(
+        adfi->getParameterIndices(), /*resultIndex*/ 0,
+        /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP,
+        *getModule(),
+        /*lookupConformance*/
+            LookUpConformanceInModule(getModule()->getSwiftModule()));
+    finalJVP = SILUndef::get(SILType::getPrimitiveObjectType(jvpType),
+                           getModule());
   }
-  // Differentiating opaque functions is not supported yet.
-  else {
+
+  auto finalVJP = emitVJPReference(
+      context, builder, SILAutoDiffIndices(0, adfi->getParameterIndices()),
+      origFnOperand, DifferentiationInvoker(adfi),
+      [](DifferentiationTask *newTask) {});
+  if (!finalVJP) {
     // Find the original differential operator expression. Show an error at the
     // operator, highlight the argument, and show a note at the definition site
     // of the argument.
@@ -5084,6 +5139,13 @@ bool Differentiation::processAutoDiffFunctionInst(AutoDiffFunctionInst *adfi,
           .highlight(expr->getSubExpr()->getSourceRange());
     return true;
   }
+
+  auto loc = parent->getLocation();
+  auto *newADFI = builder.createAutoDiffFunction(
+      loc, adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
+      origFnOperand, {finalJVP, finalVJP});
+  adfi->replaceAllUsesWith(newADFI);
+  adfi->eraseFromParent();
   PM->invalidateAnalysis(parent, SILAnalysis::InvalidationKind::FunctionBody);
   return false;
 }
@@ -5099,8 +5161,8 @@ void Differentiation::run() {
                         SILDifferentiableAttr *>, 8> diffAttrs;
   SmallVector<GradientInst *, 16> gradInsts;
   SmallVector<AutoDiffFunctionInst *, 16> autodiffInsts;
-  // Handle each `gradient` instruction and each `differentiable`
-  // attribute in the module.
+  // Handle all the instructions and attributes in the module that trigger
+  // differentiation.
   for (SILFunction &f : module) {
     // If `f` has a `[differentiable]` attribute, it should become a
     // differentiation task.
@@ -5113,10 +5175,6 @@ void Differentiation::run() {
       astCtx.Diags.diagnose(f.getLocation().getSourceLoc(),
                             diag::autodiff_incomplete_differentiable_attr);
     }
-    // Not look for `gradient` instructions in transparent functions because
-    // they are to be inlined.
-    if (f.isTransparent())
-      continue;
     for (SILBasicBlock &bb : f) {
       for (SILInstruction &i : bb) {
         // If `i` is a `gradient` instruction, i.e. the SIL-level differential
@@ -5129,9 +5187,8 @@ void Differentiation::run() {
     }
   }
 
-  // If there's no `gradient` instruction or no `[differentiable]` attributes,
-  // there's no AD to do.
-  if (gradInsts.empty() && diffAttrs.empty())
+  // If nothing has triggered differentiation, there's nothing to do.
+  if (gradInsts.empty() && diffAttrs.empty() && autodiffInsts.empty())
     return;
 
   // AD relies on stdlib (the Swift module). If it's not imported, it's an

--- a/test/AutoDiff/witness_method_autodiff.sil
+++ b/test/AutoDiff/witness_method_autodiff.sil
@@ -1,0 +1,27 @@
+// RUN: %target-sil-opt -differentiation -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+protocol DiffReq {
+  @differentiable(reverse, wrt: (.0))
+  func f(_ x: Float) -> Float
+}
+
+sil @differentiateWitnessMethod : $@convention(thin) <T where T : DiffReq> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %1 = witness_method $T, #DiffReq.f!1 : <Self where Self : DiffReq> (Self) -> (Float) -> Float : $@convention(witness_method: DiffReq) <τ_0_0 where τ_0_0 : DiffReq> (Float, @in_guaranteed τ_0_0) -> Float
+  %2 = autodiff_function [wrt 0] [order 1] %1 : $@convention(witness_method: DiffReq) <τ_0_0 where τ_0_0 : DiffReq> (Float, @in_guaranteed τ_0_0) -> Float
+
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @differentiateWitnessMethod
+// CHECK:   [[ORIG_REF:%.*]] = witness_method $T, #DiffReq.f!1
+// CHECK:   [[VJP_REF:%.*]] = witness_method $T, #DiffReq.f!1.vjp.1.SU
+// CHECK:   autodiff_function [wrt 0] [order 1] [[ORIG_REF]] : {{.*}} {undef : {{.*}}, %2 : {{.*}}}
+// CHECK: } // end sil function 'differentiateWitnessMethod'

--- a/test/AutoDiff/witness_method_autodiff.sil
+++ b/test/AutoDiff/witness_method_autodiff.sil
@@ -23,5 +23,23 @@ bb0(%0 : $*T):
 // CHECK-LABEL: sil @differentiateWitnessMethod
 // CHECK:   [[ORIG_REF:%.*]] = witness_method $T, #DiffReq.f!1
 // CHECK:   [[VJP_REF:%.*]] = witness_method $T, #DiffReq.f!1.vjp.1.SU
-// CHECK:   autodiff_function [wrt 0] [order 1] [[ORIG_REF]] : {{.*}} {undef : {{.*}}, %2 : {{.*}}}
+// CHECK:   autodiff_function [wrt 0] [order 1] [[ORIG_REF]] : {{.*}} with {undef : {{.*}}, %2 : {{.*}}}
 // CHECK: } // end sil function 'differentiateWitnessMethod'
+
+sil @differentiatePartiallyAppliedWitnessMethod : $@convention(thin) <T where T : DiffReq> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %1 = witness_method $T, #DiffReq.f!1 : <Self where Self : DiffReq> (Self) -> (Float) -> Float : $@convention(witness_method: DiffReq) <τ_0_0 where τ_0_0 : DiffReq> (Float, @in_guaranteed τ_0_0) -> Float
+  %2 = partial_apply [callee_guaranteed] %1<T>(%0) : $@convention(witness_method: DiffReq) <τ_0_0 where τ_0_0 : DiffReq> (Float, @in_guaranteed τ_0_0) -> Float
+  %3 = autodiff_function [wrt 0] [order 1] %2 : $@callee_guaranteed (Float) -> Float
+
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @differentiatePartiallyAppliedWitnessMethod
+// CHECK:  [[ORIG_REF:%.*]] = witness_method $T, #DiffReq.f!1
+// CHECK:  [[ORIG_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[ORIG_REF]]<T>(%0)
+// CHECK:  [[VJP_REF:%.*]] = witness_method $T, #DiffReq.f!1.vjp.1.SU
+// CHECK:  [[VJP_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[VJP_REF]]<T>(%0)
+// CHECK:  = autodiff_function [wrt 0] [order 1] [[ORIG_REF_PARTIALLY_APPLIED]] : {{.*}} with {undef : {{.*}}, [[VJP_REF_PARTIALLY_APPLIED]] : {{.*}}}
+// CHECK: } // end sil function 'differentiatePartiallyAppliedWitnessMethod'

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -20,83 +20,62 @@ struct S : Proto {
 
   let p: Float
 
-  @differentiable(reverse, jvp: dfunction1, vjp: pfunction1)
   func function1(_ x: Float, _ y: Float) -> Float {
     return x + y + p
   }
 
-  func dfunction1(_ x: Float, _ y: Float) -> (Float, (Float, Float) -> Float) {
-    fatalError("unimplemented")
-  }
-
-  func pfunction1(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)) {
-    fatalError("unimplemented")
-  }
-
   // CHECK-LABEL: sil {{.*}} @AD__{{.*}}function1{{.*}}_jvp_SSU : $@convention(witness_method: Proto) (Float, Float, @in_guaranteed S) -> (Float, @owned @callee_guaranteed (Float, Float) -> Float) {
-  // CHECK: [[JVP1_FNREF:%.*]] = function_ref {{.*}}function1{{.*}} : $@convention(method) (Float, Float, S) -> Float
-  // CHECK: [[JVP1_ADFUNC:%.*]] = autodiff_function [wrt 0 1] [order 1] [[JVP1_FNREF]] : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP1_ORIG_FNREF:%.*]] = function_ref {{.*}}function1{{.*}} : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP1_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function1{{.*}}__vjp_src_0_wrt_0_1
+  // CHECK: [[JVP1_ADFUNC:%.*]] = autodiff_function [wrt 0 1] [order 1] [[JVP1_ORIG_FNREF]] : {{.*}} with {undef : {{.*}}, [[JVP1_VJP_FNREF]] : {{.*}}}
   // CHECK: [[JVP1:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP1_ADFUNC]] : $@autodiff @convention(method) (Float, Float, @nondiff S) -> Float
   // CHECK: apply [[JVP1]]
   // CHECK: } // end sil function 'AD__{{.*}}function1{{.*}}_jvp_SSU'
 
   // CHECK-LABEL: sil {{.*}} @AD__{{.*}}function1{{.*}}_vjp_SSU : $@convention(witness_method: Proto) (Float, Float, @in_guaranteed S) -> (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) {
-  // CHECK: [[VJP1_FNREF:%.*]] = function_ref {{.*}}function1{{.*}} : $@convention(method) (Float, Float, S) -> Float
-  // CHECK: [[VJP1_ADFUNC:%.*]] = autodiff_function [wrt 0 1] [order 1] [[VJP1_FNREF]] : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP1_ORIG_FNREF:%.*]] = function_ref {{.*}}function1{{.*}} : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP1_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function1{{.*}}__vjp_src_0_wrt_0_1
+  // CHECK: [[VJP1_ADFUNC:%.*]] = autodiff_function [wrt 0 1] [order 1] [[VJP1_ORIG_FNREF]] : {{.*}} with {undef : {{.*}}, [[VJP1_VJP_FNREF]] : {{.*}}}
   // CHECK: [[VJP1:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP1_ADFUNC]] : $@autodiff @convention(method) (Float, Float, @nondiff S) -> Float
   // CHECK: apply [[VJP1]]
   // CHECK: } // end sil function 'AD__{{.*}}function1{{.*}}_vjp_SSU'
 
-  @differentiable(reverse, wrt: (self, .0, .1), jvp: dfunction2, vjp: pfunction2)
   func function2(_ x: Float, _ y: Float) -> Float {
     return x + y + p
   }
 
-  func dfunction2(_ x: Float, _ y: Float) -> (Float, (S, Float, Float) -> Float) {
-    fatalError("unimplemented")
-  }
-
-  func pfunction2(_ x: Float, _ y: Float) -> (Float, (Float) -> (S, Float, Float)) {
-    fatalError("unimplemented")
-  }
-
   // CHECK-LABEL: sil {{.*}} @AD__{{.*}}function2{{.*}}_jvp_SSS : $@convention(witness_method: Proto) (Float, Float, @in_guaranteed S) -> (Float, @owned @callee_guaranteed (@in_guaranteed S, Float, Float) -> Float) {
-  // CHECK: [[JVP2_FNREF:%.*]] = function_ref {{.*}}function2{{.*}} : $@convention(method) (Float, Float, S) -> Float
-  // CHECK: [[JVP2_ADFUNC:%.*]] = autodiff_function [wrt 0 1 2] [order 1] [[JVP2_FNREF]] : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP2_ORIG_FNREF:%.*]] = function_ref {{.*}}function2{{.*}} : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP2_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function2{{.*}}__vjp_src_0_wrt_0_1_2
+  // CHECK: [[JVP2_ADFUNC:%.*]] = autodiff_function [wrt 0 1 2] [order 1] [[JVP2_ORIG_FNREF]] : {{.*}} with {undef : {{.*}}, [[JVP2_VJP_FNREF]] : {{.*}}}
   // CHECK: [[JVP2:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP2_ADFUNC]] : $@autodiff @convention(method) (Float, Float, S) -> Float
   // CHECK: apply [[JVP2]]
   // CHECK: } // end sil function 'AD__{{.*}}function2{{.*}}_jvp_SSS'
 
   // CHECK-LABEL: sil {{.*}} @AD__{{.*}}function2{{.*}}_vjp_SSS : $@convention(witness_method: Proto) (Float, Float, @in_guaranteed S) -> (Float, @owned @callee_guaranteed (Float) -> (@out S, Float, Float)) {
-  // CHECK: [[VJP2_FNREF:%.*]] = function_ref {{.*}}function2{{.*}} : $@convention(method) (Float, Float, S) -> Float
-  // CHECK: [[VJP2_ADFUNC:%.*]] = autodiff_function [wrt 0 1 2] [order 1] [[VJP2_FNREF]] : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP2_ORIG_FNREF:%.*]] = function_ref {{.*}}function2{{.*}} : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP2_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function2{{.*}}__vjp_src_0_wrt_0_1_2
+  // CHECK: [[VJP2_ADFUNC:%.*]] = autodiff_function [wrt 0 1 2] [order 1] [[VJP2_ORIG_FNREF]] : {{.*}} with {undef : {{.*}}, [[VJP2_VJP_FNREF]] : {{.*}}}
   // CHECK: [[VJP2:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP2_ADFUNC]] : $@autodiff @convention(method) (Float, Float, S) -> Float
   // CHECK: apply [[VJP2]]
   // CHECK: } // end sil function 'AD__{{.*}}function2{{.*}}_vjp_SSS'
 
-  @differentiable(reverse, wrt: (.1), jvp: dfunction3, vjp: pfunction3)
   func function3(_ x: Float, _ y: Float) -> Float {
     return x + y + p
   }
 
-  func dfunction3(_ x: Float, _ y: Float) -> (Float, (Float) -> Float) {
-    fatalError("unimplemented")
-  }
-
-  func pfunction3(_ x: Float, _ y: Float) -> (Float, (Float) -> Float) {
-    fatalError("unimplemented")
-  }
-
   // CHECK-LABEL: sil {{.*}} @AD__{{.*}}function3{{.*}}_jvp_USU : $@convention(witness_method: Proto) (Float, Float, @in_guaranteed S) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
-  // CHECK: [[JVP3_FNREF:%.*]] = function_ref {{.*}}function3{{.*}} : $@convention(method) (Float, Float, S) -> Float
-  // CHECK: [[JVP3_ADFUNC:%.*]] = autodiff_function [wrt 1] [order 1] [[JVP3_FNREF]] : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP3_ORIG_FNREF:%.*]] = function_ref {{.*}}function3{{.*}} : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP3_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function3{{.*}}__vjp_src_0_wrt_1
+  // CHECK: [[JVP3_ADFUNC:%.*]] = autodiff_function [wrt 1] [order 1] [[JVP3_ORIG_FNREF]] : {{.*}} with {undef : {{.*}}, [[JVP3_VJP_FNREF]] : {{.*}}}
   // CHECK: [[JVP3:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP3_ADFUNC]] : $@autodiff @convention(method) (@nondiff Float, Float, @nondiff S) -> Float
   // CHECK: apply [[JVP3]]
   // CHECK: } // end sil function 'AD__{{.*}}function3{{.*}}_jvp_USU'
 
   // CHECK-LABEL: sil {{.*}} @AD__{{.*}}function3{{.*}}_vjp_USU : $@convention(witness_method: Proto) (Float, Float, @in_guaranteed S) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
-  // CHECK: [[VJP3_FNREF:%.*]] = function_ref {{.*}}function3{{.*}} : $@convention(method) (Float, Float, S) -> Float
-  // CHECK: [[VJP3_ADFUNC:%.*]] = autodiff_function [wrt 1] [order 1] [[VJP3_FNREF]] : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP3_ORIG_FNREF:%.*]] = function_ref {{.*}}function3{{.*}} : $@convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP3_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function3{{.*}}__vjp_src_0_wrt_1
+  // CHECK: [[VJP3_ADFUNC:%.*]] = autodiff_function [wrt 1] [order 1] [[VJP3_ORIG_FNREF]] : {{.*}} with {undef : {{.*}}, [[VJP3_VJP_FNREF]] : {{.*}}}
   // CHECK: [[VJP3:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP3_ADFUNC]] : $@autodiff @convention(method) (@nondiff Float, Float, @nondiff S) -> Float
   // CHECK: apply [[VJP3]]
   // CHECK: } // end sil function 'AD__{{.*}}function3{{.*}}_vjp_USU'


### PR DESCRIPTION
The main idea is the new `emitVJPReference` function, which does the existing lookup logic for `function_ref`, and which does new lookup logic for `witness_method`. I refactored the 2 places that had `function_ref` lookup logic (`PrimalGen::visitApplyInstWithVJP` and `Differentiation::processAutoDiffFunctionInst`) to call `emitVJPReference`.

I added a SIL FileCheck test for it. An end-to-end test is currently not possible: It requires the builtins for looking up method VJPs. I will work on that next in a separate PR.

Other minor necessary fixes:
* Made `SILFunctionType::getAutoDiffAssociatedFunctionType` work on `@convention(witness_method)` functions.
* Made differentiation process transparent functions. The witness thunks with `autodiff_function`s are transparent for some reason. See `test/AutoDiff/witness_table_silgen.swift` for an example. The CHECKs in that are checking witness thunks.
* Fixed bug so that differentiation processes `autodiff_function`s in modules without `#gradient` or `[differentiable]`.

And finally, I re-enabled the SILVerifier check because now it passes.