### PR TITLE
[ParseableInterfaces] Add -prebuilt-module-cache-path to the frontend

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -792,6 +792,30 @@ inline T accumulate(const Container &C, T init, BinaryOperation op) {
   return std::accumulate(C.begin(), C.end(), init, op);
 }
 
+/// Returns true if the range defined by \p mainBegin ..< \p mainEnd starts with
+/// the same elements as the range defined by \p prefixBegin ..< \p prefixEnd.
+///
+/// This includes cases where the prefix range is empty, as well as when the two
+/// ranges are the same length and contain the same elements.
+template <typename MainInputIterator, typename PrefixInputIterator>
+inline bool hasPrefix(MainInputIterator mainBegin,
+                      const MainInputIterator mainEnd,
+                      PrefixInputIterator prefixBegin,
+                      const PrefixInputIterator prefixEnd) {
+  while (prefixBegin != prefixEnd) {
+    // If "main" is shorter than "prefix", it does not start with "prefix".
+    if (mainBegin == mainEnd)
+      return false;
+    // If there's a mismatch, "main" does not start with "prefix".
+    if (*mainBegin != *prefixBegin)
+      return false;
+    ++prefixBegin;
+    ++mainBegin;
+  }
+  // If we checked every element of "prefix", "main" does start with "prefix".
+  return true;
+}
+
 /// Provides default implementations of !=, <=, >, and >= based on == and <.
 template <typename T>
 class RelationalOperationsBase {

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -72,6 +72,10 @@ public:
   /// The path to which we should store indexing data, if any.
   std::string IndexStorePath;
 
+  /// The path to look in when loading a parseable interface file, to see if a
+  /// binary module has already been built for use by the compiler.
+  std::string PrebuiltModuleCachePath;
+
   /// Emit index data for imported serialized swift system modules.
   bool IndexSystemModules = false;
 

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -61,13 +61,15 @@ getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
 /// directory, and loading the serialized .swiftmodules from there.
 class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
   explicit ParseableInterfaceModuleLoader(ASTContext &ctx, StringRef cacheDir,
+                                          StringRef prebuiltCacheDir,
                                           DependencyTracker *tracker,
                                           ModuleLoadingMode loadMode)
     : SerializedModuleLoaderBase(ctx, tracker, loadMode),
-      CacheDir(cacheDir)
+      CacheDir(cacheDir), PrebuiltCacheDir(prebuiltCacheDir)
   {}
 
   std::string CacheDir;
+  std::string PrebuiltCacheDir;
 
   /// Wire up the SubInvocation's InputsAndOutputs to contain both input and
   /// output filenames.
@@ -86,11 +88,11 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
 
 public:
   static std::unique_ptr<ParseableInterfaceModuleLoader>
-  create(ASTContext &ctx, StringRef cacheDir,
-         DependencyTracker *tracker,
-         ModuleLoadingMode loadMode) {
+  create(ASTContext &ctx, StringRef cacheDir, StringRef prebuiltCacheDir,
+         DependencyTracker *tracker, ModuleLoadingMode loadMode) {
     return std::unique_ptr<ParseableInterfaceModuleLoader>(
-        new ParseableInterfaceModuleLoader(ctx, cacheDir, tracker, loadMode));
+        new ParseableInterfaceModuleLoader(ctx, cacheDir, prebuiltCacheDir,
+                                           tracker, loadMode));
   }
 
   /// Unconditionally build \p InPath (a swiftinterface file) to \p OutPath (as

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -518,6 +518,13 @@ def build_module_from_parseable_interface :
   HelpText<"Treat the (single) input as a swiftinterface and produce a module">,
   ModeOpt;
 
+def prebuilt_module_cache_path :
+  Separate<["-"], "prebuilt-module-cache-path">,
+  HelpText<"Directory of prebuilt modules for loading parseable interfaces">;
+def prebuilt_module_cache_path_EQ :
+  Joined<["-"], "prebuilt-module-cache-path=">,
+  Alias<prebuilt_module_cache_path>;
+
 def enable_resilience_bypass : Flag<["-"], "enable-resilience-bypass">,
    HelpText<"Completely bypass resilience when accessing types in resilient frameworks">;
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -60,6 +60,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_index_store_path)) {
     Opts.IndexStorePath = A->getValue();
   }
