### PR TITLE
attr: fix test on Windows

### DIFF
--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -18,7 +18,11 @@ var computed: Int {
 
 struct SwiftStruct { var x, y: Int }
 enum SwiftEnum { case A, B }
+#if os(Windows) && arch(x86_64)
+@objc enum CEnum: Int32 { case A, B }
+#else
 @objc enum CEnum: Int { case A, B }
+#endif
 
 @_cdecl("swiftStruct")
 func swiftStruct(x: SwiftStruct) {} // expected-error{{cannot be represented}} expected-note{{Swift struct}}


### PR DESCRIPTION
`Int` on Windows x86_64 is different from `Int` on other targets due to
it being a LLP64 target.  Explicitly use the `Int32` type for the
enumeration to fix the test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
