### PR TITLE
[ownership] Eliminate -assume-parsing-unqualified-ownership-sil now that it is a no-op.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -114,9 +114,6 @@ public:
   /// If set to true, compile with the SIL Ownership Model enabled.
   bool EnableSILOwnership = false;
 
-  /// When parsing SIL, assume unqualified ownership.
-  bool AssumeUnqualifiedOwnershipWhenParsing = false;
-
   /// Assume that code will be executed in a single-threaded environment.
   bool AssumeSingleThreaded = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -310,9 +310,6 @@ def disable_guaranteed_normal_arguments : Flag<["-"], "disable-guaranteed-normal
 def enable_mandatory_semantic_arc_opts : Flag<["-"], "enable-mandatory-semantic-arc-opts">,
   HelpText<"Enable the mandatory semantic arc optimizer">;
 
-def assume_parsing_unqualified_ownership_sil : Flag<["-"], "assume-parsing-unqualified-ownership-sil">,
-  HelpText<"Assume unqualified SIL ownership when parsing SIL">;
-
 def suppress_static_exclusivity_swap : Flag<["-"], "suppress-static-exclusivity-swap">,
   HelpText<"Suppress static violations of exclusive access with swap()">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -731,8 +731,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DisableSILPartialApply |=
     Args.hasArg(OPT_disable_sil_partial_apply);
   Opts.EnableSILOwnership |= Args.hasArg(OPT_enable_sil_ownership);
