### PR TITLE
test: get most of the multifile tests working on Windows

### DIFF
--- a/test/multifile/default-arguments/two-modules/main.swift
+++ b/test/multifile/default-arguments/two-modules/main.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/onone %t/wmo
-// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/onone/library%{target-shared-library-suffix} -swift-version 4
-// RUN: %target-build-swift %S/main.swift %t/onone/library%{target-shared-library-suffix} -I %t/onone/ -o %t/onone/main -swift-version 4
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/onone/%target-library-name(rary) -swift-version 4
+// RUN: %target-build-swift %S/main.swift -I %t/onone/ -o %t/onone/main -swift-version 4 -L%t/onone -lrary
 
-// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/wmo/library%{target-shared-library-suffix} -swift-version 4
-// RUN: %target-build-swift %S/main.swift %t/wmo/library%{target-shared-library-suffix} -I %t/wmo/ -o %t/wmo/main -swift-version 4
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library1.swift %S/Inputs/library2.swift -o %t/wmo/%target-library-name(rary) -swift-version 4
+// RUN: %target-build-swift %S/main.swift -I %t/wmo/ -o %t/wmo/main -swift-version 4 -L%t/wmo -lrary
 
 import library
 

--- a/test/multifile/extensions/two-modules/main.swift
+++ b/test/multifile/extensions/two-modules/main.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/onone %t/wmo
-// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library%{target-shared-library-suffix}
-// RUN: %target-build-swift %S/main.swift %t/onone/library%{target-shared-library-suffix} -I %t/onone/ -o %t/onone/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/%target-library-name(rary)
+// RUN: %target-build-swift %S/main.swift -I %t/onone/ -o %t/onone/main -L%t/onone -lrary
 
-// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library%{target-shared-library-suffix}
-// RUN: %target-build-swift %S/main.swift %t/wmo/library%{target-shared-library-suffix} -I %t/wmo/ -o %t/wmo/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/%target-library-name(rary)
+// RUN: %target-build-swift %S/main.swift -I %t/wmo/ -o %t/wmo/main -L%t/wmo -lrary
 
 import library
 

--- a/test/multifile/multiconformanceimpls/main.swift
+++ b/test/multifile/multiconformanceimpls/main.swift
@@ -1,13 +1,18 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}A%{target-shared-library-suffix}) %S/Inputs/A.swift -emit-module -emit-module-path %t/A.swiftmodule -module-name A
+//
+// RUN: %target-build-swift-dylib(%t/%target-library-name(A)) %S/Inputs/A.swift -emit-module -emit-module-path %t/A.swiftmodule -module-name A
 // RUN: %target-codesign %t/%target-library-name(A)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}B%{target-shared-library-suffix}) %S/Inputs/B.swift -emit-module -emit-module-path %t/B.swiftmodule -module-name B -I%t -L%t -lA
+//
+// RUN: %target-build-swift-dylib(%t/%target-library-name(B)) %S/Inputs/B.swift -emit-module -emit-module-path %t/B.swiftmodule -module-name B -I%t -L%t -lA
 // RUN: %target-codesign %t/%target-library-name(B)
-// RUN: %target-build-swift-dylib(%t/%{target-shared-library-prefix}C%{target-shared-library-suffix}) %S/Inputs/C.swift -emit-module -emit-module-path %t/C.swiftmodule -module-name C -I%t -L%t -lA
+//
+// RUN: %target-build-swift-dylib(%t/%target-library-name(C)) %S/Inputs/C.swift -emit-module -emit-module-path %t/C.swiftmodule -module-name C -I%t -L%t -lA
 // RUN: %target-codesign %t/%target-library-name(C)
-// RUN: %target-build-swift %s -I %t -o %t/a.out -L %t %target-rpath(%t) -lA -lB -lC
-// RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C) |  %FileCheck %s
+//
+// RUN: %target-build-swift %s -I %t -o %t/main.out -L %t %target-rpath(%t) -lA -lB -lC
+// RUN: %target-codesign %t/main.out
+//
+// RUN: %target-run %t/main.out %t/%target-library-name(A) %t/%target-library-name(B) %t/%target-library-name(C) |  %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/multifile/protocol-conformance-member.swift
+++ b/test/multifile/protocol-conformance-member.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library %s %S/Inputs/protocol-conformance-member-helper.swift -o %t/libTest.dylib -module-name Test
-// RUN: llvm-nm %t/libTest.dylib | %FileCheck %s
+// RUN: %target-build-swift -emit-library %s %S/Inputs/protocol-conformance-member-helper.swift -o %t/%target-library-name(Test) -module-name Test
+// RUN: llvm-nm %t/%target-library-name(Test) | %FileCheck %s
 
 // CHECK: $s4Test10CoolStructV10coolFactorSdvg
 

--- a/test/multifile/synthesized-accessors/two-modules/main.swift
+++ b/test/multifile/synthesized-accessors/two-modules/main.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/onone %t/wmo
-// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library%{target-shared-library-suffix}
-// RUN: %target-build-swift %S/main.swift %t/onone/library%{target-shared-library-suffix} -I %t/onone/ -o %t/onone/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/%target-library-name(rary)
+// RUN: %target-build-swift %S/main.swift -I %t/onone/ -o %t/onone/main -L%t/onone -lrary
 
-// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library%{target-shared-library-suffix}
-// RUN: %target-build-swift %S/main.swift %t/wmo/library%{target-shared-library-suffix} -I %t/wmo/ -o %t/wmo/main
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/%target-library-name(rary)
+// RUN: %target-build-swift %S/main.swift -I %t/wmo/ -o %t/wmo/main -L%t/wmo -lrary
 
 import library
 


### PR DESCRIPTION
We cannot link against the DSO (dll) on Windows and instead link against
the import library.  Let the driver understand this and use the standard
linking technique.  Adjust the name of the emitted files accordingly and
use the `%target-library-name` macro more freely.

Two tests remain:
- multifile.protocol-conformance-member
    The getter is synthesized by not exported so `llvm-nm` is unable to
    see it
- multifile.nested_types
    Windows uses the singleton strategy, so the emitted full type
    metadata does not have the reference to the value witness table for
    Void

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
