### PR TITLE
Minor declaration checker fixes

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4218,7 +4218,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     // Add all of the inherited protocol requirements, recursively.
     auto inheritedReqResult =
       addInheritedRequirements(proto, selfType.getUnresolvedType(), source,
-                               proto->getModuleContext());
+                               /*inferForModule=*/nullptr);
     if (isErrorResult(inheritedReqResult))
       return inheritedReqResult;
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3197,7 +3197,11 @@ void TypeChecker::typeCheckDecl(Decl *D) {
 
 /// Validate the underlying type of the given typealias.
 static void validateTypealiasType(TypeChecker &tc, TypeAliasDecl *typeAlias) {
-  TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
+  TypeResolutionOptions options(
+    (typeAlias->getGenericParams() ?
+     TypeResolverContext::GenericTypeAliasDecl :
+     TypeResolverContext::TypeAliasDecl));
+
   if (!typeAlias->getDeclContext()->isCascadingContextForLookup(
         /*functionsAreNonCascading*/true)) {
      options |= TypeResolutionFlags::KnownNonCascadingDependency;
@@ -4198,7 +4202,10 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
         if (typealias->isBeingValidated()) return;
 
         auto helper = [&] {
-          TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
+          TypeResolutionOptions options(
+            (typealias->getGenericParams() ?
+             TypeResolverContext::GenericTypeAliasDecl :
+             TypeResolverContext::TypeAliasDecl));
           if (validateType(typealias->getUnderlyingTypeLoc(),
                            TypeResolution::forStructural(typealias), options)) {
             typealias->setInvalid();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -710,11 +710,11 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     if (recursivelyVisitGenericParams) {
       visitOuterToInner(genericParams,
                         [&](GenericParamList *gpList) {
-      auto genericParamsDC = gpList->begin()[0]->getDeclContext();
-      TypeResolution structuralResolution =
-        TypeResolution::forStructural(genericParamsDC);
-        checkGenericParamList(*this, &builder, gpList, nullptr,
-                              structuralResolution);
+        auto genericParamsDC = gpList->begin()[0]->getDeclContext();
+        TypeResolution structuralResolution =
+          TypeResolution::forStructural(genericParamsDC);
+          checkGenericParamList(*this, &builder, gpList, nullptr,
+                                structuralResolution);
       });
     } else {
       auto genericParamsDC = genericParams->begin()[0]->getDeclContext();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2914,6 +2914,7 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   case TypeResolverContext::EnumElementDecl:
   case TypeResolverContext::EnumPatternPayload:
   case TypeResolverContext::TypeAliasDecl:
+  case TypeResolverContext::GenericTypeAliasDecl:
   case TypeResolverContext::GenericRequirement:
   case TypeResolverContext::ImmediateOptionalTypeArgument:
   case TypeResolverContext::InExpression:

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -118,8 +118,11 @@ enum class TypeResolverContext : uint8_t {
   /// Whether this is the payload subpattern of an enum pattern.
   EnumPatternPayload,
 
-  /// Whether we are checking the underlying type of a typealias.
+  /// Whether we are checking the underlying type of a non-generic typealias.
   TypeAliasDecl,
+
+  /// Whether we are checking the underlying type of a generic typealias.
+  GenericTypeAliasDecl,
 
   /// Whether we are in a requirement of a generic declaration
   GenericRequirement,
@@ -207,6 +210,7 @@ public:
     case Context::EnumElementDecl:
     case Context::EnumPatternPayload:
     case Context::TypeAliasDecl:
+    case Context::GenericTypeAliasDecl:
     case Context::GenericRequirement:
     case Context::ImmediateOptionalTypeArgument:
     case Context::AbstractFunctionDecl:

--- a/test/decl/protocol/inherited.swift
+++ b/test/decl/protocol/inherited.swift
@@ -12,3 +12,15 @@ protocol Item: (DefaultItem) {}
 func test(item: Item) {
   _ = item.isEnabled
 }
+
+// Don't infer requirements from protocol inheritance clause.
+protocol HasAssoc {
+  associatedtype T
+}
+
+protocol Other {}
+
+typealias Requirements<T> = Other where T : HasAssoc, T.T == Int
+
+protocol Silly : Requirements<Self> { }
+// expected-error@-1 {{type 'Self' does not conform to protocol 'HasAssoc'}}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-struct MyType<TyA, TyB> {
+struct MyType<TyA, TyB> { // expected-note {{generic type 'MyType' declared here}}
   var a : TyA, b : TyB
 }
 
@@ -105,6 +105,9 @@ _ = C(a: 42,        // expected-error {{'Int' is not convertible to 'String'}}
 _ = G(a: "foo", b: 42)
 _ = G<Int, String>(a: "foo", b: 42)
 
+// Generic typealias cannot have unbound generic type.
+typealias VeryBad1<T> = MyType // expected-error {{reference to generic type 'MyType' requires arguments in <...>}}
+typealias VeryBad2<T> = Swift.Array // expected-error {{reference to generic type 'Array' requires arguments in <...>}}
 
 struct MyTypeWithHashable<TyA, TyB : Hashable> {
 }


### PR DESCRIPTION
Ban two language constructs, one causing a crash and one that's simply dubious.