### PR TITLE
[benchmark] Janitor Duty, Legacy Factor: Return of the String

### DIFF
--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -60,12 +60,12 @@ public let DataBenchmarks = [
     BenchmarkInfo(name: "DataAppendDataLargeToSmall", runFunction: run_AppendDataLargeToSmall, tags: [.validation, .api, .Data]),
     BenchmarkInfo(name: "DataAppendDataLargeToMedium", runFunction: run_AppendDataLargeToMedium, tags: [.validation, .api, .Data]),
     BenchmarkInfo(name: "DataAppendDataLargeToLarge", runFunction: run_AppendDataLargeToLarge, tags: [.validation, .api, .Data, .skip]),
-    BenchmarkInfo(name: "DataToStringEmpty", runFunction: run_DataToStringEmpty, tags: [.validation, .api, .Data]),
-    BenchmarkInfo(name: "DataToStringSmall", runFunction: run_DataToStringSmall, tags: [.validation, .api, .Data]),
-    BenchmarkInfo(name: "DataToStringMedium", runFunction: run_DataToStringMedium, tags: [.validation, .api, .Data]),
-    BenchmarkInfo(name: "StringToDataEmpty", runFunction: run_StringToDataEmpty, tags: [.validation, .api, .Data]),
-    BenchmarkInfo(name: "StringToDataSmall", runFunction: run_StringToDataSmall, tags: [.validation, .api, .Data]),
-    BenchmarkInfo(name: "StringToDataMedium", runFunction: run_StringToDataMedium, tags: [.validation, .api, .Data]),
+    BenchmarkInfo(name: "DataToStringEmpty", runFunction: run_DataToStringEmpty, tags: [.validation, .api, .Data], legacyFactor: 50),
+    BenchmarkInfo(name: "DataToStringSmall", runFunction: run_DataToStringSmall, tags: [.validation, .api, .Data], legacyFactor: 50),
+    BenchmarkInfo(name: "DataToStringMedium", runFunction: run_DataToStringMedium, tags: [.validation, .api, .Data], legacyFactor: 50),
+    BenchmarkInfo(name: "StringToDataEmpty", runFunction: run_StringToDataEmpty, tags: [.validation, .api, .Data], legacyFactor: 50),
+    BenchmarkInfo(name: "StringToDataSmall", runFunction: run_StringToDataSmall, tags: [.validation, .api, .Data], legacyFactor: 50),
+    BenchmarkInfo(name: "StringToDataMedium", runFunction: run_StringToDataMedium, tags: [.validation, .api, .Data], legacyFactor: 50),
 ]
 
 enum SampleKind {
@@ -165,7 +165,7 @@ func sampleData(_ type: SampleKind) -> Data {
     case .string: return sampleString()
     case .immutableBacking: return sampleBridgedNSData()
     }
-    
+
 }
 
 func benchmark_AccessBytes(_ N: Int, _ data: Data) {
@@ -598,7 +598,7 @@ public func run_createMediumArray(_ N: Int) {
 @inline(never)
 public func run_DataToStringEmpty(_ N: Int) {
     let d = Data()
-    for _ in 0..<10000 * N {
+    for _ in 0..<200 * N {
         let s = String(decoding: d, as: UTF8.self)
         blackHole(s)
     }
@@ -607,7 +607,7 @@ public func run_DataToStringEmpty(_ N: Int) {
 @inline(never)
 public func run_DataToStringSmall(_ N: Int) {
     let d = Data([0x0D, 0x0A])
-    for _ in 0..<10000 * N {
+    for _ in 0..<200 * N {
         let s = String(decoding: d, as: UTF8.self)
         blackHole(s)
     }
@@ -616,7 +616,7 @@ public func run_DataToStringSmall(_ N: Int) {
 @inline(never)
 public func run_DataToStringMedium(_ N: Int) {
     let d = Data([0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A, 0x0D, 0x0A])
-    for _ in 0..<10000 * N {
+    for _ in 0..<200 * N {
         let s = String(decoding: d, as: UTF8.self)
         blackHole(s)
     }
@@ -625,7 +625,7 @@ public func run_DataToStringMedium(_ N: Int) {
 @inline(never)
 public func run_StringToDataEmpty(_ N: Int) {
     let s = ""
-    for _ in 0..<10000 * N {
+    for _ in 0..<200 * N {
         let d = Data(s.utf8)
         blackHole(d)
     }
@@ -634,7 +634,7 @@ public func run_StringToDataEmpty(_ N: Int) {
 @inline(never)
 public func run_StringToDataSmall(_ N: Int) {
     let s = "\r\n"
-    for _ in 0..<10000 * N {
+    for _ in 0..<200 * N {
         let d = Data(s.utf8)
         blackHole(d)
     }
@@ -643,7 +643,7 @@ public func run_StringToDataSmall(_ N: Int) {
 @inline(never)
 public func run_StringToDataMedium(_ N: Int) {
     let s = "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n"
-    for _ in 0..<10000 * N {
+    for _ in 0..<200 * N {
         let d = Data(s.utf8)
         blackHole(d)
     }

--- a/benchmark/single-source/StrComplexWalk.swift
+++ b/benchmark/single-source/StrComplexWalk.swift
@@ -15,13 +15,14 @@ import TestsUtils
 public let StrComplexWalk = BenchmarkInfo(
   name: "StrComplexWalk",
   runFunction: run_StrComplexWalk,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 10)
 
 @inline(never)
 public func run_StrComplexWalk(_ N: Int) {
   var s = "निरन्तरान्धकारिता-दिगन्तर-कन्दलदमन्द-सुधारस-बिन्दु-सान्द्रतर-घनाघन-वृन्द-सन्देहकर-स्यन्दमान-मकरन्द-बिन्दु-बन्धुरतर-माकन्द-तरु-कुल-तल्प-कल्प-मृदुल-सिकता-जाल-जटिल-मूल-तल-मरुवक-मिलदलघु-लघु-लय-कलित-रमणीय-पानीय-शालिका-बालिका-करार-विन्द-गलन्तिका-गलदेला-लवङ्ग-पाटल-घनसार-कस्तूरिकातिसौरभ-मेदुर-लघुतर-मधुर-शीतलतर-सलिलधारा-निराकरिष्णु-तदीय-विमल-विलोचन-मयूख-रेखापसारित-पिपासायास-पथिक-लोकान्"
   let ref_result = 379
-  for _ in 1...2000*N {
+  for _ in 1...200*N {
     var count = 0
     for _ in s.unicodeScalars {
       count += 1
@@ -29,4 +30,3 @@ public func run_StrComplexWalk(_ N: Int) {
     CheckResults(count == ref_result)
   }
 }
-

--- a/benchmark/single-source/StrToInt.swift
+++ b/benchmark/single-source/StrToInt.swift
@@ -17,7 +17,8 @@ import TestsUtils
 public let StrToInt = BenchmarkInfo(
   name: "StrToInt",
   runFunction: run_StrToInt,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 10)
 
 @inline(never)
 public func run_StrToInt(_ N: Int) {
@@ -45,7 +46,7 @@ public func run_StrToInt(_ N: Int) {
     return r
   }
   var res = Int.max
-  for _ in 1...1000*N {
+  for _ in 1...100*N {
     res = res & DoOneIter(input)
   }
   CheckResults(res == ref_result)

--- a/benchmark/single-source/StringBuilder.swift
+++ b/benchmark/single-source/StringBuilder.swift
@@ -28,27 +28,33 @@ public let StringBuilder = [
   BenchmarkInfo(
     name: "StringUTF16Builder",
     runFunction: run_StringUTF16Builder,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
   BenchmarkInfo(
     name: "StringUTF16SubstringBuilder",
     runFunction: run_StringUTF16SubstringBuilder,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
   BenchmarkInfo(
     name: "StringBuilderLong",
     runFunction: run_StringBuilderLong,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
   BenchmarkInfo(
     name: "StringBuilderWithLongSubstring",
     runFunction: run_StringBuilderWithLongSubstring,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
   BenchmarkInfo(
     name: "StringWordBuilder",
     runFunction: run_StringWordBuilder,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
   BenchmarkInfo(
     name: "StringWordBuilderReservingCapacity",
     runFunction: run_StringWordBuilderReservingCapacity,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
 ]
 
 @inline(never)
@@ -110,14 +116,14 @@ func buildStringFromSmallSubstrings(_ i: String) -> String {
 
 @inline(never)
 public func run_StringUTF16Builder(_ N: Int) {
-  for _ in 1...5000*N {
+  for _ in 1...500*N {
     blackHole(buildStringUTF16("a"))
   }
 }
 
 @inline(never)
 public func run_StringUTF16SubstringBuilder(_ N: Int) {
-  for _ in 1...5000*N {
+  for _ in 1...500*N {
     blackHole(buildStringFromSmallSubstrings("a"))
   }
 }
@@ -153,14 +159,14 @@ func buildStringWithLongSubstring(_ i: String) -> String {
 
 @inline(never)
 public func run_StringBuilderLong(_ N: Int) {
-  for _ in 1...5000*N {
+  for _ in 1...500*N {
     blackHole(buildStringLong("👻"))
   }
 }
 
 @inline(never)
 public func run_StringBuilderWithLongSubstring(_ N: Int) {
-  for _ in 1...5000*N {
+  for _ in 1...500*N {
     blackHole(buildStringWithLongSubstring("👻"))
   }
 }
@@ -184,13 +190,16 @@ func buildString(
 
 @inline(never)
 public func run_StringWordBuilder(_ N: Int) {
-  blackHole(buildString(
-    word: "bumfuzzle", count: 50_000 * N, reservingCapacity: false))
+  for _ in 1...N {
+    blackHole(buildString(
+      word: "bumfuzzle", count: 5_000, reservingCapacity: false))
+  }
 }
 
 @inline(never)
 public func run_StringWordBuilderReservingCapacity(_ N: Int) {
-  blackHole(buildString(
-    word: "bumfuzzle", count: 50_000 * N, reservingCapacity: true))
+  for _ in 1...N {
+    blackHole(buildString(
+      word: "bumfuzzle", count: 5_000, reservingCapacity: true))
+  }
 }
-

--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -28,10 +28,6 @@ extension String {
     return self.split(separator: "\n").map { String($0) }
   }
 }
-
-
-
-
 public let StringComparison: [BenchmarkInfo] = [
   BenchmarkInfo(
     name: "StringComparison_ascii",
@@ -43,43 +39,50 @@ public let StringComparison: [BenchmarkInfo] = [
     name: "StringComparison_latin1",
     runFunction: run_StringComparison_latin1,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_latin1) }
+    setUpFunction: { blackHole(Workload_latin1) },
+		legacyFactor: 2
   ),
   BenchmarkInfo(
     name: "StringComparison_fastPrenormal",
     runFunction: run_StringComparison_fastPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_fastPrenormal) }
+    setUpFunction: { blackHole(Workload_fastPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "StringComparison_slowerPrenormal",
     runFunction: run_StringComparison_slowerPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_slowerPrenormal) }
+    setUpFunction: { blackHole(Workload_slowerPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "StringComparison_nonBMPSlowestPrenormal",
     runFunction: run_StringComparison_nonBMPSlowestPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) }
+    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "StringComparison_emoji",
     runFunction: run_StringComparison_emoji,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_emoji) }
+    setUpFunction: { blackHole(Workload_emoji) },
+		legacyFactor: 4
   ),
   BenchmarkInfo(
     name: "StringComparison_abnormal",
     runFunction: run_StringComparison_abnormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_abnormal) }
+    setUpFunction: { blackHole(Workload_abnormal) },
+		legacyFactor: 20
   ),
   BenchmarkInfo(
     name: "StringComparison_zalgo",
     runFunction: run_StringComparison_zalgo,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_zalgo) }
+    setUpFunction: { blackHole(Workload_zalgo) },
+		legacyFactor: 25
   ),
   BenchmarkInfo(
     name: "StringComparison_longSharedPrefix",
@@ -100,43 +103,50 @@ public let StringHashing: [BenchmarkInfo] = [
     name: "StringHashing_latin1",
     runFunction: run_StringHashing_latin1,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_latin1) }
+    setUpFunction: { blackHole(Workload_latin1) },
+		legacyFactor: 2
   ),
   BenchmarkInfo(
     name: "StringHashing_fastPrenormal",
     runFunction: run_StringHashing_fastPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_fastPrenormal) }
+    setUpFunction: { blackHole(Workload_fastPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "StringHashing_slowerPrenormal",
     runFunction: run_StringHashing_slowerPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_slowerPrenormal) }
+    setUpFunction: { blackHole(Workload_slowerPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "StringHashing_nonBMPSlowestPrenormal",
     runFunction: run_StringHashing_nonBMPSlowestPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) }
+    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "StringHashing_emoji",
     runFunction: run_StringHashing_emoji,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_emoji) }
+    setUpFunction: { blackHole(Workload_emoji) },
+		legacyFactor: 4
   ),
   BenchmarkInfo(
     name: "StringHashing_abnormal",
     runFunction: run_StringHashing_abnormal,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_abnormal) }
+    setUpFunction: { blackHole(Workload_abnormal) },
+		legacyFactor: 20
   ),
   BenchmarkInfo(
     name: "StringHashing_zalgo",
     runFunction: run_StringHashing_zalgo,
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_zalgo) }
+    setUpFunction: { blackHole(Workload_zalgo) },
+		legacyFactor: 25
   ),
 ]
 
@@ -151,43 +161,50 @@ public let NormalizedIterator: [BenchmarkInfo] = [
     name: "NormalizedIterator_latin1",
     runFunction: run_NormalizedIterator_latin1,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_latin1) }
+    setUpFunction: { blackHole(Workload_latin1) },
+		legacyFactor: 2
   ),
   BenchmarkInfo(
     name: "NormalizedIterator_fastPrenormal",
     runFunction: run_NormalizedIterator_fastPrenormal,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_fastPrenormal) }
+    setUpFunction: { blackHole(Workload_fastPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "NormalizedIterator_slowerPrenormal",
     runFunction: run_NormalizedIterator_slowerPrenormal,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_slowerPrenormal) }
+    setUpFunction: { blackHole(Workload_slowerPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "NormalizedIterator_nonBMPSlowestPrenormal",
     runFunction: run_NormalizedIterator_nonBMPSlowestPrenormal,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) }
+    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) },
+		legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "NormalizedIterator_emoji",
     runFunction: run_NormalizedIterator_emoji,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_emoji) }
+    setUpFunction: { blackHole(Workload_emoji) },
+		legacyFactor: 4
   ),
   BenchmarkInfo(
     name: "NormalizedIterator_abnormal",
     runFunction: run_NormalizedIterator_abnormal,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_abnormal) }
+    setUpFunction: { blackHole(Workload_abnormal) },
+		legacyFactor: 20
   ),
   BenchmarkInfo(
     name: "NormalizedIterator_zalgo",
     runFunction: run_NormalizedIterator_zalgo,
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_zalgo) }
+    setUpFunction: { blackHole(Workload_zalgo) },
+		legacyFactor: 25
   ),
 ]
 
@@ -635,7 +652,8 @@ struct Workload {
       óôõö÷øùúûüýþÿ
       123.456£=>¥
       123.456
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/2
   )
   static let fastPrenormal = Workload(
     name: "FastPrenormal",
@@ -656,7 +674,8 @@ struct Workload {
       ʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰ
       ʱʲʳʴʵʶʷʸʹʺʻʼʽʾʿˀˁ˂˃˄˅ˆˇˈˉˊˋˌˍˎˏːˑ˒˓˔˕˖˗˘˙˚˛˜˝˞˟ˠˡˢˣˤ˥˦
       ˧˨˩˪˫ˬ˭ˮ˯˰˱˲˳˴˵˶˷˸˹˺˻˼˽˾
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/10
   )
   static let slowerPrenormal = Workload(
     name: "SlowerPrenormal",
@@ -673,7 +692,8 @@ struct Workload {
       в чащах юга жил-был цитрус
       \u{300c}\u{300e}今日は\u{3001}世界\u{3002}\u{300f}\u{300d}
       но фальшивый экземпляр
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/10
   )
   // static let slowestPrenormal = """
   //   """.lines()
@@ -691,7 +711,8 @@ struct Workload {
       𓃘𓃙𓃚𓃛𓃠𓃡𓃢𓃣𓃦𓃧𓃨𓃩𓃬𓃭𓃮𓃯𓃰𓃲𓃳𓃴𓃵𓃶𓃷
       𓀀𓀁𓀂𓀃𓀄𓆇𓆈𓆉𓆊𓆋𓆌𓆍𓆎𓆏𓆐𓆑𓆒𓆓𓆔𓆗𓆘𓆙𓆚𓆛𓆝𓆞𓆟𓆠𓆡𓆢𓆣𓆤
       𓆥𓆦𓆧𓆨𓆩𓆪𓆫𓆬𓆭𓆮𓆯𓆰𓆱𓆲𓆳𓆴𓆵𓆶𓆷𓆸𓆹𓆺𓆻
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/10
   )
   static let emoji = Workload(
     name: "Emoji",
@@ -704,7 +725,8 @@ struct Workload {
       😋🤑🤗🤓😎😒😏🤠🤡😞😔😟😕😖😣☹️🙁😫😩😤😠😑😐😶😡😯
       😦😧😮😱😳😵😲😨😰😢😥
       😪😓😭🤤😴🙄🤔🤥🤧🤢🤐😬😷🤒🤕😈💩👺👹👿👻💀☠️👽
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/4
   )
 
   static let abnormal = Workload(
@@ -715,7 +737,8 @@ struct Workload {
     \u{f900}\u{f901}\u{f902}\u{f903}\u{f904}\u{f905}\u{f906}\u{f907}\u{f908}\u{f909}\u{f90a}
     \u{f90b}\u{f90c}\u{f90d}\u{f90e}\u{f90f}\u{f910}\u{f911}\u{f912}\u{f913}\u{f914}\u{f915}\u{f916}\u{f917}\u{f918}\u{f919}
     \u{f900}\u{f91a}\u{f91b}\u{f91c}\u{f91d}\u{f91e}\u{f91f}\u{f920}\u{f921}\u{f922}
-    """.lines()
+    """.lines(),
+    scaleMultiplier: 1/20
   )
   // static let pathological = """
   //   """.lines()
@@ -739,9 +762,9 @@ struct Workload {
     ơ̗̘̙̜̹̺̻̼͇͈͉͍͎̽̾̿̀́͂̓̈́͆͊͋͌̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͥͦͧͨͩͪͫͬͭͮ͘
     xͣͤͥͦͧͨͩͪͫͬͭͮ
     """.lines(),
-    scaleMultiplier: 0.25
+    scaleMultiplier: 1/100
   )
-  
+
   static let longSharedPrefix = Workload(
     name: "LongSharedPrefix",
     payload: """
@@ -756,7 +779,7 @@ struct Workload {
     🤔Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.🤔
     """.lines()
   )
-  
+
 }
 
 // Local Variables:

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -29,21 +29,30 @@ extension String {
     return self.split(separator: "\n").map { String($0) }
   }
 }
+%{
+AllWorkloads = ["ascii", "latin1", "fastPrenormal", "slowerPrenormal",
+                "nonBMPSlowestPrenormal", "emoji", "abnormal", "zalgo",
+                "longSharedPrefix"]
+ComparisonWorkloads = AllWorkloads
+HashingWorkloads = AllWorkloads[:-1]
+NormalizedIteratorWorkloads = AllWorkloads[:-1]
 
-% AllWorkloads = ["ascii", "latin1", "fastPrenormal", "slowerPrenormal", "nonBMPSlowestPrenormal", "emoji", "abnormal", "zalgo", "longSharedPrefix"]
-% ComparisonWorkloads = AllWorkloads
-% HashingWorkloads = ["ascii", "latin1", "fastPrenormal", "slowerPrenormal", "nonBMPSlowestPrenormal", "emoji", "abnormal", "zalgo"]
+LegacyFactor = dict(abnormal=20, emoji=4, latin1=2, fastPrenormal=10,
+                    slowerPrenormal=10, nonBMPSlowestPrenormal=10, zalgo=25)
 
-
-% NormalizedIteratorWorkloads = ["ascii", "latin1", "fastPrenormal", "slowerPrenormal", "nonBMPSlowestPrenormal", "emoji", "abnormal", "zalgo"]
-
+def legacyFactor(name):
+  lf = LegacyFactor.get(name)
+  return (
+    ',\n\t\tlegacyFactor: {0}'.format(lf) if lf else
+    '')
+}%
 public let StringComparison: [BenchmarkInfo] = [
 % for Name in ComparisonWorkloads:
   BenchmarkInfo(
     name: "StringComparison_${Name}",
     runFunction: run_StringComparison_${Name},
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_${Name}) }
+    setUpFunction: { blackHole(Workload_${Name}) }${legacyFactor(Name)}
   ),
 % end # ComparisonWorkloads
 ]
@@ -54,7 +63,7 @@ public let StringHashing: [BenchmarkInfo] = [
     name: "StringHashing_${Name}",
     runFunction: run_StringHashing_${Name},
     tags: [.validation, .api, .String],
-    setUpFunction: { blackHole(Workload_${Name}) }
+    setUpFunction: { blackHole(Workload_${Name}) }${legacyFactor(Name)}
   ),
 % end # HashingWorkloads
 ]
@@ -65,7 +74,7 @@ public let NormalizedIterator: [BenchmarkInfo] = [
     name: "NormalizedIterator_${Name}",
     runFunction: run_NormalizedIterator_${Name},
     tags: [.validation, .String],
-    setUpFunction: { blackHole(Workload_${Name}) }
+    setUpFunction: { blackHole(Workload_${Name}) }${legacyFactor(Name)}
   ),
 % end # NormalizedIteratorWorkloads
 ]
@@ -212,7 +221,8 @@ struct Workload {
       óôõö÷øùúûüýþÿ
       123.456£=>¥
       123.456
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/2
   )
   static let fastPrenormal = Workload(
     name: "FastPrenormal",
@@ -233,7 +243,8 @@ struct Workload {
       ʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰ
       ʱʲʳʴʵʶʷʸʹʺʻʼʽʾʿˀˁ˂˃˄˅ˆˇˈˉˊˋˌˍˎˏːˑ˒˓˔˕˖˗˘˙˚˛˜˝˞˟ˠˡˢˣˤ˥˦
       ˧˨˩˪˫ˬ˭ˮ˯˰˱˲˳˴˵˶˷˸˹˺˻˼˽˾
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/10
   )
   static let slowerPrenormal = Workload(
     name: "SlowerPrenormal",
@@ -250,7 +261,8 @@ struct Workload {
       в чащах юга жил-был цитрус
       \u{300c}\u{300e}今日は\u{3001}世界\u{3002}\u{300f}\u{300d}
       но фальшивый экземпляр
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/10
   )
   // static let slowestPrenormal = """
   //   """.lines()
@@ -268,7 +280,8 @@ struct Workload {
       𓃘𓃙𓃚𓃛𓃠𓃡𓃢𓃣𓃦𓃧𓃨𓃩𓃬𓃭𓃮𓃯𓃰𓃲𓃳𓃴𓃵𓃶𓃷
       𓀀𓀁𓀂𓀃𓀄𓆇𓆈𓆉𓆊𓆋𓆌𓆍𓆎𓆏𓆐𓆑𓆒𓆓𓆔𓆗𓆘𓆙𓆚𓆛𓆝𓆞𓆟𓆠𓆡𓆢𓆣𓆤
       𓆥𓆦𓆧𓆨𓆩𓆪𓆫𓆬𓆭𓆮𓆯𓆰𓆱𓆲𓆳𓆴𓆵𓆶𓆷𓆸𓆹𓆺𓆻
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/10
   )
   static let emoji = Workload(
     name: "Emoji",
@@ -281,7 +294,8 @@ struct Workload {
       😋🤑🤗🤓😎😒😏🤠🤡😞😔😟😕😖😣☹️🙁😫😩😤😠😑😐😶😡😯
       😦😧😮😱😳😵😲😨😰😢😥
       😪😓😭🤤😴🙄🤔🤥🤧🤢🤐😬😷🤒🤕😈💩👺👹👿👻💀☠️👽
-      """.lines()
+      """.lines(),
+      scaleMultiplier: 1/4
   )
 
   static let abnormal = Workload(
@@ -292,7 +306,8 @@ struct Workload {
     \u{f900}\u{f901}\u{f902}\u{f903}\u{f904}\u{f905}\u{f906}\u{f907}\u{f908}\u{f909}\u{f90a}
     \u{f90b}\u{f90c}\u{f90d}\u{f90e}\u{f90f}\u{f910}\u{f911}\u{f912}\u{f913}\u{f914}\u{f915}\u{f916}\u{f917}\u{f918}\u{f919}
     \u{f900}\u{f91a}\u{f91b}\u{f91c}\u{f91d}\u{f91e}\u{f91f}\u{f920}\u{f921}\u{f922}
-    """.lines()
+    """.lines(),
+    scaleMultiplier: 1/20
   )
   // static let pathological = """
   //   """.lines()
@@ -316,9 +331,9 @@ struct Workload {
     ơ̗̘̙̜̹̺̻̼͇͈͉͍͎̽̾̿̀́͂̓̈́͆͊͋͌̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͥͦͧͨͩͪͫͬͭͮ͘
     xͣͤͥͦͧͨͩͪͫͬͭͮ
     """.lines(),
-    scaleMultiplier: 0.25
+    scaleMultiplier: 1/100
   )
-  
+
   static let longSharedPrefix = Workload(
     name: "LongSharedPrefix",
     payload: """
@@ -333,7 +348,7 @@ struct Workload {
     🤔Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.🤔
     """.lines()
   )
-  
+
 }
 
 // ${'Local Variables'}:

--- a/benchmark/single-source/StringEdits.swift
+++ b/benchmark/single-source/StringEdits.swift
@@ -20,7 +20,8 @@ import Darwin
 public let StringEdits = BenchmarkInfo(
   name: "StringEdits",
   runFunction: run_StringEdits,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 100)
 
 var editWords: [String] = [
   "woodshed",
@@ -34,13 +35,13 @@ func edits(_ word: String) -> Set<String> {
   let splits = word.indices.map {
     (String(word[..<$0]), String(word[$0...]))
   }
-  
+
   var result: Array<String> = []
-  
+
   for (left, right) in splits {
     // drop a character
     result.append(left + right.dropFirst())
-    
+
     // transpose two characters
     if let fst = right.first {
       let drop1 = right.dropFirst()
@@ -48,28 +49,27 @@ func edits(_ word: String) -> Set<String> {
         result.append(left + [snd,fst] + drop1.dropFirst())
       }
     }
-    
+
     // replace each character with another
     for letter in alphabet {
       result.append(left + [letter] + right.dropFirst())
     }
-    
+
     // insert rogue characters
     for letter in alphabet {
       result.append(left + [letter] + right)
     }
   }
-  
+
   // have to map back to strings right at the end
   return Set(result)
 }
 
 @inline(never)
 public func run_StringEdits(_ N: Int) {
-  for _ in 1...N*100 {
+  for _ in 1...N {
     for word in editWords {
-      _ = edits(word)      
+      _ = edits(word)
     }
   }
 }
-

--- a/benchmark/single-source/StringEnum.swift
+++ b/benchmark/single-source/StringEnum.swift
@@ -15,7 +15,8 @@ import TestsUtils
 public let StringEnum = BenchmarkInfo(
   name: "StringEnumRawValueInitialization",
   runFunction: run_StringEnumRawValueInitialization,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 20)
 
 enum TestEnum : String {
   case c1 = "Swift"
@@ -216,11 +217,10 @@ public func run_StringEnumRawValueInitialization(_ N: Int) {
   let short = "To"
   let long = "(C, C++, Objective-C)."
   let last = "code."
-  for _ in 1...2000*N {
+  for _ in 1...100*N {
     convert(first)
     convert(short)
     convert(long)
     convert(last)
   }
 }
-

--- a/benchmark/single-source/StringInterpolation.swift
+++ b/benchmark/single-source/StringInterpolation.swift
@@ -15,15 +15,18 @@ import TestsUtils
 public let StringInterpolation = BenchmarkInfo(
   name: "StringInterpolation",
   runFunction: run_StringInterpolation,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 100)
 public let StringInterpolationSmall = BenchmarkInfo(
   name: "StringInterpolationSmall",
   runFunction: run_StringInterpolationSmall,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 10)
 public let StringInterpolationManySmallSegments = BenchmarkInfo(
   name: "StringInterpolationManySmallSegments",
   runFunction: run_StringInterpolationManySmallSegments,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 100)
 
 class RefTypePrintable : CustomStringConvertible {
   var description: String {
@@ -38,7 +41,7 @@ public func run_StringInterpolation(_ N: Int) {
   let anInt: Int64 = 0x1234567812345678
   let aRefCountedObject = RefTypePrintable()
 
-  for _ in 1...100*N {
+  for _ in 1...N {
     var result = 0
     for _ in 1...reps {
       let s: String = getString(
@@ -61,7 +64,7 @@ public func run_StringInterpolationSmall(_ N: Int) {
   let refResult = reps
   let anInt: Int64 = 0x42
 
-  for _ in 1...100*N {
+  for _ in 1...10*N {
     var result = 0
     for _ in 1...reps {
       let s: String = getString(
@@ -95,7 +98,7 @@ public func run_StringInterpolationManySmallSegments(_ N: Int) {
   }
 
   let reps = 100
-  for _ in 1...100*N {
+  for _ in 1...N {
     for _ in 1...reps {
       blackHole("""
         \(getSegment(0)) \(getSegment(1))/\(getSegment(2))_\(getSegment(3))

--- a/benchmark/single-source/StringMatch.swift
+++ b/benchmark/single-source/StringMatch.swift
@@ -20,14 +20,15 @@ import Darwin
 public let StringMatch = BenchmarkInfo(
   name: "StringMatch",
   runFunction: run_StringMatch,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 100)
 
 /* match: search for regexp anywhere in text */
 func match(regexp: String, text: String) -> Bool {
   if regexp.first == "^" {
     return matchHere(regexp.dropFirst(), text[...])
   }
-  
+
   var idx = text.startIndex
   while true {  // must look even if string is empty
     if matchHere(regexp[...], text[idx..<text.endIndex]) {
@@ -37,7 +38,7 @@ func match(regexp: String, text: String) -> Bool {
     // do while sufficed in the original C version...
     text.formIndex(after: &idx)
   } // while idx++ != string.endIndex
-  
+
   return false
 }
 
@@ -46,19 +47,19 @@ func matchHere(_ regexp: Substring, _ text: Substring) -> Bool {
   if regexp.isEmpty {
     return true
   }
-  
+
   if let c = regexp.first, regexp.dropFirst().first == "*" {
     return matchStar(c, regexp.dropFirst(2), text)
   }
-  
+
   if regexp.first == "$" && regexp.dropFirst().isEmpty {
     return text.isEmpty
   }
-  
+
   if let tc = text.first, let rc = regexp.first, rc == "." || tc == rc {
     return matchHere(regexp.dropFirst(), text.dropFirst())
   }
-  
+
   return false
 }
 
@@ -87,10 +88,9 @@ let tests: KeyValuePairs = [
 
 @inline(never)
 public func run_StringMatch(_ N: Int) {
-  for _ in 1...N*100 {
+  for _ in 1...N {
     for (regex, text) in tests {
       _ = match(regexp: regex,text: text)
     }
   }
 }
-

--- a/benchmark/single-source/StringTests.swift
+++ b/benchmark/single-source/StringTests.swift
@@ -12,11 +12,30 @@
 import TestsUtils
 
 public let StringTests = [
-  BenchmarkInfo(name: "StringEqualPointerComparison", runFunction: run_StringEqualPointerComparison, tags: [.validation, .api, .String]),
-  BenchmarkInfo(name: "StringHasPrefixAscii", runFunction: run_StringHasPrefixAscii, tags: [.validation, .api, .String]),
-  BenchmarkInfo(name: "StringHasPrefixUnicode", runFunction: run_StringHasPrefixUnicode, tags: [.validation, .api, .String]),
-  BenchmarkInfo(name: "StringHasSuffixAscii", runFunction: run_StringHasSuffixAscii, tags: [.validation, .api, .String]),
-  BenchmarkInfo(name: "StringHasSuffixUnicode", runFunction: run_StringHasSuffixUnicode, tags: [.validation, .api, .String]),
+  BenchmarkInfo(
+    name: "StringEqualPointerComparison",
+    runFunction: run_StringEqualPointerComparison,
+    tags: [.validation, .api, .String]),
+  BenchmarkInfo(
+    name: "StringHasPrefixAscii",
+    runFunction: run_StringHasPrefixAscii,
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
+  BenchmarkInfo(
+    name: "StringHasPrefixUnicode",
+    runFunction: run_StringHasPrefixUnicode,
+    tags: [.validation, .api, .String],
+    legacyFactor: 1000),
+  BenchmarkInfo(
+    name: "StringHasSuffixAscii",
+    runFunction: run_StringHasSuffixAscii,
+    tags: [.validation, .api, .String],
+    legacyFactor: 10),
+  BenchmarkInfo(
+    name: "StringHasSuffixUnicode",
+    runFunction: run_StringHasSuffixUnicode,
+    tags: [.validation, .api, .String],
+    legacyFactor: 1000),
 ]
 
 // FIXME(string)
@@ -25,7 +44,7 @@ public func run_StringHasPrefixAscii(_ N: Int) {
   let prefix = "prefix"
   let testString = "prefixedString"
   for _ in 0 ..< N {
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 10_000 {
       CheckResults(testString.hasPrefix(getString(prefix)))
     }
   }
@@ -38,7 +57,7 @@ public func run_StringHasSuffixAscii(_ N: Int) {
   let suffix = "Suffixed"
   let testString = "StringSuffixed"
   for _ in 0 ..< N {
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 10_000 {
       CheckResults(testString.hasSuffix(getString(suffix)))
     }
   }
@@ -51,7 +70,7 @@ public func run_StringHasPrefixUnicode(_ N: Int) {
   let prefix = "❄️prefix"
   let testString = "❄️prefixedString"
   for _ in 0 ..< N {
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 100 {
       CheckResults(testString.hasPrefix(getString(prefix)))
     }
   }
@@ -64,7 +83,7 @@ public func run_StringHasSuffixUnicode(_ N: Int) {
   let suffix = "❄️Suffixed"
   let testString = "String❄️Suffixed"
   for _ in 0 ..< N {
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 100 {
       CheckResults(testString.hasSuffix(getString(suffix)))
     }
   }

--- a/benchmark/single-source/StringWalk.swift
+++ b/benchmark/single-source/StringWalk.swift
@@ -84,7 +84,7 @@ public func run_StringWalk(_ N: Int) {
 }
 
 // Extended String benchmarks:
-let baseMultiplier = 10_000
+let baseMultiplier = 250
 let unicodeScalarsMultiplier = baseMultiplier
 let charactersMultiplier = baseMultiplier / 5
 
@@ -95,404 +95,477 @@ public var StringWalk = [
   BenchmarkInfo(
     name: "StringWalk",
     runFunction: run_StringWalk,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_ascii_unicodeScalars",
     runFunction: run_StringWalk_ascii_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_ascii_characters",
     runFunction: run_StringWalk_ascii_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_ascii_unicodeScalars",
     runFunction: run_CharIteration_ascii_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_ascii_unicodeScalars",
     runFunction: run_CharIndexing_ascii_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_ascii_unicodeScalars_Backwards",
     runFunction: run_StringWalk_ascii_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_ascii_characters_Backwards",
     runFunction: run_StringWalk_ascii_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_ascii_unicodeScalars_Backwards",
     runFunction: run_CharIteration_ascii_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_ascii_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_ascii_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_utf16_unicodeScalars",
     runFunction: run_StringWalk_utf16_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_utf16_characters",
     runFunction: run_StringWalk_utf16_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_utf16_unicodeScalars",
     runFunction: run_CharIteration_utf16_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_utf16_unicodeScalars",
     runFunction: run_CharIndexing_utf16_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_utf16_unicodeScalars_Backwards",
     runFunction: run_StringWalk_utf16_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_utf16_characters_Backwards",
     runFunction: run_StringWalk_utf16_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_utf16_unicodeScalars_Backwards",
     runFunction: run_CharIteration_utf16_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_utf16_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_utf16_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_tweet_unicodeScalars",
     runFunction: run_StringWalk_tweet_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_tweet_characters",
     runFunction: run_StringWalk_tweet_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_tweet_unicodeScalars",
     runFunction: run_CharIteration_tweet_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_tweet_unicodeScalars",
     runFunction: run_CharIndexing_tweet_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_tweet_unicodeScalars_Backwards",
     runFunction: run_StringWalk_tweet_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_tweet_characters_Backwards",
     runFunction: run_StringWalk_tweet_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_tweet_unicodeScalars_Backwards",
     runFunction: run_CharIteration_tweet_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_tweet_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_tweet_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_japanese_unicodeScalars",
     runFunction: run_StringWalk_japanese_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_japanese_characters",
     runFunction: run_StringWalk_japanese_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_japanese_unicodeScalars",
     runFunction: run_CharIteration_japanese_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_japanese_unicodeScalars",
     runFunction: run_CharIndexing_japanese_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_japanese_unicodeScalars_Backwards",
     runFunction: run_StringWalk_japanese_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_japanese_characters_Backwards",
     runFunction: run_StringWalk_japanese_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_japanese_unicodeScalars_Backwards",
     runFunction: run_CharIteration_japanese_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_japanese_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_japanese_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_chinese_unicodeScalars",
     runFunction: run_StringWalk_chinese_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_chinese_characters",
     runFunction: run_StringWalk_chinese_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_chinese_unicodeScalars",
     runFunction: run_CharIteration_chinese_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_chinese_unicodeScalars",
     runFunction: run_CharIndexing_chinese_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_chinese_unicodeScalars_Backwards",
     runFunction: run_StringWalk_chinese_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_chinese_characters_Backwards",
     runFunction: run_StringWalk_chinese_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_chinese_unicodeScalars_Backwards",
     runFunction: run_CharIteration_chinese_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_chinese_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_chinese_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_korean_unicodeScalars",
     runFunction: run_StringWalk_korean_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_korean_characters",
     runFunction: run_StringWalk_korean_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_korean_unicodeScalars",
     runFunction: run_CharIteration_korean_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_korean_unicodeScalars",
     runFunction: run_CharIndexing_korean_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_korean_unicodeScalars_Backwards",
     runFunction: run_StringWalk_korean_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_korean_characters_Backwards",
     runFunction: run_StringWalk_korean_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_korean_unicodeScalars_Backwards",
     runFunction: run_CharIteration_korean_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_korean_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_korean_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_russian_unicodeScalars",
     runFunction: run_StringWalk_russian_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_russian_characters",
     runFunction: run_StringWalk_russian_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_russian_unicodeScalars",
     runFunction: run_CharIteration_russian_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_russian_unicodeScalars",
     runFunction: run_CharIndexing_russian_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_russian_unicodeScalars_Backwards",
     runFunction: run_StringWalk_russian_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_russian_characters_Backwards",
     runFunction: run_StringWalk_russian_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_russian_unicodeScalars_Backwards",
     runFunction: run_CharIteration_russian_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_russian_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_russian_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_punctuated_unicodeScalars",
     runFunction: run_StringWalk_punctuated_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuated_characters",
     runFunction: run_StringWalk_punctuated_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_punctuated_unicodeScalars",
     runFunction: run_CharIteration_punctuated_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_punctuated_unicodeScalars",
     runFunction: run_CharIndexing_punctuated_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_punctuated_unicodeScalars_Backwards",
     runFunction: run_StringWalk_punctuated_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuated_characters_Backwards",
     runFunction: run_StringWalk_punctuated_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_punctuated_unicodeScalars_Backwards",
     runFunction: run_CharIteration_punctuated_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_punctuated_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_punctuated_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_unicodeScalars",
     runFunction: run_StringWalk_punctuatedJapanese_unicodeScalars,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_characters",
     runFunction: run_StringWalk_punctuatedJapanese_characters,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_punctuatedJapanese_unicodeScalars",
     runFunction: run_CharIteration_punctuatedJapanese_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_punctuatedJapanese_unicodeScalars",
     runFunction: run_CharIndexing_punctuatedJapanese_unicodeScalars,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_unicodeScalars_Backwards",
     runFunction: run_StringWalk_punctuatedJapanese_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_characters_Backwards",
     runFunction: run_StringWalk_punctuatedJapanese_characters_Backwards,
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "CharIteration_punctuatedJapanese_unicodeScalars_Backwards",
     runFunction: run_CharIteration_punctuatedJapanese_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_punctuatedJapanese_unicodeScalars_Backwards",
     runFunction: run_CharIndexing_punctuatedJapanese_unicodeScalars_Backwards,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 ]
 
 

--- a/benchmark/single-source/StringWalk.swift.gyb
+++ b/benchmark/single-source/StringWalk.swift.gyb
@@ -85,7 +85,7 @@ public func run_StringWalk(_ N: Int) {
 }
 
 // Extended String benchmarks:
-let baseMultiplier = 10_000
+let baseMultiplier = 250
 let unicodeScalarsMultiplier = baseMultiplier
 let charactersMultiplier = baseMultiplier / 5
 
@@ -99,7 +99,8 @@ public var StringWalk = [
   BenchmarkInfo(
     name: "StringWalk",
     runFunction: run_StringWalk,
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
 % for Name in Names:
 %   for Direction in Directions:
@@ -108,19 +109,22 @@ public var StringWalk = [
   BenchmarkInfo(
     name: "StringWalk_${Name}_${Kind}${Direction}",
     runFunction: run_StringWalk_${Name}_${Kind}${Direction},
-    tags: [.api, .String, .skip]),
+    tags: [.api, .String, .skip],
+    legacyFactor: 40),
 
 %     end # Kinds
 
   BenchmarkInfo(
     name: "CharIteration_${Name}_unicodeScalars${Direction}",
     runFunction: run_CharIteration_${Name}_unicodeScalars${Direction},
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 
   BenchmarkInfo(
     name: "CharIndexing_${Name}_unicodeScalars${Direction}",
     runFunction: run_CharIndexing_${Name}_unicodeScalars${Direction},
-    tags: [.validation, .api, .String]),
+    tags: [.validation, .api, .String],
+    legacyFactor: 40),
 %   end # Directions
 % end # Names
 ]


### PR DESCRIPTION
This PR follows-up #20861. It's a next batch of benchmark clean-up to enable [robust performance measurements](https://forums.swift.org/t/towards-robust-performance-measurement/11490) by adjusting workloads to run in reasonable time (< 1000 μs), minimizing the accumulated error. To maintain long-term performance tracking, it applies [legacy factor](https://github.com/apple/swift/pull/20212) where necessary.

Flavor of the day: _“Hail to the `String`, baby!”_