### PR TITLE
Platform: make MSVCRT more Unix-libc like

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -13,6 +13,10 @@
 import SwiftShims
 import SwiftOverlayShims
 
+#if os(Windows)
+import ucrt
+#endif
+
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 //===----------------------------------------------------------------------===//
 // MacTypes.h
@@ -132,6 +136,14 @@ public func snprintf(ptr: UnsafeMutablePointer<Int8>, _ len: Int, _ format: Unsa
     return vsnprintf(ptr, len, format, va_args)
   }
 }
+#elseif os(Windows)
+public var stdin: UnsafeMutablePointer<FILE> { return __acrt_iob_func(0) }
+public var stdout: UnsafeMutablePointer<FILE> { return __acrt_iob_func(1) }
+public var stderr: UnsafeMutablePointer<FILE> { return __acrt_iob_func(2) }
+
+public var STDIN_FILENO: Int32 { return _fileno(stdin) }
+public var STDOUT_FILENO: Int32 { return _fileno(stdout) }
+public var STDERR_FILENO: Int32 { return _fileno(stderr) }
 #endif
 
 

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -111,6 +111,7 @@ module ucrt [system] {
 
   module corecrt {
     header "corecrt.h"
+    header "corecrt_stdio_config.h"
     export *
 
     module io {
@@ -120,6 +121,11 @@ module ucrt [system] {
 
     module math {
       header "corecrt_math.h"
+      export *
+    }
+
+    module stdio {
+      header "corecrt_wstdio.h"
       export *
     }
   }


### PR DESCRIPTION
Since `stdin`, `stdout`, and `stderr` are defined via macros, we cannot see them
on the swift side.  Replicate these by hand.  Expose `STDIN_FILENO`,
`STDOUT_FILENO`, and `STDERR_FILENO` for compatibility with other libc
implementations.  This reduces the need for changing the codebase unnecessarily
for MSVCRT.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
