### PR TITLE
[TBDGen] Allow #warning/#error in protocols

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -425,6 +425,43 @@ static bool protocolDescriptorHasRequirements(ProtocolDecl *proto) {
   return false;
 }
 
+#ifndef NDEBUG
+static bool isValidProtocolMemberForTBDGen(const Decl *D) {
+  switch (D->getKind()) {
+  case DeclKind::TypeAlias:
+  case DeclKind::AssociatedType:
+  case DeclKind::Var:
+  case DeclKind::Subscript:
+  case DeclKind::PatternBinding:
+  case DeclKind::Func:
+  case DeclKind::Accessor:
+  case DeclKind::Constructor:
+  case DeclKind::Destructor:
+  case DeclKind::IfConfig:
+  case DeclKind::PoundDiagnostic:
+    return true;
+  case DeclKind::Enum:
+  case DeclKind::Struct:
+  case DeclKind::Class:
+  case DeclKind::Protocol:
+  case DeclKind::GenericTypeParam:
+  case DeclKind::Module:
+  case DeclKind::Param:
+  case DeclKind::EnumElement:
+  case DeclKind::Extension:
+  case DeclKind::TopLevelCode:
+  case DeclKind::Import:
+  case DeclKind::PrecedenceGroup:
+  case DeclKind::MissingMember:
+  case DeclKind::EnumCase:
+  case DeclKind::InfixOperator:
+  case DeclKind::PrefixOperator:
+  case DeclKind::PostfixOperator:
+    return false;
+  }
+}
+#endif
+
 void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
   if (!PD->isObjC()) {
     addSymbol(LinkEntity::forProtocolDescriptor(PD));
@@ -479,11 +516,7 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
   // (NB. anything within an active IfConfigDecls also appears outside). Let's
   // assert this fact:
   for (auto *member : PD->getMembers()) {
-    auto isExpectedKind =
-        isa<TypeAliasDecl>(member) || isa<AssociatedTypeDecl>(member) ||
-        isa<AbstractStorageDecl>(member) || isa<PatternBindingDecl>(member) ||
-        isa<AbstractFunctionDecl>(member) || isa<IfConfigDecl>(member);
-    assert(isExpectedKind &&
+    assert(isValidProtocolMemberForTBDGen(member) &&
            "unexpected member of protocol during TBD generation");
   }
 #endif

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -77,3 +77,8 @@ protocol MyProtocol {
   #warning("warnings can show up in protocols too!") // expected-warning {{warnings can show up in protocols too!}}
 }
 
+#warning("""
+         warnings support multi-line string literals
+         """) // expected-warning @-2 {{warnings support multi-line string literals}}
+
+#warning(#"warnings support \(custom string delimiters)"#) // expected-warning {{warnings support \\(custom string delimiters)}}

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -72,3 +72,8 @@ class C { // expected-note {{in declaration of 'C'}}
   #error("private error") // expected-error  {{private error}}
   func bar() {}
 }
+
+protocol MyProtocol {
+  #warning("warnings can show up in protocols too!") // expected-warning {{warnings can show up in protocols too!}}
+}
+


### PR DESCRIPTION
Resolves [SR-9519](https://bugs.swift.org/browse/SR-9519)

Also adds a few missing test cases for #warning.