### PR TITLE
[stdlib] fixes warning: result of call to 'initialize(from:)' is unused

### DIFF
--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -76,9 +76,8 @@ extension _AbstractStringStorage {
       fallthrough
     case (_cocoaUTF8Encoding, _):
       guard maxLength >= count + 1 else { return 0 }
-      let buffer =
-        UnsafeMutableBufferPointer(start: outputPtr, count: maxLength)
-      buffer.initialize(from: UnsafeBufferPointer(start: start, count: count))
+      let buffer = UnsafeMutableBufferPointer(start: outputPtr, count: maxLength)
+      _ = buffer.initialize(from: UnsafeBufferPointer(start: start, count: count))
       buffer[count] = 0
       return 1
     default:


### PR DESCRIPTION
Fixes the following warnings:

```
+ /usr/local/bin/cmake --build <swift-source>/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64 -- -j4 all swift-test-stdlib-macosx-x86_64 swift-benchmark-macosx-x86_64
[966/1642] Generating <swift-source>/swift/macosx/x86_64/Swift.swiftmodule
<swift-source>/swift/stdlib/public/core/StringStorage.swift:81:14: warning: result of call to 'initialize(from:)' is unused
      buffer.initialize(from: UnsafeBufferPointer(start: start, count: count))
             ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and

```
[1063/1642] Compiling <swift-source>/swift/stdlib/public/core/macosx/x86_64/Swift.o
<swift-source>/swift/stdlib/public/core/StringStorage.swift:81:14: warning: result of call to 'initialize(from:)' is unused
      buffer.initialize(from: UnsafeBufferPointer(start: start, count: count))
             ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The bounds check seems alright, so it's just removing the warning.