### PR TITLE
[CMake] Fix up and fill out swift exports.

### DIFF
--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,19 +1,66 @@
 set(SWIFT_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/swift)
 set(swift_cmake_builddir "${SWIFT_BINARY_DIR}/${SWIFT_INSTALL_PACKAGE_DIR}")
 
-# Generate build-tree exports list only
-set(SWIFT_EXPORTS_FILE ${swift_cmake_builddir}/SwiftExports.cmake)
+# Exports for those who want to build against an installed Swift
+set(SWIFT_EXPORTS_FILE "${swift_cmake_builddir}/SwiftExports.cmake")
 get_property(SWIFT_EXPORTS GLOBAL PROPERTY SWIFT_EXPORTS)
+export(TARGETS ${SWIFT_EXPORTS} FILE ${SWIFT_EXPORTS_FILE})
+
+# Export targets that are only available when building against a Swift build
+# tree
+set(SWIFT_BUILDTREE_EXPORTS_FILE "${swift_cmake_builddir}/SwiftBuildTreeExports.cmake")
 get_property(SWIFT_BUILDTREE_EXPORTS GLOBAL PROPERTY SWIFT_BUILDTREE_EXPORTS)
+export(TARGETS ${SWIFT_BUILDTREE_EXPORTS} FILE ${SWIFT_BUILDTREE_EXPORTS_FILE})
 
