### PR TITLE
[ParseableInterface] Accept no space after "swift-module-flags:"

### DIFF
--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -562,7 +562,7 @@ llvm::Regex swift::getSwiftInterfaceFormatVersionRegex() {
 }
 
 llvm::Regex swift::getSwiftInterfaceModuleFlagsRegex() {
-  return llvm::Regex("^// " SWIFT_MODULE_FLAGS_KEY ": (.*)$",
+  return llvm::Regex("^// " SWIFT_MODULE_FLAGS_KEY ":(.*)$",
                      llvm::Regex::Newline);
 }
 

--- a/test/ParseableInterface/SmokeTest.swiftinterface
+++ b/test/ParseableInterface/SmokeTest.swiftinterface
@@ -1,5 +1,9 @@
+// The "flags" line in this test deliberately has no flags and no space after
+// the colon, just to make sure that works (even though it'll never be printed
+// that way).
+
+// swift-module-flags:
 // swift-interface-format-version: 1.0
-// swift-module-flags: 
 
 // Make sure parse-only works...
 // RUN: %target-swift-frontend -parse %s


### PR DESCRIPTION
I lost about a minute or so to this with a manually-written swiftinterface, so may as well avoid that problem in the future.