### PR TITLE
SE-0110 tuple splatting should not implode argument list with varargs

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2815,11 +2815,7 @@ namespace {
     }
 
     Expr *visitParenExpr(ParenExpr *expr) {
-      auto &ctx = cs.getASTContext();
-      auto pty = cs.getType(expr->getSubExpr());
-      cs.setType(expr, ParenType::get(ctx, pty->getInOutObjectType(),
-                                      ParameterTypeFlags().withInOut(pty->is<InOutType>())));
-      return expr;
+      return simplifyExprType(expr);
     }
 
     Expr *visitTupleExpr(TupleExpr *expr) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3309,25 +3309,17 @@ public:
 /// \param sources Will be populated with information about the source of each
 /// of the elements for the result tuple. The indices into this array are the
 /// indices of the tuple type we're converting to, while the values are
-/// either one of the \c TupleShuffleExpr constants or are an index into the
-/// source tuple.
-///
-/// \param variadicArgs Will be populated with all of the variadic arguments
-/// that will be placed into the variadic tuple element (i.e., at the index
-/// \c where \c consumed[i] is \c TupleShuffleExpr::Variadic). The values
-/// are indices into the source tuple.
+/// an index into the source tuple.
 ///
 /// \returns true if no tuple conversion is possible, false otherwise.
 bool computeTupleShuffle(ArrayRef<TupleTypeElt> fromTuple,
                          ArrayRef<TupleTypeElt> toTuple,
-                         SmallVectorImpl<int> &sources,
-                         SmallVectorImpl<unsigned> &variadicArgs);
+                         SmallVectorImpl<unsigned> &sources);
 static inline bool computeTupleShuffle(TupleType *fromTuple,
                                        TupleType *toTuple,
-                                       SmallVectorImpl<int> &sources,
-                                       SmallVectorImpl<unsigned> &variadicArgs){
+                                       SmallVectorImpl<unsigned> &sources){
   return computeTupleShuffle(fromTuple->getElements(), toTuple->getElements(),
-                             sources, variadicArgs);
+                             sources);
 }
 
 /// Describes the arguments to which a parameter binds.

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1,7 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
-// See test/Compatibility/tuple_arguments_3.swift for the Swift 3 behavior.
-
 func concrete(_ x: Int) {}
 func concreteLabeled(x: Int) {}
 func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'concreteTwo' declared here}}
@@ -1670,7 +1668,6 @@ do {
   func h(_: ()) {} // expected-note {{'h' declared here}}
   h() // expected-error {{missing argument for parameter #1 in call}}
 }
-
 
 // https://bugs.swift.org/browse/SR-7191
 class Mappable<T> {

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1677,3 +1677,9 @@ class Mappable<T> {
 
 let x = Mappable(())
 _ = x.map { (_: Void) in return () }
+
+// https://bugs.swift.org/browse/SR-9470
+do {
+  func f(_: Int...) {}
+  let _ = [(1, 2, 3)].map(f) // expected-error {{cannot invoke 'map' with an argument list of type '((Int...) -> ())'}}
+}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1671,3 +1671,12 @@ do {
   func h(_: ()) {} // expected-note {{'h' declared here}}
   h() // expected-error {{missing argument for parameter #1 in call}}
 }
+
+// https://bugs.swift.org/browse/SR-7191
+class Mappable<T> {
+  init(_: T) { }
+  func map<U>(_ body: (T) -> U) -> U { fatalError() }
+}
+
+let x = Mappable(())
+_ = x.map { (_: Void) in return () }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1680,3 +1680,9 @@ class Mappable<T> {
 
 let x = Mappable(())
 _ = x.map { (_: Void) in return () }
+
+// https://bugs.swift.org/browse/SR-9470
+do {
+  func f(_: Int...) {}
+  let _ = [(1, 2, 3)].map(f) // expected-error {{cannot invoke 'map' with an argument list of type '((Int...) -> ())'}}
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-9470.