### PR TITLE
Teach SILGen to reabstract @autodiff functions

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -247,11 +247,6 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   // VJP: (T...) -> ((R...),
   //                 (R.CotangentVector...) -> (T.CotangentVector...))
 
-  // RAII that pushes our generic context to `module.Types` so that the calls
-  // `module.Types.getTypeLowering()` below can understand our generic
-  // parameter types.
-  GenericContextScope genericContextScope(module.Types, getGenericSignature());
-
   auto &ctx = getASTContext();
 
   unsigned numParamsWithoutSelf = hasSelfParam() ? getNumParameters() - 1
@@ -410,11 +405,11 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
                                              getResults().end());
     vjpResults.push_back({pullbackType, ResultConvention::Owned});
     auto vjpTy = SILFunctionType::get(getGenericSignature(),
-                                getExtInfo(),
-                                getCoroutineKind(), getCalleeConvention(),
-                                getParameters(), getYields(), vjpResults,
-                                getOptionalErrorResult(), ctx,
-                                getWitnessMethodConformanceOrNone());
+                                      getExtInfo(),
+                                      getCoroutineKind(), getCalleeConvention(),
+                                      getParameters(), getYields(), vjpResults,
+                                      getOptionalErrorResult(), ctx,
+                                      getWitnessMethodConformanceOrNone());
     return vjpTy;
   }
   }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -296,27 +296,44 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   };
 
   // Given a type, returns its formal SIL parameter info.
