### PR TITLE
WindowsSDK: add definition for INVALID_HANDLE_VALUE

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -30,3 +30,6 @@ public let FALSE: BOOL = 0
 // minwindef.h
 public let TRUE: BOOL = 1
 
+// handleapi.h
+public let INVALID_HANDLE_VALUE: HANDLE = HANDLE(bitPattern: -1)!
+


### PR DESCRIPTION
Since handle's are so common place on Windows and the clang importer cannot
import the complex macro for INVALID_HANDLE_VALUE, define it locally to provide
an easier path to writing swift code on Windows.  This repairs the Windows
builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
