### PR TITLE
stdlib: implement _FDStreams in terms of HANDLES

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -13,6 +13,73 @@
 import Swift
 import SwiftShims
 
+#if os(Windows)
+import MSVCRT
+import WinSDK
+#endif
+
+#if os(Windows)
+public struct _FDInputStream {
+  public var handle: HANDLE = INVALID_HANDLE_VALUE
+  public var isEOF: Bool = false
+  public var isClosed: Bool { return handle == INVALID_HANDLE_VALUE }
+
+  internal var _buffer: ContiguousArray<UInt8> =
+      ContiguousArray<UInt8>(repeating: 0, count: 256)
+  internal var _offset: Int = 0
+
+  public init(handle: HANDLE) {
+    self.handle = handle
+  }
+
+  public mutating func getline() -> String? {
+    // FIXME(compnerd) Windows uses \r\n for the line delimiter, we should split
+    // on that and remove the workaround in the test harness
+    if let index =
+        _buffer[0..<_offset].firstIndex(of: UInt8(Unicode.Scalar("\n").value)) {
+      let result = String(decoding: _buffer[0..<index], as: UTF8.self)
+      _buffer.removeSubrange(0...index)
+      _offset -= index + 1
+      return result
+    }
+    if isEOF && _offset > 0 {
+      let result = String(decoding: _buffer[0..<_offset], as: UTF8.self)
+      _buffer.removeAll()
+      _offset = 0
+      return result
+    }
+    return nil
+  }
+
+  public mutating func read() {
+    var space = _buffer.count - _offset
+    if space < 128 {
+      let capacity = _buffer.count + (128 - space)
+      _buffer.reserveCapacity(capacity)
+      for _ in _buffer.count..<capacity {
+        _buffer.append(0)
+      }
+      space = 128
+    }
+    let read: Int = _buffer.withUnsafeMutableBufferPointer { buffer in
+      var read: DWORD = 0
+      ReadFile(handle, buffer.baseAddress! + _offset, DWORD(space), &read, nil)
+      return Int(read)
+    }
+    if read == 0 {
+      isEOF = true
+    } else {
+      _offset += read
+    }
+  }
+
+  public mutating func close() {
+    if isClosed { return }
+    CloseHandle(handle)
+    handle = INVALID_HANDLE_VALUE
+  }
+}
+#else
 public struct _FDInputStream {
   public let fd: CInt
   public var isClosed: Bool = false
@@ -79,6 +146,7 @@ public struct _FDInputStream {
     isClosed = true
   }
 }
+#endif
 
 public struct _Stderr : TextOutputStream {
   public init() {}
@@ -90,6 +158,37 @@ public struct _Stderr : TextOutputStream {
   }
 }
 
+#if os(Windows)
+public struct _FDOutputStream : TextOutputStream {
+  public var handle: HANDLE
+
+  public init(handle: HANDLE) {
+    self.handle = handle
+  }
+
+  public mutating func write(_ string: String) {
+    string.utf8CString.withUnsafeBufferPointer { buffer in
+      let dwLength: DWORD = DWORD(buffer.count - 1)
+      var dwOffset: DWORD = 0
+      while dwOffset < dwLength {
+        var dwBytesWritten: DWORD = 0
+        if WriteFile(handle,
+                     UnsafeRawPointer(buffer.baseAddress! + Int(dwOffset)),
+                     dwLength - dwOffset, &dwBytesWritten, nil) == FALSE {
+          fatalError("WriteFile() failed")
+        }
+        dwOffset += dwBytesWritten
+      }
+    }
+  }
+
+  public mutating func close() {
+    if handle == INVALID_HANDLE_VALUE { return }
+    CloseHandle(handle)
+    handle = INVALID_HANDLE_VALUE
+  }
+}
+#else
 public struct _FDOutputStream : TextOutputStream {
   public let fd: CInt
   public var isClosed: Bool = false
@@ -127,3 +226,4 @@ public struct _FDOutputStream : TextOutputStream {
     isClosed = true
   }
 }
+#endif


### PR DESCRIPTION
Use HANDLE on Windows to create the FDStreams.  This will be used by the
standard library unit test test harness.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
