### PR TITLE
Ban one element tuples harder

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -710,11 +710,11 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     if (recursivelyVisitGenericParams) {
       visitOuterToInner(genericParams,
                         [&](GenericParamList *gpList) {
-      auto genericParamsDC = gpList->begin()[0]->getDeclContext();
-      TypeResolution structuralResolution =
-        TypeResolution::forStructural(genericParamsDC);
-        checkGenericParamList(*this, &builder, gpList, nullptr,
-                              structuralResolution);
+        auto genericParamsDC = gpList->begin()[0]->getDeclContext();
+        TypeResolution structuralResolution =
+          TypeResolution::forStructural(genericParamsDC);
+          checkGenericParamList(*this, &builder, gpList, nullptr,
+                                structuralResolution);
       });
     } else {
       auto genericParamsDC = genericParams->begin()[0]->getDeclContext();

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -56,7 +56,7 @@ f5((1,1))
 // Tuples with existentials
 var any : Any = ()
 any = (1, 2)
-any = (label: 4)
+any = (label: 4) // expected-error {{cannot create a single-element tuple with an element label}}
 
 // Scalars don't have .0/.1/etc
 i = j.0 // expected-error{{value of type 'Int' has no member '0'}}
@@ -251,4 +251,12 @@ func f(b: Bool) -> (a: Int, b: String)? {
   let x = 3
   let y = ""
   return b ? (x, y) : nil
+}
+
+// Single element tuple expressions
+func singleElementTuple() {
+  let _ = (label: 123) // expected-error {{cannot create a single-element tuple with an element label}} {{12-19=}}
+  let _ = (label: 123).label // expected-error {{cannot create a single-element tuple with an element label}} {{12-19=}}
+  let _ = ((label: 123)) // expected-error {{cannot create a single-element tuple with an element label}} {{13-20=}}
+  let _ = ((label: 123)).label // expected-error {{cannot create a single-element tuple with an element label}} {{13-20=}}
 }

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -164,9 +164,9 @@ func test5(_ myorigin: CGPoint) {
   // Dot syntax.
   _ = x2.origin.x
   _ = x1.size.area()
-  _ = (r : x1.size).r.area()
+  _ = (r : x1.size).r.area() // expected-error {{cannot create a single-element tuple with an element label}}
   _ = x1.size.area()
-  _ = (r : x1.size).r.area()
+  _ = (r : x1.size).r.area() // expected-error {{cannot create a single-element tuple with an element label}}
   
   _ = x1.area
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
@@ -4,6 +4,6 @@
 
 _ = [
 %for i in range(0, N):
-  (label: "string"),
+  (label: "string", another: 123),
 %end
 ]


### PR DESCRIPTION
We banned single-element tuple types in type position for a long time, eg, `let x: (label: Int)`. However tuple *expressions* with a single-element tuple type were sometimes accepted, and other times caused problems. The behavior was quite varied:

- In Swift 4.1, we rejected `(label: 123)` and `[(label: 123)]`, but curiously accepted `((label: 123))`.
- In Swift 4.2, we accepted both, but rejected `type(of: (label: 123))`.
- On master, `(label: 123)` crashes in SILGen.

Note that the weird behaviors in 4.1 and 4.2 were due to the vestigial tuple-to-scalar and scalar-to-tuple conversions. These are now gone, but the SILGen crash is a result of SILGen not expecting single-element tuples, which break its RValue abstraction.

Since the original intent was to ban this completely, let's diagnose such tuple expressions in the structural diagnostics pass.

Fixes <rdar://problem/30384023>, <rdar://problem/41474370>,
and <https://bugs.swift.org/browse/SR-8109>.