### PR TITLE
[stdlib] Optimize some Set operations

### DIFF
--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -484,3 +484,22 @@ extension _HashTable {
     words[hole.word].uncheckedRemove(hole.bit)
   }
 }
+
+extension _Bitset {
+  @inlinable
+  internal init(occupiedBucketsIn hashTable: _HashTable, count: Int) {
+    // FIXME: This is a bit of a hack. Find a better way to express this.
+    self.init(_uninitializedCapacity: hashTable.bucketCount)
+    if hashTable.bucketCount < Word.capacity {
+      word0 = hashTable.words[0]
+        .intersecting(elementsBelow: hashTable.bucketCount)
+    } else {
+      word0 = hashTable.words[0]
+      // Note: storage can be nil when bucket count is exactly at Word.capacity.
+      storage?.copy(contentsOf: _UnsafeBitset(
+        words: hashTable.words + 1,
+        wordCount: hashTable.wordCount - 1))
+    }
+    self.count = count
+  }
+}

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -42,7 +42,7 @@ internal struct _HashTable {
   @inlinable
   internal var bucketCount: Int {
     @inline(__always) get {
-      return bucketMask &+ 1
+      return _assumeNonNegative(bucketMask &+ 1)
     }
   }
 

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -611,4 +611,30 @@ extension _NativeSet {
     }
     return true
   }
+
+  @inlinable
+  internal __consuming func subtracting<S: Sequence>(_ other: S) -> _NativeSet
+  where S.Element == Element {
+    guard count > 0 else { return _NativeSet() }
+    // Rather than directly creating a new set, calculate the difference in a
+    // bitset first. This ensures we hash each element (in both sets) only once,
+    // and that we'll have an exact count for the result set, preventing
+    // rehashings during insertions.
+    var difference = _Bitset(occupiedBucketsIn: hashTable, count: count)
+    for element in other {
+      let (bucket, found) = find(element)
+      if found {
+        if difference.uncheckedRemove(bucket.offset), difference.count == 0 {
+          return _NativeSet()
+        }
+      }
+    }
+    _internalInvariant(difference.count > 0)
+    if difference.count == self.count { return self }
+    let result = _NativeSet(capacity: difference.count)
+    for offset in difference {
+      result._unsafeInsertNew(self.uncheckedElement(at: Bucket(offset: offset)))
+    }
+    return result
+  }
 }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -570,4 +570,28 @@ extension _NativeSet {
     }
     return false
   }
+
+  @inlinable
+  internal func isStrictSubset<S: Sequence>(of possibleSuperset: S) -> Bool
+  where S.Element == Element {
+    // Allocate a temporary bitset to mark elements in self that we've seen in
+    // possibleSuperset.
+    var seen = _Bitset(capacity: self.bucketCount)
+    var isStrict = false
+    for element in possibleSuperset {
+      let (bucket, found) = find(element)
+      guard found else {
+        if !isStrict {
+          isStrict = true
+          if seen.count == self.count { return true }
+        }
+        continue
+      }
+      let inserted = seen.uncheckedInsert(bucket.offset)
+      if inserted, seen.count == self.count, isStrict {
+        return true
+      }
+    }
+    return false
+  }
 }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -594,4 +594,21 @@ extension _NativeSet {
     }
     return false
   }
+
+  @inlinable
+  internal func isStrictSuperset<S: Sequence>(of possibleSubset: S) -> Bool
+    where S.Element == Element {
+    // Allocate a temporary bitset to mark elements in self that we've seen in
+    // possibleStrictSubset.
+    var seen = _Bitset(capacity: self.bucketCount)
+    for element in possibleSubset {
+      let (bucket, found) = find(element)
+      guard found else { return false }
+      let inserted = seen.uncheckedInsert(bucket.offset)
+      if inserted, seen.count == self.count {
+        return false
+      }
+    }
+    return true
+  }
 }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -801,8 +801,17 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSuperset<S: Sequence>(of possibleStrictSubset: S) -> Bool
   where S.Element == Element {
-    let other = Set(possibleStrictSubset)
-    return other.isStrictSubset(of: self)
+    defer { _fixLifetime(self) }
+    if isEmpty { return false }
+    if let s = possibleStrictSubset as? Set<Element> {
+      return isStrictSuperset(of: s)
+    }
+#if _runtime(_ObjC)
+    guard _variant.isNative else {
+      return isStrictSuperset(of: Set(possibleStrictSubset))
+    }
+#endif
+    return _variant.asNative.isStrictSuperset(of: possibleStrictSubset)
   }
 
   /// Returns a Boolean value that indicates whether the set has no members in
