### PR TITLE
Fix typo regarding supported FreeBSD architectures

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -212,7 +212,7 @@ macro(configure_sdk_unix name architectures)
           message(FATAL_ERROR "unknown arch for ${prefix}: ${arch}")
         endif()
       elseif("${prefix}" STREQUAL "FREEBSD")
-        if(arch STREQUAL x86_64)
+        if(NOT arch STREQUAL x86_64)
           message(FATAL_ERROR "unsupported arch for FreeBSD: ${arch}")
         endif()
 


### PR DESCRIPTION
While I'm not testing on FreeBSD, I strongly suspect that whoever added support didn't do it for every architecture besides x86_64, and that an error was made during refactoring.