### PR TITLE
[5.0] [String] Last-minute ABI adjustment: 4-bit discriminator

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -134,9 +134,9 @@ _swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
-                                         _swift_shims_UInt8 *_Nonnull buffer,
-                                         _swift_shims_CFIndex maxLength,
-                                         unsigned long encoding);
+                                           _swift_shims_UInt8 *_Nonnull buffer,
+                                           _swift_shims_CFIndex maxLength,
+                                           unsigned long encoding);
 
 SWIFT_RUNTIME_STDLIB_API
 __swift_uintptr_t

--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -134,7 +134,7 @@ _swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
-                                         _swift_shims_UInt8 *buffer,
+                                         _swift_shims_UInt8 *_Nonnull buffer,
                                          _swift_shims_CFIndex maxLength,
                                          unsigned long encoding);
 

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -105,13 +105,10 @@ extension _SmallString {
 
   // Give raw, nul-terminated code units. This is only for limited internal
   // usage: it always clears the discriminator and count (in case it's full)
-  @inlinable
+  @inlinable @inline(__always)
   internal var zeroTerminatedRawCodeUnits: RawBitPattern {
-    @inline(__always) get {
-      return (
-        self._storage.0,
-        self._storage.1 & _StringObject.Nibbles.largeAddressMask)
-    }
+    let smallStringCodeUnitMask: UInt64 = 0x00FF_FFFF_FFFF_FFFF
+    return (self._storage.0, self._storage.1 & smallStringCodeUnitMask)
   }
 
   internal func computeIsASCII() -> Bool {
@@ -239,6 +236,7 @@ extension _SmallString {
     _internalInvariant(trailing & countAndDiscriminator == 0)
 
     self.init(raw: (leading, trailing | countAndDiscriminator))
+    _internalInvariant(self.count == count)
   }
 
   // Direct from UTF-8

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -72,18 +72,9 @@ extension _SmallString {
     }
   }
 
-  @inlinable
-  internal var discriminator: _StringObject.Discriminator {
-    @inline(__always) get {
-      let value = _storage.1 &>> _StringObject.Nibbles.discriminatorShift
-      return _StringObject.Discriminator(UInt8(truncatingIfNeeded: value))
-    }
-    @inline(__always) set {
-      _storage.1 &= _StringObject.Nibbles.largeAddressMask
-      _storage.1 |= (
-        UInt64(truncatingIfNeeded: newValue._value)
-          &<< _StringObject.Nibbles.discriminatorShift)
-    }
+  @inlinable @inline(__always)
+  internal var rawDiscriminatedObject: UInt64 {
+    return _storage.1
   }
 
   @inlinable
@@ -96,7 +87,7 @@ extension _SmallString {
   @inlinable
   internal var count: Int {
     @inline(__always) get {
-      return discriminator.smallCount
+      return _StringObject.getSmallCount(fromRaw: rawDiscriminatedObject)
     }
   }
 
@@ -108,7 +99,7 @@ extension _SmallString {
   @inlinable
   internal var isASCII: Bool {
     @inline(__always) get {
-      return discriminator.smallIsASCII
+      return _StringObject.getSmallIsASCII(fromRaw: rawDiscriminatedObject)
     }
   }
 
@@ -123,12 +114,10 @@ extension _SmallString {
     }
   }
 
-  @inlinable
   internal func computeIsASCII() -> Bool {
-    // TODO(String micro-performance): Evaluate other expressions, e.g. | first
     let asciiMask: UInt64 = 0x8080_8080_8080_8080
     let raw = zeroTerminatedRawCodeUnits
-    return (raw.0 & asciiMask == 0) && (raw.1 & asciiMask == 0)
+    return (raw.0 | raw.1) & asciiMask == 0
   }
 }
 
@@ -220,7 +209,7 @@ extension _SmallString {
 
   // Overwrite stored code units, including uninitialized. `f` should return the
   // new count.
-  @inlinable @inline(__always)
+  @inline(__always)
   internal mutating func withMutableCapacity(
     _ f: (UnsafeMutableBufferPointer<UInt8>) throws -> Int
   ) rethrows {
@@ -231,14 +220,27 @@ extension _SmallString {
       return try f(UnsafeMutableBufferPointer(
         start: ptr, count: _SmallString.capacity))
     }
-
     _internalInvariant(len <= _SmallString.capacity)
-    discriminator = .small(withCount: len, isASCII: self.computeIsASCII())
+
+    let (leading, trailing) = self.zeroTerminatedRawCodeUnits
+    self = _SmallString(leading: leading, trailing: trailing, count: len)
   }
 }
 
 // Creation
 extension _SmallString {
+  @inlinable @inline(__always)
+  internal init(leading: UInt64, trailing: UInt64, count: Int) {
+    _internalInvariant(count <= _SmallString.capacity)
+
+    let isASCII = (leading | trailing) & 0x8080_8080_8080_8080 == 0
+    let countAndDiscriminator = UInt64(truncatingIfNeeded: count) &<< 56
+                              | _StringObject.Nibbles.small(isASCII: isASCII)
+    _internalInvariant(trailing & countAndDiscriminator == 0)
+
+    self.init(raw: (leading, trailing | countAndDiscriminator))
+  }
+
   // Direct from UTF-8
   @inlinable @inline(__always)
   internal init?(_ input: UnsafeBufferPointer<UInt8>) {
@@ -251,11 +253,7 @@ extension _SmallString {
     let leading = _bytesToUInt64(ptr, Swift.min(input.count, 8))
     let trailing = count > 8 ? _bytesToUInt64(ptr + 8, count &- 8) : 0
 
-    let isASCII = (leading | trailing) & 0x8080_8080_8080_8080 == 0
-    let discriminator = _StringObject.Discriminator.small(
-      withCount: count,
-      isASCII: isASCII)
-    self.init(raw: (leading, trailing | discriminator.rawBits))
+    self.init(leading: leading, trailing: trailing, count: count)
   }
 
   @usableFromInline // @testable
@@ -273,13 +271,8 @@ extension _SmallString {
     }
     _internalInvariant(writeIdx == totalCount)
 
-    let isASCII = base.isASCII && other.isASCII
-    let discriminator = _StringObject.Discriminator.small(
-      withCount: totalCount,
-      isASCII: isASCII)
-
     let (leading, trailing) = result.zeroTerminatedRawCodeUnits
-    self.init(raw: (leading, trailing | discriminator.rawBits))
+    self.init(leading: leading, trailing: trailing, count: totalCount)
   }
 }
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -281,9 +281,13 @@ extension String {
       }
     }
     if _guts._object.isImmortal {
+      // TODO: We'd rather emit a valid ObjC object statically than create a
+      // shared string class instance.
+      let gutsCountAndFlags = _guts._object._countAndFlags
       return _SharedStringStorage(
         immortal: _guts._object.fastUTF8.baseAddress!,
-        countAndFlags: _guts._object._countAndFlags)
+        countAndFlags: _StringObject.CountAndFlags(
+          sharedCount: _guts.count, isASCII: gutsCountAndFlags.isASCII))
     }
 
     _internalInvariant(_guts._object.hasObjCBridgeableObject,

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -61,8 +61,7 @@ extension _StringGuts {
   }
 
   internal init(_ storage: _SharedStringStorage) {
-    // TODO(cleanup): We should probably pass whole perf flags struct around
-    self.init(_StringObject(storage, isASCII: false))
+    self.init(_StringObject(storage))
   }
 
   internal init(
@@ -109,18 +108,15 @@ extension _StringGuts {
     @inline(__always) get { return isFastUTF8 && _object.isASCII }
   }
 
-  @inlinable
-  internal var isNFC: Bool  {
-    @inline(__always) get { return _object.isNFC }
-  }
+  @inline(__always)
+  internal var isNFC: Bool { return _object.isNFC }
 
-  @inlinable
-  internal var isNFCFastUTF8: Bool  {
+  @inline(__always)
+  internal var isNFCFastUTF8: Bool {
     // TODO(String micro-performance): Consider a dedicated bit for this
-    @inline(__always) get { return _object.isNFC && isFastUTF8 }
+    return _object.isNFC && isFastUTF8
   }
 
-  @inlinable
   internal var hasNativeStorage: Bool { return _object.hasNativeStorage }
 
   internal var hasSharedStorage: Bool { return _object.hasSharedStorage }

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -396,7 +396,8 @@ extension _StringStorage {
     capacity: Int,
     isASCII: Bool
   ) -> _StringStorage {
-    let countAndFlags = CountAndFlags(count: bufPtr.count, isASCII: isASCII)
+    let countAndFlags = CountAndFlags(
+      mortalCount: bufPtr.count, isASCII: isASCII)
     _internalInvariant(capacity >= bufPtr.count)
     let storage = _StringStorage.create(
       capacity: capacity, countAndFlags: countAndFlags)
@@ -497,6 +498,8 @@ extension _StringStorage {
     if let crumbs = _breadcrumbsAddress.pointee {
       crumbs._invariantCheck(for: self.asString)
     }
+    _internalInvariant(_countAndFlags.isNativelyStored)
+    _internalInvariant(_countAndFlags.isTailAllocated)
   }
   #endif // INTERNAL_CHECKS_ENABLED
 }
@@ -507,7 +510,7 @@ extension _StringStorage {
   @_effects(releasenone)
   private func _postRRCAdjust(newCount: Int, newIsASCII: Bool) {
     let countAndFlags = CountAndFlags(
-      count: newCount, isASCII: newIsASCII)
+      mortalCount: newCount, isASCII: newIsASCII)
 #if arch(i386) || arch(arm)
     self._count = countAndFlags.count
     self._flags = countAndFlags.flags
@@ -794,6 +797,8 @@ extension _SharedStringStorage {
       crumbs._invariantCheck(for: self.asString)
     }
     _countAndFlags._invariantCheck()
+    _internalInvariant(!_countAndFlags.isNativelyStored)
+    _internalInvariant(!_countAndFlags.isTailAllocated)
   }
 #endif // INTERNAL_CHECKS_ENABLED
 }

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -60,13 +60,13 @@ extension _StringGuts {
 
     // TODO: shared native
     _internalInvariant(_object.providesFastUTF8)
-    _internalInvariant(_object.largeFastIsNative)
     if _object.isImmortal {
       result._form = ._immortal(
         address: UInt(bitPattern: _object.nativeUTF8Start))
       return result
     }
     if _object.hasNativeStorage {
+      _internalInvariant(_object.largeFastIsTailAllocated)
       result._form = ._native(object: _object.nativeStorage)
       return result
     }

--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -39,11 +39,11 @@ public func singleNonAsciiChar() -> Character {
 }
 
 // NOTE: -9223372036854775808 = 0x80 = immortal large discrim
-// NOTE: 25 = length in UTF-8 code units
+// NOTE: 1152921504606847001 = 25 (code unit length) | `isTailAllocated` perf flag
 //
 // CHECK-LABEL: define {{.*}}singleNonSmolChar
 // CHECK-NEXT: entry:
-// CHECK:   ret { i64, %swift.bridge* } { i64 25, %swift.bridge* {{.*}}@0{{.*}}i64 -9223372036854775808
+// CHECK:   ret { i64, %swift.bridge* } { i64 1152921504606847001, %swift.bridge* {{.*}}@0{{.*}}i64 -9223372036854775808
 public func singleNonSmolChar() -> Character {
   return "👩‍👩‍👦‍👦"
 }

--- a/test/SILOptimizer/concat_string_literals.64.swift
+++ b/test/SILOptimizer/concat_string_literals.64.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck %s
 // RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // We have a separate test for 32-bit architectures.
 // REQUIRES: PTRSIZE=64
@@ -33,9 +34,9 @@ public func test_strng_strng2() -> String {
   return "aé" + "def"
 }
 
-// NOTE: 43 = code-unit length
+// NOTE: 1152921504606847019 = 43 (code-unit length) | `isTailAllocated` perf flag
 // CHECK-LABEL: test_scalar_strng
-// CHECK:  ret { i64, %swift.bridge* } { i64 43, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
+// CHECK:  ret { i64, %swift.bridge* } { i64 1152921504606847019, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
 public func test_scalar_strng() -> String {
   return "a" + "👨🏿‍💼+🧙🏿‍♂️=🕴🏿"
 }
@@ -47,9 +48,9 @@ public func test_strng_concat_smol() -> String {
   return "a" + "bc" + "dèf" + "ghī"
 }
 
-// NOTE: 23 = code-unit length
+// NOTE: 1152921504606846999 = 23 (code-unit length) | `isTailAllocated` perf flag
 // CHECK-LABEL test_strng_concat_large
-// CHECK:  ret { i64, %swift.bridge* } { i64 23, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
+// CHECK:  ret { i64, %swift.bridge* } { i64 1152921504606846999, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
 public func test_strng_concat_large() -> String {
   return "a" + "bc" + "dèf" + "ghī" + "jklmn" + "o" + "𝛒qr"
 }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -602,3 +602,20 @@ Func MutableCollection.withContiguousMutableStorageIfAvailable(_:) has been adde
 Func Sequence.withContiguousStorageIfAvailable(_:) has been added as a protocol requirement
 
 Func Strideable....(_:_:) has been removed
+
+Func _SmallString.computeIsASCII() has been removed
+Func _SmallString.withMutableCapacity(_:) has been removed
+Struct _StringObject.Discriminator has been removed
+Var _SmallString.discriminator has been removed
+Var _StringObject.CountAndFlags._storage has declared type change from UInt to UInt64
+Var _StringObject.CountAndFlags.countMask has declared type change from UInt to UInt64
+Var _StringObject.CountAndFlags.countMask is now static
+Var _StringObject.CountAndFlags.flagsMask has declared type change from UInt to UInt64
+Var _StringObject.CountAndFlags.flagsMask is now static
+Var _StringObject.Nibbles.discriminatorMask has been removed
+Var _StringObject.Nibbles.discriminatorShift has been removed
+Var _StringObject.discriminator has been removed
+Var _StringObject.objectRawBits has been renamed to Var _StringObject.discriminatedObjectRawBits
+Var _StringObject.undiscriminatedObjectRawBits has been removed
+
+

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -612,10 +612,24 @@ Var _StringObject.CountAndFlags.countMask has declared type change from UInt to 
 Var _StringObject.CountAndFlags.countMask is now static
 Var _StringObject.CountAndFlags.flagsMask has declared type change from UInt to UInt64
 Var _StringObject.CountAndFlags.flagsMask is now static
-Var _StringObject.Nibbles.discriminatorMask has been removed
 Var _StringObject.Nibbles.discriminatorShift has been removed
 Var _StringObject.discriminator has been removed
 Var _StringObject.objectRawBits has been renamed to Var _StringObject.discriminatedObjectRawBits
 Var _StringObject.undiscriminatedObjectRawBits has been removed
 
+Constructor _StringObject.CountAndFlags.init(count:) has been removed
+Constructor _StringObject.CountAndFlags.init(count:isASCII:) has been removed
+Func _StringObject.Nibbles.largeSharedMortal() has been removed
+Var _StringGuts.hasNativeStorage has been removed
+Var _StringGuts.isNFC has been removed
+Var _StringGuts.isNFCFastUTF8 has been removed
+Var _StringObject.hasNativeStorage has been removed
+Var _StringObject.isNFC has been removed
+Var _StringObject.largeFastIsNative has been removed
 
+Var _StringObject.largeFastIsShared has been removed
+Var _StringObject.largeIsCocoa has been removed
+Var _StringObject.objCBridgeableObject has been removed
+
+Var _StringObject._countAndFlags is no longer a stored property
+Var _StringObject._countAndFlagsBits is added to a non-resilient type

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -218,3 +218,6 @@ Func MutableCollection.withContiguousMutableStorageIfAvailable(_:) has been adde
 Func Sequence.withContiguousStorageIfAvailable(_:) has been added as a protocol requirement
 
 Func Strideable....(_:_:) has been removed
+
+Struct Discriminator has been removed
+

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -34,12 +34,10 @@ reflect(object: obj)
 // CHECK-64-NEXT:           (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:             (field name=_object offset=0
 // CHECK-64-NEXT:               (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
-// CHECK-64-NEXT:                 (field name=_countAndFlags offset=0
+// CHECK-64-NEXT:                 (field name=_countAndFlagsBits offset=0
 // CHECK-64-NEXT:                   (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64-NEXT:                     (field name=_storage offset=0
-// CHECK-64-NEXT:                       (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64-NEXT:                         (field name=_value offset=0
-// CHECK-64-NEXT:                           (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64-NEXT:                     (field name=_value offset=0
+// CHECK-64-NEXT:                       (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:                 (field name=_object offset=8
 // CHECK-64-NEXT:                   (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))))))))
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -132,12 +132,10 @@ reflect(object: obj)
 // CHECK-64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_object offset=0
 // CHECK-64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
-// CHECK-64-NEXT:                   (field name=_countAndFlags offset=0
+// CHECK-64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK-64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64-NEXT:                       (field name=_storage offset=0
-// CHECK-64-NEXT:                         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64-NEXT:                           (field name=_value offset=0
-// CHECK-64-NEXT:                             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64-NEXT:                       (field name=_value offset=0
+// CHECK-64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:                   (field name=_object offset=8
 // CHECK-64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))))
 


### PR DESCRIPTION
5.0 cherry-pick of https://github.com/apple/swift/pull/21310

rdar://problem/46663653

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
