### PR TITLE
Basic: convert UUIDs to uppercase

### DIFF
--- a/lib/Basic/UUID.cpp
+++ b/lib/Basic/UUID.cpp
@@ -23,6 +23,7 @@
 #define NOMINMAX
 #include <objbase.h>
 #include <string>
+#include <algorithm>
 #else
 #include <uuid/uuid.h>
 #endif
@@ -94,6 +95,7 @@ void swift::UUID::toString(llvm::SmallVectorImpl<char> &out) const {
 
   char* signedStr = reinterpret_cast<char*>(str);
   memcpy(out.data(), signedStr, StringBufferSize);
+  std::transform(std::begin(out), std::end(out), std::begin(out), toupper);
 #else
   uuid_unparse_upper(Value, out.data());
 #endif


### PR DESCRIPTION
Darwin does not follow the ITEF specification (RFC 4122) and emits the UUID in
uppercase and expects the emission to be uppercase.  Convert to upper case when
translating the UUID from the binary representation to the string
representation.  This repairs the SIL parsing tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
