### PR TITLE
[ConstraintSystem] Remove implicit from expression derived from user …

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -575,7 +575,7 @@ namespace {
                     TypeExpr::createImplicitHack(loc.getBaseNameLoc(), baseTy,
                                                  ctx);
                   refExpr = new (ctx) MemberRefExpr(base, SourceLoc(), witness,
-                                                    loc, /*Implicit=*/true);
+                                                    loc, /*Implicit=*/false);
                 } else {
                   auto declRefExpr =  new (ctx) DeclRefExpr(witness, loc,
                                                             /*Implicit=*/false);


### PR DESCRIPTION
…reference.

SourceKit ignores implicit expressions. With the designated types
feature enabled in the type checker, there are cases where we emit
expressions as implicit where we weren't otherwise. It's also possible
to write code that goes down these paths even without that feature
enabled.

Hack this particular path for the moment to not mark these as implicit.

We could consider conditionalizing this on whether we're running as
part of SourceKit, but that seems like an even more unfortunate hack.
