### PR TITLE
[ownership] Remove most -enable-sil-ownership from SILGen now that %t…

### DIFF
--- a/test/SILGen/NSApplicationMain.swift
+++ b/test/SILGen/NSApplicationMain.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 // RUN: %target-swift-emit-ir -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s -check-prefix=IR
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | %FileCheck %s
 // RUN: %target-swift-emit-ir -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | %FileCheck %s -check-prefix=IR
 
 // REQUIRES: OS=macosx

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name access_marker_gen -parse-as-library -Xllvm -sil-full-demangle -enforce-exclusivity=checked -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name access_marker_gen -parse-as-library -Xllvm -sil-full-demangle -enforce-exclusivity=checked %s | %FileCheck %s
 
 func modify<T>(_ x: inout T) {}
 

--- a/test/SILGen/accessibility_warnings.swift
+++ b/test/SILGen/accessibility_warnings.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // This file tests that the AST produced after fixing accessibility warnings
 // is valid according to SILGen and the verifiers.

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name accessors -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name accessors -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 // Hold a reference to do to magically become non-POD.
 class Reference {}

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name address_only_types -enable-sil-ownership -parse-as-library -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name address_only_types -parse-as-library -parse-stdlib %s | %FileCheck %s
 
 precedencegroup AssignmentPrecedence { assignment: true }
 

--- a/test/SILGen/argument_labels.swift
+++ b/test/SILGen/argument_labels.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name argument_labels -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name argument_labels %s | %FileCheck %s
 
 public struct X { }
 public struct Y { }

