### PR TITLE
Adding support for setting the device id at runtime.

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES
   TensorProtocol.swift
   TensorShape.swift
   Utilities.swift
+  Threading.swift
   # NumPy bridging for `ShapedArray` and `Tensor`.
   NumpyConversion.swift)
 

--- a/stdlib/public/TensorFlow/Threading.swift
+++ b/stdlib/public/TensorFlow/Threading.swift
@@ -1,0 +1,62 @@
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#else
+import Glibc
+#endif
+
+// A thread that runs the provided body.
+class Thread {
+  var thread: pthread_t
+  init(perform body: @escaping () -> ()) {
+    class ThreadArg {
+      var body : () -> ()
+      init(body : @escaping () -> ()) {
+        self.body = body
+      }
+    }
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    typealias ThreadBody = @convention(c)
+      (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer?
+#else
+    typealias ThreadBody = @convention(c)
+      (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
+#endif
+    let threadBody: ThreadBody = { arg in
+      // Set the cancelability of the detached thread.
+      pthread_setcanceltype(Int32(PTHREAD_CANCEL_DEFERRED), nil)
+      // Execute the tensor computation.
+#if !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+      let arg = arg!
+#endif
+      let param: ThreadArg = Unmanaged.fromOpaque(arg).takeRetainedValue()
+      param.body()
+      return nil
+    }
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    var newThread: pthread_t!
+#else
+    var newThread = pthread_t()
+#endif
+    let creationStatus = pthread_create(
+      &newThread, nil, threadBody,
+      Unmanaged.passRetained(ThreadArg(body: body)).toOpaque()
+    )
+    internalConsistencyCheck(creationStatus == 0)
+    self.thread = newThread
+  }
+  func join() {
+    internalConsistencyCheck(pthread_join(thread, nil) == 0)
+  }
+}
+
+public func _runOnNDevices(_ n: Int, perform body: @escaping (Int) -> ()) {
+  var threads = [] as [Thread]
+  for i in 0..<n {
+    threads.append(Thread {
+      body(i)
+    })
+  }
+  for t in threads {
+    t.join()
+  }
+}

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -61,6 +61,21 @@ CollectiveTests.testAllBackends("GroupWithSize2") {
   _hostOp(t)
   expectEqualWithScalarTensor(2, t)
 }
+#else
+CollectiveTests.testAllBackends("GroupWithSize2") {
+  // Need 2 or more CPU devices for this test.
+  let x = Tensor<Float>(1.0)
+
+  _runOnNDevices(2) { i in
+    withDevice(.cpu, UInt(i)) {
+      let t = Raw.collectiveReduce(x, groupSize: 2, groupKey: 2, instanceKey: 2,
+          mergeOp: .add, finalOp: .id, subdivOffsets: [0])
+
+      _hostOp(t)
+      expectEqualWithScalarTensor(2, t)
+    }
+  }
+}
 #endif // TF_DYNAMIC_COMPILATION
 
 _RuntimeConfig.cpuDeviceCount = 3

--- a/test/TensorFlowRuntime/device_placement.swift
+++ b/test/TensorFlowRuntime/device_placement.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+// Test device placement API.
+
+import TensorFlow
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var DevicePlacementTests = TestSuite("DevicePlacement")
+
+DevicePlacementTests.testAllBackends("GroupWithSize2") {
+  // Need 2 or more CPU devices for this test.
+  let x = Tensor<Float>(1.0)
+
+  withDefaultDevice() {
+    let t = Tensor<Float>(1.0) + Tensor<Float>(2.0)
+    expectEqualWithScalarTensor(3, t)
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
The device id is set per-thread. There is still work to be done in order to make this seamlessly work with withDevice() and multiple threads. The state should be essentially cloned when a new thread is started.