### PR TITLE
Further extended the new graph mode device placement code path to support simple withDevice + collective unit tests

### DIFF
--- a/include/swift/SIL/GraphFunctionDeviceInfo.h
+++ b/include/swift/SIL/GraphFunctionDeviceInfo.h
@@ -237,32 +237,7 @@ struct GraphFunctionDeviceInfo {
 
   // Must be called after caller has scanned all graph_ops in the SIL function
   // being processed, and called markDeviceUsed() on them.
-  void finalizeUsedDevices() {
-    // This is an edge case where we've only seen ops marked ALL_DEVICE
-    // (e.g. Const). In that case, usedDeviceIds should contain the RUNTIME
-    // device.
-    if (usedDeviceIds.empty()) {
-      primaryDeviceId = RuntimeDeviceId;
-      usedDeviceIds.insert(RuntimeDeviceId);
-      return;
-    }
-
-    if (usedDeviceIds.size() == 1) {
-      if (*usedDeviceIds.begin() == RuntimeDeviceId)
-        primaryDeviceId = RuntimeDeviceId;
-      return;
-    }
-
-    // For device partitioning to work, the device set cannot include the
-    // RUNTIME device along with some other device(s). This is because we don't
-    // know what the RUNTIME device is at compile time, so we cannot create
-    // sends/recvs graph nodes.
-    for (auto deviceId : usedDeviceIds) {
-      if (deviceId == RuntimeDeviceId)
-        assert(0 && "Cannot yet handle a multi-device function involving the "
-                    "RUNTIME device");
-    }
-  }
+  void finalizeUsedDevices();
 
   // Choose a device for the graphOpInst under construction and track the chosen
   // device in `usedDeviceIds`.

--- a/lib/SIL/GraphFunctionDeviceInfo.cpp
+++ b/lib/SIL/GraphFunctionDeviceInfo.cpp
@@ -220,10 +220,7 @@ void GraphFunctionDeviceInfo::handleDevicePlacement(
 
 GraphFunctionDeviceInfo::GraphFunctionDeviceInfo(DeviceId primaryDeviceId,
                                                  bool isTPUInfeedEnabled)
-    // When `TFUseDeviceStack` is true, ignore `primaryDeviceId` provided at
-    // compile time (e.g. via compiler flag); instead use runtime device info.
-    : primaryDeviceId(TFUseDeviceStack ? RuntimeDeviceId : primaryDeviceId),
-      isTPUInfeedEnabled(isTPUInfeedEnabled) {
+    : primaryDeviceId(primaryDeviceId), isTPUInfeedEnabled(isTPUInfeedEnabled) {
   assert(primaryDeviceId != AllDeviceId);
   if (!TFUseDeviceStack)
     usedDeviceIds.insert(primaryDeviceId);

--- a/lib/SIL/GraphFunctionDeviceInfo.cpp
+++ b/lib/SIL/GraphFunctionDeviceInfo.cpp
@@ -214,13 +214,13 @@ void GraphFunctionDeviceInfo::finalizeUsedDevices() {
   usedDeviceIds.clear();
   usedDeviceIds.insert(deviceIds.begin(), deviceIds.end());
 
-  // Example scenario where the if condition below is true: we set primary
-  // device to GPU via compiler flag, but the swift function being processed
-  // here has placed all ops on CPU. In that case, we want to set primary
-  // device to CPU.
   if (!usedDeviceIds.count(primaryDeviceId)) {
-    // For now pick an arbitrary used device as the primary. For optimized
-    // placement w.r.t the function args and return values, this might tuning.
+    // Example scenario: we set primary device to GPU via compiler flag, but the
+    // swift function being processed here has placed all ops on CPU. In that
+    // case, we want to set primary device to CPU.
+    //
+    // For now pick an arbitrary device as the primary. For optimized placement
+    // w.r.t the function args and return values, this might need tuning.
     primaryDeviceId = *usedDeviceIds.begin();
   }
 }

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2740,17 +2740,7 @@ bool TFGraphLowering::lowerTFGraphOrFunction(
   auto entryFnBaseName = graphFnNameForCaller;
   unsigned helperFuncId = 0;
   SmallVector<std::pair<StringRef, SILLocation>, 1> pendingGraphFnNames;
-  // SIL functions can be processed in non-deterministic ordering, so the
-  // ordering of device ids being inserted into `deviceInfo` is not
-  // deterministic either.
-  // To make sure we produced deterministic SIL code (e.g. produce graph
-  // function for CPU, before GPU), which is useful at least for unit testing,
-  // we sort the device IDs first.
-  SmallVector<DeviceId, 8> deviceIds(deviceInfo.getUsedDeviceIds().begin(),
-                                     deviceInfo.getUsedDeviceIds().end());
-  assert(!deviceIds.empty());
-  llvm::array_pod_sort(deviceIds.begin(), deviceIds.end());
-  for (auto deviceId : deviceIds) {
+  for (auto deviceId : deviceInfo.getUsedDeviceIds()) {
     auto *perDeviceFn = partitioner.extractFunctionForDevice(deviceId);
     SWIFT_DEFER {
       // Remove the partitioned function so it doesn't go through the normal

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2748,15 +2748,9 @@ bool TFGraphLowering::lowerTFGraphOrFunction(
   // we sort the device IDs first.
   SmallVector<DeviceId, 8> deviceIds(deviceInfo.getUsedDeviceIds().begin(),
                                      deviceInfo.getUsedDeviceIds().end());
-  // TODO: unify these two code paths
-  if (TFUseDeviceStack) {
-    assert(deviceIds.size() == 1);
-    assert(deviceIds[0] == RuntimeDeviceId);
-  }
   assert(!deviceIds.empty());
   llvm::array_pod_sort(deviceIds.begin(), deviceIds.end());
-  for (auto encodeDeviceId : deviceIds) {
-    auto deviceId = encodeDeviceId;
+  for (auto deviceId : deviceIds) {
     auto *perDeviceFn = partitioner.extractFunctionForDevice(deviceId);
     SWIFT_DEFER {
       // Remove the partitioned function so it doesn't go through the normal

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2063,6 +2063,8 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
     }
   }
   hasTensorOps = !tensorOps.empty();
+  if (hasTensorOps)
+    deviceInfo.finalizeUsedDevices();
 
   // If there is nothing to do, or the ops in this function are malformed,
   // don't touch this function.

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-use-device-stack-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
@@ -61,14 +61,15 @@ CollectiveTests.testAllBackends("GroupWithSize2") {
   _hostOp(t)
   expectEqualWithScalarTensor(2, t)
 }
-#else
-CollectiveTests.testAllBackends("GroupWithSize2") {
+#endif // TF_DYNAMIC_COMPILATION
+
+CollectiveTests.testAllBackends("GroupWithSize2_threads") {
   // Need 2 or more CPU devices for this test.
   let x = Tensor<Float>(1.0)
 
   _runOnNDevices(2) { i in
     withDevice(.cpu, UInt(i)) {
-      let t = Raw.collectiveReduce(x, groupSize: 2, groupKey: 2, instanceKey: 2,
+      let t = Raw.collectiveReduce(x, groupSize: 2, groupKey: 3, instanceKey: 3,
           mergeOp: .add, finalOp: .id, subdivOffsets: [0])
 
       _hostOp(t)
@@ -76,7 +77,6 @@ CollectiveTests.testAllBackends("GroupWithSize2") {
     }
   }
 }
-#endif // TF_DYNAMIC_COMPILATION
 
 _RuntimeConfig.cpuDeviceCount = 3
 runAllTests()


### PR DESCRIPTION
(under `-Xllvm -tf-use-device-stack`) 

The main addition is the `GraphFunctionDeviceInfo::finalizeUsedDevices()` API,
which allows us to establish the following invariants in the member fields
`primaryDeviceId` and `usedDeviceIds`:

1. `usedDeviceIds` must contain `primaryDeviceId` after the `finalizeUsedDevices()` call
2. When there are >= 2 devices, `usedDeviceIds` cannot contain the RUNTIME device.

`#2` is because we don't know what the RUNTIME device is at compile time, so we
cannot create sends/recvs graph nodes in the device partioning pass.
