### PR TITLE
[SR-8272] Drop the last remnants of LogicValue

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -175,7 +175,6 @@ IDENTIFIER(appendInterpolation)
 IDENTIFIER_WITH_NAME(dollarInterpolation, "$interpolation")
 IDENTIFIER(arrayLiteral)
 IDENTIFIER(dictionaryLiteral)
-IDENTIFIER_(getBuiltinLogicValue)
 IDENTIFIER(className)
 
 IDENTIFIER_(ErrorType)

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -996,7 +996,7 @@ public:
       case StmtConditionElement::CK_Boolean: {
         auto *E = elt.getBoolean();
         if (shouldVerifyChecked(E))
-          checkSameType(E->getType(), BuiltinIntegerType::get(1, Ctx),
+          checkSameType(E->getType(), Ctx.getBoolDecl()->getDeclaredType(),
                         "condition type");
         break;
       }
@@ -2070,8 +2070,8 @@ public:
       PrettyStackTraceExpr debugStack(Ctx, "verifying IfExpr", E);
 
       auto condTy = E->getCondExpr()->getType();
-      if (!condTy->isBuiltinIntegerType(1)) {
-        Out << "IfExpr condition is not an i1\n";
+      if (!condTy->isBool()) {
+        Out << "IfExpr condition is not Bool\n";
         abort();
       }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -696,9 +696,12 @@ copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
        getUnmanagedValue();
   }
 
+  assert(testBool->getType().getASTType()->isBool());
+  auto i1Value = SGF.emitUnwrapIntegerResult(loc, testBool);
+
   SILBasicBlock *contBB = SGF.B.splitBlockForFallthrough();
   auto falseBB = SGF.Cleanups.emitBlockForCleanups(getFailureDest(), loc);
-  SGF.B.createCondBranch(loc, testBool, contBB, falseBB);
+  SGF.B.createCondBranch(loc, i1Value, contBB, falseBB);
 
   SGF.B.setInsertionPoint(contBB);
 }
@@ -995,13 +998,7 @@ copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
   assert(isInit && "Only initialization is supported for refutable patterns");
 
   // Extract the i1 from the Bool struct.
-  StructDecl *BoolStruct = cast<StructDecl>(SGF.getASTContext().getBoolDecl());
-  auto Members = BoolStruct->lookupDirect(SGF.getASTContext().Id_value_);
-  assert(Members.size() == 1 &&
-         "Bool should have only one property with name '_value'");
-  auto Member = dyn_cast<VarDecl>(Members[0]);
-  assert(Member &&"Bool should have a property with name '_value' of type Int1");
-  auto *i1Val = SGF.B.createStructExtract(loc, value.forward(SGF), Member);
+  auto i1Value = SGF.emitUnwrapIntegerResult(loc, value.forward(SGF));
 
   // Branch on the boolean based on whether we're testing for true or false.
   SILBasicBlock *trueBB = SGF.B.splitBlockForFallthrough();
@@ -1010,7 +1007,7 @@ copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
 
   if (!pattern->getValue())
     std::swap(trueBB, falseBB);
-  SGF.B.createCondBranch(loc, i1Val, trueBB, falseBB);
+  SGF.B.createCondBranch(loc, i1Value, trueBB, falseBB);
   SGF.B.setInsertionPoint(contBB);
 }
 
@@ -1264,6 +1261,7 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
       // Evaluate the condition as an i1 value (guaranteed by Sema).
       FullExpr Scope(Cleanups, CleanupLocation(expr));
       booleanTestValue = emitRValue(expr).forwardAsSingleValue(*this, expr);
+      booleanTestValue = emitUnwrapIntegerResult(expr, booleanTestValue);
       booleanTestLoc = expr;
       break;
     }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -687,3 +687,19 @@ Optional<ASTNode> SILGenFunction::getPGOParent(ASTNode Node) const {
     return SP->getPGOParent(Node);
   return None;
 }
+
+SILValue SILGenFunction::emitUnwrapIntegerResult(SILLocation loc,
+                                                 SILValue value) {
+  // This is a loop because we want to handle types that wrap integer types,
+  // like ObjCBool (which may be Bool or Int8).
+  while (!value->getType().is<BuiltinIntegerType>()) {
+    auto structDecl = value->getType().getStructOrBoundGenericStruct();
+    assert(structDecl && "value for error result wasn't of struct type!");
+    assert(std::next(structDecl->getStoredProperties().begin())
+           == structDecl->getStoredProperties().end());
+    auto property = *structDecl->getStoredProperties().begin();
+    value = B.createStructExtract(loc, value, property);
+  }
+
+  return value;
+}

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1343,6 +1343,8 @@ public:
                                            SILValue semanticValue,
                                            SILType storageType);
 
