### PR TITLE
test: fix a couple of IRGen tests on Windows

### DIFF
--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -34,7 +34,7 @@ sil_vtable C {}
 
 //   CHECK: @"$s5class1CCMf" = internal global <{ {{.*}} }> <{
 // \ CHECK:   void ([[C_CLASS]]*)* @"$s5class1CCfD",
-// \ CHECK:   i8** @"$sBoWV",
+// \ CHECK:   i8** {{@"$sBoWV"|null}},
 // \ CHECK:   i64 ptrtoint ([[OBJCCLASS]]* @"$s5class1CCMm" to i64),
 // \ CHECK:   [[OBJCCLASS]]* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // \ CHECK:   [[OPAQUE]]* @_objc_empty_cache,

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -30,7 +30,7 @@
 
 // CHECK: @"$s16class_resilience14ResilientChildCMo" = {{(protected )?}}{{(dllexport )?}}global [[BOUNDS]] zeroinitializer
 
-// CHECK: @"$s15resilient_class22ResilientOutsideParentC8getValueSiyFTq" = external global %swift.method_descriptor
+// CHECK: @"$s15resilient_class22ResilientOutsideParentC8getValueSiyFTq" = external{{( dllimport)?}} global %swift.method_descriptor
 
 // CHECK: @"$s16class_resilience14ResilientChildCMn" = {{(protected )?}}{{(dllexport )?}}constant <{{.*}}> <{
 // --       flags: class, unique, has vtable, has override table, in-place initialization, has resilient superclass
@@ -54,7 +54,7 @@
 // --       field offset vector offset:
 // CHECK-SAME:   i32 0,
 // -- superclass:
-// CHECK-SAME:   @"got.$s15resilient_class22ResilientOutsideParentCMn"
+// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCMn"
 // --       singleton metadata initialization cache:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildCMl"
 // --       resilient pattern:
@@ -65,17 +65,17 @@
 // CHECK-SAME:   i32 2,
 // CHECK-SAME:   %swift.method_override_descriptor {
 // --       base class:
-// CHECK-SAME:   @"got.$s15resilient_class22ResilientOutsideParentCMn"
+// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCMn"
 // --       base method:
-// CHECK-SAME:   @"got.$s15resilient_class22ResilientOutsideParentC8getValueSiyFTq"
+// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentC8getValueSiyFTq"
 // --       implementation:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildC8getValueSiyF"
 // CHECK-SAME:   }
 // CHECK-SAME:   %swift.method_override_descriptor {
 // --       base class:
-// CHECK-SAME:   @"got.$s15resilient_class22ResilientOutsideParentCMn"
+// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCMn"
 // --       base method:
-// CHECK-SAME:   @"got.$s15resilient_class22ResilientOutsideParentCACycfCTq"
+// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCACycfCTq"
 // --       implementation:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildCACycfC"
 // CHECK-SAME:   }


### PR DESCRIPTION
The generated patterns are slightly different on Windows, using the
import symbol instead of a synthetic GOT reference.  Additionally, the
VWT for the BO is lazily initialized at runtime via the singleton
strategy.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
