### PR TITLE
stdlib: use the libc shims for the test harness

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -39,6 +39,7 @@
 import SwiftPrivate
 import SwiftPrivateLibcExtras
 import SwiftPrivateThreadExtras
+import SwiftShims
 #if os(macOS) || os(iOS)
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
@@ -518,8 +519,8 @@ class _InterruptibleSleep {
   }
 
   deinit {
-    close(readEnd)
-    close(writeEnd)
+    _swift_stdlib_close(readEnd)
+    _swift_stdlib_close(writeEnd)
   }
 
   /// Sleep for durationInSeconds or until another
@@ -546,7 +547,7 @@ class _InterruptibleSleep {
     if completed { return }
 
     let buffer: [UInt8] = [1]
-    let ret = write(writeEnd, buffer, 1)
+    let ret = _swift_stdlib_write(writeEnd, buffer, 1)
     precondition(ret >= 0)
   }
 }

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftPrivate
+import SwiftShims
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
@@ -121,7 +122,7 @@ public func spawnChild(_ args: [String])
     let errnoSize = MemoryLayout.size(ofValue: errno)
     var execveErrno = errno
     let writtenBytes = withUnsafePointer(to: &execveErrno) {
-      write(childToParentPipe.writeFD, UnsafePointer($0), errnoSize)
+      _swift_stdlib_write(childToParentPipe.writeFD, UnsafePointer($0), errnoSize)
     }
 
     let writeErrno = errno
@@ -138,7 +139,7 @@ public func spawnChild(_ args: [String])
     }
 
     // Close the pipe when we're done writing the error.
-    close(childToParentPipe.writeFD)
+    _swift_stdlib_close(childToParentPipe.writeFD)
   }
 #else
   var fileActions = _make_posix_spawn_file_actions_t()
@@ -206,18 +207,18 @@ public func spawnChild(_ args: [String])
 #endif
 
   // Close the read end of the pipe on the parent side.
-  if close(childStdin.readFD) != 0 {
-    preconditionFailure("close() failed")
+  if _swift_stdlib_close(childStdin.readFD) != 0 {
+    preconditionFailure("_swift_stdlib_close() failed")
   }
 
   // Close the write end of the pipe on the parent side.
-  if close(childStdout.writeFD) != 0 {
-    preconditionFailure("close() failed")
+  if _swift_stdlib_close(childStdout.writeFD) != 0 {
+    preconditionFailure("_swift_stdlib_close() failed")
   }
 
   // Close the write end of the pipe on the parent side.
-  if close(childStderr.writeFD) != 0 {
-    preconditionFailure("close() failed")
+  if _swift_stdlib_close(childStderr.writeFD) != 0 {
+    preconditionFailure("_swift_stdlib_close() failed")
   }
 
   return (pid, childStdin.writeFD, childStdout.readFD, childStderr.readFD)


### PR DESCRIPTION
Go through the libc shims for the read/write/close functions to abstract out the
differences between Windows and Unix platforms.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
