### PR TITLE
[5.0][Sema] Emit a deprecation warning if a Hashable type only implements hashValue

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4276,6 +4276,10 @@ WARNING(non_exhaustive_switch_warn,none, "switch must be exhaustive", ())
 WARNING(override_nsobject_hashvalue,none,
         "override of 'NSObject.hashValue' is deprecated; "
         "override 'NSObject.hash' to get consistent hashing behavior", ())
+WARNING(hashvalue_implementation,none,
+        "'Hashable.hashValue' is deprecated as a protocol requirement; "
+        "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",
+        (Type))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1175,7 +1175,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
       // The hashValue failure will produce a diagnostic elsewhere.
       return nullptr;
     }
-    if (hashValueDecl && hashValueDecl->isImplicit()) {
+    if (hashValueDecl->isImplicit()) {
       // Neither hashValue nor hash(into:) is explicitly defined; we need to do
       // a full Hashable derivation.
       
@@ -1209,8 +1209,11 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         llvm_unreachable("Attempt to derive Hashable for a type other "
                          "than a struct or enum");      
     } else {
-      // We can always derive hash(into:) if hashValue has an explicit
-      // implementation.
+      // hashValue has an explicit implementation, but hash(into:) doesn't.
+      // Emit a deprecation warning, then derive hash(into:) in terms of
+      // hashValue.
+      TC.diagnose(hashValueDecl->getLoc(), diag::hashvalue_implementation,
+                  Nominal->getDeclaredType());
       return deriveHashable_hashInto(*this,
                                      &deriveBodyHashable_compat_hashInto);
     }

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
@@ -305,8 +305,8 @@ public struct _CollectionState : Equatable, Hashable {
     }
   }
 
-  public var hashValue: Int {
-    return _id.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_id)
   }
 }
 

--- a/stdlib/private/StdlibUnicodeUnittest/Collation.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/Collation.swift
@@ -181,42 +181,11 @@ let ducetExtractData: [CollationTableEntry] = [
   CollationTableEntry([0xE01EF], [0x0000_0000_0000], "VARIATION SELECTOR-256"),
 ]
 
