### PR TITLE
tests: get a few additional SILGen tests passing on Windows

### DIFF
--- a/test/SILGen/collection_upcast.swift
+++ b/test/SILGen/collection_upcast.swift
@@ -1,8 +1,7 @@
 
-// RUN: %target-swift-emit-silgen -module-name collection_upcast -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name collection_upcast -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
 
 import Foundation
 

--- a/test/SILGen/enum_raw_representable_objc.swift
+++ b/test/SILGen/enum_raw_representable_objc.swift
@@ -1,21 +1,28 @@
 // RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
 
+#if os(Windows) && arch(x86_64)
+@objc public enum CLike: Int32 {
+  case a, b, c
+}
+#else
 @objc public enum CLike: Int {
   case a, b, c
 }
+#endif
 
-// CHECK-LABEL: sil [serialized] [ossa] @$s27enum_raw_representable_objc5CLikeO0B5ValueACSgSi_tcfC
+// CHECK-LABEL: sil [serialized] [ossa] @$s27enum_raw_representable_objc5CLikeO0B5ValueACSg{{Si|s5Int32V}}_tcfC
 
-// CHECK-LABEL: sil [serialized] [ossa] @$s27enum_raw_representable_objc5CLikeO0B5ValueSivg
+// CHECK-LABEL: sil [serialized] [ossa] @$s27enum_raw_representable_objc5CLikeO0B5Value{{Si|s5Int32V}}vg
 // CHECK-DAG: [[RESULT_BOX:%.+]] = alloc_stack $Int
 // CHECK-DAG: [[INPUT_BOX:%.+]] = alloc_stack $CLike
-// CHECK: [[RAW_TYPE:%.+]] = metatype $@thick Int.Type
+// CHECK: [[RAW_TYPE:%.+]] = metatype $@thick Int{{(32)?}}.Type
 // CHECK: [[CAST_FUNC:%.+]] = function_ref @$ss13unsafeBitCast_2toq_x_q_mtr0_lF
-// CHECK: = apply [[CAST_FUNC]]<CLike, Int>([[RESULT_BOX]], [[INPUT_BOX]], [[RAW_TYPE]])
+// CHECK: = apply [[CAST_FUNC]]<CLike, Int{{(32)?}}>([[RESULT_BOX]], [[INPUT_BOX]], [[RAW_TYPE]])
 // CHECK: [[RESULT:%.+]] = load [trivial] [[RESULT_BOX]]
 // CHECK: return [[RESULT]]
-// CHECK: end sil function '$s27enum_raw_representable_objc5CLikeO0B5ValueSivg'
+// CHECK: end sil function '$s27enum_raw_representable_objc5CLikeO0B5Value{{Si|s5Int32V}}vg'
 
-// CHECK-RESILIENT-DAG: sil [ossa] @$s27enum_raw_representable_objc5CLikeO0B5ValueSivg
-// CHECK-RESILIENT-DAG: sil [ossa] @$s27enum_raw_representable_objc5CLikeO0B5ValueACSgSi_tcfC
+// CHECK-RESILIENT-DAG: sil [ossa] @$s27enum_raw_representable_objc5CLikeO0B5Value{{Si|s5Int32V}}vg
+// CHECK-RESILIENT-DAG: sil [ossa] @$s27enum_raw_representable_objc5CLikeO0B5ValueACSg{{Si|s5Int32V}}_tcfC
+

--- a/test/SILGen/imported_struct_array_field.swift
+++ b/test/SILGen/imported_struct_array_field.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/array_typedef.h %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/array_typedef.h %s | %FileCheck %s
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [ossa] @$sSo4NameV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (UInt8, UInt8, UInt8, UInt8, @thin Name.Type) -> Name
 func useImportedArrayTypedefInit() -> Name {

--- a/test/SILGen/lying_about_optional_return.swift
+++ b/test/SILGen/lying_about_optional_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/c_function_pointer_in_c_struct.h %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/c_function_pointer_in_c_struct.h %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden [ossa] @$s27lying_about_optional_return0C37ChainingForeignFunctionTypeProperties{{[_0-9a-zA-Z]*}}F
 func optionalChainingForeignFunctionTypeProperties(a: SomeCallbacks?) {

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -1,8 +1,8 @@
 
-// RUN: %target-swift-emit-silgen -module-name pointer_conversion -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name pointer_conversion -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -16,15 +16,17 @@ public struct PublicResilientStruct : PublicProtocol, InternalProtocol {}
 @usableFromInline
 internal struct InternalStruct : PublicProtocol, InternalProtocol {}
 
-// CHECK: sil_witness_table [serialized] PublicStruct: PublicProtocol
-// CHECK: sil_witness_table [serialized] PublicStruct: InternalProtocol
+// CHECK-DAG: sil_witness_table [serialized] PublicStruct: PublicProtocol
+// CHECK-DAG: sil_witness_table [serialized] PublicStruct: InternalProtocol
 
-// CHECK-NONRESILIENT: sil_witness_table [serialized] PublicResilientStruct: PublicProtocol
-// CHECK-NONRESILIENT: sil_witness_table [serialized] PublicResilientStruct: InternalProtocol
-// CHECK-RESILIENT: sil_witness_table PublicResilientStruct: PublicProtocol
-// CHECK-RESILIENT: sil_witness_table PublicResilientStruct: InternalProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table InternalStruct: InternalProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table InternalStruct: PublicProtocol
 
-// CHECK-NONRESILIENT: sil_witness_table [serialized] InternalStruct: PublicProtocol
-// CHECK-NONRESILIENT: sil_witness_table [serialized] InternalStruct: InternalProtocol
-// CHECK-RESILIENT: sil_witness_table InternalStruct: PublicProtocol
-// CHECK-RESILIENT: sil_witness_table InternalStruct: InternalProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: PublicProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: InternalProtocol
+
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] InternalStruct: InternalProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] InternalStruct: PublicProtocol
+
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PublicResilientStruct: PublicProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PublicResilientStruct: InternalProtocol


### PR DESCRIPTION
These emit SIL in the correct order currently, just need some adjustment for
Windows.  Improves test coverage on Windows.  Splintered from PR21371.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
