### PR TITLE
runtime: correct `_stdlib_thread_key_create`

### DIFF
--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -90,7 +90,7 @@ static_assert(std::is_same<__swift_thread_key_t, DWORD>::value,
 
 #  define SWIFT_THREAD_KEY_CREATE _stdlib_thread_key_create
 #  define SWIFT_THREAD_GETSPECIFIC FlsGetValue
-#  define SWIFT_THREAD_SETSPECIFIC(key, value) (FlsSetValue(key, value) == TRUE)
+#  define SWIFT_THREAD_SETSPECIFIC(key, value) (FlsSetValue(key, value) == FALSE)
 
 # else
 // Otherwise use the pthread API.

--- a/stdlib/public/stubs/ThreadLocalStorage.cpp
+++ b/stdlib/public/stubs/ThreadLocalStorage.cpp
@@ -43,7 +43,9 @@ static inline int
 _stdlib_thread_key_create(__swift_thread_key_t * _Nonnull key,
                           __swift_thread_key_destructor _Nullable destructor) {
   *key = FlsAlloc(destroyTLS_CCAdjustmentThunk);
-  return *key != FLS_OUT_OF_INDEXES;
+  if (*key == FLS_OUT_OF_INDEXES)
+    return GetLastError();
+  return 0;
 }
 
 #endif


### PR DESCRIPTION
The mapping of the return value of the `FlsAlloc` was flipped resulting
in the failure of the TLS key creation.  The test suite would fail to
generate the TLS key resulting in failures.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
