### PR TITLE
[swift-evolve] More source order dependencies in tests

### DIFF
--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1072,10 +1072,10 @@ enum d2300_EnumDeclWithValues1 : Int {
 // PASS_COMMON: {{^}}enum d2300_EnumDeclWithValues1 : Int {{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV2_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV2_Second{{$}}
-// PASS_COMMON-NEXT: {{^}}  typealias RawValue = Int
-// PASS_COMMON-NEXT: {{^}}  init?(rawValue: Int){{$}}
-// PASS_COMMON-NEXT: {{^}}  var rawValue: Int { get }{{$}}
-// PASS_COMMON-NEXT: {{^}}}{{$}}
+// PASS_COMMON-DAG: {{^}}  typealias RawValue = Int
+// PASS_COMMON-DAG: {{^}}  init?(rawValue: Int){{$}}
+// PASS_COMMON-DAG: {{^}}  var rawValue: Int { get }{{$}}
+// PASS_COMMON: {{^}}}{{$}}
 
 enum d2400_EnumDeclWithValues2 : Double {
   case EDV3_First = 10
@@ -1084,10 +1084,10 @@ enum d2400_EnumDeclWithValues2 : Double {
 // PASS_COMMON: {{^}}enum d2400_EnumDeclWithValues2 : Double {{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV3_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV3_Second{{$}}
-// PASS_COMMON-NEXT: {{^}}  typealias RawValue = Double
-// PASS_COMMON-NEXT: {{^}}  init?(rawValue: Double){{$}}
-// PASS_COMMON-NEXT: {{^}}  var rawValue: Double { get }{{$}}
-// PASS_COMMON-NEXT: {{^}}}{{$}}
+// PASS_COMMON-DAG: {{^}}  typealias RawValue = Double
+// PASS_COMMON-DAG: {{^}}  init?(rawValue: Double){{$}}
+// PASS_COMMON-DAG: {{^}}  var rawValue: Double { get }{{$}}
+// PASS_COMMON: {{^}}}{{$}}
 
 //===---
 //===--- Custom operator printing.

--- a/test/ParseableInterface/synthesized.swift
+++ b/test/ParseableInterface/synthesized.swift
@@ -4,20 +4,20 @@
 public enum HasRawValue: Int {
   // CHECK-NEXT: case a, b, c
   case a, b = 5, c
-  // CHECK-NEXT: public typealias RawValue = Swift.Int
-  // CHECK-NEXT: @inlinable public init?(rawValue: Swift.Int)
-  // CHECK-NEXT: public var rawValue: Swift.Int {
-  // CHECK-NEXT:   @inlinable get{{$}}
-  // CHECK-NEXT: }
-} // CHECK-NEXT: {{^}$}}
+  // CHECK-DAG: public typealias RawValue = Swift.Int
+  // CHECK-DAG: @inlinable public init?(rawValue: Swift.Int)
+  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG:   @inlinable get{{$}}
+  // CHECK-DAG: }
+} // CHECK: {{^}$}}
 
 // CHECK-LABEL: @objc public enum ObjCEnum : Int {
 @objc public enum ObjCEnum: Int {
   // CHECK-NEXT: case a, b, c
   case a, b = 5, c
-  // CHECK-NEXT: public typealias RawValue = Swift.Int
-  // CHECK-NEXT: @inlinable public init?(rawValue: Swift.Int)
-  // CHECK-NEXT: public var rawValue: Swift.Int {
-  // CHECK-NEXT:   @inlinable get{{$}}
-  // CHECK-NEXT: }
-} // CHECK-NEXT: {{^}$}}
+  // CHECK-DAG: public typealias RawValue = Swift.Int
+  // CHECK-DAG: @inlinable public init?(rawValue: Swift.Int)
+  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG:   @inlinable get{{$}}
+  // CHECK-DAG: }
+} // CHECK: {{^}$}}

--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -2,6 +2,6 @@
 
 // Fails if the positions of the two Collection subscript requirements are
 // reversed. rdar://problem/46650834
-// XFAIL: swift_evolve
+// UNSUPPORTED: swift_evolve
 
 var W = [UInt32](repeating: 0, count: 16)

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -1,8 +1,5 @@
 // REQUIRES: objc_interop
 
-// SourceKit is expected to produce documentation in source order.
-// UNSUPPORTED: swift_evolve
-
 // FIXME: the test output we're comparing to is specific to macOS.
 // REQUIRES-ANY: OS=macosx
 

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -4,6 +4,10 @@ if 'sourcekit' not in config.available_features:
 elif 'OS=linux-gnu' in config.available_features and 'LinuxDistribution=Ubuntu-14.04' in config.available_features:
     config.unsupported = True
 
+elif 'swift_evolve' in config.available_features:
+    # A lot of tests necessarily depend on standard library source order.
+    config.unsupported = True
+
 else:
     sed_clean = r"grep -v 'key.hash: \"0\"'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -7,8 +7,6 @@
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-abi.swift.expected %t.tmp/changes.txt.tmp
 
-// The digester hasn't learned that we've stopped baking non-stored class member
-// order into the ABI. rdar://problem/46617463
 // The digester can incorrectly register a generic signature change when
 // declarations are shuffled. rdar://problem/46618883
 // UNSUPPORTED: swift_evolve

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -11,4 +11,4 @@
 // order into the ABI. rdar://problem/46617463
 // The digester can incorrectly register a generic signature change when
 // declarations are shuffled. rdar://problem/46618883
-// XFAIL: swift_evolve
+// UNSUPPORTED: swift_evolve


### PR DESCRIPTION
Grab bag of test changes for swift-evolve:

* Several ParsableInterface tests involving `RawRepresentable` could fail if that protocol's members were shuffled. Switch those to use CHECK-DAG instead of CHECK-NEXT.
* Use UNSUPPORTED instead of XFAIL to skip source-order-dependent tests. swift-evolve makes random changes, so most of these tests become flaky rather than failing reliably as XFAIL requires.
* Mark all SourceKit tests as unsupported. Many of these tests are inherently source-order-dependent and it's not worth triaging the failures at this point.
* One of the two issues preventing us from running the ABI checker test with swift-evolve has been fixed; delete the comment citing it.

Tagging @jrose-apple to make sure the ParsableInterface tests aren't made useless by this change.