### PR TITLE
[5.0] Remove check for including Runtime due to CmakeConfig.h dependencies

### DIFF
--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,6 +1,4 @@
-if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_STANDALONE_OVERLAY)
-  add_subdirectory(Runtime)
-endif()
+add_subdirectory(Runtime)
 
 if(SWIFT_BUILD_REMOTE_MIRROR)
   add_subdirectory(SwiftRemoteMirror)


### PR DESCRIPTION
Various files include Runtime/Config.h which depends on
Runtime/CMakeConfig.h and thus this check does not work.