### PR TITLE
use vjp to differentiate apply insts by default

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -390,6 +390,10 @@ NOTE(autodiff_control_flow_not_supported,none,
      "differentiating control flow is not supported yet", ())
 NOTE(autodiff_nested_not_supported,none,
      "nested differentiation is not supported yet", ())
+ERROR(autodiff_no_synthesized_primal_or_adjoint,none,
+      "function does not have primal or adjoint; define an adjoint (and "
+      "optionally, a primal) using a '@differentiable' attribute, or enable "
+      "'-differentiation-use-vjp' mode", ())
 
 ERROR(non_physical_addressof,none,
       "addressof only works with purely physical lvalues; "

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -differentiation-use-vjp=false %s
 
 //===----------------------------------------------------------------------===//
 // Top-level (before primal/adjoint synthesis)

--- a/test/AutoDiff/autodiff_e2e_basic.swift
+++ b/test/AutoDiff/autodiff_e2e_basic.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-use-vjp=false %s | %FileCheck %s
 
 @differentiable(reverse, adjoint: adjointId)
 func id(_ x: Float) -> Float {

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-use-vjp=false %s | %FileCheck %s
 
 public func closureCapture() {
   let val: Float = 10

--- a/test/AutoDiff/diagnose_missing_synthesis.swift
+++ b/test/AutoDiff/diagnose_missing_synthesis.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-use-vjp=false -verify %s
+
+@differentiable(reverse, vjp: vjpMultiply)
+func multiply(_ x: Float) -> Float {
+  return x * 10
+}
+
+func vjpMultiply(_ x: Float) -> (Float, (Float) -> Float) {
+  return (x * 10, { v in v * 10 })
+}
+
+func wrapper(_ x: Float) -> Float {
+  // expected-error @+1 {{function does not have primal or adjoint; define an adjoint (and optionally, a primal) using a '@differentiable' attribute, or enable '-differentiation-use-vjp' mode}}
+  return multiply(x)
+}
+
+print(gradient(at: 0, in: wrapper))

--- a/test/AutoDiff/differential_operators.swift
+++ b/test/AutoDiff/differential_operators.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-simple-no-vjp-swift
 // REQUIRES: executable_test
 
 import Swift

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-use-vjp-swift
+// RUN: %target-run-simple-no-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck -check-prefix=CHECK-VJP %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-use-vjp=false %s | %FileCheck -check-prefix=CHECK-NOVJP %s
 
 import Builtin
 import Swift
@@ -44,89 +45,183 @@ bb0(%0 : @trivial $Float):
   return %6 : $Float
 }
 
-// CHECK-LABEL: struct AD__func_to_diff__Type__src_0_wrt_0 {
-// CHECK-NEXT:   @sil_stored var v_0: Float
-// CHECK-NEXT:   @sil_stored var pullback_0: (Float) -> Float
-// CHECK-NEXT: }
+// CHECK-VJP-LABEL: struct AD__func_to_diff__Type__src_0_wrt_0 {
+// CHECK-VJP-NEXT:   @sil_stored var v_0: Float
+// CHECK-VJP-NEXT:   @sil_stored var pullback_0: (Float) -> Float
+// CHECK-VJP-NEXT: }
 
-// CHECK-LABEL: struct AD__nested_func_without_diffattr__Type__src_0_wrt_0 {
-// CHECK-NEXT:   @sil_stored var v_0: Float
-// CHECK-NEXT:   @sil_stored var pullback_0: (Float) -> Float
-// CHECK-NEXT: }
+// CHECK-VJP-LABEL: struct AD__nested_func_without_diffattr__Type__src_0_wrt_0 {
+// CHECK-VJP-NEXT:   @sil_stored var v_0: Float
+// CHECK-VJP-NEXT:   @sil_stored var pullback_0: (Float) -> Float
+// CHECK-VJP-NEXT: }
 
-// CHECK-LABEL: @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
-// CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = tuple (%0 : $Float, %0 : $Float)
-// CHECK:   return %1 : $(Float, Float)
-// CHECK: }
+// CHECK-VJP-LABEL: @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
+// CHECK-VJP: bb0(%0 : $Float):
+// CHECK-VJP:   %1 = tuple (%0 : $Float, %0 : $Float)
+// CHECK-VJP:   return %1 : $(Float, Float)
+// CHECK-VJP: }
 
-// CHECK-LABEL: @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
-// CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $Float):
-// CHECK:   return %0 : $Float
-// CHECK: }
+// CHECK-VJP-LABEL: @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
+// CHECK-VJP: bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $Float):
+// CHECK-VJP:   return %0 : $Float
+// CHECK-VJP: }
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj vjp @AD__foo__vjp_src_0_wrt_0] @foo : $@convention(thin) (Float) -> Float
+// CHECK-VJP-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj vjp @AD__foo__vjp_src_0_wrt_0] @foo : $@convention(thin) (Float) -> Float
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 vjp @AD__nested_func_without_diffattr__vjp_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+// CHECK-VJP-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 vjp @AD__nested_func_without_diffattr__vjp_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0 vjp @AD__func_to_diff__vjp_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float
+// CHECK-VJP-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0 vjp @AD__func_to_diff__vjp_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float
 
-// CHECK-LABEL: @AD__func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__func_to_diff__Type__src_0_wrt_0, Float) {
-// CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = function_ref @AD__nested_func_without_diffattr__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK:   %3 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 0
-// CHECK:   %4 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 1
-// CHECK:   %5 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
-// CHECK:   %6 = apply %5(%3) : $@convention(thin) (Float) -> Float
-// CHECK:   %7 = tuple (%3 : $Float, %3 : $Float)
-// CHECK:   %8 = tuple_extract %7 : $(Float, Float), 0
-// CHECK:   %9 = struct $AD__func_to_diff__Type__src_0_wrt_0 (%3 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
-// CHECK:   %10 = tuple (%9 : $AD__func_to_diff__Type__src_0_wrt_0, %8 : $Float)
-// CHECK:   return %10 : $(AD__func_to_diff__Type__src_0_wrt_0, Float)
-// CHECK: }
+// CHECK-VJP-LABEL: @AD__func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__func_to_diff__Type__src_0_wrt_0, Float) {
+// CHECK-VJP: bb0(%0 : $Float):
+// CHECK-VJP:   %1 = function_ref @AD__nested_func_without_diffattr__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-VJP:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-VJP:   %3 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 0
+// CHECK-VJP:   %4 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 1
+// CHECK-VJP:   %5 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+// CHECK-VJP:   %6 = apply %5(%3) : $@convention(thin) (Float) -> Float
+// CHECK-VJP:   %7 = tuple (%3 : $Float, %3 : $Float)
+// CHECK-VJP:   %8 = tuple_extract %7 : $(Float, Float), 0
+// CHECK-VJP:   %9 = struct $AD__func_to_diff__Type__src_0_wrt_0 (%3 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
+// CHECK-VJP:   %10 = tuple (%9 : $AD__func_to_diff__Type__src_0_wrt_0, %8 : $Float)
+// CHECK-VJP:   return %10 : $(AD__func_to_diff__Type__src_0_wrt_0, Float)
+// CHECK-VJP: }
 
-// CHECK-LABEL: @AD__func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
-// CHECK: bb0(%0 : $Float, %1 : $AD__func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
-// CHECK:   %4 = struct_extract %1 : $AD__func_to_diff__Type__src_0_wrt_0, #AD__func_to_diff__Type__src_0_wrt_0.pullback_0
-// CHECK:   %5 = alloc_stack $Float
-// CHECK:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
-// CHECK:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Float
-// CHECK:   store %0 to %7 : $*Float
-// CHECK:   end_access %7 : $*Float
-// CHECK:   end_access %6 : $*Float
-// CHECK:   %11 = begin_access [read] [static] [no_nested_conflict] %5 : $*Float
-// CHECK:   %12 = load %11 : $*Float
-// CHECK:   end_access %11 : $*Float
-// CHECK:   %14 = apply %4(%12) : $@callee_guaranteed (Float) -> Float
-// CHECK:   dealloc_stack %5 : $*Float
-// CHECK:   return %14 : $Float
-// CHECK: }
+// CHECK-VJP-LABEL: @AD__func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK-VJP: bb0(%0 : $Float, %1 : $AD__func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
+// CHECK-VJP:   %4 = struct_extract %1 : $AD__func_to_diff__Type__src_0_wrt_0, #AD__func_to_diff__Type__src_0_wrt_0.pullback_0
+// CHECK-VJP:   %5 = alloc_stack $Float
+// CHECK-VJP:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
+// CHECK-VJP:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Float
+// CHECK-VJP:   store %0 to %7 : $*Float
+// CHECK-VJP:   end_access %7 : $*Float
+// CHECK-VJP:   end_access %6 : $*Float
+// CHECK-VJP:   %11 = begin_access [read] [static] [no_nested_conflict] %5 : $*Float
+// CHECK-VJP:   %12 = load %11 : $*Float
+// CHECK-VJP:   end_access %11 : $*Float
+// CHECK-VJP:   %14 = apply %4(%12) : $@callee_guaranteed (Float) -> Float
+// CHECK-VJP:   dealloc_stack %5 : $*Float
+// CHECK-VJP:   return %14 : $Float
+// CHECK-VJP: }
 
-// CHECK-LABEL: @AD__nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float) {
-// CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = function_ref @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK:   %3 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 0
-// CHECK:   %4 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 1
-// CHECK:   %5 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%3 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
-// CHECK:   %6 = tuple (%5 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %3 : $Float)
-// CHECK:   return %6 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
-// CHECK: }
+// CHECK-VJP-LABEL: @AD__nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float) {
+// CHECK-VJP: bb0(%0 : $Float):
+// CHECK-VJP:   %1 = function_ref @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-VJP:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-VJP:   %3 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 0
+// CHECK-VJP:   %4 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 1
+// CHECK-VJP:   %5 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%3 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
+// CHECK-VJP:   %6 = tuple (%5 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %3 : $Float)
+// CHECK-VJP:   return %6 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
+// CHECK-VJP: }
 
-// CHECK-LABEL: @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float {
-// CHECK: bb0(%0 : $Float, %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
-// CHECK:   %4 = struct_extract %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, #AD__nested_func_without_diffattr__Type__src_0_wrt_0.pullback_0
-// CHECK:   %5 = alloc_stack $Float
-// CHECK:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
-// CHECK:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Float
-// CHECK:   store %0 to %7 : $*Float
-// CHECK:   end_access %7 : $*Float
-// CHECK:   end_access %6 : $*Float
-// CHECK:   %11 = begin_access [read] [static] [no_nested_conflict] %5 : $*Float
-// CHECK:   %12 = load %11 : $*Float
-// CHECK:   end_access %11 : $*Float
-// CHECK:   %14 = apply %4(%12) : $@callee_guaranteed (Float) -> Float
-// CHECK:   dealloc_stack %5 : $*Float
-// CHECK:   return %14 : $Float
-// CHECK: }
+// CHECK-VJP-LABEL: @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK-VJP: bb0(%0 : $Float, %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
+// CHECK-VJP:   %4 = struct_extract %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, #AD__nested_func_without_diffattr__Type__src_0_wrt_0.pullback_0
+// CHECK-VJP:   %5 = alloc_stack $Float
+// CHECK-VJP:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
+// CHECK-VJP:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Float
+// CHECK-VJP:   store %0 to %7 : $*Float
+// CHECK-VJP:   end_access %7 : $*Float
+// CHECK-VJP:   end_access %6 : $*Float
+// CHECK-VJP:   %11 = begin_access [read] [static] [no_nested_conflict] %5 : $*Float
+// CHECK-VJP:   %12 = load %11 : $*Float
+// CHECK-VJP:   end_access %11 : $*Float
+// CHECK-VJP:   %14 = apply %4(%12) : $@callee_guaranteed (Float) -> Float
+// CHECK-VJP:   dealloc_stack %5 : $*Float
+// CHECK-VJP:   return %14 : $Float
+// CHECK-VJP: }
+
+// CHECK-NOVJP: @usableFromInline
+// CHECK-NOVJP: struct AD__func_to_diff__Type__src_0_wrt_0 {
+// CHECK-NOVJP:   @sil_stored var pv_0: AD__nested_func_without_diffattr__Type__src_0_wrt_0
+// CHECK-NOVJP:   @sil_stored var v_0: Float
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP: @usableFromInline
+// CHECK-NOVJP: struct AD__nested_func_without_diffattr__Type__src_0_wrt_0 {
+// CHECK-NOVJP:   @sil_stored var pv_0: Float
+// CHECK-NOVJP:   @sil_stored var v_0: Float
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP-LABEL: @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
+// CHECK-NOVJP: bb0(%0 : $Float):
+// CHECK-NOVJP:   %1 = tuple (%0 : $Float, %0 : $Float)
+// CHECK-NOVJP:   return %1 : $(Float, Float)
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP-LABEL: @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
+// CHECK-NOVJP: bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $Float):
+// CHECK-NOVJP:   return %0 : $Float
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj vjp @AD__foo__vjp_src_0_wrt_0] @foo : $@convention(thin) (Float) -> Float
+
+// CHECK-NOVJP-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 vjp @AD__nested_func_without_diffattr__vjp_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+
+// CHECK-NOVJP-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0 vjp @AD__func_to_diff__vjp_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float
+
+// CHECK-NOVJP-LABEL: @AD__func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__func_to_diff__Type__src_0_wrt_0, Float) {
+// CHECK-NOVJP: bb0(%0 : $Float):
+// CHECK-NOVJP:   %1 = function_ref @AD__nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
+// CHECK-NOVJP:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
+// CHECK-NOVJP:   %3 = tuple_extract %2 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float), 0
+// CHECK-NOVJP:   %4 = tuple_extract %2 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float), 1
+// CHECK-NOVJP:   // function_ref nested_func_without_diffattr
+// CHECK-NOVJP:   %5 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+// CHECK-NOVJP:   %6 = apply %5(%4) : $@convention(thin) (Float) -> Float
+// CHECK-NOVJP:   %7 = tuple (%4 : $Float, %4 : $Float)
+// CHECK-NOVJP:   %8 = tuple_extract %7 : $(Float, Float), 0
+// CHECK-NOVJP:   %9 = struct $AD__func_to_diff__Type__src_0_wrt_0 (%3 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %4 : $Float)
+// CHECK-NOVJP:   %10 = tuple (%9 : $AD__func_to_diff__Type__src_0_wrt_0, %8 : $Float)
+// CHECK-NOVJP:   return %10 : $(AD__func_to_diff__Type__src_0_wrt_0, Float)
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP-LABEL: @AD__func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK-NOVJP: bb0(%0 : $Float, %1 : $AD__func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
+// CHECK-NOVJP:   %4 = alloc_stack $Float
+// CHECK-NOVJP:   %5 = begin_access [init] [static] [no_nested_conflict] %4 : $*Float
+// CHECK-NOVJP:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
+// CHECK-NOVJP:   store %0 to %6 : $*Float
+// CHECK-NOVJP:   end_access %6 : $*Float
+// CHECK-NOVJP:   end_access %5 : $*Float
+// CHECK-NOVJP:   %10 = begin_access [read] [static] [no_nested_conflict] %4 : $*Float
+// CHECK-NOVJP:   %11 = load %10 : $*Float
+// CHECK-NOVJP:   end_access %10 : $*Float
+// CHECK-NOVJP:   %13 = struct_extract %1 : $AD__func_to_diff__Type__src_0_wrt_0, #AD__func_to_diff__Type__src_0_wrt_0.pv_0
+// CHECK-NOVJP:   %14 = struct_extract %1 : $AD__func_to_diff__Type__src_0_wrt_0, #AD__func_to_diff__Type__src_0_wrt_0.v_0
+// CHECK-NOVJP:   %15 = function_ref @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float
+// CHECK-NOVJP:   %16 = apply %15(%11, %13, %14, %3) : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float
+// CHECK-NOVJP:   dealloc_stack %4 : $*Float
+// CHECK-NOVJP:   return %16 : $Float
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP-LABEL: @AD__nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float) {
+// CHECK-NOVJP: bb0(%0 : $Float):
+// CHECK-NOVJP:   %1 = function_ref @foo_prim : $@convention(thin) (Float) -> (Float, Float)
+// CHECK-NOVJP:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, Float)
+// CHECK-NOVJP:   %3 = tuple_extract %2 : $(Float, Float), 0
+// CHECK-NOVJP:   %4 = tuple_extract %2 : $(Float, Float), 1
+// CHECK-NOVJP:   %5 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%3 : $Float, %4 : $Float)
+// CHECK-NOVJP:   %6 = tuple (%5 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %4 : $Float)
+// CHECK-NOVJP:   return %6 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
+// CHECK-NOVJP: }
+
+// CHECK-NOVJP-LABEL: @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK-NOVJP: bb0(%0 : $Float, %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
+// CHECK-NOVJP:   %4 = alloc_stack $Float
+// CHECK-NOVJP:   %5 = begin_access [init] [static] [no_nested_conflict] %4 : $*Float
+// CHECK-NOVJP:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
+// CHECK-NOVJP:   store %0 to %6 : $*Float
+// CHECK-NOVJP:   end_access %6 : $*Float
+// CHECK-NOVJP:   end_access %5 : $*Float
+// CHECK-NOVJP:   %10 = begin_access [read] [static] [no_nested_conflict] %4 : $*Float
+// CHECK-NOVJP:   %11 = load %10 : $*Float
+// CHECK-NOVJP:   end_access %10 : $*Float
+// CHECK-NOVJP:   %13 = struct_extract %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, #AD__nested_func_without_diffattr__Type__src_0_wrt_0.pv_0
+// CHECK-NOVJP:   %14 = struct_extract %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, #AD__nested_func_without_diffattr__Type__src_0_wrt_0.v_0
+// CHECK-NOVJP:   %15 = function_ref @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float
+// CHECK-NOVJP:   %16 = apply %15(%11, %13, %14, %3) : $@convention(thin) (Float, Float, Float, Float) -> Float
+// CHECK-NOVJP:   dealloc_stack %4 : $*Float
+// CHECK-NOVJP:   return %16 : $Float
+// CHECK-NOVJP: }

--- a/test/AutoDiff/primalgen.swift
+++ b/test/AutoDiff/primalgen.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-use-vjp=false %s | %FileCheck %s
 
 @inline(never)
 func print<T>(_ x: T) {

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -1,5 +1,3 @@
-// TODO: Change to normal %target-run-simple-swift when there are stdlib
-// functions for differentiating methods.
 // RUN: %target-run-simple-parse-stdlib-swift
 
 import Swift

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck -check-prefix=CHECK-VJP %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-use-vjp=false %s | %FileCheck -check-prefix=CHECK-NOVJP %s
 
 public class NonTrivialStuff : Equatable {
   public init() {}
@@ -34,40 +35,69 @@ func testOwnedVector(_ x: Vector) -> Vector {
 }
 _ = #gradient(testOwnedVector)
 
-// CHECK-LABEL: struct {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 {
-// CHECK-NEXT:   @sil_stored @usableFromInline
-// CHECK-NEXT:   var v_0: Vector
-// CHECK-NEXT:   @sil_stored @usableFromInline
-// CHECK-NEXT:   var pullback_0: (Vector) -> (Vector, Vector)
-// CHECK-NEXT: }
+// CHECK-VJP-LABEL: struct {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 {
+// CHECK-VJP-NEXT:   @sil_stored @usableFromInline
+// CHECK-VJP-NEXT:   var v_0: Vector
+// CHECK-VJP-NEXT:   @sil_stored @usableFromInline
+// CHECK-VJP-NEXT:   var pullback_0: (Vector) -> (Vector, Vector)
+// CHECK-VJP-NEXT: }
 
-// CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__grad_src_0_wrt_0_s_p
-// CHECK:   [[PRIMAL:%.*]] = function_ref @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0
-// CHECK:   [[PRIMAL_RESULT:%.*]] = apply [[PRIMAL]]({{.*}})
-// CHECK:   [[NESTED_PRIMAL_VALUES:%.*]] = tuple_extract [[PRIMAL_RESULT]] : $({{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, Vector), 0
-// CHECK:   [[ORIGINAL_RESULT:%.*]] = tuple_extract [[PRIMAL_RESULT]] : $({{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, Vector), 1
-// CHECK:   [[ADJOINT:%.*]] = function_ref @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
-// CHECK:   {{.*}} = apply [[ADJOINT]]({{.*}}, [[NESTED_PRIMAL_VALUES]], [[ORIGINAL_RESULT]], {{.*}})
-// CHECK:   release_value [[NESTED_PRIMAL_VALUES]]
-// CHECK:   release_value [[ORIGINAL_RESULT]]
+// CHECK-VJP-LABEL: @{{.*}}testOwnedVector{{.*}}__grad_src_0_wrt_0_s_p
+// CHECK-VJP:   [[PRIMAL:%.*]] = function_ref @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0
+// CHECK-VJP:   [[PRIMAL_RESULT:%.*]] = apply [[PRIMAL]]({{.*}})
+// CHECK-VJP:   [[NESTED_PRIMAL_VALUES:%.*]] = tuple_extract [[PRIMAL_RESULT]] : $({{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, Vector), 0
+// CHECK-VJP:   [[ORIGINAL_RESULT:%.*]] = tuple_extract [[PRIMAL_RESULT]] : $({{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, Vector), 1
+// CHECK-VJP:   [[ADJOINT:%.*]] = function_ref @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
+// CHECK-VJP:   {{.*}} = apply [[ADJOINT]]({{.*}}, [[NESTED_PRIMAL_VALUES]], [[ORIGINAL_RESULT]], {{.*}})
+// CHECK-VJP:   release_value [[NESTED_PRIMAL_VALUES]]
+// CHECK-VJP:   release_value [[ORIGINAL_RESULT]]
 
 // The primal should not release primal values.
 //
-// CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0 : $@convention(thin) (@guaranteed Vector) -> (@owned {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, @owned Vector) {
-// CHECK:   [[ADD_VJP:%.*]] = function_ref @AD__$s11refcounting6VectorV1poiyA2C_ACtFZ__vjp_src_0_wrt_0_1 : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector))
-// CHECK:   [[ADD_VJP_RESULT:%.*]] = apply [[ADD_VJP]]({{.*}}, {{.*}}, {{.*}}) : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector))
-// CHECK:   [[ADD_ORIGINAL_RESULT:%.*]] = tuple_extract [[ADD_VJP_RESULT]] : $(Vector, @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector)), 0
-// CHECK:   [[ADD_PULLBACK:%.*]] = tuple_extract [[ADD_VJP_RESULT]] : $(Vector, @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector)), 1
-// CHECK-NOT:   release_value [[ADD_VJP_RESULT]]
-// CHECK-NOT:   release_value [[ADD_ORIGINAL_RESULT]]
-// CHECK-NOT:   release_value [[ADD_PULLBACK]]
-// CHECK:   } // end sil function '{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0'
+// CHECK-VJP-LABEL: @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0 : $@convention(thin) (@guaranteed Vector) -> (@owned {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, @owned Vector) {
+// CHECK-VJP:   [[ADD_VJP:%.*]] = function_ref @AD__$s11refcounting6VectorV1poiyA2C_ACtFZ__vjp_src_0_wrt_0_1 : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector))
+// CHECK-VJP:   [[ADD_VJP_RESULT:%.*]] = apply [[ADD_VJP]]({{.*}}, {{.*}}, {{.*}}) : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector))
+// CHECK-VJP:   [[ADD_ORIGINAL_RESULT:%.*]] = tuple_extract [[ADD_VJP_RESULT]] : $(Vector, @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector)), 0
+// CHECK-VJP:   [[ADD_PULLBACK:%.*]] = tuple_extract [[ADD_VJP_RESULT]] : $(Vector, @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector)), 1
+// CHECK-VJP-NOT:   release_value [[ADD_VJP_RESULT]]
+// CHECK-VJP-NOT:   release_value [[ADD_ORIGINAL_RESULT]]
+// CHECK-VJP-NOT:   release_value [[ADD_PULLBACK]]
+// CHECK-VJP:   } // end sil function '{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0'
 
 // The adjoint should not release primal values because they are passed in as @guaranteed.
 //
-// CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
-// CHECK: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, {{%.*}} : $Vector, {{%.*}} : $Vector):
-// CHECK:   [[PULLBACK0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.pullback_0
-// CHECK-NOT:   release_value [[PULLBACK0]]
-// CHECK-NOT:   release_value [[PRIMAL_VALUES]]
-// CHECK:   } // end sil function '{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0'
+// CHECK-VJP-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
+// CHECK-VJP: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, {{%.*}} : $Vector, {{%.*}} : $Vector):
+// CHECK-VJP:   [[PULLBACK0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.pullback_0
+// CHECK-VJP-NOT:   release_value [[PULLBACK0]]
+// CHECK-VJP-NOT:   release_value [[PRIMAL_VALUES]]
+// CHECK-VJP:   } // end sil function '{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0'
+
+// CHECK-NOVJP-LABEL: struct {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 {
+// CHECK-NOVJP-NEXT:   @sil_stored @usableFromInline
+// CHECK-NOVJP-NEXT:   var v_0: Vector
+// CHECK-NOVJP-NEXT: }
+// CHECK-NOVJP-LABEL: @{{.*}}testOwnedVector{{.*}}__grad_src_0_wrt_0_s_p
+// CHECK-NOVJP:   [[PRIMAL:%.*]] = function_ref @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0
+// CHECK-NOVJP:   [[PRIMAL_RESULT:%.*]] = apply [[PRIMAL]]({{.*}})
+// CHECK-NOVJP:   [[NESTED_PRIMAL_VALUES:%.*]] = tuple_extract [[PRIMAL_RESULT]] : $({{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, Vector), 0
+// CHECK-NOVJP:   [[ORIGINAL_RESULT:%.*]] = tuple_extract [[PRIMAL_RESULT]] : $({{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, Vector), 1
+// CHECK-NOVJP:   [[ADJOINT:%.*]] = function_ref @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
+// CHECK-NOVJP:   {{.*}} = apply [[ADJOINT]]({{.*}}, [[NESTED_PRIMAL_VALUES]], [[ORIGINAL_RESULT]], {{.*}})
+// CHECK-NOVJP:   release_value [[NESTED_PRIMAL_VALUES]]
+// CHECK-NOVJP:   release_value [[ORIGINAL_RESULT]]
+// The primal should not release primal values.
+//
+// CHECK-NOVJP-LABEL: @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0 : $@convention(thin) (@guaranteed Vector) -> (@owned {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, @owned Vector) {
+// CHECK-NOVJP:   [[ADD:%.*]] = function_ref @$s11refcounting6VectorV1poiyA2C_ACtFZ : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> @owned Vector
+// CHECK-NOVJP:   [[ADD_RESULT:%.*]] = apply [[ADD]]({{.*}}, {{.*}}, {{.*}}) : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> @owned Vector
+// CHECK-NOVJP-NOT: release_value [[ADD_RESULT]]
+// CHECK-NOVJP:   struct ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 ([[ADD_RESULT]] : $Vector)
+// CHECK-NOVJP-NOT: release_value [[ADD_RESULT]]
+// The adjoint should not release primal values because they are passed in as @guaranteed.
+//
+// CHECK-NOVJP-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
+// CHECK-NOVJP: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, {{%.*}} : $Vector, {{%.*}} : $Vector):
+// CHECK-NOVJP:   [[PV0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.v_0
+// CHECK-NOVJP-NOT:   release_value [[PV0]]
+// CHECK-NOVJP-NOT:   release_value [[PRIMAL_VALUES]]

--- a/test/AutoDiff/repeated_calls.swift
+++ b/test/AutoDiff/repeated_calls.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-simple-no-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-use-vjp-swift
+// RUN: %target-run-simple-no-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-use-vjp-swift
+// RUN: %target-run-simple-no-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-simple-no-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/TensorFlow/tensor_autodiff.swift
+++ b/test/TensorFlow/tensor_autodiff.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp=false -O -emit-sil %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-use-vjp-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-no-vjp-swift %swift-tensorflow-test-run-extra-options
 //
 // TODO(SR-9110): Make this pass in dynamic compilation mode.
 // %target-run-dynamic-compilation-swift

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1146,9 +1146,9 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
-    config.target_run_swift_use_vjp = (
+    config.target_run_simple_no_vjp_swift = (
         '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -differentiation-use-vjp -o %%t/a.out -module-name main %s && '
+        '%s %s %%s -Xllvm -differentiation-use-vjp=false -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
@@ -1297,7 +1297,7 @@ config.substitutions.append(('%target-run-simple-swift', config.target_run_simpl
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-send-recv-handle-swift', config.target_run_simple_swift_send_recv_handle))
 config.substitutions.append(('%target-run-dynamic-compilation-swift', config.target_run_swift_dynamic_compilation))
-config.substitutions.append(('%target-run-use-vjp-swift', config.target_run_swift_use_vjp))
+config.substitutions.append(('%target-run-simple-no-vjp-swift', config.target_run_simple_no_vjp_swift))
 config.substitutions.append(('%target-run-simple-parse-stdlib-swift', config.target_run_simple_parse_stdlib_swift))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))


### PR DESCRIPTION
* Makes VJP the default method for differentiating apply instructions.
* Keeps the non-VJP code around, under a flag. Runs tests in both modes, for the tests that involve differentiating apply instructions. This should keep the non-VJP code mostly working, for when we want to start using it again. (The non-VJP emitted SIL is simpler in some ways and possibly faster, so we think we'll eventually make the compiler try to emit non-VJP SIL whenever it can.)
* I predict that we are going to write some functions with custom VJPs and then accidentally try to differentiate calls to them in non-VJP mode. So I added a nice error message for this case.
* `test/AutoDiff/superset_adjoint.swift` caught a bug in the VJP code for differentiating applies: It used VJPs wrt supersets of the desired wrt parameters as if they were VJPs wrt the desired parameters. I fixed this.