### PR TITLE
[semantic-arc-opts] Make sure to only run this pass when optimization…

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -92,7 +92,14 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addAllocBoxToStack();
   P.addNoReturnFolding();
   addDefiniteInitialization(P);
-  if (Options.EnableMandatorySemanticARCOpts) {
+  // Only run semantic arc opts if we are optimizing and if mandatory semantic
+  // arc opts is explicitly enabled.
+  //
+  // NOTE: Eventually this pass will be split into a mandatory/more aggressive
+  // pass. This will happen when OSSA is no longer eliminated before the
+  // optimizer pipeline is run implying we can put a pass that requires OSSA
+  // there.
+  if (Options.EnableMandatorySemanticARCOpts && Options.shouldOptimize()) {
     P.addSemanticARCOpts();
   }
   P.addClosureLifetimeFixup();


### PR DESCRIPTION
… is enabled even though it is running during the mandatory passes (for now).

The idea is that eventually down the line we will split this pass into a
mandatory/performance parts once ownership SSA is eliminated after the
guaranteed passes run. For now though, just run this when optimization is
enabled.

This pass only runs on the stdlib/overlays so far so there shouldn't have been
any slow downs in non-stdlib -Onone builds.
