### PR TITLE
SwiftPrivate: fix dependencies on Windows

### DIFF
--- a/stdlib/private/SwiftPrivate/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivate/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   IO.swift
   ShardedAtomicCounter.swift
 
+  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
   SWIFT_COMPILE_FLAGS ${swift_swiftprivate_compile_flags}
   INSTALL_IN_COMPONENT stdlib-experimental)
 


### PR DESCRIPTION
This module needs MSVCRT and WinSDK on Windows.  Track the dependencies.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
