### PR TITLE
Taught IRGen to support tensor-typed attributes with a scalar string as the value

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1402,6 +1402,11 @@ FUNCTION(TFC_CreateFloatTensor, swift_tfc_CreateFloatTensor, C_CC,
          ARGS(Int32Ty, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
+FUNCTION(TFC_CreateScalarStringTensor, swift_tfc_CreateScalarStringTensor, C_CC,
+         RETURNS(Int8PtrTy),
+         ARGS(Int8PtrTy, Int32Ty, Int8PtrTy),
+         ATTRS(NoUnwind))
+
 FUNCTION(TFE_Execute, swift_tfc_TFE_Execute, C_CC,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrPtrTy, Int32PtrTy, Int8PtrTy),

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(SWIFT_ENABLE_TENSORFLOW)
+  find_package(TensorFlow REQUIRED)
+  include_directories(BEFORE "${TF_INCLUDE_DIR}")
+endif()
+
 add_swift_host_library(swiftIRGen STATIC
   AllocStackHoisting.cpp
   ClassLayout.cpp

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -49,6 +49,8 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/SILVisitor.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "tensorflow/c/c_api.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
@@ -2688,9 +2690,6 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
         assert(0 && "dtype attr must have been processed!");
       }
 
-      if (attr.value.getKind() == SymbolicValue::String)
-        assert(0 && "TODO: support string typed tensor attr.");
-
       auto addScalar = [&](SymbolicValue value,
                            SmallVectorImpl<SymbolicValue> &elements) -> bool {
         value = value.lookThroughSingleElementAggregates();
@@ -2703,6 +2702,7 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
       SmallVector<SymbolicValue, 4> elements;
       bool isFloat = false;
       SmallVector<int64_t, 4> shape;
+      llvm::Value *tensor = nullptr;
       // The scalar case is very simple, the shape of a scalar is 0d, and the
       // data type comes from an attr that should already be processed.
       auto attrValue = attr.value.lookThroughSingleElementAggregates();
@@ -2712,6 +2712,14 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
         isFloat = (attrValue.getKind() == SymbolicValue::Float);
         if (addScalar(attrValue, elements))
           assert(0 && "Bad scalar value for tensor attr.");
+
+        if (attrValue.getKind() == SymbolicValue::String) {
+          auto str = attrValue.getStringValue();
+          auto strVal = IGM.getAddrOfGlobalString(str);
+          auto strLen = llvm::ConstantInt::get(IGM.Int32Ty, str.size());
+          auto *createTensorFn = IGM.getTFC_CreateScalarStringTensorFn();
+          tensor = Builder.CreateCall(createTensorFn, {strVal, strLen, status});
+        }
       } else {
         // Add all the elements to the elements list.
         CanType eltType;
@@ -2723,8 +2731,11 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
         LLVM_DEBUG(llvm::dbgs()
                    << "The elt dtype of tensor-typed attr is " << eltType
                    << ", with tfDtype = " << tfDtype << ".\n");
-        // 1 means TF_FLOAT.
-        isFloat = tfDtype == 1;
+        isFloat = tfDtype == TF_FLOAT;
+
+        // String tensors are usually to represent metadata like file names in a
+        // dataset TF op, so scalar tensor support above should be sufficient.
+        assert(tfDtype != TF_STRING && "Only support scalar string tensors.");
 
         // Decode the shape attribute which must come next.
         auto shapeAttr = i->getAttribute(nextAttributeNumber++).value;
@@ -2736,45 +2747,49 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
       // Create llvm values for elements and shape, and then call
       // swift_tfc_CreateIntTensor() or swift_tfc_CreateFloatTensor().
-      Address tensorEltVals;
-      createArrayAndSize<SymbolicValue>(
-          elements, isFloat ? IGM.FloatTy : IGM.Int64Ty, "tensorEltVals",
-          [&](SymbolicValue elt) {
-            return isFloat ? llvm::ConstantFP::get(
-                                 IGM.FloatTy,
-                                 (double)elt.getFloatValue().convertToFloat())
-                           : llvm::ConstantInt::get(IGM.Int64Ty,
-                                                    elt.getIntegerValue()
-                                                        .sextOrTrunc(64)
-                                                        .getLimitedValue());
-          },
-          tensorEltVals);
+      if (!tensor) {
+        Address tensorEltVals;
+        createArrayAndSize<SymbolicValue>(
+            elements, isFloat ? IGM.FloatTy : IGM.Int64Ty, "tensorEltVals",
+            [&](SymbolicValue elt) {
+              return isFloat ? llvm::ConstantFP::get(
+                                   IGM.FloatTy,
+                                   (double)elt.getFloatValue().convertToFloat())
+                             : llvm::ConstantInt::get(IGM.Int64Ty,
+                                                      elt.getIntegerValue()
+                                                          .sextOrTrunc(64)
+                                                          .getLimitedValue());
+            },
+            tensorEltVals);
 
-      // Create the LLVM values representing shape.
-      Address dimVals;
-      llvm::Value *numDims = createArrayAndSize<int64_t>(
-          shape, IGM.Int64Ty, "dimVals",
-          [&](int64_t elt) { return llvm::ConstantInt::get(IGM.Int64Ty, elt); },
-          dimVals);
+        // Create the LLVM values representing shape.
+        Address dimVals;
+        llvm::Value *numDims = createArrayAndSize<int64_t>(
+            shape, IGM.Int64Ty, "dimVals",
+            [&](int64_t elt) {
+              return llvm::ConstantInt::get(IGM.Int64Ty, elt);
+            },
+            dimVals);
 
-      auto dimValsUntyped =
-          Builder.CreateBitCast(dimVals.getAddress(), IGM.Int8PtrTy);
-      auto tensorEltValsUntyped =
-          Builder.CreateBitCast(tensorEltVals.getAddress(), IGM.Int8PtrTy);
-      llvm::Value *tensor = nullptr;
-      if (isFloat) {
-        auto *createTensorFn = IGM.getTFC_CreateFloatTensorFn();
-        tensor =
-            Builder.CreateCall(createTensorFn, {numDims, dimValsUntyped,
-                                                tensorEltValsUntyped, status});
-      } else {
-        auto *createTensorFn = IGM.getTFC_CreateIntTensorFn();
-        auto dtypeVal = llvm::ConstantInt::get(IGM.Int32Ty, dtypeAttr);
-        tensor = Builder.CreateCall(
-            createTensorFn,
-            {numDims, dimValsUntyped, tensorEltValsUntyped, dtypeVal, status});
+        auto dimValsUntyped =
+            Builder.CreateBitCast(dimVals.getAddress(), IGM.Int8PtrTy);
+        auto tensorEltValsUntyped =
+            Builder.CreateBitCast(tensorEltVals.getAddress(), IGM.Int8PtrTy);
+        if (isFloat) {
+          auto *createTensorFn = IGM.getTFC_CreateFloatTensorFn();
+          tensor = Builder.CreateCall(
+              createTensorFn,
+              {numDims, dimValsUntyped, tensorEltValsUntyped, status});
+        } else {
+          auto *createTensorFn = IGM.getTFC_CreateIntTensorFn();
+          auto dtypeVal = llvm::ConstantInt::get(IGM.Int32Ty, dtypeAttr);
+          tensor = Builder.CreateCall(createTensorFn,
+                                      {numDims, dimValsUntyped,
+                                       tensorEltValsUntyped, dtypeVal, status});
+        }
+        checkOk(status);
       }
-      checkOk(status);
+      assert(tensor != nullptr);
 
       // Set up the tensor-typed value attr as in:
       //   TFE_OpSetAttrTensor(op, "value", tensor, status);

--- a/stdlib/public/CTensorFlow/ctensorflow_init.h
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.h
@@ -37,6 +37,10 @@ void *swift_tfc_CreateIntTensor(int32_t num_dims, int64_t *dims, int64_t *vals,
 void *swift_tfc_CreateFloatTensor(int32_t num_dims, int64_t *dims, float *vals,
                                   TF_Status *status);
 
+// Similar to the above API, but creates a scalar string tensor.
+void *swift_tfc_CreateScalarStringTensor(char *val, int32_t valLen,
+                                         TF_Status *status);
+
 void swift_tfc_TFE_Execute(void *op, void **retvals, int32_t *num_retvals,
                            void *status);
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -404,4 +404,15 @@ DynamicAttributeTests.testAllBackends("ShapeAttribute TensorShape? nil") {
   expectEqual(t, result)
 }
 
+// A tensor typed attribute with a scalar string value  
+DynamicAttributeTests.testAllBackends("StringTensorAttribute SR-9555") {
+  func foo() {
+    _ = StringTensor("string")
+  }
+
+  withDevice(.cpu) {
+    foo()
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
string-tensor-typed attributes are usually to represent metadata like file names in a dataset TF op, so **scalar** tensor support should be sufficient.

Extending the code to also support string-tensors of arbitrary shapes would involve extending `createArrayAndSize()` and the runtime function `swift_tfc_CreateScalarStringTensor()`, which adds complexity without sufficient justification for now.

Resolves [SR-9555](https://bugs.swift.org/browse/SR-9555).