### PR TITLE
[5.0][CSDiag] Always attempt to erase open existentials after re-typecheck

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1877,7 +1877,7 @@ Expr *FailureDiagnosis::typeCheckChildIndependently(
       (isa<OverloadedDeclRefExpr>(subExpr->getValueProvidingExpr()))) {
     return subExpr;
   }
-  
+
   // Save any existing type data of the subexpr tree, and reset it to null in
   // prep for re-type-checking the tree.  If things fail, we can revert the
   // types back to their original state.
@@ -1921,9 +1921,12 @@ Expr *FailureDiagnosis::typeCheckChildIndependently(
   // holding on to an expression containing open existential types but
   // no OpenExistentialExpr, which breaks invariants enforced by the
   // ASTChecker.
-  if (isa<OpenExistentialExpr>(subExpr))
-    eraseOpenedExistentials(CS, subExpr);
-  
+  // Another reason why we need to do this is because diagnostics might pick
+  // constraint anchor for re-typechecking which would only have opaque value
+  // expression and not enclosing open existential, which is going to trip up
+  // sanitizer.
+  eraseOpenedExistentials(CS, subExpr);
+
   // If recursive type checking failed, then an error was emitted.  Return
   // null to indicate this to the caller.
   if (!resultTy)

--- a/test/Constraints/rdar46544601.swift
+++ b/test/Constraints/rdar46544601.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+
+struct D {}
+
+class Future<T> {
+  func then<U>(_ fn: @escaping (T) -> Future<U>) -> Future<U> { fatalError() }
+  func thenThrowing<U>(_ fn: @escaping (T) throws -> U) -> Future<U> { fatalError() }
+  func whenFailure(_ fn: @escaping (Error) -> Void) {}
+
+  func and<U>(result: U) -> Future<(T,U)> { fatalError() }
+}
+
+protocol P {
+  func foo(arr: [D], data: ArraySlice<UInt8>) -> Future<D>
+  // expected-note@-1 {{found this candidate}}
+  func bar(root: D, from: P) -> Future<D>
+}
+
+extension P {
+  func foo(arr: [D] = [], data: [UInt8]) -> Future<D> { fatalError() }
+  // expected-note@-1 {{found this candidate}}
+}
+
+func crash(_ p: P, payload: [UInt8]) throws {
+  p.foo(data: payload).then { _ in
+    return Future<(D, [D])>()
+  }.then { (id, arr) in
+    p.foo(arr: arr, data: []).and(result: (id, arr))
+    // expected-error@-1 {{mbiguous reference to member 'foo(arr:data:)'}}
+  }.then { args0 in
+    let (parentID, args1) = args0
+    p.bar(root: parentID, from: p).and(args1)
+  }.whenFailure { _ in }
+}


### PR DESCRIPTION
All of the open existentials should be removed, along with their
opaque value expressions, after sub-expression type-check. Because
diagnostics might pick next sub-expression from constraint and its
anchor could point to sub-expression which has only opaque value
without enclosing open existential, which is going to trip up sanitizer.

Resolves: rdar://problem/46544601
(cherry picked from commit 09cb803e792ff97a1023f6126af87b8f951c73f6)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
