### PR TITLE
[ParameterUpdate] Clean up ParameterGroup/Parameterized synthesis.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3020,12 +3020,9 @@ bool NominalTypeDecl::isOptionalDecl() const {
 // SWIFT_ENABLE_TENSORFLOW
 void
 NominalTypeDecl::getAllTFParameters(SmallVectorImpl<VarDecl *> &result) const {
-  for (auto member : getMembers()) {
-    auto varDecl = dyn_cast<VarDecl>(member);
-    if (!varDecl) continue;
-    if (varDecl->getAttrs().hasAttribute<TFParameterAttr>())
-      result.push_back(varDecl);
-  }
+  for (auto member : getStoredProperties())
+    if (member->getAttrs().hasAttribute<TFParameterAttr>())
+      result.push_back(member);
 }
 
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,

--- a/lib/Sema/DerivedConformanceParameterized.cpp
+++ b/lib/Sema/DerivedConformanceParameterized.cpp
@@ -162,7 +162,7 @@ static void derivedBody_allParametersGetter(AbstractFunctionDecl *getterDecl) {
 
   auto *parameterizedProto = C.getProtocol(KnownProtocolKind::Parameterized);
   auto allParametersReq =
-    getProtocolRequirement(parameterizedProto, C.Id_allParameters);
+      getProtocolRequirement(parameterizedProto, C.Id_allParameters);
 
   auto getUnderlyingParameter = [&](Expr *expr, VarDecl *param) -> Expr * {
     auto module = nominal->getModuleContext();
@@ -220,7 +220,7 @@ static void derivedBody_allParametersSetter(AbstractFunctionDecl *setterDecl) {
 
   auto *parameterizedProto = C.getProtocol(KnownProtocolKind::Parameterized);
   auto allParametersReq =
-    getProtocolRequirement(parameterizedProto, C.Id_allParameters);
+      getProtocolRequirement(parameterizedProto, C.Id_allParameters);
 
   // Returns the underlying parameter of a VarDecl `x`.
   // If `x` conforms to `Parameterized`, return `x.allParameters`.
@@ -238,12 +238,8 @@ static void derivedBody_allParametersSetter(AbstractFunctionDecl *setterDecl) {
 
   // Map `Parameters` struct members to their names for efficient lookup.
   llvm::DenseMap<Identifier, VarDecl *> parametersMembers;
-  for (auto member : parametersDecl->getMembers()) {
-    auto *varDecl = dyn_cast<VarDecl>(member);
-    if (!varDecl || varDecl->isStatic() || !varDecl->hasStorage())
-      continue;
-    parametersMembers[varDecl->getName()] = varDecl;
-  }
+  for (auto member : parametersDecl->getStoredProperties())
+    parametersMembers[member->getName()] = member;
 
   SmallVector<ASTNode, 2> assignNodes;
   SmallVector<VarDecl *, 8> tfParamDecls;
@@ -394,12 +390,8 @@ static Type deriveParameterized_Parameters(DerivedConformance &derived) {
   C.addSynthesizedDecl(initDecl);
 
   // After memberwise initializer is synthesized, mark members as implicit.
-  for (auto member : parametersDecl->getMembers()) {
-    auto varDecl = dyn_cast<VarDecl>(member);
-    if (!varDecl || varDecl->isStatic() || !varDecl->hasStorage())
-      continue;
-    varDecl->setImplicit();
-  }
+  for (auto member : parametersDecl->getStoredProperties())
+    member->setImplicit();
 
   derived.addMembersToConformanceContext({parametersDecl});
   C.addSynthesizedDecl(parametersDecl);

--- a/test/Sema/parameterized.swift
+++ b/test/Sema/parameterized.swift
@@ -108,6 +108,16 @@ struct ModelWithInvalidParameters : Parameterized {
   struct Parameters {} // expected-error {{'Parameters' struct is invalid}}
 }
 
+// Test invalid `@TFParameter` usage.
+struct InvalidTFParameterUsage : Parameterized {
+  @TFParameter var layer: DenseLayer
+  @TFParameter var float: Float
+
+  @TFParameter var computed: Float { return 1 } // expected-error {{only instance stored properties can be declared @TFParameter}}
+  @TFParameter func method() -> Float { return 1 } // expected-error {{@TFParameter may only be used on 'var' declarations}}
+  @TFParameter struct MemberStruct {} // expected-error {{@TFParameter may only be used on 'var' declarations}}
+}
+
 // Test invalid `@TFParameter` usage outside of `Parameterized` type.
 struct NonParameterized {
   @TFParameter var float: Float // expected-error {{@TFParameter is allowed only in types that conform to 'Parameterized'}}


### PR DESCRIPTION
- Use `getStoredProperties` to get nominal type stored properties
  instead of filtering `getAllMembers`.
- Add invalid `@TFParameter` usage test.
- Reformat files using `clang-format`.