### PR TITLE
[test] Change stored-properties-client to an executable test

### DIFF
--- a/test/ParseableInterface/stored-properties-client.swift
+++ b/test/ParseableInterface/stored-properties-client.swift
@@ -1,145 +1,87 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %S/stored-properties.swift -module-name StoredProperties -emit-parseable-module-interface-path %t/StoredProperties.swiftinterface
-// RUN: %target-swift-frontend -emit-ir %s -I %t | %FileCheck %s -check-prefix CHECK -check-prefix COMMON
+// 1. Build ../stored-properties.swift to a dylib and emit its interface in %t
 
-// RUN: %target-swift-frontend -typecheck %S/stored-properties.swift -enable-library-evolution -module-name StoredProperties -emit-parseable-module-interface-path %t/StoredProperties.swiftinterface
-// RUN: %target-swift-frontend -emit-ir %s -I %t | %FileCheck %s -check-prefix RESILIENT -check-prefix COMMON
+// RUN: %target-build-swift-dylib(%t/%target-library-name(StoredProperties)) -emit-module-interface-path %t/StoredProperties.swiftinterface %S/stored-properties.swift -module-name StoredProperties -swift-version 5
 
-// REQUIRES: rdar_46486517
+// 2. Build this file and link with StoredProperties
 
+// RUN: %target-build-swift %s -I %t -L %t -lStoredProperties -o %t/stored-properties-client %target-rpath(%t)
+
+// 3. Codesign and run this, and ensure it exits successfully.
+
+// RUN: %target-codesign %t/stored-properties-client %t/%target-library-name(StoredProperties)
+// RUN: %target-run %t/stored-properties-client %t/%target-library-name(StoredProperties)
+
+// 4. Repeat these steps, with library evolution enabled.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(StoredProperties)) -emit-module-interface-path %t/StoredProperties.swiftinterface %S/stored-properties.swift -module-name StoredProperties -swift-version 5 -enable-library-evolution
+
+// RUN: %target-build-swift %s -I %t -L %t -lStoredProperties -o %t/stored-properties-client %target-rpath(%t)
+// RUN: %target-codesign %t/stored-properties-client %t/%target-library-name(StoredProperties)
+// RUN: %target-run %t/stored-properties-client %t/%target-library-name(StoredProperties)
+
+import StdlibUnittest
 import StoredProperties
 
 /// This test makes sure clients of a parseable interface see correct type
 /// layout and use the right access patterns in the presence of a
 /// .swiftinterface file, in both resilient and non-resilient cases.
 
-// COMMON: %[[BAGOFVARIABLES:T16StoredProperties14BagOfVariablesV]] = type <{ %TSi, %TSb, [{{(3|7)}} x i8], %TSi }>
-
-// This type is non-@_fixed_layout, so it becomes opaque in a resilient module
-// CHECK: %[[HASSTOREDPROPERTIES:T16StoredProperties03HasaB0V]] = type <{ %TSi, %TSi, %TSb, [{{(3|7)}} x i8], %TSi, %TSb, [{{3|7}} x i8], %TSi }>
-// RESILIENT: %[[HASSTOREDPROPERTIES:swift.opaque]] = type opaque
-
-// COMMON: %[[HASSTOREDPROPERTIESFIXEDLAYOUT:T16StoredProperties03HasaB11FixedLayoutV]] = type <{ %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]] }>
-
-// These are here just to make sure the compiler doesn't optimize away accesses.
-// They're overloaded instead of generic so we avoid generic dispatch.
-
-@inline(never)
-func _blackHole(_ value: Int) {}
-
-@inline(never)
-func _blackHole(_ value: Bool) {}
-
-@inline(never)
-func _blackHole(_ value: BagOfVariables) {}
-
-/// In the following code, getting and setting is split because otherwise
-/// the resulting IR is ordered differently.
-
 /// Test that we call the correct accessors in a resilient module, and that
 /// we use trivial storage accesses in a non-resilient module.
 
