### PR TITLE
[5.0] [Serialization] Only serialize inlinable body text in partial modules

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1345,9 +1345,15 @@ void Serializer::writeGenericRequirements(ArrayRef<Requirement> requirements,
 void Serializer::writeInlinableBodyTextIfNeeded(
   const AbstractFunctionDecl *AFD) {
   using namespace decls_block;
+  // Only serialize the text for an inlinable function body if we're emitting
+  // a partial module. It's not needed in the final module file, but it's
+  // needed in partial modules so you can emit a parseable interface after
+  // merging them.
+  if (!SF) return;
 
   if (AFD->getResilienceExpansion() != swift::ResilienceExpansion::Minimal)
     return;
+
   if (!AFD->hasInlinableBodyText()) return;
   SmallString<128> scratch;
   auto body = AFD->getInlinableBodyText(scratch);

--- a/test/ParseableInterface/fixed-layout-property-initializers.swift
+++ b/test/ParseableInterface/fixed-layout-property-initializers.swift
@@ -1,16 +1,16 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
-// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t.swiftinterface
 
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-resilience %s
-// RUN: %FileCheck %s < %t-resilient.swiftinterface
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t-resilient.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK
 
 // RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK
 
 // CHECK: @_fixed_layout public struct MyStruct {
 @_fixed_layout
@@ -34,7 +34,8 @@ public struct MyStruct {
   // CHECK: @_hasInitialValue public static var staticVar: [[BOOL]]
   public static var staticVar: Bool = Bool(true && false)
 
-  // CHECK: @inlinable internal init() {}
+  // FROMSOURCE: @inlinable internal init() {}
+  // FROMMODULE: @inlinable internal init(){{$}}
   @inlinable init() {}
 }
 
@@ -57,7 +58,8 @@ public class MyClass {
   // CHECK: @_hasInitialValue public static var staticVar: [[BOOL]]
   public static var staticVar: Bool = Bool(true && false)
 
-  // CHECK: @inlinable internal init() {}
+  // FROMSOURCE: @inlinable internal init() {}
+  // FROMMODULE: @inlinable internal init(){{$}}
   @inlinable init() {}
 }
 

--- a/test/ParseableInterface/inlinable-function.swift
+++ b/test/ParseableInterface/inlinable-function.swift
@@ -1,15 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-parseable-module-interface-path %t/Test.swiftinterface -module-name Test %s
-// RUN: %FileCheck %s < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path - -module-name Test | %FileCheck %s
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path %t/TestFromModule.swiftinterface -module-name Test
+// RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
 // CHECK: public struct Foo : Hashable {
 public struct Foo: Hashable {
   // CHECK: public var inlinableGetPublicSet: [[INT:(Swift.)?Int]] {
   public var inlinableGetPublicSet: Int {
-  // CHECK: @inlinable get {
-  // CHECK-NEXT: return 3
-  // CHECK-NEXT: }
+  // FROMSOURCE: @inlinable get {
+  // FROMMODULE: @inlinable get{{$}}
+  // FROMSOURCE-NEXT: return 3
+  // FROMSOURCE-NEXT: }
     @inlinable
     get {
       return 3
@@ -35,11 +37,11 @@ public struct Foo: Hashable {
     // CHECK-NEXT: {{^}}  }
   }
 
-
   // CHECK: @_transparent public var transparent: [[INT]] {
-  // CHECK-NEXT:   get {
-  // CHECK-NEXT:   return 34
-  // CHECK-NEXT: }
+  // FROMMODULE-NEXT: get{{$}}
+  // FROMSOURCE-NEXT: get {
+  // FROMSOURCE-NEXT:   return 34
+  // FROMSOURCE-NEXT: }
   // CHECK-NEXT: }
   @_transparent
   public var transparent: Int {
@@ -52,17 +54,18 @@ public struct Foo: Hashable {
     get {
       return 34
     }
-    // CHECK-NEXT: @_transparent set[[NEWVALUE]] {
-    // CHECK-NOT:   #if false
-    // CHECK-NOT:   print("I should not appear")
-    // CHECK-NOT:   #else
-    // CHECK-NOT:   #if false
-    // CHECK-NOT:   print("I also should not")
-    // CHECK-NOT:   #else
-    // CHECK:       print("I am set to \(newValue)")
-    // CHECK-NOT:   #endif
-    // CHECK-NOT:   #endif
-    // CHECK-NEXT: }
+    // FROMMODULE-NEXT: @_transparent set[[NEWVALUE]]{{$}}
+    // FROMSOURCE-NEXT: @_transparent set[[NEWVALUE]] {
+    // FROMSOURCE-NOT:   #if false
+    // FROMSOURCE-NOT:   print("I should not appear")
+    // FROMSOURCE-NOT:   #else
+    // FROMSOURCE-NOT:   #if false
+    // FROMSOURCE-NOT:   print("I also should not")
+    // FROMSOURCE-NOT:   #else
+    // FROMSOURCE:       print("I am set to \(newValue)")
+    // FROMSOURCE-NOT:   #endif
+    // FROMSOURCE-NOT:   #endif
+    // FROMSOURCE-NEXT: }
     @_transparent
     set {
       #if false
@@ -80,20 +83,22 @@ public struct Foo: Hashable {
   // CHECK: @inlinable public var inlinableProperty: [[INT]] {
   @inlinable
   public var inlinableProperty: Int {
-    // CHECK: get {
-    // CHECK:   return 32
-    // CHECK: }
+    // FROMMODULE:      get{{$}}
+    // FROMSOURCE:      get {
+    // FROMSOURCE-NEXT:   return 32
+    // FROMSOURCE-NEXT: }
     get {
       return 32
     }
 
-    // CHECK: set[[NEWVALUE]] {
-    // CHECK-NOT: #if true
-    // CHECK:     print("I am set to \(newValue)")
-    // CHECK-NOT: #else
-    // CHECK-NOT: print("I should not appear")
-    // CHECK-NOT  #endif
-    // CHECK: }
+    // FROMMODULE: set[[NEWVALUE]]{{$}}
+    // FROMSOURCE: set[[NEWVALUE]] {
+    // FROMSOURCE-NOT: #if true
+    // FROMSOURCE:     print("I am set to \(newValue)")
+    // FROMSOURCE-NOT: #else
+    // FROMSOURCE-NOT: print("I should not appear")
+    // FROMSOURCE-NOT  #endif
+    // FROMSOURCE: }
     set {
       #if true
       print("I am set to \(newValue)")
@@ -107,16 +112,18 @@ public struct Foo: Hashable {
   // CHECK: @inlinable public var inlinableReadAndModify: [[INT]] {
   @inlinable
   public var inlinableReadAndModify: Int {
-    // CHECK: _read {
-    // CHECK-NEXT: yield 0
-    // CHECK-NEXT: }
+    // FROMMODULE:      _read{{$}}
+    // FROMSOURCE:      _read {
+    // FROMSOURCE-NEXT:   yield 0
+    // FROMSOURCE-NEXT: }
     _read {
       yield 0
     }
-    // CHECK: _modify {
-    // CHECK-NEXT: var x = 0
-    // CHECK-NEXT: yield &x
-    // CHECK-NEXT: }
+    // FROMMODULE:      _modify{{$}}
+    // FROMSOURCE:      _modify {
+    // FROMSOURCE-NEXT:   var x = 0
+    // FROMSOURCE-NEXT:   yield &x
+    // FROMSOURCE-NEXT: }
     _modify {
       var x = 0
       yield &x
@@ -126,9 +133,10 @@ public struct Foo: Hashable {
 
   // CHECK: public var inlinableReadNormalModify: [[INT]] {
   public var inlinableReadNormalModify: Int {
-    // CHECK: @inlinable _read {
-    // CHECK-NEXT: yield 0
-    // CHECK-NEXT: }
+    // FROMMODULE: @inlinable _read{{$}}
+    // FROMSOURCE: @inlinable _read {
+    // FROMSOURCE-NEXT: yield 0
+    // FROMSOURCE-NEXT: }
     @inlinable _read {
       yield 0
     }
@@ -153,10 +161,11 @@ public struct Foo: Hashable {
       yield 0
     }
 
-    // CHECK: @inlinable _modify {
-    // CHECK-NEXT: var x = 0
-    // CHECK-NEXT: yield &x
-    // CHECK-NEXT: }
+    // FROMMODULE: @inlinable _modify{{$}}
+    // FROMSOURCE: @inlinable _modify {
+    // FROMSOURCE-NEXT: var x = 0
+    // FROMSOURCE-NEXT: yield &x
+    // FROMSOURCE-NEXT: }
     @inlinable _modify {
       var x = 0
       yield &x
@@ -176,12 +185,13 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: @inlinable public func inlinableMethod() {
-  // CHECK-NOT: #if NO
-  // CHECK-NOT: print("Hello, world!")
-  // CHECK-NOT: #endif
-  // CHECK:     print("Goodbye, world!")
-  // CHECK-NEXT: }
+  // FROMMODULE: @inlinable public func inlinableMethod(){{$}}
+  // FROMSOURCE: @inlinable public func inlinableMethod() {
+  // FROMSOURCE-NOT: #if NO
+  // FROMSOURCE-NOT: print("Hello, world!")
+  // FROMSOURCE-NOT: #endif
+  // FROMSOURCE:     print("Goodbye, world!")
+  // FROMSOURCE-NEXT: }
   @inlinable
   public func inlinableMethod() {
     #if NO
@@ -191,9 +201,10 @@ public struct Foo: Hashable {
   }
 
 
-  // CHECK: @_transparent [[ATTRS:(mutating public|public mutating)]] func transparentMethod() {
-  // CHECK-NEXT:   inlinableProperty = 4
-  // CHECK-NEXT: }
+  // FROMMODULE: @_transparent [[ATTRS:(mutating public|public mutating)]] func transparentMethod(){{$}}
+  // FROMSOURCE: @_transparent [[ATTRS:(mutating public|public mutating)]] func transparentMethod() {
+  // FROMSOURCE-NEXT:   inlinableProperty = 4
+  // FROMSOURCE-NEXT: }
   @_transparent
   mutating public func transparentMethod() {
     inlinableProperty = 4
@@ -207,7 +218,8 @@ public struct Foo: Hashable {
 
   // CHECK: public subscript(i: [[INT]]) -> [[INT]] {
   // CHECK-NEXT:   get{{$}}
-  // CHECK-NEXT:   @inlinable set[[NEWVALUE]] { print("set") }
+  // FROMSOURCE-NEXT:   @inlinable set[[NEWVALUE]] { print("set") }
+  // FROMMODULE-NEXT:   @inlinable set[[NEWVALUE]]{{$}}
   // CHECK-NEXT: }
   public subscript(i: Int) -> Int {
     get { return 0 }
@@ -215,7 +227,8 @@ public struct Foo: Hashable {
   }
 
   // CHECK: public subscript(j: [[INT]], k: [[INT]]) -> [[INT]] {
-  // CHECK-NEXT:   @inlinable get { return 0 }
+  // FROMMODULE-NEXT:   @inlinable get{{$}}
+  // FROMSOURCE-NEXT:   @inlinable get { return 0 }
   // CHECK-NEXT:   set[[NEWVALUE]]{{$}}
   // CHECK-NEXT: }
   public subscript(j: Int, k: Int) -> Int {
@@ -224,8 +237,10 @@ public struct Foo: Hashable {
   }
 
   // CHECK: @inlinable public subscript(l: [[INT]], m: [[INT]], n: [[INT]]) -> [[INT]] {
-  // CHECK-NEXT:   get { return 0 }
-  // CHECK-NEXT:   set[[NEWVALUE]] { print("set") }
+  // FROMMODULE-NEXT:   get{{$}}
+  // FROMSOURCE-NEXT:   get { return 0 }
+  // FROMMODULE-NEXT:   set[[NEWVALUE]]{{$}}
+  // FROMSOURCE-NEXT:   set[[NEWVALUE]] { print("set") }
   // CHECK-NEXT: }
   @inlinable
   public subscript(l: Int, m: Int, n: Int) -> Int {
@@ -233,11 +248,12 @@ public struct Foo: Hashable {
     set { print("set") }
   }
 
-  // CHECK: public init(value: [[INT]]) {
-  // CHECK-NEXT: topLevelUsableFromInline()
-  // CHECK-NEXT: noAccessors = value
-  // CHECK-NEXT: hasDidSet = value
-  // CHECK-NEXT: }
+  // FROMMODULE: @inlinable public init(value: [[INT]]){{$}}
+  // FROMSOURCE: @inlinable public init(value: [[INT]]) {
+  // FROMSOURCE-NEXT: topLevelUsableFromInline()
+  // FROMSOURCE-NEXT: noAccessors = value
+  // FROMSOURCE-NEXT: hasDidSet = value
+  // FROMSOURCE-NEXT: }
   @inlinable public init(value: Int) {
     topLevelUsableFromInline()
     noAccessors = value
@@ -266,9 +282,10 @@ internal func topLevelUsableFromInline() {
   topLevelPrivate()
 }
 
-// CHECK: @inlinable public func topLevelInlinable() {
-// CHECK-NEXT:  topLevelUsableFromInline()
-// CHECK-NEXT: }
+// FROMMODULE: @inlinable public func topLevelInlinable(){{$}}
+// FROMSOURCE: @inlinable public func topLevelInlinable() {
+// FROMSOURCE-NEXT:  topLevelUsableFromInline()
+// FROMSOURCE-NEXT: }
 @inlinable public func topLevelInlinable() {
   topLevelUsableFromInline()
 }
@@ -278,9 +295,10 @@ public class HasInlinableDeinit {
   // CHECK: public init(){{$}}
   public init() {}
 
-  // CHECK: [[OBJC:(@objc )?]]@inlinable deinit {
-  // CHECK-NEXT: print("goodbye")
-  // CHECK-NEXT: }
+  // FROMMODULE: [[OBJC:(@objc )?]]@inlinable deinit{{$}}
+  // FROMSOURCE: [[OBJC:(@objc )?]]@inlinable deinit {
+  // FROMSOURCE-NEXT: print("goodbye")
+  // FROMSOURCE-NEXT: }
   @inlinable deinit {
     print("goodbye")
   }

--- a/test/ParseableInterface/modifiers.swift
+++ b/test/ParseableInterface/modifiers.swift
@@ -1,14 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-parseable-module-interface-path %t/Test.swiftinterface -module-name Test -disable-objc-attr-requires-foundation-module -enable-objc-interop %s
-// RUN: %FileCheck %s < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path - -module-name Test -enable-objc-interop | %FileCheck %s
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path - -module-name Test -enable-objc-interop | %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK
 
 // CHECK-LABEL: final public class FinalClass {
 public final class FinalClass {
   // CHECK: @inlinable final public class var a: [[INT:(Swift.)?Int]] {
-  // CHECK-NEXT: {{^}} get {
-  // CHECK-NEXT: return 3
-  // CHECK-NEXT: }
+  // FROMSOURCE-NEXT: {{^}} get {
+  // FROMSOURCE-NEXT: return 3
+  // FROMSOURCE-NEXT: }
+  // FROMMODULE-NEXT: get{{$}}
   // CHECK-NEXT: }
   @inlinable
   public final class var a: Int {
@@ -16,9 +17,10 @@ public final class FinalClass {
   }
 
   // CHECK: final public class var b: [[INT]] {
-  // CHECK-NEXT:   {{^}} @inlinable get {
-  // CHECK-NEXT:     return 3
-  // CHECK-NEXT:   }
+  // FROMSOURCE-NEXT: {{^}} @inlinable get {
+  // FROMSOURCE-NEXT:   return 3
+  // FROMSOURCE-NEXT: }
+  // FROMMODULE-NEXT: {{^}} @inlinable get{{$}}
   // CHECK-NEXT:   set[[NEWVALUE:(\(newValue\))?]]{{$}}
   // CHECK-NEXT: }
   public final class var b: Int {
@@ -32,7 +34,8 @@ public final class FinalClass {
 
   // CHECK: public static var c: [[INT]] {
   // CHECK-NEXT: {{^}} get
-  // CHECK-NEXT:   @inlinable set[[NEWVALUE]] {}
+  // FROMSOURCE-NEXT:   @inlinable set[[NEWVALUE]] {}
+  // FROMMODULE-NEXT:   @inlinable set[[NEWVALUE]]{{$}}
   // CHECK-NEXT: }
   public static var c: Int {
     get {
@@ -85,7 +88,8 @@ public class SubExplicit: Base {
 public struct MyStruct {
   // CHECK: public var e: [[INT]] {
   // CHECK-NEXT: {{^}} mutating get{{$}}
-  // CHECK-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]] {}
+  // FROMSOURCE-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]] {}
+  // FROMMODULE-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]]{{$}}
   // CHECK-NEXT: }
   public var e: Int {
     mutating get { return 0 }


### PR DESCRIPTION
Since this text is only needed for printing a parseable interface during
a non-whole-module build, only put the text inside partial modules. When
we're merging the modules at the end, skip serializing the text.

rdar://44394186

This is not essential for Swift 5.0, but it does remove a lot of unnecessary source text from the standard library `.swiftmodule`, and it would be unfortunate to ship that if we can avoid it.