### PR TITLE
[Runtime] Eliminate a use-after-free when comparing @objc type names.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -231,13 +231,13 @@ _findNominalTypeDescriptor(Demangle::NodePointer node,
 /// Find the context descriptor for the type extended by the given extension.
 static const ContextDescriptor *
 _findExtendedTypeContextDescriptor(const ExtensionContextDescriptor *extension,
+                                   Demangler &demangler,
                                    Demangle::NodePointer *demangledNode
                                      = nullptr) {
   Demangle::NodePointer localNode;
   Demangle::NodePointer &node = demangledNode ? *demangledNode : localNode;
 
   auto mangledName = extension->getMangledExtendedContext();
-  auto demangler = getDemanglerForRuntimeTypeResolution();
   node = demangler.demangleType(mangledName);
   if (!node)
     return nullptr;
@@ -423,7 +423,7 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
 
       Demangle::NodePointer extendedContextDemangled;
       auto extendedDescriptorFromDemangled =
-        _findExtendedTypeContextDescriptor(extension,
+        _findExtendedTypeContextDescriptor(extension, demangler,
                                            &extendedContextDemangled);
 
       // Determine whether the contexts match.
@@ -822,8 +822,10 @@ bool swift::_gatherGenericParameterCounts(
                                  std::vector<unsigned> &genericParamCounts) {
   // If we have an extension descriptor, extract the extended type and use
   // that.
+  auto demangler = getDemanglerForRuntimeTypeResolution();
   if (auto extension = dyn_cast<ExtensionContextDescriptor>(descriptor)) {
-    if (auto extendedType = _findExtendedTypeContextDescriptor(extension))
+    if (auto extendedType =
+            _findExtendedTypeContextDescriptor(extension, demangler))
       descriptor = extendedType;
   }
 

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -92,6 +92,7 @@ DemangleToMetadataTests.test("synthesized declarations") {
 }
 
 DemangleToMetadataTests.test("members of runtime-only Objective-C classes") {
+  expectNotNil(_typeByName("So17OS_dispatch_queueC8DispatchE10AttributesV"))
   expectEqual(DispatchQueue.Attributes.self,
     _typeByName("So17OS_dispatch_queueC8DispatchE10AttributesV")!)
 }


### PR DESCRIPTION
We were creating a local Demangler instance, demangling a type name
using it, and then returning one of the resulting nodes to the caller.

Fixes rdar://problem/46817009.
