### PR TITLE
Fixes example snippet of AnyHashable

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -120,7 +120,7 @@ internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
 ///         AnyHashable(Set(["a", "b"])): "a set of strings"
 ///     ]
 ///     print(descriptions[AnyHashable(42)]!)      // prints "an Int"
-///     print(descriptions[AnyHashable(43)])       // prints "nil"
+///     print(descriptions[AnyHashable(45)])       // prints "nil"
 ///     print(descriptions[AnyHashable(Int8(43))]!) // prints "an Int8"
 ///     print(descriptions[AnyHashable(Set(["a", "b"]))]!) // prints "a set of strings"
 @_fixed_layout


### PR DESCRIPTION
Otherwise, `print(descriptions[AnyHashable(43)])` prints `an Int8`, not `nil`.

<!-- What's in this pull request? -->
This PR fixes example snippet in comments making it working as described.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
n/a

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