+  if (const Arg *A = Args.getLastArg(OPT_prebuilt_module_cache_path)) {
+    Opts.PrebuiltModuleCachePath = A->getValue();
+  }
 
   Opts.IndexSystemModules |= Args.hasArg(OPT_index_system_modules);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -331,8 +331,11 @@ bool CompilerInstance::setUpModuleLoaders() {
   if (MLM != ModuleLoadingMode::OnlySerialized) {
     auto const &Clang = clangImporter->getClangInstance();
     std::string ModuleCachePath = getModuleCachePathFromClang(Clang);
+    StringRef PrebuiltModuleCachePath =
+        Invocation.getFrontendOptions().PrebuiltModuleCachePath;
     auto PIML = ParseableInterfaceModuleLoader::create(*Context,
                                                        ModuleCachePath,
+                                                       PrebuiltModuleCachePath,
                                                        getDependencyTracker(),
                                                        MLM);
     Context->addModuleLoader(std::move(PIML));

--- a/test/ParseableInterface/ModuleCache/Inputs/prebuilt-module-cache/Lib.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/Inputs/prebuilt-module-cache/Lib.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name Lib
+
+public struct FromInterface {
+  @inlinable public init() {}
+}
+public var testValue: FromInterface {
+  @inlinable get { return FromInterface() }
+}

--- a/test/ParseableInterface/ModuleCache/prebuilt-module-cache-archs.swift
+++ b/test/ParseableInterface/ModuleCache/prebuilt-module-cache-archs.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/include/Lib.swiftmodule)
+// RUN: cp %S/Inputs/prebuilt-module-cache/Lib.swiftinterface %t/include/Lib.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface
+
+// Baseline check: if the prebuilt cache path does not exist, everything should
+// still work.
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %t/include -I %t/include/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+// Baseline check: if the module is not in the prebuilt cache, build it
+// normally.
+// RUN: %empty-directory(%t/prebuilt-cache)
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %t/include -I %t/include/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+// Do a manual prebuild, and see if it gets picked up.
+// RUN: %empty-directory(%t/MCP)
+// RUN: %empty-directory(%t/prebuilt-cache/Lib.swiftmodule)
+// RUN: sed -e 's/FromInterface/FromPrebuilt/g' %S/Inputs/prebuilt-module-cache/Lib.swiftinterface | %target-swift-frontend -parse-stdlib -module-cache-path %t/MCP -emit-module-path %t/prebuilt-cache/Lib.swiftmodule/%target-swiftmodule-name - -module-name Lib
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %t/include -I %t/include/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
+// RUN: ls %t/MCP | grep -v swiftmodule
+
+// What if the module is invalid?
+// RUN: rm %t/prebuilt-cache/Lib.swiftmodule/%target-swiftmodule-name && touch %t/prebuilt-cache/Lib.swiftmodule/%target-swiftmodule-name
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %t/include -I %t/include/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+// What if the arch is missing?
+// RUN: rm %t/prebuilt-cache/Lib.swiftmodule/%target-swiftmodule-name
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %t/include -I %t/include/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+import Lib
+
+struct X {}
+let _: X = Lib.testValue
+// FROM-INTERFACE: [[@LINE-1]]:16: error: cannot convert value of type 'FromInterface' to specified type 'X'
+// FROM-PREBUILT: [[@LINE-2]]:16: error: cannot convert value of type 'FromPrebuilt' to specified type 'X'

--- a/test/ParseableInterface/ModuleCache/prebuilt-module-cache.swift
+++ b/test/ParseableInterface/ModuleCache/prebuilt-module-cache.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+
+// Baseline check: if the prebuilt cache path does not exist, everything should
+// still work.
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+// Baseline check: if the module is not in the prebuilt cache, build it
+// normally.
+// RUN: %empty-directory(%t/prebuilt-cache)
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+// Do a manual prebuild, and see if it gets picked up.
+// RUN: %empty-directory(%t/MCP)
+// RUN: sed -e 's/FromInterface/FromPrebuilt/g' %S/Inputs/prebuilt-module-cache/Lib.swiftinterface | %target-swift-frontend -parse-stdlib -module-cache-path %t/MCP -emit-module-path %t/prebuilt-cache/Lib.swiftmodule - -module-name Lib
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
+// RUN: ls %t/MCP | grep -v swiftmodule
+
+// Try some variations on the detection that the search path is in the SDK:
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S//Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs/prebuilt-module-cache -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk / -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
+
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs/p -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/garbage-path -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk "" -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+// What if the module is invalid?
+// RUN: rm %t/prebuilt-cache/Lib.swiftmodule && touch %t/prebuilt-cache/Lib.swiftmodule
+// RUN: not %target-swift-frontend -typecheck -enable-parseable-module-interface -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs/ -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
+
+import Lib
+
+struct X {}
+let _: X = Lib.testValue
+// FROM-INTERFACE: [[@LINE-1]]:16: error: cannot convert value of type 'FromInterface' to specified type 'X'
+// FROM-PREBUILT: [[@LINE-2]]:16: error: cannot convert value of type 'FromPrebuilt' to specified type 'X'


### PR DESCRIPTION
When trying to load a swiftinterface, search this directory before doing all the work of building a swiftmodule.
