### PR TITLE
[Sema] Forward declare things referenced in TypeCheckType.h.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -78,6 +78,10 @@ TypeResolution TypeResolution::forContextual(DeclContext *dc,
   return result;
 }
 
+ASTContext &TypeResolution::getASTContext() const {
+  return dc->getASTContext();
+}
+
 GenericSignatureBuilder *TypeResolution::getGenericSignatureBuilder() const {
   assert(stage == TypeResolutionStage::Interface);
   if (!complete.builder) {

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -16,10 +16,18 @@
 #ifndef SWIFT_SEMA_TYPE_CHECK_TYPE_H
 #define SWIFT_SEMA_TYPE_CHECK_TYPE_H
 
+#include "swift/AST/Type.h"
 #include "swift/AST/TypeResolutionStage.h"
 #include "llvm/ADT/None.h"
 
 namespace swift {
+
+class ASTContext;
+class TypeRepr;
+class ComponentIdentTypeRepr;
+class GenericEnvironment;
+class GenericSignature;
+class GenericSignatureBuilder;
 
 /// Flags that describe the context of type checking a pattern or
 /// type.
@@ -318,7 +326,7 @@ public:
                                       GenericEnvironment *genericEnv);
 
   /// Retrieve the ASTContext in which this resolution occurs.
-  ASTContext &getASTContext() const { return dc->getASTContext(); }
+  ASTContext &getASTContext() const;
 
   /// Retrieve the declaration context in which type resolution will be
   /// performed.


### PR DESCRIPTION
And move the implementation of getASTContext() into TypeCheckType.cpp
so that we don't need to include another header.

NFC.
