### PR TITLE
stdlib: Code size improvements for Dictionary for -Osize

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -782,7 +782,6 @@ extension Dictionary {
   ///   otherwise, `nil`.
   @inlinable
   public subscript(key: Key) -> Value? {
-    @inline(__always)
     get {
       return _variant.lookup(key)
     }
@@ -819,6 +818,7 @@ extension Dictionary: ExpressibleByDictionaryLiteral {
   ///   dictionary. Each key in `elements` must be unique.
   @inlinable
   @_effects(readonly)
+  @_semantics("optimize.sil.specialize.generic.size.never")
   public init(dictionaryLiteral elements: (Key, Value)...) {
     let native = _NativeDictionary<Key, Value>(capacity: elements.count)
     for (key, value) in elements {

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -382,6 +382,7 @@ extension Dictionary._Variant {
   }
 
   @inlinable
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func remove(at index: Index) -> Element {
     // FIXME(performance): fuse data migration and element deletion into one
     // operation.
@@ -412,6 +413,7 @@ extension Dictionary._Variant {
   }
 
   @inlinable
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
     if !keepCapacity {
       self = .init(native: _NativeDictionary())

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -202,6 +202,7 @@ extension _NativeDictionary { // ensureUnique
   }
 
   @inlinable
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func copyAndResize(capacity: Int) {
     let capacity = Swift.max(capacity, self.capacity)
     let newStorage = _DictionaryStorage<Key, Value>.resize(
@@ -220,6 +221,7 @@ extension _NativeDictionary { // ensureUnique
   }
 
   @inlinable
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func copy() {
     let newStorage = _DictionaryStorage<Key, Value>.copy(original: _storage)
     _internalInvariant(newStorage._scale == _storage._scale)
@@ -241,7 +243,7 @@ extension _NativeDictionary { // ensureUnique
   /// Ensure storage of self is uniquely held and can hold at least `capacity`
   /// elements. Returns true iff contents were rehashed.
   @inlinable
-  @inline(__always)
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func ensureUnique(isUnique: Bool, capacity: Int) -> Bool {
     if _fastPath(capacity <= self.capacity && isUnique) {
       return false
@@ -490,7 +492,6 @@ extension _NativeDictionary { // Insertions
   /// held, and with enough capacity for a single insertion (if the key isn't
   /// already in the dictionary.)
   @inlinable
-  @inline(__always)
   internal mutating func mutatingFind(
     _ key: Key,
     isUnique: Bool
@@ -629,6 +630,7 @@ extension _NativeDictionary: _HashTableDelegate {
 extension _NativeDictionary { // Deletion
   @inlinable
   @_effects(releasenone)
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal func _delete(at bucket: Bucket) {
     hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
@@ -637,7 +639,7 @@ extension _NativeDictionary { // Deletion
   }
 
   @inlinable
-  @inline(__always)
+  @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func uncheckedRemove(
     at bucket: Bucket,
     isUnique: Bool

--- a/test/SILOptimizer/no_size_specialization.swift
+++ b/test/SILOptimizer/no_size_specialization.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend  %s -O -emit-sil | %FileCheck %s -check-prefix=CHECK-O
+// RUN: %target-swift-frontend  %s -Osize -emit-sil | %FileCheck %s -check-prefix=CHECK-OSIZE
+
+@_semantics("optimize.sil.specialize.generic.size.never")
+func foo<T>(_ t: T) -> T {
+  return t
+}
+
+// CHECK-O-LABEL: sil @{{.*}}test
+// CHECK-O: %0 = integer_literal
+// CHECK-O: %1 = struct $Int
+// CHECK-O: return %1
+
+// CHECK-OSIZE-LABEL: sil {{.*}} @{{.*}}foo
+
+// CHECK-OSIZE-LABEL: sil @{{.*}}test
+// CHECK-OSIZE: function_ref {{.*}}foo
+// CHECK-OSIZE: apply
+public func test() -> Int {
+  return foo(27)
+}


### PR DESCRIPTION
The first change is to remove some @inline(__always) attributes. Those were added before we had the guaranteed-by-default calling convention. They are not necessary anymore.

The second change is to not specialize some slow-path functions. This results that no specialization code for these functions is generated at the client side. Instead those functions are directly called in the libSwiftCore.
Note that Key-related hash and equality comparisons are still specialized, because otherwise the performance hit for Osize would be too big.

Some Dictionary benchmarks regress a bit with -Osize, but the code size wins are big.

rdar://problem/46534453