### PR TITLE
[Type checker] Allow extensions of typealiases naming generic specializations

### DIFF
--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -30,7 +30,7 @@ extension X<Int, Double, String> {
 
 typealias GGG = X<Int, Double, String>
 
-extension GGG { } // expected-error{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
+extension GGG { } // okay through a typealias
 
 // Lvalue check when the archetypes are not the same.
 struct LValueCheck<T> {

--- a/test/decl/ext/typealias.swift
+++ b/test/decl/ext/typealias.swift
@@ -1,0 +1,80 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Foo<T> {
+  var maybeT: T? { return nil }
+}
+
+extension Foo {
+  struct Bar<U, V> {
+    var maybeT: T? { return nil }
+    var maybeU: U? { return nil }
+    var maybeV: V? { return nil }
+
+    struct Inner {
+      var maybeT: T? { return nil }
+      var maybeU: U? { return nil }
+      var maybeV: V? { return nil }
+    }
+  }
+}
+
+typealias FooInt = Foo<Int>
+
+extension FooInt {
+  func goodT() -> Int {
+    return maybeT!
+  }
+
+  func badT() -> Float {
+    return maybeT! // expected-error{{cannot convert return expression of type 'Int' to return type 'Float'}}
+  }
+}
+
+typealias FooIntBarFloatDouble = Foo<Int>.Bar<Float, Double>
+
+extension FooIntBarFloatDouble {
+  func goodT() -> Int {
+    return maybeT!
+  }
+  func goodU() -> Float {
+    return maybeU!
+  }
+  func goodV() -> Double {
+    return maybeV!
+  }
+
+  func badT() -> Float {
+    return maybeT! // expected-error{{cannot convert return expression of type 'Int' to return type 'Float'}}
+  }
+  func badU() -> Int {
+    return maybeU! // expected-error{{cannot convert return expression of type 'Float' to return type 'Int'}}
+  }
+  func badV() -> Int {
+    return maybeV! // expected-error{{cannot convert return expression of type 'Double' to return type 'Int'}}
+  }
+}
+
+typealias FooIntBarFloatDoubleInner = Foo<Int>.Bar<Float, Double>.Inner
+
+extension FooIntBarFloatDoubleInner {
+  func goodT() -> Int {
+    return maybeT!
+  }
+  func goodU() -> Float {
+    return maybeU!
+  }
+  func goodV() -> Double {
+    return maybeV!
+  }
+
+  func badT() -> Float {
+    return maybeT! // expected-error{{cannot convert return expression of type 'Int' to return type 'Float'}}
+  }
+  func badU() -> Int {
+    return maybeU! // expected-error{{cannot convert return expression of type 'Float' to return type 'Int'}}
+  }
+  func badV() -> Int {
+    return maybeV! // expected-error{{cannot convert return expression of type 'Double' to return type 'Int'}}
+  }
+}
+


### PR DESCRIPTION
When a (non-generic) typealias refers to a specialization of a generic
type, e.g.

```swift
  typealias simd_float3 = SIMD3<Float>
```

treat an extension of the typealias as an extension of the underlying
type with same-type constraints between the generic parameters and the
specific arguments, e.g.,

```swift
  extension simd_float3 { }
```

is treated as

```swift
  extension SIMD3 where Scalar == Float { }
```

This addresses a source-compatibility problem with SE-0229, where
existing types such as simd3_float (which were separate structs)
became specializations of a generic SIMD type.

Fixes rdar://problem/46604664 and rdar://problem/46604370.
