### PR TITLE
Generalize and cleanup code for existential specialization.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Existential.h
+++ b/include/swift/SILOptimizer/Utils/Existential.h
@@ -21,33 +21,35 @@
 
 namespace swift {
 
-/// Find InitExistential from global_addr and copy_addr.
-SILValue findInitExistentialFromGlobalAddrAndCopyAddr(GlobalAddrInst *GAI,
-                                                      CopyAddrInst *CAI);
-
-/// Find InitExistential from global_addr and an apply argument.
-SILValue findInitExistentialFromGlobalAddrAndApply(GlobalAddrInst *GAI,
-                                                   ApplySite Apply, int ArgIdx);
-
-/// Returns the address of an object with which the stack location \p ASI is
-/// initialized. This is either a init_existential_addr or the destination of a
-/// copy_addr. Returns a null value if the address does not dominate the
-/// alloc_stack user \p ASIUser.
-/// If the value is copied from another stack location, \p isCopied is set to
-/// true.
-SILValue getAddressOfStackInit(SILValue allocStackAddr, SILInstruction *ASIUser,
-                               bool &isCopied);
-
-/// Find the init_existential, which could be used to determine a concrete
-/// type of the value used by \p openedUse.
-/// If the value is copied from another stack location, \p isCopied is set to
-/// true.
+/// Record information about an opened archetype.
 ///
-/// FIXME: replace all uses of this with ConcreteExistentialInfo.
-SILInstruction *findInitExistential(Operand &openedUse,
-                                    ArchetypeType *&OpenedArchetype,
-                                    SILValue &OpenedArchetypeDef,
-                                    bool &isCopied);
+/// This is used to determine whether a generic call argument originates from
+/// an opened existential. For example:
+/// %o = open_existential_ref %e : $P & Q to $@opened("PQ") P & Q
+/// %r = apply %f<@opened("PQ") P & Q>(%o)
+///   : $@convention(method) <τ_0_0 where τ_0_0 : P, τ_0_0 : Q>
+///     (@guaranteed τ_0_0) -> @owned τ_0_0
+///
+/// When successfull, ConcreteExistentialInfo can be used to determine the
+/// concrete type of the opened existential.
+struct OpenedArchetypeInfo {
+  ArchetypeType *OpenedArchetype = nullptr;
+  // The opened value.
+  SingleValueInstruction *OpenedArchetypeValue;
+  // The existential value.
+  SILValue ExistentialValue;
+  // True if the openedValue is copied from another stack location
+  bool isOpenedValueCopied = false;
+
+  // Construct a valid instance if the given use originates from a recognizable
+  // OpenedArchetype instruction.
+  OpenedArchetypeInfo(Operand &use);
+
+  bool isValid() const {
+    assert(!OpenedArchetype || (OpenedArchetypeValue && ExistentialValue));
+    return OpenedArchetype;
+  }
+};
 
 /// Record conformance and concrete type info derived from an init_existential
 /// value that is reopened before it's use. This is useful for finding the
@@ -60,20 +62,16 @@ SILInstruction *findInitExistential(Operand &openedUse,
 ///   : $@convention(method) <τ_0_0 where τ_0_0 : P, τ_0_0 : Q>
 ///     (@guaranteed τ_0_0) -> @owned τ_0_0
 struct ConcreteExistentialInfo {
-  // The opened type passed as self. `$@opened("PQ")` above.
-  // This is also the replacement type of the method's Self type.
-  ArchetypeType *OpenedArchetype = nullptr;
-  // The definition of the OpenedArchetype.
-  SILValue OpenedArchetypeDef;
-  // True if the openedValue is copied from another stack location
-  bool isCopied;
-  // The init_existential instruction that produces the opened existential.
-  SILInstruction *InitExistential = nullptr;
   // The existential type of the self argument before it is opened,
   // produced by an init_existential.
   CanType ExistentialType;
   // The concrete type of self from the init_existential. `$C` above.
   CanType ConcreteType;
+  // The concrete value used to initialize the opened existential.
+  // `%c` in the above comment.
+  SILValue ConcreteValue;
+  // True if the ConcreteValue is copied from another stack location
+  bool isConcreteValueCopied = false;
   // When ConcreteType is itself an opened existential, record the type
   // definition. May be nullptr for a valid AppliedConcreteType.
   SingleValueInstruction *ConcreteTypeDef = nullptr;
@@ -82,31 +80,20 @@ struct ConcreteExistentialInfo {
   // and includes the full list of existential conformances.
   // signature: <P & Q>, replacement: $C : conformances: [$P, $Q]
   SubstitutionMap ExistentialSubs;
-  // The value of concrete type used to initialize the existential. `%c` above.
-  SILValue ConcreteValue;
 
-  // Search for a recognized pattern in which the given value is an opened
-  // existential that was previously initialized to a concrete type.
-  // Constructs a valid ConcreteExistentialInfo object if successfull.
-  ConcreteExistentialInfo(Operand &openedUse);
+  // Search for a recognized pattern in which the given existential value is
+  // initialized to a concrete type. Constructs a valid ConcreteExistentialInfo
+  // object if successfull.
+  ConcreteExistentialInfo(SILValue existential, SILInstruction *user);
 
   // This constructor initializes a ConcreteExistentialInfo based on already
-  // known ConcreteType and ProtocolDecl pair. It determines the
-  // OpenedArchetypeDef for the ArgOperand that will be used by unchecked_cast
-  // instructions to cast OpenedArchetypeDef to ConcreteType.
-  ConcreteExistentialInfo(Operand &ArgOperand, CanType ConcreteType,
-                          ProtocolDecl *Protocol);
+  // known ConcreteType and ProtocolDecl pair.
+  ConcreteExistentialInfo(SILValue existential, SILInstruction *user,
+                          CanType ConcreteType, ProtocolDecl *Protocol);
 
   /// For scenerios where ConcreteExistentialInfo is created using a known
-  /// ConcreteType and ProtocolDecl, both of InitExistential
-  /// and ConcreteValue can be null. So there is no need for explicit check for
-  /// not null for them instead we assert on (!InitExistential ||
-  /// ConcreteValue). 
-  bool isValid() const {
-    assert(!InitExistential || ConcreteValue);
-    return OpenedArchetype && OpenedArchetypeDef && ConcreteType &&
-           !ExistentialSubs.empty();
-  }
+  /// ConcreteType and ProtocolDecl, the ConcreteValue can be null.
+  bool isValid() const { return ConcreteType && !ExistentialSubs.empty(); }
 
   // Do a conformance lookup on ConcreteType with the given requirement, P. If P
   // is satisfiable based on the existential's conformance, return the new
@@ -115,6 +102,35 @@ struct ConcreteExistentialInfo {
   lookupExistentialConformance(ProtocolDecl *P) const {
     CanType selfTy = P->getSelfInterfaceType()->getCanonicalType();
     return ExistentialSubs.lookupConformance(selfTy, P);
+  }
+
+private:
+  void initializeSubstitutionMap(
+      ArrayRef<ProtocolConformanceRef> ExistentialConformances, SILModule *M);
+
+  void initializeConcreteTypeDef(SILInstruction *typeConversionInst);
+};
+
+// Convenience for tracking both the OpenedArchetypeInfo and
+// ConcreteExistentialInfo from the same SILValue.
+struct ConcreteOpenedExistentialInfo {
+  OpenedArchetypeInfo OAI;
+  // If CEI has a value, it must be valid.
+  Optional<ConcreteExistentialInfo> CEI;
+
+  ConcreteOpenedExistentialInfo(Operand &use);
+
+  // Provide a whole module type-inferred ConcreteType to fall back on if the
+  // concrete type cannot be determined from data flow.
+  ConcreteOpenedExistentialInfo(Operand &use, CanType concreteType,
+                                ProtocolDecl *protocol);
+
+  bool isValid() const {
+    if (!CEI)
+      return false;
+
+    assert(CEI->isValid());
+    return true;
   }
 };
 

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -296,26 +296,27 @@ private:
   FullApplySite rewriteApplyCallee(FullApplySite apply, SILValue callee);
 
   // Build concrete existential information using findInitExistential.
-  Optional<ConcreteExistentialInfo>
-  buildConcreteExistentialInfo(Operand &ArgOperand);
+  Optional<ConcreteOpenedExistentialInfo>
+  buildConcreteOpenedExistentialInfo(Operand &ArgOperand);
 
   // Build concrete existential information using SoleConformingType.
-  Optional<ConcreteExistentialInfo>
-  buildConcreteExistentialInfoFromSoleConformingType(Operand &ArgOperand);
+  Optional<ConcreteOpenedExistentialInfo>
+  buildConcreteOpenedExistentialInfoFromSoleConformingType(Operand &ArgOperand);
 
   // Common utility function to build concrete existential information for all
   // arguments of an apply instruction.
-  void buildConcreteExistentialInfos(
+  void buildConcreteOpenedExistentialInfos(
       FullApplySite Apply,
-      llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> &CEIs,
+      llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> &COEIs,
       SILBuilderContext &BuilderCtx,
       SILOpenedArchetypesTracker &OpenedArchetypesTracker);
 
-  bool canReplaceArg(FullApplySite Apply, const ConcreteExistentialInfo &CEI,
-                     unsigned ArgIdx);
+  bool canReplaceArg(FullApplySite Apply, const OpenedArchetypeInfo &OAI,
+                     const ConcreteExistentialInfo &CEI, unsigned ArgIdx);
+
   SILInstruction *createApplyWithConcreteType(
       FullApplySite Apply,
-      const llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> &CEIs,
+      const llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> &COEIs,
       SILBuilderContext &BuilderCtx);
 
   // Common utility function to replace the WitnessMethodInst using a
@@ -328,6 +329,7 @@ private:
   SILInstruction *
   propagateConcreteTypeOfInitExistential(FullApplySite Apply,
                                          WitnessMethodInst *WMI);
+
   SILInstruction *propagateConcreteTypeOfInitExistential(FullApplySite Apply);
 
   /// Propagate concrete types from ProtocolConformanceAnalysis.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -693,6 +693,14 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
     return COAI;
   }
   if (auto *OEA = dyn_cast<OpenExistentialAddrInst>(OAI.OpenedArchetypeValue)) {
+    // Bail if ConcreteSILType is not the same SILType as the type stored in the
+    // existential after maximal reabstraction.
+    auto archetype = OpenedArchetypeType::getAny(SoleCEI.ExistentialType);
+    Lowering::AbstractionPattern abstractionPattern(archetype);
+    auto abstractTy = M.Types.getLoweredType(abstractionPattern, ConcreteType);
+    if (abstractTy != concreteSILType)
+       return None;
+
     SoleCEI.ConcreteValue =
       Builder.createUncheckedAddrCast(
         OEA->getLoc(), OEA, concreteSILType.getAddressType());

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -615,13 +615,11 @@ void SILCombiner::replaceWitnessMethodInst(
     eraseInstFromFunction(*WMI);
 }
 
-//  This function determines concrete type of existential self argument using
-//  ProtocolConformanceAnalysis. The concrete type of self can be a class,
-//  struct, or an enum. It replaces the witness_method instruction
-//  with one that has a concrete type, allowing other optimizations to
-//  devirtualize it later.
-Optional<ConcreteExistentialInfo>
-SILCombiner::buildConcreteExistentialInfoFromSoleConformingType(
+// This function determines concrete type of an opened existential argument
+// using ProtocolConformanceAnalysis. The concrete type of the argument can be a
+// class, struct, or an enum.
+Optional<ConcreteOpenedExistentialInfo>
+SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
     Operand &ArgOperand) {
   SILInstruction *AI = ArgOperand.getUser();
   SILModule &M = AI->getModule();
@@ -637,6 +635,9 @@ SILCombiner::buildConcreteExistentialInfoFromSoleConformingType(
   if (FAS && (WMI = dyn_cast<WitnessMethodInst>(FAS.getCallee())) &&
       (FAS.getSelfArgumentOperand().get()  == ArgOperand.get())) {
     // If the witness method mutates self, we cannot replace self.
+    //
+    // FIXME: Remove this out-dated check for mutating self. canReplaceCopiedArg
+    // is supposed to handle this case.
     if (FAS.getOrigCalleeType()->getSelfParameter().isIndirectMutating())
       return None;
     PD = WMI->getLookupProtocol();
@@ -669,53 +670,60 @@ SILCombiner::buildConcreteExistentialInfoFromSoleConformingType(
   auto ElementType = NTD->getDeclaredType();
   auto ConcreteType = ElementType->getCanonicalType();
 
-  /// Determine OpenedArchetypeDef and SubstituionMap.
-  ConcreteExistentialInfo SoleCEI(ArgOperand, ConcreteType, PD);
-  if (!SoleCEI.isValid())
+  // Determine OpenedArchetypeDef and SubstituionMap.
+  ConcreteOpenedExistentialInfo COAI(ArgOperand, ConcreteType, PD);
+  if (!COAI.CEI)
     return None;
 
-  /// Determine the CEI.ConcreteValue.
-  if (!SoleCEI.InitExistential) {
-    // Create SIL type for the concrete type.
-    SILType ConcreteSILType = M.Types.getLoweredType(ConcreteType);
+  const OpenedArchetypeInfo &OAI = COAI.OAI;
+  ConcreteExistentialInfo &SoleCEI = *COAI.CEI;
+  assert(SoleCEI.isValid());
 
-    // Prepare the code by adding UncheckedCast instructions that cast opened
-    // existentials to concrete types. Set the ConcreteValue of CEI.
-    if (auto *OER =
-            dyn_cast<OpenExistentialRefInst>(SoleCEI.OpenedArchetypeDef)) {
-      auto *URCI =
-          Builder.createUncheckedRefCast(OER->getLoc(), OER, ConcreteSILType);
-      SoleCEI.ConcreteValue = URCI;
-    } else if (auto *OEA = dyn_cast<OpenExistentialAddrInst>(
-                   SoleCEI.OpenedArchetypeDef)) {
-      auto *UACI = Builder.createUncheckedAddrCast(
-          OEA->getLoc(), OEA, ConcreteSILType.getAddressType());
-      SoleCEI.ConcreteValue = UACI;
-    } else {
-      return None;
-    }
+  if (SoleCEI.ConcreteValue)
+    return COAI;
+
+  // Create SIL type for the concrete type.
+  SILType concreteSILType = M.Types.getLoweredType(ConcreteType);
+
+  // Prepare the code by adding UncheckedCast instructions that cast opened
+  // existentials to concrete types. Set the ConcreteValue of CEI.
+  if (auto *OER = dyn_cast<OpenExistentialRefInst>(OAI.OpenedArchetypeValue)) {
+    SoleCEI.ConcreteValue =
+        Builder.createUncheckedRefCast(OER->getLoc(), OER, concreteSILType);
+    return COAI;
   }
-  return SoleCEI;
+  if (auto *OEA = dyn_cast<OpenExistentialAddrInst>(OAI.OpenedArchetypeValue)) {
+    SoleCEI.ConcreteValue =
+      Builder.createUncheckedAddrCast(
+        OEA->getLoc(), OEA, concreteSILType.getAddressType());
+    return COAI;
+  }
+  // Bail if OpenArchetypeInfo recognizes any additional opened archetype
+  // producers. This shouldn't be hit currently because metatypes don't
+  // conform to protocols.
+  return None;
 }
+
 // This function builds a ConcreteExistentialInfo by first following the data
 // flow chain from the ArgOperand. Otherwise, we check if the operand is of
 // protocol type that conforms to a single concrete type.
-Optional<ConcreteExistentialInfo>
-SILCombiner::buildConcreteExistentialInfo(Operand &ArgOperand) {
-  // Build a ConcreteExistentialInfo usfollowing the data flow chain of the
-  // ArgOperand until the init_existential.
-  ConcreteExistentialInfo CEI(ArgOperand);
-  if (CEI.isValid())
-    return CEI;
+Optional<ConcreteOpenedExistentialInfo>
+SILCombiner::buildConcreteOpenedExistentialInfo(Operand &ArgOperand) {
+  // Build a ConcreteOpenedExistentialInfo following the data flow chain of the
+  // ArgOperand through the open_existential backward to an init_existential.
+  ConcreteOpenedExistentialInfo COEI(ArgOperand);
+  if (COEI.CEI)
+    return COEI;
+
   // Use SoleConformingType information.
-  return buildConcreteExistentialInfoFromSoleConformingType(ArgOperand);
+  return buildConcreteOpenedExistentialInfoFromSoleConformingType(ArgOperand);
 }
 
 // Build ConcreteExistentialInfo for every existential argument of an Apply
 // instruction including Self.
-void SILCombiner::buildConcreteExistentialInfos(
+void SILCombiner::buildConcreteOpenedExistentialInfos(
     FullApplySite Apply,
-    llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> &CEIs,
+    llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> &COEIs,
     SILBuilderContext &BuilderCtx,
     SILOpenedArchetypesTracker &OpenedArchetypesTracker) {
   for (unsigned ArgIdx = 0; ArgIdx < Apply.getNumArguments(); ArgIdx++) {
@@ -723,17 +731,18 @@ void SILCombiner::buildConcreteExistentialInfos(
     if (!ArgASTType->hasArchetype())
       continue;
 
-    auto OptionalCEI =
-        buildConcreteExistentialInfo(Apply.getArgumentOperands()[ArgIdx]);
-    if (!OptionalCEI.hasValue())
+    auto OptionalCOEI =
+        buildConcreteOpenedExistentialInfo(Apply.getArgumentOperands()[ArgIdx]);
+    if (!OptionalCOEI.hasValue())
       continue;
-    auto CEI = OptionalCEI.getValue();
-    assert(CEI.isValid());
-    CEIs.try_emplace(ArgIdx, CEI);
+    auto COEI = OptionalCOEI.getValue();
+    assert(COEI.isValid());
+    COEIs.try_emplace(ArgIdx, COEI);
 
+    ConcreteExistentialInfo &CEI = *COEI.CEI;
     if (CEI.ConcreteType->isOpenedExistential()) {
       // Temporarily record this opened existential def in this local
-      // BuilderContext before rewriting the witness method.
+      // BuilderContext before rewriting any uses of the ConcreteType.
       OpenedArchetypesTracker.addOpenedArchetypeDef(
           cast<ArchetypeType>(CEI.ConcreteType), CEI.ConcreteTypeDef);
     }
@@ -744,9 +753,13 @@ void SILCombiner::buildConcreteExistentialInfos(
 /// return true if the argument can be replaced by a copy of its value.
 ///
 /// FIXME: remove this helper when we can assume SIL opaque values.
-static bool canReplaceCopiedArg(FullApplySite Apply,
-                                 SILInstruction *InitExistential,
-                                 DominanceAnalysis *DA, unsigned ArgIdx) {
+static bool canReplaceCopiedArg(FullApplySite Apply, SILValue Arg,
+                                DominanceAnalysis *DA, unsigned ArgIdx) {
+  auto *IEA = dyn_cast<InitExistentialAddrInst>(Arg);
+  // Only init_existential_addr may be copied.
+  if (!IEA)
+    return false;
+
   // If the witness method mutates Arg, we cannot replace Arg with
   // the source of a copy. Otherwise the call would modify another value than
   // the original argument.
@@ -756,9 +769,7 @@ static bool canReplaceCopiedArg(FullApplySite Apply,
 
   auto *DT = DA->get(Apply.getFunction());
   auto *AI = Apply.getInstruction();
-  // Only init_existential_addr may be copied.
-  SILValue existentialAddr =
-      cast<InitExistentialAddrInst>(InitExistential)->getOperand();
+  SILValue existentialAddr = IEA->getOperand();
 
   // If we peeked through an InitEnumDataAddr or some such, then don't assume we
   // can reuse the copied value. It's likely destroyed by
@@ -809,6 +820,7 @@ static bool canReplaceCopiedArg(FullApplySite Apply,
 // can be replaced with a concrete type. Concrete type info is passed as CEI
 // argument.
 bool SILCombiner::canReplaceArg(FullApplySite Apply,
+                                const OpenedArchetypeInfo &OAI,
                                 const ConcreteExistentialInfo &CEI,
                                 unsigned ArgIdx) {
 
@@ -818,7 +830,7 @@ bool SILCombiner::canReplaceArg(FullApplySite Apply,
   // references to OpenedArchetype will be substituted. So walk to type to
   // find all possible references, such as returning Optional<Arg>.
   if (Apply.getType().getASTType().findIf(
-          [&CEI](Type t) -> bool { return t->isEqual(CEI.OpenedArchetype); })) {
+          [&OAI](Type t) -> bool { return t->isEqual(OAI.OpenedArchetype); })) {
     return false;
   }
   // Bail out if any other arguments or indirect result that refer to the
@@ -837,17 +849,17 @@ bool SILCombiner::canReplaceArg(FullApplySite Apply,
     if (Idx == ArgIdx)
       continue;
     if (Apply.getArgument(Idx)->getType().getASTType().findIf(
-            [&CEI](Type t) -> bool {
-              return t->isEqual(CEI.OpenedArchetype);
+            [&OAI](Type t) -> bool {
+              return t->isEqual(OAI.OpenedArchetype);
             })) {
       return false;
     }
   }
   // The apply can only be rewritten in terms of the concrete value if it is
   // legal to pass that value as the Arg argument.
-  if (CEI.isCopied &&
-      (!CEI.InitExistential ||
-       !canReplaceCopiedArg(Apply, CEI.InitExistential, DA, ArgIdx))) {
+  if (CEI.isConcreteValueCopied
+      && (!CEI.ConcreteValue
+          || !canReplaceCopiedArg(Apply, CEI.ConcreteValue, DA, ArgIdx))) {
     return false;
   }
   // It is safe to replace Arg.
@@ -879,7 +891,7 @@ bool SILCombiner::canReplaceArg(FullApplySite Apply,
 /// SSA uses in those cases. Currently we bail out on methods that return Self.
 SILInstruction *SILCombiner::createApplyWithConcreteType(
     FullApplySite Apply,
-    const llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> &CEIs,
+    const llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> &COAIs,
     SILBuilderContext &BuilderCtx) {
 
   // Ensure that the callee is polymorphic.
@@ -897,15 +909,18 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
   }
   // Transform the parameter arguments.
   for (unsigned EndIdx = Apply.getNumArguments(); ArgIdx < EndIdx; ++ArgIdx) {
-    auto ArgIt = CEIs.find(ArgIdx);
-    if (ArgIt == CEIs.end()) {
+    auto ArgIt = COAIs.find(ArgIdx);
+    if (ArgIt == COAIs.end()) {
       // Use the old argument if it does not have a valid concrete existential.
       NewArgs.push_back(Apply.getArgument(ArgIdx));
       continue;
     }
-    auto &CEI = ArgIt->second;
+    const OpenedArchetypeInfo &OAI = ArgIt->second.OAI;
+    const ConcreteExistentialInfo &CEI = *ArgIt->second.CEI;
+    assert(CEI.isValid());
+
     // Check for Arg's concrete type propagation legality.
-    if (!canReplaceArg(Apply, CEI, ArgIdx)) {
+    if (!canReplaceArg(Apply, OAI, CEI, ArgIdx)) {
       NewArgs.push_back(Apply.getArgument(ArgIdx));
       continue;
     }
@@ -917,13 +932,13 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
     // replaced with a concrete type.
     NewCallSubs = NewCallSubs.subst(
         [&](SubstitutableType *type) -> Type {
-          if (type == CEI.OpenedArchetype)
+          if (type == OAI.OpenedArchetype)
             return CEI.ConcreteType;
           return type;
         },
         [&](CanType origTy, Type substTy,
             ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
-          if (origTy->isEqual(CEI.OpenedArchetype)) {
+          if (origTy->isEqual(OAI.OpenedArchetype)) {
             assert(substTy->isEqual(CEI.ConcreteType));
             // Do a conformance lookup on this witness requirement using the
             // existential's conformances. The witness requirement may be a
@@ -981,25 +996,33 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
   // Try to derive the concrete type and the related conformance of self and
   // other existential arguments by searching either for a preceding
   // init_existential or looking up sole conforming type.
+  //
+  // buildConcreteOpenedExistentialInfo takes a SILBuilderContext because it may
+  // insert an uncheched cast to the concrete type, and it tracks the defintion
+  // of any opened archetype needed to use the concrete type.
   SILBuilderContext BuilderCtx(Builder.getModule(), Builder.getTrackingList());
   SILOpenedArchetypesTracker OpenedArchetypesTracker(&Builder.getFunction());
   BuilderCtx.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
-  llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> CEIs;
-  buildConcreteExistentialInfos(Apply, CEIs, BuilderCtx,
-                                OpenedArchetypesTracker);
+  llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> COEIs;
+  buildConcreteOpenedExistentialInfos(Apply, COEIs, BuilderCtx,
+                                      OpenedArchetypesTracker);
 
   // Bail, if no argument has a concrete existential to propagate.
-  if (CEIs.empty())
+  if (COEIs.empty())
     return nullptr;
-  auto SelfCEIIt =
-      CEIs.find(Apply.getCalleeArgIndex(Apply.getSelfArgumentOperand()));
 
-  // If no SelfCEI is found, then just update the Apply with new CEIs for
+  auto SelfCOEIIt =
+      COEIs.find(Apply.getCalleeArgIndex(Apply.getSelfArgumentOperand()));
+
+  // If no SelfCOEI is found, then just update the Apply with new COEIs for
   // other arguments.
-  if (SelfCEIIt == CEIs.end())
-    return createApplyWithConcreteType(Apply, CEIs, BuilderCtx);
+  if (SelfCOEIIt == COEIs.end())
+    return createApplyWithConcreteType(Apply, COEIs, BuilderCtx);
 
-  auto &SelfCEI = SelfCEIIt->second;
+  auto &SelfCOEI = SelfCOEIIt->second;
+  assert(SelfCOEI.isValid());
+
+  const ConcreteExistentialInfo &SelfCEI = *SelfCOEI.CEI;
   assert(SelfCEI.isValid());
 
   // Get the conformance of the init_existential type, which is passed as the
@@ -1026,8 +1049,8 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
                              SelfConformance);
   }
 
-  // Try to rewrite the apply.
-  return createApplyWithConcreteType(Apply, CEIs, BuilderCtx);
+  /// Create the new apply instruction using concrete types for arguments.
+  return createApplyWithConcreteType(Apply, COEIs, BuilderCtx);
 }
 
 /// Rewrite a protocol extension lookup type from an archetype to a concrete
@@ -1049,17 +1072,18 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply) {
   // Try to derive the concrete type and the related conformance of self and
   // other existential arguments by searching either for a preceding
   // init_existential or looking up sole conforming type.
-  llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> CEIs;
+  llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> COEIs;
   SILBuilderContext BuilderCtx(Builder.getModule(), Builder.getTrackingList());
   SILOpenedArchetypesTracker OpenedArchetypesTracker(&Builder.getFunction());
   BuilderCtx.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
-  buildConcreteExistentialInfos(Apply, CEIs, BuilderCtx,
-                                OpenedArchetypesTracker);
+  buildConcreteOpenedExistentialInfos(Apply, COEIs, BuilderCtx,
+                                      OpenedArchetypesTracker);
 
   // Bail, if no argument has a concrete existential to propagate.
-  if (CEIs.empty())
+  if (COEIs.empty())
     return nullptr;
-  return createApplyWithConcreteType(Apply, CEIs, BuilderCtx);
+
+  return createApplyWithConcreteType(Apply, COEIs, BuilderCtx);
 }
 
 /// Check that all users of the apply are retain/release ignoring one

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -33,8 +33,8 @@ using namespace swift;
 /// apply pattern shown above) and that a valid init_existential_addr 
 /// value is returned only if it can prove that the value it 
 /// initializes is the same value at the use point.
-static SILValue findInitExistentialFromGlobalAddr(GlobalAddrInst *GAI,
-                                                  SILInstruction *Insn) {
+static InitExistentialAddrInst *
+findInitExistentialFromGlobalAddr(GlobalAddrInst *GAI, SILInstruction *Insn) {
   /// Check for a single InitExistential usage for GAI and
   /// a simple dominance check: both InitExistential and Insn are in
   /// the same basic block and only one InitExistential
@@ -49,85 +49,36 @@ static SILValue findInitExistentialFromGlobalAddr(GlobalAddrInst *GAI,
 
   /// No InitExistential found in the basic block.
   if (IEUses.empty())
-    return SILValue();
+    return nullptr;
 
   /// Walk backwards from Insn instruction till the begining of the basic block
   /// looking for an InitExistential.
-  SILValue SingleIE;
+  InitExistentialAddrInst *SingleIE = nullptr;
   for (auto II = Insn->getIterator().getReverse(),
             IE = Insn->getParent()->rend();
        II != IE; ++II) {
     if (!IEUses.count(&*II))
       continue;
     if (SingleIE)
-      return SILValue();
+      return nullptr;
 
     SingleIE = cast<InitExistentialAddrInst>(&*II);
   }
   return SingleIE;
 }
 
-/// Determine InitExistential from global_addr and copy_addr.
-/// %3 = global_addr @$P : $*SomeP
-/// %4 = init_existential_addr %3 : $*SomeP, $SomeC
-/// %5 = alloc_ref $SomeC
-/// store %5 to %4 : $*SomeC
-/// %8 = alloc_stack $SomeP
-/// copy_addr %3 to [initialization] %8 : $*SomeP
-SILValue
-swift::findInitExistentialFromGlobalAddrAndCopyAddr(GlobalAddrInst *GAI,
-                                                    CopyAddrInst *CAI) {
-  assert(CAI->getSrc() == SILValue(GAI) &&
-         "Broken Assumption! Global Addr is not the source of the passed in "
-         "copy_addr?!");
-  return findInitExistentialFromGlobalAddr(GAI, cast<SILInstruction>(CAI));
-}
-
-/// Determine InitExistential from global_addr and an apply argument.
-/// Pattern 1
-/// %3 = global_addr @$P : $*SomeP
-/// %4 = init_existential_addr %3 : $*SomeP, $SomeC
-/// %5 = alloc_ref $SomeC
-/// store %5 to %4 : $*SomeC
-/// %10 = apply %9(%3) : $@convention(thin) (@in_guaranteed SomeP)
-/// Pattern 2
-/// %3 = global_addr @$P : $*SomeP
-/// %9 = open_existential_addr mutable_access %3 : $*SomeP to $*@opened SomeP
-/// %15 = apply %11(%9) : $@convention(thin) (@in_guaranteed SomeP)
-SILValue swift::findInitExistentialFromGlobalAddrAndApply(GlobalAddrInst *GAI,
-                                                          ApplySite Apply,
-                                                          int ArgIdx) {
-  /// Code to ensure that we are calling only in two pattern matching scenarios.
-  bool isArg = false;
-  auto Arg = Apply.getArgument(ArgIdx);
-  if (auto *ApplyGAI = dyn_cast<GlobalAddrInst>(Arg)) {
-    if (ApplyGAI->isIdenticalTo(GAI)) {
-      isArg = true;
-    }
-  } else if (auto Open = dyn_cast<OpenExistentialAddrInst>(Arg)) {
-    auto Op = Open->getOperand();
-    if (auto *OpGAI = dyn_cast<GlobalAddrInst>(Op)) {
-      if (OpGAI->isIdenticalTo(GAI)) {
-        isArg = true;
-      }
-    }
-  }
-  assert(isArg && "Broken Assumption! Global Addr is not an argument to "
-                  "apply?!");
-  return findInitExistentialFromGlobalAddr(GAI, Apply.getInstruction());
-}
-
-/// Returns the address of an object with which the stack location \p ASI is
-/// initialized. This is either a init_existential_addr or the destination of a
-/// copy_addr. Returns a null value if the address does not dominate the
-/// alloc_stack user \p ASIUser.
-/// If the value is copied from another stack location, \p isCopied is set to
-/// true.
+/// Returns the instruction that initializes the given stack address. This is
+/// currently either a init_existential_addr, unconditional_checked_cast_addr,
+/// or copy_addr (if the instruction initializing the source of the copy cannot
+/// be determined). Returns nullptr if the initializer does not dominate the
+/// alloc_stack user \p ASIUser.  If the value is copied from another stack
+/// location, \p isCopied is set to true.
 ///
 /// allocStackAddr may either itself be an AllocStackInst or an
 /// InitEnumDataAddrInst that projects the value of an AllocStackInst.
-SILValue swift::getAddressOfStackInit(SILValue allocStackAddr,
-                                      SILInstruction *ASIUser, bool &isCopied) {
+static SILInstruction *getStackInitInst(SILValue allocStackAddr,
+                                        SILInstruction *ASIUser,
+                                        bool &isCopied) {
   SILInstruction *SingleWrite = nullptr;
   // Check that this alloc_stack is initialized only once.
   for (auto Use : allocStackAddr->getUses()) {
@@ -144,15 +95,25 @@ SILValue swift::getAddressOfStackInit(SILValue allocStackAddr,
     if (auto *CAI = dyn_cast<CopyAddrInst>(User)) {
       if (CAI->getDest() == allocStackAddr) {
         if (SingleWrite)
-          return SILValue();
+          return nullptr;
         SingleWrite = CAI;
+        isCopied = true;
+      }
+      continue;
+    }
+    // An unconditional_checked_cast_addr also copies a value into this addr.
+    if (auto *UCCAI = dyn_cast<UnconditionalCheckedCastAddrInst>(User)) {
+      if (UCCAI->getDest() == allocStackAddr) {
+        if (SingleWrite)
+          return nullptr;
+        SingleWrite = UCCAI;
         isCopied = true;
       }
       continue;
     }
     if (isa<InitExistentialAddrInst>(User)) {
       if (SingleWrite)
-        return SILValue();
+        return nullptr;
       SingleWrite = User;
       continue;
     }
@@ -161,17 +122,19 @@ SILValue swift::getAddressOfStackInit(SILValue allocStackAddr,
       auto Conv = FullApplySite(User).getArgumentConvention(*Use);
       if (Conv != SILArgumentConvention::Indirect_In &&
           Conv != SILArgumentConvention::Indirect_In_Guaranteed)
-        return SILValue();
+        return nullptr;
       continue;
     }
     // Bail if there is any unknown (and potentially writing) instruction.
-    return SILValue();
+    return nullptr;
   }
   if (!SingleWrite)
-    return SILValue();
+    return nullptr;
 
   // A very simple dominance check. As ASI is an operand of ASIUser,
-  // SingleWrite dominates ASIUser if it is in the same block as ASI or ASIUser.
+  // SingleWrite dominates ASIUser if it is in the same block as ASI or
+  // ASIUser. (SingleWrite can't occur after ASIUser because the address would
+  // be uninitialized on use).
   //
   // If allocStack holds an Optional, then ASI is an InitEnumDataAddrInst
   // projection and not strictly an operand of ASIUser. We rely on the guarantee
@@ -179,127 +142,192 @@ SILValue swift::getAddressOfStackInit(SILValue allocStackAddr,
   // that was the source of the existential address.
   SILBasicBlock *BB = SingleWrite->getParent();
   if (BB != allocStackAddr->getParentBlock() && BB != ASIUser->getParent())
+    return nullptr;
+
+  if (auto *IE = dyn_cast<InitExistentialAddrInst>(SingleWrite))
+    return IE;
+
+  if (auto *UCCA = dyn_cast<UnconditionalCheckedCastAddrInst>(SingleWrite)) {
+    assert(isCopied && "isCopied not set for a unconditional_checked_cast_addr");
+    return UCCA;
+  }
+  auto *CAI = cast<CopyAddrInst>(SingleWrite);
+  assert(isCopied && "isCopied not set for a copy_addr");
+  // Attempt to recurse to find a concrete type.
+  if (auto *ASI = dyn_cast<AllocStackInst>(CAI->getSrc()))
+    return getStackInitInst(ASI, CAI, isCopied);
+
+  // Peek through a stack location holding an Enum.
+  //   %stack_adr = alloc_stack
+  //   %data_adr  = init_enum_data_addr %stk_adr
+  //   %enum_adr  = inject_enum_addr %stack_adr
+  //   %copy_src  = unchecked_take_enum_data_addr %enum_adr
+  // Replace %copy_src with %data_adr and recurse.
+  //
+  // TODO: a general Optional elimination sil-combine could
+  // supersede this check.
+  if (auto *UTEDAI = dyn_cast<UncheckedTakeEnumDataAddrInst>(CAI->getSrc())) {
+    if (InitEnumDataAddrInst *IEDAI = findInitAddressForTrivialEnum(UTEDAI))
+      return getStackInitInst(IEDAI, CAI, isCopied);
+  }
+
+  // Check if the CAISrc is a global_addr.
+  if (auto *GAI = dyn_cast<GlobalAddrInst>(CAI->getSrc()))
+    return findInitExistentialFromGlobalAddr(GAI, CAI);
+
+  // If the source of the copy cannot be determined, return the copy itself
+  // because the caller may have special handling for the source address.
+  return CAI;
+}
+
+/// Return the address of the value used to initialize the given stack location.
+/// If the value originates from init_existential_addr, then it will be a
+/// different type than \p allocStackAddr.
+static SILValue getAddressOfStackInit(SILValue allocStackAddr,
+                                      SILInstruction *ASIUser, bool &isCopied) {
+  SILInstruction *initI = getStackInitInst(allocStackAddr, ASIUser, isCopied);
+  if (!initI)
     return SILValue();
 
-  if (auto *CAI = dyn_cast<CopyAddrInst>(SingleWrite)) {
-    // Try to derive the type from the copy_addr that was used to
-    // initialize the alloc_stack.
-    assert(isCopied && "isCopied not set for a copy_addr");
-    SILValue CAISrc = CAI->getSrc();
-    if (auto *ASI = dyn_cast<AllocStackInst>(CAISrc))
-      return getAddressOfStackInit(ASI, CAI, isCopied);
+  if (auto *IEA = dyn_cast<InitExistentialAddrInst>(initI))
+    return IEA;
 
-    // Recognize a stack location holding an Optional.
-    //   %stack_adr = alloc_stack
-    //   %data_adr  = init_enum_data_addr %stk_adr
-    //   %enum_adr  = inject_enum_addr %stack_adr
-    //   %copy_src  = unchecked_take_enum_data_addr %enum_adr
-    // Replace %copy_src with %data_adr and recurse.
-    //
-    // TODO: a general Optional elimination sil-combine could
-    // supersede this check.
-    if (auto *UTEDAI = dyn_cast<UncheckedTakeEnumDataAddrInst>(CAISrc)) {
-      if (InitEnumDataAddrInst *IEDAI = findInitAddressForTrivialEnum(UTEDAI))
-        return getAddressOfStackInit(IEDAI, CAI, isCopied);
-    }
+  if (auto *CAI = dyn_cast<CopyAddrInst>(initI))
+    return CAI->getSrc();
 
-    // Check if the CAISrc is a global_addr.
-    if (auto *GAI = dyn_cast<GlobalAddrInst>(CAISrc)) {
-      return findInitExistentialFromGlobalAddrAndCopyAddr(GAI, CAI);
-    }
-    return CAISrc;
-  }
-  return cast<InitExistentialAddrInst>(SingleWrite);
+  return SILValue();
 }
 
-/// Find the init_existential, which could be used to determine a concrete
-/// type of the \p Self.
-/// If the value is copied from another stack location, \p isCopied is set to
-/// true.
-SILInstruction *swift::findInitExistential(Operand &openedUse,
-                                           ArchetypeType *&OpenedArchetype,
-                                           SILValue &OpenedArchetypeDef,
-                                           bool &isCopied) {
-  SILValue Self = openedUse.get();
-  SILInstruction *User = openedUse.getUser();
-  isCopied = false;
-  if (auto *Instance = dyn_cast<AllocStackInst>(Self)) {
-    // In case the Self operand is an alloc_stack where a copy_addr copies the
-    // result of an open_existential_addr to this stack location.
-    if (SILValue Src = getAddressOfStackInit(Instance, User, isCopied))
-      Self = Src;
+/// Check if the given operand originates from a recognized OpenArchetype
+/// instruction. If so, return the Opened, otherwise return nullptr.
+OpenedArchetypeInfo::OpenedArchetypeInfo(Operand &use) {
+  SILValue openedVal = use.get();
+  SILInstruction *user = use.getUser();
+  if (auto *instance = dyn_cast<AllocStackInst>(openedVal)) {
+    // Handle:
+    //   %opened = open_existential_addr
+    //   %instance = alloc $opened
+    //   copy_addr %opened to %stack
+    //   <opened_use> %instance
+    if (auto stackInitVal =
+            getAddressOfStackInit(instance, user, isOpenedValueCopied)) {
+      openedVal = stackInitVal;
+    }
   }
-
-  if (auto *Open = dyn_cast<OpenExistentialAddrInst>(Self)) {
-    auto Op = Open->getOperand();
-    auto *ASI = dyn_cast<AllocStackInst>(Op);
-    if (!ASI)
-      return nullptr;
-
-    SILValue StackWrite = getAddressOfStackInit(ASI, Open, isCopied);
-    if (!StackWrite)
-      return nullptr;
-
-    auto *IE = dyn_cast<InitExistentialAddrInst>(StackWrite);
-    if (!IE)
-      return nullptr;
-
+  if (auto *Open = dyn_cast<OpenExistentialAddrInst>(openedVal)) {
     OpenedArchetype = Open->getType().castTo<ArchetypeType>();
-    OpenedArchetypeDef = Open;
-    return IE;
+    OpenedArchetypeValue = Open;
+    ExistentialValue = Open->getOperand();
+    return;
   }
-
-  if (auto *Open = dyn_cast<OpenExistentialRefInst>(Self)) {
-    if (auto *IE = dyn_cast<InitExistentialRefInst>(Open->getOperand())) {
-      OpenedArchetype = Open->getType().castTo<ArchetypeType>();
-      OpenedArchetypeDef = Open;
-      return IE;
-    }
-    return nullptr;
+  if (auto *Open = dyn_cast<OpenExistentialRefInst>(openedVal)) {
+    OpenedArchetype = Open->getType().castTo<ArchetypeType>();
+    OpenedArchetypeValue = Open;
+    ExistentialValue = Open->getOperand();
+    return;
   }
-
-  if (auto *Open = dyn_cast<OpenExistentialMetatypeInst>(Self)) {
-    if (auto *IE = dyn_cast<InitExistentialMetatypeInst>(Open->getOperand())) {
-      auto Ty = Open->getType().getASTType();
-      while (auto Metatype = dyn_cast<MetatypeType>(Ty))
-        Ty = Metatype.getInstanceType();
-      OpenedArchetype = cast<ArchetypeType>(Ty);
-      OpenedArchetypeDef = Open;
-      return IE;
-    }
-    return nullptr;
+  if (auto *Open = dyn_cast<OpenExistentialMetatypeInst>(openedVal)) {
+    auto Ty = Open->getType().getASTType();
+    while (auto Metatype = dyn_cast<MetatypeType>(Ty))
+      Ty = Metatype.getInstanceType();
+    OpenedArchetype = cast<ArchetypeType>(Ty);
+    OpenedArchetypeValue = Open;
+    ExistentialValue = Open->getOperand();
   }
-  return nullptr;
 }
 
-/// Derive a concrete type of self and conformance from the init_existential
-/// instruction.
-/// If successful, initializes a valid ConformanceAndConcreteType.
-ConcreteExistentialInfo::ConcreteExistentialInfo(Operand &openedUse) {
-  // Try to find the init_existential, which could be used to
-  // determine a concrete type of the self.
-  // Returns: InitExistential, OpenedArchetype, OpenedArchetypeDef, isCopied.
-  InitExistential = findInitExistential(openedUse, OpenedArchetype,
-                                        OpenedArchetypeDef, isCopied);
-  if (!InitExistential)
+/// Initialize ExistentialSubs from the given conformance list, using the
+/// already initialized ExistentialType and ConcreteType.
+void ConcreteExistentialInfo::initializeSubstitutionMap(
+    ArrayRef<ProtocolConformanceRef> ExistentialConformances, SILModule *M) {
+
+  // Construct a single-generic-parameter substitution map directly to the
+  // ConcreteType with this existential's full list of conformances.
+  CanGenericSignature ExistentialSig =
+      M->getASTContext().getExistentialSignature(ExistentialType,
+                                                 M->getSwiftModule());
+  ExistentialSubs = SubstitutionMap::get(ExistentialSig, {ConcreteType},
+                                         ExistentialConformances);
+  assert(isValid());
+}
+
+/// If the ConcreteType is an opened existential, also initialize
+/// ConcreteTypeDef to the definition of that type.
+void ConcreteExistentialInfo::initializeConcreteTypeDef(
+    SILInstruction *typeConversionInst) {
+  if (!ConcreteType->isOpenedExistential())
     return;
 
-  ArrayRef<ProtocolConformanceRef> ExistentialConformances;
+  assert(isValid());
 
-  if (auto IE = dyn_cast<InitExistentialAddrInst>(InitExistential)) {
-    ExistentialType = IE->getOperand()->getType().getASTType();
-    ExistentialConformances = IE->getConformances();
-    ConcreteType = IE->getFormalConcreteType();
-    ConcreteValue = IE;
-  } else if (auto IER = dyn_cast<InitExistentialRefInst>(InitExistential)) {
+  // If the concrete type is another existential, we're "forwarding" an
+  // opened existential type, so we must keep track of the original
+  // defining instruction.
+  if (!typeConversionInst->getTypeDependentOperands().empty()) {
+    ConcreteTypeDef = cast<SingleValueInstruction>(
+        typeConversionInst->getTypeDependentOperands()[0].get());
+    return;
+  }
+
+  auto typeOperand =
+      cast<InitExistentialMetatypeInst>(typeConversionInst)->getOperand();
+  assert(typeOperand->getType().hasOpenedExistential()
+         && "init_existential is supposed to have a typedef operand");
+  ConcreteTypeDef = cast<SingleValueInstruction>(typeOperand);
+}
+
+/// Construct this ConcreteExistentialInfo based on the given existential use.
+///
+/// Finds the init_existential, or an address with concrete type used to
+/// initialize the given \p openedUse. If the value is copied
+/// from another stack location, \p isCopied is set to true.
+///
+/// If successful, ConcreteExistentialInfo will be valid upon return, with the
+/// following fields assigned:
+/// - ExistentialType
+/// - isCopied
+/// - ConcreteType
+/// - ConcreteValue
+/// - ConcreteTypeDef
+/// - ExistentialSubs
+ConcreteExistentialInfo::ConcreteExistentialInfo(SILValue existential,
+                                                 SILInstruction *user) {
+  if (existential->getType().isAddress()) {
+    auto *ASI = dyn_cast<AllocStackInst>(existential);
+    if (!ASI)
+      return;
+
+    SILInstruction *stackInit =
+        getStackInitInst(ASI, user, isConcreteValueCopied);
+    if (!stackInit)
+      return;
+
+    if (auto *IE = dyn_cast<InitExistentialAddrInst>(stackInit)) {
+      ExistentialType = IE->getOperand()->getType().getASTType();
+      ConcreteType = IE->getFormalConcreteType();
+      ConcreteValue = IE;
+      initializeSubstitutionMap(IE->getConformances(), &IE->getModule());
+      initializeConcreteTypeDef(IE);
+      return;
+    }
+    // TODO: Once we have a way to introduce more constrained archetypes, handle
+    // any unconditional_checked_cast that wasn't already statically eliminated.
+    //
+    // Unexpected stack write.
+    return;
+  }
+
+  if (auto *IER = dyn_cast<InitExistentialRefInst>(existential)) {
     ExistentialType = IER->getType().getASTType();
-    ExistentialConformances = IER->getConformances();
     ConcreteType = IER->getFormalConcreteType();
     ConcreteValue = IER->getOperand();
-  } else if (auto IEM =
-                 dyn_cast<InitExistentialMetatypeInst>(InitExistential)) {
+    initializeSubstitutionMap(IER->getConformances(), &IER->getModule());
+    initializeConcreteTypeDef(IER);
+    return;
+  }
+
+  if (auto *IEM = dyn_cast<InitExistentialMetatypeInst>(existential)) {
     ExistentialType = IEM->getType().getASTType();
-    ExistentialConformances = IEM->getConformances();
     ConcreteValue = IEM->getOperand();
     ConcreteType = ConcreteValue->getType().getASTType();
     while (auto InstanceType =
@@ -307,85 +335,33 @@ ConcreteExistentialInfo::ConcreteExistentialInfo(Operand &openedUse) {
       ExistentialType = InstanceType.getInstanceType();
       ConcreteType = cast<MetatypeType>(ConcreteType).getInstanceType();
     }
-  } else {
-    assert(!isValid());
+    initializeSubstitutionMap(IEM->getConformances(), &IEM->getModule());
+    initializeConcreteTypeDef(IEM);
     return;
   }
-  // Construct a single-generic-parameter substitution map directly to the
-  // ConcreteType with this existential's full list of conformances.
-  SILModule &M = InitExistential->getModule();
-  CanGenericSignature ExistentialSig =
-      M.getASTContext().getExistentialSignature(ExistentialType,
-                                                M.getSwiftModule());
-  ExistentialSubs = SubstitutionMap::get(ExistentialSig, {ConcreteType},
-                                         ExistentialConformances);
-  // If the concrete type is another existential, we're "forwarding" an
-  // opened existential type, so we must keep track of the original
-  // defining instruction.
-  if (ConcreteType->isOpenedExistential()) {
-    if (InitExistential->getTypeDependentOperands().empty()) {
-      auto op = InitExistential->getOperand(0);
-      assert(op->getType().hasOpenedExistential()
-             && "init_existential is supposed to have a typedef operand");
-      ConcreteTypeDef = cast<SingleValueInstruction>(op);
-    } else {
-      ConcreteTypeDef = cast<SingleValueInstruction>(
-          InitExistential->getTypeDependentOperands()[0].get());
-    }
-  }
-  assert(isValid());
+  // Unrecognized opened existential producer.
+  return;
 }
 
-/// Initialize a ConcreteExistentialInfo based on the already computed concrete
-/// type and protocol declaration. It determines the OpenedArchetypeDef
-/// and SubstituionMap for the ArgOperand argument.
-/// We need the OpenedArchetypeDef to be able to cast it to the concrete type.
-/// findInitExistential helps us determine this OpenedArchetypeDef. For cases
-/// where OpenedArchetypeDef can not be found from findInitExistential (because
-/// there was no InitExistential), then we do
-/// extra effort in trying to find an OpenedArchetypeDef for AllocStackInst
-/// using getAddressOfStackInit.
-ConcreteExistentialInfo::ConcreteExistentialInfo(Operand &ArgOperand,
-                                                 CanType ConcreteTy,
-                                                 ProtocolDecl *Protocol)
-    : ConcreteExistentialInfo(ArgOperand) {
-
-  // If we found an InitExistential, assert that ConcreteType we determined is
-  // same as ConcreteTy argument.
-  if (InitExistential) {
-    assert(ConcreteType == ConcreteTy);
-    assert(isValid());
-    return;
-  }
-
-  ConcreteType = ConcreteTy;
-  OpenedArchetypeDef = ArgOperand.get();
-
-  // If findInitExistential call from the other constructor did not update the
-  // OpenedArchetypeDef (because it did not find an InitExistential) and that
-  // the original Arg is an alloc_stack instruction, then we determine the
-  // OpenedArchetypeDef using getAddressOfStackInit. Please keep in mind that an
-  // alloc_stack can be an argument to apply (which could have no associated
-  // InitExistential), thus we need to determine the OpenedArchetypeDef for it.
-  // This is the extra effort.
-  SILInstruction *User = ArgOperand.getUser();
-  SILModule &M = User->getModule();
-  if (auto *ASI = dyn_cast<AllocStackInst>(OpenedArchetypeDef)) {
-    bool copied = false;
-    if (SILValue Src = getAddressOfStackInit(ASI, User, copied)) {
-      OpenedArchetypeDef = Src;
-    }
-    isCopied = copied;
-  }
-
-  // Bail, if we did not find an opened existential.
-  if (!(isa<OpenExistentialRefInst>(OpenedArchetypeDef) ||
-        isa<OpenExistentialAddrInst>(OpenedArchetypeDef)))
-    return;
+/// Initialize a ConcreteExistentialInfo based on a concrete type and protocol
+/// declaration that has already been computed via whole module type
+/// inference. A cast instruction will be introduced to produce the concrete
+/// value from the opened value.
+///
+/// The simpler constructor taking only the existential value is preferred
+/// because it generates simpler SIL and does not require an extra
+/// cast. However, if that constructor fails to produce a valid
+/// ConcreteExistentialInfo, this constructor may succeed because it doesn't
+/// needs to rediscover the whole-module inferred ConcreteTypeCandidate.
+ConcreteExistentialInfo::ConcreteExistentialInfo(SILValue existential,
+                                                 SILInstruction *user,
+                                                 CanType ConcreteTypeCandidate,
+                                                 ProtocolDecl *Protocol) {
+  SILModule *M = existential->getModule();
 
   // We have the open_existential; we still need the conformance.
   auto ConformanceRef =
-      M.getSwiftModule()->lookupConformance(ConcreteType, Protocol);
+      M->getSwiftModule()->conformsToProtocol(ConcreteTypeCandidate, Protocol);
   if (!ConformanceRef)
     return;
 
@@ -393,18 +369,40 @@ ConcreteExistentialInfo::ConcreteExistentialInfo(Operand &ArgOperand,
   auto *ConcreteConformance = ConformanceRef.getValue().getConcrete();
   assert(ConcreteConformance->isComplete());
 
+  ConcreteType = ConcreteTypeCandidate;
+  // There is no ConcreteValue in this case.
+
   /// Determine the ExistentialConformances and SubstitutionMap.
   ExistentialType = Protocol->getDeclaredType()->getCanonicalType();
-  auto ExistentialSig = M.getASTContext().getExistentialSignature(
-      ExistentialType, M.getSwiftModule());
-  ExistentialSubs = SubstitutionMap::get(
-      ExistentialSig, {ConcreteType},
-      llvm::makeArrayRef(ProtocolConformanceRef(ConcreteConformance)));
+  initializeSubstitutionMap(ProtocolConformanceRef(ConcreteConformance), M);
 
-  /// Determine the OpenedArchetype.
-  OpenedArchetype =
-      OpenedArchetypeDef->getType().castTo<ArchetypeType>();
-
-  /// Check validity.
   assert(isValid());
+}
+
+ConcreteOpenedExistentialInfo::ConcreteOpenedExistentialInfo(Operand &use)
+    : OAI(use) {
+  if (!OAI.isValid())
+    return;
+
+  CEI.emplace(OAI.ExistentialValue, OAI.OpenedArchetypeValue);
+  if (!CEI->isValid()) {
+    CEI.reset();
+    return;
+  }
+  CEI->isConcreteValueCopied |= OAI.isOpenedValueCopied;
+}
+
+ConcreteOpenedExistentialInfo::ConcreteOpenedExistentialInfo(
+    Operand &use, CanType concreteType, ProtocolDecl *protocol)
+    : OAI(use) {
+  if (!OAI.isValid())
+    return;
+
+  CEI.emplace(OAI.ExistentialValue, OAI.OpenedArchetypeValue, concreteType,
+              protocol);
+  if (!CEI->isValid()) {
+    CEI.reset();
+    return;
+  }
+  CEI->isConcreteValueCopied |= OAI.isOpenedValueCopied;
 }

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -264,3 +264,27 @@ public func testPropagationOfConcreteTypeIntoExistential(v: V, x: Int32) {
   }
 }
 
+// Check that we don't attempt to cast an opened type to a concrete
+// type inferred via ProtocolConformanceAnalysis if the type requires
+// reabstraction when erased by an existential.
+protocol ReabstractedP {
+  func f()
+}
+extension Optional : ReabstractedP {
+  func f() {}
+}
+
+// CHECK-LABEL: sil hidden [noinline] @$s34devirt_protocol_method_invocations23testReabstractedWitnessyyAA0F1P_pF : $@convention(thin) (@in_guaranteed ReabstractedP) -> () {
+// CHECK: bb0(%0 : $*ReabstractedP):
+// CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*ReabstractedP to $*@opened([[ID:.*]]) ReabstractedP
+// CHECK: [[WM:%.*]] = witness_method $@opened([[ID]]) ReabstractedP, #ReabstractedP.f!1 : <Self where Self : ReabstractedP> (Self) -> () -> (), [[OPEN]] : $*@opened([[ID]]) ReabstractedP : $@convention(witness_method: ReabstractedP) <τ_0_0 where τ_0_0 : ReabstractedP> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[WM]]<@opened([[ID]]) ReabstractedP>([[OPEN]]) : $@convention(witness_method: ReabstractedP) <τ_0_0 where τ_0_0 : ReabstractedP> (@in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: } // end sil function '$s34devirt_protocol_method_invocations23testReabstractedWitnessyyAA0F1P_pF'
+@inline(never)
+func testReabstractedWitness(_ f: ReabstractedP) {
+  f.f()
+}
+
+public func testReabstracted(f: Optional<()->()>) {
+  testReabstractedWitness(f)
+}


### PR DESCRIPTION
Generalizes the ConcreteExistentialInfo abstraction so it can be used
both by the ExistentialSpecializer and SILCombine.

Splits OpenedArchetypeInfo apart from ConcreteExistentialInfo. Adds a
convenience wrapper around them both, ConcreteOpenedArchetypeInfo, for
use wherever we were originally using ConcreteExistentialInfo. This
allows a large amount of redundant code in ExistentialSpecializer.cpp
to be deleted.

Fixes a latent bug where the ExistentialSpecializer used a SIL
argument index as a function type parameter index (this will show up
if/when we decide to enable calls with indirect results).

There is still a bug where ExistentialSpecializer bit-casts an opened
existential to a concrete type. I'll attempt to fix that bug in a
follow-up PR.

Splits getAddressOfStackInit into getStackInitInst, This is cleaner and
allows both the ExistentialSpecializer and SILCombine to handle more
interesting cases in the future, like unconditional_checked_cast.

Creates utilities, initializeSubstitutionMap, and
initializeConcreteTypeDef to simplify an generalize
ConcreteExistentialInfo.