### PR TITLE
[Type checker] Cope with null function/subscript types but not error types

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2068,8 +2068,8 @@ static Type getDynamicComparisonType(ValueDecl *value) {
   }
 
   auto interfaceType = value->getInterfaceType();
-  if (interfaceType->hasError())
-    return interfaceType;
+  if (!interfaceType)
+    return ErrorType::get(value->getASTContext());
 
   return interfaceType->removeArgumentLabels(numArgumentLabels);
 }


### PR DESCRIPTION
We always ensure that functions and subscripts have
appropriately-shaped interface types, so the "error" check is
unnecessary. However, if we end up in a recursive-validation case, the
interface type *might* be null. Replace a check for the former with a
check for the latter.

Thanks @slavapestov.
