### PR TITLE
Platform: improve WinSDK coverage further

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -53,6 +53,19 @@ module WinSDK [system] [extern_c] {
       header "synchapi.h"
       export *
     }
+
+    // api-ms-win-core-sysinfo-l1-1-0.dll
+    module sysinfo {
+      header "sysinfoapi.h"
+      export *
+    }
+
+    // api-ms-win-core-timezone-l1-1-0.dll
+    module timezone {
+      header "timezoneapi.h"
+      export *
+    }
   }
+
 }
 


### PR DESCRIPTION
Additional APISets are required to implement the Foundation API surface.
Expand the module to include that.  Unfortunately, I have not been able
to get the ImageHelp or the DebugHelp APIs or the RTLSupport APISet
covered under the module.  Those are required to get stack captures to
work.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
