### PR TITLE
Interpreter: mark some tests as REQUIRES: objc_interop

### DIFF
--- a/test/Interpreter/SDK/multi-file-imported-enum.swift
+++ b/test/Interpreter/SDK/multi-file-imported-enum.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -module-name test -whole-module-optimization %s %S/Inputs/multi-file-imported-enum/main.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
-// REQUIRES: executable_test
 
-// XFAIL: linux
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -2,10 +2,11 @@
 // RUN: %target-build-swift -parse-stdlib %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
+
 // REQUIRES: executable_test
+// REQUIRES: objc_interop
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
 
 import Swift
 import SwiftShims

--- a/test/Interpreter/varargs.swift
+++ b/test/Interpreter/varargs.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
-// REQUIRES: executable_test
 
-// XFAIL: linux
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
 
 import Foundation
 


### PR DESCRIPTION
These tests require the ObjC Foundation framework currently (although it
should be possible have them use the swift corelibs Foundation project
to satisfy this requirement).  Marking the tests indicates that these
tests do not have the dependencies to run on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