-  auto getFormalParameterInfo = [&](CanType type) -> SILParameterInfo {
-    auto &typeLowering = module.Types.getTypeLowering(type);
+  auto getParameterInfoForOriginalResult = [&](
+      CanType type, ResultConvention origResConv) -> SILParameterInfo {
     ParameterConvention conv;
-    if (typeLowering.isFormallyPassedIndirectly())
-      conv = ParameterConvention::Indirect_In_Guaranteed;
-    else if (typeLowering.isTrivial())
-      conv = ParameterConvention::Direct_Unowned;
-    else
+    switch (origResConv) {
+    case ResultConvention::Owned:
+    case ResultConvention::Autoreleased:
       conv = ParameterConvention::Direct_Guaranteed;
+      break;
+    case ResultConvention::Unowned:
+    case ResultConvention::UnownedInnerPointer:
+      conv = ParameterConvention::Direct_Unowned;
+      break;
+    case ResultConvention::Indirect:
+      conv = ParameterConvention::Indirect_In_Guaranteed;
+      break;
+    }
     return {type, conv};
   };
   // Given a type, returns its formal SIL result info.
-  auto getFormalResultInfo = [&](CanType type) -> SILResultInfo {
-    auto &typeLowering = module.Types.getTypeLowering(type);
+  auto getResultInfoForOriginalParameter = [&](
+      CanType type, ParameterConvention origParamConv) -> SILResultInfo {
     ResultConvention conv;
-    if (typeLowering.isFormallyReturnedIndirectly())
-      conv = ResultConvention::Indirect;
-    else if (typeLowering.isTrivial())
-      conv = ResultConvention::Unowned;
-    else
+    switch (origParamConv) {
+    case ParameterConvention::Direct_Owned:
+    case ParameterConvention::Direct_Guaranteed:
       conv = ResultConvention::Owned;
+      break;
+    case ParameterConvention::Direct_Unowned:
+      conv = ResultConvention::Unowned;
+      break;
+    case ParameterConvention::Indirect_In:
+    case ParameterConvention::Indirect_Inout:
+    case ParameterConvention::Indirect_In_Constant:
+    case ParameterConvention::Indirect_In_Guaranteed:
+    case ParameterConvention::Indirect_InoutAliasable:
+      conv = ResultConvention::Indirect;
+      break;
+    }
     return {type, conv};
   };
   switch (kind) {
@@ -360,22 +377,30 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
     SmallVector<SILParameterInfo, 8> cotangentParams;
-    cotangentParams.push_back(getFormalParameterInfo(getAssociatedType(
-        getResults()[resultIndex].getType(), cotangentDependentType)));
+    auto &origRes = getResults()[resultIndex];
+    auto cotangentAssocTy = getAssociatedType(
+        origRes.getType(), cotangentDependentType);
+    cotangentParams.push_back(
+        getParameterInfoForOriginalResult(cotangentAssocTy,
+                                          origRes.getConvention()));
     SmallVector<SILResultInfo, 8> cotangentResults;
     if (hasSelfParam() && testParamIndex(numParamsWithoutSelf)) {
       auto &param = getParameters()[numParamsWithoutSelf];
+      auto paramCotangentTy = getAssociatedType(param.getType(),
+                                                cotangentDependentType);
       cotangentResults.push_back(
-          getFormalResultInfo(
-              getAssociatedType(param.getType(), cotangentDependentType)));
+          getResultInfoForOriginalParameter(paramCotangentTy,
+                                            param.getConvention()));
     }
     for (unsigned paramIndex : range(numParamsWithoutSelf)) {
       if (!testParamIndex(paramIndex))
         continue;
       auto &param = getParameters()[paramIndex];
+      auto paramCotangentTy = getAssociatedType(param.getType(),
+                                                cotangentDependentType);
       cotangentResults.push_back(
-          getFormalResultInfo(
-              getAssociatedType(param.getType(), cotangentDependentType)));
+          getResultInfoForOriginalParameter(paramCotangentTy,
+                                            param.getConvention()));
     }
     auto pullbackType = SILFunctionType::get(
         /*genericSignature*/ nullptr, ExtInfo(), SILCoroutineKind::None,
@@ -384,12 +409,13 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
     SmallVector<SILResultInfo, 8> vjpResults(getResults().begin(),
                                              getResults().end());
     vjpResults.push_back({pullbackType, ResultConvention::Owned});
-    return SILFunctionType::get(getGenericSignature(),
+    auto vjpTy = SILFunctionType::get(getGenericSignature(),
                                 getExtInfo(),
                                 getCoroutineKind(), getCalleeConvention(),
                                 getParameters(), getYields(), vjpResults,
                                 getOptionalErrorResult(), ctx,
                                 getWitnessMethodConformanceOrNone());
+    return vjpTy;
   }
   }
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3122,6 +3122,94 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   auto sourceType = fn.getType().castTo<SILFunctionType>();
   auto expectedType = expectedTL.getLoweredType().castTo<SILFunctionType>();
 
+  // SWIFT_ENABLE_TENSORFLOW
+  assert(sourceType->isDifferentiable() == expectedType->isDifferentiable() &&
+         "thunks can't change differentiability");
+
+  // If this is differentiable, then we need to apply a thunk to all the
+  // components. We extract them, apply a thunk to them, and then combine them
+  // back into a bundle.
+  if (sourceType->isDifferentiable()) {
+    // FIXME: The `ManagedValue`s, `forward`s, etc, in here are probably wrong
+    // because I don't understand how they work.
+
+    auto withoutDifferentiableType = [](CanAnyFunctionType type)
+        -> CanAnyFunctionType {
+      return type.withExtInfo(type->getExtInfo().withDifferentiable(false));
+    };
+    auto withoutDifferentiablePattern = [](AbstractionPattern pattern)
+        -> AbstractionPattern {
+      auto patternType = cast<AnyFunctionType>(pattern.getType());
+      pattern.rewriteType(
+          pattern.getGenericSignature(),
+          patternType.withExtInfo(
+              patternType->getExtInfo().withDifferentiable(false)));
+      return pattern;
+    };
+
+    auto inputSubstTypeNotDiff = withoutDifferentiableType(inputSubstType);
+    auto inputOrigTypeNotDiff = withoutDifferentiablePattern(inputOrigType);
+    auto outputSubstTypeNotDiff = withoutDifferentiableType(outputSubstType);
+    auto outputOrigTypeNotDiff = withoutDifferentiablePattern(outputOrigType);
+    auto &expectedTLNotDiff = SGF.getTypeLowering(outputOrigTypeNotDiff,
+                                                  outputSubstTypeNotDiff);
+    ManagedValue original = SGF.emitManagedRValueWithCleanup(
+        SGF.B.createAutoDiffFunctionExtractOriginal(loc, fn.forward(SGF)));
+    ManagedValue originalThunk = createThunk(
+        SGF, loc, original, inputOrigTypeNotDiff, inputSubstTypeNotDiff,
+        outputOrigTypeNotDiff, outputSubstTypeNotDiff, expectedTLNotDiff);
+
+    // TODO: Use parameter indices specified in the funciton type.
+    AutoDiffParameterIndicesBuilder parameterIndicesBuilder(
+        inputSubstType, /*isMethod*/ false, /*setAllParams*/ true);
+    auto *parameterIndices =
+        parameterIndicesBuilder.build(inputSubstType->getASTContext());
+
+    auto getAssocFnTy =
+        [&](CanAnyFunctionType fnTy, AutoDiffAssociatedFunctionKind kind)
+            -> CanAnyFunctionType {
+          auto assocTy = fnTy->getAutoDiffAssociatedFunctionType(
+              parameterIndices, /*resultIndex*/ 0, /*differentiationOrder*/ 1,
+              kind, LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()),
+              /*isMethod*/ false);
+          return cast<AnyFunctionType>(assocTy->getCanonicalType());
+        };
+    auto getAssocFnPattern =
+        [&](AbstractionPattern pattern, AutoDiffAssociatedFunctionKind kind)
+            -> AbstractionPattern {
+          return AbstractionPattern(
+              pattern.getGenericSignature(),
+              getAssocFnTy(cast<AnyFunctionType>(pattern.getType()), kind));
+        };
+    auto createAssocFnThunk = [&](AutoDiffAssociatedFunctionKind kind)
+        -> ManagedValue {
+      auto assocFnInputSubstType = getAssocFnTy(inputSubstTypeNotDiff, kind);
+      auto assocFnInputOrigType = getAssocFnPattern(inputOrigTypeNotDiff,
+                                                    kind);
+      auto assocFnOutputSubstType = getAssocFnTy(outputSubstTypeNotDiff, kind);
+      auto assocFnOutputOrigType = getAssocFnPattern(outputOrigTypeNotDiff,
+                                                     kind);
+      auto &assocFnExpectedTL = SGF.getTypeLowering(assocFnOutputOrigType,
+                                                    assocFnOutputSubstType);
+      auto assocFn = SGF.emitManagedRValueWithCleanup(
+          SGF.B.createAutoDiffFunctionExtract(loc, kind,
+                                              /*differentiationOrder*/ 1,
+                                              fn.forward(SGF)));
+      return createThunk(SGF, loc, assocFn, assocFnInputOrigType,
+                         assocFnInputSubstType, assocFnOutputOrigType,
+                         assocFnOutputSubstType, assocFnExpectedTL);
+    };
+
+    auto jvpThunk = createAssocFnThunk(AutoDiffAssociatedFunctionKind::JVP);
+    auto vjpThunk = createAssocFnThunk(AutoDiffAssociatedFunctionKind::VJP);
+
+    SILValue convertedBundle = SGF.B.createAutoDiffFunction(
+        loc, sourceType->getDifferentiationParameterIndices(),
+        /*differentiationOrder*/ 1, originalThunk.forward(SGF),
+        {jvpThunk.forward(SGF), vjpThunk.forward(SGF)});
+    return SGF.emitManagedRValueWithCleanup(convertedBundle);
+  }
+
   // We can't do bridging here.
   assert(expectedType->getLanguage() ==
          fn.getType().castTo<SILFunctionType>()->getLanguage() &&

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3110,6 +3110,14 @@ CanSILFunctionType SILGenFunction::buildThunkType(
                               getASTContext());
 }
 
