### PR TITLE
Add Zip2Sequence.underestimatedCount

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -144,4 +144,12 @@ extension Zip2Sequence: Sequence {
       _sequence1.makeIterator(),
       _sequence2.makeIterator())
   }
+
+  @inlinable // generic-performance
+  public var underestimatedCount: Int {
+    return Swift.min(
+      _sequence1.underestimatedCount,
+      _sequence2.underestimatedCount
+    )
+  }
 }


### PR DESCRIPTION
Partly resolves [SR-9570](https://bugs.swift.org/browse/SR-9570).  I'll create a new PR for the other cases.