### PR TITLE
[SILGen] lower camel case on enum cases in a few tests

### DIFF
--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -174,12 +174,12 @@ func PolyOptionable_specialized_cases(_ t: Int) {
 // tuple implosion were not deallocated in enum constructors.
 struct String { var ptr: Builtin.NativeObject }
 
-enum Foo { case A(P, String) }
+enum Foo { case a(P, String) }
 
-// Curry Thunk for Foo.A(_:)
+// Curry Thunk for Foo.a(_:)
 //
-// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$ss3FooO1AyABs1P_p_SStcABmF
-// CHECK:         [[FN:%.*]] = function_ref @$ss3FooO1AyABs1P_p_SStcABmF
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$ss3FooO1ayABs1P_p_SStcABmF
+// CHECK:         [[FN:%.*]] = function_ref @$ss3FooO1ayABs1P_p_SStcABmF
 // CHECK-NEXT:    [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]](%0)
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[CANONICAL_THUNK_FN:%.*]] = function_ref @$ss1P_pSSs3FooOIegixr_sAA_pSSACIegngr_TR : $@convention(thin) (@in_guaranteed P, @guaranteed String, @guaranteed @callee_guaranteed (@in P, @owned String) -> @out Foo) -> @out Foo
@@ -187,20 +187,20 @@ enum Foo { case A(P, String) }
 // CHECK-NEXT:    return [[CANONICAL_THUNK]]
 // CHECK-NEXT:  }
 
-// Foo.A(_:)
-// CHECK-LABEL: sil shared [transparent] [ossa] @$ss3FooO1AyABs1P_p_SStcABmF
+// Foo.a(_:)
+// CHECK-LABEL: sil shared [transparent] [ossa] @$ss3FooO1ayABs1P_p_SStcABmF
 // CHECK: bb0([[ARG0:%.*]] : $*Foo, [[ARG1:%.*]] : $*P, [[ARG2:%.*]] : @owned $String, [[ARG3:%.*]] : $@thin Foo.Type):
-// CHECK:         [[PAYLOAD:%.*]] = init_enum_data_addr [[ARG0]] : $*Foo, #Foo.A!enumelt.1
+// CHECK:         [[PAYLOAD:%.*]] = init_enum_data_addr [[ARG0]] : $*Foo, #Foo.a!enumelt.1
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PAYLOAD]] : $*(P, String), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PAYLOAD]] : $*(P, String), 1
 // CHECK-NEXT:    copy_addr [take] [[ARG1]] to [initialization] [[LEFT]] : $*P
 // CHECK-NEXT:    store [[ARG2]] to [init] [[RIGHT]]
-// CHECK-NEXT:    inject_enum_addr [[ARG0]] : $*Foo, #Foo.A!enumelt.1
+// CHECK-NEXT:    inject_enum_addr [[ARG0]] : $*Foo, #Foo.a!enumelt.1
 // CHECK:         return
