### PR TITLE
[5.0] Future-proof the ARM64 ABI by not reserving the entire top byte

### DIFF
--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -136,9 +136,10 @@
 /// Darwin reserves the low 4GB of address space.
 #define SWIFT_ABI_DARWIN_ARM64_LEAST_VALID_POINTER 0x100000000ULL
 
-// TBI guarantees the top byte of pointers is unused.
+// TBI guarantees the top byte of pointers is unused, but ARMv8.5-A
+// claims the bottom four bits of that for memory tagging.
 // Heap objects are eight-byte aligned.
-#define SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK 0xFF00000000000007ULL
+#define SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK 0xF000000000000007ULL
 
 // Objective-C reserves just the high bit for tagged pointers.
 #define SWIFT_ABI_ARM64_OBJC_RESERVED_BITS_MASK 0x8000000000000000ULL

--- a/test/IRGen/bridge_object_arm64.sil
+++ b/test/IRGen/bridge_object_arm64.sil
@@ -35,8 +35,8 @@ entry(%c : $C, %w : $Builtin.Word):
 // CHECK:         [[TAGGED_RESULT:%.*]] = bitcast [[BRIDGE]] %0 to [[C:%objc_object\*]]
 // CHECK:         br label %tagged-cont
 // CHECK:       not-tagged-pointer:
-// --                                                     0x00ff_ffff_ffff_fff8
-// CHECK:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 72057594037927928
+// --                                                     0x0fff_ffff_ffff_fff8
+// CHECK:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 1152921504606846968
 // CHECK:         [[MASKED_RESULT:%.*]] = inttoptr i64 [[MASKED_BITS]] to [[C]]
 // CHECK:         br label %tagged-cont
 // CHECK:      tagged-cont:

--- a/test/IRGen/enum_top_bits_reserved.sil
+++ b/test/IRGen/enum_top_bits_reserved.sil
@@ -1,0 +1,58 @@
+// RUN: %swift -module-name test -emit-ir -target arm64-apple-ios10.0 %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-arm64
+// RUN: %swift -module-name test -emit-ir -target x86_64-apple-macosx10.12 %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-x86_64
+
+class NativeClass {}
+sil_vtable NativeClass {}
+
+// On 64-bit targets, there are 3 spare bits in the alignment bits and
+// either 4 (arm64) or 8 (everywhere else) spare bits in the high byte.
+// Consume those bits one by one.
+
+enum A {
+  case either(NativeClass)
+  case or(NativeClass)
+}
+
+enum B {
+  case either(A)
+  case or(A)
+}
+
+enum C {
+  case either(B)
+  case or(B)
+}
+
+enum D {
+  case either(C)
+  case or(C)
+}
+
+enum E {
+  case either(D)
+  case or(D)
+}
+
+enum F {
+  case either(E)
+  case or(E)
+}
+
+enum G {
+  case either(F)
+  case or(F)
+}
+
+// Okay, we've claimed 7 spare bits.  On ARM64, the eighth spare bit will
+// require an extra discriminator.
+
+// CHECK-LABEL: @"$s4test1HOWV" = internal constant %swift.enum_vwtable
+// CHECK-x86_64-SAME:     i64 8,
+// CHECK-x86_64-SAME:     i64 8,
+// CHECK-arm64-SAME:      i64 9,
+// CHECK-arm64-SAME:      i64 16,
+
+enum H {
+  case either(G)
+  case or(G)
+}


### PR DESCRIPTION
Targets that want to use armv8.5a memory tagging will need this.  Hopefully nobody comes up with a brilliant reason they need to use anything else.

I considered whether to push this to other 64-bit targets and decided that it was pretty architecture-specific. If somehow x86-64 adds a similar feature, there's no reason to think it'll look exactly the same down to the range of bits it claims. (Intel is probably also less likely to be willing to sacrifice address space, whereas ARM already made that decision due to TBI.)

This is the 5.0 version of #21453, which means it is a re-submission of #21015, the 5.0 version of #21000.  It is contingent on a fix to `String` to no longer assume that that it can use the entire top 8 bits (master #21310, 5.0 #21392) and a corresponding fix to LLDB (master apple/swift-lldb#1168, 5.0 apple/swift-lldb#1169).

This is ABI-affecting.