### PR TITLE
docs: running tests on Windows

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -72,7 +72,17 @@ set swift_source_dir=path-to-directory-containing-all-cloned-repositories
 
 - Set up the `ucrt`, `visualc`, and `WinSDK` modules by copying  `ucrt.modulemap` located at
   `swift/stdlib/public/Platform/ucrt.modulemap` into
-  `${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt` as `module.modulemap`, copying `visualc.modulemap` located at `swift/stdlib/public/Platform/visualc.modulemap` into `${VCToolsInstallDir}/include` as `module.modulemap`, and copying `winsdk.modulemap` located at `swift/stdlib/public/Platform/winsdk.modulemap` into `${UniversalCRTSdkDir}/Include/10.0.107663/um`
+  `${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt` as `module.modulemap`, copying `visualc.modulemap` located at `swift/stdlib/public/Platform/visualc.modulemap` into `${VCToolsInstallDir}/include` as `module.modulemap`, and copying `winsdk.modulemap` located at `swift/stdlib/public/Platform/winsdk.modulemap` into `${UniversalCRTSdkDir}/Include/${UCRTVersion}/um` and setup the `visualc.apinotes` located at `swift/stdlib/public/Platform/visualc.apinotes` into `${VCToolsInstallDir}/include` as `visualc.apinotes`
+
+```cmd
+cd %UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt
+mklink module.modulemap %swift_source_dir%\swift\stdlib\public\Platform\ucrt.modulemap
+cd %VCToolsInstallDir%\include
+mklink module.modulemap %swift_source_dir%\swift\stdlib\public\Platform\visualc.modulemap
+mklink visualc.apinotes %swift_source_dir%\swift\stdlib\public\Platform\visualc.apinotes
+cd %UniversalCRTSdkDir\Include\%UCRTVersion%\um
+mklink module.modulemap %swift_source_dir%\swift\stdlib\public\Platform\winsdk.modulemap
+```
 
 ### 5. Build CMark
 - This must be done from within a developer command prompt. CMark is a fairly
@@ -178,7 +188,16 @@ popd
 cmake --build "%swift_source_dir%/build/Ninja-RelWithDebInfoAssert/lldb-windows-amd64"
 ```
 
-### 9. Install Swift on Windows
+### 9. Running tests on Windows
+
+Running the testsuite on Windows has additional external dependencies.  You must have a subset of the GNUWin32 programs installed and available in your path.  The following packages are currently required:
+
+  1. coreutils
+  2. diffutils
+  3. grep
+  4. sed
+
+### 10. Install Swift on Windows
 
 - Run ninja install:
 ```cmd 


### PR DESCRIPTION
Start documenting how to run the test suite on Windows so that others can easily reproduce the test results.  Document the external dependencies from the test suite.  Since the LLVM test suite depends on the GNUWin32 tools, I believe that this dependency is not too onerous.  Over time, it may be possible to implement more of the functionality in lit to reduce the dependency, but, for now, use the tools to speed up the test suite bring up.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