+static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
+                                        SILLocation loc,
+                                        ManagedValue fn,
+                                        AbstractionPattern inputOrigType,
+                                        CanAnyFunctionType inputSubstType,
+                                        AbstractionPattern outputOrigType,
+                                        CanAnyFunctionType outputSubstType);
+
 /// Create a reabstraction thunk.
 static ManagedValue createThunk(SILGenFunction &SGF,
                                 SILLocation loc,
@@ -3125,89 +3133,9 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   // SWIFT_ENABLE_TENSORFLOW
   assert(sourceType->isDifferentiable() == expectedType->isDifferentiable() &&
          "thunks can't change differentiability");
-
-  // If this is differentiable, then we need to apply a thunk to all the
-  // components. We extract them, apply a thunk to them, and then combine them
-  // back into a bundle.
   if (sourceType->isDifferentiable()) {
-    // FIXME: The `ManagedValue`s, `forward`s, etc, in here are probably wrong
-    // because I don't understand how they work.
-
-    auto withoutDifferentiableType = [](CanAnyFunctionType type)
-        -> CanAnyFunctionType {
-      return type.withExtInfo(type->getExtInfo().withDifferentiable(false));
-    };
-    auto withoutDifferentiablePattern = [](AbstractionPattern pattern)
-        -> AbstractionPattern {
-      auto patternType = cast<AnyFunctionType>(pattern.getType());
-      pattern.rewriteType(
-          pattern.getGenericSignature(),
-          patternType.withExtInfo(
-              patternType->getExtInfo().withDifferentiable(false)));
-      return pattern;
-    };
-
-    auto inputSubstTypeNotDiff = withoutDifferentiableType(inputSubstType);
-    auto inputOrigTypeNotDiff = withoutDifferentiablePattern(inputOrigType);
-    auto outputSubstTypeNotDiff = withoutDifferentiableType(outputSubstType);
-    auto outputOrigTypeNotDiff = withoutDifferentiablePattern(outputOrigType);
-    auto &expectedTLNotDiff = SGF.getTypeLowering(outputOrigTypeNotDiff,
-                                                  outputSubstTypeNotDiff);
-    ManagedValue original = SGF.emitManagedRValueWithCleanup(
-        SGF.B.createAutoDiffFunctionExtractOriginal(loc, fn.forward(SGF)));
-    ManagedValue originalThunk = createThunk(
-        SGF, loc, original, inputOrigTypeNotDiff, inputSubstTypeNotDiff,
-        outputOrigTypeNotDiff, outputSubstTypeNotDiff, expectedTLNotDiff);
-
-    // TODO: Use parameter indices specified in the funciton type.
-    AutoDiffParameterIndicesBuilder parameterIndicesBuilder(
-        inputSubstType, /*isMethod*/ false, /*setAllParams*/ true);
-    auto *parameterIndices =
-        parameterIndicesBuilder.build(inputSubstType->getASTContext());
-
-    auto getAssocFnTy =
-        [&](CanAnyFunctionType fnTy, AutoDiffAssociatedFunctionKind kind)
-            -> CanAnyFunctionType {
-          auto assocTy = fnTy->getAutoDiffAssociatedFunctionType(
-              parameterIndices, /*resultIndex*/ 0, /*differentiationOrder*/ 1,
-              kind, LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()),
-              /*isMethod*/ false);
-          return cast<AnyFunctionType>(assocTy->getCanonicalType());
-        };
-    auto getAssocFnPattern =
-        [&](AbstractionPattern pattern, AutoDiffAssociatedFunctionKind kind)
-            -> AbstractionPattern {
-          return AbstractionPattern(
-              pattern.getGenericSignature(),
-              getAssocFnTy(cast<AnyFunctionType>(pattern.getType()), kind));
-        };
-    auto createAssocFnThunk = [&](AutoDiffAssociatedFunctionKind kind)
-        -> ManagedValue {
-      auto assocFnInputSubstType = getAssocFnTy(inputSubstTypeNotDiff, kind);
-      auto assocFnInputOrigType = getAssocFnPattern(inputOrigTypeNotDiff,
-                                                    kind);
-      auto assocFnOutputSubstType = getAssocFnTy(outputSubstTypeNotDiff, kind);
-      auto assocFnOutputOrigType = getAssocFnPattern(outputOrigTypeNotDiff,
-                                                     kind);
-      auto &assocFnExpectedTL = SGF.getTypeLowering(assocFnOutputOrigType,
-                                                    assocFnOutputSubstType);
-      auto assocFn = SGF.emitManagedRValueWithCleanup(
-          SGF.B.createAutoDiffFunctionExtract(loc, kind,
-                                              /*differentiationOrder*/ 1,
-                                              fn.forward(SGF)));
-      return createThunk(SGF, loc, assocFn, assocFnInputOrigType,
-                         assocFnInputSubstType, assocFnOutputOrigType,
-                         assocFnOutputSubstType, assocFnExpectedTL);
-    };
-
-    auto jvpThunk = createAssocFnThunk(AutoDiffAssociatedFunctionKind::JVP);
-    auto vjpThunk = createAssocFnThunk(AutoDiffAssociatedFunctionKind::VJP);
-
-    SILValue convertedBundle = SGF.B.createAutoDiffFunction(
-        loc, sourceType->getDifferentiationParameterIndices(),
-        /*differentiationOrder*/ 1, originalThunk.forward(SGF),
-        {jvpThunk.forward(SGF), vjpThunk.forward(SGF)});
-    return SGF.emitManagedRValueWithCleanup(convertedBundle);
+    return createAutoDiffThunk(SGF, loc, fn, inputOrigType, inputSubstType,
+                               outputOrigType, outputSubstType);
   }
 
   // We can't do bridging here.
