### PR TITLE
sil-opt: fix a use-after-move on Windows

### DIFF
--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -427,10 +427,10 @@ int main(int argc, char **argv) {
       llvm::errs() << EC.message() << '\n';
       return 1;
     }
-    CI.getSILModule()->setOptRecordStream(
-        llvm::make_unique<llvm::yaml::Output>(*OptRecordFile,
-                                              &CI.getSourceMgr()),
-        std::move(OptRecordFile));
+    auto Stream = llvm::make_unique<llvm::yaml::Output>(*OptRecordFile,
+                                                        &CI.getSourceMgr());
+    CI.getSILModule()->setOptRecordStream(std::move(Stream),
+                                          std::move(OptRecordFile));
   }
 
   if (OptimizationGroup == OptGroup::Diagnostics) {


### PR DESCRIPTION
The order of argument evaluation is reversed on Windows, and the move is
evaluated prior to the stream being passed.  This is resulting in the
remarks file not being prepared for use.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
