### PR TITLE
Sema: Fix order dependency between lazy getter body synthesis and capture computation [5.0]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -226,10 +226,10 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
   getter->setImplicit();
 
   // If we're stealing the 'self' from a lazy initializer, set it now.
-  if (selfDecl) {
+  // Note that we don't re-parent the 'self' declaration to be part of
+  // the getter until we synthesize the body of the getter later.
+  if (selfDecl)
     *getter->getImplicitSelfDeclStorage() = selfDecl;
-    selfDecl->setDeclContext(getter);
-  }
 
   // We need to install the generic environment here because:
   // 1) validating the getter will change the implicit self decl's DC to it,
@@ -1315,6 +1315,7 @@ static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
 
   // Recontextualize any closure declcontexts nested in the initializer to
   // realize that they are in the getter function.
+  Get->getImplicitSelfDecl()->setDeclContext(Get);
   InitValue->walk(RecontextualizeClosures(Get));
 
   // Wrap the initializer in a LazyInitializerExpr to avoid problems with

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -283,15 +283,14 @@ public:
         // recontextualized into it, so treat it as if it's already there.
         if (auto init = dyn_cast<PatternBindingInitializer>(TmpDC)) {
           if (auto lazyVar = init->getInitializedLazyVar()) {
-            // Referring to the 'self' parameter is fine.
-            if (D == init->getImplicitSelfDecl())
-              return { false, DRE };
-
-            // Otherwise, act as if we're in the getter.
-            auto getter = lazyVar->getGetter();
-            assert(getter && "lazy variable without getter");
-            TmpDC = getter;
-            continue;
+            // If we have a getter with a body, we're already re-parented
+            // everything so pretend we're inside the getter.
+            if (auto getter = lazyVar->getGetter()) {
+              if (getter->getBody(/*canSynthesize=*/false)) {
+                TmpDC = getter;
+                continue;
+              }
+            }
           }
         }
 

--- a/test/multifile/Inputs/external_lazy_property.swift
+++ b/test/multifile/Inputs/external_lazy_property.swift
@@ -1,3 +1,12 @@
 public struct Test1 {
-    lazy var property: String = "help"
+  lazy var property: String = "help"
+}
+
+public class Test2 {
+  var x = 0
+  var y = 1
+
+  lazy var property = {
+    return [self.x, self.y]
+  }()
 }

--- a/test/multifile/lazy.swift
+++ b/test/multifile/lazy.swift
@@ -1,6 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil -verify -primary-file %s %S/Inputs/external_lazy_property.swift
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s -primary-file %S/Inputs/external_lazy_property.swift
 
 // rdar://45712204
 func test1(s: Test1) {
-  s.property // expected-error {{cannot use mutating getter on immutable value: 's' is a 'let' constant}}
+  _ = s.property // expected-error {{cannot use mutating getter on immutable value: 's' is a 'let' constant}}
+}
+
+func test2(s: Test2) {
+  _ = s.property
 }


### PR DESCRIPTION
Fixes <rdar://problem/46735170>.