+  SILValue emitUnwrapIntegerResult(SILLocation loc, SILValue value);
+  
   /// Load an r-value out of the given address. This does not handle
   /// reabstraction or bridging. If that is needed, use the other emit load
   /// entry point.

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -232,15 +232,14 @@ Condition SILGenFunction::emitCondition(Expr *E, bool invertValue,
   assert(B.hasValidInsertionPoint() &&
          "emitting condition at unreachable point");
 
-  // Sema forces conditions to have Builtin.i1 type, which guarantees this.
+  // Sema forces conditions to have Bool type, which guarantees this.
   SILValue V;
   {
     FullExpr Scope(Cleanups, CleanupLocation(E));
     V = emitRValue(E).forwardAsSingleValue(*this, E);
   }
-  assert(V->getType().castTo<BuiltinIntegerType>()->isFixedWidth(1));
-
-  return emitCondition(V, E, invertValue, contArgs, NumTrueTaken,
+  auto i1Value = emitUnwrapIntegerResult(E, V);
+  return emitCondition(i1Value, E, invertValue, contArgs, NumTrueTaken,
                        NumFalseTaken);
 }
 
@@ -525,8 +524,8 @@ void StmtEmitter::visitPoundAssertStmt(PoundAssertStmt *stmt) {
         SGF.emitRValueAsSingleValue(stmt->getCondition()).getUnmanagedValue();
   }
 
-  // Sema forces conditions to have Builtin.i1 type.
-  assert(condition->getType().castTo<BuiltinIntegerType>()->isFixedWidth(1));
+  // Extract the i1 from the Bool struct.
+  auto i1Value = SGF.emitUnwrapIntegerResult(stmt, condition);
 
   SILValue message = SGF.B.createStringLiteral(
       stmt, stmt->getMessage(), StringLiteralInst::Encoding::UTF8);
@@ -534,7 +533,7 @@ void StmtEmitter::visitPoundAssertStmt(PoundAssertStmt *stmt) {
   auto resultType = SGF.getASTContext().TheEmptyTupleType;
   SGF.B.createBuiltin(
       stmt, SGF.getASTContext().getIdentifier("poundAssert"),
-      SGF.getLoweredType(resultType), {}, {condition, message});
+      SGF.getLoweredType(resultType), {}, {i1Value, message});
 }
 
 namespace {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3313,22 +3313,6 @@ namespace {
           continue;
         }
 
-        // Strip off 'Bool' to 'Builtin.Int1' conversion. Otherwise, we'll have
-        // to handle multiple ways of type-checking.
-        if (expr->isImplicit()) {
-          if (auto call = dyn_cast<CallExpr>(expr)) {
-            if (auto DSCE = dyn_cast<DotSyntaxCallExpr>(call->getFn())) {
-              auto RefD = DSCE->getFn()->getReferencedDecl().getDecl();
-              if (RefD->getBaseName() == TC.Context.Id_getBuiltinLogicValue &&
-                  RefD->getDeclContext()->getSelfNominalTypeDecl() ==
-                      TC.Context.getBoolDecl()) {
-                expr = DSCE->getBase();
-                continue;
-              }
-            }
-          }
-        }
-
         // Remove any semantic expression injected by typechecking.
         if (auto CE = dyn_cast<CollectionExpr>(expr)) {
           CE->setSemanticExpr(nullptr);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -636,19 +636,6 @@ public:
                      bool ignoreTopLevelInjection = false,
                      Optional<Pattern*> typeFromPattern = None) const;
 
-  /// Convert the given expression to a logic value.
-  ///
-  /// This operation cannot fail.
-  ///
-  /// \param expr The expression to coerce. The type of this expression
-  /// must conform to the LogicValue protocol.
-  ///
-  /// \param locator Locator used to describe the location of this expression.
-  ///
-  /// \returns the expression converted to a logic value (Builtin i1).
-  Expr *convertBooleanTypeToBuiltinI1(Expr *expr,
-                                      ConstraintLocator *locator) const;
-
   /// Convert the given optional-producing expression to a Bool
   /// indicating whether the optional has a value.
   ///

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2699,10 +2699,9 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
 }
 
 bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
