### PR TITLE
[5.0][Stdlib][Overlays] Rename various classes to avoid conflicting ObjC names.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -536,10 +536,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   }
 
   case DAK_ObjCRuntimeName: {
-    Printer.printAttrName("@objc");
+    Printer.printAttrName("@_objcRuntimeName");
     Printer << "(";
     auto *attr = cast<ObjCRuntimeNameAttr>(this);
-    Printer << "\"" << attr->Name << "\"";
+    Printer << attr->Name;
     Printer << ")";
     break;
   }

--- a/stdlib/public/SDK/AppKit/NSGraphics.swift
+++ b/stdlib/public/SDK/AppKit/NSGraphics.swift
@@ -181,7 +181,10 @@ extension NSWindow.Depth {
 }
 
 extension NSAnimationEffect {
-  private class _CompletionHandlerDelegate : NSObject {
+  // NOTE: older overlays called this class _CompletionHandlerDelegate.
+  // The two must coexist without a conflicting ObjC class name, so it
+  // was renamed. The old name must not be used in the new runtime.
+  private class __CompletionHandlerDelegate : NSObject {
     var completionHandler: () -> Void = { }
     @objc func animationEffectDidEnd(_ contextInfo: UnsafeMutableRawPointer?) {
       completionHandler()
@@ -190,7 +193,7 @@ extension NSAnimationEffect {
   @available(swift 4)
   public func show(centeredAt centerLocation: NSPoint, size: NSSize,
                    completionHandler: @escaping () -> Void = { }) {
-    let delegate = _CompletionHandlerDelegate()
+    let delegate = __CompletionHandlerDelegate()
     delegate.completionHandler = completionHandler
     // Note that the delegate of `__NSShowAnimationEffect` is retained for the
     // duration of the animation.
@@ -199,7 +202,7 @@ extension NSAnimationEffect {
         centerLocation,
         size,
         delegate,
-        #selector(_CompletionHandlerDelegate.animationEffectDidEnd(_:)),
+        #selector(__CompletionHandlerDelegate.animationEffectDidEnd(_:)),
         nil)
   }
 }

--- a/stdlib/public/SDK/Dispatch/Block.swift
+++ b/stdlib/public/SDK/Dispatch/Block.swift
@@ -34,7 +34,12 @@ public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 	public static let enforceQoS = DispatchWorkItemFlags(rawValue: 0x20)
 }
 
+// NOTE: older overlays had Dispatch.DispatchWorkItem as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC8Dispatch17_DispatchWorkItem is the
+// mangled name for Dispatch._DispatchWorkItem.
 @available(macOS 10.10, iOS 8.0, *)
+@_objcRuntimeName(_TtC8Dispatch17_DispatchWorkItem)
 public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -64,8 +64,11 @@ internal func __NSDataIsCompact(_ data: NSData) -> Bool {
 
 // Underlying storage representation for medium and large data.
 // Inlinability strategy: methods from here should not inline into InlineSlice or LargeSlice unless trivial.
+// NOTE: older overlays called this class _DataStorage. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
 @usableFromInline
-internal final class _DataStorage {
+internal final class __DataStorage {
     @usableFromInline static let maxSize = Int.max >> 1
     @usableFromInline static let vmOpsThreshold = NSPageSize() * 4
     
@@ -83,7 +86,7 @@ internal final class _DataStorage {
         var dest = dest_
         var source = source_
         var num = num_
-        if _DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | Int(bitPattern: dest)) & (NSPageSize() - 1)) == 0 {
+        if __DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | Int(bitPattern: dest)) & (NSPageSize() - 1)) == 0 {
             let pages = NSRoundDownToMultipleOfPageSize(num)
             NSCopyMemoryPages(source!, dest, pages)
             source = source!.advanced(by: pages)
@@ -146,7 +149,7 @@ internal final class _DataStorage {
     
     @inlinable // This is inlinable as trivially computable.
     var isExternallyOwned: Bool {
-        // all _DataStorages will have some sort of capacity, because empty cases hit the .empty enum _Representation
+        // all __DataStorages will have some sort of capacity, because empty cases hit the .empty enum _Representation
         // anything with 0 capacity means that we have not allocated this pointer and concequently mutation is not ours to make.
         return _capacity == 0
     }
@@ -158,8 +161,8 @@ internal final class _DataStorage {
         if newLength == 0 {
             if isExternallyOwned {
                 let newCapacity = malloc_good_size(_length)
-                let newBytes = _DataStorage.allocate(newCapacity, false)
-                _DataStorage.move(newBytes!, _bytes!, _length)
+                let newBytes = __DataStorage.allocate(newCapacity, false)
+                __DataStorage.move(newBytes!, _bytes!, _length)
                 _freeBytes()
                 _bytes = newBytes
                 _capacity = newCapacity
@@ -167,9 +170,9 @@ internal final class _DataStorage {
             }
         } else if isExternallyOwned {
             let newCapacity = malloc_good_size(newLength)
-            let newBytes = _DataStorage.allocate(newCapacity, clear)
+            let newBytes = __DataStorage.allocate(newCapacity, clear)
             if let bytes = _bytes {
-                _DataStorage.move(newBytes!, bytes, _length)
+                __DataStorage.move(newBytes!, bytes, _length)
             }
             _freeBytes()
             _bytes = newBytes
@@ -178,27 +181,27 @@ internal final class _DataStorage {
             _needToZero = true
         } else {
             let cap = _capacity
-            var additionalCapacity = (newLength >> (_DataStorage.vmOpsThreshold <= newLength ? 2 : 1))
+            var additionalCapacity = (newLength >> (__DataStorage.vmOpsThreshold <= newLength ? 2 : 1))
             if Int.max - additionalCapacity < newLength {
                 additionalCapacity = 0
             }
             var newCapacity = malloc_good_size(Swift.max(cap, newLength + additionalCapacity))
             let origLength = _length
-            var allocateCleared = clear && _DataStorage.shouldAllocateCleared(newCapacity)
+            var allocateCleared = clear && __DataStorage.shouldAllocateCleared(newCapacity)
             var newBytes: UnsafeMutableRawPointer? = nil
             if _bytes == nil {
-                newBytes = _DataStorage.allocate(newCapacity, allocateCleared)
+                newBytes = __DataStorage.allocate(newCapacity, allocateCleared)
                 if newBytes == nil {
                     /* Try again with minimum length */
-                    allocateCleared = clear && _DataStorage.shouldAllocateCleared(newLength)
-                    newBytes = _DataStorage.allocate(newLength, allocateCleared)
+                    allocateCleared = clear && __DataStorage.shouldAllocateCleared(newLength)
+                    newBytes = __DataStorage.allocate(newLength, allocateCleared)
                 }
             } else {
                 let tryCalloc = (origLength == 0 || (newLength / origLength) >= 4)
                 if allocateCleared && tryCalloc {
-                    newBytes = _DataStorage.allocate(newCapacity, true)
+                    newBytes = __DataStorage.allocate(newCapacity, true)
                     if let newBytes = newBytes {
-                        _DataStorage.move(newBytes, _bytes!, origLength)
+                        __DataStorage.move(newBytes, _bytes!, origLength)
                         _freeBytes()
                     }
                 }
@@ -206,9 +209,9 @@ internal final class _DataStorage {
                 if newBytes == nil {
                     allocateCleared = false
                     if _deallocator != nil {
-                        newBytes = _DataStorage.allocate(newCapacity, true)
+                        newBytes = __DataStorage.allocate(newCapacity, true)
                         if let newBytes = newBytes {
-                            _DataStorage.move(newBytes, _bytes!, origLength)
+                            __DataStorage.move(newBytes, _bytes!, origLength)
                             _freeBytes()
                         }
                     } else {
@@ -218,11 +221,11 @@ internal final class _DataStorage {
                 /* Try again with minimum length */
                 if newBytes == nil {
                     newCapacity = malloc_good_size(newLength)
-                    allocateCleared = clear && _DataStorage.shouldAllocateCleared(newCapacity)
+                    allocateCleared = clear && __DataStorage.shouldAllocateCleared(newCapacity)
                     if allocateCleared && tryCalloc {
-                        newBytes = _DataStorage.allocate(newCapacity, true)
+                        newBytes = __DataStorage.allocate(newCapacity, true)
                         if let newBytes = newBytes {
-                            _DataStorage.move(newBytes, _bytes!, origLength)
+                            __DataStorage.move(newBytes, _bytes!, origLength)
                             _freeBytes()
                         }
                     }
@@ -293,10 +296,10 @@ internal final class _DataStorage {
             ensureUniqueBufferReference(growingTo: newLength, clear: false)
         }
         _length = newLength
-        _DataStorage.move(_bytes!.advanced(by: origLength), bytes, length)
+        __DataStorage.move(_bytes!.advanced(by: origLength), bytes, length)
     }
     
-    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func get(_ index: Int) -> UInt8 {
         return _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
     }
@@ -364,14 +367,14 @@ internal final class _DataStorage {
 
     @usableFromInline // This is not @inlinable as a non-trivial, non-convenience initializer.
     init(length: Int) {
-        precondition(length < _DataStorage.maxSize)
+        precondition(length < __DataStorage.maxSize)
         var capacity = (length < 1024 * 1024 * 1024) ? length + (length >> 2) : length
-        if _DataStorage.vmOpsThreshold <= capacity {
+        if __DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         
-        let clear = _DataStorage.shouldAllocateCleared(length)
-        _bytes = _DataStorage.allocate(capacity, clear)!
+        let clear = __DataStorage.shouldAllocateCleared(length)
+        _bytes = __DataStorage.allocate(capacity, clear)!
         _capacity = capacity
         _needToZero = !clear
         _length = 0
@@ -382,12 +385,12 @@ internal final class _DataStorage {
     @usableFromInline // This is not @inlinable as a non-convience initializer.
     init(capacity capacity_: Int = 0) {
         var capacity = capacity_
-        precondition(capacity < _DataStorage.maxSize)
-        if _DataStorage.vmOpsThreshold <= capacity {
+        precondition(capacity < __DataStorage.maxSize)
+        if __DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         _length = 0
-        _bytes = _DataStorage.allocate(capacity, false)!
+        _bytes = __DataStorage.allocate(capacity, false)!
         _capacity = capacity
         _needToZero = true
         _offset = 0
@@ -395,35 +398,35 @@ internal final class _DataStorage {
     
     @usableFromInline // This is not @inlinable as a non-convience initializer.
     init(bytes: UnsafeRawPointer?, length: Int) {
-        precondition(length < _DataStorage.maxSize)
+        precondition(length < __DataStorage.maxSize)
         _offset = 0
         if length == 0 {
             _capacity = 0
             _length = 0
             _needToZero = false
             _bytes = nil
-        } else if _DataStorage.vmOpsThreshold <= length {
+        } else if __DataStorage.vmOpsThreshold <= length {
             _capacity = length
             _length = length
             _needToZero = true
-            _bytes = _DataStorage.allocate(length, false)!
-            _DataStorage.move(_bytes!, bytes, length)
+            _bytes = __DataStorage.allocate(length, false)!
+            __DataStorage.move(_bytes!, bytes, length)
         } else {
             var capacity = length
-            if _DataStorage.vmOpsThreshold <= capacity {
+            if __DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
-            _bytes = _DataStorage.allocate(capacity, false)!
+            _bytes = __DataStorage.allocate(capacity, false)!
             _capacity = capacity
             _needToZero = true
-            _DataStorage.move(_bytes!, bytes, length)
+            __DataStorage.move(_bytes!, bytes, length)
         }
     }
     
     @usableFromInline // This is not @inlinable as a non-convience initializer.
     init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?, offset: Int) {
-        precondition(length < _DataStorage.maxSize)
+        precondition(length < __DataStorage.maxSize)
         _offset = offset
         if length == 0 {
             _capacity = 0
@@ -440,25 +443,25 @@ internal final class _DataStorage {
             _needToZero = false
             _bytes = bytes
             _deallocator = deallocator
-        } else if _DataStorage.vmOpsThreshold <= length {
+        } else if __DataStorage.vmOpsThreshold <= length {
             _capacity = length
             _length = length
             _needToZero = true
-            _bytes = _DataStorage.allocate(length, false)!
-            _DataStorage.move(_bytes!, bytes, length)
+            _bytes = __DataStorage.allocate(length, false)!
+            __DataStorage.move(_bytes!, bytes, length)
             if let dealloc = deallocator {
                 dealloc(bytes!, length)
             }
         } else {
             var capacity = length
-            if _DataStorage.vmOpsThreshold <= capacity {
+            if __DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
-            _bytes = _DataStorage.allocate(capacity, false)!
+            _bytes = __DataStorage.allocate(capacity, false)!
             _capacity = capacity
             _needToZero = true
-            _DataStorage.move(_bytes!, bytes, length)
+            __DataStorage.move(_bytes!, bytes, length)
             if let dealloc = deallocator {
                 dealloc(bytes!, length)
             }
@@ -517,9 +520,9 @@ internal final class _DataStorage {
         _freeBytes()
     }
     
-    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
-    func mutableCopy(_ range: Range<Int>) -> _DataStorage {
-        return _DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, copy: true, deallocator: nil, offset: range.lowerBound)
+    @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
+    func mutableCopy(_ range: Range<Int>) -> __DataStorage {
+        return __DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, copy: true, deallocator: nil, offset: range.lowerBound)
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially computed.
@@ -541,14 +544,14 @@ internal final class _DataStorage {
     }
 }
 
-// NOTE: older runtimes called this _NSSwiftData. The two must
+// NOTE: older overlays called this _NSSwiftData. The two must
 // coexist, so it was renamed. The old name must not be used in the new
 // runtime.
 internal class __NSSwiftData : NSData {
-    var _backing: _DataStorage!
+    var _backing: __DataStorage!
     var _range: Range<Data.Index>!
 
-    convenience init(backing: _DataStorage, range: Range<Data.Index>) {
+    convenience init(backing: __DataStorage, range: Range<Data.Index>) {
         self.init()
         _backing = backing
         _range = range
@@ -841,7 +844,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         // ***WARNING***
         // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
         @usableFromInline var slice: Range<HalfInt>
-        @usableFromInline var storage: _DataStorage
+        @usableFromInline var storage: __DataStorage
 
         @inlinable // This is @inlinable as trivially computable.
         static func canStore(count: Int) -> Bool {
@@ -851,32 +854,32 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         @inlinable // This is @inlinable as a convenience initializer.
         init(_ buffer: UnsafeRawBufferPointer) {
             assert(buffer.count < HalfInt.max)
-            self.init(_DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
+            self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(capacity: Int) {
             assert(capacity < HalfInt.max)
-            self.init(_DataStorage(capacity: capacity), count: 0)
+            self.init(__DataStorage(capacity: capacity), count: 0)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(count: Int) {
             assert(count < HalfInt.max)
-            self.init(_DataStorage(length: count), count: count)
+            self.init(__DataStorage(length: count), count: count)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(_ inline: InlineData) {
             assert(inline.count < HalfInt.max)
-            self.init(inline.withUnsafeBytes { return _DataStorage(bytes: $0.baseAddress, length: $0.count) }, count: inline.count)
+            self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, count: inline.count)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(_ inline: InlineData, range: Range<Int>) {
             assert(range.lowerBound < HalfInt.max)
             assert(range.upperBound < HalfInt.max)
-            self.init(inline.withUnsafeBytes { return _DataStorage(bytes: $0.baseAddress, length: $0.count) }, range: range)
+            self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, range: range)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
@@ -894,14 +897,14 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
 
         @inlinable // This is @inlinable as a trivial initializer.
-        init(_ storage: _DataStorage, count: Int) {
+        init(_ storage: __DataStorage, count: Int) {
             assert(count < HalfInt.max)
             self.storage = storage
             slice = 0..<HalfInt(count)
         }
 
         @inlinable // This is @inlinable as a trivial initializer.
-        init(_ storage: _DataStorage, range: Range<Int>) {
+        init(_ storage: __DataStorage, range: Range<Int>) {
             assert(range.lowerBound < HalfInt.max)
             assert(range.upperBound < HalfInt.max)
             self.storage = storage
@@ -1087,26 +1090,26 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         // ***WARNING***
         // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
         @usableFromInline var slice: RangeReference
-        @usableFromInline var storage: _DataStorage
+        @usableFromInline var storage: __DataStorage
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(_ buffer: UnsafeRawBufferPointer) {
-            self.init(_DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
+            self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(capacity: Int) {
-            self.init(_DataStorage(capacity: capacity), count: 0)
+            self.init(__DataStorage(capacity: capacity), count: 0)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(count: Int) {
-            self.init(_DataStorage(length: count), count: count)
+            self.init(__DataStorage(length: count), count: count)
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(_ inline: InlineData) {
-            let storage = inline.withUnsafeBytes { return _DataStorage(bytes: $0.baseAddress, length: $0.count) }
+            let storage = inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }
             self.init(storage, count: inline.count)
         }
 
@@ -1117,7 +1120,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
 
         @inlinable // This is @inlinable as a trivial initializer.
-        init(_ storage: _DataStorage, count: Int) {
+        init(_ storage: __DataStorage, count: Int) {
             self.storage = storage
             self.slice = RangeReference(0..<count)
         }
@@ -1286,7 +1289,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                 self = .inline(InlineData(buffer))
             } else {
                 let count = buffer.count
-                let storage = _DataStorage(bytes: UnsafeMutableRawPointer(mutating: buffer.baseAddress), length: count, copy: false, deallocator: { _, _ in
+                let storage = __DataStorage(bytes: UnsafeMutableRawPointer(mutating: buffer.baseAddress), length: count, copy: false, deallocator: { _, _ in
                     _fixLifetime(owner)
                 }, offset: 0)
                 if InlineSlice.canStore(count: count) {
@@ -1324,7 +1327,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
 
         @inlinable // This is @inlinable as a trivial initializer.
-        init(_ storage: _DataStorage, count: Int) {
+        init(_ storage: __DataStorage, count: Int) {
             if count == 0 {
                 self = .empty
             } else if InlineData.canStore(count: count) {
@@ -1974,7 +1977,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             deallocator._deallocator(bytes, count)
             _representation = .empty
         } else {
-            _representation = _Representation(_DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator, offset: 0), count: count)
+            _representation = _Representation(__DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator, offset: 0), count: count)
         }
     }
     
@@ -2037,9 +2040,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             let providesConcreteBacking = (reference as AnyObject)._providesConcreteBacking?() ?? false
 #endif
             if providesConcreteBacking {
-                _representation = _Representation(_DataStorage(immutableReference: reference.copy() as! NSData, offset: 0), count: length)
+                _representation = _Representation(__DataStorage(immutableReference: reference.copy() as! NSData, offset: 0), count: length)
             } else {
-                _representation = _Representation(_DataStorage(customReference: reference.copy() as! NSData, offset: 0), count: length)
+                _representation = _Representation(__DataStorage(customReference: reference.copy() as! NSData, offset: 0), count: length)
             }
         }
         

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -51,6 +51,11 @@ extension Dictionary : _JSONStringDictionaryDecodableMarker where Key == String,
 //===----------------------------------------------------------------------===//
 
 /// `JSONEncoder` facilitates the encoding of `Encodable` values into JSON.
+// NOTE: older overlays had Foundation.JSONEncoder as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC10Foundation12_JSONEncoder is the
+// mangled name for Foundation._JSONEncoder.
+@_objcRuntimeName(_TtC10Foundation12_JSONEncoder)
 open class JSONEncoder {
     // MARK: Options
 
@@ -245,7 +250,7 @@ open class JSONEncoder {
     /// - throws: `EncodingError.invalidValue` if a non-conforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
     /// - throws: An error if any value throws an error during encoding.
     open func encode<T : Encodable>(_ value: T) throws -> Data {
-        let encoder = _JSONEncoder(options: self.options)
+        let encoder = __JSONEncoder(options: self.options)
 
         guard let topLevel = try encoder.box_(value) else {
             throw EncodingError.invalidValue(value, 
@@ -273,9 +278,12 @@ open class JSONEncoder {
     }
 }
 
-// MARK: - _JSONEncoder
+// MARK: - __JSONEncoder
 
-fileprivate class _JSONEncoder : Encoder {
+// NOTE: older overlays called this class _JSONEncoder.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+fileprivate class __JSONEncoder : Encoder {
     // MARK: Properties
 
     /// The encoder's storage.
@@ -405,7 +413,7 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     // MARK: Properties
 
     /// A reference to the encoder we're writing to.
-    private let encoder: _JSONEncoder
+    private let encoder: __JSONEncoder
 
     /// A reference to the container we're writing to.
     private let container: NSMutableDictionary
@@ -416,7 +424,7 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     // MARK: - Initialization
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: _JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
+    fileprivate init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -519,11 +527,11 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     }
 
     public mutating func superEncoder() -> Encoder {
-        return _JSONReferencingEncoder(referencing: self.encoder, key: _JSONKey.super, convertedKey: _converted(_JSONKey.super), wrapping: self.container)
+        return __JSONReferencingEncoder(referencing: self.encoder, key: _JSONKey.super, convertedKey: _converted(_JSONKey.super), wrapping: self.container)
     }
 
     public mutating func superEncoder(forKey key: Key) -> Encoder {
-        return _JSONReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), wrapping: self.container)
+        return __JSONReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), wrapping: self.container)
     }
 }
 
@@ -531,7 +539,7 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: Properties
 
     /// A reference to the encoder we're writing to.
-    private let encoder: _JSONEncoder
+    private let encoder: __JSONEncoder
 
     /// A reference to the container we're writing to.
     private let container: NSMutableArray
@@ -547,7 +555,7 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: _JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
+    fileprivate init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -610,11 +618,11 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     }
 
     public mutating func superEncoder() -> Encoder {
-        return _JSONReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+        return __JSONReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
     }
 }
 
-extension _JSONEncoder : SingleValueEncodingContainer {
+extension __JSONEncoder : SingleValueEncodingContainer {
     // MARK: - SingleValueEncodingContainer Methods
 
     fileprivate func assertCanEncodeNewValue() {
@@ -704,7 +712,7 @@ extension _JSONEncoder : SingleValueEncodingContainer {
 
 // MARK: - Concrete Value Representations
 
-extension _JSONEncoder {
+extension __JSONEncoder {
     /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
     fileprivate func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
     fileprivate func box(_ value: Int)    -> NSObject { return NSNumber(value: value) }
@@ -902,7 +910,7 @@ extension _JSONEncoder {
             return try self.box(value as! [String : Encodable])
         }
 
-        // The value should request a container from the _JSONEncoder.
+        // The value should request a container from the __JSONEncoder.
         let depth = self.storage.count
         do {
             try value.encode(to: self)
@@ -924,11 +932,14 @@ extension _JSONEncoder {
     }
 }
 
-// MARK: - _JSONReferencingEncoder
+// MARK: - __JSONReferencingEncoder
 
-/// _JSONReferencingEncoder is a special subclass of _JSONEncoder which has its own storage, but references the contents of a different encoder.
+/// __JSONReferencingEncoder is a special subclass of __JSONEncoder which has its own storage, but references the contents of a different encoder.
 /// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
-fileprivate class _JSONReferencingEncoder : _JSONEncoder {
+// NOTE: older overlays called this class _JSONReferencingEncoder.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+fileprivate class __JSONReferencingEncoder : __JSONEncoder {
     // MARK: Reference types.
 
     /// The type of container we're referencing.
@@ -943,7 +954,7 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
     // MARK: - Properties
 
     /// The encoder we're referencing.
-    fileprivate let encoder: _JSONEncoder
+    fileprivate let encoder: __JSONEncoder
 
     /// The container reference itself.
     private let reference: Reference
@@ -951,7 +962,7 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given array container in the given encoder.
-    fileprivate init(referencing encoder: _JSONEncoder, at index: Int, wrapping array: NSMutableArray) {
+    fileprivate init(referencing encoder: __JSONEncoder, at index: Int, wrapping array: NSMutableArray) {
         self.encoder = encoder
         self.reference = .array(array, index)
         super.init(options: encoder.options, codingPath: encoder.codingPath)
@@ -960,7 +971,7 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
     }
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
-    fileprivate init(referencing encoder: _JSONEncoder,
+    fileprivate init(referencing encoder: __JSONEncoder,
                      key: CodingKey, convertedKey: __shared CodingKey, wrapping dictionary: NSMutableDictionary) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, convertedKey.stringValue)
@@ -1004,6 +1015,11 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
 //===----------------------------------------------------------------------===//
 
 /// `JSONDecoder` facilitates the decoding of JSON into semantic `Decodable` types.
+// NOTE: older overlays had Foundation.JSONDecoder as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC10Foundation12_JSONDecoder is the
+// mangled name for Foundation._JSONDecoder.
+@_objcRuntimeName(_TtC10Foundation12_JSONDecoder)
 open class JSONDecoder {
     // MARK: Options
 

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -147,6 +147,11 @@ extension NSDictionary : _HasCustomAnyHashableRepresentation {
 extension NSDictionary : Sequence {
   // FIXME: A class because we can't pass a struct with class fields through an
   // [objc] interface without prematurely destroying the references.
+  // NOTE: older runtimes had
+  // _TtCE10FoundationCSo12NSDictionary8Iterator as the ObjC name. The
+  // two must coexist, so it was renamed. The old name must not be used
+  // in the new runtime.
+  @_objcRuntimeName(_TtCE10FoundationCSo12NSDictionary9_Iterator)
   final public class Iterator : IteratorProtocol {
     var _fastIterator: NSFastEnumerationIterator
     var _dictionary: NSDictionary {

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -74,7 +74,10 @@ public extension LocalizedError {
 /// Class that implements the informal protocol
 /// NSErrorRecoveryAttempting, which is used by NSError when it
 /// attempts recovery from an error.
-class _NSErrorRecoveryAttempter {
+// NOTE: older overlays called this class _NSErrorRecoveryAttempter.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+class __NSErrorRecoveryAttempter {
   @objc(attemptRecoveryFromError:optionIndex:delegate:didRecoverSelector:contextInfo:)
   func attemptRecovery(fromError nsError: NSError,
                        optionIndex recoveryOptionIndex: Int,
@@ -252,7 +255,7 @@ public func _getErrorDefaultUserInfo<T: Error>(_ error: T)
 
           case NSRecoveryAttempterErrorKey:
             if error is RecoverableError {
-              return _NSErrorRecoveryAttempter()
+              return __NSErrorRecoveryAttempter()
             }
             return nil
 
@@ -308,7 +311,7 @@ public func _getErrorDefaultUserInfo<T: Error>(_ error: T)
      let recoverableError = error as? RecoverableError {
     result[NSLocalizedRecoveryOptionsErrorKey] =
       recoverableError.recoveryOptions
-    result[NSRecoveryAttempterErrorKey] = _NSErrorRecoveryAttempter()
+    result[NSRecoveryAttempterErrorKey] = __NSErrorRecoveryAttempter()
   }
 
   return result as AnyObject

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -15,6 +15,11 @@
 //===----------------------------------------------------------------------===//
 
 /// `PropertyListEncoder` facilitates the encoding of `Encodable` values into property lists.
+// NOTE: older overlays had Foundation.PropertyListEncoder as the ObjC
+// name. The two must coexist, so it was renamed. The old name must not
+// be used in the new runtime. _TtC10Foundation20_PropertyListEncoder
+// is the mangled name for Foundation._PropertyListEncoder.
+@_objcRuntimeName(_TtC10Foundation20_PropertyListEncoder)
 open class PropertyListEncoder {
 
     // MARK: - Options
@@ -80,7 +85,7 @@ open class PropertyListEncoder {
     /// - throws: `EncodingError.invalidValue` if a non-conforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
     /// - throws: An error if any value throws an error during encoding.
     internal func encodeToTopLevelContainer<Value : Encodable>(_ value: Value) throws -> Any {
-        let encoder = _PlistEncoder(options: self.options)
+        let encoder = __PlistEncoder(options: self.options)
         guard let topLevel = try encoder.box_(value) else {
             throw EncodingError.invalidValue(value,
                                              EncodingError.Context(codingPath: [],
@@ -91,9 +96,12 @@ open class PropertyListEncoder {
     }
 }
 
-// MARK: - _PlistEncoder
+// MARK: - __PlistEncoder
 
-fileprivate class _PlistEncoder : Encoder {
+// NOTE: older overlays called this class _PlistEncoder. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+fileprivate class __PlistEncoder : Encoder {
     // MARK: Properties
 
     /// The encoder's storage.
@@ -223,7 +231,7 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
     // MARK: Properties
 
     /// A reference to the encoder we're writing to.
-    private let encoder: _PlistEncoder
+    private let encoder: __PlistEncoder
 
     /// A reference to the container we're writing to.
     private let container: NSMutableDictionary
@@ -234,7 +242,7 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
     // MARK: - Initialization
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: _PlistEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
+    fileprivate init(referencing encoder: __PlistEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -285,11 +293,11 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
     }
 
     public mutating func superEncoder() -> Encoder {
-        return _PlistReferencingEncoder(referencing: self.encoder, at: _PlistKey.super, wrapping: self.container)
+        return __PlistReferencingEncoder(referencing: self.encoder, at: _PlistKey.super, wrapping: self.container)
     }
 
     public mutating func superEncoder(forKey key: Key) -> Encoder {
-        return _PlistReferencingEncoder(referencing: self.encoder, at: key, wrapping: self.container)
+        return __PlistReferencingEncoder(referencing: self.encoder, at: key, wrapping: self.container)
     }
 }
 
@@ -297,7 +305,7 @@ fileprivate struct _PlistUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: Properties
 
     /// A reference to the encoder we're writing to.
-    private let encoder: _PlistEncoder
+    private let encoder: __PlistEncoder
 
     /// A reference to the container we're writing to.
     private let container: NSMutableArray
@@ -313,7 +321,7 @@ fileprivate struct _PlistUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: _PlistEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
+    fileprivate init(referencing encoder: __PlistEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -364,11 +372,11 @@ fileprivate struct _PlistUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     }
 
     public mutating func superEncoder() -> Encoder {
-        return _PlistReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+        return __PlistReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
     }
 }
 
-extension _PlistEncoder : SingleValueEncodingContainer {
+extension __PlistEncoder : SingleValueEncodingContainer {
     // MARK: - SingleValueEncodingContainer Methods
 
     private func assertCanEncodeNewValue() {
@@ -458,7 +466,7 @@ extension _PlistEncoder : SingleValueEncodingContainer {
 
 // MARK: - Concrete Value Representations
 
-extension _PlistEncoder {
+extension __PlistEncoder {
 
     /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
     fileprivate func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
@@ -489,7 +497,7 @@ extension _PlistEncoder {
             return (value as! NSData)
         }
 
-        // The value should request a container from the _PlistEncoder.
+        // The value should request a container from the __PlistEncoder.
         let depth = self.storage.count
         do {
             try value.encode(to: self)
@@ -511,11 +519,14 @@ extension _PlistEncoder {
     }
 }
 
-// MARK: - _PlistReferencingEncoder
+// MARK: - __PlistReferencingEncoder
 
-/// _PlistReferencingEncoder is a special subclass of _PlistEncoder which has its own storage, but references the contents of a different encoder.
+/// __PlistReferencingEncoder is a special subclass of __PlistEncoder which has its own storage, but references the contents of a different encoder.
 /// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
-fileprivate class _PlistReferencingEncoder : _PlistEncoder {
+// NOTE: older overlays called this class _PlistReferencingEncoder.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+fileprivate class __PlistReferencingEncoder : __PlistEncoder {
     // MARK: Reference types.
 
     /// The type of container we're referencing.
@@ -530,7 +541,7 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
     // MARK: - Properties
 
     /// The encoder we're referencing.
-    private let encoder: _PlistEncoder
+    private let encoder: __PlistEncoder
 
     /// The container reference itself.
     private let reference: Reference
@@ -538,7 +549,7 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given array container in the given encoder.
-    fileprivate init(referencing encoder: _PlistEncoder, at index: Int, wrapping array: NSMutableArray) {
+    fileprivate init(referencing encoder: __PlistEncoder, at index: Int, wrapping array: NSMutableArray) {
         self.encoder = encoder
         self.reference = .array(array, index)
         super.init(options: encoder.options, codingPath: encoder.codingPath)
@@ -547,7 +558,7 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
     }
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
-    fileprivate init(referencing encoder: _PlistEncoder, at key: CodingKey, wrapping dictionary: NSMutableDictionary) {
+    fileprivate init(referencing encoder: __PlistEncoder, at key: CodingKey, wrapping dictionary: NSMutableDictionary) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, key.stringValue)
         super.init(options: encoder.options, codingPath: encoder.codingPath)
@@ -590,6 +601,11 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
 //===----------------------------------------------------------------------===//
 
 /// `PropertyListDecoder` facilitates the decoding of property list values into semantic `Decodable` types.
+// NOTE: older overlays had Foundation.PropertyListDecoder as the ObjC
+// name. The two must coexist, so it was renamed. The old name must not
+// be used in the new runtime. _TtC10Foundation20_PropertyListDecoder
+// is the mangled name for Foundation._PropertyListDecoder.
+@_objcRuntimeName(_TtC10Foundation20_PropertyListDecoder)
 open class PropertyListDecoder {
     // MARK: Options
 
@@ -652,7 +668,7 @@ open class PropertyListDecoder {
     /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not a valid property list.
     /// - throws: An error if any value throws an error during decoding.
     internal func decode<T : Decodable>(_ type: T.Type, fromTopLevel container: Any) throws -> T {
-        let decoder = _PlistDecoder(referencing: container, options: self.options)
+        let decoder = __PlistDecoder(referencing: container, options: self.options)
         guard let value = try decoder.unbox(container, as: type) else {
             throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
         }
@@ -661,9 +677,12 @@ open class PropertyListDecoder {
     }
 }
 
-// MARK: - _PlistDecoder
+// MARK: - __PlistDecoder
 
-fileprivate class _PlistDecoder : Decoder {
+// NOTE: older overlays called this class _PlistDecoder. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+fileprivate class __PlistDecoder : Decoder {
     // MARK: Properties
 
     /// The decoder's storage.
@@ -769,7 +788,7 @@ fileprivate struct _PlistKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCo
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
-    private let decoder: _PlistDecoder
+    private let decoder: __PlistDecoder
 
     /// A reference to the container we're reading from.
     private let container: [String : Any]
@@ -780,7 +799,7 @@ fileprivate struct _PlistKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCo
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    fileprivate init(referencing decoder: _PlistDecoder, wrapping container: [String : Any]) {
+    fileprivate init(referencing decoder: __PlistDecoder, wrapping container: [String : Any]) {
         self.decoder = decoder
         self.container = container
         self.codingPath = decoder.codingPath
@@ -1072,7 +1091,7 @@ fileprivate struct _PlistKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCo
         defer { self.decoder.codingPath.removeLast() }
 
         let value: Any = self.container[key.stringValue] ?? NSNull()
-        return _PlistDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+        return __PlistDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
     }
 
     public func superDecoder() throws -> Decoder {
@@ -1088,7 +1107,7 @@ fileprivate struct _PlistUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
-    private let decoder: _PlistDecoder
+    private let decoder: __PlistDecoder
 
     /// A reference to the container we're reading from.
     private let container: [Any]
@@ -1102,7 +1121,7 @@ fileprivate struct _PlistUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    fileprivate init(referencing decoder: _PlistDecoder, wrapping container: [Any]) {
+    fileprivate init(referencing decoder: __PlistDecoder, wrapping container: [Any]) {
         self.decoder = decoder
         self.container = container
         self.codingPath = decoder.codingPath
@@ -1434,11 +1453,11 @@ fileprivate struct _PlistUnkeyedDecodingContainer : UnkeyedDecodingContainer {
 
         let value = self.container[self.currentIndex]
         self.currentIndex += 1
-        return _PlistDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+        return __PlistDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
     }
 }
 
-extension _PlistDecoder : SingleValueDecodingContainer {
+extension __PlistDecoder : SingleValueDecodingContainer {
     // MARK: SingleValueDecodingContainer Methods
 
     private func expectNonNull<T>(_ type: T.Type) throws {
@@ -1533,7 +1552,7 @@ extension _PlistDecoder : SingleValueDecodingContainer {
 
 // MARK: - Concrete Value Representations
 
-extension _PlistDecoder {
+extension __PlistDecoder {
     /// Returns the given value unboxed from a container.
     fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         if let string = value as? String, string == _plistNull { return nil }

--- a/stdlib/public/SDK/Network/NWConnection.swift
+++ b/stdlib/public/SDK/Network/NWConnection.swift
@@ -20,6 +20,11 @@ import _SwiftNetworkOverlayShims
 /// A connection handles establishment of any transport, security, or application-level protocols
 /// required to transmit and receive user data. Multiple protocol instances may be attempted during
 /// the establishment phase of the connection.
+// NOTE: older overlays had Network.NWConnection as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network13_NWConnection is the
+// mangled name for Network._NWConnection.
+@_objcRuntimeName(_TtC7Network13_NWConnection)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public final class NWConnection : CustomDebugStringConvertible {
 
@@ -297,6 +302,8 @@ public final class NWConnection : CustomDebugStringConvertible {
 	/// Content Context controls options for how data is sent, and access for metadata to send or receive.
 	/// All properties of Content Context are valid for sending. For received Content Context, only the protocolMetadata
 	/// values will be set.
+	// Set the ObjC name of this class to be nested in the customized ObjC name of NWConnection.
+	@_objcRuntimeName(_TtCC7Network13_NWConnection14ContentContext)
 	public class ContentContext {
         internal let nw: nw_content_context_t
 

--- a/stdlib/public/SDK/Network/NWListener.swift
+++ b/stdlib/public/SDK/Network/NWListener.swift
@@ -22,6 +22,11 @@ import Foundation
 /// accepted connections will represent multiplexed streams on a new or existing transport
 /// binding.
 
+// NOTE: older overlays had Network.NWListener as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network11_NWListener is the
+// mangled name for Network._NWListener.
+@_objcRuntimeName(_TtC7Network11_NWListener)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public final class NWListener: CustomDebugStringConvertible {
 	public var debugDescription: String {

--- a/stdlib/public/SDK/Network/NWParameters.swift
+++ b/stdlib/public/SDK/Network/NWParameters.swift
@@ -16,6 +16,11 @@
 /// endpoint requirements); preferences for data transfer and quality of service;
 /// and the protocols to be used for a connection along with any protocol-specific
 /// options.
+// NOTE: older overlays had Network.NWParameters as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network13_NWParameters is the
+// mangled name for Network._NWParameters.
+@_objcRuntimeName(_TtC7Network13_NWParameters)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public final class NWParameters : CustomDebugStringConvertible {
 	public var debugDescription: String {
@@ -422,6 +427,9 @@ public final class NWParameters : CustomDebugStringConvertible {
 	/// transport-level protocol, and an optional internet-level protocol. If the internet-
 	/// level protocol is not specified, any available and applicable IP address family
 	/// may be used.
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWParameters.
+	@_objcRuntimeName(_TtCC7Network13_NWParameters13ProtocolStack)
 	public class ProtocolStack {
 		public var applicationProtocols: [NWProtocolOptions] {
 			set {

--- a/stdlib/public/SDK/Network/NWPath.swift
+++ b/stdlib/public/SDK/Network/NWPath.swift
@@ -225,6 +225,11 @@ public struct NWPath : Equatable, CustomDebugStringConvertible {
 /// The paths will watch the state of multiple interfaces, and allows the
 /// application to enumerate the available interfaces for use in creating connections
 /// or listeners bound to specific interfaces.
+// NOTE: older overlays had Network.NWPathMonitor as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network14_NWPathMonitor is the
+// mangled name for Network._NWPathMonitor.
+@_objcRuntimeName(_TtC7Network14_NWPathMonitor)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public final class NWPathMonitor {
 

--- a/stdlib/public/SDK/Network/NWProtocol.swift
+++ b/stdlib/public/SDK/Network/NWProtocol.swift
@@ -12,6 +12,11 @@
 
 /// NWProtocolDefinition is an abstract superclass that represents the identifier of a
 /// protocol that can be used with connections and listeners, such as TCP.
+// NOTE: older overlays had Network.NWProtocolDefinition as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network21_NWProtocolDefinition is the
+// mangled name for Network._NWProtocolDefinition.
+@_objcRuntimeName(_TtC7Network21_NWProtocolDefinition)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolDefinition : Equatable, CustomDebugStringConvertible {
 	public static func == (lhs: NWProtocolDefinition, rhs: NWProtocolDefinition) -> Bool {
@@ -35,6 +40,11 @@ public class NWProtocolDefinition : Equatable, CustomDebugStringConvertible {
 /// NWProtocolOptions is an abstract superclass that represents a configuration options
 /// that can be used to add a protocol into an NWParameters.ProtocolStack. These options
 /// configure the behavior of a protocol and cannot be changed after starting a connection.
+// NOTE: older overlays had Network.NWProtocolOptions as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network18_NWProtocolOptions is the
+// mangled name for Network._NWProtocolOptions.
+@_objcRuntimeName(_TtC7Network18_NWProtocolOptions)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolOptions {
 	internal let nw: nw_protocol_options_t
@@ -50,6 +60,11 @@ public class NWProtocolOptions {
 /// specific to some content being sent; as well as to retrieve metadata specific to some
 /// content that was received. Each protocol is responsible for defining its own accessor
 /// functions to set and get metadata.
+// NOTE: older overlays had Network.NWProtocolMetadata as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network19_NWProtocolMetadata is the
+// mangled name for Network._NWProtocolMetadata.
+@_objcRuntimeName(_TtC7Network19_NWProtocolMetadata)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolMetadata {
 	internal let nw: nw_protocol_metadata_t
@@ -60,6 +75,11 @@ public class NWProtocolMetadata {
 }
 
 /// NWProtocol is an abstract superclass to which protocol implementations conform.
+// NOTE: older overlays had Network.NWProtocol as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network11_NWProtocol is the
+// mangled name for Network._NWProtocol.
+@_objcRuntimeName(_TtC7Network11_NWProtocol)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocol {
 

--- a/stdlib/public/SDK/Network/NWProtocolIP.swift
+++ b/stdlib/public/SDK/Network/NWProtocolIP.swift
@@ -10,12 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOTE: older overlays had Network.NWProtocolIP as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network13_NWProtocolIP is the
+// mangled name for Network._NWProtocolIP.
+@_objcRuntimeName(_TtC7Network13_NWProtocolIP)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolIP : NWProtocol {
 	public static let definition: NWProtocolDefinition = {
 		NWProtocolDefinition(nw_protocol_copy_ip_definition(), "ip")
 	}()
 
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolIP.
+  @_objcRuntimeName(_TtCC7Network13_NWProtocolIP7Options)
 	public class Options : NWProtocolOptions {
 		public enum Version {
 			/// Allow any IP version
@@ -167,6 +175,9 @@ public class NWProtocolIP : NWProtocol {
 	}
 
 	/// IP Metadata can be sent or received as part of ContentContext
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolIP.
+  @_objcRuntimeName(_TtCC7Network13_NWProtocolIP8Metadata)
 	public class Metadata: NWProtocolMetadata {
 		/// Set ECN flags to be sent on a packet, or get ECN flags
 		/// received on a packet. These flags will not take effect

--- a/stdlib/public/SDK/Network/NWProtocolTCP.swift
+++ b/stdlib/public/SDK/Network/NWProtocolTCP.swift
@@ -10,12 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOTE: older overlays had Network.NWProtocolTCP as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network14_NWProtocolTCP is the
+// mangled name for Network._NWProtocolTCP.
+@_objcRuntimeName(_TtC7Network14_NWProtocolTCP)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolTCP : NWProtocol {
 	public static let definition: NWProtocolDefinition = {
 		NWProtocolDefinition(nw_protocol_copy_tcp_definition(), "tcp")
 	}()
 
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolTCP.
+  @_objcRuntimeName(_TtCC7Network14_NWProtocolTCP7Options)
 	public class Options : NWProtocolOptions {
 
 		private var _noDelay: Bool = false
@@ -244,6 +252,9 @@ public class NWProtocolTCP : NWProtocol {
 
 	/// Access TCP metadata using NWConnection.metadata(protocolDefinition: NWProtocolTCP.definition)
 	/// or in received ContentContext
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolTCP.
+  @_objcRuntimeName(_TtCC7Network14_NWProtocolTCP8Metadata)
 	public class Metadata: NWProtocolMetadata {
 		override internal init(_ nw: nw_protocol_metadata_t) {
 			super.init(nw)

--- a/stdlib/public/SDK/Network/NWProtocolTLS.swift
+++ b/stdlib/public/SDK/Network/NWProtocolTLS.swift
@@ -10,12 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOTE: older overlays had Network.NWProtocolTLS as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network14_NWProtocolTLS is the
+// mangled name for Network._NWProtocolTLS.
+@_objcRuntimeName(_TtC7Network14_NWProtocolTLS)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolTLS : NWProtocol {
 	public static let definition: NWProtocolDefinition = {
 		NWProtocolDefinition(nw_protocol_copy_tls_definition(), "tls")
 	}()
 
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolTLS.
+  @_objcRuntimeName(_TtCC7Network14_NWProtocolTLS7Options)
 	public class Options : NWProtocolOptions {
 		/// Access the sec_protocol_options_t for a given network protocol
 		/// options instance. See <Security/SecProtocolOptions.h> for functions
@@ -36,6 +44,9 @@ public class NWProtocolTLS : NWProtocol {
 
 	/// Access TLS metadata using NWConnection.metadata(protocolDefinition: NWProtocolTLS.definition)
 	/// or in received ContentContext
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWNWProtocolTLSProtocolIP.
+  @_objcRuntimeName(_TtCC7Network14_NWProtocolTLS8Metadata)
 	public class Metadata: NWProtocolMetadata {
 		/// Access the sec_protocol_metadata_t for a given network protocol
 		/// metadata instance. See <Security/SecProtocolMetadata.h> for functions

--- a/stdlib/public/SDK/Network/NWProtocolUDP.swift
+++ b/stdlib/public/SDK/Network/NWProtocolUDP.swift
@@ -10,12 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOTE: older overlays had Network.NWProtocolUDP as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC7Network14_NWProtocolUDP is the
+// mangled name for Network._NWProtocolUDP.
+@_objcRuntimeName(_TtC7Network14_NWProtocolUDP)
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public class NWProtocolUDP : NWProtocol {
 	public static let definition: NWProtocolDefinition = {
 		NWProtocolDefinition(nw_protocol_copy_udp_definition(), "udp")
 	}()
 
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolUDP.
+  @_objcRuntimeName(_TtCC7Network14_NWProtocolUDP7Options)
 	public class Options : NWProtocolOptions {
 
 		private var _preferNoChecksum: Bool = false
@@ -42,7 +50,10 @@ public class NWProtocolUDP : NWProtocol {
 		}
 	}
 
-    public class Metadata: NWProtocolMetadata {
+  // Set the ObjC name of this class to be nested in the customized ObjC
+  // name of NWProtocolUDP.
+  @_objcRuntimeName(_TtCC7Network14_NWProtocolUDP8Metadata)
+  public class Metadata: NWProtocolMetadata {
 		override internal init(_ nw: nw_protocol_metadata_t) {
 			super.init(nw)
 		}

--- a/stdlib/public/SDK/SpriteKit/SpriteKit.swift
+++ b/stdlib/public/SDK/SpriteKit/SpriteKit.swift
@@ -25,7 +25,7 @@ public typealias SKColor = UIColor
 // since that method only exists in a private header in SpriteKit, the lookup
 // mechanism by default fails to accept it as a valid AnyObject call
 //
-// NOTE: older runtimes called this _SpriteKitMethodProvider. The two must
+// NOTE: older overlays called this _SpriteKitMethodProvider. The two must
 // coexist, so it was renamed. The old name must not be used in the new
 // runtime.
 @objc class __SpriteKitMethodProvider : NSObject {

--- a/stdlib/public/core/BridgingBuffer.swift
+++ b/stdlib/public/core/BridgingBuffer.swift
@@ -15,7 +15,10 @@ internal struct _BridgingBufferHeader {
   internal var count: Int
 }
 
-internal final class _BridgingBufferStorage
+// NOTE: older runtimes called this class _BridgingBufferStorage.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+internal final class __BridgingBufferStorage
   : ManagedBuffer<_BridgingBufferHeader, AnyObject> {
 }
 
@@ -26,7 +29,7 @@ extension ManagedBufferPointer
 where Header == _BridgingBufferHeader, Element == AnyObject {
   internal init(_ count: Int) {
     self.init(
-      _uncheckedBufferClass: _BridgingBufferStorage.self,
+      _uncheckedBufferClass: __BridgingBufferStorage.self,
       minimumCapacity: count)
     self.withUnsafeMutablePointerToHeader {
       $0.initialize(to: Header(count))

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -40,7 +40,7 @@
 //       /
 //      |
 //      V
-//   class _RawDictionaryStorage
+//   class __RawDictionaryStorage
 //   +-----------------------------------------------------------+
 //   | <isa>                                                     |
 //   | <refcount>                                                |
@@ -62,7 +62,7 @@
 //   +----------------------------------------------+
 //   | enum Dictionary<K,V>._Variant                |
 //   | +----------------------------------------+   |
-//   | | [ struct _CocoaDictionary              |   |
+//   | | [ struct __CocoaDictionary             |   |
 //   | +---|------------------------------------+   |
 //   +----/-----------------------------------------+
 //       /
@@ -75,9 +75,9 @@
 //   +--------------+
 //     ^
 //     |
-//      \  struct _CocoaDictionary.Index
+//      \  struct __CocoaDictionary.Index
 //   +--|------------------------------------+
-//   |  * base: _CocoaDictionary             |
+//   |  * base: __CocoaDictionary            |
 //   |  allKeys: array of all keys           |
 //   |  currentKeyIndex: index into allKeys  |
 //   +---------------------------------------+
@@ -87,8 +87,8 @@
 // ---------------------------
 //
 // The native backing store is represented by three different classes:
-// * `_RawDictionaryStorage`
-// * `_EmptyDictionarySingleton` (extends Raw)
+// * `__RawDictionaryStorage`
+// * `__EmptyDictionarySingleton` (extends Raw)
 // * `_DictionaryStorage<K: Hashable, V>` (extends Raw)
 //
 // (Hereafter `Raw`, `Empty`, and `Storage`, respectively)
@@ -401,7 +401,7 @@ public struct Dictionary<Key: Hashable, Value> {
 
 #if _runtime(_ObjC)
   @inlinable
-  internal init(_cocoa: __owned _CocoaDictionary) {
+  internal init(_cocoa: __owned __CocoaDictionary) {
     _variant = _Variant(cocoa: _cocoa)
   }
 
@@ -422,7 +422,7 @@ public struct Dictionary<Key: Hashable, Value> {
       Dictionary can be backed by NSDictionary buffer only when both Key \
       and Value are bridged verbatim to Objective-C
       """)
-    self.init(_cocoa: _CocoaDictionary(_immutableCocoaDictionary))
+    self.init(_cocoa: __CocoaDictionary(_immutableCocoaDictionary))
   }
 #endif
 
@@ -1744,7 +1744,7 @@ extension Dictionary {
     internal enum _Variant {
       case native(_HashTable.Index)
 #if _runtime(_ObjC)
-      case cocoa(_CocoaDictionary.Index)
+      case cocoa(__CocoaDictionary.Index)
 #endif
     }
 
@@ -1766,7 +1766,7 @@ extension Dictionary {
 #if _runtime(_ObjC)
     @inlinable
     @inline(__always)
-    internal init(_cocoa index: __owned _CocoaDictionary.Index) {
+    internal init(_cocoa index: __owned __CocoaDictionary.Index) {
       self.init(_variant: .cocoa(index))
     }
 #endif
@@ -1824,7 +1824,7 @@ extension Dictionary.Index {
 
 #if _runtime(_ObjC)
   @usableFromInline
-  internal var _asCocoa: _CocoaDictionary.Index {
+  internal var _asCocoa: __CocoaDictionary.Index {
     @_transparent
     get {
       switch _variant {
@@ -1925,7 +1925,7 @@ extension Dictionary {
     internal enum _Variant {
       case native(_NativeDictionary<Key, Value>.Iterator)
 #if _runtime(_ObjC)
-      case cocoa(_CocoaDictionary.Iterator)
+      case cocoa(__CocoaDictionary.Iterator)
 #endif
     }
 
@@ -1944,7 +1944,7 @@ extension Dictionary {
 
 #if _runtime(_ObjC)
     @inlinable
-    internal init(_cocoa: __owned _CocoaDictionary.Iterator) {
+    internal init(_cocoa: __owned __CocoaDictionary.Iterator) {
       self.init(_variant: .cocoa(_cocoa))
     }
 #endif
@@ -1998,7 +1998,7 @@ extension Dictionary.Iterator {
 
 #if _runtime(_ObjC)
   @usableFromInline @_transparent
-  internal var _asCocoa: _CocoaDictionary.Iterator {
+  internal var _asCocoa: __CocoaDictionary.Iterator {
     get {
       switch _variant {
       case .native:

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -35,8 +35,8 @@ extension _NativeDictionary { // Bridging
     // Temporary var for SOME type safety.
     let nsDictionary: _NSDictionaryCore
 
-    if _storage === _RawDictionaryStorage.empty || count == 0 {
-      nsDictionary = _RawDictionaryStorage.empty
+    if _storage === __RawDictionaryStorage.empty || count == 0 {
+      nsDictionary = __RawDictionaryStorage.empty
     } else if _isBridgedVerbatimToObjectiveC(Key.self),
       _isBridgedVerbatimToObjectiveC(Value.self) {
       nsDictionary = unsafeDowncast(
@@ -56,7 +56,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
   : __SwiftNativeNSEnumerator, _NSEnumerator {
 
   @nonobjc internal var base: _NativeDictionary<Key, Value>
-  @nonobjc internal var bridgedKeys: _BridgingHashBuffer?
+  @nonobjc internal var bridgedKeys: __BridgingHashBuffer?
   @nonobjc internal var nextBucket: _NativeDictionary<Key, Value>.Bucket
   @nonobjc internal var endBucket: _NativeDictionary<Key, Value>.Bucket
 
@@ -186,41 +186,41 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
 
   /// The buffer for bridged keys, if present.
   @nonobjc
-  private var _bridgedKeys: _BridgingHashBuffer? {
+  private var _bridgedKeys: __BridgingHashBuffer? {
     guard let ref = _stdlib_atomicLoadARCRef(object: _bridgedKeysPtr) else {
       return nil
     }
-    return unsafeDowncast(ref, to: _BridgingHashBuffer.self)
+    return unsafeDowncast(ref, to: __BridgingHashBuffer.self)
   }
 
   /// The buffer for bridged values, if present.
   @nonobjc
-  private var _bridgedValues: _BridgingHashBuffer? {
+  private var _bridgedValues: __BridgingHashBuffer? {
     guard let ref = _stdlib_atomicLoadARCRef(object: _bridgedValuesPtr) else {
       return nil
     }
-    return unsafeDowncast(ref, to: _BridgingHashBuffer.self)
+    return unsafeDowncast(ref, to: __BridgingHashBuffer.self)
   }
 
   /// Attach a buffer for bridged Dictionary keys.
   @nonobjc
-  private func _initializeBridgedKeys(_ storage: _BridgingHashBuffer) {
+  private func _initializeBridgedKeys(_ storage: __BridgingHashBuffer) {
     _stdlib_atomicInitializeARCRef(object: _bridgedKeysPtr, desired: storage)
   }
 
   /// Attach a buffer for bridged Dictionary values.
   @nonobjc
-  private func _initializeBridgedValues(_ storage: _BridgingHashBuffer) {
+  private func _initializeBridgedValues(_ storage: __BridgingHashBuffer) {
     _stdlib_atomicInitializeARCRef(object: _bridgedValuesPtr, desired: storage)
   }
 
   @nonobjc
-  internal func bridgeKeys() -> _BridgingHashBuffer? {
+  internal func bridgeKeys() -> __BridgingHashBuffer? {
     if _isBridgedVerbatimToObjectiveC(Key.self) { return nil }
     if let bridgedKeys = _bridgedKeys { return bridgedKeys }
 
     // Allocate and initialize heap storage for bridged keys.
-    let bridged = _BridgingHashBuffer.allocate(
+    let bridged = __BridgingHashBuffer.allocate(
       owner: native._storage,
       hashTable: native.hashTable)
     for bucket in native.hashTable {
@@ -234,12 +234,12 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 
   @nonobjc
-  internal func bridgeValues() -> _BridgingHashBuffer? {
+  internal func bridgeValues() -> __BridgingHashBuffer? {
     if _isBridgedVerbatimToObjectiveC(Value.self) { return nil }
     if let bridgedValues = _bridgedValues { return bridgedValues }
 
     // Allocate and initialize heap storage for bridged values.
-    let bridged = _BridgingHashBuffer.allocate(
+    let bridged = __BridgingHashBuffer.allocate(
       owner: native._storage,
       hashTable: native.hashTable)
     for bucket in native.hashTable {
@@ -263,7 +263,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   @inline(__always)
   private func _key(
     at bucket: Bucket,
-    bridgedKeys: _BridgingHashBuffer?
+    bridgedKeys: __BridgingHashBuffer?
   ) -> AnyObject {
     if let bridgedKeys = bridgedKeys {
       return bridgedKeys[bucket]
@@ -274,7 +274,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   @inline(__always)
   private func _value(
     at bucket: Bucket,
-    bridgedValues: _BridgingHashBuffer?
+    bridgedValues: __BridgingHashBuffer?
   ) -> AnyObject {
     if let bridgedValues = bridgedValues {
       return bridgedValues[bucket]
@@ -417,9 +417,13 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 }
 
+// NOTE: older runtimes called this struct _CocoaDictionary. The two
+// must coexist without conflicting ObjC class names from the nested
+// classes, so it was renamed. The old names must not be used in the new
+// runtime.
 @usableFromInline
 @_fixed_layout
-internal struct _CocoaDictionary {
+internal struct __CocoaDictionary {
   @usableFromInline
   internal let object: AnyObject
 
@@ -429,14 +433,14 @@ internal struct _CocoaDictionary {
   }
 }
 
-extension _CocoaDictionary {
+extension __CocoaDictionary {
   @usableFromInline
-  internal func isEqual(to other: _CocoaDictionary) -> Bool {
+  internal func isEqual(to other: __CocoaDictionary) -> Bool {
     return _stdlib_NSObject_isEqual(self.object, other.object)
   }
 }
 
-extension _CocoaDictionary: _DictionaryBuffer {
+extension __CocoaDictionary: _DictionaryBuffer {
   @usableFromInline
   internal typealias Key = AnyObject
   @usableFromInline
@@ -545,7 +549,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
   }
 }
 
-extension _CocoaDictionary {
+extension __CocoaDictionary {
   @inlinable
   internal func mapValues<Key: Hashable, Value, T>(
     _ transform: (Value) throws -> T
@@ -560,7 +564,7 @@ extension _CocoaDictionary {
   }
 }
 
-extension _CocoaDictionary {
+extension __CocoaDictionary {
   @_fixed_layout
   @usableFromInline
   internal struct Index {
@@ -582,7 +586,7 @@ extension _CocoaDictionary {
   }
 }
 
-extension _CocoaDictionary.Index {
+extension __CocoaDictionary.Index {
   // FIXME(cocoa-index): Try using an NSEnumerator to speed this up.
   internal class Storage {
   // Assumption: we rely on NSDictionary.getObjects when being
@@ -592,7 +596,7 @@ extension _CocoaDictionary.Index {
 
     /// A reference to the NSDictionary, which owns members in `allObjects`,
     /// or `allKeys`, for NSSet and NSDictionary respectively.
-    internal let base: _CocoaDictionary
+    internal let base: __CocoaDictionary
     // FIXME: swift-3-indexing-model: try to remove the cocoa reference, but
     // make sure that we have a safety check for accessing `allKeys`.  Maybe
     // move both into the dictionary/set itself.
@@ -601,7 +605,7 @@ extension _CocoaDictionary.Index {
     internal var allKeys: _BridgingBuffer
 
     internal init(
-      _ base: __owned _CocoaDictionary,
+      _ base: __owned __CocoaDictionary,
       _ allKeys: __owned _BridgingBuffer
     ) {
       self.base = base
@@ -610,7 +614,7 @@ extension _CocoaDictionary.Index {
   }
 }
 
-extension _CocoaDictionary.Index {
+extension __CocoaDictionary.Index {
   @usableFromInline
   internal var handleBitPattern: UInt {
     @_effects(readonly)
@@ -620,7 +624,7 @@ extension _CocoaDictionary.Index {
   }
 
   @usableFromInline
-  internal var dictionary: _CocoaDictionary {
+  internal var dictionary: __CocoaDictionary {
     @_effects(releasenone)
     get {
       return storage.base
@@ -628,7 +632,7 @@ extension _CocoaDictionary.Index {
   }
 }
 
-extension _CocoaDictionary.Index {
+extension __CocoaDictionary.Index {
   @usableFromInline // FIXME(cocoa-index): Make inlinable
   @nonobjc
   internal var key: AnyObject {
@@ -650,12 +654,12 @@ extension _CocoaDictionary.Index {
   }
 }
 
-extension _CocoaDictionary.Index: Equatable {
+extension __CocoaDictionary.Index: Equatable {
   @usableFromInline // FIXME(cocoa-index): Make inlinable
   @_effects(readonly)
   internal static func == (
-    lhs: _CocoaDictionary.Index,
-    rhs: _CocoaDictionary.Index
+    lhs: __CocoaDictionary.Index,
+    rhs: __CocoaDictionary.Index
   ) -> Bool {
     _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different dictionaries")
@@ -663,12 +667,12 @@ extension _CocoaDictionary.Index: Equatable {
   }
 }
 
-extension _CocoaDictionary.Index: Comparable {
+extension __CocoaDictionary.Index: Comparable {
   @usableFromInline // FIXME(cocoa-index): Make inlinable
   @_effects(readonly)
   internal static func < (
-    lhs: _CocoaDictionary.Index,
-    rhs: _CocoaDictionary.Index
+    lhs: __CocoaDictionary.Index,
+    rhs: __CocoaDictionary.Index
   ) -> Bool {
     _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different dictionaries")
@@ -676,7 +680,7 @@ extension _CocoaDictionary.Index: Comparable {
   }
 }
 
-extension _CocoaDictionary: Sequence {
+extension __CocoaDictionary: Sequence {
   @usableFromInline
   final internal class Iterator {
     // Cocoa Dictionary iterator has to be a class, otherwise we cannot
@@ -692,7 +696,7 @@ extension _CocoaDictionary: Sequence {
     // `_fastEnumerationState`.  There's code below relying on this.
     internal var _fastEnumerationStackBuf = _CocoaFastEnumerationStackBuf()
 
-    internal let base: _CocoaDictionary
+    internal let base: __CocoaDictionary
 
     internal var _fastEnumerationStatePtr:
       UnsafeMutablePointer<_SwiftNSFastEnumerationState> {
@@ -713,7 +717,7 @@ extension _CocoaDictionary: Sequence {
     internal var itemIndex: Int = 0
     internal var itemCount: Int = 0
 
-    internal init(_ base: __owned _CocoaDictionary) {
+    internal init(_ base: __owned __CocoaDictionary) {
       self.base = base
     }
   }
@@ -725,7 +729,7 @@ extension _CocoaDictionary: Sequence {
   }
 }
 
-extension _CocoaDictionary.Iterator: IteratorProtocol {
+extension __CocoaDictionary.Iterator: IteratorProtocol {
   @usableFromInline
   internal typealias Element = (key: AnyObject, value: AnyObject)
 
@@ -796,7 +800,7 @@ extension Dictionary {
       return Dictionary(_native: _NativeDictionary(nativeStorage))
     }
 
-    if s === _RawDictionaryStorage.empty {
+    if s === __RawDictionaryStorage.empty {
       return Dictionary()
     }
 

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -16,10 +16,13 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
+// NOTE: older runtimes called this class _RawDictionaryStorage. The two
+// must coexist without a conflicting ObjC class name, so it was
+// renamed. The old name must not be used in the new runtime.
 @_fixed_layout
 @usableFromInline
 @_objc_non_lazy_realization
-internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
+internal class __RawDictionaryStorage: __SwiftNativeNSDictionary {
   // NOTE: The precise layout of this type is relied on in the runtime to
   // provide a statically allocated empty singleton.  See
   // stdlib/public/stubs/GlobalObjects.cpp for details.
@@ -109,9 +112,12 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
 
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
+// NOTE: older runtimes called this class _EmptyDictionarySingleton.
+// The two must coexist without a conflicting ObjC class name, so it was
+// renamed. The old name must not be used in the new runtime.
 @_fixed_layout
 @usableFromInline
-internal class _EmptyDictionarySingleton: _RawDictionaryStorage {
+internal class __EmptyDictionarySingleton: __RawDictionaryStorage {
   @nonobjc
   internal override init(_doNotCallMe: ()) {
     _internalInvariantFailure("This class cannot be directly initialized")
@@ -130,7 +136,7 @@ internal class _EmptyDictionarySingleton: _RawDictionaryStorage {
 }
 
 #if _runtime(_ObjC)
-extension _EmptyDictionarySingleton: _NSDictionaryCore {
+extension __EmptyDictionarySingleton: _NSDictionaryCore {
   @objc(copyWithZone:)
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     return self
@@ -167,7 +173,7 @@ extension _EmptyDictionarySingleton: _NSDictionaryCore {
 
   @objc(keyEnumerator)
   internal func keyEnumerator() -> _NSEnumerator {
-    return _SwiftEmptyNSEnumerator()
+    return __SwiftEmptyNSEnumerator()
   }
 
   @objc(getObjects:andKeys:count:)
@@ -180,13 +186,13 @@ extension _EmptyDictionarySingleton: _NSDictionaryCore {
 }
 #endif
 
-extension _RawDictionaryStorage {
+extension __RawDictionaryStorage {
   /// The empty singleton that is used for every single Dictionary that is
   /// created without any elements. The contents of the storage should never
   /// be mutated.
   @inlinable
   @nonobjc
-  internal static var empty: _EmptyDictionarySingleton {
+  internal static var empty: __EmptyDictionarySingleton {
     return Builtin.bridgeFromRawPointer(
       Builtin.addressof(&_swiftEmptyDictionarySingleton))
   }
@@ -194,7 +200,7 @@ extension _RawDictionaryStorage {
 
 @usableFromInline
 final internal class _DictionaryStorage<Key: Hashable, Value>
-  : _RawDictionaryStorage, _NSDictionaryCore {
+  : __RawDictionaryStorage, _NSDictionaryCore {
   // This type is made with allocWithTailElems, so no init is ever called.
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
@@ -359,7 +365,7 @@ extension _DictionaryStorage {
   @usableFromInline
   @_effects(releasenone)
   internal static func copy(
-    original: _RawDictionaryStorage
+    original: __RawDictionaryStorage
   ) -> _DictionaryStorage {
     return allocate(
       scale: original._scale,
@@ -370,7 +376,7 @@ extension _DictionaryStorage {
   @usableFromInline
   @_effects(releasenone)
   static internal func resize(
-    original: _RawDictionaryStorage,
+    original: __RawDictionaryStorage,
     capacity: Int,
     move: Bool
   ) -> _DictionaryStorage {
@@ -389,7 +395,7 @@ extension _DictionaryStorage {
   @usableFromInline
   @_effects(releasenone)
   static internal func convert(
-    _ cocoa: _CocoaDictionary,
+    _ cocoa: __CocoaDictionary,
     capacity: Int
   ) -> _DictionaryStorage {
     let scale = _HashTable.scale(forCapacity: capacity)

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -35,7 +35,7 @@ extension Dictionary {
   @_fixed_layout
   internal struct _Variant {
     @usableFromInline
-    internal var object: _BridgeStorage<_RawDictionaryStorage>
+    internal var object: _BridgeStorage<__RawDictionaryStorage>
 
     @inlinable
     @inline(__always)
@@ -56,7 +56,7 @@ extension Dictionary {
 #if _runtime(_ObjC)
     @inlinable
     @inline(__always)
-    init(cocoa: __owned _CocoaDictionary) {
+    init(cocoa: __owned __CocoaDictionary) {
       self.object = _BridgeStorage(objC: cocoa.object)
     }
 #endif
@@ -102,8 +102,8 @@ extension Dictionary._Variant {
 
 #if _runtime(_ObjC)
   @inlinable
-  internal var asCocoa: _CocoaDictionary {
-    return _CocoaDictionary(object.objCInstance)
+  internal var asCocoa: __CocoaDictionary {
+    return __CocoaDictionary(object.objCInstance)
   }
 #endif
 

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -71,7 +71,10 @@ internal struct _UnmanagedAnyObjectArray {
 #if _runtime(_ObjC)
 /// An NSEnumerator implementation returning zero elements. This is useful when
 /// a concrete element type is not recoverable from the empty singleton.
-final internal class _SwiftEmptyNSEnumerator
+// NOTE: older runtimes called this class _SwiftEmptyNSEnumerator. The two
+// must coexist without conflicting ObjC class names, so it was
+// renamed. The old name must not be used in the new runtime.
+final internal class __SwiftEmptyNSEnumerator
   : __SwiftNativeNSEnumerator, _NSEnumerator {
   internal override required init() {}
 
@@ -107,8 +110,11 @@ final internal class _SwiftEmptyNSEnumerator
 ///
 /// Using a dedicated class for this rather than a _BridgingBuffer makes it easy
 /// to recognize these in heap dumps etc.
-internal final class _BridgingHashBuffer
-  : ManagedBuffer<_BridgingHashBuffer.Header, AnyObject> {
+// NOTE: older runtimes called this class _BridgingHashBuffer.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+internal final class __BridgingHashBuffer
+  : ManagedBuffer<__BridgingHashBuffer.Header, AnyObject> {
   struct Header {
     internal var owner: AnyObject
     internal var hashTable: _HashTable
@@ -122,11 +128,11 @@ internal final class _BridgingHashBuffer
   internal static func allocate(
     owner: AnyObject,
     hashTable: _HashTable
-  ) -> _BridgingHashBuffer {
+  ) -> __BridgingHashBuffer {
     let buffer = self.create(minimumCapacity: hashTable.bucketCount) { _ in
       Header(owner: owner, hashTable: hashTable)
     }
-    return unsafeDowncast(buffer, to: _BridgingHashBuffer.self)
+    return unsafeDowncast(buffer, to: __BridgingHashBuffer.self)
   }
 
   deinit {

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A wrapper around _RawDictionaryStorage that provides most of the
+/// A wrapper around __RawDictionaryStorage that provides most of the
 /// implementation of Dictionary.
 @usableFromInline
 @_fixed_layout
@@ -18,20 +18,20 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
   @usableFromInline
   internal typealias Element = (key: Key, value: Value)
 
-  /// See this comments on _RawDictionaryStorage and its subclasses to
+  /// See this comments on __RawDictionaryStorage and its subclasses to
   /// understand why we store an untyped storage here.
   @usableFromInline
-  internal var _storage: _RawDictionaryStorage
+  internal var _storage: __RawDictionaryStorage
 
   /// Constructs an instance from the empty singleton.
   @inlinable
   internal init() {
-    self._storage = _RawDictionaryStorage.empty
+    self._storage = __RawDictionaryStorage.empty
   }
 
   /// Constructs a dictionary adopting the given storage.
   @inlinable
-  internal init(_ storage: __owned _RawDictionaryStorage) {
+  internal init(_ storage: __owned __RawDictionaryStorage) {
     self._storage = storage
   }
 
@@ -42,12 +42,12 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
 
 #if _runtime(_ObjC)
   @inlinable
-  internal init(_ cocoa: __owned _CocoaDictionary) {
+  internal init(_ cocoa: __owned __CocoaDictionary) {
     self.init(cocoa, capacity: cocoa.count)
   }
 
   @inlinable
-  internal init(_ cocoa: __owned _CocoaDictionary, capacity: Int) {
+  internal init(_ cocoa: __owned __CocoaDictionary, capacity: Int) {
     _internalInvariant(cocoa.count <= capacity)
     self._storage =
       _DictionaryStorage<Key, Value>.convert(cocoa, capacity: capacity)
@@ -590,7 +590,7 @@ extension _NativeDictionary where Value: Equatable {
 
 #if _runtime(_ObjC)
   @inlinable
-  func isEqual(to other: _CocoaDictionary) -> Bool {
+  func isEqual(to other: __CocoaDictionary) -> Bool {
     if self.count != other.count { return false }
 
     defer { _fixLifetime(self) }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -10,27 +10,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A wrapper around _RawSetStorage that provides most of the
+/// A wrapper around __RawSetStorage that provides most of the
 /// implementation of Set.
 @usableFromInline
 @_fixed_layout
 internal struct _NativeSet<Element: Hashable> {
-  /// See the comments on _RawSetStorage and its subclasses to understand why we
+  /// See the comments on __RawSetStorage and its subclasses to understand why we
   /// store an untyped storage here.
   @usableFromInline
-  internal var _storage: _RawSetStorage
+  internal var _storage: __RawSetStorage
 
   /// Constructs an instance from the empty singleton.
   @inlinable
   @inline(__always)
   internal init() {
-    self._storage = _RawSetStorage.empty
+    self._storage = __RawSetStorage.empty
   }
 
   /// Constructs a native set adopting the given storage.
   @inlinable
   @inline(__always)
-  internal init(_ storage: __owned _RawSetStorage) {
+  internal init(_ storage: __owned __RawSetStorage) {
     self._storage = storage
   }
 
@@ -41,12 +41,12 @@ internal struct _NativeSet<Element: Hashable> {
 
 #if _runtime(_ObjC)
   @inlinable
-  internal init(_ cocoa: __owned _CocoaSet) {
+  internal init(_ cocoa: __owned __CocoaSet) {
     self.init(cocoa, capacity: cocoa.count)
   }
 
   @inlinable
-  internal init(_ cocoa: __owned _CocoaSet, capacity: Int) {
+  internal init(_ cocoa: __owned __CocoaSet, capacity: Int) {
     _internalInvariant(cocoa.count <= capacity)
     self._storage = _SetStorage<Element>.convert(cocoa, capacity: capacity)
     for element in cocoa {
@@ -439,7 +439,7 @@ extension _NativeSet {
 
 #if _runtime(_ObjC)
   @inlinable
-  func isEqual(to other: _CocoaSet) -> Bool {
+  func isEqual(to other: __CocoaSet) -> Bool {
     if self.count != other.count { return false }
 
     defer { _fixLifetime(self) }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -174,7 +174,7 @@ public struct Set<Element: Hashable> {
 
 #if _runtime(_ObjC)
   @inlinable
-  internal init(_cocoa: __owned _CocoaSet) {
+  internal init(_cocoa: __owned __CocoaSet) {
     _variant = _Variant(cocoa: _cocoa)
   }
 
@@ -190,7 +190,7 @@ public struct Set<Element: Hashable> {
   init(_immutableCocoaSet: __owned AnyObject) {
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variant only when the member type can be bridged verbatim to Objective-C")
-    self.init(_cocoa: _CocoaSet(_immutableCocoaSet))
+    self.init(_cocoa: __CocoaSet(_immutableCocoaSet))
   }
 #endif
 }
@@ -1266,7 +1266,7 @@ extension Set {
     internal enum _Variant {
       case native(_HashTable.Index)
 #if _runtime(_ObjC)
-      case cocoa(_CocoaSet.Index)
+      case cocoa(__CocoaSet.Index)
 #endif
     }
 
@@ -1288,7 +1288,7 @@ extension Set {
 #if _runtime(_ObjC)
     @inlinable
     @inline(__always)
-    internal init(_cocoa index: __owned _CocoaSet.Index) {
+    internal init(_cocoa index: __owned __CocoaSet.Index) {
       self.init(_variant: .cocoa(index))
     }
 #endif
@@ -1349,7 +1349,7 @@ extension Set.Index {
 
 #if _runtime(_ObjC)
   @usableFromInline
-  internal var _asCocoa: _CocoaSet.Index {
+  internal var _asCocoa: __CocoaSet.Index {
     @_transparent
     get {
       switch _variant {
@@ -1454,7 +1454,7 @@ extension Set {
     internal enum _Variant {
       case native(_NativeSet<Element>.Iterator)
 #if _runtime(_ObjC)
-      case cocoa(_CocoaSet.Iterator)
+      case cocoa(__CocoaSet.Iterator)
 #endif
     }
 
@@ -1473,7 +1473,7 @@ extension Set {
 
 #if _runtime(_ObjC)
     @usableFromInline
-    internal init(_cocoa: __owned _CocoaSet.Iterator) {
+    internal init(_cocoa: __owned __CocoaSet.Iterator) {
       self.init(_variant: .cocoa(_cocoa))
     }
 #endif
@@ -1529,7 +1529,7 @@ extension Set.Iterator {
 
 #if _runtime(_ObjC)
   @usableFromInline @_transparent
-  internal var _asCocoa: _CocoaSet.Iterator {
+  internal var _asCocoa: __CocoaSet.Iterator {
     get {
       switch _variant {
       case .native:

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -16,10 +16,13 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
+// NOTE: older runtimes called this class _RawSetStorage. The two
+// must coexist without a conflicting ObjC class name, so it was
+// renamed. The old name must not be used in the new runtime.
 @_fixed_layout
 @usableFromInline
 @_objc_non_lazy_realization
-internal class _RawSetStorage: __SwiftNativeNSSet {
+internal class __RawSetStorage: __SwiftNativeNSSet {
   // NOTE: The precise layout of this type is relied on in the runtime to
   // provide a statically allocated empty singleton.  See
   // stdlib/public/stubs/GlobalObjects.cpp for details.
@@ -104,9 +107,12 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
 
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
+// NOTE: older runtimes called this class _EmptySetSingleton. The two
+// must coexist without conflicting ObjC class names, so it was renamed.
+// The old names must not be used in the new runtime.
 @_fixed_layout
 @usableFromInline
-internal class _EmptySetSingleton: _RawSetStorage {
+internal class __EmptySetSingleton: __RawSetStorage {
   @nonobjc
   override internal init(_doNotCallMe: ()) {
     _internalInvariantFailure("This class cannot be directly initialized")
@@ -120,18 +126,18 @@ internal class _EmptySetSingleton: _RawSetStorage {
 #endif
 }
 
-extension _RawSetStorage {
+extension __RawSetStorage {
   /// The empty singleton that is used for every single Set that is created
   /// without any elements. The contents of the storage must never be mutated.
   @inlinable
   @nonobjc
-  internal static var empty: _EmptySetSingleton {
+  internal static var empty: __EmptySetSingleton {
     return Builtin.bridgeFromRawPointer(
       Builtin.addressof(&_swiftEmptySetSingleton))
   }
 }
 
-extension _EmptySetSingleton: _NSSetCore {
+extension __EmptySetSingleton: _NSSetCore {
 #if _runtime(_ObjC)
   //
   // NSSet implementation, assuming Self is the empty singleton
@@ -153,7 +159,7 @@ extension _EmptySetSingleton: _NSSetCore {
 
   @objc
   internal func objectEnumerator() -> _NSEnumerator {
-    return _SwiftEmptyNSEnumerator()
+    return __SwiftEmptyNSEnumerator()
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -177,7 +183,7 @@ extension _EmptySetSingleton: _NSSetCore {
 
 @usableFromInline
 final internal class _SetStorage<Element: Hashable>
-  : _RawSetStorage, _NSSetCore {
+  : __RawSetStorage, _NSSetCore {
   // This type is made with allocWithTailElems, so no init is ever called.
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
@@ -284,7 +290,7 @@ final internal class _SetStorage<Element: Hashable>
 extension _SetStorage {
   @usableFromInline
   @_effects(releasenone)
-  internal static func copy(original: _RawSetStorage) -> _SetStorage {
+  internal static func copy(original: __RawSetStorage) -> _SetStorage {
     return .allocate(
       scale: original._scale,
       age: original._age,
@@ -294,7 +300,7 @@ extension _SetStorage {
   @usableFromInline
   @_effects(releasenone)
   static internal func resize(
-    original: _RawSetStorage,
+    original: __RawSetStorage,
     capacity: Int,
     move: Bool
   ) -> _SetStorage {
@@ -313,7 +319,7 @@ extension _SetStorage {
   @usableFromInline
   @_effects(releasenone)
   static internal func convert(
-    _ cocoa: _CocoaSet,
+    _ cocoa: __CocoaSet,
     capacity: Int
   ) -> _SetStorage {
     let scale = _HashTable.scale(forCapacity: capacity)

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -31,7 +31,7 @@ extension Set {
   @_fixed_layout
   internal struct _Variant {
     @usableFromInline
-    internal var object: _BridgeStorage<_RawSetStorage>
+    internal var object: _BridgeStorage<__RawSetStorage>
 
     @inlinable
     @inline(__always)
@@ -52,7 +52,7 @@ extension Set {
 #if _runtime(_ObjC)
     @inlinable
     @inline(__always)
-    init(cocoa: __owned _CocoaSet) {
+    init(cocoa: __owned __CocoaSet) {
       self.object = _BridgeStorage(objC: cocoa.object)
     }
 #endif
@@ -103,8 +103,8 @@ extension Set._Variant {
 
 #if _runtime(_ObjC)
   @inlinable
-  internal var asCocoa: _CocoaSet {
-    return _CocoaSet(object.objCInstance)
+  internal var asCocoa: __CocoaSet {
+    return __CocoaSet(object.objCInstance)
   }
 #endif
 
@@ -318,7 +318,7 @@ extension Set._Variant {
 #if _runtime(_ObjC)
   @inlinable
   internal mutating func _migrateToNative(
-    _ cocoa: _CocoaSet,
+    _ cocoa: __CocoaSet,
     removing member: Element
   ) -> Element {
     // FIXME(performance): fuse data migration and element deletion into one

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -149,9 +149,9 @@ internal enum _KnownCocoaString {
 #endif
     
     switch _unsafeAddressOfCocoaStringClass(str) {
-    case unsafeBitCast(_StringStorage.self, to: UInt.self):
+    case unsafeBitCast(__StringStorage.self, to: UInt.self):
       self = .storage
-    case unsafeBitCast(_SharedStringStorage.self, to: UInt.self):
+    case unsafeBitCast(__SharedStringStorage.self, to: UInt.self):
       self = .shared
     default:
       self = .cocoa
@@ -216,10 +216,10 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
   switch _KnownCocoaString(cocoaString) {
   case .storage:
     return _unsafeUncheckedDowncast(
-      cocoaString, to: _StringStorage.self).asString._guts
+      cocoaString, to: __StringStorage.self).asString._guts
   case .shared:
     return _unsafeUncheckedDowncast(
-      cocoaString, to: _SharedStringStorage.self).asString._guts
+      cocoaString, to: __SharedStringStorage.self).asString._guts
 #if !(arch(i386) || arch(arm))
   case .tagged:
     return _StringGuts(_SmallString(taggedCocoa: cocoaString))
@@ -284,7 +284,7 @@ extension String {
       // TODO: We'd rather emit a valid ObjC object statically than create a
       // shared string class instance.
       let gutsCountAndFlags = _guts._object._countAndFlags
-      return _SharedStringStorage(
+      return __SharedStringStorage(
         immortal: _guts._object.fastUTF8.baseAddress!,
         countAndFlags: _StringObject.CountAndFlags(
           sharedCount: _guts.count, isASCII: gutsCountAndFlags.isASCII))

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -38,7 +38,7 @@ extension String {
       return String(_StringGuts(smol))
     }
 
-    let storage = _StringStorage.create(initializingFrom: input, isASCII: true)
+    let storage = __StringStorage.create(initializingFrom: input, isASCII: true)
     return storage.asString
   }
 
@@ -83,7 +83,7 @@ extension String {
       return String(_StringGuts(smol))
     }
 
-    let storage = _StringStorage.create(
+    let storage = __StringStorage.create(
       initializingFrom: input, isASCII: isASCII)
     return storage.asString
   }
@@ -98,7 +98,7 @@ extension String {
     }
 
     let isASCII = asciiPreScanResult
-    let storage = _StringStorage.create(
+    let storage = __StringStorage.create(
       initializingFrom: input, isASCII: isASCII)
     return storage.asString
   }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -56,11 +56,11 @@ extension _StringGuts {
   }
 
   @inline(__always)
-  internal init(_ storage: _StringStorage) {
+  internal init(_ storage: __StringStorage) {
     self.init(_StringObject(storage))
   }
 
-  internal init(_ storage: _SharedStringStorage) {
+  internal init(_ storage: __SharedStringStorage) {
     self.init(_StringObject(storage))
   }
 

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -84,7 +84,7 @@ extension _StringGuts {
     if _fastPath(isFastUTF8) {
       let isASCII = self.isASCII
       let storage = self.withFastUTF8 {
-        _StringStorage.create(
+        __StringStorage.create(
           initializingFrom: $0, capacity: growthTarget, isASCII: isASCII)
       }
 
@@ -101,7 +101,7 @@ extension _StringGuts {
     // into a StringStorage space.
     let selfUTF8 = Array(String(self).utf8)
     selfUTF8.withUnsafeBufferPointer {
-      self = _StringGuts(_StringStorage.create(
+      self = _StringGuts(__StringStorage.create(
         initializingFrom: $0, capacity: n, isASCII: self.isASCII))
     }
   }

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -838,13 +838,13 @@ extension _StringObject {
     }
   }
 
-  internal var nativeStorage: _StringStorage {
+  internal var nativeStorage: __StringStorage {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
       guard case .native(let storage) = _variant else {
         _internalInvariantFailure()
       }
-      return _unsafeUncheckedDowncast(storage, to: _StringStorage.self)
+      return _unsafeUncheckedDowncast(storage, to: __StringStorage.self)
 #else
       _internalInvariant(hasNativeStorage)
       return Builtin.reinterpretCast(largeAddressBits)
@@ -852,13 +852,13 @@ extension _StringObject {
     }
   }
 
-  internal var sharedStorage: _SharedStringStorage {
+  internal var sharedStorage: __SharedStringStorage {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
       guard case .native(let storage) = _variant else {
         _internalInvariantFailure()
       }
-      return _unsafeUncheckedDowncast(storage, to: _SharedStringStorage.self)
+      return _unsafeUncheckedDowncast(storage, to: __SharedStringStorage.self)
 #else
       _internalInvariant(largeFastIsShared && !largeIsCocoa)
       _internalInvariant(hasSharedStorage)
@@ -982,7 +982,7 @@ extension _StringObject {
   }
 
   @inline(__always)
-  internal init(_ storage: _StringStorage) {
+  internal init(_ storage: __StringStorage) {
 #if arch(i386) || arch(arm)
     self.init(
       variant: .native(storage),
@@ -996,7 +996,7 @@ extension _StringObject {
 #endif
   }
 
-  internal init(_ storage: _SharedStringStorage) {
+  internal init(_ storage: __SharedStringStorage) {
 #if arch(i386) || arch(arm)
     self.init(
       variant: .native(storage),

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -1100,7 +1100,7 @@ extension _StringObject {
       }
       if _countAndFlags.isNativelyStored {
         let anyObj = Builtin.reinterpretCast(largeAddressBits) as AnyObject
-        _internalInvariant(anyObj is _StringStorage)
+        _internalInvariant(anyObj is __StringStorage)
       }
     }
 

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -126,10 +126,10 @@ extension _AbstractStringStorage {
     switch knownOther {
     case .storage:
       return _nativeIsEqual(
-        _unsafeUncheckedDowncast(other, to: _StringStorage.self))
+        _unsafeUncheckedDowncast(other, to: __StringStorage.self))
     case .shared:
       return _nativeIsEqual(
-        _unsafeUncheckedDowncast(other, to: _SharedStringStorage.self))
+        _unsafeUncheckedDowncast(other, to: __SharedStringStorage.self))
 #if !(arch(i386) || arch(arm))
     case .tagged:
       fallthrough

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -172,7 +172,10 @@ private typealias CountAndFlags = _StringObject.CountAndFlags
 // Optional<_StringBreadcrumbs>.
 //
 
-final internal class _StringStorage
+// NOTE: older runtimes called this class _StringStorage. The two
+// must coexist without conflicting ObjC class names, so it was
+// renamed. The old name must not be used in the new runtime.
+final internal class __StringStorage
   : __SwiftNativeNSString, _AbstractStringStorage {
 #if arch(i386) || arch(arm)
   // The total allocated storage capacity. Note that this includes the required
@@ -299,7 +302,7 @@ final internal class _StringStorage
 
   @objc(copyWithZone:)
   final internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
-    // While _StringStorage instances aren't immutable in general,
+    // While __StringStorage instances aren't immutable in general,
     // mutations may only occur when instances are uniquely referenced.
     // Therefore, it is safe to return self here; any outstanding Objective-C
     // reference will make the instance non-unique.
@@ -350,13 +353,13 @@ private func determineCodeUnitCapacity(_ desiredCapacity: Int) -> Int {
 }
 
 // Creation
-extension _StringStorage {
+extension __StringStorage {
   @_effects(releasenone)
   private static func create(
     realCodeUnitCapacity: Int, countAndFlags: CountAndFlags
-  ) -> _StringStorage {
+  ) -> __StringStorage {
     let storage = Builtin.allocWithTailElems_2(
-      _StringStorage.self,
+      __StringStorage.self,
       realCodeUnitCapacity._builtinWordValue, UInt8.self,
       1._builtinWordValue, Optional<_StringBreadcrumbs>.self)
 #if arch(i386) || arch(arm)
@@ -380,12 +383,12 @@ extension _StringStorage {
   @_effects(releasenone)
   private static func create(
     capacity: Int, countAndFlags: CountAndFlags
-  ) -> _StringStorage {
+  ) -> __StringStorage {
     _internalInvariant(capacity >= countAndFlags.count)
 
     let realCapacity = determineCodeUnitCapacity(capacity)
     _internalInvariant(realCapacity > capacity)
-    return _StringStorage.create(
+    return __StringStorage.create(
       realCodeUnitCapacity: realCapacity, countAndFlags: countAndFlags)
   }
 
@@ -394,11 +397,11 @@ extension _StringStorage {
     initializingFrom bufPtr: UnsafeBufferPointer<UInt8>,
     capacity: Int,
     isASCII: Bool
-  ) -> _StringStorage {
+  ) -> __StringStorage {
     let countAndFlags = CountAndFlags(
       mortalCount: bufPtr.count, isASCII: isASCII)
     _internalInvariant(capacity >= bufPtr.count)
-    let storage = _StringStorage.create(
+    let storage = __StringStorage.create(
       capacity: capacity, countAndFlags: countAndFlags)
     let addr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
     storage.mutableStart.initialize(from: addr, count: bufPtr.count)
@@ -409,14 +412,14 @@ extension _StringStorage {
   @_effects(releasenone)
   internal static func create(
     initializingFrom bufPtr: UnsafeBufferPointer<UInt8>, isASCII: Bool
-  ) -> _StringStorage {
-    return _StringStorage.create(
+  ) -> __StringStorage {
+    return __StringStorage.create(
       initializingFrom: bufPtr, capacity: bufPtr.count, isASCII: isASCII)
   }
 }
 
 // Usage
-extension _StringStorage {
+extension __StringStorage {
   @inline(__always)
   private var mutableStart: UnsafeMutablePointer<UInt8> {
     return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt8.self))
@@ -504,7 +507,7 @@ extension _StringStorage {
 }
 
 // Appending
-extension _StringStorage {
+extension __StringStorage {
   // Perform common post-RRC adjustments and invariant enforcement.
   @_effects(releasenone)
   private func _postRRCAdjust(newCount: Int, newIsASCII: Bool) {
@@ -564,7 +567,7 @@ extension _StringStorage {
 }
 
 // Removing
-extension _StringStorage {
+extension __StringStorage {
   @_effects(releasenone)
   internal func remove(from lower: Int, to upper: Int) {
     _internalInvariant(lower <= upper)
@@ -646,7 +649,10 @@ extension _StringStorage {
 }
 
 // For shared storage and bridging literals
-final internal class _SharedStringStorage
+// NOTE: older runtimes called this class _SharedStringStorage. The two
+// must coexist without conflicting ObjC class names, so it was
+// renamed. The old name must not be used in the new runtime.
+final internal class __SharedStringStorage
   : __SwiftNativeNSString, _AbstractStringStorage {
   internal var _owner: AnyObject?
   internal var start: UnsafePointer<UInt8>
@@ -775,7 +781,7 @@ final internal class _SharedStringStorage
 
   @objc(copyWithZone:)
   final internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
-    // While _StringStorage instances aren't immutable in general,
+    // While __StringStorage instances aren't immutable in general,
     // mutations may only occur when instances are uniquely referenced.
     // Therefore, it is safe to return self here; any outstanding Objective-C
     // reference will make the instance non-unique.
@@ -786,7 +792,7 @@ final internal class _SharedStringStorage
 
 }
 
-extension _SharedStringStorage {
+extension __SharedStringStorage {
 #if !INTERNAL_CHECKS_ENABLED
   @inline(__always)
   internal func _invariantCheck() {}

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -160,10 +160,10 @@ extension __SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
       to: Optional<AnyObject>.self)
   }
 
-  internal var _heapBufferBridged: _BridgingBufferStorage? {
+  internal var _heapBufferBridged: __BridgingBufferStorage? {
     if let ref =
       _stdlib_atomicLoadARCRef(object: _heapBufferBridgedPtr) {
-      return unsafeBitCast(ref, to: _BridgingBufferStorage.self)
+      return unsafeBitCast(ref, to: __BridgingBufferStorage.self)
     }
     return nil
   }
@@ -174,7 +174,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
     self._nativeStorage = _nativeStorage
   }
 
-  internal func _destroyBridgedStorage(_ hb: _BridgingBufferStorage?) {
+  internal func _destroyBridgedStorage(_ hb: __BridgingBufferStorage?) {
     if let bridgedStorage = hb {
       let buffer = _BridgingBuffer(bridgedStorage)
       let count = buffer.count
@@ -216,7 +216,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
 
           // Another thread won the race.  Throw out our buffer.
           _destroyBridgedStorage(
-            unsafeDowncast(objects.storage!, to: _BridgingBufferStorage.self))
+            unsafeDowncast(objects.storage!, to: __BridgingBufferStorage.self))
         }
         continue // Try again
       }

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -28,13 +28,13 @@ namespace swift {
 SWIFT_RUNTIME_STDLIB_API
 ClassMetadata CLASS_METADATA_SYM(s19__EmptyArrayStorage);
 
-// _direct type metadata for Swift._EmptyDictionarySingleton
+// _direct type metadata for Swift.__EmptyDictionarySingleton
 SWIFT_RUNTIME_STDLIB_API
-ClassMetadata CLASS_METADATA_SYM(s25_EmptyDictionarySingleton);
+ClassMetadata CLASS_METADATA_SYM(s26__EmptyDictionarySingleton);
 
-// _direct type metadata for Swift._EmptySetSingleton
+// _direct type metadata for Swift.__EmptySetSingleton
 SWIFT_RUNTIME_STDLIB_API
-ClassMetadata CLASS_METADATA_SYM(s18_EmptySetSingleton);
+ClassMetadata CLASS_METADATA_SYM(s19__EmptySetSingleton);
 } // namespace swift
 
 SWIFT_RUNTIME_STDLIB_API
@@ -55,7 +55,7 @@ SWIFT_RUNTIME_STDLIB_API
 swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
   // HeapObject header;
   {
-    &swift::CLASS_METADATA_SYM(s25_EmptyDictionarySingleton), // isa pointer
+    &swift::CLASS_METADATA_SYM(s26__EmptyDictionarySingleton), // isa pointer
   },
   
   // _SwiftDictionaryBodyStorage body;
@@ -82,7 +82,7 @@ SWIFT_RUNTIME_STDLIB_API
 swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
   // HeapObject header;
   {
-    &swift::CLASS_METADATA_SYM(s18_EmptySetSingleton), // isa pointer
+    &swift::CLASS_METADATA_SYM(s19__EmptySetSingleton), // isa pointer
   },
   
   // _SwiftSetBodyStorage body;

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -1,1 +1,46 @@
 Class __SwiftNativeNSString has been removed
+
+Class _DictionaryStorage has changed its super class from _RawDictionaryStorage to __RawDictionaryStorage
+Class _EmptyDictionarySingleton has been renamed to Class __EmptyDictionarySingleton
+Class _EmptyDictionarySingleton has changed its super class from _RawDictionaryStorage to __RawDictionaryStorage
+Class _EmptySetSingleton has been renamed to Class __EmptySetSingleton
+Class _EmptySetSingleton has changed its super class from _RawSetStorage to __RawSetStorage
+Class _RawDictionaryStorage has been renamed to Class __RawDictionaryStorage
+Class _RawSetStorage has been renamed to Class __RawSetStorage
+Class _SetStorage has changed its super class from _RawSetStorage to __RawSetStorage
+Class _SharedStringStorage has been renamed to Class __SharedStringStorage
+Class _StringStorage has been renamed to Class __StringStorage
+Constructor Dictionary._Variant.init(cocoa:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Constructor Dictionary.init(_cocoa:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Constructor Set._Variant.init(cocoa:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Constructor Set.init(_cocoa:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Constructor _CocoaDictionary.init(_:) has return type change from _CocoaDictionary to __CocoaDictionary
+Constructor _CocoaSet.init(_:) has return type change from _CocoaSet to __CocoaSet
+Constructor _NativeDictionary.init(_:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Constructor _NativeDictionary.init(_:) has parameter 0 type change from _RawDictionaryStorage to __RawDictionaryStorage
+Constructor _NativeDictionary.init(_:capacity:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Constructor _NativeSet.init(_:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Constructor _NativeSet.init(_:) has parameter 0 type change from _RawSetStorage to __RawSetStorage
+Constructor _NativeSet.init(_:capacity:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Func Set._Variant._migrateToNative(_:removing:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Func _CocoaDictionary.isEqual(to:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Func _CocoaSet.isEqual(to:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Func _DictionaryStorage.convert(_:capacity:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Func _DictionaryStorage.copy(original:) has parameter 0 type change from _RawDictionaryStorage to __RawDictionaryStorage
+Func _DictionaryStorage.resize(original:capacity:move:) has parameter 0 type change from _RawDictionaryStorage to __RawDictionaryStorage
+Func _NativeDictionary.isEqual(to:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
+Func _NativeSet.isEqual(to:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Func _SetStorage.convert(_:capacity:) has parameter 0 type change from _CocoaSet to __CocoaSet
+Func _SetStorage.copy(original:) has parameter 0 type change from _RawSetStorage to __RawSetStorage
+Func _SetStorage.resize(original:capacity:move:) has parameter 0 type change from _RawSetStorage to __RawSetStorage
+Struct _CocoaDictionary has been renamed to Struct __CocoaDictionary
+Struct _CocoaSet has been renamed to Struct __CocoaSet
+Var Dictionary._Variant.asCocoa has declared type change from _CocoaDictionary to __CocoaDictionary
+Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage, _NSDictionary> to _BridgeStorage<__RawDictionaryStorage>
+Var Set._Variant.asCocoa has declared type change from _CocoaSet to __CocoaSet
+Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage, _NSSet> to _BridgeStorage<__RawSetStorage>
+Var _CocoaDictionary.Index.dictionary has declared type change from _CocoaDictionary to __CocoaDictionary
+Var _NativeDictionary._storage has declared type change from _RawDictionaryStorage to __RawDictionaryStorage
+Var _NativeSet._storage has declared type change from _RawSetStorage to __RawSetStorage
+Var _RawDictionaryStorage.empty has declared type change from _EmptyDictionarySingleton to __EmptyDictionarySingleton
+Var _RawSetStorage.empty has declared type change from _EmptySetSingleton to __EmptySetSingleton

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -8,8 +8,6 @@ Class _EmptySetSingleton has changed its super class from _RawSetStorage to __Ra
 Class _RawDictionaryStorage has been renamed to Class __RawDictionaryStorage
 Class _RawSetStorage has been renamed to Class __RawSetStorage
 Class _SetStorage has changed its super class from _RawSetStorage to __RawSetStorage
-Class _SharedStringStorage has been renamed to Class __SharedStringStorage
-Class _StringStorage has been renamed to Class __StringStorage
 Constructor Dictionary._Variant.init(cocoa:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
 Constructor Dictionary.init(_cocoa:) has parameter 0 type change from _CocoaDictionary to __CocoaDictionary
 Constructor Set._Variant.init(cocoa:) has parameter 0 type change from _CocoaSet to __CocoaSet
@@ -36,9 +34,9 @@ Func _SetStorage.resize(original:capacity:move:) has parameter 0 type change fro
 Struct _CocoaDictionary has been renamed to Struct __CocoaDictionary
 Struct _CocoaSet has been renamed to Struct __CocoaSet
 Var Dictionary._Variant.asCocoa has declared type change from _CocoaDictionary to __CocoaDictionary
-Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage, _NSDictionary> to _BridgeStorage<__RawDictionaryStorage>
+Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage> to _BridgeStorage<__RawDictionaryStorage>
 Var Set._Variant.asCocoa has declared type change from _CocoaSet to __CocoaSet
-Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage, _NSSet> to _BridgeStorage<__RawSetStorage>
+Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage> to _BridgeStorage<__RawSetStorage>
 Var _CocoaDictionary.Index.dictionary has declared type change from _CocoaDictionary to __CocoaDictionary
 Var _NativeDictionary._storage has declared type change from _RawDictionaryStorage to __RawDictionaryStorage
 Var _NativeSet._storage has declared type change from _RawSetStorage to __RawSetStorage

--- a/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -33,7 +33,7 @@ func isNativeNSDictionary(_ d: NSDictionary) -> Bool {
   let className: NSString = NSStringFromClass(type(of: d)) as NSString
   return [
     "_SwiftDeferredNSDictionary",
-    "_EmptyDictionarySingleton",
+    "__EmptyDictionarySingleton",
     "_DictionaryStorage"].contains {
     className.range(of: $0).length > 0
   }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/21331 for `swift-5.0-branch`.

Old Swift and new Swift runtimes and overlays need to coexist in the same process. This means there must not be any classes which have the same ObjC runtime name in old and new, because the ObjC runtime doesn't like name collisions.

When possible without breaking source compatibility, classes were renamed in Swift, which results in a different ObjC name.

Public classes were renamed only on the ObjC side using the @_objcRuntimeName attribute.

This is similar to the work done in pull request #19295. That only renamed @objc classes. This renames all of the others, since even pure Swift classes still get an ObjC name.

rdar://problem/46646438