### PR TITLE
[stdlib] tee _stdlib_AtomicInt > SwiftPrivate

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -395,7 +395,7 @@ class _RaceTestSharedState<RT : RaceTestWithPerTrialData> {
   var stopNow = _stdlib_AtomicInt(0)
 
   var trialBarrier: _stdlib_Barrier
-  var trialSpinBarrier: _stdlib_AtomicInt = _stdlib_AtomicInt()
+  var trialSpinBarrier = _stdlib_AtomicInt()
 
   var raceData: [RT.RaceData] = []
   var workerStates: [_RaceTestWorkerState<RT>] = []

--- a/stdlib/private/SwiftPrivate/AtomicInt.swift.gyb
+++ b/stdlib/private/SwiftPrivate/AtomicInt.swift.gyb
@@ -12,6 +12,8 @@
 
 import Swift
 
+// This type intentionally shadows the stdlib one
+@available(swift, introduced: 5.0)
 public final class _stdlib_AtomicInt {
   internal var _value: Int
 
@@ -47,7 +49,7 @@ public final class _stdlib_AtomicInt {
 
   public func compareExchange(expected: inout Int, desired: Int) -> Bool {
     var expectedVar = expected
-    let result = _stdlib_atomicCompareExchangeStrongInt(
+    let result = _swift_stdlib_atomicCompareExchangeStrongInt(
       object: _valuePtr,
       expected: &expectedVar,
       desired: desired)
@@ -55,75 +57,4 @@ public final class _stdlib_AtomicInt {
     return result
   }
 }
-
-public func _swift_stdlib_atomicLoadInt(
-  object target: UnsafeMutablePointer<Int>) -> Int {
-#if arch(i386) || arch(arm)
-  let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
-  return Int(value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  let value = Builtin.atomicload_seqcst_Int64(target._rawValue)
-  return Int(value)
-#endif
-}
-
-public func _swift_stdlib_atomicStoreInt(
-  object target: UnsafeMutablePointer<Int>,
-  desired: Int) {
-#if arch(i386) || arch(arm)
-  Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
-#endif
-}
-
-public func _stdlib_atomicCompareExchangeStrongInt(
-  object target: UnsafeMutablePointer<Int>,
-  expected: UnsafeMutablePointer<Int>,
-  desired: Int) -> Bool {
-#if arch(i386) || arch(arm)
-  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
-    target._rawValue, expected.pointee._value, desired._value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int64(
-    target._rawValue, expected.pointee._value, desired._value)
-#endif
-  expected.pointee._value = oldValue
-  return Bool(won)
-}
-
-% for operation in ['Add', 'And', 'Or', 'Xor']:
-// Warning: no overflow checking.
-public func _swift_stdlib_atomicFetch${operation}Int(
-  object target: UnsafeMutablePointer<Int>,
-  operand: Int) -> Int {
-  let rawTarget = UnsafeMutableRawPointer(target)
-#if arch(i386) || arch(arm)
-  let value = _swift_stdlib_atomicFetch${operation}Int32(
-    object: rawTarget.assumingMemoryBound(to: Int32.self),
-    operand: Int32(operand))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  let value = _swift_stdlib_atomicFetch${operation}Int64(
-    object: rawTarget.assumingMemoryBound(to: Int64.self),
-    operand: Int64(operand))
-#endif
-  return Int(value)
-}
-
-%   for bits in [ 32, 64 ]:
-
-// Warning: no overflow checking.
-public func _swift_stdlib_atomicFetch${operation}Int${bits}(
-  object target: UnsafeMutablePointer<Int${bits}>,
-  operand: Int${bits}) -> Int${bits} {
-
-  let value = Builtin.atomicrmw_${operation.lower()}_seqcst_Int${bits}(
-    target._rawValue, operand._value)
-
-  return Int${bits}(value)
-}
-
-%   end
-
-% end
 

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(swift, deprecated: 4.2, obsoleted: 5.0)
+public final class _stdlib_AtomicInt {
+  internal var _value: Int
+
+  internal var _valuePtr: UnsafeMutablePointer<Int> {
+    return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
+      to: Int.self)
+  }
+
+  public init(_ value: Int = 0) {
+    _value = value
+  }
+
+  public func store(_ desired: Int) {
+    return _swift_stdlib_atomicStoreInt(object: _valuePtr, desired: desired)
+  }
+
+  public func load() -> Int {
+    return _swift_stdlib_atomicLoadInt(object: _valuePtr)
+  }
+
+% for operation_name, operation in [ ('Add', '+'), ('And', '&'), ('Or', '|'), ('Xor', '^') ]:
+  @discardableResult
+  public func fetchAnd${operation_name}(_ operand: Int) -> Int {
+    return _swift_stdlib_atomicFetch${operation_name}Int(
+      object: _valuePtr,
+      operand: operand)
+  }
+
+  public func ${operation_name.lower()}AndFetch(_ operand: Int) -> Int {
+    return fetchAnd${operation_name}(operand) ${operation} operand
+  }
+% end
+
+  public func compareExchange(expected: inout Int, desired: Int) -> Bool {
+    var expectedVar = expected
+    let result = _swift_stdlib_atomicCompareExchangeStrongInt(
+      object: _valuePtr,
+      expected: &expectedVar,
+      desired: desired)
+    expected = expectedVar
+    return result
+  }
+}
+
+@usableFromInline // used by SwiftPrivate._stdlib_AtomicInt
+internal func _swift_stdlib_atomicCompareExchangeStrongInt(
+  object target: UnsafeMutablePointer<Int>,
+  expected: UnsafeMutablePointer<Int>,
+  desired: Int) -> Bool {
+#if arch(i386) || arch(arm) || arch(arm64_32)
+  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
+    target._rawValue, expected.pointee._value, desired._value)
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int64(
+    target._rawValue, expected.pointee._value, desired._value)
+#endif
+  expected.pointee._value = oldValue
+  return Bool(won)
+}
+
+
+@usableFromInline // used by SwiftPrivate._stdlib_AtomicInt
+internal func _swift_stdlib_atomicLoadInt(
+  object target: UnsafeMutablePointer<Int>) -> Int {
+#if arch(i386) || arch(arm) || arch(arm64_32)
+  let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
+  return Int(value)
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  let value = Builtin.atomicload_seqcst_Int64(target._rawValue)
+  return Int(value)
+#endif
+}
+
+@usableFromInline // used by SwiftPrivate._stdlib_AtomicInt
+internal func _swift_stdlib_atomicStoreInt(
+  object target: UnsafeMutablePointer<Int>,
+  desired: Int) {
+#if arch(i386) || arch(arm) || arch(arm64_32)
+  Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
+#endif
+}
+
+% for operation in ['Add', 'And', 'Or', 'Xor']:
+// Warning: no overflow checking.
+@usableFromInline // used by SwiftPrivate._stdlib_AtomicInt
+internal func _swift_stdlib_atomicFetch${operation}Int(
+  object target: UnsafeMutablePointer<Int>,
+  operand: Int) -> Int {
+  let rawTarget = UnsafeMutableRawPointer(target)
+#if arch(i386) || arch(arm)
+  let value = _swift_stdlib_atomicFetch${operation}Int32(
+    object: rawTarget.assumingMemoryBound(to: Int32.self),
+    operand: Int32(operand))
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  let value = _swift_stdlib_atomicFetch${operation}Int64(
+    object: rawTarget.assumingMemoryBound(to: Int64.self),
+    operand: Int64(operand))
+#endif
+  return Int(value)
+}
+
+%   for bits in [ 32, 64 ]:
+
+// Warning: no overflow checking.
+@usableFromInline // used by SwiftPrivate._stdlib_AtomicInt
+internal func _swift_stdlib_atomicFetch${operation}Int${bits}(
+  object target: UnsafeMutablePointer<Int${bits}>,
+  operand: Int${bits}) -> Int${bits} {
+
+  let value = Builtin.atomicrmw_${operation.lower()}_seqcst_Int${bits}(
+    target._rawValue, operand._value)
+
+  return Int${bits}(value)
+}
+
+%   end
+
+% end
+

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SWIFTLIB_ESSENTIAL
   ASCII.swift
   Assert.swift
   AssertCommon.swift
+  AtomicInt.swift.gyb
   BidirectionalCollection.swift
   Bitset.swift
   Bool.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -197,6 +197,7 @@
     "Bitset.swift"
   ],
   "Misc": [
+    "AtomicInt.swift",
     "ErrorType.swift",
     "InputStream.swift",
     "LifetimeManager.swift",

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -115,54 +115,6 @@ func _stdlib_atomicLoadARCRef(
 }
 
 //===----------------------------------------------------------------------===//
-// These pieces are used in ThreadLocalStorage.swift in debug builds.
-// For tests, see similar functions from SwiftPrivate/AtomicInt.swift.gyb
-//===----------------------------------------------------------------------===//
-internal func _swift_stdlib_atomicLoadInt(
-  object target: UnsafeMutablePointer<Int>) -> Int {
-#if arch(i386) || arch(arm)
-  let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
-  return Int(value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  let value = Builtin.atomicload_seqcst_Int64(target._rawValue)
-  return Int(value)
-#endif
-}
-
-% for bits in [ 32, 64 ]:
-
-// Warning: no overflow checking.
-internal func _swift_stdlib_atomicFetchAddInt${bits}(
-  object target: UnsafeMutablePointer<Int${bits}>,
-  operand: Int${bits}) -> Int${bits} {
-
-  let value = Builtin.atomicrmw_add_seqcst_Int${bits}(
-    target._rawValue, operand._value)
-
-  return Int${bits}(value)
-}
-
-% end
-
-// Warning: no overflow checking.
-internal func _swift_stdlib_atomicFetchAddInt(
-  object target: UnsafeMutablePointer<Int>,
-  operand: Int) -> Int {
-  let rawTarget = UnsafeMutableRawPointer(target)
-#if arch(i386) || arch(arm)
-  let value = _swift_stdlib_atomicFetchAddInt32(
-    object: rawTarget.assumingMemoryBound(to: Int32.self),
-    operand: Int32(operand))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  let value = _swift_stdlib_atomicFetchAddInt64(
-    object: rawTarget.assumingMemoryBound(to: Int64.self),
-    operand: Int64(operand))
-#endif
-  return Int(value)
-}
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
 // Conversion of primitive types to `String`
 //===----------------------------------------------------------------------===//
 

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -641,7 +641,7 @@ final public class ForkJoinPool {
   internal let _maxThreads: Int
   /// Total number of threads: number of running threads plus the number of
   /// threads that are preparing to start).
-  internal let _totalThreads: _stdlib_AtomicInt = _stdlib_AtomicInt(0)
+  internal let _totalThreads = _stdlib_AtomicInt(0)
 
   internal var _runningThreads: [_ForkJoinWorkerThread] = []
   internal var _runningThreadsMutex: _ForkJoinMutex = _ForkJoinMutex()

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/PersistentVector.swift
-// RUN: %line-directive %t/PersistentVector.swift -- %target-build-swift -parse-stdlib %t/PersistentVector.swift -o %t/a.out
+// RUN: %line-directive %t/PersistentVector.swift -- %target-build-swift -parse-stdlib -Xfrontend -disable-access-control %t/PersistentVector.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/PersistentVector.swift -- %target-run %t/a.out
 // REQUIRES: executable_test


### PR DESCRIPTION
Turns out some people used this type despite it being prefixed with
`_stdlib_`, so we have to keep it, with an obsoletion message this time.
Second copy of the same type is kept available past Swift 5 in
SwiftPrivate for use in tests.