### PR TITLE
[Devirtualizer] Make the getWitnessMethodSubstitutions function of Devirtualizer.cpp available to other passes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -48,6 +48,18 @@ void getAllSubclasses(ClassHierarchyAnalysis *CHA,
                       SILModule &M,
                       ClassHierarchyAnalysis::ClassList &Subs);
 
+/// Given an apply instruction of a protocol requirement and a witness method
+/// for the requirement, compute a substitution suitable for a direct call
+/// to the witness method.
+///
+/// \p Module SILModule
+/// \p AI ApplySite that applies a procotol method
+/// \p F SILFunction with convention @convention(witness_method)
+/// \p CRef a concrete ProtocolConformanceRef
+SubstitutionMap getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
+                                              SILFunction *F,
+                                              ProtocolConformanceRef CRef);
+
 /// Attempt to devirtualize the given apply site.  If this fails,
 /// the returned ApplySite will be null.
 ///

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -883,9 +883,10 @@ getWitnessMethodSubstitutions(
       witnessThunkSig);
 }
 
-static SubstitutionMap
-getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI, SILFunction *F,
-                              ProtocolConformanceRef CRef) {
+SubstitutionMap
+swift::getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
+                                     SILFunction *F,
+                                     ProtocolConformanceRef CRef) {
   auto witnessFnTy = F->getLoweredFunctionType();
   assert(witnessFnTy->getRepresentation() ==
          SILFunctionTypeRepresentation::WitnessMethod);
@@ -901,9 +902,9 @@ getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI, SILFunction *F,
       == CRef.getRequirement());
   auto *classWitness = witnessFnTy->getWitnessMethodClass(*mod);
 
-  return getWitnessMethodSubstitutions(
-      mod, CRef, requirementSig, witnessThunkSig,
-      origSubs, isDefaultWitness, classWitness);
+  return ::getWitnessMethodSubstitutions(mod, CRef, requirementSig,
+                                         witnessThunkSig, origSubs,
+                                         isDefaultWitness, classWitness);
 }
 
 /// Generate a new apply of a function_ref to replace an apply of a


### PR DESCRIPTION
This will enable the compile-time interpreter to use this functionality.