### PR TITLE
[ABI] [Mangling] Disambiguate protocol-conformance-ref better

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -633,7 +633,8 @@ Property behaviors are implemented using private protocol conformances.
 ::
 
   concrete-protocol-conformance ::= type protocol-conformance-ref any-protocol-conformance-list 'HC'
-  protocol-conformance-ref ::= protocol module? 'HP'
+  protocol-conformance-ref ::= protocol
+  protocol-conformance-ref ::= protocol module 'HP'
 
   any-protocol-conformance ::= concrete-protocol-conformance
   any-protocol-conformance ::= dependent-protocol-conformance

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2280,10 +2280,10 @@ void ASTMangler::appendProtocolConformanceRef(
   // For retroactive conformances, add a reference to the module in which the
   // conformance resides. For @objc protocols, there is no point: conformances
   // are global anyway.
-  if (isRetroactiveConformance(conformance))
+  if (isRetroactiveConformance(conformance)) {
     appendModule(conformance->getDeclContext()->getParentModule());
-
-  appendOperator("HP");
+    appendOperator("HP");
+  }
 }
 
 /// Retrieve the index of the conformance requirement indicated by the

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1299,18 +1299,17 @@ NodePointer Demangler::demangleProtocolConformanceRef() {
   NodePointer module = popModule();
   NodePointer proto = popProtocol();
   auto protocolConformanceRef =
-    createWithChild(Node::Kind::ProtocolConformanceRef, proto);
-
-  // The module is optional, present only for retroactive conformances. Add it
-  // as the second child.
-  if (protocolConformanceRef && module)
-    protocolConformanceRef->addChild(module, *this);
+      createWithChildren(Node::Kind::ProtocolConformanceRef, proto, module);
   return protocolConformanceRef;
 }
 
 NodePointer Demangler::demangleConcreteProtocolConformance() {
   NodePointer conditionalConformanceList = popAnyProtocolConformanceList();
   NodePointer conformanceRef = popNode(Node::Kind::ProtocolConformanceRef);
+  if (!conformanceRef) {
+    NodePointer proto = popProtocol();
+    conformanceRef = createWithChild(Node::Kind::ProtocolConformanceRef, proto);
+  }
   NodePointer type = popNode(Node::Kind::Type);
   return createWithChildren(Node::Kind::ConcreteProtocolConformance,
                             type, conformanceRef, conditionalConformanceList);

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1657,9 +1657,10 @@ void Remangler::mangleProtocolConformance(Node *node) {
 
 void Remangler::mangleProtocolConformanceRef(Node *node) {
   manglePureProtocol(node->getChild(0));
-  if (node->getNumChildren() > 1)
+  if (node->getNumChildren() > 1) {
     mangleChildNode(node, 1);
-  Buffer << "HP";
+    Buffer << "HP";
+  }
 }
 
 void Remangler::mangleConcreteProtocolConformance(Node *node) {

--- a/test/SILGen/mangling_retroactive.swift
+++ b/test/SILGen/mangling_retroactive.swift
@@ -38,5 +38,14 @@ extension Z: Equatable where T: Hashable, V: Equatable {
 struct RequiresEquatable<T: Equatable> { }
 
 // Conditional requirement involves retroactive conformances.
-// CHECK: sil hidden [ossa] @$s20mangling_retroactive5test2yyAA17RequiresEquatableVyAA1ZVy12RetroactiveB1XVSiAG1YVAI0F1A1PAAHPyHCg_AkL1QAAHPyHCg1_GAOSQHPAISHAAHPyHC_AKSQAAHPyHCHCg_GF
+// CHECK: sil hidden [ossa] @$s20mangling_retroactive5test2yyAA17RequiresEquatableVyAA1ZVy12RetroactiveB1XVSiAG1YVAI0F1A1PAAHPyHCg_AkL1QAAHPyHCg1_GAOSQAISHAAHPyHC_AKSQAAHPyHCHCg_GF
 func test2(_: RequiresEquatable<Z<X, Int, Y>>) { }
+
+struct UnconditionallyP<T: Q>: P {}
+struct RequiresP<T: P> {}
+
+// RequiresP uses a non-retroactive conformance for its generic param
+// UnconditionallyP, even though UnconditionallyP's generic param uses a
+// retroactive conformance to conform to Q.
+func rdar46735592(_: RequiresP<UnconditionallyP<Y>>) { }
+// CHECK: sil hidden [ossa] @$s20mangling_retroactive12rdar46735592yyAA9RequiresPVyAA16UnconditionallyPVy12RetroactiveB1YVAI0F1A1QAAHPyHCg_GAlJ1PyHCg_GF


### PR DESCRIPTION
Fix to #21397. The mangling operator "HP" has to distinguish between "protocol" and "protocol + module", not between the presence or absence of protocol-conformance-ref. New grammar:

    protocol-conformance-ref ::= protocol
    protocol-conformance-ref ::= protocol module 'HP'

rdar://problem/46735592, again. This is a narrow fix for that issue; the problem only occurs when mangling a reference to a non-retroactive conformance, but it's happening in a context where we only need retroactive conformances anyway. I'll look into that next and if it's simple enough maybe we can take that too.