### PR TITLE
[Sema] Warn about tuple shuffles

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4225,6 +4225,14 @@ WARNING(hashvalue_implementation,none,
         "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",
         (Type))
 
+//------------------------------------------------------------------------------
+// MARK: Tuple Shuffle Diagnostics
+//------------------------------------------------------------------------------
+
+WARNING(warn_reordering_tuple_shuffle_deprecated,none,
+        "expression shuffles the elements of this tuple; "
+        "this behavior is deprecated", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/test/Compatibility/tuple_shuffle.swift
+++ b/test/Compatibility/tuple_shuffle.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+func consume<T>(_ x: T) {} // Suppress unused variable warnings
+
+func shuffle_through_initialization() {
+  let a = (x: 1, y: 2)
+  let b: (y: Int, x: Int)
+  b = a // expected-warning {{expression shuffles the elements of this tuple}}
+  consume(b)
+}
+
+func shuffle_through_destructuring() {
+  let a = (x: 1, y: 2)
+  let (y: b, x: c) = a // expected-warning {{expression shuffles the elements of this tuple}}
+  consume((b, c))
+}
+
+func shuffle_through_call() {
+  func foo(_ : (x: Int, y: Int)) {}
+  foo((y: 5, x: 10)) // expected-warning {{expression shuffles the elements of this tuple}}
+}
+
+func shuffle_through_cast() {
+  let x = ((a: Int(), b: Int()) as (b: Int, a: Int)).0 // expected-warning {{expression shuffles the elements of this tuple}}
+  
+  // Ah, the famous double-shuffle
+  let (c1, (c2, c3)): (c: Int, (b: Int, a: Int)) = ((a: Int(), b: Int()), c: Int())
+  // expected-warning@-1 {{expression shuffles the elements of this tuple}}
+  // expected-warning@-2 {{expression shuffles the elements of this tuple}}
+  consume((x, c1, c2, c3))
+}

--- a/test/Constraints/tuple_shuffle.swift
+++ b/test/Constraints/tuple_shuffle.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+func consume<T>(_ x: T) {} // Suppress unused variable warnings
+
+func shuffle_through_initialization() {
+  let a = (x: 1, y: 2)
+  let b: (y: Int, x: Int)
+  b = a // expected-warning {{expression shuffles the elements of this tuple}}
+  consume(b)
+}
+
+func shuffle_through_destructuring() {
+  let a = (x: 1, y: 2)
+  let (y: b, x: c) = a // expected-warning {{expression shuffles the elements of this tuple}}
+  consume((b, c))
+}
+
+func shuffle_through_call() {
+  func foo(_ : (x: Int, y: Int)) {}
+  foo((y: 5, x: 10)) // expected-warning {{expression shuffles the elements of this tuple}}
+}
+
+func shuffle_through_cast() {
+  let x = ((a: Int(), b: Int()) as (b: Int, a: Int)).0 // expected-warning {{expression shuffles the elements of this tuple}}
+
+  // Ah, the famous double-shuffle
+  let (c1, (c2, c3)): (c: Int, (b: Int, a: Int)) = ((a: Int(), b: Int()), c: Int())
+  // expected-warning@-1 {{expression shuffles the elements of this tuple}}
+  // expected-warning@-2 {{expression shuffles the elements of this tuple}}
+  consume((x, c1, c2, c3))
+}

--- a/test/Sema/diag_unowned_immediate_deallocation.swift
+++ b/test/Sema/diag_unowned_immediate_deallocation.swift
@@ -433,7 +433,23 @@ func testInitializationThroughTupleElementDiag() {
   // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-6 {{'c3' declared here}}
 
-  _ = c1; _ = c2; _ = c3
+  unowned let ((c4, c5), c6): ((C, C), C) = ((a: D(), b: C()), c: D())
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c4' is 'unowned'}}
+  // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
+  // expected-note@-3 {{'c4' declared here}}
+  // expected-warning@-4 {{instance will be immediately deallocated because variable 'c5' is 'unowned'}}
+  // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
+  // expected-note@-6 {{'c5' declared here}}
+  // expected-warning@-7 {{instance will be immediately deallocated because variable 'c6' is 'unowned'}}
+  // expected-note@-8 {{a strong reference is required to prevent the instance from being deallocated}}
+  // expected-note@-9 {{'c6' declared here}}
+
+  unowned let c7 = ((C(), C()) as (a: C, b: C)).0
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c7' is 'unowned'}}
+  // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
+  // expected-note@-3 {{'c7' declared here}}
+
+  _ = c1; _ = c2; _ = c3; _ = c4; _ = c5; _ = c6; _ = c7
 }
 
 class E<T> {}
@@ -445,14 +461,6 @@ func testGenericWeakClassDiag() {
   // expected-note@-3 {{'e' declared here}}
 
   _ = e
-}
-
-// The diagnostic doesn't currently support tuple shuffles.
-func testDontDiagnoseThroughTupleShuffles() {
-  unowned let (c1, (c2, c3)): (c: C, (b: C, a: C)) = ((a: D(), b: C()), c: D())
-  unowned let c4 = ((a: C(), b: C()) as (b: C, a: C)).0
-
-  _ = c1; _ = c2; _ = c3; _ = c4
 }
 
 extension Optional {

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -112,7 +112,7 @@ var f2 : (Int) -> Int = (+-+)
 var f3 : (inout Int) -> Int = (-+-) // expected-error{{ambiguous use of operator '-+-'}}
 var f4 : (inout Int, Int) -> Int = (+-+=)
 var r5 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (+, -)
-var r6 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (b : +, a : -)
+var r6 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (b : +, a : -) // expected-warning {{expression shuffles the elements of this tuple}}
 
 struct f6_S {
   subscript(op : (Int, Int) -> Int) -> Int {

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -52,7 +52,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   var b = a.1+a.f
 
   // Tuple expressions with named elements.
-  var i : (y : Int, x : Int) = (x : 42, y : 11)
+  var i : (y : Int, x : Int) = (x : 42, y : 11) // expected-warning {{expression shuffles the elements of this tuple}}
   funcdecl1(123, 444)
   
   // Calls.

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -189,7 +189,7 @@ func test5() {
 
 
   let c: (a: Int, b: Int) = (1,2)
-  let _: (b: Int, a: Int) = c  // Ok, reshuffle tuple.
+  let _: (b: Int, a: Int) = c  // expected-warning {{expression shuffles the elements of this tuple}} 
 }
 
 


### PR DESCRIPTION
Implements @slavapestov's [compromise](https://forums.swift.org/t/deprecating-tuple-shuffles-round-2/16884/30) on tuple shuffles - emit a warning that shuffling behavior is deprecated in all compiler modes.