### PR TITLE
test: simplify `%target-build-swift` on Windows

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -802,12 +802,12 @@ elif run_os in ['windows-msvc']:
     config.target_runtime = 'native'
 
     config.target_build_swift =                                                  \
-            ('%r -target %s %s %s %s %s %s' % (config.swiftc,                    \
-                                               config.variant_triple,            \
-                                               resource_dir_opt, mcp_opt,        \
-                                               config.swift_test_options,        \
-                                               config.swift_driver_test_options, \
-                                               swift_execution_tests_extra_flags))
+            ('%r -target %s %s %s %s %s' % (config.swiftc,                       \
+                                            config.variant_triple,               \
+                                            resource_dir_opt,                    \
+                                            config.swift_test_options,           \
+                                            config.swift_driver_test_options,    \
+                                            swift_execution_tests_extra_flags))
 
     config.target_run = ''
 


### PR DESCRIPTION
Behave like macOS and do not add a `-module-cache-path` argument in the
`%target-build-swift` substitution.  In the cases it was needed, we
would end up with it duplicated which just complicates the command line
and makes it harder to debug.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
