### PR TITLE
[Diagnostics] NFC: Remove redundant "because" from `witness_not_usabl…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1703,11 +1703,11 @@ ERROR(type_witness_not_accessible_type,none,
       "matches a requirement in protocol %3",
       (DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
 ERROR(witness_not_usable_from_inline,none,
-      "%0 %1 must be declared '@usableFromInline' because "
+      "%0 %1 must be declared '@usableFromInline' "
       "because it matches a requirement in protocol %2",
       (DescriptiveDeclKind, DeclName, DeclName))
 WARNING(witness_not_usable_from_inline_warn,none,
-        "%0 %1 should be declared '@usableFromInline' because "
+        "%0 %1 should be declared '@usableFromInline' "
         "because it matches a requirement in protocol %2",
         (DescriptiveDeclKind, DeclName, DeclName))
 ERROR(type_witness_objc_generic_parameter,none,

--- a/test/Compatibility/attr_usableFromInline_protocol.swift
+++ b/test/Compatibility/attr_usableFromInline_protocol.swift
@@ -7,8 +7,8 @@ public protocol PublicProtoWithReqs {
 }
 
 @usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
-// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
-// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 extension UFIAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
@@ -18,9 +18,9 @@ extension UFIAdopter {
 
 @usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
   typealias Assoc = Int
-  // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
   func foo() {}
-  // expected-warning@-1 {{instance method 'foo()' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  // expected-warning@-1 {{instance method 'foo()' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 }
 
 internal struct InternalAdopter<T> : PublicProtoWithReqs {}
@@ -36,8 +36,8 @@ extension InternalAdopter {
 }
 
 public struct PublicAdopter<T> : UFIProtoWithReqs {}
-// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
-// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
 extension PublicAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}

--- a/test/attr/attr_usableFromInline_protocol.swift
+++ b/test/attr/attr_usableFromInline_protocol.swift
@@ -7,8 +7,8 @@ public protocol PublicProtoWithReqs {
 }
 
 @usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
-// expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
-// expected-error@-2 {{instance method 'foo()' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-error@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 extension UFIAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
@@ -18,9 +18,9 @@ extension UFIAdopter {
 
 @usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
   typealias Assoc = Int
-  // expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  // expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
   func foo() {}
-  // expected-error@-1 {{instance method 'foo()' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  // expected-error@-1 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 }
 
 internal struct InternalAdopter<T> : PublicProtoWithReqs {}
@@ -36,8 +36,8 @@ extension InternalAdopter {
 }
 
 public struct PublicAdopter<T> : UFIProtoWithReqs {}
-// expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
-// expected-error@-2 {{instance method 'foo()' must be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-error@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
 extension PublicAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}


### PR DESCRIPTION
…e_from_inline`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
