### PR TITLE
docs: add some notes on Windows source management

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -30,6 +30,7 @@ it provides some of the needed headers and libraries.
   installation.
 
 ### 2. Clone the repositories
+1. Configure git to work with Unix file endings
 1. Create a folder to contain all the Swift repositories
 1. Clone `apple/swift-cmark` into a folder named `cmark`
 1. Clone `apple/swift-clang` into a folder named `clang`
@@ -37,8 +38,22 @@ it provides some of the needed headers and libraries.
 1. Clone `apple/swift-compiler-rt` into a folder named `compiler-rt`
 1. Clone `apple/swift` into a folder named `swift`
 1. Clone `apple/swift-corelibs-libdispatch` into a folder named `swift-corelibs-libdispatch`
+1. Clone `apple/swift-corelibs-foundation` into a folder name `swift-corelibs-foundation`
+
 - Currently, other repositories in the Swift project have not been tested and
   may not be supported.
+
+```cmd
+git config --global core.autocrlf input
+S:
+git clone https://github.com/apple/swift-cmark cmark
+git clone https://github.com/apple/swift-clang clang
+git clone https://github.com/apple/swift-llvm llvm
+git clone https://github.com/apple/swift-compiler-rt compiler-rt
+git clone https://github.com/apple/swift
+git clone https://github.com/apple/swift-corelibs-libdispatch
+git clone https://github.com/apple/swift-corelibs-foundation
+```
 
 ### 3. Acquire ICU
 1. Download ICU from [ICU Project](http://site.icu-project.org) for Windows x64 and extract the binaries.


### PR DESCRIPTION
Windows uses CR+LF for line endings while Unix uses LF.  The tests are setup to expect Unix-style line endings.  Ensure that git does not convert between them which will result in test failures.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
