### PR TITLE
[stdlib] Fix Unicode.Scalar to String cast on big endian machines

### DIFF
--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -474,6 +474,9 @@ extension Unicode.Scalar {
   ) rethrows -> Result {
     let encodedScalar = UTF8.encode(self)!
     var (codeUnits, utf8Count) = encodedScalar._bytes
+
+    // The first code unit is in the least significant byte of codeUnits.
+    codeUnits = codeUnits.littleEndian
     return try Swift.withUnsafePointer(to: &codeUnits) {
       return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
         return try body(UnsafeBufferPointer(start: $0, count: utf8Count))


### PR DESCRIPTION
We need to explicity ensure that an integer is in the required byte
order (little-endian in this case) before accessing it as an array
of bytes through an unsafe pointer.