-  // If this expression is already typechecked and has an i1 type, then it has
-  // already got its conversion from Boolean back to i1.  Just re-typecheck
-  // it.
-  if (expr->getType() && expr->getType()->isBuiltinIntegerType(1)) {
+  // If this expression is already typechecked and has type Bool, then just
+  // re-typecheck it.
+  if (expr->getType() && expr->getType()->isBool()) {
     auto resultTy = typeCheckExpression(expr, dc);
     return !resultTy;
   }
@@ -2728,19 +2727,6 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
                        cs.getConstraintLocator(expr));
       return false;
     }
-
-    // Convert the result to a Builtin.i1.
-    Expr *appliedSolution(constraints::Solution &solution,
-                          Expr *expr) override {
-      auto &cs = solution.getConstraintSystem();
-
-      auto converted =
-        solution.convertBooleanTypeToBuiltinI1(expr,
-                                             cs.getConstraintLocator(OrigExpr));
-      cs.setExprTypes(converted);
-      return converted;
-    }
-    
   };
 
   ConditionListener listener;

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -170,15 +170,6 @@ extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLitera
   }
 }
 
-extension Bool {
-  // This is a magic entry point known to the compiler.
-  @_transparent
-  public // COMPILER_INTRINSIC
-  func _getBuiltinLogicValue() -> Builtin.Int1 {
-    return _value
-  }
-}
-
 extension Bool : CustomStringConvertible {
   /// A textual representation of the Boolean value.
   @inlinable

--- a/test/DebugInfo/patternmatching.swift
+++ b/test/DebugInfo/patternmatching.swift
@@ -15,9 +15,10 @@ func classifyPoint2(_ p: (Double, Double)) {
 switch p {
     case (let x, let y) where
       // CHECK:   call {{.*}}double {{.*}}return_same{{.*}}, !dbg ![[LOC1:.*]]
-      // CHECK: br {{.*}}, label {{.*}}, label {{.*}}, !dbg ![[LOC1]]
+      // CHECK: br {{.*}}, label {{.*}}, label {{.*}}, !dbg ![[LOC2:.*]]
       // CHECK: call{{.*}}markUsed{{.*}}, !dbg ![[LOC3:.*]]
-      // CHECK: ![[LOC1]] = !DILocation(line: [[@LINE+1]],
+      // CHECK: ![[LOC1]] = !DILocation(line: [[@LINE+2]],
+      // CHECK: ![[LOC2]] = !DILocation(line: [[@LINE+1]],
                         return_same(x) == return_same(y):
       // CHECK: ![[LOC3]] = !DILocation(line: [[@LINE+1]],
       markUsed(x)

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -416,7 +416,6 @@ struct Sentinel2 {}
 // CHECK-DAG: - !private ["s33ExpressibleByUnicodeScalarLiteralP", ""]
 // CHECK-DAG: - !private ["Sx", "Stride"]
 // CHECK-DAG: - !private ["Sa", "reduce"]
-// CHECK-DAG: - !private ["Sb", "_getBuiltinLogicValue"]
 // CHECK-DAG: - ["Sb", "InnerToBool"]
 // CHECK-DAG: - !private ["4main17OtherFileIntArrayV", "deinit"]
 // CHECK-DAG: - !private ["4main18OtherFileOuterTypeV", "InnerType"]

--- a/test/Parse/if_expr.swift
+++ b/test/Parse/if_expr.swift
@@ -3,13 +3,10 @@
 // CHECK: (func_decl{{.*}}"r13756261(_:_:)"
 func r13756261(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (call_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
   // CHECK:     (declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   return (x) ? y : (x) ? y : (x) ? y : y
@@ -18,13 +15,10 @@ func r13756261(_ x: Bool, _ y: Int) -> Int {
 // CHECK: (func_decl{{.*}}"r13756221(_:_:)"
 func r13756221(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (call_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
   // CHECK:     (declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   return (x) ? y
@@ -36,11 +30,8 @@ func r13756221(_ x: Bool, _ y: Int) -> Int {
 // CHECK: (func_decl{{.*}}"telescoping_if(_:_:)"
 func telescoping_if(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (call_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   // CHECK:     (declref_expr
@@ -91,11 +82,9 @@ func prec_below(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (if_expr
-  // CHECK:         (call_expr
   // CHECK:         (binary_expr
   // CHECK:         (declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (call_expr
   // CHECK:       (binary_expr
   // CHECK:       (declref_expr
   // CHECK:   (declref_expr
@@ -109,14 +98,12 @@ func prec_equal(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // CHECK: (binary_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (call_expr
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (if_expr
-  // CHECK:         (call_expr
   // CHECK:         (binary_expr
   // CHECK:           (declref_expr
   // CHECK:           (declref_expr

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -444,7 +444,7 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
     : z
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBA]]
   // CHECK:   [[A:%[0-9]+]] = load [trivial] [[READ]]
-  // CHECK:   [[ACOND:%[0-9]+]] = apply {{.*}}([[A]])
+  // CHECK:   [[ACOND:%[0-9]+]] = struct_extract [[A]] : $Bool, #Bool._value
   // CHECK:   cond_br [[ACOND]], [[IF_A:bb[0-9]+]], [[ELSE_A:bb[0-9]+]]
   // CHECK: [[IF_A]]:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
@@ -453,7 +453,7 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   // CHECK: [[ELSE_A]]:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBB]]
   // CHECK:   [[B:%[0-9]+]] = load [trivial] [[READ]]
-  // CHECK:   [[BCOND:%[0-9]+]] = apply {{.*}}([[B]])
+  // CHECK:   [[BCOND:%[0-9]+]] = struct_extract [[B]] : $Bool, #Bool._value
   // CHECK:   cond_br [[BCOND]], [[IF_B:bb[0-9]+]], [[ELSE_B:bb[0-9]+]]
   // CHECK: [[IF_B]]:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -247,7 +247,7 @@ func if_multi_where() {
   // CHECK:   br [[DONE]]
 
   // CHECK: [[CHECK_WHERE]]([[B:%[0-9]+]] : @owned $String):
-  // CHECK:   function_ref Swift.Bool._getBuiltinLogicValue() -> Builtin.Int1
+  // CHECK:   struct_extract {{.*}}
   // CHECK:   cond_br {{.*}}, [[IF_BODY:bb[0-9]+]], [[IF_EXIT3:bb[0-9]+]]
   if let a = foo(), var b = bar(), a == b {
     // CHECK: [[IF_BODY]]:
@@ -274,8 +274,7 @@ func if_leading_boolean(_ a : Int) {
   // CHECK: debug_value %0 : $Int, let, name "a"
   // CHECK: [[EQRESULT:%[0-9]+]] = apply {{.*}}(%0, %0{{.*}}) : $@convention({{.*}}) (Int, Int{{.*}}) -> Bool
 
-  // CHECK:      [[FN:%.*]] = function_ref {{.*}}
-  // CHECK-NEXT: [[EQRESULTI1:%[0-9]+]] = apply [[FN:%.*]]([[EQRESULT]]) : $@convention(method) (Bool) -> Builtin.Int1
+  // CHECK: [[EQRESULTI1:%[0-9]+]] = struct_extract {{.*}} : $Bool, #Bool._value
   // CHECK-NEXT: cond_br [[EQRESULTI1]], [[CHECKFOO:bb[0-9]+]], [[ELSE:bb[0-9]+]]
 
   // Call Foo and test for the optional being present.

--- a/test/SILGen/pound_assert.swift
+++ b/test/SILGen/pound_assert.swift
@@ -3,8 +3,7 @@
 // CHECK-LABEL: sil hidden [ossa] @$s12pound_assert15noCustomMessage{{[_0-9a-zA-Z]*}}
 func noCustomMessage() {
   #assert(true)
-  // CHECK: [[GET_LOGIC_VALUE:%.*]] = function_ref {{.*}}_getBuiltinLogicValue
-  // CHECK-NEXT: [[LOGIC_VALUE:%.*]] = apply [[GET_LOGIC_VALUE]]
+  // CHECK: [[LOGIC_VALUE:%.*]] = struct_extract {{.*}}
   // CHECK-NEXT: [[MESSAGE:%.*]] = string_literal utf8 ""
   // CHECK-NEXT: builtin "poundAssert"([[LOGIC_VALUE]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer)
 }
@@ -13,8 +12,7 @@ func noCustomMessage() {
 // CHECK-LABEL: sil hidden [ossa] @$s12pound_assert13customMessage{{[_0-9a-zA-Z]*}}
 func customMessage() {
   #assert(true, "custom message")
-  // CHECK: [[GET_LOGIC_VALUE:%.*]] = function_ref {{.*}}_getBuiltinLogicValue
-  // CHECK-NEXT: [[LOGIC_VALUE:%.*]] = apply [[GET_LOGIC_VALUE]]
+  // CHECK: [[LOGIC_VALUE:%.*]] = struct_extract {{.*}}
   // CHECK-NEXT: [[MESSAGE:%.*]] = string_literal utf8 "custom message"
   // CHECK-NEXT: builtin "poundAssert"([[LOGIC_VALUE]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer)
 }

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -335,7 +335,7 @@ func testStringForEachStmt() {
   // CHECK-LABEL: sil hidden [ossa] @$s13sil_locations21testStringForEachStmtyyF
   // CHECK: br {{.*}} line:[[@LINE-8]]:3
   // CHECK: switch_enum {{.*}} line:[[@LINE-9]]:3
-  // CHECK: cond_br {{.*}} line:[[@LINE-8]]:8
+  // CHECK: cond_br {{.*}} line:[[@LINE-8]]:10
   // Break branch:
   // CHECK: br {{.*}} line:[[@LINE-9]]:7
   // Looping back branch:
@@ -388,9 +388,9 @@ func testRepeatWhile() {
   
   // CHECK-LABEL: sil hidden [ossa] @$s13sil_locations15testRepeatWhileyyF
   // CHECK: br {{.*}} line:[[@LINE-6]]:3
-  // CHECK: cond_br {{.*}} line:[[@LINE-5]]:11
+  // CHECK: cond_br {{.*}} line:[[@LINE-5]]:14
   // Loop back branch:
-  // CHECK: br {{.*}} line:[[@LINE-7]]:11  
+  // CHECK: br {{.*}} line:[[@LINE-7]]:14
 }
 
 
@@ -408,9 +408,9 @@ func testWhile() {
   // CHECK-LABEL: sil hidden [ossa] @$s13sil_locations9testWhileyyF
   // CHECK: br {{.*}} line:[[@LINE-9]]:3
   // While loop conditional branch:
-  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:9
+  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:11
   // If stmt condition branch:
-  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:8
+  // CHECK: cond_br {{.*}} line:[[@LINE-11]]:10
   // Break branch:
   // CHECK: br {{.*}} line:[[@LINE-12]]:7
   // Looping back branch:

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -323,8 +323,7 @@ label3:
 func test_if_break(_ a : Bool) {
   // CHECK: br [[LOOP:bb[0-9]+]]
   // CHECK: [[LOOP]]:
-  // CHECK: function_ref @$sSb21_getBuiltinLogicValue{{[_0-9a-zA-Z]*}}F
-  // CHECK-NEXT: apply
+  // CHECK-NEXT: struct_extract {{.*}}
   // CHECK-NEXT: cond_br {{.*}}, [[LOOPTRUE:bb[0-9]+]], [[EXIT:bb[0-9]+]]
   while a {
     if a {
@@ -335,8 +334,7 @@ func test_if_break(_ a : Bool) {
   }
 
   // CHECK: [[LOOPTRUE]]:
-  // CHECK: function_ref @$sSb21_getBuiltinLogicValue{{[_0-9a-zA-Z]*}}F
-  // CHECK-NEXT: apply
+  // CHECK-NEXT: struct_extract {{.*}}
   // CHECK-NEXT: cond_br {{.*}}, [[IFTRUE:bb[0-9]+]], [[IFFALSE:bb[0-9]+]]
 
   // [[IFTRUE]]:
@@ -473,7 +471,7 @@ func defer_test2(_ cond : Bool) {
   callee3()
   
 // test the condition.
-// CHECK:  [[CONDTRUE:%.*]] = apply {{.*}}(%0)
+// CHECK:  [[CONDTRUE:%.*]] = struct_extract {{.*}}
 // CHECK: cond_br [[CONDTRUE]], [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
   while cond {
 // CHECK: [[BODY]]:

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -437,9 +437,6 @@ bb14(%48 : $Int32):
 }
 
 
-sil [transparent] [serialized] @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@convention(method) (Bool) -> Builtin.Int1
-
-
 sil [serialized] @_TZFsoi3eeeFTGSqPs9AnyObject__GSqPS____Sb : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
 
 


### PR DESCRIPTION
Removes the _getBuiltinLogicValue intrinsic in favor of an open-coded struct_extract in SIL.  This removes Sema's last non-literal use of builtin integer types and unblocks a bunch of cleanup.

This patch would be NFC, but it improves line information for conditional expression codegen.

Resolves [SR-8272](https://bugs.swift.org/browse/SR-8272).

Since this seems to have hit the trifecta of ABI change, compiler change, and stdlib change: lots of reviews please.  This oughta go into 5.0 as well.