### PR TITLE
Fix stack overflow containsTensorFlowValue for recursive data structures.

### DIFF
--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -92,7 +92,13 @@ namespace tf {
     bool containsTensorFlowValue(Type ty, bool checkHigherOrderFunctions);
 
   private:
-    bool structContainsTensorFlowValue(StructDecl *decl);
+    bool containsTensorFlowValueImpl(
+        Type ty, bool checkHigherOrderFunctions,
+        llvm::SmallPtrSetImpl<NominalTypeDecl *> &parentDecls);
+
+    bool
+    structContainsTensorFlowValue(StructDecl *decl,
+                                  llvm::SmallPtrSetImpl<NominalTypeDecl *> &parentDecls);
   };
 
   /// This class provides a single source of truth for the set of types that are

--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -20,6 +20,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace swift {
   class CanType;
@@ -94,11 +95,10 @@ namespace tf {
   private:
     bool containsTensorFlowValueImpl(
         Type ty, bool checkHigherOrderFunctions,
-        llvm::SmallPtrSetImpl<NominalTypeDecl *> &parentDecls);
+        llvm::SetVector<NominalTypeDecl *> &parentDecls);
 
-    bool
-    structContainsTensorFlowValue(StructDecl *decl,
-                                  llvm::SmallPtrSetImpl<NominalTypeDecl *> &parentDecls);
+    bool structContainsTensorFlowValue(
+        StructDecl *decl, llvm::SetVector<NominalTypeDecl *> &parentDecls);
   };
 
   /// This class provides a single source of truth for the set of types that are

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -4,6 +4,8 @@ add_swift_unittest(SwiftASTTests
   # SWIFT_ENABLE_TENSORFLOW
   SILAutoDiffIndices.cpp
   SourceLocTests.cpp
+  # SWIFT_ENABLE_TENSORFLOW
+	TensorFlow.cpp
   TestContext.cpp
   TypeMatchTests.cpp
   VersionRangeLattice.cpp

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -5,7 +5,7 @@ add_swift_unittest(SwiftASTTests
   SILAutoDiffIndices.cpp
   SourceLocTests.cpp
   # SWIFT_ENABLE_TENSORFLOW
-	TensorFlow.cpp
+  TensorFlow.cpp
   TestContext.cpp
   TypeMatchTests.cpp
   VersionRangeLattice.cpp

--- a/unittests/AST/TensorFlow.cpp
+++ b/unittests/AST/TensorFlow.cpp
@@ -21,18 +21,81 @@
 using namespace swift;
 using namespace swift::unittest;
 
-TEST(TensorFlow, ContainsTensorValueWorks) {
-  TestContext C;
-  auto *structDecl = C.makeNominal<StructDecl>("PairedStructure");
-  structDecl->dump();
-  auto *structType = StructType::get(structDecl, Type(), C.Ctx);
-  structType->dump();
-  auto *structType2 = StructType::get(structDecl, structType, C.Ctx);
-  structType2->dump();
-  // auto* blah = ArraySliceType::get(structType);
-  // blah->dump();
-  // auto *arrayDecl = C.makeNominal<StructDecl>("Array", Type(), {structDecl});
-  // arrayDecl->dump();
-  // auto
-  EXPECT_TRUE(1 == 1);
+class TypeContainsTensorFlowValueTest : public ::testing::Test {
+protected:
+  TestContext testContext;
+  ASTContext& Ctx;
+  Type floatType;
+  BoundGenericClassType *tensorHandleType;
+  tf::TypeContainsTensorFlowValue tctf;
+
+  TypeContainsTensorFlowValueTest()
+      : Ctx(testContext.Ctx), floatType(createFloatType()),
+        tensorHandleType(createTensorHandleType(floatType)) {}
+
+  Type createStructWithField(const char *name, Type fieldType) {
+    auto *structDecl = testContext.makeNominal<StructDecl>(name);
+    structDecl->computeType();
+    auto *structType = StructType::get(structDecl, Type(), Ctx);
+    auto *varDecl = new (Ctx) VarDecl(
+        /*IsStatic*/ false, VarDecl::Specifier::Var,
+        /*IsCaptureList*/ false, SourceLoc(), Ctx.getIdentifier("field"),
+        structDecl);
+    varDecl->setInterfaceType(fieldType);
+    structDecl->addMember(varDecl);
+    return structType;
+  }
+
+  bool containsTensorFlowValue(Type t) {
+    // TODO: Add tests with CheckHigherOrderFunctions set to true.
+    return tctf.containsTensorFlowValue(t, /*CheckHigherOrderFunctions*/false);
+  }
+
+
+private:
+  Type createFloatType() {
+    // Float type.
+    auto *floatDecl = testContext.makeNominal<StructDecl>("Float");
+    return StructType::get(floatDecl, Type(), Ctx);
+  }
+
+  BoundGenericClassType *createTensorHandleType(Type genericType) {
+    auto *tensorDecl = testContext.makeNominal<ClassDecl>("TensorHandle");
+
+    // Generic parameter list.
+    auto *floatGenericParamDecl = new (Ctx)
+        GenericTypeParamDecl(tensorDecl->getDeclContext(),
+                             Ctx.getIdentifier("Scalar"), SourceLoc(), 0, 0);
+    auto *paramList = GenericParamList::create(
+        Ctx, SourceLoc(), {floatGenericParamDecl}, SourceLoc());
+    tensorDecl->setGenericParams(paramList);
+
+    return BoundGenericClassType::get(tensorDecl, Type(), {genericType});
+  }
+};
+
+TEST_F(TypeContainsTensorFlowValueTest, ClassifiesCorrectly) {
+  EXPECT_TRUE(containsTensorFlowValue(tensorHandleType));
+  EXPECT_TRUE(containsTensorFlowValue(
+      createStructWithField("StructWithTensor", tensorHandleType)));
+  EXPECT_FALSE(containsTensorFlowValue(
+      createStructWithField("StructWithNoTensor", floatType)));
+}
+
+TEST_F(TypeContainsTensorFlowValueTest, WorksForRecursiveTypes) {
+  // Creates a recursive type for testing purposes. Note that this is not a
+  // valid swift type, but should suffice for the purposes of this unit test.
+  //
+  auto *recursiveDecl = testContext.makeNominal<StructDecl>("RecursiveStruct");
+  recursiveDecl->computeType();
+  auto *recursiveType = StructType::get(recursiveDecl, Type(), Ctx);
+  // Add a field of the recursiveType.
+  // (This is not possible in swift, but ok for tests.)
+  auto *varDecl = new (Ctx) VarDecl(
+      /*IsStatic*/ false, VarDecl::Specifier::Var,
+      /*IsCaptureList*/ false, SourceLoc(), Ctx.getIdentifier("someField"),
+      recursiveDecl);
+  varDecl->setInterfaceType(recursiveType);
+  recursiveDecl->addMember(varDecl);
+  EXPECT_FALSE(containsTensorFlowValue(recursiveType));
 }

--- a/unittests/AST/TensorFlow.cpp
+++ b/unittests/AST/TensorFlow.cpp
@@ -1,0 +1,38 @@
+//===--- SILAutoDiffIndices.cpp - Tests SILAutoDiffIndices ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// SWIFT_ENABLE_TENSORFLOW
+
+#include "TestContext.h"
+#include "swift/AST/AutoDiff.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/TensorFlow.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+TEST(TensorFlow, ContainsTensorValueWorks) {
+  TestContext C;
+  auto *structDecl = C.makeNominal<StructDecl>("PairedStructure");
+  structDecl->dump();
+  auto *structType = StructType::get(structDecl, Type(), C.Ctx);
+  structType->dump();
+  auto *structType2 = StructType::get(structDecl, structType, C.Ctx);
+  structType2->dump();
+  // auto* blah = ArraySliceType::get(structType);
+  // blah->dump();
+  // auto *arrayDecl = C.makeNominal<StructDecl>("Array", Type(), {structDecl});
+  // arrayDecl->dump();
+  // auto
+  EXPECT_TRUE(1 == 1);
+}


### PR DESCRIPTION
The utility function `containsTensorFlowValue` fails with a stack overflow error when it is invoked on a recursive data structure such as [PairedStructure](https://github.com/apple/swift/blob/be17ef3d8e36e05aa0394132efc0a302fe35c28b/test/Prototypes/PatternMatching.swift#L371) struct in [Prototypes/PatternMatching.swift](https://github.com/bgogul/swift/blob/master/test/Prototypes/PatternMatching.swift) test.

This PR simply breaks cycles by keeping track of the parent decls. 
