### PR TITLE
[5.0] [Type checker] Allow extensions of typealiases naming generic specializations

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4973,7 +4973,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 static bool isNonGenericTypeAliasType(Type type) {
   // A non-generic typealias can extend a specialized type.
   if (auto *aliasType = dyn_cast<NameAliasType>(type.getPointer()))
-    return aliasType->getDecl()->getGenericContextDepth() == (unsigned)-1;
+    return aliasType->getDecl()->getGenericParamsOfContext() == nullptr;
 
   return false;
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4844,26 +4844,21 @@ static bool isPassThroughTypealias(TypeAliasDecl *typealias) {
 
 /// Form the interface type of an extension from the raw type and the
 /// extension's list of generic parameters.
-static Type formExtensionInterfaceType(TypeChecker &tc, ExtensionDecl *ext,
-                                       Type type,
-                                       GenericParamList *genericParams,
-                                       bool &mustInferRequirements) {
+static Type formExtensionInterfaceType(
+                         TypeChecker &tc, ExtensionDecl *ext,
+                         Type type,
+                         GenericParamList *genericParams,
+                         SmallVectorImpl<std::pair<Type, Type>> &sameTypeReqs,
+                         bool &mustInferRequirements) {
   if (type->is<ErrorType>())
     return type;
 
   // Find the nominal type declaration and its parent type.
-  Type parentType;
-  GenericTypeDecl *genericDecl;
-  if (auto unbound = type->getAs<UnboundGenericType>()) {
-    parentType = unbound->getParent();
-    genericDecl = unbound->getDecl();
-  } else {
-    if (type->is<ProtocolCompositionType>())
-      type = type->getCanonicalType();
-    auto nominalType = type->castTo<NominalType>();
-    parentType = nominalType->getParent();
-    genericDecl = nominalType->getDecl();
-  }
+  if (type->is<ProtocolCompositionType>())
+    type = type->getCanonicalType();
+
+  Type parentType = type->getNominalParent();
+  GenericTypeDecl *genericDecl = type->getAnyGeneric();
 
   // Reconstruct the parent, if there is one.
   if (parentType) {
@@ -4873,7 +4868,7 @@ static Type formExtensionInterfaceType(TypeChecker &tc, ExtensionDecl *ext,
                                  : genericParams;
     parentType =
       formExtensionInterfaceType(tc, ext, parentType, parentGenericParams,
-                                 mustInferRequirements);
+                                 sameTypeReqs, mustInferRequirements);
   }
 
   // Find the nominal type.
@@ -4891,9 +4886,20 @@ static Type formExtensionInterfaceType(TypeChecker &tc, ExtensionDecl *ext,
     resultType = NominalType::get(nominal, parentType,
                                   nominal->getASTContext());
   } else {
+    auto currentBoundType = type->getAs<BoundGenericType>();
+
     // Form the bound generic type with the type parameters provided.
+    unsigned gpIndex = 0;
     for (auto gp : *genericParams) {
-      genericArgs.push_back(gp->getDeclaredInterfaceType());
+      SWIFT_DEFER { ++gpIndex; };
+
+      auto gpType = gp->getDeclaredInterfaceType();
+      genericArgs.push_back(gpType);
+
+      if (currentBoundType) {
+        sameTypeReqs.push_back({gpType,
+                                currentBoundType->getGenericArgs()[gpIndex]});
+      }
     }
 
     resultType = BoundGenericType::get(nominal, parentType, genericArgs);
@@ -4930,8 +4936,9 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Form the interface type of the extension.
   bool mustInferRequirements = false;
+  SmallVector<std::pair<Type, Type>, 4> sameTypeReqs;
   Type extInterfaceType =
-    formExtensionInterfaceType(tc, ext, type, genericParams,
+    formExtensionInterfaceType(tc, ext, type, genericParams, sameTypeReqs,
                                mustInferRequirements);
 
   // Local function used to infer requirements from the extended type.
@@ -4943,6 +4950,13 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
                               extInterfaceType,
                               nullptr,
                               source);
+
+    for (const auto &sameTypeReq : sameTypeReqs) {
+      builder.addRequirement(
+        Requirement(RequirementKind::SameType, sameTypeReq.first,
+                    sameTypeReq.second),
+        source, ext->getModuleContext());
+    }
   };
 
   // Validate the generic type signature.
@@ -4950,9 +4964,18 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
                                          ext->getDeclContext(), nullptr,
                                          /*allowConcreteGenericParams=*/true,
                                          ext, inferExtendedTypeReqs,
-                                         mustInferRequirements);
+                                         (mustInferRequirements ||
+                                            !sameTypeReqs.empty()));
 
   return { env, extInterfaceType };
+}
+
+static bool isNonGenericTypeAliasType(Type type) {
+  // A non-generic typealias can extend a specialized type.
+  if (auto *aliasType = dyn_cast<NameAliasType>(type.getPointer()))
+    return aliasType->getDecl()->getGenericContextDepth() == (unsigned)-1;
+
+  return false;
 }
 
 static void validateExtendedType(ExtensionDecl *ext, TypeChecker &tc) {
@@ -4998,20 +5021,22 @@ static void validateExtendedType(ExtensionDecl *ext, TypeChecker &tc) {
     return;
   }
 
-  // Cannot extend a bound generic type.
-  if (extendedType->isSpecialized()) {
-    tc.diagnose(ext->getLoc(), diag::extension_specialization,
-             extendedType->getAnyNominal()->getName())
+  // Cannot extend function types, tuple types, etc.
+  if (!extendedType->getAnyNominal()) {
+    tc.diagnose(ext->getLoc(), diag::non_nominal_extension, extendedType)
       .highlight(ext->getExtendedTypeLoc().getSourceRange());
     ext->setInvalid();
     ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;
   }
 
-  // Cannot extend function types, tuple types, etc.
-  if (!extendedType->getAnyNominal()) {
-    tc.diagnose(ext->getLoc(), diag::non_nominal_extension, extendedType)
-      .highlight(ext->getExtendedTypeLoc().getSourceRange());
+  // Cannot extend a bound generic type, unless it's referenced via a
+  // non-generic typealias type.
+  if (extendedType->isSpecialized() &&
+      !isNonGenericTypeAliasType(extendedType)) {
+    tc.diagnose(ext->getLoc(), diag::extension_specialization,
+                extendedType->getAnyNominal()->getName())
+    .highlight(ext->getExtendedTypeLoc().getSourceRange());
     ext->setInvalid();
     ext->getExtendedTypeLoc().setInvalidType(tc.Context);
     return;

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -30,7 +30,7 @@ extension X<Int, Double, String> {
 
 typealias GGG = X<Int, Double, String>
 
-extension GGG { } // expected-error{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
+extension GGG { } // okay through a typealias
 
 // Lvalue check when the archetypes are not the same.
 struct LValueCheck<T> {
@@ -209,4 +209,3 @@ extension A.B {
 extension A.B.D {
   func g() { }
 }
-

--- a/test/decl/ext/typealias.swift
+++ b/test/decl/ext/typealias.swift
@@ -1,0 +1,80 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Foo<T> {
+  var maybeT: T? { return nil }
+}
+
+extension Foo {
+  struct Bar<U, V> {
+    var maybeT: T? { return nil }
+    var maybeU: U? { return nil }
+    var maybeV: V? { return nil }
+
+    struct Inner {
+      var maybeT: T? { return nil }
+      var maybeU: U? { return nil }
+      var maybeV: V? { return nil }
+    }
+  }
+}
+
+typealias FooInt = Foo<Int>
+
+extension FooInt {
+  func goodT() -> Int {
+    return maybeT!
+  }
+
+  func badT() -> Float {
+    return maybeT! // expected-error{{cannot convert return expression of type 'Int' to return type 'Float'}}
+  }
+}
+
+typealias FooIntBarFloatDouble = Foo<Int>.Bar<Float, Double>
+
+extension FooIntBarFloatDouble {
+  func goodT() -> Int {
+    return maybeT!
+  }
+  func goodU() -> Float {
+    return maybeU!
+  }
+  func goodV() -> Double {
+    return maybeV!
+  }
+
+  func badT() -> Float {
+    return maybeT! // expected-error{{cannot convert return expression of type 'Int' to return type 'Float'}}
+  }
+  func badU() -> Int {
+    return maybeU! // expected-error{{cannot convert return expression of type 'Float' to return type 'Int'}}
+  }
+  func badV() -> Int {
+    return maybeV! // expected-error{{cannot convert return expression of type 'Double' to return type 'Int'}}
+  }
+}
+
+typealias FooIntBarFloatDoubleInner = Foo<Int>.Bar<Float, Double>.Inner
+
+extension FooIntBarFloatDoubleInner {
+  func goodT() -> Int {
+    return maybeT!
+  }
+  func goodU() -> Float {
+    return maybeU!
+  }
+  func goodV() -> Double {
+    return maybeV!
+  }
+
+  func badT() -> Float {
+    return maybeT! // expected-error{{cannot convert return expression of type 'Int' to return type 'Float'}}
+  }
+  func badU() -> Int {
+    return maybeU! // expected-error{{cannot convert return expression of type 'Float' to return type 'Int'}}
+  }
+  func badV() -> Int {
+    return maybeV! // expected-error{{cannot convert return expression of type 'Double' to return type 'Int'}}
+  }
+}
+


### PR DESCRIPTION
When a (non-generic) typealias refers to a specialization of a generic
type, e.g.

```swift
  typealias simd_float3 = SIMD3<Float>
```

treat an extension of the typealias as an extension of the underlying
type with same-type constraints between the generic parameters and the
specific arguments, e.g.,

```swift
  extension simd_float3 { }
```

is treated as

```swift
  extension SIMD3 where Scalar == Float { }
```

This addresses a source-compatibility problem with SE-0229, where
existing types such as simd3_float (which were separate structs)
became specializations of a generic SIMD type.

Fixes rdar://problem/46604664 and rdar://problem/46604370.
