### PR TITLE
Split `VectorNumeric` into `ShapedVectorNumeric` protocol.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -99,6 +99,8 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   }
 }
 
+extension Tensor : ShapedVectorNumeric where Scalar : Numeric {}
+
 extension Tensor : Differentiable where Scalar : FloatingPoint {
   public typealias TangentVector = Tensor
   public typealias CotangentVector = Tensor

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -21,22 +21,10 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that represents an unranked vector space. Values of this type are
-/// elements in this vector space and with a specific shape.
+/// elements in this vector space and have either no shape or a static shape.
 public protocol VectorNumeric : AdditiveArithmetic {
   /// The type of scalars in the vector space.
   associatedtype Scalar : AdditiveArithmetic
-
-  /// The type whose values specifies the dimensionality of an object in the
-  /// vector space.
-  associatedtype Shape
-
-  /// Create an object in the vector space with the specified shape by
-  /// repeatedly filling the object with the specified scalar value.
-  ///
-  /// - Parameters:
-  ///   - shape: the shape
-  ///   - repeatedValue: the value repeat for the specified shape
-  init(repeating repeatedValue: Scalar, shape: Shape)
 
   static func * (lhs: Scalar, rhs: Self) -> Self
   static func *= (lhs: inout Self, rhs: Scalar)
@@ -50,6 +38,22 @@ public extension VectorNumeric {
   static func *= (lhs: inout Self, rhs: Scalar) {
     lhs = rhs * lhs
   }
+}
+
+/// A type that represents an unranked vector space. Values of this type are
+/// elements in this vector space and have a dynamic shape.
+public protocol ShapedVectorNumeric : VectorNumeric {
+  /// The type whose values specifies the dimensionality of an object in the
+  /// vector space.
+  associatedtype Shape
+
+  /// Create an object in the vector space with the specified shape by filling
+  /// the object with the specified scalar value.
+  ///
+  /// - Parameters:
+  ///   - shape: the shape
+  ///   - repeatedValue: the value repeat for the specified shape
+  init(repeating repeatedValue: Scalar, shape: Shape)
 }
 
 /// A type that mathematically represents a differentiable manifold whose

--- a/test/AutoDiff/generic_real_vector.swift
+++ b/test/AutoDiff/generic_real_vector.swift
@@ -7,11 +7,6 @@ public struct Vector<T> : VectorNumeric {
   public var y: T
 
   public typealias ScalarElement = T
-  public typealias Dimensionality = ()
-
-  public init(dimensionality: (), repeating repeatedValue: T) {
-    self.init(repeatedValue)
-  }
 
   public init(_ scalar: T) {
     self.x = scalar

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -13,11 +13,7 @@ public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable, Equata
   public var nonTrivialStuff = NonTrivialStuff()
   public typealias TangentVector = Vector
   public typealias Scalar = Float
-  public typealias Shape = ()
   public static var zero: Vector { return Vector(0) }
-  public init(repeating repeatedValue: Float, shape: ()) {
-    self.init(repeatedValue)
-  }
   public init(_ scalar: Float) { self.x = scalar; self.y = scalar }
   @differentiable(reverse, adjoint: fakeAdj)
   public static func + (lhs: Vector, rhs: Vector) -> Vector { abort() }

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -22,9 +22,6 @@ extension DenseLayer : Differentiable, VectorNumeric {
   static var zero: DenseLayer {
     return DenseLayer(w: 0, b: 0)
   }
-  init(repeating r: Float, shape: ()) {
-    self.init(w: r, b: r)
-  }
   static func + (lhs: DenseLayer, rhs: DenseLayer) -> DenseLayer {
     return DenseLayer(w: lhs.w + rhs.w, b: lhs.b + rhs.b)
   }
@@ -57,11 +54,6 @@ extension Model : Differentiable, VectorNumeric {
   typealias Scalar = Float
   static var zero: Model {
     return Model(l1: DenseLayer.zero, l2: DenseLayer.zero, l3: DenseLayer.zero)
-  }
-  init(repeating r: Float, shape: ()) {
-    self.init(l1: DenseLayer(repeating: r, shape: ()),
-              l2: DenseLayer(repeating: r, shape: ()),
-              l3: DenseLayer(repeating: r, shape: ()))
   }
   static func + (lhs: Model, rhs: Model) -> Model {
     return Model(l1: lhs.l1 + rhs.l1, l2: lhs.l2 + rhs.l2, l3: lhs.l3 + rhs.l3)

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -7,14 +7,9 @@ public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable {
 
   public typealias TangentVector = Vector
   public typealias Scalar = Float
-  public typealias Shape = ()
 
   public static var zero: Vector {
     return Vector(0)
-  }
-
-  public init(repeating repeatedValue: Float, shape: ()) {
-    self.init(repeatedValue)
   }
 
   public init(_ scalar: Float) {


### PR DESCRIPTION
Split `VectorNumeric` into a new `ShapedVectorNumeric` protocol that
refines `VectorNumeric`.

`VectorNumeric` now no longer defines shape-related requirements and can
be used for types with no shape or one possible static shape.
This involves scalar types and statically-shaped types like `SIMD4` and
`Matrix3x3`. Previously, these types used `()` as the `Shape` associated
type, which was semantically unclear.

`ShapedVectorNumeric` defines shape-related requirements and can used
for types with dynamic shapes. This includes `Tensor`.

These changes will simplify `VectorNumeric` derived conformances for
aggregates of non-dynamically-shaped `VectorNumeric` types. For example,
it's no longer necessary to decide what `Shape` to use for an aggregate of
scalar `VectorNumeric` types.