### PR TITLE
[CSDiag] Account for expression sanitizer mutating AST

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0186-rdar46497155.swift
+++ b/validation-test/compiler_crashers_2_fixed/0186-rdar46497155.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  func isEqual(_ other: P) -> Bool
+}
+
+struct A {
+  var value: P? = nil
+}
+
+struct B {
+  func foo() throws -> A {}
+}
+
+struct E {
+  func getB(_ flag: inout Bool) throws -> B {
+    return B()
+  }
+}
+
+func foo(arr: [E], other: P) -> Bool {
+  return arr.compactMap { i in
+    // expected-error@-1 {{unable to infer complex closure return type; add explicit type to disambiguate}} {{29-29=-> B? }}
+    var flag = false
+    return try? i.getB(&flag)
+  }.compactMap { u -> P? in
+    guard let a = try? u.foo() else { return nil }
+    return a.value!
+  }.contains {
+    $0.isEqual(other)
+  }
+}


### PR DESCRIPTION
After calling `get{Possible}Type{s}WithoutApplying` types have to be
re-cached afterwards because sanitizer (run as part of the constraint
generator) can mutate AST to e.g. re-introduce member references.

Resolves: rdar://problem/46497155

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
