### PR TITLE
Eliminate an unnecessary REQUIRES executable_test line from an IRGen …

### DIFF
--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime --check-prefix=CHECK-%target-cpu
-// REQUIRES: executable_test
 
 sil_stage canonical
 


### PR DESCRIPTION
…test that just generates llvm-ir.
