### PR TITLE
[CMake] Require SWIFT_COMPONENT for add_swift_host_tool

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2322,26 +2322,26 @@ function(add_swift_host_tool executable)
       "${ADDSWIFTHOSTTOOL_multiple_parameter_options}" # multi-value args
       ${ARGN})
 
+  precondition(ADDSWIFTHOSTTOOL_SWIFT_COMPONENT
+               MESSAGE "Swift Component is required to add a host tool")
+
   # Create the executable rule.
   add_swift_executable(
     ${executable} 
     ${ADDSWIFTHOSTTOOL_UNPARSED_ARGUMENTS}
   )
 
-  # And then create the install rule if we are asked to.
-  if (ADDSWIFTHOSTTOOL_SWIFT_COMPONENT)
-    swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
-      TARGETS ${executable}
-      RUNTIME DESTINATION bin)
+  swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+    TARGETS ${executable}
+    RUNTIME DESTINATION bin)
 
-    swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
-      is_installing)
-  
-    if(NOT is_installing)
-      set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${executable})
-    else()
-      set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${executable})
-    endif()
+  swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+    is_installing)
+
+  if(NOT is_installing)
+    set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${executable})
+  else()
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${executable})
   endif()
 endfunction()
 

--- a/tools/swift-stdlib-tool/CMakeLists.txt
+++ b/tools/swift-stdlib-tool/CMakeLists.txt
@@ -1,10 +1,6 @@
 add_swift_host_tool(swift-stdlib-tool
-  swift-stdlib-tool.mm)
+  swift-stdlib-tool.mm
+  SWIFT_COMPONENT compiler)
 
 find_library(FOUNDATION NAMES Foundation)
 target_link_libraries(swift-stdlib-tool PRIVATE ${FOUNDATION})
-
-swift_install_in_component(compiler
-    TARGETS swift-stdlib-tool
-    RUNTIME DESTINATION "bin")
-


### PR DESCRIPTION
Previously, all but one instance of `add_swift_host_tool` were specifying a `SWIFT_COMPONENT`. The one that did not (swift-stdlib-tool) was calling `swift_install_in_component` manually. This means that we never were adding swift-stdlib-tool to `SWIFT_EXPORTS` or `SWIFT_BUILDTREE_EXPORTS`.

In this PR I make swift-stdlib-tool specify `SWIFT_COMPONENT` in its `add_swift_host_tool` invocation and remove the manual call to `swift_install_in_component`.
Additionally, I change `add_swift_host_tool` to require a `SWIFT_COMPONENT` so that tool installations are always associated with at least one swift component.