@@ -3266,6 +3194,100 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   assert(expectedType->isNoEscape());
   return SGF.B.createConvertEscapeToNoEscape(
       loc, thunkedFn, SILType::getPrimitiveObjectType(expectedType), false);
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+/// Create a reabstraction thunk for an @autodiff function.
+static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
+                                        SILLocation loc,
+                                        ManagedValue fn,
+                                        AbstractionPattern inputOrigType,
+                                        CanAnyFunctionType inputSubstType,
+                                        AbstractionPattern outputOrigType,
+                                        CanAnyFunctionType outputSubstType) {
+  // Applies a thunk to all the components by extracting them, applying thunks
+  // to all of them, and then putting them back together.
+
+  // FIXME: The `ManagedValue`s, `forward`s, etc, in here are probably wrong
+  // because I don't understand how they work.
+
+  auto sourceType = fn.getType().castTo<SILFunctionType>();
+
+  auto withoutDifferentiableType = [](CanAnyFunctionType type)
+      -> CanAnyFunctionType {
+    return type.withExtInfo(type->getExtInfo().withDifferentiable(false));
+  };
+  auto withoutDifferentiablePattern = [](AbstractionPattern pattern)
+      -> AbstractionPattern {
+    auto patternType = cast<AnyFunctionType>(pattern.getType());
+    pattern.rewriteType(
+        pattern.getGenericSignature(),
+        patternType.withExtInfo(
+            patternType->getExtInfo().withDifferentiable(false)));
+    return pattern;
+  };
+
+  auto inputSubstTypeNotDiff = withoutDifferentiableType(inputSubstType);
+  auto inputOrigTypeNotDiff = withoutDifferentiablePattern(inputOrigType);
+  auto outputSubstTypeNotDiff = withoutDifferentiableType(outputSubstType);
+  auto outputOrigTypeNotDiff = withoutDifferentiablePattern(outputOrigType);
+  auto &expectedTLNotDiff = SGF.getTypeLowering(outputOrigTypeNotDiff,
+                                                outputSubstTypeNotDiff);
+  ManagedValue original = SGF.emitManagedRValueWithCleanup(
+      SGF.B.createAutoDiffFunctionExtractOriginal(loc, fn.forward(SGF)));
+  ManagedValue originalThunk = createThunk(
+      SGF, loc, original, inputOrigTypeNotDiff, inputSubstTypeNotDiff,
+      outputOrigTypeNotDiff, outputSubstTypeNotDiff, expectedTLNotDiff);
+
+  // TODO: Use parameter indices specified in the function type.
+  AutoDiffParameterIndicesBuilder parameterIndicesBuilder(
+      inputSubstType, /*isMethod*/ false, /*setAllParams*/ true);
+  auto *parameterIndices =
+      parameterIndicesBuilder.build(inputSubstType->getASTContext());
+
+  auto getAssocFnTy =
+      [&](CanAnyFunctionType fnTy, AutoDiffAssociatedFunctionKind kind)
+          -> CanAnyFunctionType {
+        auto assocTy = fnTy->getAutoDiffAssociatedFunctionType(
+            parameterIndices, /*resultIndex*/ 0, /*differentiationOrder*/ 1,
+            kind, LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()),
+            /*isMethod*/ false);
+        return cast<AnyFunctionType>(assocTy->getCanonicalType());
+      };
+  auto getAssocFnPattern =
+      [&](AbstractionPattern pattern, AutoDiffAssociatedFunctionKind kind)
+          -> AbstractionPattern {
+        return AbstractionPattern(
+            pattern.getGenericSignature(),
+            getAssocFnTy(cast<AnyFunctionType>(pattern.getType()), kind));
+      };
+  auto createAssocFnThunk = [&](AutoDiffAssociatedFunctionKind kind)
+      -> ManagedValue {
+    auto assocFnInputSubstType = getAssocFnTy(inputSubstTypeNotDiff, kind);
+    auto assocFnInputOrigType = getAssocFnPattern(inputOrigTypeNotDiff,
+                                                  kind);
+    auto assocFnOutputSubstType = getAssocFnTy(outputSubstTypeNotDiff, kind);
+    auto assocFnOutputOrigType = getAssocFnPattern(outputOrigTypeNotDiff,
+                                                   kind);
+    auto &assocFnExpectedTL = SGF.getTypeLowering(assocFnOutputOrigType,
+                                                  assocFnOutputSubstType);
+    auto assocFn = SGF.emitManagedRValueWithCleanup(
+        SGF.B.createAutoDiffFunctionExtract(loc, kind,
+                                            /*differentiationOrder*/ 1,
+                                            fn.forward(SGF)));
+    return createThunk(SGF, loc, assocFn, assocFnInputOrigType,
+                       assocFnInputSubstType, assocFnOutputOrigType,
+                       assocFnOutputSubstType, assocFnExpectedTL);
+  };
+
+  auto jvpThunk = createAssocFnThunk(AutoDiffAssociatedFunctionKind::JVP);
+  auto vjpThunk = createAssocFnThunk(AutoDiffAssociatedFunctionKind::VJP);
+
+  SILValue convertedBundle = SGF.B.createAutoDiffFunction(
+      loc, sourceType->getDifferentiationParameterIndices(),
+      /*differentiationOrder*/ 1, originalThunk.forward(SGF),
+      {jvpThunk.forward(SGF), vjpThunk.forward(SGF)});
+  return SGF.emitManagedRValueWithCleanup(convertedBundle);
 }
 
 static CanSILFunctionType buildWithoutActuallyEscapingThunkType(

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4782,6 +4782,8 @@ void DifferentiationTask::createVJP() {
       // This assumes that the primal direct results correspond exactly to the
       // adjoint's direct parameters, an assumption that we check in assertions
       // above.
+      builder.createRetainValue(loc, primalDirectResults[dirResIdx],
+                                builder.getDefaultAtomicity());
       partialAdjointArgs.push_back(primalDirectResults[dirResIdx++]);
     } else {
       // This assumes that the primal indirect results correspond exactly to the
@@ -4792,8 +4794,10 @@ void DifferentiationTask::createVJP() {
   }
 
   // Add original parameters.
-  for (auto arg : vjp->getArgumentsWithoutIndirectResults())
+  for (auto arg : vjp->getArgumentsWithoutIndirectResults()) {
+    builder.createRetainValue(loc, arg, builder.getDefaultAtomicity());
     partialAdjointArgs.push_back(arg);
+  }
 
   // Get and partially apply the adjoint.
   auto *adjointRef = builder.createFunctionRef(loc, adjoint);

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4795,7 +4795,10 @@ void DifferentiationTask::createVJP() {
 
   // Add original parameters.
   for (auto arg : vjp->getArgumentsWithoutIndirectResults()) {
-    builder.createRetainValue(loc, arg, builder.getDefaultAtomicity());
+    if (arg->getType().isObject())
+      builder.createRetainValue(loc, arg, builder.getDefaultAtomicity());
+    else
+      builder.createRetainValueAddr(loc, arg, builder.getDefaultAtomicity());
     partialAdjointArgs.push_back(arg);
   }
 

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4797,8 +4797,9 @@ void DifferentiationTask::createVJP() {
   for (auto arg : vjp->getArgumentsWithoutIndirectResults()) {
     if (arg->getType().isObject())
       builder.createRetainValue(loc, arg, builder.getDefaultAtomicity());
-    else
-      builder.createRetainValueAddr(loc, arg, builder.getDefaultAtomicity());
+    // TODO: We need to copy address arguments into a Box, and give the Box to
+    // the adjoint. We'll need to wrap the adjoint in a function that projects
+    // Boxes to acheive this.
     partialAdjointArgs.push_back(arg);
   }
 

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -13,8 +13,8 @@ func apply() {
 
 // CHECK-AST-LABEL:  (func_decl {{.*}} "myfunction(_:)"
 // CHECK-AST:          (return_stmt
-// CHECK-AST-NEXT:       (autodiff_function_extract_original implicit type='(Float) -> Float'
-// CHECK-AST-NEXT:         (function_conversion_expr implicit type='@autodiff (Float) -> Float'
+// CHECK-AST-NEXT:       (function_conversion_expr implicit type='(Float) -> Float'
+// CHECK-AST-NEXT:         (autodiff_function_extract_original implicit type='(Float) -> (Float)'
 // CHECK-AST-NEXT:           (declref_expr type='@autodiff (Float) -> (Float)'
 // CHECK-AST-LABEL:  (func_decl {{.*}} "apply()"
 // CHECK-AST:          (autodiff_function implicit type='@autodiff (Float) -> (Float)'

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -13,12 +13,12 @@ func apply() {
 
 // CHECK-AST-LABEL:  (func_decl {{.*}} "myfunction(_:)"
 // CHECK-AST:          (return_stmt
-// CHECK-AST-NEXT:       (function_conversion_expr implicit type='(Float) -> Float'
-// CHECK-AST-NEXT:         (autodiff_function_extract_original implicit type='(Float) -> (Float)'
+// CHECK-AST-NEXT:       (autodiff_function_extract_original implicit type='(Float) -> Float'
+// CHECK-AST-NEXT:         (function_conversion_expr implicit type='@autodiff (Float) -> Float'
 // CHECK-AST-NEXT:           (declref_expr type='@autodiff (Float) -> (Float)'
 // CHECK-AST-LABEL:  (func_decl {{.*}} "apply()"
-// CHECK-AST:          (function_conversion_expr implicit type='@autodiff (Float) -> (Float)'
-// CHECK-AST-NEXT:       (autodiff_function implicit type='@autodiff (Float) -> Float'
+// CHECK-AST:          (autodiff_function implicit type='@autodiff (Float) -> (Float)'
+// CHECK-AST-NEXT:       (function_conversion_expr implicit type='(Float) -> (Float)'
 // CHECK-AST-NEXT:         (declref_expr type='(Float) -> Float'
 
 // CHECK-SIL-LABEL: @{{.*}}myfunction{{.*}}

--- a/test/AutoDiff/bad_reabstraction.swift
+++ b/test/AutoDiff/bad_reabstraction.swift
@@ -1,0 +1,47 @@
+// RUN: not --crash %target-swift-frontend -parse-stdlib -emit-sil %s 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+import Swift
+
+protocol FloatTangent : Differentiable
+  where TangentVector == Float, CotangentVector == Float {}
+
+func gradient<T: Differentiable, R: FloatTangent>(
+  of f: @autodiff (T) -> R, at x: T
+) -> T.CotangentVector {
+  fatalError("unimplemented")
+}
+
+extension Float : FloatTangent {}
+
+func example(_ x: Float) -> Float {
+  return x
+}
+
+func test<T: FloatTangent>(_ x: T) {
+  let _ = gradient(of: example, at: 1)
+}
+
+// CHECK: SIL verification failed: Unexpected JVP function type: expectedJVPType == jvpType
+
+// Ideally, the above code would compile and work correctly. This test
+// documents the current non-ideal SIL verification failure.
+//
+// The reabstraction thunk for passing `example` into `gradient` fails SIL
+// verification. The reabstracted function types are:
+//
+//  original: $@noescape @callee_guaranteed (@in_guaranteed Float) -> @out Float
+//  JVP: @noescape @callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> Float)
+//  VJP: @noescape @callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (Float) -> @out Float)
+//
+// However, when these get bundled together, SIL verification expects that the
+// associated function types are:
+//
+//  JVP: @noescape @callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)
+//  VJP: @noescape @callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)
+//
+// This happens because SIL verification only looks at the reabstracted
+// original function type when determining the expected reabstracted associated
+// function types, and the reabstracted original function type does not have
+// enough information to precisely determine how the associated fuctions have
+// been reabstracted.

--- a/test/AutoDiff/builtin_differential_operators.swift
+++ b/test/AutoDiff/builtin_differential_operators.swift
@@ -1,9 +1,5 @@
 // RUN: %target-run-simple-parse-stdlib-swift
 // REQUIRES: executable_test
-// XFAIL: *
-
-// FIXME(rxwei): The proper fix here is to make `convert_escaping_to_noescape` work
-// on differentiable functions.
 
 import Swift
 import StdlibUnittest

--- a/test/AutoDiff/differential_operators.swift
+++ b/test/AutoDiff/differential_operators.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-parse-stdlib-swift
 // REQUIRES: executable_test
-// XFAIL: *
 
 import Swift
 import StdlibUnittest
@@ -14,9 +13,6 @@ func valueWithPullback<T, R>(
   where T : Differentiable, R : Differentiable {
   return Builtin.autodiffApplyVJP(f, x)
 }
-
-// FIXME(rxwei): It's crashing because the compiler does not know how to emit reabstraction
-// thunks for @autodiff functions yet.
 
 BuiltinDifferentialOperatorTests.test("Trivial") {
   let t = 1.0


### PR DESCRIPTION
This PR teaches SILGen to reabstract `@autodiff` functions by splitting them into their components, reabstracting all the components, and then putting them back together again. cc @slavapestov for your thoughts on this approach.

I pulled in some additional fixes from @rxwei:
1. rxwei@372748e: Update autodiff-associated function type calculation to work with abstraction thunks.
2. rxwei@fe47c71: Add a conversion rule for convert_function where the converted function has `@noescape`.
3. rxwei@ed8e7d0: Retain arguments before partial_apply, fixing a crasher.

I also switched the order of `autodiff_function` and `function_conversion_expr` in CSApply, to work around the problem where we can't convert escaping `@autodiff` functions to noescape.

As a result of these changes, differential operators work, so I enabled the tests.