### PR TITLE
[CSApply] `ExprRewritter` has to make sure that tuple elements are of…

### DIFF
--- a/test/Constraints/rdar46742002.swift
+++ b/test/Constraints/rdar46742002.swift
@@ -1,12 +1,28 @@
 // RUN: %target-typecheck-verify-swift
 
+prefix  operator +++
+postfix operator ---
+
 protocol P : class {}
 
 class F<T> {
   func wait() throws -> T { fatalError() }
 }
 
-func bar(_ a: F<P>, _ b: F<P>) throws {
-  _ = (try  a.wait()) === (try  b.wait()) // Ok
-  _ = (try? a.wait()) === (try? b.wait()) // Ok
+func foo(_ v: AnyObject?) {}
+func bar(_ a: AnyObject?, _ b: AnyObject?) {}
+
+prefix  func +++(_ v: AnyObject?) {}
+postfix func ---(_ v: AnyObject?) {}
+
+func baz(_ a: F<P>, _ b: F<P>) throws {
+  _ = (try  a.wait()) === (try  b.wait())   // Ok
+  _ = (try? a.wait()) === (try? b.wait())   // Ok
+  _ = foo(try? a.wait())                    // Ok
+  _ = foo((try? a.wait()))                  // Ok
+  _ = bar((try? a.wait()), (try? b.wait())) // Ok
+  _ = +++(try? a.wait())                    // Ok
+  _ = +++((try? a.wait()))                  // Ok
+  _ = (try? a.wait())---                    // Ok
+  _ = ((try? a.wait()))---                  // Ok
 }

--- a/test/Constraints/rdar46742002.swift
+++ b/test/Constraints/rdar46742002.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P : class {}
+
+class F<T> {
+  func wait() throws -> T { fatalError() }
+}
+
+func bar(_ a: F<P>, _ b: F<P>) throws {
+  _ = (try  a.wait()) === (try  b.wait()) // Ok
+  _ = (try? a.wait()) === (try? b.wait()) // Ok
+}


### PR DESCRIPTION
… expected type

Problem exposed by SE-0230 - `Flatten nested optionals resulting from 'try?'`

Example:

```swift
protocol P : class {}

class F<T> {
  func wait() throws -> T { fatalError() }
}

func bar(_ a: F<P>, _ b: F<P>) throws {
  _ = (try? a.wait()) === (try? b.wait())
}
```

Here result of `try? {a, b}.wait()` used to be inferred to `P` because
of `OptionalObject` constraint connecting type of `{a, b}.wait()` with
`try?`. Since `OptionalObject` has been replaced with `Conversion`
constraint to avoid introducing new level of optionality it creates
a side-effect of inferring type of `try?` to be `AnyObject?` which
comes from parameter-to-argument conversion.

Resolves: rdar://problem/46742002

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
