### PR TITLE
[sourcekitd][AST] Fix CursorInfo crash on method with unresolved default value

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5101,6 +5101,14 @@ ParamDecl::getDefaultValueStringRepresentation(
     auto existing = DefaultValueAndFlags.getPointer()->StringRepresentation;
     if (!existing.empty())
       return existing;
+
+    if (!getDefaultValue()) {
+      // TypeChecker::checkDefaultArguments() nulls out the default value
+      // if it fails to type check it. This only seems to happen with an
+      // invalid/incomplete parameter list that contains a parameter with an
+      // unresolved default value.
+      return "<<empty>>";
+    }
     return extractInlinableText(getASTContext().SourceMgr, getDefaultValue(),
                                 scratch);
   }

--- a/test/SourceKit/CursorInfo/undefined-default-value.swift
+++ b/test/SourceKit/CursorInfo/undefined-default-value.swift
@@ -1,0 +1,9 @@
+enum LogLevel { case error }
+
+func logAsync(level: LogLevel = undefined, messageProducer producer
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:44 %s -- %s | %FileCheck %s
+
+// CHECK: source.lang.swift.decl.function.free (3:6-3:68)
+// CHECK: logAsync(level:messageProducer:)
+// CHECK: LogLevel</Type> = &lt;&lt;empty&gt;&gt


### PR DESCRIPTION
When printing its annotated decl, we would would assume the param's default value is present if the default value kind was "Normal". It looks like the type checker [sets the default value to nullptr](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckStmt.cpp#L1536) if it doesn't type check though, so we were crashing for that case. Added the check.

Resolves rdar://problem/46694149
Resolves https://bugs.swift.org/browse/SR-9546