### PR TITLE
test: add ClangImporter test for _setjmp APINote

### DIFF
--- a/stdlib/public/Platform/visualc.apinotes
+++ b/stdlib/public/Platform/visualc.apinotes
@@ -1,0 +1,7 @@
+---
+Name: VisualC
+Functions:
+- Name: _setjmp
+  Availability: nonswift
+  AvailabilityMsg: 'Functions that return more than once are unavailable in swift'
+

--- a/test/ClangImporter/availability_returns_twice-msvc.swift
+++ b/test/ClangImporter/availability_returns_twice-msvc.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=windows-msvc
+
+import MSVCRT
+typealias JumpBuffer = _JBTYPE
+
+func test_unavailable_returns_twice_function() {
+  var x: JumpBuffer
+  _ = _setjmp(&x) // expected-error {{'_setjmp' is unavailable in Swift: Functions that return more than once are unavailable in swift}}
+}
+

--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -1,13 +1,11 @@
 // RUN: %target-typecheck-verify-swift
+// UNSUPPORTED: OS=windows-msvc
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   import Darwin
   typealias JumpBuffer = Int32
 #elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
   import Glibc
-  typealias JumpBuffer = jmp_buf
-#elseif os(Windows)
-  import MSVCRT
   typealias JumpBuffer = jmp_buf
 #endif
 


### PR DESCRIPTION
This ensures that we do not allow someone to import `_setjmp` on Windows
which is not annotated with `__attribute__((__returns_twice__))` and
cannot be adjusted without assistance from Microsoft.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
