### PR TITLE
Change error domains on @objc enums to ensure they're unique

### DIFF
--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -47,6 +47,7 @@ public:
   bool isPublic() const { return !Value.getPointer(); }
   bool isPrivate() const { return Value.getInt(); }
   bool isFileScope() const;
+  bool isInternal() const;
 
   /// Returns true if this is a child scope of the specified other access scope.
   ///

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -18,6 +18,7 @@
 
 namespace swift {
   class ValueDecl;
+  class EnumDecl;
   class EnumElementDecl;
 
 namespace objc_translation {
@@ -28,6 +29,8 @@ namespace objc_translation {
 
   StringRef getNameForObjC(const ValueDecl *VD,
                            CustomNamesOnly_t customNamesOnly = Normal);
+
+  std::string getErrorDomainStringForObjC(const EnumDecl *ED);
 
   /// Print the ObjC name of an enum element decl to OS, also allowing the client
   /// to specify a preferred name other than the decl's original name.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -839,6 +839,11 @@ bool AccessScope::isFileScope() const {
   return DC && isa<FileUnit>(DC);
 }
 
+bool AccessScope::isInternal() const {
+  auto DC = getDeclContext();
+  return DC && isa<ModuleDecl>(DC);
+}
+
 AccessLevel AccessScope::accessLevelForDiagnostics() const {
   if (isPublic())
     return AccessLevel::Public;

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/Basic/StringExtras.h"
@@ -49,6 +50,14 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
   }
 
   return VD->getBaseName().getIdentifier().str();
+}
+
+std::string swift::objc_translation::
+getErrorDomainStringForObjC(const EnumDecl *ED) {
+  std::string buffer = ED->getParentModule()->getNameStr();
+  buffer += ".";
+  buffer += ED->getNameStr();
+  return buffer;
 }
 
 bool swift::objc_translation::

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -2511,7 +2511,7 @@ public:
       });
       if (!hasDomainCase) {
         os << "static NSString * _Nonnull const " << getNameForObjC(ED)
-           << "Domain = @\"" << M.getName() << "." << ED->getName() << "\";\n";
+           << "Domain = @\"" << getErrorDomainStringForObjC(ED) << "\";\n";
       }
     }
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -32,7 +32,7 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {
-  //     return _typeName(self, qualified: true)
+  //     return String(reflecting: self)
   //   }
   // }
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -22,8 +22,10 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/SwiftNameTranslation.h"
 
 using namespace swift;
+using namespace swift::objc_translation;
 
 static void deriveBodyBridgedNSError_enum_nsErrorDomain(
               AbstractFunctionDecl *domainDecl, void *) {
@@ -39,10 +41,7 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
   auto TC = domainDecl->getInnermostTypeContext();
   auto ED = TC->getSelfEnumDecl();
 
-  std::string buffer = M->getNameStr();
-  buffer += ".";
-  buffer += ED->getNameStr();
-  StringRef value(C.AllocateCopy(buffer));
+  StringRef value(C.AllocateCopy(getErrorDomainStringForObjC(ED)));
 
   auto string = new (C) StringLiteralExpr(value, SourceRange(), /*implicit*/ true);
   auto ret = new (C) ReturnStmt(SourceLoc(), string, /*implicit*/ true);
@@ -57,12 +56,9 @@ deriveBridgedNSError_enum_nsErrorDomain(DerivedConformance &derived) {
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {
-  //     return "\(self)"
+  //     return "ModuleName.SomeEnum"
   //   }
   // }
-
-  // Note that for @objc enums the format is assumed to be "MyModule.SomeEnum".
-  // If this changes, please change PrintAsObjC as well.
 
   ASTContext &C = derived.TC.Context;
 

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -722,6 +722,17 @@ ErrorBridgingTests.test("Error archetype identity") {
     === nsError)
 }
 
+// SR-9389
+class ParentA: NSObject {
+  @objc(ParentAError) enum Error: Int, Swift.Error {
+    case failed
+  }
+}
+class ParentB: NSObject {
+  @objc(ParentBError) enum Error: Int, Swift.Error {
+    case failed
+  }
+}
 private class NonPrintAsObjCClass: NSObject {
   @objc enum Error: Int, Swift.Error {
     case foo
@@ -731,7 +742,22 @@ private class NonPrintAsObjCClass: NSObject {
   case bar
 }
 
-ErrorBridgingTests.test("@objc enum error domains") {
+ErrorBridgingTests.test("@objc error domains for nested types") {
+  // Domain strings should correspond to Swift types, including parent types.
+  expectEqual(ParentA.Error.failed._domain, "main.ParentA.Error")
+  expectEqual(ParentB.Error.failed._domain, "main.ParentB.Error")
+
+  func makeNSError(like error: Error) -> NSError {
+    return NSError(domain: error._domain, code: error._code)
+  }
+
+  // NSErrors corresponding to Error types with the same name but nested in
+  // different enclosing types should not be castable to the wrong error type.
+  expectTrue(makeNSError(like: ParentA.Error.failed) is ParentA.Error)
+  expectFalse(makeNSError(like: ParentA.Error.failed) is ParentB.Error)
+  expectFalse(makeNSError(like: ParentB.Error.failed) is ParentA.Error)
+  expectTrue(makeNSError(like: ParentB.Error.failed) is ParentB.Error)
+
   // If an @objc enum error is not eligible for PrintAsObjC, we should treat it
   // as though it inherited the default implementation, which calls
   // String(reflecting:).

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -722,4 +722,23 @@ ErrorBridgingTests.test("Error archetype identity") {
     === nsError)
 }
 
+private class NonPrintAsObjCClass: NSObject {
+  @objc enum Error: Int, Swift.Error {
+    case foo
+  }
+}
+@objc private enum NonPrintAsObjCError: Int, Error {
+  case bar
+}
+
+ErrorBridgingTests.test("@objc enum error domains") {
+  // If an @objc enum error is not eligible for PrintAsObjC, we should treat it
+  // as though it inherited the default implementation, which calls
+  // String(reflecting:).
+  expectEqual(NonPrintAsObjCClass.Error.foo._domain,
+              String(reflecting: NonPrintAsObjCClass.Error.self))
+  expectEqual(NonPrintAsObjCError.bar._domain,
+              String(reflecting: NonPrintAsObjCError.self))
+}
+
 runAllTests()


### PR DESCRIPTION
Consider this code:

```swift
class GithubAccount: NSObject {
  @objc(GithubSyncError) enum SyncError: Int, Error { ... }
}
class BitbucketAccount: NSObject {
  @objc(BitbucketSyncError) enum SyncError: Int, Error { ... }
}
```

Because they are @objc enums, Swift automatically derives error domain strings for these two error types of the form "ModuleName.SyncError", ignoring the fact that they are nested in different types and have different Objective-C names. That means an error created in Objective-C with `[[NSError alloc] initWithDomain:GithubSyncErrorDomain code:… userInfo:…]` can be interpreted as a `BitbucketAccount.SyncError` in Swift and vice versa.

(Thankfully, this can't happen if you cast an error created in Swift to `NSError` and then back to the other type.)

This pull request generates domain strings more robustly:

* There is now one function which both PrintAsObjC and @objc enum error derivation use to generate their error domain strings. It doesn't support all types, but it does support everything PrintAsObjC should include.
* This function now includes the parents of nested types.
* If a type is not within the subset supported by the function, the compiler will derive an implementation which calls `String(reflecting:)` on the error type at runtime.

The result is that all Swift error types (except those which have customized their error domains) should have error domain strings equal to calling `String(reflecting:)` on the type, but if there are any bugs in the algorithm, the error domain constant in the generated Objective-C header will match the one seen at runtime. Error domains for most types will not change, but error domains for nested types will; this should only matter in code which has hardcoded those domain strings instead of using the constants.

Resolves [SR-9389](https://bugs.swift.org/browse/SR-9389) and rdar://problem/46420910.