### PR TITLE
SwiftShims: break circular dependency in MSVCRT

### DIFF
--- a/stdlib/public/SwiftShims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/LibcOverlayShims.h
@@ -21,9 +21,8 @@
 #include "Visibility.h"
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
+#include <errno.h>
 #include <io.h>
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
 typedef int mode_t;
 #else
 #include <semaphore.h>


### PR DESCRIPTION
The inclusion of Windows.h would cause the Shims to depend on WinSDK, which
would in turn depend on MSVCRT.  However, the SwiftShims are using in MSVCRT
causing a circular dependency between WinSDK and MSVCRT preventing a clean build
from succeeding.  Break the dependency by only including libc headers in the
shims header.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
