### PR TITLE
[ModuleInterface] <rdar://46073729> Re-enable test that appears to be working now.

### DIFF
--- a/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar46073729
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/modulecache)
 //
@@ -55,7 +54,7 @@
 // RUN: not %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err.txt 2>&1
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR <%t/err.txt
-// CHECK-ERROR: LeafModule.swiftinterface:6:8: error: no such module 'NotAModule'
+// CHECK-ERROR: LeafModule.swiftinterface:7:8: error: no such module 'NotAModule'
 // CHECK-ERROR: OtherModule.swiftinterface:4:8: error: no such module 'LeafModule'
 //
 //


### PR DESCRIPTION
I spent several days now trying to produce anything like the failure we saw earlier in CI and I cannot. I read through all the code paths related to generating the diagnostic in question and they all look like they send the right source manager to the formatting operation, and asan shows nothing going wrong.

I'm annoyed at the absence of an explanation but absent one I don't see a reason to leave this disabled, so I'm proposing re-enabling it (there was also a change to a line number in the meantime, due to import printing changes).

rdar://46073729