### PR TITLE
[predictable-mem-opts] Eliminate unused PMOUseKind.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -155,13 +155,6 @@ enum PMOUseKind {
   /// This instruction is a general escape of the value, e.g. a call to a
   /// closure that captures it.
   Escape,
-
-  /// This instruction is a call to 'super.init' in a 'self' initializer of a
-  /// derived class.
-  SuperInit,
-
-  /// This instruction is a call to 'self.init' in a delegating initializer.
-  SelfInit
 };
 
 /// This struct represents a single classified access to the memory object

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1250,9 +1250,6 @@ bool AllocOptimize::tryToRemoveDeadAllocation() {
     if (U.Inst == nullptr) continue;
 
     switch (U.Kind) {
-    case PMOUseKind::SelfInit:
-    case PMOUseKind::SuperInit:
-      llvm_unreachable("Can't happen on allocations");
     case PMOUseKind::Assign:
     case PMOUseKind::PartialStore:
     case PMOUseKind::InitOrAssign:


### PR DESCRIPTION
These are vestigal remnants of the code when it needed to support DI and
PredMemOpts. Since both of the passes have been split, these are now dead in
PMO. So eliminate them.
