### PR TITLE
test: make the last SIL.Parse test pass on Windows

### DIFF
--- a/test/SIL/Parser/apply_with_conformance.sil
+++ b/test/SIL/Parser/apply_with_conformance.sil
@@ -18,7 +18,7 @@ struct S {
 // test.S.foo (test.S)<A : test.P>(A) -> ()
 sil @_TFV4test1S3foofS0_US_1P__FQ_T_ : $@convention(method) <T where T : P> (@in T, S) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_TF4test3barFTVS_1SVS_1X_T_()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @_TF4test3barFTVS_1SVS_1X_T_()
 // CHECK: call
 // test.bar (test.S, test.X) -> ()
 sil [ossa] @_TF4test3barFTVS_1SVS_1X_T_ : $@convention(thin) (S, X) -> () {


### PR DESCRIPTION
With the UUID conversion, this is the last SIL.Parse test failure on Windows due
to the DLLExport annotation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