-set(SWIFT_CONFIG_EXPORTS ${SWIFT_EXPORTS} ${SWIFT_BUILDTREE_EXPORTS})
-export(TARGETS ${SWIFT_CONFIG_EXPORTS} FILE ${SWIFT_EXPORTS_FILE})
-
-
-set(SWIFT_INCLUDE_DIRS ${SWIFT_INCLUDE_DIR} ${SWIFT_MAIN_INCLUDE_DIR})
-set(SWIFT_LIBRARY_DIRS ${SWIFT_LIBRARY_OUTPUT_INTDIR})
+# Generate SwiftConfig.cmake for the build tree
+set(SWIFT_CONFIG_EXPORTS "${SWIFT_EXPORTS};${SWIFT_BUILDTREE_EXPORTS}")
+set(SWIFT_CONFIG_EXPORTS_FILE "${SWIFT_EXPORTS_FILE}")
+set(SWIFT_CONFIG_BINARY_DIR "${SWIFT_BINARY_DIR}")
+set(SWIFT_CONFIG_INCLUDE_DIRS
+  "${SWIFT_INCLUDE_DIR}"
+  "${SWIFT_MAIN_INCLUDE_DIR}"
+)
+set(SWIFT_CONFIG_INCLUDE_DIR "${SWIFT_INCLUDE_DIR}")
+set(SWIFT_CONFIG_LIBRARY_DIRS "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
+set(SWIFT_CONFIG_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(swift_config_include_buildtree_exports
+"include(\"${SWIFT_BUILDTREE_EXPORTS_FILE}\")")
 
 configure_file(
   SwiftConfig.cmake.in
   ${swift_cmake_builddir}/SwiftConfig.cmake
   @ONLY)
+set(swift_config_include_buildtree_exports)
+
+# Generate SwiftConfig.cmake for the install tree
+set(SWIFT_CONFIG_CODE
+"# Compute the installation prefix from this SwiftConfig.cmake location.
+get_filename_component(SWIFT_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)")
+# Construct the proper number of get_filename_component(... PATH)
+# calls to compute the installation prefix.
+file(TO_CMAKE_PATH "${SWIFT_INSTALL_PACKAGE_DIR}" SWIFT_INSTALL_PACKAGE_DIR)
+string(REGEX REPLACE "/" ";" _count "${SWIFT_INSTALL_PACKAGE_DIR}")
+foreach(p ${_count})
+  set(SWIFT_CONFIG_CODE "${SWIFT_CONFIG_CODE}
+get_filename_component(SWIFT_INSTALL_PREFIX \"\${SWIFT_INSTALL_PREFIX}\" PATH)")
+endforeach(p)
+set(SWIFT_CONFIG_BINARY_DIR "\${SWIFT_INSTALL_PREFIX}")
+set(SWIFT_CONFIG_CMAKE_DIR "\${SWIFT_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}")
+set(SWIFT_CONFIG_EXPORTS "${SWIFT_EXPORTS}")
+set(SWIFT_CONFIG_EXPORTS_FILE "\${SWIFT_CMAKE_DIR}/SwiftExports.cmake")
+set(SWIFT_CONFIG_INCLUDE_DIRS "\${SWIFT_INSTALL_PREFIX}/include")
+set(SWIFT_CONFIG_LIBRARY_DIRS "\${SWIFT_INSTALL_PREFIX}/lib\${LLVM_LIBDIR_SUFFIX}")
+configure_file(
+  SwiftConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/SwiftConfig.cmake
+  @ONLY)
+
+if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  get_property(swift_has_exports GLOBAL PROPERTY SWIFT_HAS_EXPORTS)
+  if(swift_has_exports)
+    install(EXPORT SwiftExports DESTINATION ${SWIFT_INSTALL_PACKAGE_DIR})
+  endif()
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/SwiftConfig.cmake
+    DESTINATION ${SWIFT_INSTALL_PACKAGE_DIR})
+endif()

--- a/cmake/modules/SwiftConfig.cmake.in
+++ b/cmake/modules/SwiftConfig.cmake.in
@@ -5,17 +5,17 @@
 set(SWIFT_VERSION @SWIFT_VERSION@)
 set(SWIFT_MAIN_SRC_DIR @SWIFT_SOURCE_DIR@)
 
-set(SWIFT_INCLUDE_DIRS "@SWIFT_INCLUDE_DIRS@")
+set(SWIFT_INCLUDE_DIRS "@SWIFT_CONFIG_INCLUDE_DIRS@")
 set(SWIFT_LIBRARY_DIRS "@SWIFT_CONFIG_LIBRARY_DIRS@")
 
 # These variables are duplicated, but they must match the LLVM variables of the
 # same name. The variables ending in "S" could some day become lists, and are
 # preserved for convention and compatibility.
-set(SWIFT_INCLUDE_DIR "@SWIFT_INCLUDE_DIRS@")
+set(SWIFT_INCLUDE_DIR "@SWIFT_CONFIG_INCLUDE_DIRS@")
 set(SWIFT_LIBRARY_DIR "@SWIFT_CONFIG_LIBRARY_DIRS@")
 
-set(SWIFT_CMAKE_DIR "@SWIFT_CMAKE_DIR@")
-set(SWIFT_BINARY_DIR "@SWIFT_BINARY_DIR@")
+set(SWIFT_CMAKE_DIR "@SWIFT_CONFIG_CMAKE_DIR@")
+set(SWIFT_BINARY_DIR "@SWIFT_CONFIG_BINARY_DIR@")
 
 set(CMARK_TARGETS_FILE @SWIFT_PATH_TO_CMARK_BUILD@/src/CMarkExports.cmake)
 if(NOT TARGET libcmark_static AND EXISTS ${CMARK_TARGETS_FILE})
@@ -24,5 +24,6 @@ endif()
 
 if(NOT TARGET swift)
   set(SWIFT_EXPORTED_TARGETS "@SWIFT_CONFIG_EXPORTS@")
-  include("@SWIFT_EXPORTS_FILE@")
+  include("@SWIFT_CONFIG_EXPORTS_FILE@")
+  @swift_config_include_buildtree_exports@
 endif()


### PR DESCRIPTION
This PR accomplishes the following:
1. Split up `SWIFT_EXPORTS` and `SWIFT_BUILDTREE_EXPORTS` in the same fashion that LLVM/Clang does. That is, they have separate export files so that we can have a `SwiftExport.cmake` that doesn't have targets that are not intended to be exported at installation.
2. Generate `SwiftConfig.cmake` for both the build tree and the install tree. This is also what LLVM/Clang does.

This also fixes some minor bugs:
1. Fixes a bug in generating SwiftConfig.cmake where `SWIFT_LIBRARY_DIRS` wasn't being set correctly because `SWIFT_CONFIG_LIBRARY_DIRS` was never set.
2. In SwiftConfig.cmake.in, `SWIFT_INCLUDE_DIR` and `SWIFT_INCLUDE_DIRS` were subtly different.