-func testGetting() {
-  // CHECK: %[[VALUE:.*]] = alloca %[[HASSTOREDPROPERTIES]]
-  // CHECK: call swiftcc void @"$s16StoredProperties03HasaB0VACycfC"(%[[HASSTOREDPROPERTIES]]* {{.*}} %[[VALUE]])
-  // RESILIENT: %[[VALUE:.*]] = alloca i8, [[WORD:i[0-9]+]] %size
-  // RESILIENT: %[[VALUECAST:.*]] = bitcast i8* %value to %[[HASSTOREDPROPERTIES]]*
-  // RESILIENT: call swiftcc void @"$s16StoredProperties03HasaB0VACycfC"(%[[HASSTOREDPROPERTIES]]* noalias nocapture sret %[[VALUECAST]])
+var StoredPropertyTests = TestSuite("StoredProperty")
+
+StoredPropertyTests.test("Getting/NonFixedLayout") {
   var value = HasStoredProperties()
-
-  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 1
-  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 2
-
-  // These are accessed in declaration order so the IR is emitted in the same
-  // order.
-
-  // COMMON: call swiftcc [[WORD:i[0-9]+]] @"$s16StoredProperties03HasaB0V14computedGetterSivg"
-  _blackHole(value.computedGetter)
-
-  // COMMON: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V14computedGetSetSivg"
-  _blackHole(value.computedGetSet)
-
-  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 0
-  // CHECK: getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* %[[VALUE]], i32 0, i32 4
-
-  // RESILIENT: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V06simpleA9ImmutableSivg"
-  _blackHole(value.simpleStoredImmutable)
-
-  // RESILIENT: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V06simpleA7MutableSivg"
-  _blackHole(value.simpleStoredMutable)
-
-  // RESILIENT: call swiftcc i1 @"$s16StoredProperties03HasaB0V19storedWithObserversSbvg"
-  _blackHole(value.storedWithObservers)
-
-  // RESILIENT: call swiftcc [[WORD]] @"$s16StoredProperties03HasaB0V16storedPrivateSetSivg"
-  _blackHole(value.storedPrivateSet)
+  expectEqual(3, value.computedGetter)
+  expectEqual(3, value.computedGetSet)
+  expectEqual(0, value.simpleStoredImmutable)
+  expectEqual(0, value.simpleStoredMutable)
+  expectEqual(false, value.storedWithObservers)
+  expectEqual(0, value.storedPrivateSet)
 }
 
-func testSetting() {
-  // CHECK: call swiftcc void @"$s16StoredProperties03HasaB0VACycfC"(%[[HASSTOREDPROPERTIES]]* {{.*}})
-  // RESILIENT: call swiftcc %swift.metadata_response @"$s16StoredProperties03HasaB0VMa"([[WORD]] 0)
-  // RESILIENT: %[[VALUEALLOC:.*]] = alloca i8, [[WORD]] %size
-  // RESILIENT: bitcast i8* %[[VALUEALLOC]] to %[[HASSTOREDPROPERTIES]]*
+StoredPropertyTests.test("Setting/NonFixedLayout") {
   var value = HasStoredProperties()
-
-  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB0V19storedWithObserversSbvs"(i1 false, %[[HASSTOREDPROPERTIES]]* {{.*}})
-  value.storedWithObservers = false
-
-  // COMMON-NEXT: call swiftcc void @"$s16StoredProperties03HasaB0V14computedGetSetSivs"([[WORD]] 4, %[[HASSTOREDPROPERTIES]]* {{.*}})
+  value.storedWithObservers = true
   value.computedGetSet = 4
-
-  // CHECK: %[[MUTABLE_PTR:.*]] = getelementptr inbounds %[[HASSTOREDPROPERTIES]], %[[HASSTOREDPROPERTIES]]* {{.*}}, i32 0, i32 1
-  // CHECK: %[[MUTABLE_INT_PTR:.*]] = getelementptr inbounds %TSi, %TSi* %[[MUTABLE_PTR]], i32 0, i32 0
-  // CHECK: store [[WORD]] 4, [[WORD]]* %[[MUTABLE_INT_PTR]]
-  // RESILIENT: call swiftcc void @"$s16StoredProperties03HasaB0V06simpleA7MutableSivs"([[WORD]] 4, %[[HASSTOREDPROPERTIES]]* {{.*}})
   value.simpleStoredMutable = 4
+
+  expectEqual(3, value.computedGetter)
+  expectEqual(3, value.computedGetSet)
+  expectEqual(0, value.simpleStoredImmutable)
+  expectEqual(4, value.simpleStoredMutable)
+  expectEqual(true, value.storedWithObservers)
+  expectEqual(0, value.storedPrivateSet)
 }
 
-testGetting()
-testSetting()
-
-/// Test that we always use trivial access patterns for @_fixed_layout types
-/// in resilient or non-resilient modules.
-
-func testFixedLayoutGetting() {
-  // COMMON: %[[VALUEALLOCA:.*]] = alloca %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]
-  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB11FixedLayoutVACycfC"(%[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* {{.*}} %[[VALUEALLOCA]])
+StoredPropertyTests.test("Getting/FixedLayout") {
   var value = HasStoredPropertiesFixedLayout()
+  expectEqual(0, value.simpleStoredMutable.a)
+  expectEqual(false, value.simpleStoredMutable.b)
+  expectEqual(0, value.simpleStoredMutable.c)
 
-  // These next two tests just make sure we don't use resilient access patterns
-  // for these fixed_layout structs.
-
-  // COMMON: getelementptr inbounds %[[HASSTOREDPROPERTIESFIXEDLAYOUT]], %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* %[[VALUEALLOCA]], i32 0, i32 0
-  // COMMON: getelementptr inbounds %[[HASSTOREDPROPERTIESFIXEDLAYOUT]], %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* %[[VALUEALLOCA]], i32 0, i32 1
-
-  // COMMON: call swiftcc void @"$s4main10_blackHoleyy16StoredProperties14BagOfVariablesVF"([[WORD]] %{{.*}}, i1 %{{.*}}, [[WORD]] %{{.*}})
-  _blackHole(value.simpleStoredMutable)
-
-  // COMMON: call swiftcc void @"$s4main10_blackHoleyy16StoredProperties14BagOfVariablesVF"([[WORD]] %{{.*}}, i1 %{{.*}}, [[WORD]] %{{.*}})
-  _blackHole(value.storedWithObservers)
+  expectEqual(0, value.storedWithObservers.a)
+  expectEqual(false, value.storedWithObservers.b)
+  expectEqual(0, value.storedWithObservers.c)
 }
 
-func testFixedLayoutSetting() {
-  // COMMON: %[[VALUEALLOCA:.*]] = alloca %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]
-  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB11FixedLayoutVACycfC"(%[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* {{.*}} %[[VALUEALLOCA]])
+StoredPropertyTests.test("Setting/FixedLayout") {
   var value = HasStoredPropertiesFixedLayout()
 
-  // COMMON: call swiftcc void @"$s16StoredProperties03HasaB11FixedLayoutV19storedWithObserversAA14BagOfVariablesVvs"
-  value.storedWithObservers = BagOfVariables()
-
-  // COMMON: %[[PROP:.*]] = getelementptr inbounds %[[HASSTOREDPROPERTIESFIXEDLAYOUT]], %[[HASSTOREDPROPERTIESFIXEDLAYOUT]]* %value, i32 0, i32 0
-  // COMMON: %[[PROPA:.*]] = getelementptr inbounds %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]]* %[[PROP]], i32 0, i32 0
-  // COMMON: %[[PROPAVAL:.*]] = getelementptr inbounds %TSi, %TSi* %[[PROPA]], i32 0, i32 0
-  // COMMON: store [[WORD]] {{.*}} %[[PROPAVAL]]
-  // COMMON: %[[PROPB:.*]] = getelementptr inbounds %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]]* %[[PROP]], i32 0, i32 1
-  // COMMON: %[[PROPBVAL:.*]] = getelementptr inbounds %TSb, %TSb* %[[PROPB]], i32 0, i32 0
-  // COMMON: store i1 {{.*}} %[[PROPBVAL]]
-  // COMMON: %[[PROPC:.*]] = getelementptr inbounds %[[BAGOFVARIABLES]], %[[BAGOFVARIABLES]]* %[[PROP]], i32 0, i32 3
-  // COMMON: %[[PROPCVAL:.*]] = getelementptr inbounds %TSi, %TSi* %[[PROPC]], i32 0, i32 0
-  // COMMON: store [[WORD]] {{.*}} %[[PROPCVAL]]
   value.simpleStoredMutable = BagOfVariables()
+  expectEqual(0, value.simpleStoredMutable.a)
+  expectEqual(false, value.simpleStoredMutable.b)
+  expectEqual(0, value.simpleStoredMutable.c)
+
+  value.storedWithObservers = BagOfVariables()
+  expectEqual(0, value.storedWithObservers.a)
+  expectEqual(false, value.storedWithObservers.b)
+  expectEqual(0, value.storedWithObservers.c)
 }
 
-testFixedLayoutGetting()
-testFixedLayoutSetting()
+runAllTests()

--- a/test/ParseableInterface/stored-properties.swift
+++ b/test/ParseableInterface/stored-properties.swift
@@ -77,6 +77,9 @@ public struct HasStoredProperties {
 // COMMON: @_fixed_layout public struct BagOfVariables {
 @_fixed_layout
 public struct BagOfVariables {
+  // COMMON: private let hidden: [[INT]] = 0
+  private let hidden: Int = 0
+
   // COMMON: public let a: [[INT]] = 0
   public let a: Int = 0
 


### PR DESCRIPTION
This test was overfitting what it was trying to test, causing different
targets (and even different assert configurations) to fail to match.
Instead, make this an executable test and ensure that round-tripping
through setting and getting behaves as expected.

Fixes rdar://46486517