### PR TITLE
Force manual allocation (via Unsafe*Pointer) to use >= 16 alignment.

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -423,9 +423,24 @@ BUILTIN_MISC_OPERATION(IsSameMetatype, "is_same_metatype", "n", Special)
 BUILTIN_MISC_OPERATION(Alignof, "alignof", "n", Special)
 
 /// AllocRaw has type (Int, Int) -> Builtin.RawPointer
+///
+/// Parameters: object size, object alignment.
+///
+/// This alignment is not a mask; the compiler decrements by one to provide
+/// a mask to the runtime.
+///
+/// If alignment == 0, then runtime will use the "aligned" allocation path,
+/// and the memory will be aligned to Swift._minAllocationAlignment.
 BUILTIN_MISC_OPERATION(AllocRaw, "allocRaw", "", Special)
 
 /// DeallocRaw has type (Builtin.RawPointer, Int, Int) -> ()
+///
+/// Parameters: object address, object size, object alignment.
+///
+/// This alignment is not a mask; the compiler decrements by one to provide
+/// a mask to the runtime.
+///
+/// If alignment == 0, then runtime will use the "aligned" deallocation path.
 BUILTIN_MISC_OPERATION(DeallocRaw, "deallocRaw", "", Special)
 
 /// Fence has type () -> ().

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -342,6 +342,29 @@ internal func _isValidAddress(_ address: UInt) -> Bool {
   return address >= _swift_abi_LeastValidPointerValue
 }
 
+// Manually allocated memory is at least 16-byte aligned in Swift.
+//
+// This is done so that users do not need to specify the allocation
+// alignment when manually deallocating memory via Unsafe[Raw][Buffer]Pointer.
+//
+// Any user specified alignment less than or equal to
+// _minAllocationAlignment results in a runtime request for "default"
+// alignment. This guarantees that manual allocation always uses an
+// "aligned" runtime allocation. If an allocation is "aligned" then it
+// must be freed using an "aligned" deallocation. The converse must
+// also hold. Since manual Unsafe*Pointer deallocation is always
+// "aligned", the user does not actually need to specify the original
+// alignment.
+//
+// This not not @inlinable, because it has not been exposed as ABI,
+// but it does need to agree with the runtime implementation of
+// swift_slowAlloc.
+@inline(__always)
+@usableFromInline
+internal func _minAllocationAlignment() -> Int {
+  return 16
+}
+
 //===--- Builtin.BridgeObject ---------------------------------------------===//
 
 // TODO(<rdar://problem/34837023>): Get rid of superfluous UInt constructor

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -567,7 +567,15 @@ extension Unsafe${Mutable}BufferPointer {
   public static func allocate(capacity count: Int) 
     -> UnsafeMutableBufferPointer<Element> {
     let size = MemoryLayout<Element>.stride * count
-    let raw  = Builtin.allocRaw(size._builtinWordValue, Builtin.alignof(Element.self))
+    var align = Builtin.alignof(Element.self)
+    // Force manually allocated memory to use the "aligned" allocation
+    // path so that deallocation does not require the original
+    // alignment. The runtime guarantees "aligned" allocation for either 
+    // alignment > _minAllocationAlignment or alignment == 0.
+    if Int(align) <= _minAllocationAlignment() {
+      align = (0)._builtinWordValue
+    }
+    let raw  = Builtin.allocRaw(size._builtinWordValue, align)
     Builtin.bindMemory(raw, count._builtinWordValue, Element.self)
     return UnsafeMutableBufferPointer(
       start: UnsafeMutablePointer(raw), count: count)

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -241,7 +241,10 @@ public struct UnsafeRawPointer: _Pointer {
   /// trivial type.
   @inlinable
   public func deallocate() {
-    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (-1)._builtinWordValue)
+    // Passing zero alignment to the runtime forces aligned
+    // deallocation. This ensures that the runtime's allocation and
+    // deallocation paths are compatible.
+    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue)
   }
 
   /// Binds the memory to the specified type and returns a typed pointer to the
@@ -577,6 +580,14 @@ public struct UnsafeMutableRawPointer: _Pointer {
   public static func allocate(
     byteCount: Int, alignment: Int
   ) -> UnsafeMutableRawPointer {
+    // Force manually allocated memory to use the "aligned" allocation
+    // path so that deallocation does not require the original
+    // alignment. The runtime guarantees "aligned" allocation for either 
+    // alignment > _minAllocationAlignment or alignment == 0.
+    var alignment = alignment
+    if alignment <= _minAllocationAlignment() {
+      alignment = 0
+    }
     return UnsafeMutableRawPointer(Builtin.allocRaw(
         byteCount._builtinWordValue, alignment._builtinWordValue))
   }
@@ -587,7 +598,10 @@ public struct UnsafeMutableRawPointer: _Pointer {
   /// trivial type.
   @inlinable
   public func deallocate() {
-    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (-1)._builtinWordValue)
+    // Passing zero alignment to the runtime forces aligned
+    // deallocation. This ensures that the runtime's allocation and
+    // deallocation paths are compatible.
+    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue)
   }
 
   /// Binds the memory to the specified type and returns a typed pointer to the


### PR DESCRIPTION
This fixes the Windows platform, where the aligned allocation path is
not malloc-compatible. It won't have any observable difference on
Darwin or Linux, aside from manually allocated memory on Linux now
being consistently 16-byte aligned (heap objects will still be 8-byte
aligned on Linux).

It is sad that we can't guarantee Swift-allocated memory via
Unsafe*Pointer is malloc compatible on Windows. It would have been
nice for that to be a cross platform guarantee since it's normal to
allocate in C and deallocate in Swift or vice-versa. Now we have to
tell devs to always use _aligned_malloc/_aligned_free when
transitioning between Swift/C if they expect their code to work on
Windows.

Even though this fix isn't required today on Darwin/Linux, it makes
good sense to guarantee that the allocation/deallocation paths are
consistent.

This is done by specifying a constant that stdlib can use to round up
alignment, minAllocationAlignment, and the runtime can assert is
greater than MALLOC_ALIGN_MASK for all platforms. (Manually allocated
buffers will always round up so users don't need to pass alignment to
deallocate). This doesn't need to be ABI, so defining a shared
constant in SwiftShims.h may not be appropriate. Since I don't know
how to share the constant without making it ABI, the stdlib and
runtime each provide their own definition.

Alternatives are:

1. Require users of Unsafe*Pointer to specify the same alignment
   during deallocation. This is obviously madness.

2. Introduce new runtime entry points:
   swift_alignedAlloc/swift_alignedDealloc, introduce corresponding
   new builtins, and have Unsafe*Pointer always call those. This would
   make the runtime API a little more obvious but would introduce
   complexity all over the place and doesn't have any other
   significant benefit. Less than 16-byte alignment of manually
   allocated buffers on Linux is a non-goal.