-  Opts.AssumeUnqualifiedOwnershipWhenParsing
-    |= Args.hasArg(OPT_assume_parsing_unqualified_ownership_sil);
   Opts.EnableMandatorySemanticARCOpts |=
       Args.hasArg(OPT_enable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5180,13 +5180,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
   F->getBlocks().remove(BB);
   F->getBlocks().push_back(BB);
 
-  bool AssumeUnqualifiedOwnershipWhenParsing =
-    F->getModule().getOptions().AssumeUnqualifiedOwnershipWhenParsing;
-  if (AssumeUnqualifiedOwnershipWhenParsing) {
-    F->setOwnershipEliminated();
-  }
   B.setInsertionPoint(BB);
-  B.setHasOwnership(F->hasOwnership());
   do {
     if (parseSILInstruction(B))
       return true;
@@ -5317,7 +5311,7 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
       // Parse the basic block list.
       FunctionState.OwnershipEvaluator.reset(FunctionState.F);
       SILOpenedArchetypesTracker OpenedArchetypesTracker(FunctionState.F);
-      SILBuilder B(*FunctionState.F, /*isParsing*/ true);
+      SILBuilder B(*FunctionState.F);
       // Track the archetypes just like SILGen. This
       // is required for adding typedef operands to instructions.
       B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -24,7 +24,7 @@ using namespace swift;
 SILBuilder::SILBuilder(SILGlobalVariable *GlobVar,
                        SmallVectorImpl<SILInstruction *> *InsertedInstrs)
     : TempContext(GlobVar->getModule(), InsertedInstrs), C(TempContext),
-      F(nullptr), hasOwnership(false) {
+      F(nullptr) {
   setInsertionPoint(&GlobVar->StaticInitializerBlock);
 }
 

--- a/test/ClangImporter/static_inline.swift
+++ b/test/ClangImporter/static_inline.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-sil %S/Inputs/static_inline.swift -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.sil
 // RUN: %FileCheck < %t/static_inline.sil %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
 
 // CHECK: sil shared [serializable] [clang c_inline_func] @c_inline_func : $@convention(c) (Int32) -> Int32
 

--- a/test/IRGen/UseObjCMethod.swift
+++ b/test/IRGen/UseObjCMethod.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 import Foundation

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s -module-name test_v7k | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -S -primary-file %s -module-name test_v7k | %FileCheck -check-prefix=V7K %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -module-name test_v7k | %FileCheck %s
+// RUN: %target-swift-frontend -S -primary-file %s -module-name test_v7k | %FileCheck -check-prefix=V7K %s
 
 // REQUIRES: CPU=armv7k
 // REQUIRES: OS=watchos

--- a/test/IRGen/access_control.sil
+++ b/test/IRGen/access_control.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 4 -enforce-exclusivity=checked -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -swift-version 4 -enforce-exclusivity=checked %s -emit-ir | %FileCheck %s --check-prefix=CHECK
 
 import Builtin
 import Swift

--- a/test/IRGen/alignment.sil
+++ b/test/IRGen/alignment.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 import Swift
 

--- a/test/IRGen/alloc_stack.swift
+++ b/test/IRGen/alloc_stack.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 import Builtin
 

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/assert_conf_default.sil
+++ b/test/IRGen/assert_conf_default.sil
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -assert-config DisableReplacement -emit-ir %s   | %FileCheck %s --check-prefix=DISABLED
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -assert-config Release -emit-ir %s   | %FileCheck %s --check-prefix=RELEASE
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -assert-config Debug -emit-ir %s   | %FileCheck %s --check-prefix=DEBUG
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -assert-config Unchecked -emit-ir %s   | %FileCheck %s --check-prefix=UNCHECKED
+// RUN: %target-swift-frontend -assert-config DisableReplacement -emit-ir %s   | %FileCheck %s --check-prefix=DISABLED
+// RUN: %target-swift-frontend -assert-config Release -emit-ir %s   | %FileCheck %s --check-prefix=RELEASE
+// RUN: %target-swift-frontend -assert-config Debug -emit-ir %s   | %FileCheck %s --check-prefix=DEBUG
+// RUN: %target-swift-frontend -assert-config Unchecked -emit-ir %s   | %FileCheck %s --check-prefix=UNCHECKED
 
 import Builtin
 

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -primary-file %s -emit-ir > %t.ll
 // RUN: %FileCheck %s -check-prefix=GLOBAL < %t.ll
 // RUN: %FileCheck %s < %t.ll
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -wmo -num-threads 1 > %t.ll.wmo
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -wmo -num-threads 1 > %t.ll.wmo
 // RUN: %FileCheck %s -check-prefix=GLOBAL < %t.ll.wmo
 // RUN: %FileCheck %s < %t.ll.wmo
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -primary-file %s | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/assume.sil
+++ b/test/IRGen/assume.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-ir %s | %FileCheck %s
 sil_stage canonical
 
 import Swift

--- a/test/IRGen/availability.swift
+++ b/test/IRGen/availability.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=OPT
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=OPT
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
+// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-large-loadable-types %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: optimized_stdlib
 
 public struct BigStruct {

--- a/test/IRGen/big_types_corner_cases_as_library.swift
+++ b/test/IRGen/big_types_corner_cases_as_library.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-large-loadable-types %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 public struct BigStruct {
   var i0 : Int32 = 0

--- a/test/IRGen/big_types_corner_cases_tiny.swift
+++ b/test/IRGen/big_types_corner_cases_tiny.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types -primary-file %s %S/big_types_corner_cases.swift -emit-ir | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -enable-large-loadable-types -primary-file %s %S/big_types_corner_cases.swift -emit-ir | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: optimized_stdlib
 
 // DO NOT ADD ANY MORE CODE TO THIS FILE!

--- a/test/IRGen/big_types_coroutine.sil
+++ b/test/IRGen/big_types_coroutine.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -loadable-address -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -loadable-address -enable-sil-verify-all %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx

--- a/test/IRGen/big_types_tests.sil
+++ b/test/IRGen/big_types_tests.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
+// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir| %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir| %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/bitcast_different_size.sil
+++ b/test/IRGen/bitcast_different_size.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -verify | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s -verify | %FileCheck %s --check-prefix=OPT
+// RUN: %target-swift-frontend -emit-ir %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -O %s -verify | %FileCheck %s --check-prefix=OPT
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/bitcast_specialization.swift
+++ b/test/IRGen/bitcast_specialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-object -O %s
+// RUN: %target-swift-frontend -emit-object -O %s
 
 // This is a compile-only test. It checks that the compiler does not crash for
 // a (not executed) bitcast with different sizes. This appears in the

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
 
 import Swift
 

--- a/test/IRGen/bridge_object_arm64.sil
+++ b/test/IRGen/bridge_object_arm64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -assume-parsing-unqualified-ownership-sil -module-name bridge_object -emit-ir -target arm64-apple-ios8.0 %s | %FileCheck %s
+// RUN: %swift -module-name bridge_object -emit-ir -target arm64-apple-ios8.0 %s | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=AArch64
 

--- a/test/IRGen/bridge_object_armv7.sil
+++ b/test/IRGen/bridge_object_armv7.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -assume-parsing-unqualified-ownership-sil -module-name bridge_object -emit-ir -target armv7-apple-ios8.0 %s | %FileCheck %s
+// RUN: %swift -module-name bridge_object -emit-ir -target armv7-apple-ios8.0 %s | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/bridge_object_x86_64.sil
+++ b/test/IRGen/bridge_object_x86_64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -assume-parsing-unqualified-ownership-sil -module-name bridge_object -emit-ir -target x86_64-apple-macosx10.9 %s | %FileCheck %s
+// RUN: %swift -module-name bridge_object -emit-ir -target x86_64-apple-macosx10.9 %s | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-os
+// RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-os
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -module-name builtins -assume-parsing-unqualified-ownership-sil -parse-stdlib -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -module-name builtins -parse-stdlib -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/builtins_objc.swift
+++ b/test/IRGen/builtins_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-stdlib -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/IRGen/c_function_pointer.sil
+++ b/test/IRGen/c_function_pointer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 
 import Swift
 

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix %target-cpu
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix %target-cpu
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 

--- a/test/IRGen/c_functions_error.swift
+++ b/test/IRGen/c_functions_error.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -assume-parsing-unqualified-ownership-sil -Xcc -mno-sse -import-objc-header %S/Inputs/c_functions_error.h -primary-file %s -emit-ir
+// RUN: not %target-swift-frontend -Xcc -mno-sse -import-objc-header %S/Inputs/c_functions_error.h -primary-file %s -emit-ir
 
 // This should fail, but not crash.
 

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-cpu
 
 sil_stage canonical
 import c_layout

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/cf.sil
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs %t/cf.sil -emit-ir -import-cf-types | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %t/cf.sil -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -enable-objc-interop -sdk %S/Inputs %t/cf.sil -emit-ir -import-cf-types | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %t/cf.sil -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/cf_members.sil
+++ b/test/IRGen/cf_members.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify -I %S/../IDE/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -verify -I %S/../IDE/Inputs/custom-modules %s
 
 sil_stage canonical
 

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -I %t | %FileCheck %s
 
 // RUN: %empty-directory(%t/Empty.framework/Modules/Empty.swiftmodule)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty -I %t
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -I %t -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty -I %t
+// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -I %t -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -enable-objc-interop | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/clang_inline_reverse.swift
+++ b/test/IRGen/clang_inline_reverse.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -enable-objc-interop -emit-ir -module-name clang_inline -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -enable-objc-interop -emit-ir -module-name clang_inline -I %t | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/class_constraint.sil
+++ b/test/IRGen/class_constraint.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s | %FileCheck %s
 
 protocol P {}
 class A : P {}

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 
 import Builtin
 import Swift

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -g -S  | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu --check-prefix CHECK-OPT-%target-os
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -g -S  | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu --check-prefix CHECK-NOOPT-%target-os
+// RUN: %target-swift-frontend -primary-file %s -O -g -S  | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu --check-prefix CHECK-OPT-%target-os
+// RUN: %target-swift-frontend -primary-file %s -g -S  | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu --check-prefix CHECK-NOOPT-%target-os
 
 import Builtin
 import Swift

--- a/test/IRGen/conformance_access_path.swift
+++ b/test/IRGen/conformance_access_path.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -primary-file %s -emit-ir > %t.ll
 // RUN: %FileCheck %s < %t.ll
 
 

--- a/test/IRGen/conformance_multifile.swift
+++ b/test/IRGen/conformance_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s %S/Inputs/conformance_multifile_1.swift | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s %S/Inputs/conformance_multifile_1.swift | %FileCheck %s
 
 func g<U>(_ f : (E) throws -> (U)) {}
 

--- a/test/IRGen/constant_struct_with_padding.sil
+++ b/test/IRGen/constant_struct_with_padding.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -module-name main %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -module-name main %s -emit-ir -o - | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/decls.swift
+++ b/test/IRGen/decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // Check that we emit all local decls, not just the first one.
 func test1() {

--- a/test/IRGen/dependent_generic_base_class_constraint.swift
+++ b/test/IRGen/dependent_generic_base_class_constraint.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -verify %s
 class GenericClass<T> { }
 
 protocol MyProtocol { }

--- a/test/IRGen/dependent_reabstraction.swift
+++ b/test/IRGen/dependent_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/dynamic_replaceable.sil
+++ b/test/IRGen/dynamic_replaceable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/dynamic_self.sil
+++ b/test/IRGen/dynamic_self.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -parse-as-library | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1,7 +1,7 @@
 // #if directives don't work with SIL keywords, therefore please put ObjC tests
 // in `enum_objc.sil`.
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend %s -gnone -emit-ir -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize -DWORD=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/enum_32_bit.sil
+++ b/test/IRGen/enum_32_bit.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -assume-parsing-unqualified-ownership-sil -target i386-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
-// RUN: %swift -assume-parsing-unqualified-ownership-sil -target armv7-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
+// RUN: %swift -target i386-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
+// RUN: %swift -target armv7-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %t -O -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-NORMAL %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %t -O -primary-file %s -enable-testing -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-TESTABLE %s
+// RUN: %target-swift-frontend -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift
+// RUN: %target-swift-frontend -I %t -O -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-NORMAL %s
+// RUN: %target-swift-frontend -I %t -O -primary-file %s -enable-testing -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-TESTABLE %s
 
 import def_enum
 

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -I %S/Inputs | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend %s -gnone -emit-ir -I %S/Inputs | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 import Builtin
 

--- a/test/IRGen/enum_empty_payloads.sil
+++ b/test/IRGen/enum_empty_payloads.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -verify %s
 sil_stage canonical
 
 typealias Void = ()

--- a/test/IRGen/enum_function.sil
+++ b/test/IRGen/enum_function.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -gnone -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -gnone -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/enum_function_payload.swift
+++ b/test/IRGen/enum_function_payload.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s
 
 enum Singleton {
   case F((Singleton) -> ())

--- a/test/IRGen/enum_objc.sil
+++ b/test/IRGen/enum_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-simulator-%target-is-simulator
+// RUN: %target-swift-frontend %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-simulator-%target-is-simulator
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/enum_pack.sil
+++ b/test/IRGen/enum_pack.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s
 
 // This is a compile-only test. It checks if IRGen does not crash when packing
 // and unpacking enums (e.g. optionals) which contain empty structs as payloads.

--- a/test/IRGen/enum_switch_singleton_enum_in_optional.sil
+++ b/test/IRGen/enum_switch_singleton_enum_in_optional.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 sil_stage canonical
 
 enum Optional<T> { case some(T), none }

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-simulator-%target-is-simulator --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-native-%target-os
+// RUN: %target-swift-frontend %s -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-simulator-%target-is-simulator --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
+// RUN: %target-swift-frontend %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-native-%target-os
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime  --check-prefix=CHECK-%target-runtime-simulator-%target-is-simulator
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime  --check-prefix=CHECK-%target-runtime-simulator-%target-is-simulator
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/enum_value_semantics_special_cases_objc.sil
+++ b/test/IRGen/enum_value_semantics_special_cases_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -enable-objc-interop -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -enable-objc-interop -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/error_self_conformance.sil
+++ b/test/IRGen/error_self_conformance.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 
 import Swift
 

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime --check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime --check-prefix=CHECK-%target-cpu
 // REQUIRES: executable_test
 
 sil_stage canonical

--- a/test/IRGen/errors_optimized.sil
+++ b/test/IRGen/errors_optimized.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/exactcast.sil
+++ b/test/IRGen/exactcast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/exactcast2.sil
+++ b/test/IRGen/exactcast2.sil
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s -Xfrontend -assume-parsing-unqualified-ownership-sil -Xfrontend -enable-objc-interop -emit-ir -o -
+// RUN: %target-build-swift %s -Xfrontend -enable-objc-interop -emit-ir -o -
 // REQUIRES: executable_test
 
 // Make sure we are not crashing here.

--- a/test/IRGen/existential_metatypes.sil
+++ b/test/IRGen/existential_metatypes.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -o - -primary-file %s | %FileCheck %s
 // REQUIRES: CPU=x86_64
 
 sil_stage canonical

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 sil_stage canonical
 

--- a/test/IRGen/expressions.swift
+++ b/test/IRGen/expressions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -parse-stdlib -disable-access-control | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -parse-stdlib -disable-access-control | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/extension_conformance_anyobject_conformance.swift
+++ b/test/IRGen/extension_conformance_anyobject_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -verify %s
 
 public struct TestGeneratorCrashy <Key: AnyObject, Value: AnyObject> {
     public mutating func next() -> (Key, Value)? {

--- a/test/IRGen/fixed_size_buffer_peepholes.sil
+++ b/test/IRGen/fixed_size_buffer_peepholes.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 import Builtin
 

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-sil -emit-ir -disable-llvm-optzns -O %s | %FileCheck --check-prefix=CHECK-%target-runtime %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-sil -emit-ir -disable-llvm-optzns -Ounchecked %s | %FileCheck --check-prefix=CHECK-%target-runtime %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-sil -emit-ir -disable-llvm-optzns -Onone %s | %FileCheck --check-prefix=ONONE %s
+// RUN: %target-swift-frontend -parse-sil -emit-ir -disable-llvm-optzns -O %s | %FileCheck --check-prefix=CHECK-%target-runtime %s
+// RUN: %target-swift-frontend -parse-sil -emit-ir -disable-llvm-optzns -Ounchecked %s | %FileCheck --check-prefix=CHECK-%target-runtime %s
+// RUN: %target-swift-frontend -parse-sil -emit-ir -disable-llvm-optzns -Onone %s | %FileCheck --check-prefix=ONONE %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 sil_stage canonical
 import c_layout

--- a/test/IRGen/fulfillment.sil
+++ b/test/IRGen/fulfillment.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/function-target-features.swift
+++ b/test/IRGen/function-target-features.swift
@@ -1,12 +1,12 @@
 // This test verifies that we produce target-cpu and target-features attributes
 // on functions.
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | %FileCheck %s -check-prefix=AVX-FEATURE
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512f -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512er | %FileCheck %s -check-prefix=TWO-AVX
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 | %FileCheck %s -check-prefix=CORE-CPU
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | %FileCheck %s -check-prefix=CORE-CPU-AND-FEATURES
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc x86-64 | %FileCheck %s -check-prefix=X86-64-CPU
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7-avx -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc -avx | %FileCheck %s -check-prefix=AVX-MINUS-FEATURE
+// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | %FileCheck %s -check-prefix=AVX-FEATURE
+// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512f -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512er | %FileCheck %s -check-prefix=TWO-AVX
+// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 | %FileCheck %s -check-prefix=CORE-CPU
+// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | %FileCheck %s -check-prefix=CORE-CPU-AND-FEATURES
+// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc x86-64 | %FileCheck %s -check-prefix=X86-64-CPU
+// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7-avx -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc -avx | %FileCheck %s -check-prefix=AVX-MINUS-FEATURE
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s | %FileCheck %s
 
 func arch<F>(_ f: F) {}
 

--- a/test/IRGen/function_param_convention.sil
+++ b/test/IRGen/function_param_convention.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -module-name Test | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -module-name Test | %FileCheck %s
 
 import Builtin
 

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -1,9 +1,9 @@
-// RUN: %swift -target x86_64-apple-macosx10.9 -module-name function_types -assume-parsing-unqualified-ownership-sil %s -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target i386-apple-ios7.1 %s -module-name function_types -assume-parsing-unqualified-ownership-sil -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-apple-ios7.1 %s -module-name function_types -assume-parsing-unqualified-ownership-sil -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target armv7-apple-ios7.1 %s -module-name function_types -assume-parsing-unqualified-ownership-sil -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target arm64-apple-ios7.1 %s -module-name function_types -assume-parsing-unqualified-ownership-sil -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-unknown-linux-gnu -disable-objc-interop %s -module-name function_types -assume-parsing-unqualified-ownership-sil -emit-ir -o - | %FileCheck %s
+// RUN: %swift -target x86_64-apple-macosx10.9 -module-name function_types %s -emit-ir -o - | %FileCheck %s
+// RUN: %swift -target i386-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -target x86_64-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -target armv7-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -target arm64-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -target x86_64-unknown-linux-gnu -disable-objc-interop %s -module-name function_types -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/generic_class_anyobject.swift
+++ b/test/IRGen/generic_class_anyobject.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -enable-objc-interop -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -enable-objc-interop -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/generic_enums.swift
+++ b/test/IRGen/generic_enums.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
 
 struct Bar<A1, A2> {
   var a: A1

--- a/test/IRGen/generic_requirement_objc.sil
+++ b/test/IRGen/generic_requirement_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/generic_structs.sil
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %t/generic_structs.sil -emit-ir | %FileCheck %t/generic_structs.sil
+// RUN: %target-swift-frontend %t/generic_structs.sil -emit-ir | %FileCheck %t/generic_structs.sil
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/generic_structs.swift
+++ b/test/IRGen/generic_structs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize -DINT_32=i32
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize -DINT_32=i32
 
 struct A<T1, T2>
 {

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -1,8 +1,8 @@
 
-// RUN: %target-swift-frontend -module-name generic_tuples -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name generic_tuples -emit-ir -primary-file %s | %FileCheck %s
 
 // Make sure that optimization passes don't choke on storage types for generic tuples
-// RUN: %target-swift-frontend -module-name generic_tuples -assume-parsing-unqualified-ownership-sil -emit-ir -O %s
+// RUN: %target-swift-frontend -module-name generic_tuples -emit-ir -O %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend %S/../Inputs/resilient_struct.swift -enable-resilience -emit-module -emit-module-path %t/resilient_struct.swiftmodule
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -I %t -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -I %t -emit-ir -O %s
+// RUN: %target-swift-frontend -enable-resilience -I %t -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-resilience -I %t -emit-ir -O %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/indexing.sil
+++ b/test/IRGen/indexing.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s
 import Swift
 import Builtin
 

--- a/test/IRGen/indirect_enum.sil
+++ b/test/IRGen/indirect_enum.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 import Swift
 

--- a/test/IRGen/indirect_return.swift
+++ b/test/IRGen/indirect_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/infinite_archetype.swift
+++ b/test/IRGen/infinite_archetype.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/invalid_alignment.swift
+++ b/test/IRGen/invalid_alignment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -verify
+// RUN: %target-swift-frontend -emit-ir %s -verify
 
 @_alignment(1) // expected-error{{cannot decrease alignment below natural alignment of 4}}
 struct Bar { var x, y, z, w: Float }

--- a/test/IRGen/ivar_destroyer.sil
+++ b/test/IRGen/ivar_destroyer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/lazy_globals.swift
+++ b/test/IRGen/lazy_globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-as-library -emit-ir -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -emit-ir -primary-file %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/lazy_multi_file.swift
+++ b/test/IRGen/lazy_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s %S/Inputs/lazy_multi_file_helper.swift -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/lazy_multi_file_helper.swift -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/lifetime.sil
+++ b/test/IRGen/lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -gnone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -gnone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 
 // CHECK: [[OPAQUE:%swift.opaque]] = type opaque
 // CHECK: [[TYPE:%swift.type]] = type

--- a/test/IRGen/literals.sil
+++ b/test/IRGen/literals.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module %S/Inputs/local_types_helper.swift -o %t
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir -parse-as-library %s -I %t | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE %s
+// RUN: %target-swift-frontend -emit-module %S/Inputs/local_types_helper.swift -o %t
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir -parse-as-library %s -I %t | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE %s
 
 import local_types_helper
 

--- a/test/IRGen/lowered_optional_self_metadata.sil
+++ b/test/IRGen/lowered_optional_self_metadata.sil
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s
 sil_stage canonical
 
 import Swift

--- a/test/IRGen/mangle-anonclosure.swift
+++ b/test/IRGen/mangle-anonclosure.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -o - | %FileCheck %s
 
 func someValidPointer<T>() -> UnsafeMutablePointer<T> { fatalError() }
 

--- a/test/IRGen/meta_meta_type.swift
+++ b/test/IRGen/meta_meta_type.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECKIR %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECKIR %s
 // REQUIRES: executable_test
 
 protocol Proto {

--- a/test/IRGen/metadata_dominance.swift
+++ b/test/IRGen/metadata_dominance.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s | %FileCheck %s -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -emit-ir -primary-file %s | %FileCheck %s --check-prefix=CHECK-OPT -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -primary-file %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -O -emit-ir -primary-file %s | %FileCheck %s --check-prefix=CHECK-OPT -DINT=i%target-ptrsize
 
 func use_metadata<F>(_ f: F) {}
 

--- a/test/IRGen/metatype.sil
+++ b/test/IRGen/metatype.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -enable-objc-interop -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend %s -enable-objc-interop -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/mixed_objc_native_protocol_constraints.swift
+++ b/test/IRGen/mixed_objc_native_protocol_constraints.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -verify %s
 
 // compiler_crashers/029-class-with-anyobject-type-constraint.swift
 // Test case submitted to project by https://github.com/jansabbe (Jan Sabbe)

--- a/test/IRGen/module_hash.swift
+++ b/test/IRGen/module_hash.swift
@@ -4,28 +4,28 @@
 // Test with a single output file
 
 // RUN: echo "single-threaded initial" >%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: single-threaded initial
 // CHECK: test.o: MD5=[[TEST_MD5:[0-9a-f]+]]
 // CHECK-NOT: prev MD5
 
 // RUN: echo "single-threaded same compilation" >>%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: single-threaded same compilation
 // CHECK: test.o: MD5=[[TEST_MD5]]
 // CHECK: test.o: prev MD5=[[TEST_MD5]] skipping
 
 // RUN: echo "single-threaded file changed" >>%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo %s %S/Inputs/simple2.swift -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo %s %S/Inputs/simple2.swift -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: single-threaded file changed
 // CHECK: test.o: MD5=[[TEST2_MD5:[0-9a-f]+]]
 // CHECK: test.o: prev MD5=[[TEST_MD5]] recompiling
 
 // RUN: echo "single-threaded option changed" >>%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo %s %S/Inputs/simple2.swift -disable-llvm-optzns -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo %s %S/Inputs/simple2.swift -disable-llvm-optzns -module-name=test -c -o %t/test.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: single-threaded option changed
 // CHECK: test.o: MD5=[[TEST3_MD5:[0-9a-f]+]]
@@ -35,7 +35,7 @@
 // Test with multiple output files
 
 // RUN: echo "multi-threaded initial" >>%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo -num-threads 2 %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -o %t/simple.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo -num-threads 2 %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -o %t/simple.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: multi-threaded initial
 // CHECK-DAG: test.o: MD5=[[TEST4_MD5:[0-9a-f]+]]
@@ -43,7 +43,7 @@
 // CHECK-DAG: simple.o: MD5=[[SIMPLE_MD5:[0-9a-f]+]]
 
 // RUN: echo "multi-threaded same compilation" >>%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo -num-threads 2 %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -o %t/simple.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo -num-threads 2 %s %S/Inputs/simple.swift -module-name=test -c -o %t/test.o -o %t/simple.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: multi-threaded same compilation
 // CHECK-DAG: test.o: MD5=[[TEST4_MD5]]
@@ -52,7 +52,7 @@
 // CHECK-DAG: simple.o: prev MD5=[[SIMPLE_MD5]] skipping
 
 // RUN: echo "multi-threaded one file changed" >>%t/log
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -wmo -num-threads 2 %s %S/Inputs/simple2.swift -module-name=test -c -o %t/test.o -o %t/simple.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -O -wmo -num-threads 2 %s %S/Inputs/simple2.swift -module-name=test -c -o %t/test.o -o %t/simple.o -Xllvm -debug-only=irgen 2>>%t/log
 
 // CHECK-LABEL: multi-threaded one file changed
 // CHECK-DAG: test.o: MD5=[[TEST4_MD5]]

--- a/test/IRGen/multi_payload_shifting.swift
+++ b/test/IRGen/multi_payload_shifting.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %S/Inputs/multithread_module/main.swift -emit-ir -o %t/main.ll %/s -o %t/mt_module.ll -num-threads 2 -O -g -module-name test
+// RUN: %target-swift-frontend %S/Inputs/multithread_module/main.swift -emit-ir -o %t/main.ll %/s -o %t/mt_module.ll -num-threads 2 -O -g -module-name test
 // RUN: %FileCheck --check-prefix=CHECK-MAINLL %s <%t/main.ll
 // RUN: %FileCheck --check-prefix=CHECK-MODULELL %s <%t/mt_module.ll
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -c %S/Inputs/multithread_module/main.swift -o %t/main.o %s -o %t/mt_module.o -num-threads 2 -O -g -module-name test
+// RUN: %target-swift-frontend -c %S/Inputs/multithread_module/main.swift -o %t/main.o %s -o %t/mt_module.o -num-threads 2 -O -g -module-name test
 // RUN: %target-build-swift %t/main.o %t/mt_module.o -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/IRGen/nested_types.sil
+++ b/test/IRGen/nested_types.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 
 sil_stage canonical
 

--- a/test/IRGen/noinline.swift
+++ b/test/IRGen/noinline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -O -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-ir | %FileCheck %s
 
 public var x = 0
 

--- a/test/IRGen/nonatomic_reference_counting.sil
+++ b/test/IRGen/nonatomic_reference_counting.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-sil-perf-optzns -O -Xllvm -swiftmergefunc-threshold=0 -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-sil-perf-optzns -O -Xllvm -swiftmergefunc-threshold=0 -emit-ir %s | %FileCheck %s
 
 // Check that IRGen lowers non-atomic reference counting instructions to
 // proper runtime calls.

--- a/test/IRGen/nondominant.sil
+++ b/test/IRGen/nondominant.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/objc_alloc.sil
+++ b/test/IRGen/objc_alloc.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -gnone -enable-objc-interop -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -gnone -enable-objc-interop -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_class_empty_fields.swift
+++ b/test/IRGen/objc_class_empty_fields.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -enable-objc-interop -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -enable-objc-interop -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // SR-1055
 

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -I %t -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_class_property.swift
+++ b/test/IRGen/objc_class_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/objc_deprecated_objc_thunks.swift
+++ b/test/IRGen/objc_deprecated_objc_thunks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-swift3-objc-inference -swift-version 4 | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-swift3-objc-inference -swift-version 4 | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir | %FileCheck %s
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-objc-attr-requires-foundation-module -enable-objc-interop -emit-module %S/Inputs/objc_enum_multi_file_helper.swift -o %t
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -module-name main -primary-file %s -I %t -DIMPORT -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -emit-module %S/Inputs/objc_enum_multi_file_helper.swift -o %t
+// RUN: %target-swift-frontend -module-name main -primary-file %s -I %t -DIMPORT -emit-ir | %FileCheck %s
 
 #if IMPORT
 import objc_enum_multi_file_helper

--- a/test/IRGen/objc_protocol_conversion.sil
+++ b/test/IRGen/objc_protocol_conversion.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_protocol_multi_file.swift
+++ b/test/IRGen/objc_protocol_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir | %FileCheck %s
 
 // This used to crash <rdar://problem/17929944>.
 // To tickle the crash, SubProto must not be used elsewhere in this file.

--- a/test/IRGen/objc_protocols_jit.swift
+++ b/test/IRGen/objc_protocols_jit.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -I %t -primary-file %s -use-jit -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -use-jit -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_remapped_inits.swift
+++ b/test/IRGen/objc_remapped_inits.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // FIXME: This test could use %clang-importer-sdk, but the compiler crashes.
 

--- a/test/IRGen/objc_retainAutoreleasedReturnValue.swift
+++ b/test/IRGen/objc_retainAutoreleasedReturnValue.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -O -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s --check-prefix=OPT
+// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -O -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s --check-prefix=OPT
 
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/objc_runtime_visible.sil
+++ b/test/IRGen/objc_runtime_visible.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -I %S/../Inputs/custom-modules %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -I %S/../Inputs/custom-modules %s -emit-ir | %FileCheck %s
 
 sil_stage raw
 

--- a/test/IRGen/objc_selector.sil
+++ b/test/IRGen/objc_selector.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/objc_subscripts.swift
+++ b/test/IRGen/objc_subscripts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/opaque_values_irgen.sil
+++ b/test/IRGen/opaque_values_irgen.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -parse-stdlib -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-opaque-values -parse-stdlib -primary-file %s -emit-ir | %FileCheck %s
 
 import Builtin
 

--- a/test/IRGen/open_boxed_existential.sil
+++ b/test/IRGen/open_boxed_existential.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
 
 import Swift
 

--- a/test/IRGen/optimize_for_size.sil
+++ b/test/IRGen/optimize_for_size.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -O -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=O
+// RUN: %target-swift-frontend -Osize -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-ir %s | %FileCheck %s --check-prefix=O
 sil_stage canonical
 
 import Builtin

--- a/test/IRGen/optional_metatype.sil
+++ b/test/IRGen/optional_metatype.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s --check-prefix=%target-cpu
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s --check-prefix=%target-cpu
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -assume-parsing-unqualified-ownership-sil | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 sil_stage canonical
 
 import Builtin

--- a/test/IRGen/partial_apply_generic.swift
+++ b/test/IRGen/partial_apply_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -assume-parsing-unqualified-ownership-sil -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -1,7 +1,7 @@
 // <rdar://problem/15358345> Check that we always use PIC relocations on all
 // platforms.
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -module-name main -S -o - | %FileCheck -check-prefix=%target-cpu %s
+// RUN: %target-swift-frontend %s -module-name main -S -o - | %FileCheck -check-prefix=%target-cpu %s
 
 var global: Int = 0
 

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -use-jit -playground -parse-stdlib %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -use-jit -playground -parse-stdlib %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/protocol_extensions.sil
+++ b/test/IRGen/protocol_extensions.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/protocol_extensions_constrain.swift
+++ b/test/IRGen/protocol_extensions_constrain.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // rdar://20532214 -- Wrong code for witness method lookup lets executable crash
 

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O -assume-parsing-unqualified-ownership-sil %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %s
 
 sil_stage canonical
 

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -6,7 +6,7 @@
 // Resilient protocol usage
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
 
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE
 
 // ----------------------------------------------------------------------------
 // Resilient protocol definition

--- a/test/IRGen/readonly.sil
+++ b/test/IRGen/readonly.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 //sil_stage canonical
 
 import Builtin

--- a/test/IRGen/reference_storage_extra_inhabitants.sil
+++ b/test/IRGen/reference_storage_extra_inhabitants.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-objc-interop -emit-ir -primary-file %s | %FileCheck %s -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -disable-objc-interop -emit-ir -primary-file %s | %FileCheck %s -DWORD=i%target-ptrsize
 
 sil_stage canonical
 

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-reflection-names -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-reflection-metadata -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-reflection-names -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
+// RUN: %target-swift-frontend -disable-reflection-metadata -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
 
 // STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_reflect|.sw5rfst\$B}}
 // STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-frontend -module-name runtime_calling_conventions -assume-parsing-unqualified-ownership-sil -parse-as-library -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name runtime_calling_conventions -assume-parsing-unqualified-ownership-sil -parse-as-library -O -emit-ir %s | %FileCheck --check-prefix=OPT-CHECK %s
+// RUN: %target-swift-frontend -module-name runtime_calling_conventions -parse-as-library -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name runtime_calling_conventions -parse-as-library -O -emit-ir %s | %FileCheck --check-prefix=OPT-CHECK %s
 
 // Test that runtime functions are invoked using the new calling convention.
 

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
-// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=OSIZE
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=OSIZE
 
 // Ensure that same-type constraints between generic arguments get reflected
 // correctly in the type context descriptor.

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -1,12 +1,12 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=func %s | %FileCheck %s -check-prefix=SANCOV
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=bb %s | %FileCheck %s -check-prefix=SANCOV
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge %s | %FileCheck %s -check-prefix=SANCOV
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge,trace-cmp %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge,trace-bb %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_BB
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge,indirect-calls %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_INDIRECT_CALLS
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=func %s | %FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=bb %s | %FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge %s | %FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,trace-cmp %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,trace-bb %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_BB
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,indirect-calls %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_INDIRECT_CALLS
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
+// RUN: %target-swift-frontend -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin

--- a/test/IRGen/select_enum.sil
+++ b/test/IRGen/select_enum.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -gnone -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -gnone -emit-ir %s | %FileCheck %s
 
 import Builtin
 

--- a/test/IRGen/select_enum_optimized.swift
+++ b/test/IRGen/select_enum_optimized.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -module-name=test -disable-llvm-optzns -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -module-name=test -disable-llvm-optzns -emit-ir | %FileCheck %s
 
 enum NoPayload {
   case E0

--- a/test/IRGen/select_enum_single_payload.sil
+++ b/test/IRGen/select_enum_single_payload.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: CPU=i386 || CPU=x86_64
 
 sil_stage canonical

--- a/test/IRGen/sil_generic_witness_methods.swift
+++ b/test/IRGen/sil_generic_witness_methods.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/sil_generic_witness_methods_objc.swift
+++ b/test/IRGen/sil_generic_witness_methods_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/sil_irgen_library.swift
+++ b/test/IRGen/sil_irgen_library.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -parse-as-library
+// RUN: %target-swift-frontend %s -emit-ir -parse-as-library
 
 // Smoke test that SIL-IRGen can compile a library module offline.
 func f() {}

--- a/test/IRGen/sil_irgen_standalone.swift
+++ b/test/IRGen/sil_irgen_standalone.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir
 
 // Smoke test that SIL-IRGen can compile a standalone program offline.
 func f() {}

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -o %t %S/sil_witness_tables_external_conformance.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %t -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t %S/sil_witness_tables_external_conformance.swift
+// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/sil_witness_tables_external_witnesstable.swift
+++ b/test/IRGen/sil_witness_tables_external_witnesstable.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %t -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
+// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
 
 import Swift
 

--- a/test/IRGen/sil_witness_tables_inherited_conformance.swift
+++ b/test/IRGen/sil_witness_tables_inherited_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // rdar://problem/20628295
 

--- a/test/IRGen/special_protocols.sil
+++ b/test/IRGen/special_protocols.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -parse-stdlib -module-name Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir -parse-stdlib -module-name Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 public protocol Error {}
 // CHECK: [[ERROR_NAME:@.*]] = private constant [6 x i8] c"Error\00"

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/struct_layout.sil
+++ b/test/IRGen/struct_layout.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -module-name main -emit-ir -o - | %FileCheck -check-prefix=%target-ptrsize %s
+// RUN: %target-swift-frontend %s -module-name main -emit-ir -o - | %FileCheck -check-prefix=%target-ptrsize %s
 
 import Builtin
 import Swift

--- a/test/IRGen/subclass.swift
+++ b/test/IRGen/subclass.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -8,7 +8,7 @@
 
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/../Inputs/fixed_layout_class.swift
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/superclass_constraint.swift
+++ b/test/IRGen/superclass_constraint.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 public protocol A {}
 

--- a/test/IRGen/swift_native_objc_runtime_base.sil
+++ b/test/IRGen/swift_native_objc_runtime_base.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // CHECK-LABEL: @"$s30swift_native_objc_runtime_base1CCMm" = hidden global %objc_class {
 // -- metaclass "isa" is root metaclass

--- a/test/IRGen/synthesized_conformance.swift
+++ b/test/IRGen/synthesized_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -swift-version 4 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 4 | %FileCheck %s
 
 struct Struct<T> {
     var x: T

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
 //
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -1,6 +1,6 @@
 // This test verifies that we add the function attributes used by TSan.
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
+// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
 
 // TSan is currently only supported on 64 bit mac and simulators.
 // (We do not test the simulators here.)

--- a/test/IRGen/tsan_instrumentation.sil
+++ b/test/IRGen/tsan_instrumentation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 class C {}
 

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -enable-objc-interop  | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -disable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s -enable-objc-interop  | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s -disable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native-%target-ptrsize
 
 class C {}
 protocol P: class {}

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 sil_stage canonical
 
 import Builtin

--- a/test/IRGen/typemetadata.sil
+++ b/test/IRGen/typemetadata.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefix=OSIZE -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -Osize -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefix=OSIZE -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/unconditional_checked_cast.sil
+++ b/test/IRGen/unconditional_checked_cast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/undef.sil
+++ b/test/IRGen/undef.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/unowned.sil
+++ b/test/IRGen/unowned.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/unowned_store.sil
+++ b/test/IRGen/unowned_store.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -verify %s
 
 import Swift
 

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/upcast.sil
+++ b/test/IRGen/upcast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // Make sure that we are able to lower upcast addresses.
 

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/vector_reduction.swift
+++ b/test/IRGen/vector_reduction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -Ounchecked %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -Ounchecked %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/vtable.sil
+++ b/test/IRGen/vtable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 // REQUIRES: executable_test
 
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/vtable_multi_file.swift
+++ b/test/IRGen/vtable_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -S %s | %FileCheck %s --check-prefix=TAILCALL
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -S %s | %FileCheck %s --check-prefix=TAILCALL
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/weak_class_protocol.sil
+++ b/test/IRGen/weak_class_protocol.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/weak_value_witnesses.sil
+++ b/test/IRGen/weak_value_witnesses.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/witness_method_after_devirt.swift
+++ b/test/IRGen/witness_method_after_devirt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s 
+// RUN: %target-swift-frontend -emit-ir -verify %s 
 
 protocol BaseProtocol {
     static func run()

--- a/test/IRGen/witness_method_phi.sil
+++ b/test/IRGen/witness_method_phi.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/witness_table_indirect_conformances.swift
+++ b/test/IRGen/witness_table_indirect_conformances.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -swift-version 4 | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -swift-version 4 | %FileCheck %s -DINT=i%target-ptrsize
 
 protocol P1 {
 	associatedtype AssocP1

--- a/test/IRGen/witness_table_multifile.swift
+++ b/test/IRGen/witness_table_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s %S/Inputs/witness_table_multifile_2.swift -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/witness_table_multifile_2.swift -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // CHECK: [[P_WITNESS_TABLE:%[A-Za-z0-9_]+]] = type { [{{24|12}} x i8], %swift.type*, i8** }
 

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
 
 protocol A {}
 

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s
 
 // rdar://24121475
 //   Ideally, these wouldn't be in the v-table at all; but as long as they

--- a/test/Profiler/coverage_irgen.swift
+++ b/test/Profiler/coverage_irgen.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-sil -o - -module-name=irgen | %FileCheck %s --check-prefix=SIL
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-ir -o - -module-name=irgen | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -emit-sil -o - -module-name=irgen | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -emit-ir -o - -module-name=irgen | %FileCheck %s --check-prefix=IR
 
 // IR-NOT: __llvm_coverage_names
 // IR-NOT: __profn

--- a/test/Profiler/coverage_irgen_ignored.swift
+++ b/test/Profiler/coverage_irgen_ignored.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -profile-generate -emit-sil -o %t.sil
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %t.sil -module-name=coverage_ignored -emit-ir -o - | %FileCheck %s -check-prefix=CHECK-IGNORED
+// RUN: %target-swift-frontend %t.sil -module-name=coverage_ignored -emit-ir -o - | %FileCheck %s -check-prefix=CHECK-IGNORED
 
 // CHECK-IGNORED-NOT: llvm.instrprof
 // CHECK-IGNORED-NOT: profc

--- a/test/Profiler/coverage_with_asan.swift
+++ b/test/Profiler/coverage_with_asan.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -sanitize=address -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -sanitize=address -emit-ir -o - | %FileCheck %s
 // REQUIRES: OS=macosx
 
 // CHECK: main

--- a/test/Profiler/instrprof_symtab_valid.sil
+++ b/test/Profiler/instrprof_symtab_valid.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-ir -o - -module-name=irgen | %FileCheck %s
+// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -emit-ir -o - -module-name=irgen | %FileCheck %s
 
 // CHECK-NOT: @__llvm_coverage_mapping
 

--- a/test/SIL/Parser/SILDeclRef.sil
+++ b/test/SIL/Parser/SILDeclRef.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef" %s
+// RUN: %target-sil-opt -enable-sil-verify-all -module-name="SILDeclRef" %s
 
 // Check that SILDeclRefs with interface types can be parsed properly.
 

--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -Ounchecked | %target-sil-opt -assume-parsing-unqualified-ownership-sil
+// RUN: %target-swift-frontend %s -emit-sil -Ounchecked | %target-sil-opt
 
 // Fails if the positions of the two Collection subscript requirements are
 // reversed. rdar://problem/46650834

--- a/test/SIL/Parser/attributes.sil
+++ b/test/SIL/Parser/attributes.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 
 // CHECK-LABEL: sil [_semantics "123"] [_semantics "456"] @foo : $@convention(thin) () -> () {
 sil [_semantics "123"] [_semantics "456"] @foo : $@convention(thin) () -> () {

--- a/test/SIL/Parser/available.sil
+++ b/test/SIL/Parser/available.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 
 @available(*,unavailable,message: "it has been renamed")
 public struct mmConstUnsafePointer<T> {

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=true %s | %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=true | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all=true %s | %target-sil-opt -enable-objc-interop -enable-sil-verify-all=true | %FileCheck %s
 
 sil_stage raw // CHECK: sil_stage raw
 

--- a/test/SIL/Parser/coverage_maps.sil
+++ b/test/SIL/Parser/coverage_maps.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=coverage_maps | %target-sil-opt -assume-parsing-unqualified-ownership-sil -verify -module-name=coverage_maps | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=coverage_maps | %target-sil-opt -verify -module-name=coverage_maps | %FileCheck %s
 
 sil @someFunction : $@convention(thin) () -> () {
 bb0:

--- a/test/SIL/Parser/default_witness_tables.sil
+++ b/test/SIL/Parser/default_witness_tables.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=witness_tables -enable-resilience | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=witness_tables -enable-resilience | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=witness_tables -enable-resilience -O | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=witness_tables -enable-resilience | %target-sil-opt -module-name=witness_tables -enable-resilience | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=witness_tables -enable-resilience -O | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Parser/global_decl.sil
+++ b/test/SIL/Parser/global_decl.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s
 
 // Check that sil_globals and their corresponding decls are
 // parsed. There is no direct way to verify that the declarations are

--- a/test/SIL/Parser/nonatomic_reference_counting.sil
+++ b/test/SIL/Parser/nonatomic_reference_counting.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
 
 // Check that all reference counting instructions can take the [nonatomic]
 // attribute. SIL parser should be able to parse this attribute and

--- a/test/SIL/Parser/opaque_values_parse.sil
+++ b/test/SIL/Parser/opaque_values_parse.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-opaque-values -enable-sil-verify-all -emit-sorted-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -emit-sorted-sil %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SIL/Parser/polymorphic_function.sil
+++ b/test/SIL/Parser/polymorphic_function.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 
 import Swift
 

--- a/test/SIL/Parser/projection_lowered_type_parse.sil
+++ b/test/SIL/Parser/projection_lowered_type_parse.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// RUN: %target-sil-opt %s
 
 import Builtin
 

--- a/test/SIL/Parser/protocol_getter.sil
+++ b/test/SIL/Parser/protocol_getter.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
 
 // Verify that SILParser correctly handles witness_method on a getter.
 import Swift

--- a/test/SIL/Parser/self_substitution.sil
+++ b/test/SIL/Parser/self_substitution.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SIL/Parser/sil_scope.sil
+++ b/test/SIL/Parser/sil_scope.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-debuginfo -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo %s | %FileCheck %s
 
 // CHECK: sil_scope 1 { loc "foo.sil":12:34 parent @foo : $@convention(thin) () -> () }
           sil_scope 1 { loc "foo.sil":12:34 parent @foo : $@convention(thin) () -> () }

--- a/test/SIL/Parser/sil_scope_inline_fn.sil
+++ b/test/SIL/Parser/sil_scope_inline_fn.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-debuginfo -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -O %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all -O %s | %FileCheck %s
 
 sil_scope 1 { loc "foo.sil":3:4 parent @foo : $@convention(thin) () -> () }
 sil_scope 2 { loc "foo.sil":3:4 parent 1 }

--- a/test/SIL/Parser/sillocation.sil
+++ b/test/SIL/Parser/sillocation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-debuginfo -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo %s | %FileCheck %s
 
 sil @foo : $@convention(thin) () -> () {
 bb0:

--- a/test/SIL/Parser/static_initializer.sil
+++ b/test/SIL/Parser/static_initializer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 
 // Generated from
 // var x : Int32 = 2

--- a/test/SIL/Parser/stored_property.sil
+++ b/test/SIL/Parser/stored_property.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 
 import Swift
 

--- a/test/SIL/Parser/string_literal.sil
+++ b/test/SIL/Parser/string_literal.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// RUN: %target-sil-opt %s
 
 sil @test : $@convention(thin) () -> () {
 bb0:

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil %s | %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop %s | %target-sil-opt -enable-objc-interop | %FileCheck %s
 sil_stage raw
 
 import Builtin

--- a/test/SIL/Parser/undef_objc.sil
+++ b/test/SIL/Parser/undef_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 // REQUIRES: objc_interop
 
 sil_stage raw

--- a/test/SIL/Parser/unnamed_struct_identifiers.sil
+++ b/test/SIL/Parser/unnamed_struct_identifiers.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sdk %clang-importer-sdk-path %s
+// RUN: %target-sil-opt -sdk %clang-importer-sdk-path %s
 
 import ctypes
 

--- a/test/SIL/Parser/witness_bug.sil
+++ b/test/SIL/Parser/witness_bug.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// RUN: %target-sil-opt %s
 
 import Builtin
 import Swift

--- a/test/SIL/Parser/witness_method.sil
+++ b/test/SIL/Parser/witness_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=witness_tables | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=witness_tables | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=witness_tables | %target-sil-opt -module-name=witness_tables | %FileCheck %s
 
 protocol AssocReqt {
   func requiredMethod()

--- a/test/SIL/Parser/witness_protocol_from_import.sil
+++ b/test/SIL/Parser/witness_protocol_from_import.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -assume-parsing-unqualified-ownership-sil -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Parser/witness_specialize.sil
+++ b/test/SIL/Parser/witness_specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=witness_specialize | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=witness_specialize | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=witness_specialize | %target-sil-opt -module-name=witness_specialize | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=witness_tables | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=witness_tables | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=witness_tables | %target-sil-opt -module-name=witness_tables | %FileCheck %s
 
 protocol AssocReqt {
   func requiredMethod()

--- a/test/SIL/Parser/witness_with_inherited_gp.sil
+++ b/test/SIL/Parser/witness_with_inherited_gp.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name WitnessTableWithGP | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name WitnessTableWithGP | %FileCheck %s
 
 // REQUIRES: disabled
 // FIXME: <rdar://problem/20592011>

--- a/test/SIL/Serialization/clang_conformances.swift
+++ b/test/SIL/Serialization/clang_conformances.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/clang_conformances.sil -module-name clang_conformances -import-objc-header %S/Inputs/clang_conformances_helper.h -assume-parsing-unqualified-ownership-sil
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/clang_conformances.sil -module-name clang_conformances -import-objc-header %S/Inputs/clang_conformances_helper.h
 // RUN: %target-swift-frontend -emit-sil -o %t -I %t -primary-file %s -module-name main -O
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/deserialize_appkit.sil
+++ b/test/SIL/Serialization/deserialize_appkit.sil
@@ -1,5 +1,5 @@
 // Make sure that we can deserialize AppKit.
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/AppKit.swiftmodule > /dev/null
+// RUN: %target-sil-opt %platform-sdk-overlay-dir/AppKit.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/AppKit.swiftmodule | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/deserialize_coregraphics.swift
+++ b/test/SIL/Serialization/deserialize_coregraphics.swift
@@ -1,5 +1,5 @@
 // Make sure that we can deserialize CoreGraphics.
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/CoreGraphics.swiftmodule > /dev/null
+// RUN: %target-sil-opt %platform-sdk-overlay-dir/CoreGraphics.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/CoreGraphics.swiftmodule | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/deserialize_darwin.sil
+++ b/test/SIL/Serialization/deserialize_darwin.sil
@@ -1,5 +1,5 @@
 // Make sure that we can deserialize darwin.
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/Darwin.swiftmodule > /dev/null
+// RUN: %target-sil-opt %platform-sdk-overlay-dir/Darwin.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/Darwin.swiftmodule | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/deserialize_foundation.sil
+++ b/test/SIL/Serialization/deserialize_foundation.sil
@@ -1,5 +1,5 @@
 // Make sure that we can deserialize foundation.
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/Foundation.swiftmodule > /dev/null
+// RUN: %target-sil-opt %platform-sdk-overlay-dir/Foundation.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/Foundation.swiftmodule | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/deserialize_generic.sil
+++ b/test/SIL/Serialization/deserialize_generic.sil
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_generic.swift
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -performance-linker -I %t %s | %FileCheck %s
 
 // Make sure that SILFunctionType with GenericSignature can match up with
 // SILFunctionType deserialized from module.

--- a/test/SIL/Serialization/deserialize_generic_marker.sil
+++ b/test/SIL/Serialization/deserialize_generic_marker.sil
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_generic_marker.swift
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -performance-linker -I %t %s | %FileCheck %s
 
 // Make sure that SILFunctionType with GenericSignature can match up with
 // SILFunctionType deserialized from module.

--- a/test/SIL/Serialization/deserialize_objectivec.sil
+++ b/test/SIL/Serialization/deserialize_objectivec.sil
@@ -1,5 +1,5 @@
 // Make sure that we can deserialize Objective-C.
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/ObjectiveC.swiftmodule > /dev/null
+// RUN: %target-sil-opt %platform-sdk-overlay-dir/ObjectiveC.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/ObjectiveC.swiftmodule | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/deserialize_stdlib.sil
+++ b/test/SIL/Serialization/deserialize_stdlib.sil
@@ -1,5 +1,5 @@
 // Make sure that we can deserialize the stdlib.
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-module-dir/Swift.swiftmodule > /dev/null
+// RUN: %target-sil-opt %platform-module-dir/Swift.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-module-dir/Swift.swiftmodule | %FileCheck %s
 
 // CHECK-NOT: Unknown

--- a/test/SIL/Serialization/effectsattr.sil
+++ b/test/SIL/Serialization/effectsattr.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -o - | %FileCheck %s
+// RUN: %target-sil-opt %s -o - | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/function_param_convention.sil
+++ b/test/SIL/Serialization/function_param_convention.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -sil-inline-threshold 0 %S/Inputs/function_param_convention_input.sil -o %t/FunctionInput.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-name FunctionInput -O
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -I %t -performance-linker %s -o - | %FileCheck %s
+// RUN: %target-sil-opt -I %t -performance-linker %s -o - | %FileCheck %s
 
 import Swift
 import FunctionInput

--- a/test/SIL/Serialization/metatype_casts.sil
+++ b/test/SIL/Serialization/metatype_casts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -o - | %FileCheck %s
+// RUN: %target-sil-opt %s -o - | %FileCheck %s
 
 // Check that this file can be parsed at all.
 // SIL verifier should not crash on metatypes of metatypes.

--- a/test/SIL/Serialization/opaque_values_serialize.sil
+++ b/test/SIL/Serialization/opaque_values_serialize.sil
@@ -1,9 +1,9 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: %empty-directory(%t)
 // FIXME: <rdar://problem/29281364> sil-opt -verify is broken
-// RUN: %target-sil-opt %s -assume-parsing-unqualified-ownership-sil -enable-sil-opaque-values -emit-sib -o %t/tmp.sib -module-name opaqueval
-// RUN: %target-sil-opt %t/tmp.sib -assume-parsing-unqualified-ownership-sil -enable-sil-opaque-values -verify -o %t/tmp.2.sib -module-name opaqueval
-// RUN: %target-sil-opt %t/tmp.2.sib -assume-parsing-unqualified-ownership-sil -enable-sil-opaque-values -emit-sorted-sil -verify -module-name opaqueval | %FileCheck %s
+// RUN: %target-sil-opt %s -enable-sil-opaque-values -emit-sib -o %t/tmp.sib -module-name opaqueval
+// RUN: %target-sil-opt %t/tmp.sib -enable-sil-opaque-values -verify -o %t/tmp.2.sib -module-name opaqueval
+// RUN: %target-sil-opt %t/tmp.2.sib -enable-sil-opaque-values -emit-sorted-sil -verify -module-name opaqueval | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/projection_lowered_type_parse.sil
+++ b/test/SIL/Serialization/projection_lowered_type_parse.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module %s -module-name Swift -module-link-name swiftCore -parse-as-library -parse-sil -parse-stdlib -o - | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=Swift
+// RUN: %target-swift-frontend -emit-module %s -module-name Swift -module-link-name swiftCore -parse-as-library -parse-sil -parse-stdlib -o - | %target-sil-opt -module-name=Swift
 
 struct A {
   var f : () -> ()

--- a/test/SIL/Serialization/public_external.sil
+++ b/test/SIL/Serialization/public_external.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -parse-sil -emit-module -module-name Swift -module-link-name swiftCore -parse-stdlib -parse-as-library -o - | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -emit-sorted-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -parse-sil -emit-module -module-name Swift -module-link-name swiftCore -parse-stdlib -parse-as-library -o - | %target-sil-opt -module-name Swift -emit-sorted-sil | %FileCheck %s
 
 sil_stage raw
 import Builtin

--- a/test/SIL/Serialization/semanticsattr.sil
+++ b/test/SIL/Serialization/semanticsattr.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -emit-sib -parse-as-library -parse-stdlib -module-name SemanticsAttr -o %t/SemanticsAttr.sib %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/SemanticsAttr.sib -o - -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %t/SemanticsAttr.sib -o - -emit-sorted-sil | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/shared_function_serialization.sil
+++ b/test/SIL/Serialization/shared_function_serialization.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/shared_function_serialization_input.swift -o %t/Swift.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-link-name swiftCore -module-name Swift -O
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -I %t -performance-linker -inline %s -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -I %t -performance-linker -inline %s -o - | %FileCheck %s
 
 // CHECK: sil private @top_level_code
 // CHECK: sil public_external [serialized] @$ss1XVABycfC{{.*}}

--- a/test/SIL/Serialization/visibility.sil
+++ b/test/SIL/Serialization/visibility.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -parse-sil -emit-module -o - -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -module-name Swift > %t.sil
+// RUN: %target-swift-frontend %s -parse-sil -emit-module -o - -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib | %target-sil-opt -enable-sil-verify-all=false -module-name Swift > %t.sil
 // RUN: %FileCheck %s < %t.sil
 // RUN: %FileCheck -check-prefix=NEG-CHECK %s < %t.sil
 

--- a/test/SIL/Serialization/witness_tables.sil
+++ b/test/SIL/Serialization/witness_tables.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-as-library -module-name witness_tables -emit-module -o - %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name witness_tables | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -module-name witness_tables -emit-module -o - %s | %target-sil-opt -module-name witness_tables | %FileCheck %s
 
 protocol AssocReqt {
   func requiredMethod()

--- a/test/SIL/clone_init_existential.sil
+++ b/test/SIL/clone_init_existential.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -inline %s | %FileCheck %s
 
 // Check if cloning of init_existential_* works correctly with multiple
 // conformances.

--- a/test/SIL/clone_select_switch_value.sil
+++ b/test/SIL/clone_select_switch_value.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -inline %s | %FileCheck %s
 
 // Check if cloning of select_value and switch_value works correctly without
 // producing illegal SIL.

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -inline %s | %FileCheck %s
 
 // Check cloning of instructions.
 

--- a/test/SIL/opaque-verify.sil
+++ b/test/SIL/opaque-verify.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil %s
+// RUN: %target-sil-opt -enable-sil-opaque-values %s
 
 // REQUIRES: asserts
 

--- a/test/SIL/printer_include_decls.swift
+++ b/test/SIL/printer_include_decls.swift
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.*
 // RUN: %target-swift-frontend -emit-sil %s -o %t.sil
 // RUN: %FileCheck --input-file=%t.sil %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %t.sil -module-name=printer_include_decl | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %t.sil -module-name=printer_include_decl | %FileCheck %s
 
 var x: Int
 // CHECK: var x: Int

--- a/test/SIL/verifier-fail-bb.sil
+++ b/test/SIL/verifier-fail-bb.sil
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// RUN: not --crash %target-sil-opt %s
 // REQUIRES: asserts
 
 sil @no_terminator : $@convention(thin) () -> () {

--- a/test/SIL/verifier-fail-instruction.sil
+++ b/test/SIL/verifier-fail-instruction.sil
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// RUN: not --crash %target-sil-opt %s
 // REQUIRES: asserts
 
 class A {

--- a/test/SIL/verifier-init-existential.sil
+++ b/test/SIL/verifier-init-existential.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// RUN: %target-sil-opt %s
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SIL/verifier-value-metatype-lowering.sil
+++ b/test/SIL/verifier-value-metatype-lowering.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift %s
+// RUN: %target-sil-opt -module-name Swift %s
 // REQUIRES: asserts
 //
 // Make sure that we properly verify the lowering of optional value

--- a/test/SILGen/SILDeclRef.swift
+++ b/test/SILGen/SILDeclRef.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-sil %s | %FileCheck %s
-// RUN: %target-swift-emit-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
+// RUN: %target-swift-emit-sil %s | %target-sil-opt -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
 
 // Check that all SILDeclRefs are represented in the text form with a signature.
 // This allows to avoid ambiguities which sometimes arise e.g. when a

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 | %FileCheck %s
 
 final class Final<T> {
     var x: T

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 -enable-resilience | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 -enable-resilience | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 enum Enum<T> {
     case a(T), b(T)

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 -enable-resilience | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 -enable-resilience | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 struct Struct<T> {
     var x: T

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -abcopts -enable-abcopts=1 %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -abcopts -dce -enable-abcopts -enable-abc-hoisting %s | %FileCheck %s --check-prefix=HOIST
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all  -abcopts  %s | %FileCheck %s --check-prefix=RANGECHECK
+// RUN: %target-sil-opt -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -abcopts -enable-abcopts=1 %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -abcopts -dce -enable-abcopts -enable-abc-hoisting %s | %FileCheck %s --check-prefix=HOIST
+// RUN: %target-sil-opt -enable-sil-verify-all  -abcopts  %s | %FileCheck %s --check-prefix=RANGECHECK
 
 sil_stage canonical
 

--- a/test/SILOptimizer/access_dom.sil
+++ b/test/SILOptimizer/access_dom.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -access-enforcement-dom -assume-parsing-unqualified-ownership-sil %s -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt -access-enforcement-dom %s -enable-sil-verify-all | %FileCheck %s
 //
 // Test the AccessEnforcementDom pass in isolation. This ensures that
 // no upstream passes have removed SIL-level access markers that are

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -access-enforcement-opts -I %S/Inputs/abi -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -access-enforcement-opts -I %S/Inputs/abi %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/access_sink.sil
+++ b/test/SILOptimizer/access_sink.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -access-enforcement-release -assume-parsing-unqualified-ownership-sil %s -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt -access-enforcement-release %s -enable-sil-verify-all | %FileCheck %s
 //
 // Test the AccessEnforcementReleaseSinking pass in isolation.
 // This ensures that no upstream passes have removed SIL-level access markers

--- a/test/SILOptimizer/access_wmo.sil
+++ b/test/SILOptimizer/access_wmo.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -wmo -access-enforcement-wmo -assume-parsing-unqualified-ownership-sil %s -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt -wmo -access-enforcement-wmo %s -enable-sil-verify-all | %FileCheck %s
 //
 // Test the AccessEnforcementWMO pass in isolation. This ensures that
 // no upstream passes have removed SIL-level access markers that are

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -accessed-storage-dump -enable-sil-verify-all -o /dev/null -assume-parsing-unqualified-ownership-sil | %FileCheck %s
+// RUN: %target-sil-opt %s -accessed-storage-dump -enable-sil-verify-all -o /dev/null | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -address-lowering -enable-sil-opaque-values -emit-sorted-sil -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -address-lowering -enable-sil-opaque-values -emit-sorted-sil %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/address_projection.sil
+++ b/test/SILOptimizer/address_projection.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -address-lowering -enable-sil-opaque-values -optimize-opaque-address-lowering -emit-sorted-sil -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -address-lowering -enable-sil-opaque-values -optimize-opaque-address-lowering -emit-sorted-sil %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/alias-crash.sil
+++ b/test/SILOptimizer/alias-crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -redundant-load-elim | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -redundant-load-elim | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/allocstack_hoisting.sil
+++ b/test/SILOptimizer/allocstack_hoisting.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -alloc-stack-hoisting | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -alloc-stack-hoisting -sil-merge-stack-slots=false | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -alloc-stack-hoisting | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -alloc-stack-hoisting -sil-merge-stack-slots=false | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/always_inline.sil
+++ b/test/SILOptimizer/always_inline.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -dce -sil-inline-threshold=1 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -dce -sil-inline-threshold=1 | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-LOOP %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -arc-loop-opts  %s | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-LOOP %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-LOOP %s
+// RUN: %target-sil-opt -enable-sil-verify-all -arc-loop-opts  %s | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-LOOP %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/arcsequenceopts_casts.sil
+++ b/test/SILOptimizer/arcsequenceopts_casts.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all -arc-sequence-opts -enable-loop-arc=0 %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all -arc-sequence-opts -enable-loop-arc=1 %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -arc-sequence-opts -enable-loop-arc=0 %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -arc-sequence-opts -enable-loop-arc=1 %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/arcsequenceopts_loops.sil
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts  %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts  %s | %FileCheck %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/arcsequenceopts_loops.sil.gyb
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil.gyb
@@ -1,7 +1,7 @@
 %# -*- mode: sil -*-
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/arc-sequence-opts-loops.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -arc-sequence-opts %t/arc-sequence-opts-loops.sil -enable-loop-arc=0 | %FileCheck %t/arc-sequence-opts-loops.sil
+// RUN: %target-sil-opt -enable-sil-verify-all -arc-sequence-opts %t/arc-sequence-opts-loops.sil -enable-loop-arc=0 | %FileCheck %t/arc-sequence-opts-loops.sil
 
 %# Ignore the following admonition; it applies to the resulting .sil
 %# test file only.

--- a/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
+++ b/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s -module-name Swift | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s -module-name Swift | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s -module-name Swift | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s -module-name Swift | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
+++ b/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/array_count_propagation.sil
+++ b/test/SILOptimizer/array_count_propagation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -array-count-propagation %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -array-count-propagation %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/array_element_propagation.sil
+++ b/test/SILOptimizer/array_element_propagation.sil
@@ -1,5 +1,5 @@
 
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -array-element-propagation %s | %FileCheck %s
+// RUN: %target-sil-opt -array-element-propagation %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/array_specialize.sil
+++ b/test/SILOptimizer/array_specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -array-specialize
+// RUN: %target-sil-opt -enable-sil-verify-all %s -array-specialize
 
 sil_stage canonical
 

--- a/test/SILOptimizer/assert_configuration.sil
+++ b/test/SILOptimizer/assert_configuration.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnostic-constant-propagation -assert-conf-id 1 | %FileCheck %s --check-prefix=ONE
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnostic-constant-propagation -assert-conf-id 4294967295 | %FileCheck %s --check-prefix=DISABLED
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -performance-constant-propagation -assert-conf-id 1 | %FileCheck %s --check-prefix=PERFONE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation -assert-conf-id 1 | %FileCheck %s --check-prefix=ONE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation -assert-conf-id 4294967295 | %FileCheck %s --check-prefix=DISABLED
+// RUN: %target-sil-opt -enable-sil-verify-all %s -performance-constant-propagation -assert-conf-id 1 | %FileCheck %s --check-prefix=PERFONE
 
 import Builtin
 

--- a/test/SILOptimizer/assume_single_threaded.sil
+++ b/test/SILOptimizer/assume_single_threaded.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -assume-parsing-unqualified-ownership-sil %s -assume-single-threaded | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -assume-parsing-unqualified-ownership-sil %s -O -assume-single-threaded | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s -assume-single-threaded | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s -O -assume-single-threaded | %FileCheck %s
 
 // Check that all reference counting instructions are converted to [nonatomic]
 // if -assume-single-threaded is used.

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -module-name Swift %s -aa-kind=basic-aa -aa-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -module-name Swift %s -aa-kind=basic-aa -aa-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/basic-callee-printer.sil
+++ b/test/SILOptimizer/basic-callee-printer.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NOWMO %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -wmo -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-WMO %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NOWMO %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -wmo -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-WMO %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/basic-instruction-properties.sil
+++ b/test/SILOptimizer/basic-instruction-properties.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -basic-instruction-property-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -basic-instruction-property-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/bridged_casts_crash.sil
+++ b/test/SILOptimizer/bridged_casts_crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -performance-constant-propagation %s | %FileCheck %s
+// RUN: %target-sil-opt -performance-constant-propagation %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/bridging_checked_cast.sil
+++ b/test/SILOptimizer/bridging_checked_cast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -inline %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/SILOptimizer/caller_analysis.sil
+++ b/test/SILOptimizer/caller_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -caller-analysis-printer -o /dev/null | %FileCheck --check-prefix=CHECK %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -caller-analysis-printer -o /dev/null | %FileCheck --check-prefix=CHECK %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/canonicalize_switch_enum.sil
+++ b/test/SILOptimizer/canonicalize_switch_enum.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/capture_promotion.sil
+++ b/test/SILOptimizer/capture_promotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -capture-promotion | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -capture-promotion | %FileCheck %s
 
 // Check to make sure that the process of promoting closure captures results in
 // a correctly cloned and modified closure function body. This test

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -O -Xllvm -sil-fso-enable-generics=false %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O -Xllvm -sil-fso-enable-generics=false %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/capture_promotion_reachability.sil
+++ b/test/SILOptimizer/capture_promotion_reachability.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -capture-promotion | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -capture-promotion | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -capture-prop | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -capture-prop | %FileCheck %s
 
 // Check the CapturePropagation specialized the reabstraction thunk.
 

--- a/test/SILOptimizer/cast_folding_no_bridging.sil
+++ b/test/SILOptimizer/cast_folding_no_bridging.sil
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 // We want to check that casts between two types which are both Swift types or

--- a/test/SILOptimizer/cast_foldings.sil
+++ b/test/SILOptimizer/cast_foldings.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all -sil-combine %s | %FileCheck %s
 
 import Swift
 

--- a/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
+++ b/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -assume-parsing-unqualified-ownership-sil -wmo -performance-constant-propagation -simplify-cfg -sil-combine -jumpthread-simplify-cfg -sil-combine -devirtualizer -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -wmo -performance-constant-propagation -simplify-cfg -sil-combine -jumpthread-simplify-cfg -sil-combine -devirtualizer -generic-specializer %s | %FileCheck %s
 //
 // <rdar://problem/46322928> Failure to devirtualize a protocol method applied to an opened existential blocks implemention of
 // DataProtocol.

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/closure_specialize_and_cfg.sil
+++ b/test/SILOptimizer/closure_specialize_and_cfg.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-verify-without-invalidation -enable-sil-verify-all -simplify-cfg -closure-specialize %s
+// RUN: %target-sil-opt -sil-verify-without-invalidation -enable-sil-verify-all -simplify-cfg -closure-specialize %s
 
 // Test if the ClosureSpecializer correctly invalidates the dominator tree
 // even if there are no functions specialized.

--- a/test/SILOptimizer/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/closure_specialize_consolidated.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -closure-specialize %s | %FileCheck %s -check-prefix=REMOVECLOSURES
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -closure-specialize-eliminate-dead-closures=0 -closure-specialize %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialize %s | %FileCheck %s -check-prefix=REMOVECLOSURES
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialize-eliminate-dead-closures=0 -closure-specialize %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/closure_specialize_fragile.sil
+++ b/test/SILOptimizer/closure_specialize_fragile.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt  %s -verify -closure-specialize -assume-parsing-unqualified-ownership-sil -o -  | %FileCheck %s
+// RUN: %target-sil-opt  %s -verify -closure-specialize -o -  | %FileCheck %s
 
 // Make sure we do not specialize resilientCallee.
 

--- a/test/SILOptimizer/closure_specialize_opaque.sil
+++ b/test/SILOptimizer/closure_specialize_opaque.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
 
 struct TestView {}
 struct TestRange {}

--- a/test/SILOptimizer/closure_specialize_simple.sil
+++ b/test/SILOptimizer/closure_specialize_simple.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/conditionforwarding.sil
+++ b/test/SILOptimizer/conditionforwarding.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -condition-forwarding | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -condition-forwarding | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/const_fold_objc_bridge.sil
+++ b/test/SILOptimizer/const_fold_objc_bridge.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
 
 import Swift
 import Builtin

--- a/test/SILOptimizer/constant_propagation_castopt_analysis_invalidation.sil
+++ b/test/SILOptimizer/constant_propagation_castopt_analysis_invalidation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline -performance-constant-propagation -sil-verify-without-invalidation
+// RUN: %target-sil-opt -enable-sil-verify-all -inline -performance-constant-propagation -sil-verify-without-invalidation
 
 sil_stage canonical
 

--- a/test/SILOptimizer/constant_propagation_floats.sil
+++ b/test/SILOptimizer/constant_propagation_floats.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
 //
 // Tests that check constant-folding of conversions of floating point values
 // to integer types.

--- a/test/SILOptimizer/constant_propagation_floats_x86.sil
+++ b/test/SILOptimizer/constant_propagation_floats_x86.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
 //
 // REQUIRES: CPU=i386 || CPU=x86_64
 //

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -copy-forwarding -enable-copyforwarding -enable-destroyhoisting | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all %s -copy-forwarding -enable-copyforwarding -enable-destroyhoisting | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/cowarray_opt.sil
+++ b/test/SILOptimizer/cowarray_opt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all -cowarray-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all -cowarray-opt %s | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/cropoverflow.sil
+++ b/test/SILOptimizer/cropoverflow.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -remove-redundant-overflow-checks | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -remove-redundant-overflow-checks | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -cse | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/cse_apply.sil
+++ b/test/SILOptimizer/cse_apply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -cse | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/cse_objc.sil
+++ b/test/SILOptimizer/cse_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -cse | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Builtin

--- a/test/SILOptimizer/cyclic_entry.sil
+++ b/test/SILOptimizer/cyclic_entry.sil
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: not --crash %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
 // RUN: %FileCheck %s < %t/err.txt
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
 
 import Swift
 import Builtin

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
 
 // Linux doesn't have the same symbol name for _ArrayBuffer.
 // XFAIL: linux

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -dce %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -dce %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/dead_func_init_method.sil
+++ b/test/SILOptimizer/dead_func_init_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-deadfuncelim %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-deadfuncelim %s | %FileCheck %s
 
 // Check that we don't crash on this.
 

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -dead-store-elim -max-partial-store-count=2 -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt %s -dead-store-elim -max-partial-store-count=2 -enable-sil-verify-all | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/deadargsignatureopt.sil
+++ b/test/SILOptimizer/deadargsignatureopt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -dead-arg-signature-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -dead-arg-signature-opt %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/destructor_analysis.sil
+++ b/test/SILOptimizer/destructor_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -abcopts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -abcopts %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_access.sil
+++ b/test/SILOptimizer/devirt_access.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_access_serialized.sil
+++ b/test/SILOptimizer/devirt_access_serialized.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_alloc_ref_dynamic.sil
+++ b/test/SILOptimizer/devirt_alloc_ref_dynamic.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -devirtualizer -dce | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -devirtualizer -dce | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_class_witness_method.sil
+++ b/test/SILOptimizer/devirt_class_witness_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -sil-combine -enable-resilience -save-optimization-record-path=%t.opt.yaml | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -sil-combine -enable-resilience -save-optimization-record-path=%t.opt.yaml | %FileCheck %s
 sil_stage canonical
 // RUN: %FileCheck -check-prefix=YAML -input-file=%t.opt.yaml %s
 

--- a/test/SILOptimizer/devirt_ctors.sil
+++ b/test/SILOptimizer/devirt_ctors.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_default_witness_method.sil
+++ b/test/SILOptimizer/devirt_default_witness_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -sil-combine -enable-resilience | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -sil-combine -enable-resilience | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/devirt_generic_witness_method.sil
+++ b/test/SILOptimizer/devirt_generic_witness_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -jumpthread-simplify-cfg -cse | %FileCheck %s
 
 // Check that jump-threading works for sequences of checked_cast_br instructions produced by the devirtualizer.
 // This allows for simplifications of code like e.g. f.foo() + f.foo()

--- a/test/SILOptimizer/devirt_jump_thread_crasher.sil
+++ b/test/SILOptimizer/devirt_jump_thread_crasher.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
 // REQUIRES: objc_interop
 // FIXME: this test relies on standard library implementation details that are

--- a/test/SILOptimizer/devirt_override.sil
+++ b/test/SILOptimizer/devirt_override.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_release.sil
+++ b/test/SILOptimizer/devirt_release.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -release-devirtualizer -module-name=test | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -release-devirtualizer -module-name=test | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_speculative.sil
+++ b/test/SILOptimizer/devirt_speculative.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -module-name devirt_speculative -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt  | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -module-name devirt_speculative -enable-sil-verify-all %s -specdevirt  | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_static_witness_method.sil
+++ b/test/SILOptimizer/devirt_static_witness_method.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -sil-combine | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/devirt_try_apply.sil
+++ b/test/SILOptimizer/devirt_try_apply.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -inline  | %FileCheck %s --check-prefix=CHECK-DEVIRT
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt  | %FileCheck %s --check-prefix=CHECK-SPECDEVIRT
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mandatory-inlining  | %FileCheck %s --check-prefix=CHECK-MANDATORY-INLINING
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -inline  | %FileCheck %s --check-prefix=CHECK-DEVIRT
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt  | %FileCheck %s --check-prefix=CHECK-SPECDEVIRT
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining  | %FileCheck %s --check-prefix=CHECK-MANDATORY-INLINING
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirtualize.sil
+++ b/test/SILOptimizer/devirtualize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -dce -save-optimization-record-path=%t.yaml | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -dce -save-optimization-record-path=%t.yaml | %FileCheck %s
 // RUN: %FileCheck -check-prefix=YAML -input-file=%t.yaml %s
 
 sil_stage canonical

--- a/test/SILOptimizer/devirtualize2.sil
+++ b/test/SILOptimizer/devirtualize2.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -dce | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -dce | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -1,7 +1,7 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer  %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -sil-deadfuncelim  %s | %FileCheck --check-prefix=CHECK-DEADFUNCELIM %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -assume-parsing-unqualified-ownership-sil -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -sil-inline-generics=true -inline %s | %FileCheck --check-prefix=CHECK-EAGER-SPECIALIZE-AND-GENERICS-INLINE %s
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer -sil-deadfuncelim  %s | %FileCheck --check-prefix=CHECK-DEADFUNCELIM %s
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN %s
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer -sil-inline-generics=true -inline %s | %FileCheck --check-prefix=CHECK-EAGER-SPECIALIZE-AND-GENERICS-INLINE %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/early-rle.sil
+++ b/test/SILOptimizer/early-rle.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -early-redundant-load-elim | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -early-redundant-load-elim | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all %s -early-codemotion -retain-sinking | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all %s -early-codemotion -retain-sinking | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/enum_jump_thread.sil
+++ b/test/SILOptimizer/enum_jump_thread.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg -cse | %FileCheck %s
 
 // Test if jump-threading is done to combine two enum instructions
 // into a single block.

--- a/test/SILOptimizer/epilogue_arc_dumper.sil
+++ b/test/SILOptimizer/epilogue_arc_dumper.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-epilogue-arc-dumper %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-epilogue-arc-dumper %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/epilogue_release_dumper.sil
+++ b/test/SILOptimizer/epilogue_release_dumper.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-epilogue-retain-release-dumper %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-epilogue-retain-release-dumper %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -escapes-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -escapes-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/exclusivity_static_diagnostics_inlined.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_inlined.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enforce-exclusivity=none -emit-sil -Onone %s -o %t/Onone.sil
-// RUN: %target-sil-opt %t/Onone.sil -inline -assume-parsing-unqualified-ownership-sil -o %t/inlined.sil
+// RUN: %target-sil-opt %t/Onone.sil -inline -o %t/inlined.sil
 // RUN: %FileCheck %s --check-prefix=INLINE < %t/inlined.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t/inlined.sil -enforce-exclusivity=unchecked -diagnose-static-exclusivity -assume-parsing-unqualified-ownership-sil -o /dev/null
+// RUN: %target-sil-opt -enable-sil-verify-all %t/inlined.sil -enforce-exclusivity=unchecked -diagnose-static-exclusivity -o /dev/null
 
 public protocol SomeP {
   var someV: Int { get set }

--- a/test/SILOptimizer/existential_transform_extras.sil
+++ b/test/SILOptimizer/existential_transform_extras.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -enable-sil-existential-specializer -existential-specializer   | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -enable-sil-existential-specializer -existential-specializer   | %FileCheck %s
 
 // Additional tests for existential_specializer
 

--- a/test/SILOptimizer/existential_type_propagation.sil
+++ b/test/SILOptimizer/existential_type_propagation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -devirtualizer -inline -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine -devirtualizer -inline -sil-combine | %FileCheck %s
 
 // Check that type propagation is performed correctly for existentials.
 // The concrete type set in init_existential instructions should be propagated

--- a/test/SILOptimizer/fold_enums.sil
+++ b/test/SILOptimizer/fold_enums.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
 
 // Check that the optimizer can detect when an enum (e.g. Optional) is being deconstructed
 // and then recreated in the same form. It should replace it with the original value in

--- a/test/SILOptimizer/funcsig_deadarg_explode.sil
+++ b/test/SILOptimizer/funcsig_deadarg_explode.sil
@@ -1,7 +1,7 @@
 
 // This file makes sure that we do not explode dead parameters.
 
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -function-signature-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opts %s | %FileCheck %s
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SILOptimizer/funcsig_opaque.sil
+++ b/test/SILOptimizer/funcsig_opaque.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -function-signature-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -function-signature-opts %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/function_order.sil
+++ b/test/SILOptimizer/function_order.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -function-order-printer -o /dev/null | %FileCheck --check-prefix=CHECK %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -function-order-printer -o /dev/null | %FileCheck --check-prefix=CHECK %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck -check-prefix=CHECK-NEGATIVE %s
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck -check-prefix=CHECK-NEGATIVE %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/functionsigopts_sroa.sil
+++ b/test/SILOptimizer/functionsigopts_sroa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-expand-all -inline -function-signature-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all -enable-expand-all -inline -function-signature-opts %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/global_property_opt.sil
+++ b/test/SILOptimizer/global_property_opt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -global-property-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -global-property-opt %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/global_property_opt_objc.sil
+++ b/test/SILOptimizer/global_property_opt_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -global-property-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -global-property-opt %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/globalopt-iter.sil
+++ b/test/SILOptimizer/globalopt-iter.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -object-outliner | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -object-outliner | %FileCheck %s
 
 
 import Builtin

--- a/test/SILOptimizer/globalopt.sil
+++ b/test/SILOptimizer/globalopt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -global-opt | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
 //
 // ginit.cold has a hammock with an initializer call on the slow path.
 // ginit.loop has a loop containing an initializer call.

--- a/test/SILOptimizer/guaranteed_arc_opts_qualified.sil
+++ b/test/SILOptimizer/guaranteed_arc_opts_qualified.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt  -assume-parsing-unqualified-ownership-sil -guaranteed-arc-opts %s | %FileCheck %s
+// RUN: %target-sil-opt  -guaranteed-arc-opts %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/high_level_cse.sil
+++ b/test/SILOptimizer/high_level_cse.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -high-level-cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -high-level-cse | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/high_level_licm.sil
+++ b/test/SILOptimizer/high_level_licm.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -high-level-licm | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -high-level-licm | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inline_caches.sil
+++ b/test/SILOptimizer/inline_caches.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt -code-sinking  | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inline_devirtualize_specialize.sil
+++ b/test/SILOptimizer/inline_devirtualize_specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -generic-specializer -inline -dce | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -generic-specializer -inline -dce | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-inline-generics=true | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-inline-generics=false | %FileCheck --check-prefix=DISABLED-GENERIC-INLINING-CHECK %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-inline-generics=true | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-inline-generics=false | %FileCheck --check-prefix=DISABLED-GENERIC-INLINING-CHECK %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inline_heuristics.sil
+++ b/test/SILOptimizer/inline_heuristics.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-inline-generics=true -sil-partial-specialization=false -debug-only=sil-inliner 2>%t/log | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-inline-generics=true -sil-partial-specialization=false -debug-only=sil-inliner 2>%t/log | %FileCheck %s
 // RUN: %FileCheck %s --check-prefix=CHECK-LOG <%t/log
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-inline-generics=true -sil-partial-specialization=true -generic-specializer -debug-only=sil-inliner 2>%t/log | %FileCheck %s --check-prefix=CHECK-PARTIAL-SPECIALIZATION
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-inline-generics=true -sil-partial-specialization=true -generic-specializer -debug-only=sil-inliner 2>%t/log | %FileCheck %s --check-prefix=CHECK-PARTIAL-SPECIALIZATION
 // REQUIRES: asserts
 
 // This test checks the inline heuristics based on the debug log output of

--- a/test/SILOptimizer/inline_late.sil
+++ b/test/SILOptimizer/inline_late.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -early-inline -sil-inline-threshold=50 | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -late-inline -sil-inline-threshold=50 | %FileCheck %s --check-prefix=LATE
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -late-inline -sil-inline-threshold=50 -module-name Swift | %FileCheck %s --check-prefix=STDLIBLATE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -early-inline -sil-inline-threshold=50 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -late-inline -sil-inline-threshold=50 | %FileCheck %s --check-prefix=LATE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -late-inline -sil-inline-threshold=50 -module-name Swift | %FileCheck %s --check-prefix=STDLIBLATE
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inline_semantics.sil
+++ b/test/SILOptimizer/inline_semantics.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -early-inline -sil-inline-threshold=50 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -early-inline -sil-inline-threshold=50 | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inline_tryApply.sil
+++ b/test/SILOptimizer/inline_tryApply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -early-inline -sil-inline-threshold=50 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -early-inline -sil-inline-threshold=50 | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inlinecaches_arc.sil
+++ b/test/SILOptimizer/inlinecaches_arc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt -code-sinking  -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  -emit-sorted-sil | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inlinecaches_invalidate_failure.sil
+++ b/test/SILOptimizer/inlinecaches_invalidate_failure.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -specdevirt -code-sinking  -sil-verify-without-invalidation
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -specdevirt -code-sinking  -sil-verify-without-invalidation
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inlinecaches_objc.sil
+++ b/test/SILOptimizer/inlinecaches_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt -code-sinking  | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -specdevirt -code-sinking  | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-remarks=sil-inliner -o %t.sil 2>&1 | %FileCheck -check-prefix=REMARKS_PASSED %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-remarks=sil-inliner -o %t.sil 2>&1 | %FileCheck -check-prefix=REMARKS_PASSED %s
 // RUN: %FileCheck %s < %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-remarks-missed=sil-inliner -o /dev/null 2>&1 | %FileCheck -check-prefix=REMARKS_MISSED %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -save-optimization-record-path %t.yaml -o /dev/null 2>&1 | %FileCheck -allow-empty -check-prefix=NO_REMARKS %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-remarks-missed=sil-inliner -o /dev/null 2>&1 | %FileCheck -check-prefix=REMARKS_MISSED %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -save-optimization-record-path %t.yaml -o /dev/null 2>&1 | %FileCheck -allow-empty -check-prefix=NO_REMARKS %s
 // RUN: %FileCheck -check-prefix=YAML %s < %t.yaml
 
 // REMARKS_PASSED-NOT: remark:

--- a/test/SILOptimizer/inliner_spa.sil
+++ b/test/SILOptimizer/inliner_spa.sil
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -inline -print-shortest-path-info 2>%t/log >/dev/null
+// RUN: %target-sil-opt %s -inline -print-shortest-path-info 2>%t/log >/dev/null
 // RUN: %FileCheck %s <%t/log
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/iv_info_printer.sil
+++ b/test/SILOptimizer/iv_info_printer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -iv-info-printer 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -iv-info-printer 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -late-codemotion -release-hoisting -retain-sinking | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -late-codemotion -release-hoisting -retain-sinking | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/let_properties_opts.sil
+++ b/test/SILOptimizer/let_properties_opts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -let-properties-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -let-properties-opt -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -licm | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all %s -licm | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/licm_apply.sil
+++ b/test/SILOptimizer/licm_apply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -licm | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -licm | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/licm_exclusivity.sil
+++ b/test/SILOptimizer/licm_exclusivity.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=checked -enable-sil-verify-all %s -licm | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=checked -enable-sil-verify-all %s -licm | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/licm_multiend.sil
+++ b/test/SILOptimizer/licm_multiend.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -licm | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -licm | %FileCheck %s
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 

--- a/test/SILOptimizer/loop-region-analysis.sil
+++ b/test/SILOptimizer/loop-region-analysis.sil
@@ -1,6 +1,6 @@
 // All bbs should have IDs that match the rpo order put out when printing with -emit-sorted-sil
 
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name Swift -loop-region-view-text -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name Swift -loop-region-view-text -o /dev/null | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/loop_canonicalizer.sil
+++ b/test/SILOptimizer/loop_canonicalizer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -compute-dominance-info -compute-loop-info -loop-canonicalizer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -compute-dominance-info -compute-loop-info -loop-canonicalizer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/loop_info_printer.sil
+++ b/test/SILOptimizer/loop_info_printer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -loop-info-printer 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -loop-info-printer 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -loop-unroll %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -loop-unroll %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/loweraggregateinstrs.sil
+++ b/test/SILOptimizer/loweraggregateinstrs.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -lower-aggregate-instrs | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -lower-aggregate-instrs | %FileCheck %s
 
 // This file makes sure that given the current code-size metric we properly
 // expand operations for small structs and not for large structs in a consistent

--- a/test/SILOptimizer/loweraggregateinstrs_expandall.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_expandall.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-expand-all %s -lower-aggregate-instrs | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-expand-all %s -lower-aggregate-instrs | %FileCheck %s
 
 // This file makes sure that the mechanics of expanding aggregate instructions
 // work. With that in mind, we expand all structs here ignoring code-size

--- a/test/SILOptimizer/lslocation_expansion.sil
+++ b/test/SILOptimizer/lslocation_expansion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-expand-all %s -lslocation-dump -ml=only-expansion | %FileCheck %s
+// RUN: %target-sil-opt -enable-expand-all %s -lslocation-dump -ml=only-expansion | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/lslocation_reduction.sil
+++ b/test/SILOptimizer/lslocation_reduction.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -lslocation-dump -ml=only-reduction | %FileCheck %s
+// RUN: %target-sil-opt %s -lslocation-dump -ml=only-reduction | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/lslocation_type_only_expansion.sil
+++ b/test/SILOptimizer/lslocation_type_only_expansion.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -lslocation-dump -ml=only-type-expansion | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -lslocation-dump-use-new-projection -lslocation-dump -ml=only-type-expansion | %FileCheck %s
+// RUN: %target-sil-opt %s -lslocation-dump -ml=only-type-expansion | %FileCheck %s
+// RUN: %target-sil-opt %s -lslocation-dump-use-new-projection -lslocation-dump -ml=only-type-expansion | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -module-name mandatory_inlining -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -module-name mandatory_inlining -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mandatory_inlining_circular.sil
+++ b/test/SILOptimizer/mandatory_inlining_circular.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mandatory-inlining -verify
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining -verify
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -aa-kind=basic-aa -mem-behavior-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -aa-kind=basic-aa -mem-behavior-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mem2reg | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_liveness.sil
+++ b/test/SILOptimizer/mem2reg_liveness.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mem2reg | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_simple.sil
+++ b/test/SILOptimizer/mem2reg_simple.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mem2reg | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/mem2reg_unreachable.sil
+++ b/test/SILOptimizer/mem2reg_unreachable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -mem2reg
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mem2reg
 
 // Make sure we are not crashing on blocks that are not dominated by the entry block.
 

--- a/test/SILOptimizer/merge_cond_fail.sil
+++ b/test/SILOptimizer/merge_cond_fail.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -merge-cond_fails | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -merge-cond_fails | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/mm_inlinecaches_multiple.sil
+++ b/test/SILOptimizer/mm_inlinecaches_multiple.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt -code-sinking  | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt -code-sinking  -wmo | %FileCheck --check-prefix=CHECK-WMO %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  -wmo | %FileCheck --check-prefix=CHECK-WMO %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
+++ b/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -move-cond-fail-to-preds | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -move-cond-fail-to-preds | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/noreturn_folding.sil
+++ b/test/SILOptimizer/noreturn_folding.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all -noreturn-folding < %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -noreturn-folding < %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/objectoutliner.sil
+++ b/test/SILOptimizer/objectoutliner.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -object-outliner | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -object-outliner | %FileCheck %s
 //
 
 sil_stage canonical

--- a/test/SILOptimizer/opaque_values_opt.sil
+++ b/test/SILOptimizer/opaque_values_opt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -O -enable-sil-opaque-values -emit-sorted-sil -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -O -enable-sil-opaque-values -emit-sorted-sil %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics -enable-sil-verify-all %s -O | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -jumpthread-simplify-cfg -enable-sil-verify-all %s -O | %FileCheck --check-prefix=CHECK-SIMPLIFY-CFG %s
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all %s -O | %FileCheck %s
+// RUN: %target-sil-opt -jumpthread-simplify-cfg -enable-sil-verify-all %s -O | %FileCheck --check-prefix=CHECK-SIMPLIFY-CFG %s
 
 // Check some corner cases related to tracking of opened archetypes.
 // For example, the compiler used to crash compiling the "process" function (rdar://28024272)

--- a/test/SILOptimizer/optimize_never.sil
+++ b/test/SILOptimizer/optimize_never.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline -generic-specializer -inline %s > %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-full-demangle -enable-sil-verify-all -specdevirt %t.sil | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -inline -generic-specializer -inline %s > %t.sil
+// RUN: %target-sil-opt -sil-full-demangle -enable-sil-verify-all -specdevirt %t.sil | %FileCheck %s
 
 // Check that the  @_optimize(none) annotation prevents
 // any optimizations of the annotated function:

--- a/test/SILOptimizer/optimizer_counters.sil
+++ b/test/SILOptimizer/optimizer_counters.sil
@@ -1,9 +1,9 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O -sil-stats-modules 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-MODULES %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O -sil-stats-functions 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-FUNCTIONS %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O -sil-stats-dump-all 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ALL %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O -sil-stats-modules -sil-stats-only-instructions=integer_literal,builtin 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ONLY-INSTRUCTIONS %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O -sil-stats-functions -sil-stats-only-function=test_simple 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ONLY-FUNCTION %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O -sil-stats-functions -sil-stats-only-functions=test 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ONLY-FUNCTIONS %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O -sil-stats-modules 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-MODULES %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O -sil-stats-functions 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-FUNCTIONS %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O -sil-stats-dump-all 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ALL %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O -sil-stats-modules -sil-stats-only-instructions=integer_literal,builtin 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ONLY-INSTRUCTIONS %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O -sil-stats-functions -sil-stats-only-function=test_simple 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ONLY-FUNCTION %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O -sil-stats-functions -sil-stats-only-functions=test 2>&1 | %FileCheck --check-prefix=CHECK-SIL-STATS-ONLY-FUNCTIONS %s
 
 
 // Test different modes of optimizer counters statistics collection.

--- a/test/SILOptimizer/pa_removal.sil
+++ b/test/SILOptimizer/pa_removal.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/partial_specialization.sil
+++ b/test/SILOptimizer/partial_specialization.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer -sil-partial-specialization -sil-partial-specialization-with-generic-substitutions  %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -sil-partial-specialization -sil-partial-specialization-with-generic-substitutions  %s | %FileCheck %s
 
 // Test different cases of partial specialization.
 // In particular, test the correctness of partial specializaitons where substitutions may be generic.

--- a/test/SILOptimizer/partial_specialization_debug.sil
+++ b/test/SILOptimizer/partial_specialization_debug.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer -sil-partial-specialization=0 -sil-partial-specialization-with-generic-substitutions -debug-only=generic-specializer %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -sil-partial-specialization=0 -sil-partial-specialization-with-generic-substitutions -debug-only=generic-specializer %s -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/peephole_thick_to_objc_metatype.sil
+++ b/test/SILOptimizer/peephole_thick_to_objc_metatype.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/peephole_trunc_and_ext.sil
+++ b/test/SILOptimizer/peephole_trunc_and_ext.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -assume-parsing-unqualified-ownership-sil -emit-sil -O -o - -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-sil -O -o - -sil-verify-all | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/performance_inliner.sil
+++ b/test/SILOptimizer/performance_inliner.sil
@@ -1,5 +1,5 @@
 
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -sil-combine | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/polymorphic_inline_caches.sil
+++ b/test/SILOptimizer/polymorphic_inline_caches.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -specdevirt -code-sinking  -dce -early-codemotion -disable-sil-cm-rr-cm=0  -retain-sinking | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  -dce -early-codemotion -disable-sil-cm-rr-cm=0  -retain-sinking | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/postdomtree_verification_crash.sil
+++ b/test/SILOptimizer/postdomtree_verification_crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all  -sil-verify-without-invalidation %s -compute-dominance-info
+// RUN: %target-sil-opt -enable-sil-verify-all  -sil-verify-without-invalidation %s -compute-dominance-info
 
 // Check if post-dominator verification does not crash on multiple roots.
 

--- a/test/SILOptimizer/pound_assert.sil
+++ b/test/SILOptimizer/pound_assert.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-experimental-static-assert -assume-parsing-unqualified-ownership-sil %s -dataflow-diagnostics -verify
+// RUN: %target-sil-opt -enable-experimental-static-assert %s -dataflow-diagnostics -verify
 
 sil_stage canonical
 

--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -predictable-memopt  | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -predictable-memopt  | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/prespecialization_with_definition.sil
+++ b/test/SILOptimizer/prespecialization_with_definition.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -module-name main -assume-parsing-unqualified-ownership-sil | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -module-name main | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/pure_apply.swift
+++ b/test/SILOptimizer/pure_apply.swift
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/rcidentity.sil
+++ b/test/SILOptimizer/rcidentity.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -rc-id-dumper %s -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt -rc-id-dumper %s -o /dev/null | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/recursive_func.sil
+++ b/test/SILOptimizer/recursive_func.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O %s  -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -O %s  -emit-sil | %FileCheck %s
 
 // rdar://16761933
 // Make sure we can handle recursive function within a class.

--- a/test/SILOptimizer/recursive_single.sil
+++ b/test/SILOptimizer/recursive_single.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O %s -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -O %s -emit-sil | %FileCheck %s
 
 // rdar://16761933
 // Make sure we can handle recursive function within a class that

--- a/test/SILOptimizer/redundant_load_and_dead_store_elim.sil
+++ b/test/SILOptimizer/redundant_load_and_dead_store_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -redundant-load-elim -dead-store-elim | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -redundant-load-elim -dead-store-elim | %FileCheck %s
 
 // NOTE, the order redundant-load and dead-store are ran is important. we have a pass dependence for some
 // of the tests to work.

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -redundant-load-elim | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all %s -redundant-load-elim | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/redundant_load_elim_with_casts.sil
+++ b/test/SILOptimizer/redundant_load_elim_with_casts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -module-name Swift -redundant-load-elim | %FileCheck -check-prefix=CHECK-FUTURE %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -module-name Swift -redundant-load-elim | %FileCheck -check-prefix=CHECK-FUTURE %s
 //
 // FIXME: Contains tests which are handled by old RLE, but not current one. Mostly due to casting. Eventually we probably should
 // handle these cases if they turn out to be important.

--- a/test/SILOptimizer/ref_elt_addr.sil
+++ b/test/SILOptimizer/ref_elt_addr.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -cse | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/remove_unused_func.sil
+++ b/test/SILOptimizer/remove_unused_func.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-deadfuncelim | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-deadfuncelim | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -retain-sinking -late-release-hoisting %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -release-hoisting %s | %FileCheck --check-prefix=CHECK-RELEASE-HOISTING %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -retain-sinking -retain-sinking -late-release-hoisting %s | %FileCheck --check-prefix=CHECK-MULTIPLE-RS-ROUNDS %s
+// RUN: %target-sil-opt -enable-sil-verify-all -retain-sinking -late-release-hoisting %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -release-hoisting %s | %FileCheck --check-prefix=CHECK-RELEASE-HOISTING %s
+// RUN: %target-sil-opt -enable-sil-verify-all -retain-sinking -retain-sinking -late-release-hoisting %s | %FileCheck --check-prefix=CHECK-MULTIPLE-RS-ROUNDS %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/select_enum_addr_reads_memory.sil
+++ b/test/SILOptimizer/select_enum_addr_reads_memory.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name Swift -side-effects-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name Swift -side-effects-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last -sil-combine-disable-alloc-stack-opts | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/sil_combine_bitops.sil
+++ b/test/SILOptimizer/sil_combine_bitops.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // Test optimizations for binary bit operations.
 

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // These tests exercise the same SILCombine optimization as
 // existential_type_propagation.sil, but cover additional corner

--- a/test/SILOptimizer/sil_combine_devirt.sil
+++ b/test/SILOptimizer/sil_combine_devirt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -jumpthread-simplify-cfg | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sil_combine_global_addr.sil
+++ b/test/SILOptimizer/sil_combine_global_addr.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last -devirtualizer | %FileCheck %s
 
 // Test to see if concrete type can be propagated from
 // global_addr in sil_combiner.

--- a/test/SILOptimizer/sil_combine_objc.sil
+++ b/test/SILOptimizer/sil_combine_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
 // REQUIRES: objc_interop
 
 // See https://bugs.swift.org/browse/SR-5065, rdar://32511494

--- a/test/SILOptimizer/sil_combine_objc_bridge.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/sil_combine_opaque.sil
+++ b/test/SILOptimizer/sil_combine_opaque.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -sil-combine %s | %FileCheck %s
 
 struct S<T> {
   var t : T

--- a/test/SILOptimizer/sil_combine_same_ops.sil
+++ b/test/SILOptimizer/sil_combine_same_ops.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // Test optimization of various builtins which receive the same value in their first and second operand.
 

--- a/test/SILOptimizer/sil_combine_uncheck.sil
+++ b/test/SILOptimizer/sil_combine_uncheck.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -remove-runtime-asserts | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -remove-runtime-asserts | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sil_combiner_concrete_prop_all_args.sil
+++ b/test/SILOptimizer/sil_combiner_concrete_prop_all_args.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -wmo -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-combine -generic-specializer  -allocbox-to-stack -copy-forwarding -lower-aggregate-instrs -mem2reg -devirtualizer -late-inline -dead-arg-signature-opt -dce | %FileCheck %s
+// RUN: %target-sil-opt -wmo -enable-sil-verify-all %s -inline -sil-combine -generic-specializer  -allocbox-to-stack -copy-forwarding -lower-aggregate-instrs -mem2reg -devirtualizer -late-inline -dead-arg-signature-opt -dce | %FileCheck %s
 import Builtin
 import Swift
 import SwiftShims

--- a/test/SILOptimizer/sil_locations.sil
+++ b/test/SILOptimizer/sil_locations.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all -mandatory-inlining -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all -mandatory-inlining -emit-verbose-sil %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/simp_enum.sil
+++ b/test/SILOptimizer/simp_enum.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 // FIXME: Update for select_enum change.
 
 // Declare this SIL to be canonical because some tests break raw SIL

--- a/test/SILOptimizer/simplify_cfg_and_combine.sil
+++ b/test/SILOptimizer/simplify_cfg_and_combine.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg -sil-combine -jumpthread-simplify-cfg -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg -sil-combine -jumpthread-simplify-cfg -sil-combine | %FileCheck %s
 
 // These require both SimplifyCFG and SILCombine
 

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -late-codemotion -jumpthread-simplify-cfg | %FileCheck %s --check-prefix=CHECK_WITH_CODEMOTION
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -late-codemotion -jumpthread-simplify-cfg | %FileCheck %s --check-prefix=CHECK_WITH_CODEMOTION
 
 sil_stage raw
 

--- a/test/SILOptimizer/simplify_cfg_args_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_args_crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -simplify-bb-args -sroa-bb-args | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-bb-args -sroa-bb-args | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/simplify_cfg_opaque.sil
+++ b/test/SILOptimizer/simplify_cfg_opaque.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/simplify_cfg_select_enum.sil
+++ b/test/SILOptimizer/simplify_cfg_select_enum.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
 // Two select_enum instructions must not be considered as the same "condition",
 // even if they have the same enum operand.

--- a/test/SILOptimizer/simplify_cfg_simple.sil
+++ b/test/SILOptimizer/simplify_cfg_simple.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -simplify-cfg %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -simplify-cfg %s | %FileCheck %s
 //
 // Make sure that we can succesfully call simplify-cfg with that name via sil-opt.
 

--- a/test/SILOptimizer/simplify_cfg_unique_values.sil
+++ b/test/SILOptimizer/simplify_cfg_unique_values.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/simplify_unreachable_containing_blocks.sil
+++ b/test/SILOptimizer/simplify_unreachable_containing_blocks.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -simplify-unreachable-containing-blocks -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -simplify-unreachable-containing-blocks -module-name Swift -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sink.sil
+++ b/test/SILOptimizer/sink.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -code-sinking | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -code-sinking | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-partial-specialization -generic-specializer -save-optimization-record-path=%t.yaml %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-partial-specialization -generic-specializer -save-optimization-record-path=%t.yaml %s | %FileCheck %s
 // RUN: %FileCheck -check-prefix=YAML %s < %t.yaml
 
 sil_stage canonical

--- a/test/SILOptimizer/specialize_cg_update_crash.sil
+++ b/test/SILOptimizer/specialize_cg_update_crash.sil
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-stdlib -assume-parsing-unqualified-ownership-sil -parse-as-library  -module-name TestMod %S/Inputs/TestMod.sil -emit-module-path %t/TestMod.swiftmodule
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -parse-as-library  -module-name TestMod %S/Inputs/TestMod.sil -emit-module-path %t/TestMod.swiftmodule
+// RUN: %target-sil-opt -enable-sil-verify-all -inline -I %t %s | %FileCheck %s
 
 // Test if the CG is updated correctly during specialization and
 // there is no crash because of a missing CG node for a deserialized function.

--- a/test/SILOptimizer/specialize_default_witness.sil
+++ b/test/SILOptimizer/specialize_default_witness.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_default_witness_resilience.sil
+++ b/test/SILOptimizer/specialize_default_witness_resilience.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-resilience -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-resilience -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -generic-specializer -module-name inherit | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -generic-specializer -module-name inherit | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/specialize_metatypes_with_nondefault_representation.sil
+++ b/test/SILOptimizer/specialize_metatypes_with_nondefault_representation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -generic-specializer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -generic-specializer | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/specialize_no_definition.sil
+++ b/test/SILOptimizer/specialize_no_definition.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer -save-optimization-record-path=%t.yaml -o /dev/null %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -save-optimization-record-path=%t.yaml -o /dev/null %s
 // RUN: %FileCheck %s < %t.yaml
 
 import Builtin

--- a/test/SILOptimizer/specialize_opaque.sil
+++ b/test/SILOptimizer/specialize_opaque.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_reabstraction.sil
+++ b/test/SILOptimizer/specialize_reabstraction.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 
 sil_stage canonical

--- a/test/SILOptimizer/specialize_recursive_generics.sil
+++ b/test/SILOptimizer/specialize_recursive_generics.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -generic-specializer -cse | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -generic-specializer -cse | %FileCheck %s
 
 // Check that SIL cloner can correctly handle specialization of recursive
 // functions with generic arguments.

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -split-critical-edges | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -split-critical-edges | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/sr-5068.sil
+++ b/test/SILOptimizer/sr-5068.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt %s -sil-combine | %FileCheck %s
 
 // REQUIRES: PTRSIZE=64
 

--- a/test/SILOptimizer/sroa.sil
+++ b/test/SILOptimizer/sroa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sroa %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -sroa %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sroa_bbargs.sil
+++ b/test/SILOptimizer/sroa_bbargs.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all -sroa-bb-args %s | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all -sroa-bb-args %s | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -stack-promotion -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -stack-promotion -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/static_initializer.sil
+++ b/test/SILOptimizer/static_initializer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -global-opt | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/strip_debug_info.sil
+++ b/test/SILOptimizer/strip_debug_info.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -strip-debug-info %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -strip-debug-info %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -temp-rvalue-opt | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -temp-rvalue-opt | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/typed-access-tb-aa.sil
+++ b/test/SILOptimizer/typed-access-tb-aa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -aa-kind=typed-access-tb-aa -aa-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -aa-kind=typed-access-tb-aa -aa-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/unexpected_error.sil
+++ b/test/SILOptimizer/unexpected_error.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -dce %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -dce %s | %FileCheck %s
 import Swift
 
 // CHECK-LABEL: sil @unexpected_error : $@convention(thin) (Error) -> () {

--- a/test/SILOptimizer/unreachable_dealloc_stack.sil
+++ b/test/SILOptimizer/unreachable_dealloc_stack.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all %s -diagnostics | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all %s -diagnostics | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/unsafe_guaranteed_peephole.sil
+++ b/test/SILOptimizer/unsafe_guaranteed_peephole.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -unsafe-guaranteed-peephole %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -unsafe-guaranteed-peephole %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/verifier.sil
+++ b/test/SILOptimizer/verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/verifier_reject.sil
+++ b/test/SILOptimizer/verifier_reject.sil
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: not --crash %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
 // RUN: %FileCheck %s < %t/err.txt
 
 // REQUIRES: asserts

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
+// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: llvm-bcanalyzer %t/def_basic.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -emit-sil -I %t %s -o %t/basic_sil.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil
+// RUN: %target-sil-opt -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil
 
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -3,7 +3,7 @@
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
 
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/basic_sil_objc.sil -performance-linker -I %t | %FileCheck %S/Inputs/def_basic_objc.sil
+// RUN: %target-sil-opt %t/basic_sil_objc.sil -performance-linker -I %t | %FileCheck %S/Inputs/def_basic_objc.sil
 
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none

--- a/test/Serialization/sil_partial_apply_ownership.sil
+++ b/test/Serialization/sil_partial_apply_ownership.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xllvm -verify-skip-convert-escape-to-noescape-attributes -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
-// RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -Xllvm -verify-skip-convert-escape-to-noescape-attributes -emit-sil -I %t %s | %FileCheck %s
+// RUN: %target-build-swift -emit-module -Xllvm -verify-skip-convert-escape-to-noescape-attributes -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
+// RUN: %target-build-swift -Xllvm -verify-skip-convert-escape-to-noescape-attributes -emit-sil -I %t %s | %FileCheck %s
 
 import Builtin
 

--- a/test/Serialization/transparent-std.swift
+++ b/test/Serialization/transparent-std.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t %S/Inputs/def_transparent_std.swift
 // RUN: llvm-bcanalyzer %t/def_transparent_std.swiftmodule | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -sil-debug-serialization -parse-stdlib -I %t %s | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -emit-sil -sil-debug-serialization -parse-stdlib -I %t %s | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 

--- a/test/sil-func-extractor/basic.sil
+++ b/test/sil-func-extractor/basic.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -func=use_before_init | %FileCheck %s
+// RUN: %target-sil-func-extractor %s -func=use_before_init | %FileCheck %s
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -func=use_before_init -emit-sib -o %t/out.sib -module-name main && %target-sil-opt %t/out.sib -module-name main | %FileCheck %s
+// RUN: %target-sil-func-extractor %s -func=use_before_init -emit-sib -o %t/out.sib -module-name main && %target-sil-opt %t/out.sib -module-name main | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/sil-func-extractor/multiple-functions.sil
+++ b/test/sil-func-extractor/multiple-functions.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -func=f2 -func=f5 -func=f6 -func=f8 | %FileCheck %s
-// RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -invert -func=f2 -func=f5 -func=f6 -func=f8 | %FileCheck -check-prefix=INVERSE %s
-// RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -func=f2 -func=f5 -func-file=%S/functions_to_preserve | %FileCheck %s
+// RUN: %target-sil-func-extractor %s -func=f2 -func=f5 -func=f6 -func=f8 | %FileCheck %s
+// RUN: %target-sil-func-extractor %s -invert -func=f2 -func=f5 -func=f6 -func=f8 | %FileCheck -check-prefix=INVERSE %s
+// RUN: %target-sil-func-extractor %s -func=f2 -func=f5 -func-file=%S/functions_to_preserve | %FileCheck %s
 
 import Builtin
 

--- a/test/sil-nm/basic.sil
+++ b/test/sil-nm/basic.sil
@@ -1,9 +1,9 @@
-// RUN: %target-sil-nm -assume-parsing-unqualified-ownership-sil %s | %FileCheck -check-prefix=SIL-NM -check-prefix=CHECK %s
-// RUN: %target-sil-nm -demangle -assume-parsing-unqualified-ownership-sil %s | %FileCheck -check-prefix=DEMANGLE %s
+// RUN: %target-sil-nm %s | %FileCheck -check-prefix=SIL-NM -check-prefix=CHECK %s
+// RUN: %target-sil-nm -demangle %s | %FileCheck -check-prefix=DEMANGLE %s
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -module-name main -assume-parsing-unqualified-ownership-sil -emit-sib -o %t/out.sib %s
-// RUN: %target-sil-nm -module-name main -assume-parsing-unqualified-ownership-sil %t/out.sib | %FileCheck %s
-// RUN: %target-sil-nm -module-name main -demangle -assume-parsing-unqualified-ownership-sil %t/out.sib | %FileCheck -check-prefix=DEMANGLE %s
+// RUN: %target-sil-opt -module-name main -emit-sib -o %t/out.sib %s
+// RUN: %target-sil-nm -module-name main %t/out.sib | %FileCheck %s
+// RUN: %target-sil-nm -module-name main -demangle %t/out.sib | %FileCheck -check-prefix=DEMANGLE %s
 
 import Builtin
 

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -111,11 +111,6 @@ DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
                llvm::cl::init(false),
                llvm::cl::desc("Do not dump AST."));
 
-static llvm::cl::opt<bool> AssumeUnqualifiedOwnershipWhenParsing(
-    "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden,
-    llvm::cl::init(false),
-    llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
-
 static llvm::cl::opt<bool>
 DisableSILLinking("disable-sil-linking",
                   llvm::cl::init(true),
@@ -264,10 +259,6 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Error! Failed to open file: %s\n", InputFilename.c_str());
     exit(-1);
   }
-
-  SILOptions &SILOpts = Invocation.getSILOptions();
-  SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
-      AssumeUnqualifiedOwnershipWhenParsing;
 
   CompilerInstance CI;
   PrintingDiagnosticConsumer PrintDiags;

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -88,11 +88,6 @@ static llvm::cl::opt<std::string>
 static llvm::cl::opt<bool>
     PerformWMO("wmo", llvm::cl::desc("Enable whole-module optimizations"));
 
-static llvm::cl::opt<bool> AssumeUnqualifiedOwnershipWhenParsing(
-    "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden,
-    llvm::cl::init(false),
-    llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
-
 static llvm::cl::opt<IRGenOutputKind>
     OutputKind("output-kind", llvm::cl::desc("Type of output to produce"),
                llvm::cl::values(clEnumValN(IRGenOutputKind::LLVMAssembly,
@@ -156,11 +151,6 @@ int main(int argc, char **argv) {
   LangOpts.EnableAccessControl = false;
   LangOpts.EnableObjCAttrRequiresFoundation = false;
   LangOpts.EnableObjCInterop = LangOpts.Target.isOSDarwin();
-
-  // Setup the SIL Options.
-  SILOptions &SILOpts = Invocation.getSILOptions();
-  SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
-      AssumeUnqualifiedOwnershipWhenParsing;
 
   // Setup the IRGen Options.
   IRGenOptions &Opts = Invocation.getIRGenOptions();

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -80,11 +80,6 @@ static llvm::cl::opt<std::string>
 static llvm::cl::opt<std::string> Triple("target",
                                          llvm::cl::desc("target triple"));
 
-static llvm::cl::opt<bool> AssumeUnqualifiedOwnershipWhenParsing(
-    "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden,
-    llvm::cl::init(false),
-    llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
-
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
 // getMainExecutable (since some platforms don't support taking the
@@ -178,10 +173,6 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Error! Failed to open file: %s\n", InputFilename.c_str());
     exit(-1);
   }
-
-  SILOptions &SILOpts = Invocation.getSILOptions();
-  SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
-      AssumeUnqualifiedOwnershipWhenParsing;
 
   CompilerInstance CI;
   PrintingDiagnosticConsumer PrintDiags;

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -208,11 +208,6 @@ DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
 static llvm::cl::opt<bool>
 PerformWMO("wmo", llvm::cl::desc("Enable whole-module optimizations"));
 
-static llvm::cl::opt<bool>
-AssumeUnqualifiedOwnershipWhenParsing(
-    "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden, llvm::cl::init(false),
-    llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
-
 static llvm::cl::opt<bool> DisableGuaranteedNormalArguments(
     "disable-guaranteed-normal-arguments", llvm::cl::Hidden,
     llvm::cl::init(false),
@@ -348,8 +343,6 @@ int main(int argc, char **argv) {
   if (OptimizationGroup != OptGroup::Diagnostics)
     SILOpts.OptMode = OptimizationMode::ForSpeed;
   SILOpts.EnableSILOwnership = EnableSILOwnershipOpt;
-  SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
-    AssumeUnqualifiedOwnershipWhenParsing;
 
   SILOpts.VerifyExclusivity = VerifyExclusivity;
   if (EnforceExclusivity.getNumOccurrences() != 0) {

--- a/validation-test/SIL/parse_stdlib.sil
+++ b/validation-test/SIL/parse_stdlib.sil
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=true -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=true %t.sil > /dev/null
+// RUN: %target-sil-opt -enable-sil-verify-all=true -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -enable-sil-verify-all=true %t.sil > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test


### PR DESCRIPTION
NOTE: I split the test changes into a separate commit to ease review.