### PR TITLE
[5.0] Fix rename refactoring/migration issues with (1) trailing closures and (2) overridden properties

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -598,6 +598,7 @@ enum class LabelRangeEndAt: int8_t {
 struct CallArgInfo {
   Expr *ArgExp;
   CharSourceRange LabelRange;
+  bool IsTrailingClosure;
   CharSourceRange getEntireCharRange(const SourceManager &SM) const;
 };
 
@@ -605,6 +606,8 @@ std::vector<CallArgInfo>
 getCallArgInfo(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind);
 
 // Get the ranges of argument labels from an Arg, either tuple or paren.
+// This includes empty ranges for any unlabelled arguments, and excludes
+// trailing closures.
 std::vector<CharSourceRange>
 getCallArgLabelRanges(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind);
 

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1404,6 +1404,19 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
         D->walk(Removal);
       }
     }
+
+    // Handle property overriding migration.
+    if (auto *VD = dyn_cast<VarDecl>(D)) {
+      for (auto *Item: getRelatedDiffItems(VD)) {
+        if (auto *CD = dyn_cast<CommonDiffItem>(Item)) {
+          // If the overriden property has been renamed, we should rename
+          // this property decl as well.
+          if (CD->isRename() && VD->getNameLoc().isValid()) {
+            Editor.replaceToken(VD->getNameLoc(), CD->getNewName());
+          }
+        }
+      }
+    }
     return true;
   }
 };

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -531,6 +531,17 @@
   },
   {
     "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities12ToplevelTypeC8trailingyyySayypGSgcF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "trailing2(a:)",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
     "NodeKind": "TypeDecl",
     "NodeAnnotation": "Rename",
     "ChildIndex": "0",

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -539,5 +539,16 @@
     "RightUsr": "",
     "RightComment": "FontWeighting",
     "ModuleName": "Cities"
-  }
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Var",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6CitiesAAC6yogurtSivp",
+    "LeftComment": "yogurt",
+    "RightUsr": "",
+    "RightComment": "cheese",
+    "ModuleName": "Cities"
+  },
 ]

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -9,6 +9,7 @@ open class Cities {
   open func buderim() -> Cities? { return Cities(x: 1) }
   open func noosa() -> [[String : Cities]?] { return [] }
   open func maroochy(x: Int?, y: Int?) {}
+  open var yogurt: Int { return 1 }
   public struct CityKind {
     public static let Town = 1
     public static let Village = 1

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -62,6 +62,7 @@ open class ToplevelType {
   public init() {}
   public init(recordName: String) {}
   open func member(_ x: @escaping ([Any]?) -> Void) {}
+  open func trailing(_ x: @escaping ([Any]?) -> Void) {}
 }
 
 public var GlobalAttribute: String = ""

--- a/test/Migrator/rename-func-decl.swift
+++ b/test/Migrator/rename-func-decl.swift
@@ -22,3 +22,7 @@ class MySubTopLevelType2: ToplevelType {
 class SubCities: Cities {
   override var yogurt: Int { return 2 }
 }
+
+func boo(_ a: ToplevelType) {
+  a.trailing {  print($0!) }
+}

--- a/test/Migrator/rename-func-decl.swift
+++ b/test/Migrator/rename-func-decl.swift
@@ -18,3 +18,7 @@ class MySubTopLevelType: ToplevelType {
 class MySubTopLevelType2: ToplevelType {
   override func member(_ x: @escaping (((([(Any)])?))) -> Void) {}
 }
+
+class SubCities: Cities {
+  override var yogurt: Int { return 2 }
+}

--- a/test/Migrator/rename-func-decl.swift.expected
+++ b/test/Migrator/rename-func-decl.swift.expected
@@ -18,3 +18,7 @@ class MySubTopLevelType: ToplevelType {
 class MySubTopLevelType2: ToplevelType {
   override func member(_ x: @escaping (((([(Int)])?))) -> Void) {}
 }
+
+class SubCities: Cities {
+  override var cheese: Int { return 2 }
+}

--- a/test/Migrator/rename-func-decl.swift.expected
+++ b/test/Migrator/rename-func-decl.swift.expected
@@ -22,3 +22,7 @@ class MySubTopLevelType2: ToplevelType {
 class SubCities: Cities {
   override var cheese: Int { return 2 }
 }
+
+func boo(_ a: ToplevelType) {
+  a.trailing2 {  print($0!) }
+}

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/callsites/defaults.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/callsites/defaults.swift.expected
@@ -28,6 +28,10 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/callsites/trailing.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/callsites/trailing.swift.expected
@@ -28,6 +28,10 @@ func /*trailing:def*/<base>withTrailingClosure</base>(<arglabel index=0>x</argla
 /*trailing:call*/<base>withTrailingClosure</base>(<callarg index=0>x</callarg><callcolon index=0>: </callcolon>2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/callsites/trailing_only.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/callsites/trailing_only.swift.expected
@@ -28,19 +28,19 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
-func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
-/*trailing-only:call*/trailingOnly(a: {})
-/*trailing-only:call*/trailingOnly {}
+func /*trailing-only:def*/<base>trailingOnly</base>(<arglabel index=0>a</arglabel><param index=0></param>: () -> ()) {}
+/*trailing-only:call*/<base>trailingOnly</base>(<callarg index=0>a</callarg><callcolon index=0>: </callcolon>{})
+/*trailing-only:call*/<base>trailingOnly</base> {}
 
 
-func /*varargs:def*/betterName(a: Int..., b: Int, c: Int) {}
+func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 
 // valid
-/*varargs:call*/betterName(a: 1, 2, 3, b: 2, c: 4)
-/*varargs:call*/betterName(b: 2, c: 4)
+/*varargs:call*/withVarargs(x: 1, 2, 3, y: 2, 4)
+/*varargs:call*/withVarargs(y: 2, 4)
 
 // false positives
-/*varargs:call*/betterName(a: 1, b: 2, c: 4, 5)
+/*varargs:call*/withVarargs(x: 1, y: 2, 4, 5)
 
 //invalid
 /*varargs:call*/withVarargs(2, y: 2)

--- a/test/refactoring/SyntacticRename/Outputs/callsites/defaults.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/callsites/defaults.swift.expected
@@ -28,6 +28,10 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 

--- a/test/refactoring/SyntacticRename/Outputs/callsites/mixed.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/callsites/mixed.swift.expected
@@ -28,6 +28,10 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 

--- a/test/refactoring/SyntacticRename/Outputs/callsites/trailing.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/callsites/trailing.swift.expected
@@ -28,6 +28,10 @@ func /*trailing:def*/betterName(a: Int, b: () -> Int) {}
 /*trailing:call*/betterName(a: 2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 

--- a/test/refactoring/SyntacticRename/Outputs/callsites/trailing_only.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/callsites/trailing_only.swift.expected
@@ -28,19 +28,19 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
-func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
-/*trailing-only:call*/trailingOnly(a: {})
-/*trailing-only:call*/trailingOnly {}
+func /*trailing-only:def*/betterName(b: () -> ()) {}
+/*trailing-only:call*/betterName(b: {})
+/*trailing-only:call*/betterName {}
 
 
-func /*varargs:def*/betterName(a: Int..., b: Int, c: Int) {}
+func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 
 // valid
-/*varargs:call*/betterName(a: 1, 2, 3, b: 2, c: 4)
-/*varargs:call*/betterName(b: 2, c: 4)
+/*varargs:call*/withVarargs(x: 1, 2, 3, y: 2, 4)
+/*varargs:call*/withVarargs(y: 2, 4)
 
 // false positives
-/*varargs:call*/betterName(a: 1, b: 2, c: 4, 5)
+/*varargs:call*/withVarargs(x: 1, y: 2, 4, 5)
 
 //invalid
 /*varargs:call*/withVarargs(2, y: 2)

--- a/test/refactoring/SyntacticRename/Outputs/callsites/varargs2.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/callsites/varargs2.swift.expected
@@ -28,6 +28,10 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 

--- a/test/refactoring/SyntacticRename/callsites.swift
+++ b/test/refactoring/SyntacticRename/callsites.swift
@@ -28,6 +28,10 @@ func /*trailing:def*/withTrailingClosure(x: Int, y: () -> Int) {}
 /*trailing:call*/withTrailingClosure(x: 2)
 { return 1}
 
+func /*trailing-only:def*/trailingOnly(a: () -> ()) {}
+/*trailing-only:call*/trailingOnly(a: {})
+/*trailing-only:call*/trailingOnly {}
+
 
 func /*varargs:def*/withVarargs(x: Int..., y: Int, _: Int) {}
 
@@ -69,6 +73,8 @@ func /*mixed:def*/withAllOfTheAbove(x: Int = 2, _: Int..., z: Int = 2, c: () -> 
 // RUN: diff -u %S/Outputs/callsites/defaults.swift.expected %t.result/callsites_defaults.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="trailing" -is-function-like -old-name "withTrailingClosure(x:y:)" -new-name "betterName(a:b:)" >> %t.result/callsites_trailing.swift
 // RUN: diff -u %S/Outputs/callsites/trailing.swift.expected %t.result/callsites_trailing.swift
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="trailing-only" -is-function-like -old-name "trailingOnly(a:)" -new-name "betterName(b:)" >> %t.result/callsites_trailing_only.swift
+// RUN: diff -u %S/Outputs/callsites/trailing_only.swift.expected %t.result/callsites_trailing_only.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="varargs" -is-function-like -old-name "withVarargs(x:y:_:)" -new-name "betterName(a:b:c:)" >> %t.result/callsites_varargs.swift
 // RUN: diff -u %S/Outputs/callsites/varargs.swift.expected %t.result/callsites_varargs.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="varargs2" -is-function-like -old-name "withVarargs(x:y:_:)" -new-name "betterName(a:b:c:)" >> %t.result/callsites_varargs2.swift
@@ -80,3 +86,5 @@ func /*mixed:def*/withAllOfTheAbove(x: Int = 2, _: Int..., z: Int = 2, c: () -> 
 // RUN: diff -u %S/FindRangeOutputs/callsites/defaults.swift.expected %t.ranges/callsites_defaults.swift
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="trailing" -is-function-like -old-name "withTrailingClosure(x:y:)" >> %t.ranges/callsites_trailing.swift
 // RUN: diff -u %S/FindRangeOutputs/callsites/trailing.swift.expected %t.ranges/callsites_trailing.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="trailing-only" -is-function-like -old-name "trailingOnly(a:)" >> %t.ranges/callsites_trailing_only.swift
+// RUN: diff -u %S/FindRangeOutputs/callsites/trailing_only.swift.expected %t.ranges/callsites_trailing_only.swift


### PR DESCRIPTION
1) My commit fixes an issue with the rename refactoring and migrator API rename pass when renaming call sites with trailing closures.

When getting the argument labels of the call, a label range of 0 length was being reported as the label of trailing closure argument, just before the opening '{'. For the rename refactoring, this meant that if the corresponding parameter had an external argument label (e.g. 'a') the occurrence would be treated as not matching the expected existing symbol name (as trailing closure's argument label '' does not match 'a'), and so not be updated at all. This affected only call sites with a trailing closure and no other arguments due to the lenient syntactic label matching rules that assume empty labels that don't match a label in the symbol name are varargs of the previous matching argument.

For the migrator, when renaming a function to give a parameter corresponding to a trailing closure an argument label, where it previously had none, it would incorrectly insert the new label in front of the opening '{'

@nkcsgexi reviewed on master already, here: https://github.com/apple/swift/pull/21447

Resolves rdar://problem/42162571

2) Xi's commit fixes a migrator issue where property declarations that override properties from a framework weren't being updated when the framework property had been renamed.

I reviewed here, but can't add myself as reviewer.