--- a/test/SILGen/argument_shuffle.swift
+++ b/test/SILGen/argument_shuffle.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s
+// RUN: %target-swift-emit-silgen %s
 
 struct Horse<T> {
   func walk(_: (String, Int), reverse: Bool) {}

--- a/test/SILGen/arguments.swift
+++ b/test/SILGen/arguments.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name Swift -enable-sil-ownership -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name Swift -parse-stdlib %s | %FileCheck %s
 
 struct Int {}
 struct Float {}

--- a/test/SILGen/arguments_as_tuple_overloads.swift
+++ b/test/SILGen/arguments_as_tuple_overloads.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name=test -enable-sil-ownership -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name=test -primary-file %s | %FileCheck %s
 
 // Check if we mangle the following constructors, functions, and
 // subscripts correctly.

--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -enforce-exclusivity=checked %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enforce-exclusivity=checked %s | %FileCheck %s
 
 class C {}
 

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name auto_closures -enable-sil-ownership -parse-stdlib -swift-version 5 %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name auto_closures -parse-stdlib -swift-version 5 %s | %FileCheck %s
 
 struct Bool {}
 var false_ = Bool()

--- a/test/SILGen/auto_closures_swift4.swift
+++ b/test/SILGen/auto_closures_swift4.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name auto_closures -enable-sil-ownership -parse-stdlib -swift-version 4 %s
+// RUN: %target-swift-emit-silgen -module-name auto_closures -parse-stdlib -swift-version 4 %s
 
 // Swift 4-style autoclosure forwarding should not crash - rdar://problem/44657505
 

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-debuginfo -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-debuginfo %s | %FileCheck %s
 
 // Test that we emit a call to super.init at the end of the initializer, when none has been previously added.
 

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-sil %s -target x86_64-apple-macosx10.50 -verify
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -target x86_64-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.50 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name borrow -enable-sil-ownership -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name borrow -parse-stdlib %s | %FileCheck %s
 
 import Swift
 

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name boxed_existentials -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -module-name boxed_existentials -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s --check-prefix=GUARANTEED
+// RUN: %target-swift-emit-silgen -module-name boxed_existentials -Xllvm -sil-full-demangle %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name boxed_existentials -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=GUARANTEED
 
 func test_type_lowering(_ x: Error) { }
 // CHECK-LABEL: sil hidden @$s18boxed_existentials18test_type_loweringyys5Error_pF : $@convention(thin) (@guaranteed Error) -> () {

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -verify %s | %FileCheck %s
 
 func values(_ arg: @escaping @convention(c) (Int) -> Int) -> @convention(c) (Int) -> Int {
   return arg

--- a/test/SILGen/c_modify_linkage.swift
+++ b/test/SILGen/c_modify_linkage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import AppKit
 

--- a/test/SILGen/call_chain_reabstraction.swift
+++ b/test/SILGen/call_chain_reabstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name call_chain_reabstraction -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name call_chain_reabstraction %s | %FileCheck %s
 
 struct A {
         func g<U>(_ recur: (A, U) -> U) -> (A, U) -> U {

--- a/test/SILGen/capture-canonicalization.swift
+++ b/test/SILGen/capture-canonicalization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct Foo<T> {}
 struct Bar {}

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 // SR-8398
 func fibonacci(_ n: Int) -> Int {
   var cache: [Int: Int] = [:]

--- a/test/SILGen/capture_inout.swift
+++ b/test/SILGen/capture_inout.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 typealias Int = Builtin.Int64
 

--- a/test/SILGen/capture_list.swift
+++ b/test/SILGen/capture_list.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s
+// RUN: %target-swift-emit-silgen %s
 
 // Capture list with weak capture vs noescape closure
 func transform<T>(fn: () -> T) -> T {

--- a/test/SILGen/capture_typealias.swift
+++ b/test/SILGen/capture_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 typealias Int = Builtin.Int64
 

--- a/test/SILGen/capture_typed_boxes.swift
+++ b/test/SILGen/capture_typed_boxes.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name capture_typed_boxes -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name capture_typed_boxes %s | %FileCheck %s
 
 func foo(_ x: Int) -> () -> Int {
   var x = x

--- a/test/SILGen/casts.swift
+++ b/test/SILGen/casts.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name casts -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name casts %s | %FileCheck %s
 
 class B { }
 class D : B { }

--- a/test/SILGen/cdecl.swift
+++ b/test/SILGen/cdecl.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden [thunk] @pear : $@convention(c)
 // CHECK:         function_ref @$s5cdecl5apple{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %S/../IDE/Inputs/custom-modules %s -enable-objc-interop -I %S/Inputs/usr/include | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %S/../IDE/Inputs/custom-modules %s -enable-objc-interop -I %S/Inputs/usr/include | %FileCheck %s
 
 import ImportAsMember
 

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
 
 enum Optional<T> {
   case some(T)

--- a/test/SILGen/class_resilience.swift
+++ b/test/SILGen/class_resilience.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-emit-silgen -module-name class_resilience -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name class_resilience -I %t -enable-resilience %s | %FileCheck %s
 
 import resilient_class
 

--- a/test/SILGen/closure_inline_initializer.swift
+++ b/test/SILGen/closure_inline_initializer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil private @$s26closure_inline_initializer3FooV3fooSivpfiSiyXEfU_
 

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name closures -enable-sil-ownership -parse-stdlib -parse-as-library %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -module-name closures -enable-sil-ownership -parse-stdlib -parse-as-library  %s | %FileCheck %s --check-prefix=GUARANTEED
+// RUN: %target-swift-emit-silgen -module-name closures -parse-stdlib -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name closures -parse-stdlib -parse-as-library  %s | %FileCheck %s --check-prefix=GUARANTEED
 
 import Swift
 

--- a/test/SILGen/closures_callee_guaranteed.swift
+++ b/test/SILGen/closures_callee_guaranteed.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib -parse-as-library  %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -parse-as-library  %s | %FileCheck %s
 import Swift
 
 // CHECK-LABEL: sil @{{.*}}apply{{.*}} : $@convention(thin) (@noescape @callee_guaranteed () -> Int)

--- a/test/SILGen/collection_subtype_downcast.swift
+++ b/test/SILGen/collection_subtype_downcast.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name collection_subtype_downcast -enable-sil-ownership -sdk %S/Inputs %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name collection_subtype_downcast -sdk %S/Inputs %s | %FileCheck %s
 
 struct S { var x, y: Int }
 

--- a/test/SILGen/collection_subtype_upcast.swift
+++ b/test/SILGen/collection_subtype_upcast.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name collection_subtype_upcast -enable-sil-ownership -sdk %S/Inputs %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name collection_subtype_upcast -sdk %S/Inputs %s | %FileCheck %s
 
 struct S { var x, y: Int }
 

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct X { }
 

--- a/test/SILGen/conditional_conformance.swift
+++ b/test/SILGen/conditional_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol P1 {
   func normal()

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name constrained_extensions -enable-sil-ownership -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name constrained_extensions -primary-file %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name constrained_extensions -O -primary-file %s > /dev/null
 // RUN: %target-swift-emit-ir -module-name constrained_extensions -primary-file %s > /dev/null
 

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -parse-as-library %s | %FileCheck %s
 
 precedencegroup AssignmentPrecedence { assignment: true }
 

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s5decls11void_returnyyF
 // CHECK: = tuple

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name default_arguments -Xllvm -sil-full-demangle -enable-sil-ownership -swift-version 4 %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -module-name default_arguments -Xllvm -sil-full-demangle -enable-sil-ownership -swift-version 4 %s | %FileCheck %s --check-prefix=NEGATIVE
+// RUN: %target-swift-emit-silgen -module-name default_arguments -Xllvm -sil-full-demangle -swift-version 4 %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name default_arguments -Xllvm -sil-full-demangle -swift-version 4 %s | %FileCheck %s --check-prefix=NEGATIVE
 
 // __FUNCTION__ used as top-level parameter produces the module name.
 // CHECK-LABEL: sil @main

--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name default_arguments_generic -enable-sil-ownership -swift-version 4 %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name default_arguments_generic -swift-version 4 %s | %FileCheck %s
 
 func foo<T: ExpressibleByIntegerLiteral>(_: T.Type, x: T = 0) { }
 

--- a/test/SILGen/default_arguments_imported.swift
+++ b/test/SILGen/default_arguments_imported.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // Test SIL generation for imported default arguments.
 

--- a/test/SILGen/default_arguments_inherited.swift
+++ b/test/SILGen/default_arguments_inherited.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // When we synthesize an inherited designated initializer, the default
 // arguments are still conceptually rooted on the base declaration.

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-sil-ownership -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -primary-file %s | %FileCheck %s
 
 struct B {
   var i : Int, j : Float

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name dependent_member_lowering -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name dependent_member_lowering %s | %FileCheck %s
 
 protocol P {
   associatedtype A

--- a/test/SILGen/downcast_reabstraction.swift
+++ b/test/SILGen/downcast_reabstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name downcast_reabstraction -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name downcast_reabstraction %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s22downcast_reabstraction19condFunctionFromAnyyyypF
 // CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed () -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 // CHECK: sil_global [[DSO:@__dso_handle]] : $Builtin.RawPointer
 

--- a/test/SILGen/dynamic_init.swift
+++ b/test/SILGen/dynamic_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class C {
   required init() { }

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name dynamic_self -enable-sil-ownership %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name dynamic_self %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name dynamic_self -O %s -disable-objc-attr-requires-foundation-module -enable-objc-interop
 // RUN: %target-swift-emit-ir -module-name dynamic_self %s -disable-objc-attr-requires-foundation-module -enable-objc-interop
 

--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -swift-version 5 %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -swift-version 5 %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=IMPLICIT
+// RUN: %target-swift-emit-silgen -swift-version 5 %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 5 %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=IMPLICIT
 
 // CHECK-LABEL: sil hidden @$s23dynamically_replaceable014maybe_dynamic_B0yyF : $@convention(thin) () -> () {
 // IMPLICIT-LABEL: sil hidden [dynamically_replacable] @$s23dynamically_replaceable014maybe_dynamic_B0yyF : $@convention(thin) () -> () {

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 
 //CHECK: [readonly] @func1

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -parse-stdlib -parse-as-library -enable-sil-ownership -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
 
 precedencegroup AssignmentPrecedence { assignment: true }
 

--- a/test/SILGen/enum_generic_raw_value.swift
+++ b/test/SILGen/enum_generic_raw_value.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s22enum_generic_raw_value1EO
 enum E<T>: Int {

--- a/test/SILGen/enum_raw_representable.swift
+++ b/test/SILGen/enum_raw_representable.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-sorted-sil %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-sorted-sil -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
 
 public enum E: Int {
   case a, b, c

--- a/test/SILGen/enum_raw_representable_objc.swift
+++ b/test/SILGen/enum_raw_representable_objc.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
 
 @objc public enum CLike: Int {
   case a, b, c

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
-// RUN: %target-swift-emit-silgen -module-name enum_resilience -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name enum_resilience -I %t -enable-resilience %s | %FileCheck %s
 
 import resilient_enum
 

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift -enable-testing
-// RUN: %target-swift-emit-silgen -module-name enum_resilience_testable -I %t -enable-sil-ownership -enable-nonfrozen-enum-exhaustivity-diagnostics -swift-version 5 %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name enum_resilience_testable -I %t -enable-nonfrozen-enum-exhaustivity-diagnostics -swift-version 5 %s | %FileCheck %s
 
 // This is mostly testing the same things as enum_resilienc.swift, just in a
 // context where the user will never be forced to write a default case. It's the

--- a/test/SILGen/erasure_reabstraction.swift
+++ b/test/SILGen/erasure_reabstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct Foo {}
 class Bar {}

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-stdlib -enable-sil-ownership -Xllvm -sil-print-debuginfo -verify -swift-version 5 -primary-file %s %S/Inputs/errors_other.swift | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -Xllvm -sil-print-debuginfo -verify -swift-version 5 -primary-file %s %S/Inputs/errors_other.swift | %FileCheck %s
 
 import Swift
 

--- a/test/SILGen/existential_erasure.swift
+++ b/test/SILGen/existential_erasure.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name existential_erasure -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name existential_erasure %s | %FileCheck %s
 
 protocol P {
   func downgrade(_ m68k: Bool) -> Self

--- a/test/SILGen/existential_metatypes.swift
+++ b/test/SILGen/existential_metatypes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-stdlib -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 @_semantics("typechecker.type(of:)")
 public func type<T, Metatype>(of value: T) -> Metatype {}

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: echo "public var x = Int()" | %target-swift-frontend -module-name FooBar -emit-module -o %t -
-// RUN: %target-swift-emit-silgen -parse-stdlib -module-name expressions -enable-sil-ownership %s -I%t -disable-access-control | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -module-name expressions %s -I%t -disable-access-control | %FileCheck %s
 
 import Swift
 import FooBar

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class Foo {
   // CHECK-LABEL: sil hidden @$s10extensions3FooC3zim{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/extensions_multifile.swift
+++ b/test/SILGen/extensions_multifile.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile -enable-sil-ownership | %FileCheck %s --check-prefix=FRAGILE --check-prefix=CHECK
-// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile -enable-sil-ownership -enable-resilience | %FileCheck %s --check-prefix=RESILIENT --check-prefix=CHECK
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile | %FileCheck %s --check-prefix=FRAGILE --check-prefix=CHECK
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile -enable-resilience | %FileCheck %s --check-prefix=RESILIENT --check-prefix=CHECK
 
 // CHECK-LABEL: sil hidden @$s20extensions_multifile12HasInitValueV1zACSi_tcfC : $@convention(method) (Int, @thin HasInitValue.Type) -> @owned HasInitValue {
 // CHECK: function_ref @$s20extensions_multifile12HasInitValueV1xSivpfi : $@convention(thin) () -> Int

--- a/test/SILGen/extensions_objc.swift
+++ b/test/SILGen/extensions_objc.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name extensions_objc -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name extensions_objc -sdk %S/Inputs %s -I %S/Inputs -enable-source-import | %FileCheck %s
 //
 // REQUIRES: objc_interop
 

--- a/test/SILGen/external-associated-type-conformance.swift
+++ b/test/SILGen/external-associated-type-conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/external-associated-type-conformance.h %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/external-associated-type-conformance.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 extension BadError: LocalizedError {}

--- a/test/SILGen/external_definitions.swift
+++ b/test/SILGen/external_definitions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs %s -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs %s -enable-objc-interop | %FileCheck %s
 
 import ansible
 

--- a/test/SILGen/final.swift
+++ b/test/SILGen/final.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name final -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name final %s | %FileCheck %s
 
 class TestClass {
 

--- a/test/SILGen/fixed_layout_attribute.swift
+++ b/test/SILGen/fixed_layout_attribute.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-as-library %s | %FileCheck %s --check-prefix=FRAGILE --check-prefix=CHECK
-// RUN: %target-swift-emit-silgen -enable-resilience -enable-sil-ownership -parse-as-library %s | %FileCheck %s --check-prefix=RESILIENT --check-prefix=CHECK
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s --check-prefix=FRAGILE --check-prefix=CHECK
+// RUN: %target-swift-emit-silgen -enable-resilience -parse-as-library %s | %FileCheck %s --check-prefix=RESILIENT --check-prefix=CHECK
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-as-library -enable-testing %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-as-library -enable-testing -enable-resilience %s
+// RUN: %target-swift-emit-silgen -parse-as-library -enable-testing %s
+// RUN: %target-swift-emit-silgen -parse-as-library -enable-testing -enable-resilience %s
 
 public let global = 0
 

--- a/test/SILGen/for_loop_tuple_destructure_reabstraction.swift
+++ b/test/SILGen/for_loop_tuple_destructure_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen -verify %s
 
 protocol P {}
 

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name force_cast_chained_optional -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name force_cast_chained_optional %s | %FileCheck %s
 
 class Foo {
   var bar: Bar!

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name foreach -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name foreach %s | %FileCheck %s
 
 //////////////////
 // Declarations //

--- a/test/SILGen/fully-concrete-extension-of-generic.swift
+++ b/test/SILGen/fully-concrete-extension-of-generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s 
+// RUN: %target-swift-emit-silgen -verify %s 
 
 class C<T> {
   init() {}

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name function_conversion_objc -sdk %S/Inputs %s -I %S/Inputs -enable-sil-ownership -enable-source-import -enable-objc-interop -verify | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name function_conversion_objc -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -enable-objc-interop -verify | %FileCheck %s
 
 import Foundation
 

--- a/test/SILGen/function_conversion_se0110.swift
+++ b/test/SILGen/function_conversion_se0110.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name function_conversion -enable-sil-ownership -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name function_conversion -primary-file %s | %FileCheck %s
 
 // Check SILGen against various FunctionConversionExprs emitted by Sema.
 

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name functions -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name functions -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library %s | %FileCheck %s
 
 import Swift // just for Optional
 

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -swift-version 5 -module-name generic_casts -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
+// RUN: %target-swift-emit-silgen -swift-version 5 -module-name generic_casts -Xllvm -sil-full-demangle %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
 
 protocol ClassBound : class {}
 protocol NotClassBound {}

--- a/test/SILGen/generic_casts_swift4.swift
+++ b/test/SILGen/generic_casts_swift4.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -swift-version 4 -module-name generic_casts -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 4 -module-name generic_casts -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 // The below tests are to ensure we maintain compatibility with Swift 4.1's
 // behaviour when casting to an archetype – the compiler assumes a non-optional

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name generic_closures  -parse-stdlib -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name generic_closures  -parse-stdlib %s | %FileCheck %s
 
 import Swift
 

--- a/test/SILGen/generic_literals.swift
+++ b/test/SILGen/generic_literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s16generic_literals0A14IntegerLiteral1xyx_ts013ExpressibleBycD0RzlF : $@convention(thin) <T where T : ExpressibleByIntegerLiteral> (@in_guaranteed T) -> () {
 func genericIntegerLiteral<T : ExpressibleByIntegerLiteral>(x: T) {

--- a/test/SILGen/generic_local_property.swift
+++ b/test/SILGen/generic_local_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 func use<T>(_: T) {}
 

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name generic_property_base_lifetime %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name generic_property_base_lifetime %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 
 protocol ProtocolA: class {
     var intProp: Int { get set }

--- a/test/SILGen/generic_signatures.swift
+++ b/test/SILGen/generic_signatures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s
 
 protocol P {
   associatedtype Assoc

--- a/test/SILGen/generic_tuples.swift
+++ b/test/SILGen/generic_tuples.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name generic_tuples -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name generic_tuples -parse-as-library %s | %FileCheck %s
 
 
 func dup<T>(_ x: T) -> (T, T) { return (x,x) }

--- a/test/SILGen/global_init_attribute.swift
+++ b/test/SILGen/global_init_attribute.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-module -o %t %S/Inputs/def_global.swift -enable-sil-ownership
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library -enable-sil-ownership -I %t %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library -I %t %s | %FileCheck %s
 //
 // Test that SILGen uses the "global_init" attribute for all global
 // variable addressors.

--- a/test/SILGen/guaranteed-let-peephole-reabstraction.swift
+++ b/test/SILGen/guaranteed-let-peephole-reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s 
+// RUN: %target-swift-emit-silgen -verify %s 
 class BlockBox<T> {
   let block: (T) -> Void = { _ in }
 

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership  %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library  %s | %FileCheck %s
 
 func use<T>(_: T) {}
 

--- a/test/SILGen/guaranteed_normal_args.swift
+++ b/test/SILGen/guaranteed_normal_args.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name Swift -parse-stdlib -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name Swift -parse-stdlib %s | %FileCheck %s
 
 // This test checks specific codegen related to normal arguments being passed at
 // +0. Eventually, it should be merged into normal SILGen tests.

--- a/test/SILGen/guaranteed_normal_args_curry_thunks.swift
+++ b/test/SILGen/guaranteed_normal_args_curry_thunks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name Swift -parse-stdlib -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name Swift -parse-stdlib %s | %FileCheck %s
 
 // This test checks specific codegen related to converting curry thunks to
 // canonical representations when we are emitting guaranteed normal

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name guaranteed_self -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name guaranteed_self -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 
 protocol Fooable {
   init()

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 func fizzbuzz(i: Int) -> String {
   return i % 3 == 0

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name if_while_binding -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name if_while_binding -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 func foo() -> String? { return "" }
 func bar() -> String? { return "" }

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name implicitly_unwrapped_optional -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name implicitly_unwrapped_optional %s | %FileCheck %s
 
 func foo(f f: (() -> ())!) {
   var f: (() -> ())! = f

--- a/test/SILGen/import_as_member_cf.swift
+++ b/test/SILGen/import_as_member_cf.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %S/../IDE/Inputs/custom-modules %s -enable-objc-interop -sdk %S/Inputs 2>&1 | %FileCheck --check-prefix=SIL %s
+// RUN: %target-swift-emit-silgen -I %S/../IDE/Inputs/custom-modules %s -enable-objc-interop -sdk %S/Inputs 2>&1 | %FileCheck --check-prefix=SIL %s
 
 import ImportAsMember.C
 

--- a/test/SILGen/imported_struct_array_field.swift
+++ b/test/SILGen/imported_struct_array_field.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -import-objc-header %S/Inputs/array_typedef.h %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/array_typedef.h %s | %FileCheck %s
 
 // CHECK-LABEL: sil shared [transparent] [serializable] @$sSo4NameV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (UInt8, UInt8, UInt8, UInt8, @thin Name.Type) -> Name
 func useImportedArrayTypedefInit() -> Name {

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name indirect_enum -Xllvm -sil-print-debuginfo %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name indirect_enum -Xllvm -sil-print-debuginfo %s | %FileCheck %s
 
 indirect enum TreeA<T> {
   case Nil

--- a/test/SILGen/inherit_initializers.swift
+++ b/test/SILGen/inherit_initializers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -verify
+// RUN: %target-swift-emit-silgen %s -verify
 
 // We just want to SILGen this and ensure it doesn't crash. Don't particularly
 // care about the generated SIL.

--- a/test/SILGen/inherited_protocol_conformance_multi_file.swift
+++ b/test/SILGen/inherited_protocol_conformance_multi_file.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file.swift -module-name main | %FileCheck %s --check-prefix=THIS_FILE
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file.swift -module-name main | %FileCheck %s --check-prefix=OTHER_FILE
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file.swift -module-name main | %FileCheck %s --check-prefix=THIS_FILE
+// RUN: %target-swift-emit-silgen %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file.swift -module-name main | %FileCheck %s --check-prefix=OTHER_FILE
 
 // THIS_FILE-NOT: sil_witness_table {{.*}} B: P
 // THIS_FILE-LABEL: sil_witness_table hidden D: R module main

--- a/test/SILGen/inherited_protocol_conformance_multi_file_2.swift
+++ b/test/SILGen/inherited_protocol_conformance_multi_file_2.swift
@@ -1,46 +1,46 @@
 // -- Try all the permutations of file order possible.
 
 // Abc
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
 // aBc
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
+// RUN: %target-swift-emit-silgen %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
 // abC
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
+// RUN: %target-swift-emit-silgen %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
 
 // Bac
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
+// RUN: %target-swift-emit-silgen -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
 // bAc
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
 // baC
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
 
 // OS X 10.9
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
+// RUN: %target-swift-emit-silgen -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
 // cAb
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
 // caB
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
 
 // Acb
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_A
 // aCb
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
+// RUN: %target-swift-emit-silgen %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
 // abC
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
+// RUN: %target-swift-emit-silgen %s %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_B
 
 // Bca
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_B
+// RUN: %target-swift-emit-silgen -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_B
 // bCa
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_C
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_C
 // bcA
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %s -module-name main | %FileCheck %s --check-prefix=FILE_A
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %s -module-name main | %FileCheck %s --check-prefix=FILE_A
 
 // Cba
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_C
+// RUN: %target-swift-emit-silgen -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_C
 // cBa
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_B
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -module-name main | %FileCheck %s --check-prefix=FILE_B
 // cbA
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %s -module-name main | %FileCheck %s --check-prefix=FILE_A
+// RUN: %target-swift-emit-silgen %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -primary-file %s -module-name main | %FileCheck %s --check-prefix=FILE_A
 
 // FILE_A-NOT: sil [transparent] [thunk] @$s4main5ThingVSQAAsADP2eeoi{{[_0-9a-zA-Z]*}}FZTW
 // FILE_A-NOT: sil [transparent] [thunk] @$s4main5ThingVSkAAsADP9hashValueSivgTW

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -disable-objc-attr-requires-foundation-module -enable-objc-interop %s -module-name failable_initializers | %FileCheck %s
+// RUN: %target-swift-emit-silgen -disable-objc-attr-requires-foundation-module -enable-objc-interop %s -module-name failable_initializers | %FileCheck %s
 
 // High-level tests that silgen properly emits code for failable and thorwing
 // initializers.

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name inlinable_attribute -enable-sil-ownership -emit-verbose-sil -warnings-as-errors %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors %s | %FileCheck %s
 
 // CHECK-LABEL: sil [serialized] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()
 @inlinable public func fragileFunction() {

--- a/test/SILGen/inline_always.swift
+++ b/test/SILGen/inline_always.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden [always_inline] @$s13inline_always0b1_A7_calleeyyF : $@convention(thin) () -> ()
 @inline(__always)

--- a/test/SILGen/interface_type_mangling.swift
+++ b/test/SILGen/interface_type_mangling.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 protocol P {
   associatedtype Assoc1

--- a/test/SILGen/ivar_destroyer.swift
+++ b/test/SILGen/ivar_destroyer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
 // Only derived classes with non-trivial ivars need an ivar destroyer.
 

--- a/test/SILGen/keypath_application.swift
+++ b/test/SILGen/keypath_application.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class A {}
 class B {}

--- a/test/SILGen/keypath_dynamic.swift
+++ b/test/SILGen/keypath_dynamic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name A %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name A %s | %FileCheck %s
 
 struct Foo {
   var x : Int {

--- a/test/SILGen/lazy_global_access.swift
+++ b/test/SILGen/lazy_global_access.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s -check-prefix=MAIN
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | %FileCheck %s -check-prefix=LIBRARY
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s -check-prefix=MAIN
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s -check-prefix=LIBRARY
 
 // The following code is valid as a library or as a main source file. Script
 // variables should be accessed directly, whereas library global variables

--- a/test/SILGen/lazy_globals.swift
+++ b/test/SILGen/lazy_globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
 // CHECK: sil private @globalinit_[[T:.*]]_func0 : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals1xSiv

--- a/test/SILGen/lazy_globals_multiple_vars.swift
+++ b/test/SILGen/lazy_globals_multiple_vars.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
 // CHECK:       sil private [[INIT_A_B:@globalinit_.*]] :
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1aSiv

--- a/test/SILGen/lazy_properties.swift
+++ b/test/SILGen/lazy_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library -enable-sil-ownership -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library -primary-file %s | %FileCheck %s
 
 // <rdar://problem/17405715> lazy property crashes silgen of implicit memberwise initializer
 

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name let_decls -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name let_decls -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 func takeClosure(_ a : () -> Int) {}
 

--- a/test/SILGen/lifetime_nonmutating_address_only.swift
+++ b/test/SILGen/lifetime_nonmutating_address_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen -verify %s
 
 // SR-8990
 

--- a/test/SILGen/lifetime_unions.swift
+++ b/test/SILGen/lifetime_unions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
 enum TrivialUnion {
   case Foo

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 func takesOptionalFunction(_: (() -> ())?) {}
 

--- a/test/SILGen/load_from_lvalue_in_plus_zero_context.swift
+++ b/test/SILGen/load_from_lvalue_in_plus_zero_context.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class A {
   lazy var b: B = B()

--- a/test/SILGen/local_captures.swift
+++ b/test/SILGen/local_captures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen  -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen  -parse-as-library %s | %FileCheck %s
 
 // Check that we don't crash if a local function references another local
 // function without captures.

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen  -parse-as-library -enable-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-astscope-lookup  -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen  -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-astscope-lookup  -parse-as-library %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s15local_recursionAA_1yySi_SitF : $@convention(thin) (Int, Int) -> () {
 // CHECK:       bb0([[X:%0]] : $Int, [[Y:%1]] : $Int):

--- a/test/SILGen/lying_about_optional_return.swift
+++ b/test/SILGen/lying_about_optional_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/c_function_pointer_in_c_struct.h -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/c_function_pointer_in_c_struct.h %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s27lying_about_optional_return0C37ChainingForeignFunctionTypeProperties{{[_0-9a-zA-Z]*}}F
 func optionalChainingForeignFunctionTypeProperties(a: SomeCallbacks?) {

--- a/test/SILGen/lying_about_optional_return_objc.swift
+++ b/test/SILGen/lying_about_optional_return_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/block_property_in_objc_class.h -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/block_property_in_objc_class.h %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s32lying_about_optional_return_objc0C37ChainingForeignFunctionTypeProperties{{[_0-9a-zA-Z]*}}F
 func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {

--- a/test/SILGen/magic_identifiers_inside_property_initializers.swift
+++ b/test/SILGen/magic_identifiers_inside_property_initializers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class Test {
     // CHECK-LABEL: sil hidden [transparent] @$s46magic_identifiers_inside_property_initializers4TestC4fileSSvpfi

--- a/test/SILGen/mangling_generic_extensions.swift
+++ b/test/SILGen/mangling_generic_extensions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct Foo<T> {
 }

--- a/test/SILGen/mangling_retroactive_overlay.swift
+++ b/test/SILGen/mangling_retroactive_overlay.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import ObjectiveC

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name Swift -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name Swift -parse-stdlib %s | %FileCheck %s
 
 @_semantics("typechecker.type(of:)")
 public func type<T, Metatype>(of value: T) -> Metatype {}

--- a/test/SILGen/metatype_casts.swift
+++ b/test/SILGen/metatype_casts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s14metatype_casts6t_is_u{{[_0-9a-zA-Z]*}}F
 // CHECK:         checked_cast_br {{.*}} $@thick T.Type to $@thick U.Type

--- a/test/SILGen/metatype_object_conversion.swift
+++ b/test/SILGen/metatype_object_conversion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -sdk %S/Inputs -I %S/Inputs -enable-source-import -enable-objc-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import -enable-objc-interop %s | %FileCheck %s
 
 import Foundation
 

--- a/test/SILGen/metatypes.swift
+++ b/test/SILGen/metatypes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-stdlib -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 import Swift
 

--- a/test/SILGen/minimum_foreach.swift
+++ b/test/SILGen/minimum_foreach.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name Swift -parse-stdlib -parse-as-library -enable-sil-ownership %s
+// RUN: %target-swift-emit-silgen -module-name Swift -parse-stdlib -parse-as-library %s
 
 // This files contains a minimal implementation for Swift to emit foreach loops
 // for a type. It acts partially as a guide for users and since it is in the

--- a/test/SILGen/multi_file.swift
+++ b/test/SILGen/multi_file.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name multi_file -enable-sil-ownership -primary-file %s %S/Inputs/multi_file_helper.swift | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name multi_file -primary-file %s %S/Inputs/multi_file_helper.swift | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/SILGen/nested_types_referencing_nested_functions.swift
+++ b/test/SILGen/nested_types_referencing_nested_functions.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name nested_types_referencing_nested_functions -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name nested_types_referencing_nested_functions %s | %FileCheck %s
 
 do {
   func foo() { bar(2) }

--- a/test/SILGen/noescape_reabstraction.swift
+++ b/test/SILGen/noescape_reabstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name noescape_reabstraction -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name noescape_reabstraction %s | %FileCheck %s
 
 struct S {}
 

--- a/test/SILGen/nsmanaged-witness.swift
+++ b/test/SILGen/nsmanaged-witness.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -sdk %S/Inputs %s -I %S/Inputs -enable-source-import | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs %s -I %S/Inputs -enable-source-import | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_attr_NSManaged.swift
+++ b/test/SILGen/objc_attr_NSManaged.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_attr_NSManaged -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_attr_NSManaged -sdk %S/Inputs %s -I %S/Inputs -enable-source-import | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_attr_NSManaged_multi.swift
+++ b/test/SILGen/objc_attr_NSManaged_multi.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_attr_NSManaged_multi -sdk %S/Inputs -primary-file %s %S/objc_attr_NSManaged.swift -I %S/Inputs -enable-source-import -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_attr_NSManaged_multi -sdk %S/Inputs -primary-file %s %S/objc_attr_NSManaged.swift -I %S/Inputs -enable-source-import | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -1,8 +1,8 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_blocks_bridging -verify -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_blocks_bridging -verify -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership  %s | %FileCheck %s --check-prefix=GUARANTEED
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_blocks_bridging -verify -I %S/Inputs -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_blocks_bridging -verify -I %S/Inputs -disable-objc-attr-requires-foundation-module  %s | %FileCheck %s --check-prefix=GUARANTEED
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_bridged_generic_nonnull.swift
+++ b/test/SILGen/objc_bridged_generic_nonnull.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -verify -import-objc-header %S/Inputs/objc_bridged_generic_nonnull.h -enable-sil-ownership %s
+// RUN: %target-swift-emit-silgen -verify -import-objc-header %S/Inputs/objc_bridged_generic_nonnull.h %s
 // REQUIRES: objc_interop
 
 public func test<T>(_ x: NonnullMembers<T>) -> T? {

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_bridged_results %s -Xllvm -sil-print-debuginfo -import-objc-header %S/Inputs/objc_bridged_results.h -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_bridged_results %s -Xllvm -sil-print-debuginfo -import-objc-header %S/Inputs/objc_bridged_results.h | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_bridged_using_protocol_extension_impl.swift
+++ b/test/SILGen/objc_bridged_using_protocol_extension_impl.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_bridging -I %S/../Inputs/ObjCBridging -Xllvm -sil-full-demangle %s -enable-sil-ownership | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_bridging -I %S/../Inputs/ObjCBridging -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_bridging_any -Xllvm -sil-print-debuginfo -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_bridging_any -Xllvm -sil-print-debuginfo %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_bridging_peephole.swift
+++ b/test/SILGen/objc_bridging_peephole.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_bridging_peephole -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_bridging_peephole %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_currying -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_currying %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import gizmo
 

--- a/test/SILGen/objc_deprecated_objc_thunks.swift
+++ b/test/SILGen/objc_deprecated_objc_thunks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -enable-swift3-objc-inference -swift-version 4 -enable-sil-ownership -enable-objc-interop | %FileCheck -check-prefix CHECK-SWIFT4 %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -enable-swift3-objc-inference -swift-version 4 -enable-objc-interop | %FileCheck -check-prefix CHECK-SWIFT4 %s
 
 import Foundation
 

--- a/test/SILGen/objc_dictionary_bridging.swift
+++ b/test/SILGen/objc_dictionary_bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_dictionary_bridging -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_dictionary_bridging %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_dynamic_init.swift
+++ b/test/SILGen/objc_dynamic_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_dynamic_init.h -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_dynamic_init.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership > %t.out
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s > %t.out
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s < %t.out
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.out
 

--- a/test/SILGen/objc_enum_unused_witnesses.swift
+++ b/test/SILGen/objc_enum_unused_witnesses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import gizmo
 

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name objc_error -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name objc_error %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_extensions -enable-sil-ownership -sdk %S/Inputs/ -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_extensions -sdk %S/Inputs/ -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -I %S/../IDE/Inputs/custom-modules %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -I %S/../IDE/Inputs/custom-modules %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_final.swift
+++ b/test/SILGen/objc_final.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_generic_class.swift
+++ b/test/SILGen/objc_generic_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_imported_generic %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_imported_generic %s | %FileCheck %s
 // For integration testing, ensure we get through IRGen too.
 // RUN: %target-swift-emit-ir(mock-sdk: %clang-importer-sdk) -module-name objc_imported_generic -verify -DIRGEN_INTEGRATION_TEST %s
 

--- a/test/SILGen/objc_imported_init.swift
+++ b/test/SILGen/objc_imported_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -verify -sdk %S/Inputs -I %S/Inputs -enable-source-import -enable-sil-ownership %s -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -verify -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import Foundation
 

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import gizmo
 

--- a/test/SILGen/objc_local.swift
+++ b/test/SILGen/objc_local.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-sil-ownership -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_metatypes.swift
+++ b/test/SILGen/objc_metatypes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 
 import gizmo
 

--- a/test/SILGen/objc_nonnull_lie_hack.swift
+++ b/test/SILGen/objc_nonnull_lie_hack.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -I %S/Inputs/objc_nonnull_lie_hack/ -enable-source-import -primary-file -enable-sil-ownership %s | %FileCheck -check-prefix=SILGEN %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -I %S/Inputs/objc_nonnull_lie_hack/ -enable-source-import -primary-file %s | %FileCheck -check-prefix=SILGEN %s
 // RUN: %target-swiftemit-sil -O -sdk %S/Inputs -I %S/Inputs -I %S/Inputs/objc_nonnull_lie_hack/ -enable-source-import -primary-file %s | %FileCheck -check-prefix=OPT %s
 
 // REQUIRES: objc_interop

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name objc_ownership_conventions -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-sil-ownership -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_ownership_conventions -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import gizmo
 

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -emit-verbose-sil -sdk %S/Inputs -I %S/Inputs -enable-source-import | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -emit-verbose-sil -sdk %S/Inputs -I %S/Inputs -enable-source-import | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_protocol_native_thunk.swift
+++ b/test/SILGen/objc_protocol_native_thunk.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_protocols -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_protocols -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_set_bridging.swift
+++ b/test/SILGen/objc_set_bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_set_bridging %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name objc_set_bridging %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_subscript.swift
+++ b/test/SILGen/objc_subscript.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -enable-sil-ownership %s -emit-verbose-sil -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-verbose-sil -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_super.swift
+++ b/test/SILGen/objc_super.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import gizmo
 

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -enable-sil-ownership | %FileCheck %s
-// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -enable-sil-ownership -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/opaque_ownership.swift
+++ b/test/SILGen/opaque_ownership.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -enable-sil-ownership -emit-sorted-sil -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -target x86_64-apple-macosx10.9 -enable-sil-opaque-values -enable-sil-ownership -emit-sorted-sil -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck --check-prefix=CHECK-OSX %s
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target x86_64-apple-macosx10.9 -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck --check-prefix=CHECK-OSX %s
 
 public typealias AnyObject = Builtin.AnyObject
 

--- a/test/SILGen/opaque_values_silgen_lib.swift
+++ b/test/SILGen/opaque_values_silgen_lib.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -module-name Swift %s | %FileCheck %s
 
 precedencegroup AssignmentPrecedence { assignment: true }
 

--- a/test/SILGen/opaque_values_silgen_todo.swift
+++ b/test/SILGen/opaque_values_silgen_todo.swift
@@ -1,2 +1,2 @@
-// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle %s | %FileCheck %s
 // REQUIRES: EnableSILOpaqueValues

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class A {}
 class B : A {}

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name optional -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name optional %s | %FileCheck %s
 
 func testCall(_ f: (() -> ())?) {
   f?()

--- a/test/SILGen/optional_chain_addressor.swift
+++ b/test/SILGen/optional_chain_addressor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -verify -parse-as-library -enable-sil-ownership %s
+// RUN: %target-swift-emit-silgen -verify -parse-as-library %s
 
 func foo(x: UnsafeMutablePointer<UnsafeMutablePointer<()>?>) { // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
   _ = x.pointee?.pointee

--- a/test/SILGen/optional_lvalue.swift
+++ b/test/SILGen/optional_lvalue.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name optional_lvalue -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name optional_lvalue %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s15optional_lvalue07assign_a1_B0yySiSgz_SitF
 // CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<Int>

--- a/test/SILGen/optional_to_bool.swift
+++ b/test/SILGen/optional_to_bool.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 public protocol P {}
 extension Int: P {}

--- a/test/SILGen/optional_to_optional.swift
+++ b/test/SILGen/optional_to_optional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol P {}
 

--- a/test/SILGen/owned.swift
+++ b/test/SILGen/owned.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // see shared.swift for thunks/conversions between __shared and __owned.
 

--- a/test/SILGen/ownership.swift
+++ b/test/SILGen/ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-stdlib -module-name Swift -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -module-name Swift -parse-as-library %s | %FileCheck %s
 
 protocol Error {}
 

--- a/test/SILGen/partial_apply_generic.swift
+++ b/test/SILGen/partial_apply_generic.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name partial_apply_generic -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name partial_apply_generic %s | %FileCheck %s
 
 protocol Panda {
   associatedtype Cuddles : Foo

--- a/test/SILGen/partial_apply_init.swift
+++ b/test/SILGen/partial_apply_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 class C {
   init(x: Int) {}

--- a/test/SILGen/partial_apply_protocol_class_refinement_method.swift
+++ b/test/SILGen/partial_apply_protocol_class_refinement_method.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name partial_apply_protocol_class_refinement_method -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name partial_apply_protocol_class_refinement_method %s | %FileCheck %s
 
 protocol P { func foo() }
 protocol Q: class, P {}

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -9,7 +9,7 @@
 
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/../Inputs/fixed_layout_class.swift
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name partial_apply_super -enable-resilience -parse-as-library -I %t %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name partial_apply_super -enable-resilience -parse-as-library -I %t %s | %FileCheck %s
 
 import resilient_class
 import fixed_layout_class

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name pointer_conversion -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name pointer_conversion -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
 // XFAIL: linux

--- a/test/SILGen/pointer_conversion_nonaccessing.swift
+++ b/test/SILGen/pointer_conversion_nonaccessing.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -swift-version 4 -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 4 %s | %FileCheck %s
 
 // rdar://33265254
 

--- a/test/SILGen/pointer_conversion_nonaccessing_objc.swift
+++ b/test/SILGen/pointer_conversion_nonaccessing_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -swift-version 4 -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -swift-version 4 %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name property_abstraction -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name property_abstraction %s | %FileCheck %s
 
 struct Int {
   mutating func foo() {}

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol UID {
     func uid() -> Int

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name protocol_optional -parse-as-library -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name protocol_optional -parse-as-library -disable-objc-attr-requires-foundation-module -enable-objc-interop %s | %FileCheck %s
 
 @objc protocol P1 {
   @objc optional func method(_ x: Int)

--- a/test/SILGen/protocol_resilience_objc.swift
+++ b/test/SILGen/protocol_resilience_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-sil-ownership -enable-resilience %s | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-emit-silgen -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience %s | %FileCheck %s --check-prefix=CHECK
 
 // @objc protocols don't need default witness tables
 @objc public protocol ObjCProtocol {

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name protocols -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name protocols %s | %FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // Calling Existential Subscripts

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -verify %s | %FileCheck %s
 
 // SR-3090:
 

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name reabstract_lvalue -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name reabstract_lvalue %s | %FileCheck %s
 
 struct MyMetatypeIsThin {}
 

--- a/test/SILGen/required_init.swift
+++ b/test/SILGen/required_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 func subclassFloatLiteral() -> Bar {
   let x: Bar = 1.0

--- a/test/SILGen/result_abstraction.swift
+++ b/test/SILGen/result_abstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name result_abstraction -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name result_abstraction %s | %FileCheck %s
 
 struct S {}
 struct R {}

--- a/test/SILGen/retaining_globals.swift
+++ b/test/SILGen/retaining_globals.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name retaining_globals -import-objc-header %S/Inputs/globals.h -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name retaining_globals -import-objc-header %S/Inputs/globals.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol Associated {
   associatedtype Assoc

--- a/test/SILGen/same_type_across_generic_depths.swift
+++ b/test/SILGen/same_type_across_generic_depths.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s > %t/out.sil
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %t/out.sil | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s > %t/out.sil
+// RUN: %target-swift-emit-silgen %t/out.sil | %FileCheck %s
 class X<A> {}
 struct Foo<T> {
   // CHECK-LABEL: sil hidden @{{.*}}Foo{{.*}}bar{{.*}} : $@convention(method) <T><U where T == X<U>>

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name scalar_to_tuple_args -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name scalar_to_tuple_args %s | %FileCheck %s
 
 func inoutWithDefaults(_ x: inout Int, y: Int = 0, z: Int = 0) {}
 func inoutWithCallerSideDefaults(_ x: inout Int, y: Int = #line) {}

--- a/test/SILGen/semanticsattr.swift
+++ b/test/SILGen/semanticsattr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -parse-stdlib -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s
 
 // CHECK: [_semantics "123"] [_semantics "223"] @func1
 @_semantics("223") @_semantics("123")

--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: owned_parameters
 

--- a/test/SILGen/sibling-nested-generic.swift
+++ b/test/SILGen/sibling-nested-generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen -verify %s
 
 protocol AP {
   associatedtype B: BP

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name sil_locations -Xllvm -sil-print-debuginfo -emit-verbose-sil -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name sil_locations -Xllvm -sil-print-debuginfo -emit-verbose-sil %s | %FileCheck %s
 
 // FIXME: Not sure if this an ideal source info for the branch - 
 // it points to if, not the last instruction in the block.

--- a/test/SILGen/sil_locations_top_level.swift
+++ b/test/SILGen/sil_locations_top_level.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -emit-verbose-sil -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -emit-verbose-sil %s | %FileCheck %s
 
 // Test top-level/module locations.
 class TopLevelObjectTy {

--- a/test/SILGen/source_location.swift
+++ b/test/SILGen/source_location.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name source_location -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name source_location -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo %s | %FileCheck %s
 
 func printSourceLocation(file: String = #file, line: Int = #line) {}
 

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name specialize_attr -enable-sil-ownership -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name specialize_attr -emit-verbose-sil %s | %FileCheck %s
 
 // CHECK-LABEL: @_specialize(exported: false, kind: full, where T == Int, U == Float)
 // CHECK-NEXT: func specializeThis<T, U>(_ t: T, u: U)

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name statements -Xllvm -sil-full-demangle -parse-as-library -enable-sil-ownership -verify %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name statements -Xllvm -sil-full-demangle -parse-as-library -verify %s | %FileCheck %s
 
 class MyClass { 
   func foo() { }

--- a/test/SILGen/static-stored-properties-in-concrete-contexts.swift
+++ b/test/SILGen/static-stored-properties-in-concrete-contexts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct Foo<T> {
   static var foo: T { return (0 as Int) as! T }

--- a/test/SILGen/subscripts.swift
+++ b/test/SILGen/subscripts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -o /dev/null %s
+// RUN: %target-swift-emit-silgen -o /dev/null %s
 
 func inoutFunc(_ x: inout Int) {}
 

--- a/test/SILGen/swift_newtype_result_convention.swift
+++ b/test/SILGen/swift_newtype_result_convention.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/swift_newtype_result_convention.h -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/swift_newtype_result_convention.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name switch %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name switch %s | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/SILGen/switch_abstraction.swift
+++ b/test/SILGen/switch_abstraction.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name switch_abstraction -enable-sil-ownership -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name switch_abstraction -parse-stdlib %s | %FileCheck %s
 
 struct A {}
 

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // Some fake predicates for pattern guards.
 func runced() -> Bool { return true }

--- a/test/SILGen/switch_objc.swift
+++ b/test/SILGen/switch_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/switch_ownership.swift
+++ b/test/SILGen/switch_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name switch -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name switch %s | %FileCheck %s
 //
 // A temporary file for testing switch code around ownership. Once SILGenPattern
 // refactoring is complete, this will be merged into the normal pattern file.

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name switch_var %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name switch_var %s | %FileCheck %s
 
 // TODO: Implement tuple equality in the library.
 // BLOCKED: <rdar://problem/13822406>

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 enum MyError : Error {
   case A, B

--- a/test/SILGen/transparent_attribute.swift
+++ b/test/SILGen/transparent_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -emit-verbose-sil -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-verbose-sil %s | %FileCheck %s
 
 // Test that the attribute gets set on default argument generators.
 

--- a/test/SILGen/tuple_attribute_reabstraction.swift
+++ b/test/SILGen/tuple_attribute_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 public struct G<T> {
   var t: T

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name tuples -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name tuples %s | %FileCheck %s
 class C {}
 
 enum Foo {

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name types -parse-as-library -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name types -parse-as-library %s | %FileCheck %s
 
 class C {
   var member: Int = 0

--- a/test/SILGen/unicode_scalar_concat.swift
+++ b/test/SILGen/unicode_scalar_concat.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // Check that string literals that are unicode scalar literals 
 // are emitted as string_literal instead of integers.

--- a/test/SILGen/unmanaged_ownership.swift
+++ b/test/SILGen/unmanaged_ownership.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -parse-stdlib -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -module-name Swift %s | %FileCheck %s
 
 class C {}
 

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name unowned -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name unowned %s | %FileCheck %s
 
 func takeClosure(_ fn: () -> Int) {}
 

--- a/test/SILGen/value_ownership.swift
+++ b/test/SILGen/value_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-verbose-sil %s | %FileCheck %s
 
 protocol OwnershipProto {
   __consuming func elided(_ default: String, _ shared: __shared String, _ owned: __owned String)

--- a/test/SILGen/variadic-subscript-single-arg.swift
+++ b/test/SILGen/variadic-subscript-single-arg.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen -verify %s
 
 struct Butt {
   subscript(butts: Int...) -> Int {

--- a/test/SILGen/versioned_attribute.swift
+++ b/test/SILGen/versioned_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-verbose-sil %s | %FileCheck %s
 
 // Check that @usableFromInline entities have public linkage.
 // CHECK-LABEL: sil @$s19versioned_attribute25referencedFromTransparentyyF : $@convention(thin) () -> () {

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 
 protocol AddrOnly {}
 

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
 struct S {}

--- a/test/SILGen/vtable_thunks_reabstraction_final.swift
+++ b/test/SILGen/vtable_thunks_reabstraction_final.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name vtable_thunks_reabstraction_final -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name vtable_thunks_reabstraction_final %s | %FileCheck %s
 
 protocol Fooable {
   func foo(_ x: Int) -> Int?

--- a/test/SILGen/vtables.swift
+++ b/test/SILGen/vtables.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // Test for compilation order independence
 class C : B {

--- a/test/SILGen/vtables_objc.swift
+++ b/test/SILGen/vtables_objc.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name vtables_objc -enable-sil-ownership -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name vtables_objc -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name weak -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name weak -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 class C {
   func f() -> Int { return 42 }

--- a/test/SILGen/weak_multiple_modules.swift
+++ b/test/SILGen/weak_multiple_modules.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/weak_other.swiftmodule -module-name=weak_other %S/Inputs/weak_other.swift
-// RUN: %target-swift-emit-silgen -module-name weak_multiple_modules -I %t -enable-sil-ownership %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-emit-silgen -module-name weak_multiple_modules -I %t %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 import weak_other
 

--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name without_actually_escaping -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name without_actually_escaping %s | %FileCheck %s
 
 var escapeHatch: Any = 0
 

--- a/test/SILGen/without_actually_escaping_block.swift
+++ b/test/SILGen/without_actually_escaping_block.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name without_actually_escaping -enable-sil-ownership %s -sdk %S/Inputs -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -module-name without_actually_escaping %s -sdk %S/Inputs -enable-objc-interop | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/witness_accessibility.swift
+++ b/test/SILGen/witness_accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 public protocol P {
   func publicRequirement()

--- a/test/SILGen/witness_single_tuple.swift
+++ b/test/SILGen/witness_single_tuple.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol Runcible {
   func runce(x: Int)

--- a/test/SILGen/witness_table_overrides.swift
+++ b/test/SILGen/witness_table_overrides.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // Test the use of "override" on protocol requirements.
 

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -1,9 +1,9 @@
 
-// RUN: %target-swift-emit-silgen -module-name witness_tables  -enable-sil-ownership -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop > %t.sil
+// RUN: %target-swift-emit-silgen -module-name witness_tables  -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop > %t.sil
 // RUN: %FileCheck -check-prefix=TABLE -check-prefix=TABLE-ALL %s < %t.sil
 // RUN: %FileCheck -check-prefix=SYMBOL %s < %t.sil
 
-// RUN: %target-swift-emit-silgen -module-name witness_tables  -enable-sil-ownership -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing > %t.testable.sil
+// RUN: %target-swift-emit-silgen -module-name witness_tables  -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing > %t.testable.sil
 // RUN: %FileCheck -check-prefix=TABLE-TESTABLE -check-prefix=TABLE-ALL %s < %t.testable.sil
 // RUN: %FileCheck -check-prefix=SYMBOL-TESTABLE %s < %t.testable.sil
 

--- a/test/SILGen/witness_tables_multifile.swift
+++ b/test/SILGen/witness_tables_multifile.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %s %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=CHECK-FIRST-FILE
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -primary-file %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %S/Inputs/witness_tables_multifile_2.swift -check-prefix=CHECK-SECOND-FILE
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=CHECK-FIRST-FILE
+// RUN: %target-swift-emit-silgen %s -primary-file %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %S/Inputs/witness_tables_multifile_2.swift -check-prefix=CHECK-SECOND-FILE
 
 
 protocol InheritsFooable : Fooable {}

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -1,7 +1,7 @@
 // This file is also used by witness_tables_serialized_import.swift.
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-NONRESILIENT %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -enable-resilience %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-NONRESILIENT %s
+// RUN: %target-swift-emit-silgen -enable-resilience %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 public protocol PublicProtocol {}
 

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name witnesses -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name witnesses -Xllvm -sil-full-demangle %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 
 infix operator <~>
 

--- a/test/SILGen/witnesses_canonical.swift
+++ b/test/SILGen/witnesses_canonical.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // rdar://problem/20714534 -- we need to canonicalize an associated type's
 // protocols when emitting witness method table for a conformance.

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name witnesses_class -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name witnesses_class %s | %FileCheck %s
 
 protocol Fooable: class {
   func foo()

--- a/test/SILGen/witnesses_inheritance.swift
+++ b/test/SILGen/witnesses_inheritance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol Fooable {
   func foo()

--- a/test/SILGen/witnesses_refinement.swift
+++ b/test/SILGen/witnesses_refinement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol Saturable: Comparable {
   func saturated(max: Self) -> Self

--- a/test/SILGen/writeback.swift
+++ b/test/SILGen/writeback.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -Xllvm -sil-full-demangle %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 struct Foo {
   mutating           // used to test writeback.

--- a/test/SILGen/writeback_conflict_diagnostics.swift
+++ b/test/SILGen/writeback_conflict_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -o /dev/null -verify
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -enforce-exclusivity=checked %s -o /dev/null -verify
+// RUN: %target-swift-emit-silgen %s -o /dev/null -verify
+// RUN: %target-swift-emit-silgen -enforce-exclusivity=checked %s -o /dev/null -verify
 
 func takeInOut<T>(_: inout T) {}
 


### PR DESCRIPTION
…arget-swift-emit-silgen does it automatically.

I did this using a sed pattern and verified by hand that I was only touching
target-swift-emit-silgen lines.
