### PR TITLE
IRGen: give non_abi LinkOnceODR linkage

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1448,13 +1448,16 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
     return {llvm::GlobalValue::ExternalLinkage, PublicDefinitionVisibility,
             ExportedStorage};
 
+  case SILLinkage::PublicNonABI:
+    return isDefinition ? RESULT(WeakODR, Hidden, Default)
+                        : RESULT(External, Hidden, Default);
+
   case SILLinkage::Shared:
   case SILLinkage::SharedExternal:
     return isDefinition ? RESULT(LinkOnceODR, Hidden, Default)
                         : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
-  case SILLinkage::PublicNonABI:
     return RESULT(External, Hidden, Default);
 
   case SILLinkage::Private: {

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -5,7 +5,7 @@ sil_stage canonical
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
-// CHECK: define hidden swiftcc void @public_non_abi_function_test() {{.*}} {
+// CHECK: define weak_odr hidden swiftcc void @public_non_abi_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {


### PR DESCRIPTION
Mark the non_abi functions as linkonce_odr.  This is needed on Windows
where the default argument generators are emitted as non-ABI functions.
These can be emitted multiple times and need to be coalesced by the
linker - that is be COMDATed as per LinkOnceODR semantics as multiple
definitions are a hard error with PE/COFF.  This would cause a problem
with `-z muldefs` on ELFish targets as well as the functions are
multiply emitted strongly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
