### PR TITLE
[AutoDiff] NFC: Use `SILCloner::isValueMapped` instead of maintaining a separate map

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -3187,20 +3187,13 @@ private:
   SmallVector<std::pair<SILInstruction *, SILInstruction *>, 8>
       scopeMarkingInstructions;
 
-  SmallPtrSet<SILValue, 32> mapped;
-
   SILFunction &getOriginal() { return getBuilder().getFunction(); }
 
 public:
   AdjointRematCloner(SILFunction &fn) : SILClonerWithScopes(fn) {}
 
-  void mapValue(SILValue origValue, SILValue mappedValue) {
-    SILClonerWithScopes::mapValue(origValue, mappedValue);
-    mapped.insert(origValue);
-  }
-
   SILValue lookUpValue(SILValue valueInOriginal) {
-    if (!mapped.count(valueInOriginal))
+    if (!isValueCloned(valueInOriginal))
       return nullptr;
     return getMappedValue(valueInOriginal);
   }


### PR DESCRIPTION
This is a follow-up to #21376.