### PR TITLE
[5.0] Overlays: Modernize hashing for Selector and CGFloat

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -392,6 +392,16 @@ extension CGFloat : Hashable {
   public var hashValue: Int {
     return native.hashValue
   }
+
+  /// Hashes the essential components of this value by feeding them into the
+  /// given hasher.
+  ///
+  /// - Parameter hasher: The hasher to use when combining the components
+  ///   of this instance.
+  @inlinable @_transparent
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(native)
+  }
 }
 
 % for dst_ty in all_integer_types(word_bits):

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -402,6 +402,11 @@ extension CGFloat : Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(native)
   }
+
+  @inlinable @_transparent
+  public func _rawHashValue(seed: Int) -> Int {
+    return native._rawHashValue(seed: seed)
+  }
 }
 
 % for dst_ty in all_integer_types(word_bits):

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -112,21 +112,10 @@ public struct Selector : ExpressibleByStringLiteral {
   }
 }
 
-extension Selector : Equatable, Hashable {
-  public static func ==(lhs: Selector, rhs: Selector) -> Bool {
-    return sel_isEqual(lhs, rhs)
-  }
-
-  /// The hash value.
-  ///
-  /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
-  ///
-  /// - Note: the hash value is not guaranteed to be stable across
-  ///   different invocations of the same program.  Do not persist the
-  ///   hash value across program runs.
-  public var hashValue: Int {
-    return ptr.hashValue
-  }
+extension Selector: Equatable, Hashable {
+  // Note: The implementations for `==` and `hash(into:)` are synthesized by the
+  // compiler. The generated implementations use the value of `ptr` as the basis
+  // for equality.
 }
 
 extension Selector : CustomStringConvertible {


### PR DESCRIPTION
(Cherry-picked from #20872 and #20873)

These fix two low-hanging deprecation warnings (introduced by #21445) in the overlays.

Foundation still generates a bunch of these; however, these two are particularly easy to fix, and should lead to a nice speedup, so we should just do it.

rdar://problem/43394032