### PR TITLE
Eliminate non-generic dependent types in ASD::getValueInterfaceType()

### DIFF
--- a/test/SILGen/subscript_accessor.swift
+++ b/test/SILGen/subscript_accessor.swift
@@ -18,3 +18,16 @@ func testXRead<T>(x: X<T>) -> T {
   return x[]!
 }
 // CHECK: $s18subscript_accessor1XVxSgycisTf4dn_n
+
+// Don't crash dealing with T? in a non-generic context.
+// rdar://44762116
+struct WillBeConcretelyConstrained<T> {}
+extension WillBeConcretelyConstrained where T == Int {
+  subscript(key: Int) -> T? {
+    get { return nil }
+    set {}
+  }
+}
+
+// CHECK-LABEL: sil hidden [transparent] @$s18subscript_accessor27WillBeConcretelyConstrainedVAASiRszlEySiSgSiciM
+// CHECK-SAME: $@yield_once @convention(method) (Int, @inout WillBeConcretelyConstrained<Int>) -> @yields @inout Optional<Int>


### PR DESCRIPTION
This feels like a hack.

rdar://44762116