-// CHECK-NEXT:  } // end sil function '$ss3FooO1AyABs1P_p_SStcABmF'
+// CHECK-NEXT:  } // end sil function '$ss3FooO1ayABs1P_p_SStcABmF'
 
 func Foo_cases() {
-  _ = Foo.A
+  _ = Foo.a
 }
 
 enum Indirect<T> {

--- a/test/SILGen/enum_curry_thunks.swift
+++ b/test/SILGen/enum_curry_thunks.swift
@@ -1,51 +1,51 @@
 // RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
 enum PartialApplyEnumPayload<T, U> {
-  case Left(T)
-  case Both(T, U)
+  case left(T)
+  case both(T, U)
 
-  case LeftWithLabel(left: T)
-  case BothWithLabel(left: T, right: U)
+  case leftWithLabel(left: T)
+  case bothWithLabel(left: T, right: U)
 
-  case TupleWithLabel(both: (T, U))
+  case tupleWithLabel(both: (T, U))
 
   // Note: SILGen can emit these thunks correctly, but we disabled
   // the feature since calling the constructor directly (without a
   // thunk) doesn't work yet.
-  /* case Variadic(_: Int...)
-  case VariadicWithLabel(indices: Int...)
-  case VariadicTuple(_: (Int, Int)...)
-  case VariadicWithOther(String, _: Int...) */
+  /* case variadic(_: Int...)
+  case variadicWithLabel(indices: Int...)
+  case variadicTuple(_: (Int, Int)...)
+  case variadicWithOther(String, _: Int...) */
 
-  case Autoclosure(@autoclosure () -> ())
+  case autoclosure(@autoclosure () -> ())
 }
 
 struct S {}
 struct C {}
 
 func partialApplyEnumCases(_ x: S, y: C) {
-  _ = PartialApplyEnumPayload<S, C>.Left
-  _ = PartialApplyEnumPayload<S, C>.Both
-  _ = PartialApplyEnumPayload<S, C>.LeftWithLabel
-  _ = PartialApplyEnumPayload<S, C>.TupleWithLabel
-  /* _ = PartialApplyEnumPayload<S, C>.Variadic
-  _ = PartialApplyEnumPayload<S, C>.VariadicWithLabel
-  _ = PartialApplyEnumPayload<S, C>.VariadicTuple
-  _ = PartialApplyEnumPayload<S, C>.VariadicWithOther */
-  _ = PartialApplyEnumPayload<S, C>.Autoclosure
+  _ = PartialApplyEnumPayload<S, C>.left
+  _ = PartialApplyEnumPayload<S, C>.both
+  _ = PartialApplyEnumPayload<S, C>.leftWithLabel
+  _ = PartialApplyEnumPayload<S, C>.tupleWithLabel
+  /* _ = PartialApplyEnumPayload<S, C>.variadic
+  _ = PartialApplyEnumPayload<S, C>.variadicWithLabel
+  _ = PartialApplyEnumPayload<S, C>.variadicTuple
+  _ = PartialApplyEnumPayload<S, C>.variadicWithOther */
+  _ = PartialApplyEnumPayload<S, C>.autoclosure
 }
 
-// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4LeftyACyxq_GxcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T) -> @out PartialApplyEnumPayload<T, U> {
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4LeftyACyxq_GxcAEmr0_lF : $@convention(method) <T, U> (@in T, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4leftyACyxq_GxcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4leftyACyxq_GxcAEmr0_lF : $@convention(method) <T, U> (@in T, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
 
-// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4BothyACyxq_Gx_q_tcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out PartialApplyEnumPayload<T, U> {
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4BothyACyxq_Gx_q_tcAEmr0_lF : $@convention(method) <T, U> (@in T, @in U, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4bothyACyxq_Gx_q_tcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO4bothyACyxq_Gx_q_tcAEmr0_lF : $@convention(method) <T, U> (@in T, @in U, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
 
-// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO13LeftWithLabelyACyxq_Gx_tcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T) -> @out PartialApplyEnumPayload<T, U> {
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO13LeftWithLabelyACyxq_Gx_tcAEmr0_lF : $@convention(method) <T, U> (@in T, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO13leftWithLabelyACyxq_Gx_tcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO13leftWithLabelyACyxq_Gx_tcAEmr0_lF : $@convention(method) <T, U> (@in T, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
 
-// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO14TupleWithLabelyACyxq_Gx_q_t_tcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out PartialApplyEnumPayload<T, U> {
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO14TupleWithLabelyACyxq_Gx_q_t_tcAEmr0_lF : $@convention(method) <T, U> (@in T, @in U, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO14tupleWithLabelyACyxq_Gx_q_t_tcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO14tupleWithLabelyACyxq_Gx_q_t_tcAEmr0_lF : $@convention(method) <T, U> (@in T, @in U, @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
 
-// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO11AutoclosureyACyxq_GyyXAcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@guaranteed @callee_guaranteed () -> ()) -> @out PartialApplyEnumPayload<T, U> {
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO11AutoclosureyACyxq_GyyXAcAEmr0_lF : $@convention(method) <T, U> (@owned @callee_guaranteed () -> (), @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO11autoclosureyACyxq_GyyXAcAEmr0_lFTc : $@convention(thin) <T, U> (@thin PartialApplyEnumPayload<T, U>.Type) -> @owned @callee_guaranteed (@guaranteed @callee_guaranteed () -> ()) -> @out PartialApplyEnumPayload<T, U> {
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s17enum_curry_thunks23PartialApplyEnumPayloadO11autoclosureyACyxq_GyyXAcAEmr0_lF : $@convention(method) <T, U> (@owned @callee_guaranteed () -> (), @thin PartialApplyEnumPayload<T, U>.Type) -> @out PartialApplyEnumPayload<T, U> {

--- a/test/SILGen/enum_generic_raw_value.swift
+++ b/test/SILGen/enum_generic_raw_value.swift
@@ -2,10 +2,10 @@
 
 // CHECK-LABEL: sil hidden [ossa] @$s22enum_generic_raw_value1EO
 enum E<T>: Int {
-  case A = 1
+  case a = 1
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s22enum_generic_raw_value1FO
 enum F<T: ExpressibleByIntegerLiteral>: T where T: Equatable {
-  case A = 1
+  case a = 1
 }


### PR DESCRIPTION
Tests were using an old Swift naming convention for enum cases, now there are some fewer.

@slavapestov 