-public struct HashableArray<Element : Hashable> : Hashable {
-  internal var _elements: [Element]
-
-  public init(_ elements: [Element]) {
-    _elements = elements
-  }
-
-  public var hashValue: Int {
-    // FIXME: this is a bad approach to combining hash values.
-    var result = 0
-    for x in _elements {
-      result ^= x.hashValue
-      result = result &* 997
-    }
-    return result
-  }
-}
-
-public func == <Element>(
-  lhs: HashableArray<Element>,
-  rhs: HashableArray<Element>
-) -> Bool {
-  return lhs._elements.elementsEqual(rhs._elements)
-}
-
-extension HashableArray : ExpressibleByArrayLiteral {
-  public init(arrayLiteral elements: Element...) {
-    self._elements = elements
-  }
-}
-
-let ducetExtract: [HashableArray<Unicode.Scalar> : CollationTableEntry] = {
+let ducetExtract: [[Unicode.Scalar]: CollationTableEntry] = {
   () in
-  var result: [HashableArray<Unicode.Scalar> : CollationTableEntry] = [:]
+  var result: [[Unicode.Scalar]: CollationTableEntry] = [:]
   for entry in ducetExtractData {
-    result[HashableArray(entry.scalars)] = entry
+    result[entry.scalars] = entry
   }
   return result
 }()
@@ -232,7 +201,7 @@ extension String {
   internal var _collationElements: [UInt64] {
     var result: [UInt64] = []
     for us in self.unicodeScalars {
-      let scalars: HashableArray<Unicode.Scalar> = [us]
+      let scalars: [Unicode.Scalar] = [us]
       let collationElements = ducetExtract[scalars]!.collationElements
       if collationElements[0] != 0 {
         result += collationElements

--- a/stdlib/private/StdlibUnittest/LifetimeTracked.swift
+++ b/stdlib/private/StdlibUnittest/LifetimeTracked.swift
@@ -51,6 +51,9 @@ extension LifetimeTracked : Hashable {
   public var hashValue: Int {
     return value
   }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 }
 
 extension LifetimeTracked : Strideable {

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -110,14 +110,20 @@ public func <=> <T: Comparable>(lhs: T, rhs: T) -> ExpectedComparisonResult {
 }
 
 public struct TypeIdentifier : Hashable, Comparable {
+  public var value: Any.Type
+
   public init(_ value: Any.Type) {
     self.value = value
   }
 
   public var hashValue: Int { return objectID.hashValue }
-  public var value: Any.Type
-  
-  internal var objectID : ObjectIdentifier { return ObjectIdentifier(value) }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(objectID)
+  }
+
+  internal var objectID : ObjectIdentifier {
+    return ObjectIdentifier(value)
+  }
 }
 
 public func < (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {

--- a/stdlib/private/StdlibUnittest/StringConvertible.swift
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift
@@ -65,6 +65,10 @@ public struct CustomPrintableValue
     return value.hashValue
   }
 
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
+
   public typealias Stride = Int
 
   public func distance(to other: CustomPrintableValue) -> Stride {

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -106,6 +106,9 @@ public protocol Hashable : Equatable {
   ///
   /// Hash values are not guaranteed to be equal across different executions of
   /// your program. Do not save hash values to use during a future execution.
+  ///
+  /// - Important: `hashValue` is deprecated as a Hashable requirement. To
+  ///   conform to `Hashable`, implement the `hash(into:)` requirement instead.
   var hashValue: Int { get }
 
   /// Hashes the essential components of this value by feeding them into the

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -107,7 +107,7 @@ public protocol Hashable : Equatable {
   /// Hash values are not guaranteed to be equal across different executions of
   /// your program. Do not save hash values to use during a future execution.
   ///
-  /// - Important: `hashValue` is deprecated as a Hashable requirement. To
+  /// - Important: `hashValue` is deprecated as a `Hashable` requirement. To
   ///   conform to `Hashable`, implement the `hash(into:)` requirement instead.
   var hashValue: Int { get }
 

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -110,7 +110,7 @@ class CallbackSubC : CallbackBase {
 
 //
 class MyHashableNSObject: NSObject {
-  override var hashValue: Int { // expected-warning{{override of 'NSObject.hashValue' is deprecated}}
+  override var hashValue: Int { // expected-error{{overriding non-open property outside of its defining module}} expected-error{{overriding non-@objc declarations from extensions is not supported}}
     return 0
   }
 }

--- a/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -38,7 +38,12 @@ extension Equatable {
     fatalError("hella cray")
   }
 }
-extension Hashable { public var hashValue: Int { fatalError("trill hiphy") } }
+extension Hashable {
+  public func hash(into hasher: inout Hasher) {
+    fatalError("trill hiphy")
+  }
+}
+
 extension CGSize: Hashable {}
 extension CGPoint: Hashable {}
 extension CGRect: Hashable {}

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -43,7 +43,7 @@ extension LazyFilterSequence.Iterator : _ObjectiveCBridgeable { // expected-erro
 
 
 struct BridgedStruct : Hashable, _ObjectiveCBridgeable {
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 
   func _bridgeToObjectiveC() -> BridgedClass {
     return BridgedClass()
@@ -71,14 +71,14 @@ struct BridgedStruct : Hashable, _ObjectiveCBridgeable {
 
 func ==(x: BridgedStruct, y: BridgedStruct) -> Bool { return true }
 
-struct NotBridgedStruct : Hashable { 
-  var hashValue: Int { return 0 }
+struct NotBridgedStruct : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(x: NotBridgedStruct, y: NotBridgedStruct) -> Bool { return true }
 
 class OtherClass : Hashable { 
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 func ==(x: OtherClass, y: OtherClass) -> Bool { return true }
 

--- a/test/DebugInfo/DumpTypeFromMangledName.swift
+++ b/test/DebugInfo/DumpTypeFromMangledName.swift
@@ -53,9 +53,7 @@ let _ = main()
 public struct tinky : Equatable, Hashable {
   internal let _value: Int
 
-  public var hashValue: Int {
-    return 0
-  }
+  public func hash(into hasher: inout Hasher) {}
 }
 
 public func == (lhs: tinky, rhs: tinky) -> Bool {

--- a/test/IRGen/Inputs/ObjectiveC.swift
+++ b/test/IRGen/Inputs/ObjectiveC.swift
@@ -47,7 +47,7 @@ public func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
 }
 
 extension NSObject : Hashable {
-  @objc open var hashValue: Int { return 0 }
+  public func hash(into hasher: inout Hasher) {}
 }
 public func ==(x: NSObject, y: NSObject) -> Bool { return x === y }
 

--- a/test/IRGen/Inputs/usr/include/BridgeTestObjectiveC.h
+++ b/test/IRGen/Inputs/usr/include/BridgeTestObjectiveC.h
@@ -2,6 +2,9 @@
 
 typedef struct _NSZone NSZone;
 
+typedef long NSInteger;
+typedef unsigned long NSUInteger;
+
 @protocol NSCopying
 - copyWithZone:(nullable NSZone*)z;
 @end
@@ -14,6 +17,5 @@ typedef struct _NSZone NSZone;
 + (void) initialize;
 
 @property (readonly, copy) NSString *description;
+@property (readonly) NSUInteger hash;
 @end
-
-typedef long NSInteger;

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -13,7 +13,7 @@ public struct S: Hashable {
   public var z: C
   public var reabstracted: () -> ()
 
-  public var hashValue: Int { get }
+  public func hash(into hasher: inout Hasher)
   public static func ==(_: S, _: S) -> Bool
 }
 public class C: Hashable {
@@ -24,7 +24,7 @@ public class C: Hashable {
 
   public init()
 
-  public var hashValue: Int { get }
+  public func hash(into hasher: inout Hasher)
   public static func ==(_: C, _: C) -> Bool
 }
 

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -191,7 +191,7 @@ class Bas : NSObject {
 
   deinit { var x = 10 }
 
-  override var hashValue: Int { return 0 }
+  override var hash: Int { return 0 }
 
   @objc func acceptSet(_ set: Set<Bas>) { }
 }

--- a/test/Inputs/clang-importer-sdk/swift-modules-without-ns/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-without-ns/ObjectiveC.swift
@@ -77,6 +77,9 @@ extension NSObject : Equatable, Hashable {
   public var hashValue: Int {
     return hash
   }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(hash)
+  }
 }
 
 public func == (lhs: NSObject, rhs: NSObject) -> Bool {

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
@@ -60,8 +60,8 @@ public struct Selector : ExpressibleByStringLiteral {
     self = sel_registerName(value)
   }
 
-  public var hashValue: Int {
-    return ptr.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ptr)
   }
 }
 
@@ -88,12 +88,16 @@ public func ~=(x: NSObject, y: NSObject) -> Bool {
 }
 
 extension NSObject : Equatable, Hashable {
-  @objc open var hashValue: Int {
+  public static func == (lhs: NSObject, rhs: NSObject) -> Bool {
+    return lhs.isEqual(rhs)
+  }
+
+  public var hashValue: Int {
     return hash
   }
 
-  public static func == (lhs: NSObject, rhs: NSObject) -> Bool {
-    return lhs.isEqual(rhs)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(hash)
   }
 }
 

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -272,8 +272,9 @@ FunctionConversionTestSuite.test("CollectionUpCastsInFuncParameters") {
 protocol X: Hashable {}
 class B: X {
   var hashValue: Int { return 42 }
+  func hash(into hasher: inout Hasher) {}
   static func == (lhs: B, rhs: B) -> Bool {
-    return lhs.hashValue == rhs.hashValue
+    return true
   }
 }
 

--- a/test/Interpreter/collection_casts.swift
+++ b/test/Interpreter/collection_casts.swift
@@ -23,8 +23,8 @@ struct A : Preening, Hashable, Equatable {
     return lhs.value == rhs.value
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 }
 

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -1064,17 +1064,9 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
 
   //===--- Hashable -------------------------------------------------------===//
 
-  public var hashValue: Int {
-#if arch(i386) || arch(arm)
-    let p: UInt = 16777619
-    let h: UInt = (2166136261 &* p) ^ (isNegative ? 1 : 0)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-    let p: UInt = 1099511628211
-    let h: UInt = (14695981039346656037 &* p) ^ (isNegative ? 1 : 0)
-#else
-    fatalError("Unimplemented")
-#endif
-    return Int(bitPattern: _data.reduce(h, { ($0 &* p) ^ UInt($1) }))
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(isNegative)
+    hasher.combine(_data)
   }
 
   //===--- Bit shifting operators -----------------------------------------===//
@@ -1282,8 +1274,8 @@ struct Bit : FixedWidthInteger, UnsignedInteger {
 
   // Hashable, CustomStringConvertible
 
-  var hashValue: Int {
-    return Int(value)
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   var description: String {

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -206,8 +206,8 @@ import Dispatch
 public struct _stdlib_pthread_t : Equatable, Hashable {
   internal let _value: pthread_t
 
-  public var hashValue: Int {
-    return _value.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_value)
   }
 }
 

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -10,7 +10,7 @@ struct S: Hashable {
   let y: String
   var z: C
 
-  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
   static func ==(x: S, y: S) -> Bool
 }
 class C: Hashable {
@@ -23,7 +23,7 @@ class C: Hashable {
     get set
   }
 
-  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
   static func ==(x: C, y: C) -> Bool
 }
 

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -14,7 +14,7 @@ struct S: Hashable {
   let y: String
   var z: C
 
-  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
   static func ==(x: S, y: S) -> Bool
 }
 class C: Hashable {
@@ -27,7 +27,7 @@ class C: Hashable {
     get set
   }
 
-  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
   static func ==(x: C, y: C) -> Bool
 }
 

--- a/test/SILGen/Inputs/ObjectiveC.swift
+++ b/test/SILGen/Inputs/ObjectiveC.swift
@@ -35,7 +35,7 @@ public struct Selector : ExpressibleByStringLiteral {
 }
 
 extension NSObject : Hashable {
-  public var hashValue: Int { return 0 }
+  public func hash(into hasher: inout Hasher) {}
   public static func == (x: NSObject, y: NSObject) -> Bool { return true }
 }
 

--- a/test/SILGen/Inputs/inherited_protocol_conformance_other_file_2_b.swift
+++ b/test/SILGen/Inputs/inherited_protocol_conformance_other_file_2_b.swift
@@ -1,3 +1,5 @@
 extension Thing : Hashable {
-    var hashValue: Int { return value }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 }

--- a/test/SILGen/collection_cast_crash.swift
+++ b/test/SILGen/collection_cast_crash.swift
@@ -6,7 +6,7 @@
 class MyClass {}
 
 class KeyClass : Hashable {
-	var hashValue : Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 func ==(lhs: KeyClass, rhs: KeyClass) -> Bool { return true }
 

--- a/test/SILGen/collection_downcast.swift
+++ b/test/SILGen/collection_downcast.swift
@@ -20,7 +20,7 @@ class BridgedObjC : NSObject { }
 func == (x: BridgedObjC, y: BridgedObjC) -> Bool { return true }
 
 struct BridgedSwift : Hashable, _ObjectiveCBridgeable {
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 
   func _bridgeToObjectiveC() -> BridgedObjC {
     return BridgedObjC()

--- a/test/SILGen/collection_subtype_downcast.swift
+++ b/test/SILGen/collection_subtype_downcast.swift
@@ -17,8 +17,9 @@ func array_downcast(array: [Any]) -> [S]? {
 }
 
 extension S : Hashable {
-  var hashValue : Int {
-    return x + y
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
+    hasher.combine(y)
   }
 }
 func ==(lhs: S, rhs: S) -> Bool {

--- a/test/SILGen/collection_subtype_upcast.swift
+++ b/test/SILGen/collection_subtype_upcast.swift
@@ -17,8 +17,9 @@ func array_upcast(array: [S]) -> [Any] {
 }
 
 extension S : Hashable {
-  var hashValue : Int {
-    return x + y
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
+    hasher.combine(y)
   }
 }
 func ==(lhs: S, rhs: S) -> Bool {

--- a/test/SILGen/collection_upcast.swift
+++ b/test/SILGen/collection_upcast.swift
@@ -21,7 +21,7 @@ class BridgedObjC : NSObject { }
 func == (x: BridgedObjC, y: BridgedObjC) -> Bool { return true }
 
 struct BridgedSwift : Hashable, _ObjectiveCBridgeable {
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 
   func _bridgeToObjectiveC() -> BridgedObjC {
     return BridgedObjC()

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -605,10 +605,8 @@ func rdar35702810() {
 
 protocol X: Hashable {}
 class B: X {
-  var hashValue: Int { return 42 }
-  static func == (lhs: B, rhs: B) -> Bool {
-    return lhs.hashValue == rhs.hashValue
-  }
+  func hash(into hasher: inout Hasher) {}
+  static func == (lhs: B, rhs: B) -> Bool { return true }
 }
 
 func bar_arr<T: X>(type: T.Type, _ fn: ([T]?) -> Void) {}

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -280,7 +280,7 @@ func iuoKeyPaths() {
 
 class Bass: Hashable {
   static func ==(_: Bass, _: Bass) -> Bool { return false }
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 
 class Treble: Bass { }

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -923,10 +923,8 @@ class MyThing: Hashable {
     deinit {
         Swift.print("Deinit \(name)")
     }
-    
-    var hashValue: Int {
-        return 0
-    }
+
+    func hash(into hasher: inout Hasher) {}
     
     static func ==(lhs: MyThing, rhs: MyThing) -> Bool {
         return false

--- a/test/SILOptimizer/di-loadable-by-addr-scope.swift
+++ b/test/SILOptimizer/di-loadable-by-addr-scope.swift
@@ -29,9 +29,9 @@ extension Version: Hashable {
         return lhs.major == rhs.major &&
                lhs.buildMetadataIdentifiers == rhs.buildMetadataIdentifiers
     }
-    public var hashValue: Int {
-        var result: UInt64 = 0
-        return Int(truncatingIfNeeded: result)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(major)
+        hasher.combine(buildMetadataIdentifiers)
     }
 }
 

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -40,7 +40,7 @@ public func getGenericContainer<T>(g: G<T>, e: T.Elt) -> T where T.Elt : AnElt
 
 enum ArithmeticError : Error {
   case DivByZero
-  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
   var _code: Int { get }
 }
 

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -12,7 +12,7 @@ struct MMStorage<Key : Hashable, Value> {
 func ==(lhs: MMObject, rhs: MMObject) -> Bool
 
 class MMObject : Hashable {
-  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
 }
 
 class MMString : MMObject {

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -43,7 +43,7 @@ func localEnum() -> Bool {
 enum CustomHashable {
   case A, B
 
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 func ==(x: CustomHashable, y: CustomHashable) -> Bool {
   return true
@@ -239,7 +239,7 @@ extension OtherFileNonconforming: Hashable {
   static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool {
     return true
   }
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
 extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -48,9 +48,8 @@ struct CustomHashValue: Hashable {
   let x: Int
   let y: Int
 
-  var hashValue: Int { return 0 }
-
   static func ==(x: CustomHashValue, y: CustomHashValue) -> Bool { return true }
+  func hash(into hasher: inout Hasher) {}
 }
 
 func customHashValue() {
@@ -192,7 +191,7 @@ extension OtherFileNonconforming: Hashable {
   static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool {
     return true
   }
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
 extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -262,6 +262,60 @@ protocol ImplierMain: Equatable {}
 struct ImpliedMain: ImplierMain {}
 extension ImpliedOther: ImplierMain {}
 
+
+// Hashable conformances that rely on a manual implementation of `hashValue`
+// should produce a deprecation warning.
+struct OldSchoolStruct: Hashable {
+  static func ==(left: OldSchoolStruct, right: OldSchoolStruct) -> Bool {
+    return true
+  }
+  var hashValue: Int { return 42 }
+  // expected-warning@-1{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'OldSchoolStruct' to 'Hashable' by implementing 'hash(into:)' instead}}
+}
+enum OldSchoolEnum: Hashable {
+  case foo
+  case bar
+
+  static func ==(left: OldSchoolEnum, right: OldSchoolEnum) -> Bool {
+    return true
+  }
+  var hashValue: Int { return 23 }
+  // expected-warning@-1{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'OldSchoolEnum' to 'Hashable' by implementing 'hash(into:)' instead}}
+}
+class OldSchoolClass: Hashable {
+  static func ==(left: OldSchoolClass, right: OldSchoolClass) -> Bool {
+    return true
+  }
+  var hashValue: Int { return -9000 }
+  // expected-warning@-1{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'OldSchoolClass' to 'Hashable' by implementing 'hash(into:)' instead}}
+}
+
+// However, it's okay to implement `hashValue` as long as `hash(into:)` is also
+// provided.
+struct MixedStruct: Hashable {
+  static func ==(left: MixedStruct, right: MixedStruct) -> Bool {
+    return true
+  }
+  func hash(into hasher: inout Hasher) {}
+  var hashValue: Int { return 42 }
+}
+enum MixedEnum: Hashable {
+  case foo
+  case bar
+  static func ==(left: MixedEnum, right: MixedEnum) -> Bool {
+    return true
+  }
+  func hash(into hasher: inout Hasher) {}
+  var hashValue: Int { return 23 }
+}
+class MixedClass: Hashable {
+  static func ==(left: MixedClass, right: MixedClass) -> Bool {
+    return true
+  }
+  func hash(into hasher: inout Hasher) {}
+  var hashValue: Int { return -9000 }
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2186,8 +2186,8 @@ class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
   @nonobjc final func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
 }
 
-@objc class ObjC_Class1 : Hashable { 
-  var hashValue: Int { return 0 }
+@objc class ObjC_Class1 : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(lhs: ObjC_Class1, rhs: ObjC_Class1) -> Bool {

--- a/test/attr/attr_objc_clang.swift
+++ b/test/attr/attr_objc_clang.swift
@@ -21,16 +21,16 @@ class infer_instanceVar1 {
   }
 }
 
-class ObjC_Class1 : NSObject, Hashable { 
-  var hashValue: Int { return 0 }
+class ObjC_Class1 : NSObject, Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(lhs: ObjC_Class1, rhs: ObjC_Class1) -> Bool {
   return true
 }
 
-@objc class ObjC_Class2 : Hashable { 
-  var hashValue: Int { return 0 }
+@objc class ObjC_Class2 : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(lhs: ObjC_Class2, rhs: ObjC_Class2) -> Bool {

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 struct NonCodable : Hashable {
-    var hashValue: Int {
-        return 1
-    }
+    func hash(into hasher: inout Hasher) {}
 
     static func ==(_ lhs: NonCodable, _ rhs: NonCodable) -> Bool {
         return true

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 struct NonCodable : Hashable {
-    var hashValue: Int {
-        return 1
-    }
+    func hash(into hasher: inout Hasher) {}
 
     static func ==(_ lhs: NonCodable, _ rhs: NonCodable) -> Bool {
         return true

--- a/test/expr/cast/dictionary_bridge.swift
+++ b/test/expr/cast/dictionary_bridge.swift
@@ -12,10 +12,8 @@ public extension _ObjectiveCBridgeable {
   }
 }
 
-class Root : Hashable { 
-  var hashValue: Int {
-    return 0
-  }
+class Root : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(x: Root, y: Root) -> Bool { return true }
@@ -42,9 +40,7 @@ struct BridgedToObjC : Hashable, _ObjectiveCBridgeable {
     return true
   }
 
-  var hashValue: Int {
-    return 0
-  }
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(x: BridgedToObjC, y: BridgedToObjC) -> Bool { return true }

--- a/test/expr/cast/dictionary_coerce.swift
+++ b/test/expr/cast/dictionary_coerce.swift
@@ -3,8 +3,8 @@
 class C : Hashable {
 	var x = 0
 
-  var hashValue: Int {
-    return x
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
   }
 }
 

--- a/test/expr/cast/dictionary_downcast.swift
+++ b/test/expr/cast/dictionary_downcast.swift
@@ -3,8 +3,8 @@
 class C : Hashable {
 	var x = 0
 
-  var hashValue: Int {
-    return x
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
   }
 }
 
@@ -14,10 +14,8 @@ func == (x: C, y: C) -> Bool { return true }
 class D : C {}
 
 // Unrelated to the classes above.
-class U : Hashable { 
-  var hashValue: Int {
-    return 0
-  }
+class U : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func == (x: U, y: U) -> Bool { return true }

--- a/test/expr/cast/optional.swift
+++ b/test/expr/cast/optional.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
-class Base : Hashable { 
-  var hashValue: Int { return 0 }
+class Base : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 class Derived : Base { }

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -12,10 +12,8 @@ public extension _ObjectiveCBridgeable {
   }
 }
 
-class Root : Hashable { 
-  var hashValue: Int {
-    return 0
-  }
+class Root : Hashable {
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(x: Root, y: Root) -> Bool { return true }
@@ -44,9 +42,7 @@ struct BridgedToObjC : Hashable, _ObjectiveCBridgeable {
     return true
   }
 
-  var hashValue: Int {
-    return 0
-  }
+  func hash(into hasher: inout Hasher) {}
 }
 
 func ==(x: BridgedToObjC, y: BridgedToObjC) -> Bool { return true }

--- a/test/expr/cast/set_coerce.swift
+++ b/test/expr/cast/set_coerce.swift
@@ -3,8 +3,8 @@
 class C : Hashable {
 	var x = 0
 
-  var hashValue: Int {
-    return x
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
   }
 }
 

--- a/test/expr/cast/set_downcast.swift
+++ b/test/expr/cast/set_downcast.swift
@@ -3,8 +3,8 @@
 class C : Hashable {
 	var x = 0
 
-  var hashValue: Int {
-    return x
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
   }
 }
 
@@ -15,9 +15,7 @@ class D : C {}
 
 // Unrelated to the classes above.
 class U : Hashable { 
-  var hashValue: Int {
-    return 0
-  }
+  func hash(into hasher: inout Hasher) {}
 }
 
 func == (x: U, y: U) -> Bool { return true }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -2,11 +2,11 @@
 
 struct Sub: Hashable {
   static func ==(_: Sub, _: Sub) -> Bool { return true }
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 struct OptSub: Hashable {
   static func ==(_: OptSub, _: OptSub) -> Bool { return true }
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 struct NonHashableSub {}
 
@@ -33,7 +33,7 @@ struct A: Hashable {
   subscript(sub: Sub) -> A { get { return self } set { } }
 
   static func ==(_: A, _: A) -> Bool { fatalError() }
-  var hashValue: Int { fatalError() }
+  func hash(into hasher: inout Hasher) { fatalError() }
 }
 struct B {}
 struct C<T> {
@@ -486,7 +486,7 @@ func testStaticKeyPathComponent() {
 
 class Bass: Hashable {
   static func ==(_: Bass, _: Bass) -> Bool { return false }
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 }
 
 class Treble: Bass { }

--- a/test/stdlib/AnyHashableCasts.swift.gyb
+++ b/test/stdlib/AnyHashableCasts.swift.gyb
@@ -26,7 +26,9 @@ struct HashableStruct : Hashable {
   static func ==(lhs: HashableStruct, rhs: HashableStruct) -> Bool {
     return lhs.value == rhs.value
   }
-  var hashValue : Int { return value }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 }
 
 class HashableClass : Hashable {
@@ -35,7 +37,9 @@ class HashableClass : Hashable {
   static func ==(lhs: HashableClass, rhs: HashableClass) -> Bool {
     return lhs.value == rhs.value
   }
-  var hashValue : Int { return value }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 }
 
 enum HashableEnum : Hashable {
@@ -45,9 +49,10 @@ enum HashableEnum : Hashable {
     case (.value(let l), .value(let r)): return l == r
     }
   }
-  var hashValue : Int {
+  func hash(into hasher: inout Hasher) {
     switch self {
-    case .value(let v): return v
+    case .value(let v):
+      hasher.combine(v)
     }
   }
 }

--- a/test/stdlib/BinaryIntegerRequirements.swift
+++ b/test/stdlib/BinaryIntegerRequirements.swift
@@ -42,7 +42,7 @@ struct MyInt: FixedWidthInteger { // expected-error {{type 'MyInt' does not conf
   func quotientAndRemainder(dividingBy rhs: MyInt) -> (quotient: MyInt, remainder: MyInt) { fatalError() }
   func signum() -> MyInt { fatalError() }
 
-  var hashValue: Int { fatalError() }
+  func hash(into hasher: inout Hasher) { fatalError() }
   var byteSwapped: MyInt { fatalError() }
   static var max: MyInt { fatalError() }
   static var min: MyInt { fatalError() }

--- a/test/stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/stdlib/BridgeIdAsAny.swift.gyb
@@ -33,8 +33,9 @@ struct KnownUnbridged: Equatable, Hashable {
     return a.x === b.x && a.y === b.y
   }
 
-  public var hashValue: Int {
-    return x.hashValue ^ y.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
+    hasher.combine(y)
   }
 }
 

--- a/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -235,6 +235,10 @@ var _bridgedKeyBridgeOperations = _stdlib_AtomicInt(0)
 
 struct TestBridgedKeyTy
   : Equatable, Hashable, CustomStringConvertible, _ObjectiveCBridgeable {
+  var value: Int
+  var _hashValue: Int
+  var serial: Int
+
   static var bridgeOperations: Int {
     get {
       return _bridgedKeyBridgeOperations.load()
@@ -257,6 +261,10 @@ struct TestBridgedKeyTy
 
   var hashValue: Int {
     return _hashValue
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(_hashValue)
   }
 
   func _bridgeToObjectiveC() -> TestObjCKeyTy {
@@ -286,10 +294,6 @@ struct TestBridgedKeyTy
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }
-
-  var value: Int
-  var _hashValue: Int
-  var serial: Int
 }
 
 func == (lhs: TestBridgedKeyTy, rhs: TestBridgedKeyTy) -> Bool {

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -96,8 +96,8 @@ extension MockBinaryInteger : Comparable {
 }
 
 extension MockBinaryInteger : Hashable {
-  var hashValue: Int {
-    return _value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(_value)
   }
 }
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -592,7 +592,9 @@ struct KeyA: Hashable {
   init(value: String) { self.value = value }
 
   static func ==(a: KeyA, b: KeyA) -> Bool { return a.value == b.value }
-  var hashValue: Int { return value.hashValue }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 }
 struct KeyB: Hashable {
   var canary = LifetimeTracked(2222)
@@ -602,7 +604,9 @@ struct KeyB: Hashable {
   init(value: Int) { self.value = value }
 
   static func ==(a: KeyB, b: KeyB) -> Bool { return a.value == b.value }
-  var hashValue: Int { return value.hashValue }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 }
 
 func fullGenericContext<T: Hashable, U: Hashable>(x: T, y: U) -> KeyPath<Subscripts<T>, SubscriptResult<T, U>> {

--- a/test/stdlib/OptionalBridge.swift
+++ b/test/stdlib/OptionalBridge.swift
@@ -70,7 +70,9 @@ tests.test("wrapped value") {
 struct NotBridged: Hashable {
   var x: Int
 
-  var hashValue: Int { return x }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
+  }
 
   static func ==(x: NotBridged, y: NotBridged) -> Bool {
     return x.x == y.x

--- a/test/stdlib/SetTrapsObjC.swift
+++ b/test/stdlib/SetTrapsObjC.swift
@@ -18,8 +18,8 @@ struct NotBridgedKeyTy : Equatable, Hashable {
   init(_ value: Int) {
     self.value = value
   }
-  var hashValue: Int {
-    return value
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
   var value: Int
 }
@@ -38,8 +38,8 @@ class BridgedVerbatimRefTy : Equatable, Hashable {
   init(_ value: Int) {
     self.value = value
   }
-  var hashValue: Int {
-    return value
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
   var value: Int
 }
@@ -83,7 +83,9 @@ class TestObjCKeyTy : NSObject {
 struct TestBridgedKeyTy : Hashable, _ObjectiveCBridgeable {
   init(_ value: Int) { self.value = value }
 
-  var hashValue: Int { return value }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 
   func _bridgeToObjectiveC() -> TestObjCKeyTy {
     return TestObjCKeyTy(value)

--- a/test/stdlib/TestUserInfo.swift
+++ b/test/stdlib/TestUserInfo.swift
@@ -42,7 +42,12 @@ struct SomeStructure: Hashable {
     }
 
     // FIXME: we don't care about this, but Any only finds == on Hashables
-    var hashValue: Int { return i }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(i)
+        hasher.combine(str)
+        hasher.combine(sub.i)
+        hasher.combine(sub.str)
+    }
 }
 
 /*

--- a/test/type/dictionary.swift
+++ b/test/type/dictionary.swift
@@ -35,7 +35,7 @@ struct NotHashable { }
 var nh1 : [NotHashable : Int] // expected-error{{'NotHashable' does not conform to protocol 'Hashable'}}
 
 struct Y<T> : Hashable {
-  var hashValue: Int { return 0 }
+  func hash(into hasher: inout Hasher) {}
 
   static func ==(this: Y<T>, other: Y<T>) -> Bool { return true }
 }

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -214,6 +214,9 @@ ${kw} HasCustomRepresentation_${name}
   var hashValue: Int {
     return value
   }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
   func _toCustomAnyHashable() -> AnyHashable? {
     if hasDefaultAnyHashableRepresentation {
       return nil
@@ -247,6 +250,9 @@ ${kw} HasCustomRepresentation_Generic${name}<Wrapped>
   }
   var hashValue: Int {
     return asGenericMinimalHashableValue.hashValue
+  }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(asGenericMinimalHashableValue)
   }
   func _toCustomAnyHashable() -> AnyHashable? {
     if hasDefaultAnyHashableRepresentation {
@@ -360,6 +366,9 @@ struct HasCustomRepresentationRecursively
   var hashValue: Int {
     return value
   }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
   func _toCustomAnyHashable() -> AnyHashable? {
     if value == 0 {
       return AnyHashable(HasCustomRepresentationRecursively(value + 1))
@@ -456,6 +465,9 @@ class ${hashable_base.full_name} : ${', '.join([b.full_name for b in bases])} {
 %   else:
   var hashValue: Int {
     return value
+  }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
   static func == ${hashable_base.generic_parameters_decl} (
     lhs: ${hashable_base.full_name},
@@ -697,14 +709,14 @@ enum MinimalHashableRCSwiftError : Error, Hashable {
   case caseB(LifetimeTracked)
   case caseC(LifetimeTracked)
 
-  var hashValue: Int {
+  func hash(into hasher: inout Hasher) {
     switch self {
     case .caseA:
-      return 10
+      hasher.combine(10)
     case .caseB:
-      return 20
+      hasher.combine(20)
     case .caseC:
-      return 30
+      hasher.combine(30)
     }
   }
 

--- a/validation-test/stdlib/CollectionCasts.swift.gyb
+++ b/validation-test/stdlib/CollectionCasts.swift.gyb
@@ -18,12 +18,12 @@
 import StdlibUnittest
 
 class Base : Hashable {
+  var value: Int
   init(_ value: Int) {
     self.value = value
   }
-  var value: Int
-  var hashValue : Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 }
 

--- a/validation-test/stdlib/DictionaryTrapsObjC.swift
+++ b/validation-test/stdlib/DictionaryTrapsObjC.swift
@@ -17,13 +17,15 @@ let testSuiteSuffix = _isDebugAssertConfiguration() ? "_debug" : "_release"
 var DictionaryTraps = TestSuite("DictionaryTraps" + testSuiteSuffix)
 
 struct NotBridgedKeyTy : Equatable, Hashable {
+  var value: Int
+
   init(_ value: Int) {
     self.value = value
   }
-  var hashValue: Int {
-    return value
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
-  var value: Int
 }
 
 func == (lhs: NotBridgedKeyTy, rhs: NotBridgedKeyTy) -> Bool {
@@ -37,13 +39,14 @@ struct NotBridgedValueTy {}
 assert(!_isBridgedToObjectiveC(NotBridgedValueTy.self))
 
 class BridgedVerbatimRefTy : Equatable, Hashable {
+  var value: Int
+
   init(_ value: Int) {
     self.value = value
   }
-  var hashValue: Int {
-    return value
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
-  var value: Int
 }
 
 func == (lhs: BridgedVerbatimRefTy, rhs: BridgedVerbatimRefTy) -> Bool {
@@ -81,9 +84,13 @@ class TestObjCKeyTy : NSObject {
 }
 
 struct TestBridgedKeyTy : Hashable, _ObjectiveCBridgeable {
+  var value: Int
+
   init(_ value: Int) { self.value = value }
 
-  var hashValue: Int { return value }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
 
   func _bridgeToObjectiveC() -> TestObjCKeyTy {
     return TestObjCKeyTy(value)
@@ -110,8 +117,6 @@ struct TestBridgedKeyTy : Hashable, _ObjectiveCBridgeable {
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }
-
-  var value: Int
 }
 
 func ==(x: TestBridgedKeyTy, y: TestBridgedKeyTy) -> Bool {

--- a/validation-test/stdlib/SetAlgebra.swift
+++ b/validation-test/stdlib/SetAlgebra.swift
@@ -5,8 +5,8 @@ import StdlibUnittest
 import StdlibCollectionUnittest
 
 extension MinimalEquatableValue : Hashable {
-  public var hashValue: Int {
-    return value
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 }
 

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -10,8 +10,8 @@ class TestHashableBase : Hashable {
     self.value = value
     self.identity = identity
   }
-  var hashValue: Int {
-    return value
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
   static func == (
     lhs: TestHashableBase,


### PR DESCRIPTION
(Cherry-picked from #21057 and #20866)

SE-206 deprecated `hashValue` as a protocol requirement. We should gently encourage people to migrate to `hash(into:)`, for its more secure, easier and faster hashing.

- Emit a compiler warning whenever `hashValue` has an explicit implementation, but `hash(into:)` doesn’t. (#21057)
- Update the test suite to fix regressions caused by the new warning.

rdar://problem/39838478, rdar://problem/46344811
