### PR TITLE
[ConstraintSystem] Don't assume that LazyInitializerExpr has a type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3885,8 +3885,10 @@ namespace {
     }
 
     Expr *visitLazyInitializerExpr(LazyInitializerExpr *expr) {
-      simplifyExprType(expr);
-      assert(expr->getType()->isEqual(expr->getSubExpr()->getType()));
+      auto type = simplifyType(cs.getType(expr));
+      cs.setType(expr, type);
+
+      assert(type->isEqual(expr->getSubExpr()->getType()));
       return expr;
     }
     

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2918,7 +2918,10 @@ namespace {
     }
 
     Type visitLazyInitializerExpr(LazyInitializerExpr *expr) {
-      return expr->getType();
+      if (auto type = expr->getType())
+        return type;
+
+      return CS.createTypeVariable(CS.getConstraintLocator(expr));
     }
 
     Type visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {


### PR DESCRIPTION
Currently when `LazyInitializerExpr` is added to the AST it's not
given an explicit type. Constraint solver has to account for that
and generate type variable to infer the type, otherwise constraint
generation would silently fail without producing a diagnostic.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
