### PR TITLE
[SourceKit] Add SwiftLang API to parse a file into a byte tree

### DIFF
--- a/tools/SourceKit/tools/swift-lang/SwiftLang.swift
+++ b/tools/SourceKit/tools/swift-lang/SwiftLang.swift
@@ -28,33 +28,101 @@ enum SourceKitdError: Error, CustomStringConvertible {
   }
 }
 
-public class SwiftLang {
-  private static let syntaxTreeKey = SourceKitdUID.key_SerializedSyntaxTree
+// MARK: Public APIs
 
-  fileprivate struct SourceFile {
-    let name: String
-    let contentKey: SourceKitdUID
-    let contentValue: String
+public enum SwiftLang {
+  /// Synchronously parses Swift source code into a syntax tree.
+  ///
+  /// - Parameter url: A file URL pointing to a Swift source file.
+  /// - Parameter format: The format to use for the returned syntax tree.
+  /// - Returns: The syntax tree in the indicated format.
+  /// - Throws: If SourceKit responds to the request with an error. This is
+  ///           usually a communication or configuration error, not a
+  ///           syntax error in the code being parsed.
+  /// - Precondition: `url` must be a file URL.
+  public static func parse<Tree>(
+    contentsOf url: URL, into format: SyntaxTreeFormat<Tree>
+  ) throws -> Tree {
+    precondition(url.isFileURL, "Can only parse files at file URLs")
+    return try parse(SourceFile(path: url.path), into: format)
+  }
+}
 
-    static func path(_ path: String) -> SourceFile {
-      return SourceFile(
-        name: path,
-        contentKey: .key_SourceFile,
-        contentValue: path
-      )
-    }
+extension SwiftLang.SyntaxTreeFormat {
+  /// Return the syntax tree serialized in JSON format. JSON is easy to inspect
+  /// and test with but very inefficient to deserialize. Use it for testing and
+  /// debugging.
+  public static var json: SwiftLang.SyntaxTreeFormat<Data> {
+    return jsonString.withTreeMapped { $0.data(using: .utf8)! }
+  }
 
-    static func source(_ source: String) -> SourceFile {
-      return SourceFile(
-        name: "foo",
-        contentKey: .key_SourceText,
-        contentValue: source
-      )
+  /// Return the syntax tree serialized as ByteTree. ByteTree is fast and
+  /// compact but difficult to inspect or manipulate with textual tools.
+  /// It's recommended in production.
+  public static var byteTree: SwiftLang.SyntaxTreeFormat<Data> {
+    return .init(kind: .kind_SyntaxTreeSerializationByteTree) { dict in
+      dict.getData(syntaxTreeKey)
     }
   }
 
+  /// Creates a new `SyntaxTreeFormat` instance which converts the tree of an
+  /// existing format.
+  ///
+  /// You can use this method to add new `SyntaxTreeFormat`s; simply declare a
+  /// new static constant in an extension of `SyntaxTreeFormat` which maps one
+  /// of the existing formats.
+  ///
+  /// - Parameter transform: A function which converts `self`'s Tree type to
+  ///             the result type's Tree type.
+  /// - Returns: A new format which creates a tree in `self`'s format, then
+  ///            applies `transform` to the tree to convert it.
+  public func withTreeMapped<NewTree>(
+    by transform: @escaping (Tree) throws -> NewTree
+  ) -> SwiftLang.SyntaxTreeFormat<NewTree> {
+    return .init(kind: kind) { [makeTree] dict in
+      try transform(makeTree(dict))
+    }
+  }
+}
+
+// MARK: Deprecated APIs
+
+extension SwiftLang {
+  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
+  /// serialization format by querying SourceKitd service. This function isn't
+  /// thread safe.
+  /// - Parameter path: The URL you wish to parse.
+  /// - Returns: The syntax tree in Json format string.
+  @available(swift, deprecated: 5.0, renamed: "parse(_:into:)")
+  public static func parse(path: String) throws -> String {
+    return try parse(SourceFile(path: path), into: .jsonString)
+  }
+
+  /// Parses a given source buffer into a `Syntax` tree in Json serialization
+  /// format by querying SourceKitd service. This function isn't thread safe.
+  /// - Parameter source: The source buffer you wish to parse.
+  /// - Returns: The syntax tree in Json format string.
+  @available(swift, deprecated: 5.0, message: "use parse(_:into:) with a file instead")
+  public static func parse(source: String) throws -> String {
+    let content = SourceFile(
+      name: "foo", contentKey: .key_SourceText, contentValue: source
+    )
+    return try parse(content, into: .jsonString)
+  }
+}
+
+// MARK: Internals
+
+extension SwiftLang {
   /// The format to serialize the syntax tree in.
   public struct SyntaxTreeFormat<Tree> {
+    /// Value for EditorOpen's key_SyntaxTreeSerializationFormat key.
+    fileprivate let kind: SourceKitdUID
+
+    /// Extracts the syntax tree from the response dictionary and converts it
+    /// into a value of type Tree.
+    fileprivate let makeTree: (SourceKitdResponse.Dictionary) throws -> Tree
+
     /// Serialize the syntax tree into a JSON string. For backwards
     /// compatibility only.
     fileprivate static var jsonString: SyntaxTreeFormat<String> {
@@ -62,52 +130,19 @@ public class SwiftLang {
         dict.getString(syntaxTreeKey)
       }
     }
+  }
+}
 
-    /// Return the syntax tree as JSON. The JSON serialization is more
-    /// human-readable but less efficient to deserialize.
-    public static var json: SyntaxTreeFormat<Data> {
-      return jsonString.withTreeMapped { $0.data(using: .utf8)! }
-    }
-
-    /// Return the syntax tree as ByteTree. The ByteTree serialization is fast
-    /// and compact but difficult to inspect.
-    public static var byteTree: SyntaxTreeFormat<Data> {
-      return .init(kind: .kind_SyntaxTreeSerializationByteTree) { dict in
-        dict.getData(syntaxTreeKey)
-      }
-    }
-
-    /// Value for EditorOpen's key_SyntaxTreeSerializationFormat key.
-    let kind: SourceKitdUID
-
-    /// Extracts the syntax tree from the response dictionary and converts it
-    /// into a value of type Tree.
-    let makeTree: (SourceKitdResponse.Dictionary) throws -> Tree
-
-    /// Creates a new `SyntaxTreeFormat` instance which converts the tree of an
-    /// existing format.
-    ///
-    /// You can use this method to add new `SyntaxTreeFormat`s; simply declare a
-    /// new static constant in an extension of `SyntaxTreeFormat` which maps one
-    /// of the existing formats.
-    ///
-    /// - Parameter transform: A function which converts `self`'s Tree type to
-    ///             the result type's Tree type.
-    /// - Returns: A new format which creates a tree in `self`'s format, then
-    ///            applies `transform` to the tree to convert it.
-    public func withTreeMapped<NewTree>(
-      by transform: @escaping (Tree) throws -> NewTree
-    ) -> SyntaxTreeFormat<NewTree> {
-      return .init(kind: kind) { [makeTree] dict in
-        try transform(makeTree(dict))
-      }
-    }
+extension SwiftLang {
+  fileprivate struct SourceFile {
+    let name: String
+    let contentKey: SourceKitdUID
+    let contentValue: String
   }
 
   /// Parses the SourceFile in question using the provided serialization format.
   fileprivate static func parse<Tree>(
-    _ content: SourceFile,
-    into serialization: SyntaxTreeFormat<Tree>
+    _ content: SourceFile, into format: SyntaxTreeFormat<Tree>
   ) throws -> Tree {
     let Service = SourceKitdService()
     let Request = SourceKitdRequest(uid: .request_EditorOpen)
@@ -118,7 +153,7 @@ public class SwiftLang {
     Request.addParameter(.key_SyntaxTreeTransferMode,
                          value: .kind_SyntaxTreeFull)
     Request.addParameter(.key_SyntaxTreeSerializationFormat,
-                         value: serialization.kind)
+                         value: format.kind)
     Request.addParameter(.key_EnableSyntaxMap, value: 0)
     Request.addParameter(.key_EnableStructure, value: 0)
     Request.addParameter(.key_SyntacticOnly, value: 1)
@@ -135,45 +170,14 @@ public class SwiftLang {
     if CloseResp.isError {
       throw SourceKitdError.EditorCloseError(message: CloseResp.description)
     }
-    return try serialization.makeTree(Resp.value)
-  }
-
-  /// Synchronously parses Swift source code into a syntax tree serialized in
-  /// the indicated format.
-  ///
-  /// - Parameter url: A file URL pointing to a Swift source file.
-  /// - Parameter serialization: The serialization format to use for the syntax
-  ///   tree.
-  /// - Returns: The syntax tree in the indicated serialization format.
-  /// - Throws: If SourceKit responds to the request with an error. This is
-  ///           usually a communication or configuration error, not a
-  ///           syntax error in the code being parsed.
-  /// - Precondition: `url` must be a file URL.
-  public static func parse<Tree>(
-    contentsOf url: URL, into serialization: SyntaxTreeFormat<Tree>
-  ) throws -> Tree {
-    precondition(url.isFileURL, "Can only parse files at file URLs")
-    return try parse(.path(url.path), into: serialization)
+    return try format.makeTree(Resp.value)
   }
 }
 
-extension SwiftLang {
-  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
-  /// serialization format by querying SourceKitd service. This function isn't
-  /// thread safe.
-  /// - Parameter path: The URL you wish to parse.
-  /// - Returns: The syntax tree in Json format string.
-  @available(swift, deprecated: 5.0, renamed: "parse(_:into:)")
-  public static func parse(path: String) throws -> String {
-    return try parse(.path(path), into: .jsonString)
-  }
-
-  /// Parses a given source buffer into a `Syntax` tree in Json serialization
-  /// format by querying SourceKitd service. This function isn't thread safe.
-  /// - Parameter source: The source buffer you wish to parse.
-  /// - Returns: The syntax tree in Json format string.
-  @available(swift, deprecated: 5.0, message: "Use parse(_:into:) with a file instead")
-  public static func parse(source: String) throws -> String {
-    return try parse(.source(source), into: .jsonString)
+extension SwiftLang.SourceFile {
+  init(path: String) {
+    self.init(name: path, contentKey: .key_SourceFile, contentValue: path)
   }
 }
+
+private let syntaxTreeKey = SourceKitdUID.key_SerializedSyntaxTree


### PR DESCRIPTION
This is a redesign of `SwiftLang.parse` to accommodate a format parameter so that it doesn't always use JSON. The format is specified by an instance of `SwiftLang.SyntaxTreeFormat`, which is designed to be extended (as apple/swift-stress-tester#27 does to add a `swiftSyntax` format).

The old APIs are still available, but are now deprecated.

To do:

- [x] Check on the state of byte tree support in SwiftLang and SwiftSyntax.
- [x] Design something more elegant than `SwiftLang.parseByteTree(path:)` (I mean, come on).
- [x] Add tests similar to whatever we have for `SwiftLang.parse`.
- [x] Review by someone on SourceKit.