### PR TITLE
[SIMD] Add CustomDebugStringConvertible conformance for SIMD types.

### DIFF
--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -109,6 +109,14 @@ public extension SIMD${n} where Scalar : FixedWidthInteger {
   }
 }
 
+extension SIMD${n} : CustomDebugStringConvertible {
+  /// Debug string representation
+  public var debugDescription: String {
+    return "SIMD${n}<\(Scalar.self)>(${', '.join(map(lambda c:
+                       '\\(self['+ str(c) + '])',
+                       xrange(n)))})"
+  }
+}
 
 public extension SIMD${n} where Scalar : BinaryFloatingPoint {
   @inlinable

--- a/test/stdlib/simd.swift.gyb
+++ b/test/stdlib/simd.swift.gyb
@@ -313,5 +313,10 @@ simdTestSuite.test("matrix elements") {
 % end # for type
 }
 
+simdTestSuite.test("debug description") {
+  expectEqual("SIMD2<Float>(1.0, 2.5)",
+    SIMD2<Float>(1.0, 2.5).debugDescription)
+}
+
 runAllTests()
 


### PR DESCRIPTION
The old SIMD types had a conformance to CustomDebugStringConvertible,
but the new ones do not, causing a source compatibility
regression. Add back a CustomDebugStringConvertible conformance.

Fixes rdar://problem/46746829.
