### PR TITLE
[5.0][build] Fix generated header files in standalone overlay builds.

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -58,6 +58,10 @@ precondition(SWIFT_DEST_ROOT)
 precondition(SWIFT_HOST_VARIANT_SDK)
 precondition(TOOLCHAIN_DIR)
 
+# Some overlays include the runtime's headers,
+# and some of those headers are generated at build time.
+add_subdirectory("${SWIFT_SOURCE_DIR}/include" "swift/include")
+
 # Without this line, installing components is broken. This needs refactoring.
 swift_configure_components()
 

--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,6 +1,14 @@
-configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
-               ESCAPE_QUOTES @ONLY)
+if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_STANDALONE_OVERLAY)
+  add_subdirectory(Runtime)
+endif()
 
-add_subdirectory(Option)
-add_subdirectory(SwiftRemoteMirror)
-add_subdirectory(Syntax)
+if(SWIFT_BUILD_REMOTE_MIRROR)
+  add_subdirectory(SwiftRemoteMirror)
+endif()
+
+if(SWIFT_INCLUDE_TOOLS)
+  configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
+                ESCAPE_QUOTES @ONLY)
+  add_subdirectory(Option)
+  add_subdirectory(Syntax)
+endif()


### PR DESCRIPTION
Cherry-picked from #21206.