### PR TITLE
Sema: Don't allow generic typealiases to have an unbound generic underlying type

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3197,7 +3197,11 @@ void TypeChecker::typeCheckDecl(Decl *D) {
 
 /// Validate the underlying type of the given typealias.
 static void validateTypealiasType(TypeChecker &tc, TypeAliasDecl *typeAlias) {
-  TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
+  TypeResolutionOptions options(
+    (typeAlias->getGenericParams() ?
+     TypeResolverContext::GenericTypeAliasDecl :
+     TypeResolverContext::TypeAliasDecl));
+
   if (!typeAlias->getDeclContext()->isCascadingContextForLookup(
         /*functionsAreNonCascading*/true)) {
      options |= TypeResolutionFlags::KnownNonCascadingDependency;
@@ -4198,7 +4202,10 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
         if (typealias->isBeingValidated()) return;
 
         auto helper = [&] {
-          TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
+          TypeResolutionOptions options(
+            (typealias->getGenericParams() ?
+             TypeResolverContext::GenericTypeAliasDecl :
+             TypeResolverContext::TypeAliasDecl));
           if (validateType(typealias->getUnderlyingTypeLoc(),
                            TypeResolution::forStructural(typealias), options)) {
             typealias->setInvalid();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2914,6 +2914,7 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   case TypeResolverContext::EnumElementDecl:
   case TypeResolverContext::EnumPatternPayload:
   case TypeResolverContext::TypeAliasDecl:
+  case TypeResolverContext::GenericTypeAliasDecl:
   case TypeResolverContext::GenericRequirement:
   case TypeResolverContext::ImmediateOptionalTypeArgument:
   case TypeResolverContext::InExpression:

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -118,8 +118,11 @@ enum class TypeResolverContext : uint8_t {
   /// Whether this is the payload subpattern of an enum pattern.
   EnumPatternPayload,
 
-  /// Whether we are checking the underlying type of a typealias.
+  /// Whether we are checking the underlying type of a non-generic typealias.
   TypeAliasDecl,
+
+  /// Whether we are checking the underlying type of a generic typealias.
+  GenericTypeAliasDecl,
 
   /// Whether we are in a requirement of a generic declaration
   GenericRequirement,
@@ -207,6 +210,7 @@ public:
     case Context::EnumElementDecl:
     case Context::EnumPatternPayload:
     case Context::TypeAliasDecl:
+    case Context::GenericTypeAliasDecl:
     case Context::GenericRequirement:
     case Context::ImmediateOptionalTypeArgument:
     case Context::AbstractFunctionDecl:

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -298,9 +298,9 @@ extension OuterGeneric.MidGeneric : HasAssocType {
   func takesAssocType(first: D, second: F) {}
 }
 
-typealias OuterGenericMidGeneric<T> = OuterGeneric<T>.MidGeneric
+typealias OuterGenericMidNonGeneric<T> = OuterGeneric<T>.MidNonGeneric
 
-extension OuterGenericMidGeneric {
+extension OuterGenericMidNonGeneric {
 
 }
 

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-struct MyType<TyA, TyB> {
+struct MyType<TyA, TyB> { // expected-note {{generic type 'MyType' declared here}}
   var a : TyA, b : TyB
 }
 
@@ -105,6 +105,9 @@ _ = C(a: 42,        // expected-error {{'Int' is not convertible to 'String'}}
 _ = G(a: "foo", b: 42)
 _ = G<Int, String>(a: "foo", b: 42)
 
+// Generic typealias cannot have unbound generic type.
+typealias VeryBad1<T> = MyType // expected-error {{reference to generic type 'MyType' requires arguments in <...>}}
+typealias VeryBad2<T> = Swift.Array // expected-error {{reference to generic type 'Array' requires arguments in <...>}}
 
 struct MyTypeWithHashable<TyA, TyB : Hashable> {
 }


### PR DESCRIPTION
We allow this sort of thing:

```
struct Generic<T> {}
typealias Alias = Generic
...
Alias<Int>
```

However we have to be sure to ban this if the typealias is itself generic, ie

```
typealias Alias<T> = Generic
```

Otherwise we will crash.