### PR TITLE
simplify conversions between AutoDiffAssociatedFunctionKind <-> Extractee

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7659,6 +7659,9 @@ public:
     Extractee(AutoDiffAssociatedFunctionKind kind);
     explicit Extractee(StringRef name);
     operator innerty() const { return rawValue; }
+
+    Optional<AutoDiffAssociatedFunctionKind>
+    getExtracteeAsAssociatedFunction() const;
   };
 
 private:
@@ -7684,12 +7687,9 @@ public:
   }
 
   AutoDiffAssociatedFunctionKind getAssociatedFunctionKind() const {
-    assert(extractee != Extractee::Original);
-    switch (extractee) {
-    case Extractee::JVP: return AutoDiffAssociatedFunctionKind::JVP;
-    case Extractee::VJP: return AutoDiffAssociatedFunctionKind::VJP;
-    case Extractee::Original: llvm_unreachable("Cannot be Original");
-    }
+    auto kind = extractee.getExtracteeAsAssociatedFunction();
+    assert(kind);
+    return *kind;
   }
 
   SILValue getFunctionOperand() const {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3652,17 +3652,10 @@ getWitnessFunctionRef(SILGenFunction &SGF,
           /*isMethod*/ true);
       auto autoDiffFn = SGF.B.createAutoDiffFunction(
           loc, loweredIndices, /*differentiationOrder*/ 1, originalFn);
-      AutoDiffFunctionExtractInst::Extractee extractee;
-      switch (autoDiffFuncId->getKind()) {
-      case AutoDiffAssociatedFunctionKind::JVP:
-        extractee = AutoDiffFunctionExtractInst::Extractee::JVP;
-        break;
-      case AutoDiffAssociatedFunctionKind::VJP:
-        extractee = AutoDiffFunctionExtractInst::Extractee::VJP;
-        break;
-      }
       return SGF.B.createAutoDiffFunctionExtract(
-          loc, extractee, /*differentiationOrder*/ 1, autoDiffFn);
+          loc,
+          AutoDiffFunctionExtractInst::Extractee(autoDiffFuncId->getKind()),
+          /*differentiationOrder*/ 1, autoDiffFn);
     }
 
     return SGF.emitGlobalFunctionRef(loc, witness);


### PR DESCRIPTION
Defines a new utility function for converting Extractee -> AutoDiffAssociatedFunctionKind. Uses it in one place. Also changes another place to use an existing AutoDiffAssociatedFunctionKind -> Extractee utility.

I did this while working on a separate PR but it turned out to be unnecessary for that PR. I think it's a nice refactoring anyways, so I have split it out into its own PR.