### PR TITLE
stdlib: extend WinSDK module for Foundation

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -30,6 +30,12 @@ module WinSDK [system] [extern_c] {
       export *
     }
 
+    // api-ms-win-core-interlocked-l1-1-0.dll
+    module interlocked {
+      header "interlockedapi.h"
+      export *
+    }
+
     // api-ms-win-core-libloader-l1-1-0.dll
     module libloader {
       header "libloaderapi.h"


### PR DESCRIPTION
When building foundation, we end up including the interlocked module
through CoreFoundation.  Extend the modulemap for this.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
