### PR TITLE
platform: widen winsdk modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -12,9 +12,33 @@
 
 module WinSDK [system] [extern_c] {
   module core {
+    // api-ms-win-core-errhandling-l1-1-0.dll
+    module errhandling {
+      header "errhandlingapi.h"
+      export *
+    }
+
+    // api-ms-win-core-file-l1-1-0.dll
+    module file {
+      header "fileapi.h"
+      export *
+    }
+
     // api-ms-win-core-handle-l1-1-0.dll
     module handle {
       header "handleapi.h"
+      export *
+    }
+
+    // api-ms-win-core-libloader-l1-1-0.dll
+    module libloader {
+      header "libloaderapi.h"
+      export *
+    }
+
+    // api-ms-win-core-namedpipe-l1-1-2-0.dll
+    module namedpipe {
+      header "namedpipeapi.h"
       export *
     }
 


### PR DESCRIPTION
Add NamedPipe API Set for LibcExtras.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
