### PR TITLE
[Type checker] Basic ambiguity resolution + diagnostics for dynamic replacement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3886,6 +3886,10 @@ ERROR(dynamic_replacement_function_not_found, none,
      "replaced function %0 could not be found", (DeclName))
 ERROR(dynamic_replacement_accessor_not_found, none,
       "replaced accessor for %0 could not be found", (DeclName))
+ERROR(dynamic_replacement_accessor_ambiguous, none,
+      "replaced accessor for %0 occurs in multiple places", (DeclName))
+NOTE(dynamic_replacement_accessor_ambiguous_candidate, none,
+      "candidate accessor found in module %0", (DeclName))
 ERROR(dynamic_replacement_function_of_type_not_found, none,
       "replaced function %0 of type %1 could not be found", (DeclName, Type))
 NOTE(dynamic_replacement_found_function_of_type, none,

--- a/test/attr/Inputs/dynamicReplacementA.swift
+++ b/test/attr/Inputs/dynamicReplacementA.swift
@@ -1,0 +1,2 @@
+public struct TheReplaceables {
+}

--- a/test/attr/Inputs/dynamicReplacementB.swift
+++ b/test/attr/Inputs/dynamicReplacementB.swift
@@ -1,0 +1,9 @@
+import A
+
+public extension TheReplaceables {
+  dynamic var property1: Int { return 0 }
+  dynamic var property2: Int { return 0 }
+
+  dynamic subscript (i: Int) -> Int { return 0 }
+  dynamic subscript (i: Int) -> String { return "" }
+}

--- a/test/attr/Inputs/dynamicReplacementC.swift
+++ b/test/attr/Inputs/dynamicReplacementC.swift
@@ -1,0 +1,9 @@
+import A
+
+public extension TheReplaceables {
+  dynamic var property1: Int { return 0 }
+  dynamic var property2: String { return "" }
+
+  dynamic subscript (i: Int) -> Int { return 0 }
+  dynamic subscript (s: String) -> String { return "" }
+}

--- a/test/attr/dynamicReplacement.swift
+++ b/test/attr/dynamicReplacement.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -enable-implicit-dynamic %S/Inputs/dynamicReplacementA.swift -o %t -module-name A
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -enable-implicit-dynamic -c %S/Inputs/dynamicReplacementB.swift -o %t -I %t -module-name B
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -enable-implicit-dynamic -c %S/Inputs/dynamicReplacementC.swift -o %t -I %t -module-name C
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-implicit-dynamic  -I %t
+import A
+import B
+import C
+
+// rdar://problem/46737657: static properties
+struct StaticProperties {
+  dynamic var property: Int { return 1 }
+  dynamic static var property: Int { return 11 }
+}
+
+extension StaticProperties {
+  @_dynamicReplacement(for: property)
+  var replacement_property: Int { return 2 }
+}
+
+// Replacements involving different types.
+extension TheReplaceables {
+  @_dynamicReplacement(for: property1) // expected-error{{replaced accessor for 'property1' occurs in multiple places}}
+  var replace_property1: Int { return 0 }
+  
+  @_dynamicReplacement(for: property2)
+  var replace_property2_int: Int { return 1 }
+  
+  @_dynamicReplacement(for: property2)
+  var replace_property2_string: String { return "replaced" }
+
+  @_dynamicReplacement(for: subscript(_:)) // expected-error{{replaced accessor for 'subscript(_:)' occurs in multiple places}}
+  subscript (int_int i: Int) -> Int { return 0 }
+
+  @_dynamicReplacement(for: subscript(_:))
+  subscript (int_string i: Int) -> String { return "" }
+
+  @_dynamicReplacement(for: subscript(_:))
+  subscript (string_string i: String) -> String { return "" }
+}


### PR DESCRIPTION
We weren't doing much validation when dynamically replacing storage
declarations, and has an assert() that should be an error. Clean up this
area a bit, dealing with simple ambiguities (i.e., there are two
properties or subscripts with different type signatures; pick the
matching one) and reporting an error when there is a true ambiguity.

Fixes rdar://problem/46737657.