@@ -1190,7 +1199,7 @@ extension Set {
   ///   `other`; otherwise, `false`.
   @inlinable
   public func isStrictSuperset(of other: Set<Element>) -> Bool {
-    return self.isSuperset(of: other) && self != other
+    return self.count > other.count && other.isSubset(of: self)
   }
 
   /// Returns a Boolean value that indicates whether the set is a strict subset

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -713,9 +713,11 @@ extension Set: SetAlgebra {
   public func isSubset<S: Sequence>(of possibleSuperset: S) -> Bool
   where S.Element == Element {
     guard !isEmpty else { return true }
-    
-    let other = Set(possibleSuperset)
-    return isSubset(of: other)
+    if self.count == 1 { return possibleSuperset.contains(self.first!) }
+    if let s = possibleSuperset as? Set<Element> {
+      return isSubset(of: s)
+    }
+    return _variant.isSubset(of: possibleSuperset)
   }
 
   /// Returns a Boolean value that indicates whether the set is a strict subset
@@ -1082,9 +1084,11 @@ extension Set {
   /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
   @inlinable
   public func isSubset(of other: Set<Element>) -> Bool {
+    defer { _fixLifetime(self) }
+    defer { _fixLifetime(other) }
     guard self.count <= other.count else { return false }
     for member in self {
-      if !other.contains(member) {
+      guard other.contains(member) else {
         return false
       }
     }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -911,9 +911,7 @@ extension Set: SetAlgebra {
     _ other: S
   ) -> Set<Element>
   where S.Element == Element {
-    var newSet = self
-    newSet.subtract(other)
-    return newSet
+    return Set(_native: _variant.subtracting(other))
   }
 
   /// Removes the elements of the given sequence from the set.

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -298,14 +298,7 @@ extension Set {
   public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Set {
-    // FIXME(performance): Eliminate rehashes by using a bitmap.
-    var result = Set()
-    for element in self {
-      if try isIncluded(element) {
-        result.insert(element)
-      }
-    }
-    return result
+    return try Set(_native: _variant.filter(isIncluded))
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -767,7 +767,11 @@ extension Set: SetAlgebra {
   ///   otherwise, `false`.
   @inlinable
   public func isSuperset<S: Sequence>(of possibleSubset: __owned S) -> Bool
-    where S.Element == Element {
+  where S.Element == Element {
+    defer { _fixLifetime(self) }
+    if let s = possibleSubset as? Set<Element> {
+      return isSuperset(of: s)
+    }
     for member in possibleSubset {
       if !contains(member) {
         return false

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -743,9 +743,11 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSubset<S: Sequence>(of possibleStrictSuperset: S) -> Bool
   where S.Element == Element {
-    // FIXME: code duplication.
-    let other = Set(possibleStrictSuperset)
-    return isStrictSubset(of: other)
+    defer { _fixLifetime(self) }
+    if let s = possibleStrictSuperset as? Set<Element> {
+      return isStrictSubset(of: s)
+    }
+    return _variant.isStrictSubset(of: possibleStrictSuperset)
   }
 
   /// Returns a Boolean value that indicates whether the set is a superset of
@@ -1208,7 +1210,7 @@ extension Set {
   ///   `other`; otherwise, `false`.
   @inlinable
   public func isStrictSubset(of other: Set<Element>) -> Bool {
-    return other.isStrictSuperset(of: self)
+    return self.count < other.count && self.isSubset(of: other)
   }
 
   /// Returns a new set with the elements that are common to both this set and

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1145,9 +1145,13 @@ extension Set {
   ///   otherwise, `false`.
   @inlinable
   public func isDisjoint(with other: Set<Element>) -> Bool {
+    // Prefer to iterate over the smaller set.
+    if self.count < other.count {
+      return other._isDisjoint(with: self)
+    }
     return _isDisjoint(with: other)
   }
-    
+
   @inlinable
   internal func _isDisjoint<S: Sequence>(with other: S) -> Bool
   where S.Element == Element {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -957,8 +957,7 @@ extension Set: SetAlgebra {
   @inlinable
   public __consuming func intersection<S: Sequence>(_ other: S) -> Set<Element>
   where S.Element == Element {
-    let otherSet = Set(other)
-    return intersection(otherSet)
+    return Set(_native: _variant.intersection(other))
   }
 
   /// Removes the elements of the set that aren't also in the given sequence.
@@ -977,20 +976,10 @@ extension Set: SetAlgebra {
   @inlinable
   public mutating func formIntersection<S: Sequence>(_ other: S)
   where S.Element == Element {
-    // Because `intersect` needs to both modify and iterate over
-    // the left-hand side, the index may become invalidated during
-    // traversal so an intermediate set must be created.
-    //
-    // FIXME(performance): perform this operation at a lower level
-    // to avoid invalidating the index and avoiding a copy.
-    let result = self.intersection(other)
-
-    // The result can only have fewer or the same number of elements.
-    // If no elements were removed, don't perform a reassignment
-    // as this may cause an unnecessary uniquing COW.
-    if result.count != count {
-      self = result
-    }
+    // FIXME: This discards storage reserved with reserveCapacity.
+    // FIXME: Depending on the ratio of elements kept in the result, it may be
+    // faster to do the removals in place, in bulk.
+    self = self.intersection(other)
   }
 
   /// Returns a new set with the elements that are either in this set or in the
@@ -1239,13 +1228,7 @@ extension Set {
   /// - Returns: A new set.
   @inlinable
   public __consuming func intersection(_ other: Set<Element>) -> Set<Element> {
-    var newSet = Set<Element>()
-    for member in self {
-      if other.contains(member) {
-        newSet.insert(member)
-      }
-    }
-    return newSet
+    return Set(_native: _variant.intersection(other))
   }
 
   /// Removes the elements of the set that are also in the given sequence and

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -368,3 +368,16 @@ extension Set._Variant {
   }
 }
 
+extension Set._Variant {
+  @inlinable
+  @inline(__always)
+  internal func isSubset<S: Sequence>(of possibleSuperset: S) -> Bool
+  where S.Element == Element {
+#if _runtime(_ObjC)
+    guard isNative else {
+      return _NativeSet<Element>(asCocoa).isSubset(of: possibleSuperset)
+    }
+#endif
+    return asNative.isSubset(of: possibleSuperset)
+  }
+}

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -380,4 +380,17 @@ extension Set._Variant {
 #endif
     return asNative.isSubset(of: possibleSuperset)
   }
+
+  @inlinable
+  @inline(__always)
+  public func isStrictSubset<S: Sequence>(of possibleStrictSuperset: S) -> Bool
+  where S.Element == Element {
+#if _runtime(_ObjC)
+    guard isNative else {
+      return _NativeSet<Element>(asCocoa)
+        .isStrictSubset(of: possibleStrictSuperset)
+    }
+#endif
+    return asNative.isStrictSubset(of: possibleStrictSuperset)
+  }
 }

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -407,4 +407,25 @@ extension Set._Variant {
 #endif
     return asNative.subtracting(other)
   }
+
+  @inlinable
+  @inline(__always)
+  internal __consuming func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> _NativeSet<Element> {
+#if _runtime(_ObjC)
+    guard isNative else {
+      var result = _NativeSet<Element>()
+      for cocoaElement in asCocoa {
+        let nativeElement = _forceBridgeFromObjectiveC(
+          cocoaElement, Element.self)
+        if try isIncluded(nativeElement) {
+          result.insertNew(nativeElement, isUnique: true)
+        }
+      }
+      return result
+    }
+#endif
+    return try asNative.filter(isIncluded)
+  }
 }

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -449,10 +449,10 @@ extension Set._Variant {
   internal __consuming func intersection(
     _ other: Set<Element>
   ) -> _NativeSet<Element> {
+#if _runtime(_ObjC)
     switch (self.isNative, other._variant.isNative) {
     case (true, true):
       return asNative.intersection(other._variant.asNative)
-#if _runtime(_ObjC)
     case (true, false):
       return asNative.genericIntersection(other)
     case (false, false):
@@ -471,7 +471,9 @@ extension Set._Variant {
         }
       }
       return result
-#endif
     }
+#else
+    return asNative.intersection(other._variant.asNative)
+#endif
   }
 }

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -393,4 +393,18 @@ extension Set._Variant {
 #endif
     return asNative.isStrictSubset(of: possibleStrictSuperset)
   }
+
+  @inlinable
+  @inline(__always)
+  internal __consuming func subtracting<S: Sequence>(
+    _ other: S
+  ) -> _NativeSet<Element>
+  where S.Element == Element {
+#if _runtime(_ObjC)
+    guard isNative else {
+      return _NativeSet(asCocoa).subtracting(other)
+    }
+#endif
+    return asNative.subtracting(other)
+  }
 }

--- a/validation-test/stdlib/Bitset.swift
+++ b/validation-test/stdlib/Bitset.swift
@@ -84,11 +84,11 @@ BitsetTests.test("_UnsafeBitset.split(_:)") {
 }
 
 BitsetTests.test("Word.capacity") {
-  expectEqual(_UnsafeBitset.Word.capacity, UInt.bitWidth)
+  expectEqual(_Bitset.Word.capacity, UInt.bitWidth)
 }
 
 BitsetTests.test("Word.uncheckedContains(_:)") {
-  typealias Word = _UnsafeBitset.Word
+  typealias Word = _Bitset.Word
   for i in 0 ..< Word.capacity {
     expectEqual(Word(0).uncheckedContains(i), false, "i=\(i)")
     expectEqual(Word(1).uncheckedContains(i), i == 0, "i=\(i)")
@@ -106,7 +106,7 @@ BitsetTests.test("Word.uncheckedContains(_:)") {
 }
 
 BitsetTests.test("Word.uncheckedInsert(_:)") {
-  typealias Word = _UnsafeBitset.Word
+  typealias Word = _Bitset.Word
   var word = Word(0)
   for i in 0 ..< Word.capacity {
     expectFalse(word.uncheckedContains(i))
@@ -118,7 +118,7 @@ BitsetTests.test("Word.uncheckedInsert(_:)") {
 }
 
 BitsetTests.test("Word.uncheckedRemove(_:)") {
-  typealias Word = _UnsafeBitset.Word
+  typealias Word = _Bitset.Word
   var word = Word(UInt.max)
   for i in 0 ..< Word.capacity {
     expectTrue(word.uncheckedContains(i))
@@ -130,7 +130,7 @@ BitsetTests.test("Word.uncheckedRemove(_:)") {
 }
 
 BitsetTests.test("Word.count") {
-  typealias Word = _UnsafeBitset.Word
+  typealias Word = _Bitset.Word
   var word = Word(0)
   for i in 0 ..< Word.capacity {
     expectEqual(word.count, i)
@@ -145,13 +145,143 @@ BitsetTests.test("Word.count") {
 }
 
 BitsetTests.test("Word.makeIterator()") {
-  typealias Word = _UnsafeBitset.Word
+  typealias Word = _Bitset.Word
   expectEqual(Array(Word(0)), [])
   expectEqual(Array(Word(1)), [0])
   expectEqual(Array(Word(2)), [1])
   expectEqual(Array(Word(3)), [0, 1])
   expectEqual(Array(Word(42)), [1, 3, 5])
   expectEqual(Array(Word(UInt.max)), Array(0..<UInt.bitWidth))
+}
+
+let capacities = [
+  0, 1, 2, 3, 7, 8, 9, 31, 32, 33, 48, 63, 64, 65, 127, 128, 129, 1024, 10000
+]
+
+let primes: Set<Int> = [
+  2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+  73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
+  157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
+  239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317,
+  331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419,
+  421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499
+]
+
+BitsetTests.test("_Bitset:InitializedToZero")
+.forEach(in: capacities) { capacity in
+  let bitset = _Bitset(capacity: capacity)
+  expectEqual(bitset.count, 0)
+  for bit in 0 ..< capacity {
+    expectFalse(bitset.uncheckedContains(bit))
+  }
+}
+
+BitsetTests.test("_Bitset:Allocation")
+.forEach(in: capacities) { capacity in
+  let bitset = _Bitset(capacity: capacity)
+  expectEqual(bitset.storage != nil, capacity > _Bitset.Word.capacity)
+}
+
+BitsetTests.test("_Bitset.uncheckedContains(_:)")
+.forEach(in: capacities) { capacity in
+  var bitset = _Bitset(capacity: capacity)
+  for p in primes where p < capacity {
+    expectFalse(bitset.uncheckedContains(p), "\(p)")
+    _ = bitset.uncheckedInsert(p)
+    expectTrue(bitset.uncheckedContains(p), "\(p)")
+  }
+  for i in 0 ..< capacity {
+    expectEqual(
+      bitset.uncheckedContains(i),
+      primes.contains(i),
+      "\(i)")
+  }
+}
+
+BitsetTests.test("_Bitset.uncheckedInsert(_:)")
+.forEach(in: capacities) { capacity in
+  var bitset = _Bitset(capacity: capacity)
+  for p in primes where p < capacity {
+    let inserted = bitset.uncheckedInsert(p)
+    expectTrue(inserted, "\(p)")
+  }
+  for p in primes where p < capacity {
+    let inserted = bitset.uncheckedInsert(p)
+    expectFalse(inserted, "\(p)")
+  }
+  for i in 0 ..< capacity {
+    expectEqual(
+      bitset.uncheckedContains(i),
+      primes.contains(i),
+      "\(i)")
+  }
+}
+
+BitsetTests.test("_Bitset.uncheckedInsert(_:):COW")
+.forEach(in: capacities) { capacity in
+  for bit in primes where bit < capacity {
+    var bitset = _Bitset(capacity: capacity)
+    let copy = bitset
+
+    bitset.uncheckedInsert(bit)
+    expectTrue(bitset.uncheckedContains(bit), "\(bit)")
+    expectFalse(copy.uncheckedContains(bit), "\(bit)")
+  }
+}
+
+BitsetTests.test("_Bitset.uncheckedRemove(_:)")
+.forEach(in: capacities) { capacity in
+  var bitset = _Bitset(capacity: capacity)
+  for i in 0 ..< capacity {
+    bitset.uncheckedInsert(i)
+  }
+  for bit in primes where bit < capacity {
+    expectTrue(bitset.uncheckedRemove(bit), "\(bit)")
+  }
+  for bit in primes where bit < capacity {
+    expectFalse(bitset.uncheckedRemove(bit), "\(bit)")
+  }
+  for i in 0 ..< capacity {
+    expectEqual(
+      bitset.uncheckedContains(i),
+      !primes.contains(i),
+      "\(i)")
+  }
+}
+
+BitsetTests.test("_Bitset.uncheckedRemove(_:):COW")
+.forEach(in: capacities) { capacity in
+  var bitset = _Bitset(capacity: capacity)
+  for bit in primes where bit < capacity {
+    bitset.uncheckedInsert(bit)
+  }
+  for bit in primes where bit < capacity {
+    var copy = bitset
+    expectTrue(copy.uncheckedRemove(bit), "\(bit)")
+    expectFalse(copy.uncheckedContains(bit), "\(bit)")
+    expectTrue(bitset.uncheckedContains(bit), "\(bit)")
+  }
+}
+
+BitsetTests.test("_Bitset.count")
+.forEach(in: capacities) { capacity in
+  var bitset = _Bitset(capacity: capacity)
+  var c = 0
+  for bit in primes where bit < capacity {
+    bitset.uncheckedInsert(bit)
+    c += 1
+  }
+  expectEqual(c, bitset.count)
+}
+
+BitsetTests.test("_Bitset.makeIterator()")
+.forEach(in: capacities) { capacity in
+  var bitset = _Bitset(capacity: capacity)
+  let bits = primes.filter { $0 < capacity }
+  for b in bits {
+    bitset.uncheckedInsert(b)
+  }
+  expectEqual(Array(bitset), bits.sorted())
 }
 
 runAllTests()


### PR DESCRIPTION
This uses temporary bitmaps to considerably speed up some high-level Set operations.

Operation | Speedup
---|---
`Set.isSubset<S>(of:)` | 3x
`Set.isStrictSubset<S>(of:)` | 3x
`Set.isSuperset<S>(of:)` | 4x
`Set.isStrictSuperset<S>(of:)` | 4x
`Set.isDisjoint<S>(with:)` | 4x
`Set.subtracting(_:)` | 1-4x
`Set.filter(_:)` | 1-4x
`Set.intersection<S>(_:)` | 4-6x
`Set.intersection(_:)` | 1-4x

Benchmark results depend on the size of the sets and the element type. The numbers above were measured with integer keys across a range of counts from 1 to 1 million items.