### PR TITLE
driver, frontend: add support for the none OS

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -314,6 +314,7 @@ namespace swift {
       } else if (Target.isOSLinux() || Target.isOSFreeBSD() ||
                  Target.isAndroid() || Target.isOSWindows() ||
                  Target.isPS4() || Target.isOSHaiku() ||
+                 Target.isOSUnknown() ||
                  Target.getTriple().empty()) {
         major = minor = revision = 0;
       } else {

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -192,6 +192,8 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     addPlatformConditionValue(PlatformConditionKind::OS, "PS4");
   else if (Target.isOSHaiku())
     addPlatformConditionValue(PlatformConditionKind::OS, "Haiku");
+  else if (Target.isOSUnknown())
+    addPlatformConditionValue(PlatformConditionKind::OS, "None");
   else
     UnsupportedOS = true;
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -115,8 +115,6 @@ static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
 
 StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   switch (triple.getOS()) {
-  case llvm::Triple::UnknownOS:
-    llvm_unreachable("unknown OS");
   case llvm::Triple::Ananas:
   case llvm::Triple::CloudABI:
   case llvm::Triple::DragonFly:
@@ -165,6 +163,8 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     return "ps4";
   case llvm::Triple::Haiku:
     return "haiku";
+  case llvm::Triple::UnknownOS:
+    return "none";
   }
   llvm_unreachable("unsupported OS");
 }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -285,6 +285,8 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
     return llvm::make_unique<toolchains::Windows>(*this, target);
   case llvm::Triple::Haiku:
     return llvm::make_unique<toolchains::GenericUnix>(*this, target);
+  case llvm::Triple::UnknownOS:
+    return llvm::make_unique<toolchains::GenericUnix>(*this, target);
   default:
     Diags.diagnose(SourceLoc(), diag::error_unknown_target,
                    ArgList.getLastArg(options::OPT_target)->getValue());

--- a/test/Driver/baremetal-target.swift
+++ b/test/Driver/baremetal-target.swift
@@ -1,0 +1,5 @@
+// RUN: %swiftc_driver_plain -target aarch64-unknown-none-none -driver-print-jobs %s 2.&1 | %fileCheck %s
+
+// CHECK: {{.*}}swift{{(.exe)?}} -frontend -c
+// CHECK: {{.*}}clang++{{((.exe)?}} -fuse-ld=gold
+


### PR DESCRIPTION
This adds support for the none-OS type allowing swift on a baremetal
target to be possible.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
