### PR TITLE
[Runtime] Properly unique foreign witness tables.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3669,7 +3669,8 @@ namespace {
     int compareWithKey(const Key other) const {
       if (auto r = comparePointers(other.protocol, key.protocol))
         return r;
-      return strcmp(other.type->Name.get(), key.type->Name.get());
+
+      return TypeContextIdentity(other.type).compare(TypeContextIdentity(key.type));
     }
 
     static size_t getExtraAllocationSize(const Key,

--- a/test/Runtime/conformance_uniquing.swift
+++ b/test/Runtime/conformance_uniquing.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+let conformanceUniquingTests = TestSuite("ConformanceUniquing")
+
+func isSimpleSetAlgebra<T: SetAlgebra>(_: T.Type) -> Bool {
+  return T.self == T.Element.self
+}
+
+// rdar://problem/46685973
+conformanceUniquingTests.test("Nested types with the same name") {
+  expectTrue(isSimpleSetAlgebra(NSData.WritingOptions.self))
+  expectTrue(isSimpleSetAlgebra(JSONSerialization.WritingOptions.self))
+}
+
+runAllTests()


### PR DESCRIPTION
The Name field of a type descriptor is not the appropriate
way to compare types for uniquing. Instead, use TypeContextIdentity.

Fixes rdar://problem/46685973.
