### PR TITLE
stdlib: reorder `add_subdirectory` to repair the Windows build

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1273,7 +1273,7 @@ function(_add_swift_library_single target name)
   # doing so will result in incorrect symbol resolution and linkage.  We created
   # import library targets when the library was added.  Use that to adjust the
   # link libraries.
-  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "WINDOWS")
+  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS AND NOT CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
     foreach(library_list LINK_LIBRARIES INTERFACE_LINK_LIBRARIES PRIVATE_LINK_LIBRARIES)
       set(import_libraries)
       foreach(library ${SWIFTLIB_SINGLE_${library_list}})
@@ -1283,7 +1283,7 @@ function(_add_swift_library_single target name)
         # libraries are only associated with shared libraries, so add an
         # additional check for that as well.
         set(import_library ${library})
-        if(TARGET ${library} AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+        if(TARGET ${library})
           get_target_property(type ${library} TYPE)
           if(${type} STREQUAL "SHARED_LIBRARY")
             set(import_library ${library}_IMPLIB)

--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -6,11 +6,15 @@ if(SWIFT_BUILD_SDK_OVERLAY)
   # SwiftPrivateThreadExtras makes use of Darwin/Glibc, which is part of the
   # SDK overlay. It can't be built separately from the SDK overlay.
   add_subdirectory(RuntimeUnittest)
-  add_subdirectory(StdlibUnittest)
   add_subdirectory(StdlibUnicodeUnittest)
   add_subdirectory(StdlibCollectionUnittest)
   add_subdirectory(SwiftPrivateLibcExtras)
   add_subdirectory(SwiftPrivateThreadExtras)
+
+  # NOTE(compnerd) this must come after SwiftPrivateLibcExtras and
+  # SwiftPrivateThreadExtras to ensure that the dependency targets are setup in
+  # the correct order for Windows.
+  add_subdirectory(StdlibUnittest)
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     add_subdirectory(StdlibUnittestFoundationExtras)


### PR DESCRIPTION
Due to the horrible attrocities against software of the attempt to perform
cross-compilation in the swift build system, we need to emulate the linking
behaviour for Windows with the link against the import library.  The emulation
requires the custom creation of import library targets.  In order to actually
get the linking semantics correct, the dependendency targets must be created
prior to use (unlike standard CMake).  The reordering ensures that we get
correct linkage when building for Windows.

Perform a simple optimization to avoid a number of string comparisions for the
host system.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
