### PR TITLE
[benchmark] Really Fix: random fail Benchmark_O.test.md

### DIFF
--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -163,7 +163,7 @@ MEASUREENV: ICS {{[0-9]+}} - {{[0-9]+}} = {{[0-9]+}}
 MEASUREENV: VCS {{[0-9]+}} - {{[0-9]+}} = {{[0-9]+}}
 RUNJUSTONCE-LABEL: 1,Ackermann
 RUNJUSTONCE-NOT: 1,Ackermann
-LOGFORMAT: ,{{[0-9]+}},{{[0-9]+}},,{{,|[0-9]+}},{{[0-9]+}}
+LOGFORMAT: ,{{[0-9]+}},{{[0-9]+}},,{{[0-9]*}},{{[0-9]+}}
 LOGVERBOSE-LABEL: Running AngryPhonebook
 LOGVERBOSE: Collecting 2 samples.
 ````


### PR DESCRIPTION
The first attempt at fixing this didn't work out… https://github.com/apple/swift/pull/21459#issuecomment-449503659. This fixes it for real 🤞

When the two measured samples from `Ackermann` happen to have the exact same value, the delta compression omits the number. Accept both forms.

https://bugs.swift.org/browse/SR-9544