### PR TITLE
test: execute `round-trip-test` with the interpreter

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1282,7 +1282,9 @@ config.substitutions.append(
 config.substitutions.append(('%utils', config.swift_utils))
 config.substitutions.append(('%line-directive', '%r %s' % (sys.executable, config.line_directive)))
 config.substitutions.append(('%gyb', '%r %s' % (sys.executable, config.gyb)))
-config.substitutions.append(('%round-trip-syntax-test', config.round_trip_syntax_test))
+config.substitutions.append(('%round-trip-syntax-test',
+                             '%r %s' % (sys.executable,
+                                        config.round_trip_syntax_test)))
 config.substitutions.append(('%rth', config.rth))
 config.substitutions.append(('%scale-test',
                              '{} --swiftc-binary={} --tmpdir=%t'.format(


### PR DESCRIPTION
This is a python script that is run by tests.  However, they do not
explicitly use the interpreter.  This may result in the wrong python
interpreter being used on some systems.  On Windows this will fail to
execute since the shebang is not honoured.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
