### PR TITLE
[5.0] Ban variadic enum cases

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3498,6 +3498,8 @@ ERROR(tuple_single_element,none,
       "cannot create a single-element tuple with an element label", ())
 ERROR(tuple_ellipsis,none,
       "cannot create a variadic tuple", ())
+ERROR(enum_element_ellipsis,none,
+      "variadic enum cases are not supported", ())
 
 WARNING(implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional,none,
         "using '!' is not allowed here; treating this as '?' instead", ())

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -723,6 +723,7 @@ static bool validateParameterType(ParamDecl *decl, TypeResolution resolution,
   if (auto ty = decl->getTypeLoc().getType())
     return ty->hasError();
 
+  auto origContext = options.getContext();
   options.setContext(None);
 
   // If the element is a variadic parameter, resolve the parameter type as if
@@ -764,6 +765,12 @@ static bool validateParameterType(ParamDecl *decl, TypeResolution resolution,
       hadError = true;
     }
     TL.setType(Ty);
+
+    // Disallow variadic parameters in enum elements.
+    if (!hadError && origContext == TypeResolverContext::EnumElementDecl) {
+      TC.diagnose(decl->getStartLoc(), diag::enum_element_ellipsis);
+      hadError = true;
+    }
   }
 
   if (hadError)

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -326,3 +326,10 @@ enum Lens<T> {
   case baz((inout T) -> ()) // ok
   case quux((inout T, inout T) -> ()) // ok
 }
+
+// In the long term, these should be legal, but we don't support them right
+// now and we shouldn't pretend to.
+// rdar://46684504
+enum HasVariadic {
+  case variadic(x: Int...) // expected-error {{variadic enum cases are not supported}}
+}


### PR DESCRIPTION
These should be supported in the long term, but in the short term, crashing is not accepable behavior.

rdar://46821582

5.0 version of #21419.  TODO: CCC