### PR TITLE
Minor tweaks to `Differentiable` protocol.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -63,16 +63,18 @@ public protocol ShapedVectorNumeric : VectorNumeric {
 /// elements are of `Tangent` type.
 public protocol Differentiable {
   /// The tangent vector space of this differentiable manifold.
-  associatedtype TangentVector : Differentiable
-    where TangentVector.TangentVector == TangentVector
+  associatedtype TangentVector : Differentiable, VectorNumeric
+    where TangentVector.TangentVector == TangentVector,
+          TangentVector.Scalar : FloatingPoint
   /// The cotangent space of this differentiable manifold.
-  associatedtype CotangentVector : Differentiable
-    where CotangentVector.CotangentVector == CotangentVector
+  associatedtype CotangentVector : Differentiable, VectorNumeric
+    where CotangentVector.CotangentVector == CotangentVector,
+          CotangentVector.Scalar : FloatingPoint
 
   /// Returns `self` moved along the value space towards the given tangent
   /// vector. In Riemannian geometry (mathematics), this represents an
   /// exponential map.
-  func moved(toward direction: TangentVector) -> Self
+  func moved(along direction: TangentVector) -> Self
 
   /// Convert a cotangent vector to its corresponding tangent vector.
   func tangentVector(from cotangent: CotangentVector) -> TangentVector
@@ -80,7 +82,7 @@ public protocol Differentiable {
 
 public extension Differentiable
   where Self : VectorNumeric, TangentVector == Self {
-  func moved(toward direction: TangentVector) -> Self {
+  func moved(along direction: TangentVector) -> Self {
     return self + direction
   }
 }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1832,12 +1832,7 @@ extension ${Self} : Strideable {
 //===----------------------------------------------------------------------===//
 
 extension ${Self} : VectorNumeric {
-  public typealias Shape = ()
   public typealias Scalar = ${Self}
-
-  public init(repeating repeatedValue: ${Self}, shape: ()) {
-    self = repeatedValue
-  }
 }
 
 extension ${Self} : Differentiable {

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -540,15 +540,23 @@ struct JVPStruct {
   let p: Float
 }
 
+extension JVPStruct : VectorNumeric {
+  static var zero: JVPStruct { return JVPStruct(p: 0) }
+  static func + (lhs: JVPStruct, rhs: JVPStruct) -> JVPStruct {
+    return JVPStruct(p: lhs.p + rhs.p)
+  }
+  static func - (lhs: JVPStruct, rhs: JVPStruct) -> JVPStruct {
+    return JVPStruct(p: lhs.p - rhs.p)
+  }
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: JVPStruct) -> JVPStruct {
+    return JVPStruct(p: lhs * rhs.p)
+  }
+}
+
 extension JVPStruct : Differentiable {
   typealias TangentVector = JVPStruct
   typealias CotangentVector = JVPStruct
-  func moved(toward direction: JVPStruct) -> JVPStruct {
-    return JVPStruct(p: p + direction.p)
-  }
-  func tangentVector(from cotangent: JVPStruct) -> JVPStruct {
-    return cotangent
-  }
 }
 
 extension JVPStruct {
@@ -634,15 +642,23 @@ struct VJPStruct {
   let p: Float
 }
 
+extension VJPStruct : VectorNumeric {
+  static var zero: VJPStruct { return VJPStruct(p: 0) }
+  static func + (lhs: VJPStruct, rhs: VJPStruct) -> VJPStruct {
+    return VJPStruct(p: lhs.p + rhs.p)
+  }
+  static func - (lhs: VJPStruct, rhs: VJPStruct) -> VJPStruct {
+    return VJPStruct(p: lhs.p - rhs.p)
+  }
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: VJPStruct) -> VJPStruct {
+    return VJPStruct(p: lhs * rhs.p)
+  }
+}
+
 extension VJPStruct : Differentiable {
   typealias TangentVector = VJPStruct
   typealias CotangentVector = VJPStruct
-  func moved(toward direction: VJPStruct) -> VJPStruct {
-    return VJPStruct(p: p + direction.p)
-  }
-  func tangentVector(from cotangent: VJPStruct) -> VJPStruct {
-    return cotangent
-  }
 }
 
 extension VJPStruct {

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -25,10 +25,7 @@ extension DiffReq {
 
 struct Quadratic : DiffReq, Equatable {
   typealias TangentVector = Quadratic
-  typealias CoangentVector = Quadratic
-  func moved(toward q: Quadratic) -> Quadratic {
-    return Quadratic(a + q.a, b + q.b, c + q.c)
-  }
+  typealias CotangentVector = Quadratic
 
   let a, b, c: Float
   init(_ a: Float, _ b: Float, _ c: Float) {
@@ -42,13 +39,26 @@ struct Quadratic : DiffReq, Equatable {
   }
 }
 
+extension Quadratic : VectorNumeric {
+  static var zero: Quadratic { return Quadratic(0, 0, 0) }
+  static func + (lhs: Quadratic, rhs: Quadratic) -> Quadratic {
+    return Quadratic(lhs.a + rhs.a, lhs.b + rhs.b, lhs.c + rhs.c)
+  }
+  static func - (lhs: Quadratic, rhs: Quadratic) -> Quadratic {
+  return Quadratic(lhs.a + rhs.a, lhs.b + rhs.b, lhs.c + rhs.c)
+}
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: Quadratic) -> Quadratic {
+    return Quadratic(lhs * rhs.a, lhs * rhs.b, lhs * rhs.c)
+  }
+}
+
 ProtocolRequirementAutodiffTests.test("Trivial") {
   expectEqual((Quadratic(0, 0, 1), 12), Quadratic(11, 12, 13).gradF(at: 0))
   expectEqual((Quadratic(1, 1, 1), 2 * 11 + 12),
               Quadratic(11, 12, 13).gradF(at: 1))
   expectEqual((Quadratic(4, 2, 1), 2 * 11 * 2 + 12),
               Quadratic(11, 12, 13).gradF(at: 2))
-
 }
 
 runAllTests()

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -11,12 +11,15 @@ protocol Proto : Differentiable {
   func function3(_ x: Float, _ y: Float) -> Float
 }
 
-struct S : Proto {
+struct S : Proto, VectorNumeric {
+  static var zero: S { return S(p: 0) }
+  typealias Scalar = Float
+  static func + (lhs: S, rhs: S) -> S { return S(p: lhs.p + rhs.p) }
+  static func - (lhs: S, rhs: S) -> S { return S(p: lhs.p - rhs.p) }
+  static func * (lhs: Float, rhs: S) -> S { return S(p: lhs * rhs.p) }
+
   typealias TangentVector = S
   typealias CotangentVector = S
-  func moved(toward vector: TangentVector) -> S {
-    fatalError("unimplemented")
-  }
 
   let p: Float
 


### PR DESCRIPTION
- Conform `TangentVector` and `CotangentVector` to
  `VectorNumeric where Scalar : FloatingPoint`.
- Rename `moved(toward:)` to `moved(along:)`.

Also remove extraneous shape-related `VectorNumeric` requirements from
`FloatingPoint` types. Those requirements are no longer necessary now
that `ShapedVectorNumeric` has been split from `VectorNumeric`.