### PR TITLE
[SIL] Do not drop inner ExtInfo while rebuilding FunctionTypes

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2713,7 +2713,7 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   // Build the curried function type.
   auto inner =
     CanFunctionType::get(llvm::makeArrayRef(bridgedParams),
-                         bridgedResultType);
+                         bridgedResultType, innerExtInfo);
 
   auto curried =
     CanAnyFunctionType::get(genericSig, {selfParam}, inner, extInfo);


### PR DESCRIPTION
This is really a question in the form of a pull request. Why are we dropping the inner `ExtInfo` here? This seems like a bug.