### PR TITLE
test: improve DebugInfo test coverage on Windows

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -7,7 +7,7 @@
 
 // CHECK-DAG: ![[FOOMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Foo", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[FOOMODULE]]
-// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "Imports.swift", directory: "{{.*}}test/DebugInfo")
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "Imports.swift", directory: "{{.*}}test{{/|\\5C}}DebugInfo")
 // CHECK-DAG: ![[SWIFTFILE:[0-9]+]] = !DIFile(filename: "Swift.swiftmodule"
 // CHECK-DAG: ![[SWIFTMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Swift"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[SWIFTMODULE]]

--- a/test/DebugInfo/ImportsStdlib.swift
+++ b/test/DebugInfo/ImportsStdlib.swift
@@ -11,7 +11,7 @@
 
 // CHECK-DAG: ![[MODULE:[0-9]+]] = !DIModule({{.*}}, name: "NotTheStdlib", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[MODULE]]
-// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "ImportsStdlib.swift", directory: "{{.*}}test/DebugInfo")
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "ImportsStdlib.swift", directory: "{{.*}}test{{/|\\5C}}DebugInfo")
 
 // NEGATIVE-NOT: !DIFile(filename: "Swift.swiftmodule"
 // NEGATIVE-NOT: !DIModule({{.*}}, name: "Swift"

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -19,18 +19,18 @@
 // CHECK-LINETABLES-NOT: DW_TAG_basic_type
 // --------------------------------------------------------------------
 // Now check that we do generate line+scope info with -g.
-// RUN: %target-swift-frontend %s -emit-ir -g -o - \
+// RUN: %target-swift-frontend %/s -emit-ir -g -o - \
 // RUN:   | %FileCheck %s --check-prefixes CHECK,DWARF-CHECK
 // --------------------------------------------------------------------
 // Currently -gdwarf-types should give the same results as -g.
-// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - \
+// RUN: %target-swift-frontend %/s -emit-ir -gdwarf-types -o - \
 // RUN:   | %FileCheck %s --check-prefixes CHECK,DWARF-CHECK
 // --------------------------------------------------------------------
 // Verify that -g -debug-info-format=dwarf gives the same results as -g.
-// RUN: %target-swift-frontend %s -emit-ir -g -debug-info-format=dwarf -o - \
+// RUN: %target-swift-frontend %/s -emit-ir -g -debug-info-format=dwarf -o - \
 // RUN:   | %FileCheck %s --check-prefixes CHECK,DWARF-CHECK
 // --------------------------------------------------------------------
-// RUN: %target-swift-frontend %s -emit-ir -g -debug-info-format=codeview -o - \
+// RUN: %target-swift-frontend %/s -emit-ir -g -debug-info-format=codeview -o - \
 // RUN:   | %FileCheck %s --check-prefixes CHECK,CV-CHECK
 // --------------------------------------------------------------------
 //

--- a/test/DebugInfo/compiler-flags-macosx.swift
+++ b/test/DebugInfo/compiler-flags-macosx.swift
@@ -1,8 +1,9 @@
 // Check that the sdk and resource dirs end up in the debug info if we build for
 // a Darwin target and set the RC_DEBUG_OPTIONS environment variable. This
 // matches the behavior found in Clang.
+
 // RUN: %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck %s
-// RUN: RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
+// RUN: env RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
 // CHECK:               !DICompileUnit({{.*}} producer: "{{(Apple )?Swift version [^"]+}}"
 // CHECK-NOT:                          flags: "
 // CHECK-VAR-SET:       !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"

--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -1,6 +1,7 @@
 // Check that the sdk and resource dirs end up in the debug info if we pass the
 // frontend flag. This tests the general functionality; we test the macosx
 // specific toolchain logic in compiler-flags-macosx.swift.
+
 // RUN: %target-swiftc_driver %s -emit-ir -debug-info-store-invocation -g -o - | %FileCheck %s
 // RUN: %target-swiftc_driver %s -emit-ir -debug-info-store-invocation -sdk "/Weird Location/SDK" -g -o - | %FileCheck --check-prefix CHECK-EXPLICIT %s
 // CHECK:          !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"
@@ -15,6 +16,6 @@
 // CHECK-EXPLICIT-SAME:           -resource-dir 
 
 // Check that we don't write temporary file names in the debug info
-// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -debug-info-store-invocation -o - | %FileCheck --check-prefix CHECK-TEMP %s
+// RUN: env TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -debug-info-store-invocation -o - | %FileCheck --check-prefix CHECK-TEMP %s
 // CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>
 

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -1,4 +1,4 @@
-// RUN: %swiftc_driver -g -debug-prefix-map %S=/var/empty %s -emit-ir -o - | %FileCheck %s
+// RUN: %swiftc_driver -g -debug-prefix-map %/S=/var/empty %/s -emit-ir -o - | %FileCheck %s
 
 func square(_ n: Int) -> Int {
   return n * n

--- a/test/DebugInfo/inlinescopes.swift
+++ b/test/DebugInfo/inlinescopes.swift
@@ -5,7 +5,7 @@
 // RUN: %FileCheck %s < %t.ll
 // RUN: %FileCheck %s -check-prefix=TRANSPARENT-CHECK < %t.ll
 
-// CHECK: define{{( protected)?( signext)?}} i32 @main
+// CHECK: define{{( dllexport)?}}{{( protected)?( signext)?}} i32 @main
 // CHECK: call {{.*}}noinline{{.*}}, !dbg ![[CALL:.*]]
 // CHECK-DAG: ![[TOPLEVEL:.*]] = !DIFile(filename: "inlinescopes.swift"
 

--- a/test/DebugInfo/prologue.swift
+++ b/test/DebugInfo/prologue.swift
@@ -12,4 +12,4 @@ func bar<T, U>(_ x: T, y: U) { markUsed("bar") }
 // prologue and the beginning of the function body.
 // CHECK-NOT: callq	*
 // CHECK: .loc	[[F]] [[@LINE-6]] {{.}}
-// CHECK: callq	{{.*}}builtinStringLiteral
+// CHECK: {{callq	.*builtinStringLiteral|movq __imp_.*builtinStringLiteral}}

--- a/test/DebugInfo/top_level_code.swift
+++ b/test/DebugInfo/top_level_code.swift
@@ -1,13 +1,11 @@
 // RUN: %target-swift-frontend %s -S -g -o - | %FileCheck %s
 
-// XFAIL: linux
-
 func markUsed<T>(_ t: T) {}
-// CHECK: _main:
+// CHECK: {{_?}}main:
 // CHECK-NEXT: Lfunc_begin0:
 // Verify that the top-level function (main) begins at line 0 and then
 // proceeds to the first line.
-// CHECK: .loc    {{[0-9]}} 0 {{[0-9]}} 
+// CHECK: .loc    {{[0-9]}} 0 {{[0-9]}}
 // CHECK-NOT: Lfunc_end0:
 // CHECK: .loc    {{[0-9]}} [[@LINE+1]] {{[0-9]}} prologue_end
 var a = 1

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend %s -g -S -o - | %FileCheck %s --check-prefix ASM-%target-object-format
 // ASM-macho: .section __DWARF,__debug_info
 // ASM-elf: .section .debug_info,"",{{[@%]}}progbits
+// ASM-coff: .section .debug_info,"dr"
 
 // Test variables-interpreter.swift runs this code with `swift -g -i`.
 // Test variables-repl.swift runs this code with `swift -g < variables.swift`.


### PR DESCRIPTION
This makes a number of tests now pass on Windows.  One additional test
should also be repaired on Linux (XFAIL -> PASS).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
