### PR TITLE
[build-preset] Add Android AArch64 preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -806,6 +806,13 @@ android-icu-i18n=%(arm_dir)s/libicui18nswift.so
 android-icu-i18n-include=%(arm_dir)s/icu/source/i18n
 android-icu-data=%(arm_dir)s/libicudataswift.so
 
+[preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,aarch64]
+mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
+
+dash-dash
+
+android-arch=aarch64
+
 # Ubuntu 18.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1804]
 mixin-preset=buildbot_linux


### PR DESCRIPTION
A preset for Android AArch64. It uses the existing Android preset as a base, and only changes the target Android architecture. The name is also copied from the Android present, adding `aarch64` at the end (even if I think that the bit `stdlib=RD` is misleading).