### PR TITLE
make adjoint type use CotangentVector

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -314,6 +314,15 @@ public:
   }
 };
 
+/// The kind of an associated type.
+struct AutoDiffAssociatedTypeKind {
+  enum innerty : uint8_t { TangentVector = 0, CotangentVector = 1 } rawValue;
+
+  AutoDiffAssociatedTypeKind() = default;
+  AutoDiffAssociatedTypeKind(innerty rawValue) : rawValue(rawValue) {}
+  operator innerty() const { return rawValue; }
+};
+
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -122,6 +122,8 @@ IDENTIFIER(allParameters)
 IDENTIFIER(Parameter)
 IDENTIFIER(Parameters)
 IDENTIFIER(TensorFlow)
+IDENTIFIER(CotangentVector)
+IDENTIFIER(TangentVector)
 
 // Kinds of layout constraints
 IDENTIFIER_WITH_NAME(UnknownLayout, "_UnknownLayout")

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1078,6 +1078,21 @@ public:
   /// object type.
   TypeTraitResult canBeClass();
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Returns the associated tangent or cotangent type. Returns the null type if
+  /// there is no associated tangent/cotangent type.
+  ///
+  /// `kind` specifies whether to return the tangent or cotangent type.
+  ///
+  /// If the type conforms to `Differentiable`, then the associated
+  /// tangent/cotangent type is the associated `TangentVector`/`CotangentVector`
+  /// from the `Differentiable` requirement. If the type is a tuple, then the
+  /// associated tangent/cotangent type is the elementwise tangent/cotangent
+  /// type of its elements. If the type is a builtin float, then the associated
+  /// tangent/cotangent type is itself. Otherwise, there is no associated type.
+  Type getAutoDiffAssociatedType(AutoDiffAssociatedTypeKind kind,
+                                 LookupConformanceFn lookupConformance);
+
 private:
   // Make vanilla new/delete illegal for Types.
   void *operator new(size_t Bytes) throw() = delete;
@@ -3094,10 +3109,9 @@ public:
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
       LookupConformanceFn lookupConformance);
 
-  AnyFunctionType *
-  getAutoDiffAdjointFunctionType(AutoDiffParameterIndices *indices,
-                                 const TupleType *primalResultTy,
-                                 bool isMethod);
+  AnyFunctionType *getAutoDiffAdjointFunctionType(
+      AutoDiffParameterIndices *indices, const TupleType *primalResultTy,
+      LookupConformanceFn lookupConformance, bool isMethod);
 
   /// \brief True if this type allows an implicit conversion from a function
   /// argument expression of type T to a function of type () -> T.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1089,16 +1089,15 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
   auto *paramIndices = AutoDiffParameterIndicesBuilder(
       origFnTy, /*setAllParams*/ true).build(Context);
   // Generator for the resultant function type, i.e. the AD associated function.
-  BuiltinGenericSignatureBuilder::LambdaGenerator resultGen {
-    [=](BuiltinGenericSignatureBuilder &builder) -> Type {
-      auto assocFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
-          paramIndices, /*resultIndex*/ 0, /*differentiationOrder*/ 1,
-          kind, /*lookupConformance*/ nullptr);
-      if (isMethod)
-        return assocFnTy->getResult()->castTo<AnyFunctionType>()->getResult();
-      return assocFnTy->getResult();
-    }
-  };
+  BuiltinGenericSignatureBuilder::LambdaGenerator resultGen{
+      [=, &Context](BuiltinGenericSignatureBuilder &builder) -> Type {
+        auto assocFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
+            paramIndices, /*resultIndex*/ 0, /*differentiationOrder*/ 1, kind,
+            LookUpConformanceInModule(Context.TheBuiltinModule));
+        if (isMethod)
+          return assocFnTy->getResult()->castTo<AnyFunctionType>()->getResult();
+        return assocFnTy->getResult();
+      }};
   builder.addParameter(firstArgGen);
   if (isMethod)
     builder.addParameter(*selfArgGen);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4089,6 +4089,58 @@ Type TypeBase::openAnyExistentialType(ArchetypeType *&opened) {
 }
 
 // SWIFT_ENABLE_TENSORFLOW
+Type TypeBase::getAutoDiffAssociatedType(
+    AutoDiffAssociatedTypeKind kind, LookupConformanceFn lookupConformance) {
+  assert(lookupConformance);
+  auto &ctx = getASTContext();
+
+  // Builtins floats are their own Tangent/Cotangent.
+  if (is<BuiltinType>())
+    return this;
+
+  // Tuples' Tangent/Cotangent is a tuple of each element's Tangent/Cotangent.
+  if (auto *tupleTy = getAs<TupleType>()) {
+    SmallVector<TupleTypeElt, 8> newElts;
+    for (auto elt : tupleTy->getElements()) {
+      auto eltAssocTy =
+          elt.getType()->getAutoDiffAssociatedType(kind, lookupConformance);
+      if (!eltAssocTy)
+        return Type();
+      newElts.push_back(elt.getWithType(eltAssocTy));
+    }
+    return TupleType::get(newElts, ctx);
+  }
+
+  // Find the TangentVector/CotangentVector associated type on the
+  // Differentiable protocol.
+  auto *differentiableProtocol =
+      ctx.getProtocol(KnownProtocolKind::Differentiable);
+  assert(differentiableProtocol && "could not find differentiable protocol");
+  Identifier associatedTypeIdentifier;
+  switch (kind) {
+  case AutoDiffAssociatedTypeKind::TangentVector:
+    associatedTypeIdentifier = ctx.Id_TangentVector;
+    break;
+  case AutoDiffAssociatedTypeKind::CotangentVector:
+    associatedTypeIdentifier = ctx.Id_CotangentVector;
+    break;
+  }
+  auto associatedTypeLookup =
+      differentiableProtocol->lookupDirect(associatedTypeIdentifier);
+  assert(associatedTypeLookup.size() == 1);
+  auto *dependentType = DependentMemberType::get(
+      differentiableProtocol->getDeclaredInterfaceType(),
+      cast<AssociatedTypeDecl>(associatedTypeLookup[0]));
+
+  // Try to get the associated type by substituting the base type for a protocol
+  // associated type, and return it if found.
+  if (auto assocTy = dependentType->substBaseType(this, lookupConformance))
+    return assocTy;
+
+  // There is no associated type.
+  return Type();
+}
+
 // Makes a function with the same generic signature and extinfo as `copy`, but
 // with `params` parameters and `retTy` return type.
 static AnyFunctionType *
@@ -4103,7 +4155,7 @@ makeFunctionType(AnyFunctionType *copy, ArrayRef<AnyFunctionType::Param> params,
 
 AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
     AutoDiffParameterIndices *indices, const TupleType *primalResultTy,
-    bool isMethod) {
+    LookupConformanceFn lookupConformance, bool isMethod) {
   assert(!indices->isEmpty() && "there must be at least one wrt index");
 
   // Compute the return type of the adjoint.
@@ -4111,7 +4163,8 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
   SmallVector<Type, 8> wrtParamTypes;
   indices->getSubsetParameterTypes(this, wrtParamTypes);
   for (auto wrtParamType : wrtParamTypes)
-    retElts.push_back(wrtParamType);
+    retElts.push_back(wrtParamType->getAutoDiffAssociatedType(
+        AutoDiffAssociatedTypeKind::CotangentVector, lookupConformance));
 
   // If collected `retElts` has only 1 element, use that element as adjoint's
   // return type. Otherwise, make a tuple out of `retElts` as adjoint's return
@@ -4128,9 +4181,11 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
   // Compute the adjoint parameters.
   SmallVector<AnyFunctionType::Param, 8> adjointParams;
 
-  // The first parameter is the seed, which has the same type as the original
-  // return type.
-  adjointParams.push_back(AnyFunctionType::Param(unwrapped->getResult()));
+  // The first parameter is the seed, which is in the cotangent space of the
+  // original return type.
+  adjointParams.push_back(
+      AnyFunctionType::Param(unwrapped->getResult()->getAutoDiffAssociatedType(
+          AutoDiffAssociatedTypeKind::CotangentVector, lookupConformance)));
 
   // If the primal exists, the checkpoints type is the primal result type.
   if (primalResultTy) {
@@ -4174,53 +4229,6 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
 
   auto &ctx = getASTContext();
 
-  auto *differentiableProtocol =
-      ctx.getProtocol(KnownProtocolKind::Differentiable);
-  assert(differentiableProtocol && "could not find differentiable protocol");
-  auto tangentLookup = differentiableProtocol->lookupDirect(
-      ctx.getIdentifier("TangentVector"));
-  assert(tangentLookup.size() == 1);
-  auto *tangentDependentType = DependentMemberType::get(
-      differentiableProtocol->getDeclaredInterfaceType(),
-      cast<AssociatedTypeDecl>(tangentLookup[0]));
-  auto cotangentLookup = differentiableProtocol->lookupDirect(
-      ctx.getIdentifier("CotangentVector"));
-  assert(cotangentLookup.size() == 1);
-  auto *cotangentDependentType = DependentMemberType::get(
-      differentiableProtocol->getDeclaredInterfaceType(),
-      cast<AssociatedTypeDecl>(cotangentLookup[0]));
-
-  // `getAssociatedFunctionType` takes a base type and a protocol-dependent type
-  // and returns a canonical type representing the associated type after any
-  // possible substitutions.
-  // For base types that are tuples, applies `getAssociatedFunctionType` to
-  // every element type and a tuple type of new elements.
-  // For base types that are builtins, returns the types themselves.
-  std::function<CanType(Type, DependentMemberType *)> getAssociatedType
-        = [&](Type type, DependentMemberType *dependentType) {
-    // Builtins floats are their own Tangent/Cotangent.
-    if (type->is<BuiltinType>())
-      return type->getCanonicalType();
-    // Tuples' Tangent/Cotangent is a tuple of each element's Tangent/Cotangent.
-    if (auto *tupleTy = type->getAs<TupleType>()) {
-      SmallVector<TupleTypeElt, 8> newElts;
-      for (auto elt : tupleTy->getElements())
-        newElts.push_back(
-            elt.getWithType(getAssociatedType(elt.getType(), dependentType)));
-      return TupleType::get(newElts, ctx)->getCanonicalType();
-    }
-    // If `lookupConformance` is not provided by the caller, try to get the
-    // associated type by substituting the base type for a protocol associated
-    // type, and return it if found (if the result is non-null and
-    // non-`DependentMemberType`).
-    if (lookupConformance)
-      if (auto assocTy = dependentType->substBaseType(type, lookupConformance))
-        return assocTy->getCanonicalType();
-    // Otherwise, just return the base type's dependent member type.
-    return DependentMemberType::get(type, dependentType->getAssocType())
-        ->getCanonicalType();
-  };
-
   SmallVector<Type, 8> wrtParamTypes;
   indices->getSubsetParameterTypes(this, wrtParamTypes);
 
@@ -4243,18 +4251,20 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
     //   (T.TangentVector...) -> (R.TangentVector...)
     SmallVector<AnyFunctionType::Param, 8> differentialParams;
     for (auto wrtParamType : wrtParamTypes)
-      differentialParams.push_back(AnyFunctionType::Param(getAssociatedType(
-          wrtParamType, tangentDependentType)));
+      differentialParams.push_back(
+          AnyFunctionType::Param(wrtParamType->getAutoDiffAssociatedType(
+              AutoDiffAssociatedTypeKind::TangentVector, lookupConformance)));
 
     SmallVector<TupleTypeElt, 8> differentialResults;
     if (auto *resultTuple = originalResult->getAs<TupleType>()) {
       auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      differentialResults.push_back(getAssociatedType(
-          resultTupleEltType, tangentDependentType));
+      differentialResults.push_back(
+          resultTupleEltType->getAutoDiffAssociatedType(
+              AutoDiffAssociatedTypeKind::TangentVector, lookupConformance));
     } else {
       assert(resultIndex == 0 && "resultIndex out of bounds");
-      differentialResults.push_back(getAssociatedType(
-          originalResult, tangentDependentType));
+      differentialResults.push_back(originalResult->getAutoDiffAssociatedType(
+          AutoDiffAssociatedTypeKind::TangentVector, lookupConformance));
     }
     Type differentialResult =
         differentialResults.size() > 1
@@ -4270,18 +4280,20 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
     SmallVector<AnyFunctionType::Param, 8> pullbackParams;
     if (auto *resultTuple = originalResult->getAs<TupleType>()) {
       auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
-          resultTupleEltType, cotangentDependentType)));
+      pullbackParams.push_back(
+          AnyFunctionType::Param(resultTupleEltType->getAutoDiffAssociatedType(
+              AutoDiffAssociatedTypeKind::CotangentVector, lookupConformance)));
     } else {
       assert(resultIndex == 0 && "resultIndex out of bounds");
-      pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
-          originalResult, cotangentDependentType)));
+      pullbackParams.push_back(
+          AnyFunctionType::Param(originalResult->getAutoDiffAssociatedType(
+              AutoDiffAssociatedTypeKind::CotangentVector, lookupConformance)));
     }
 
     SmallVector<TupleTypeElt, 8> pullbackResults;
     for (auto wrtParamType : wrtParamTypes)
-      pullbackResults.push_back(getAssociatedType(
-          wrtParamType, cotangentDependentType));
+      pullbackResults.push_back(wrtParamType->getAutoDiffAssociatedType(
+          AutoDiffAssociatedTypeKind::CotangentVector, lookupConformance));
     Type pullbackResult = pullbackResults.size() > 1
                               ? TupleType::get(pullbackResults, ctx)
                               : pullbackResults[0].getType();

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -265,7 +265,9 @@ extension Tensor {
 // Normalization
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : BinaryFloatingPoint {
+extension Tensor where Scalar : BinaryFloatingPoint,
+                       Scalar : Differentiable,
+                       Scalar.CotangentVector == Scalar {
   // TODO: Verify that these calculations are correct.
   @inlinable
   func _adjointBatchNormalized(

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1307,7 +1307,17 @@ public extension Tensor {
 // Normalization
 //===----------------------------------------------------------------------===//
 
-public extension Tensor where Scalar : BinaryFloatingPoint {
+// The `Scalar : Differentiable` and `Scalar.CotangentVector == Scalar`
+// constraints make `batchNormalized` differentiable with respect to `offset`
+// and `scale`.
+// TODO: With improved support for constraints on the @differentiable attribute,
+// we could move the constraints to the @differentiable attribute so that
+// `batchNormalized` exists even for scalars not satisfying the constraints. If
+// we did that now, type checking for the adjoint would fail because it
+// doesn't see @differentiable attribute constraints.
+public extension Tensor where Scalar : BinaryFloatingPoint,
+                              Scalar : Differentiable,
+                              Scalar.CotangentVector == Scalar {
   /// Computes the batch normalized tensor along the specified axis.
   ///
   /// Specifically, returns `(self - mu)/(var + epsilon) * gamma + beta` where

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1854,7 +1854,9 @@ extension FloatingPoint {
   /// - Returns: The product of `lhs` and `rhs`, added to this value.
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: (self, .0, .1), adjoint: _adjointAddingProduct)
+  // FIXME: Need to make FloatingPoint refine Differentiable to make this
+  // method differentiable, but that causes stdlib compilation to crash.
+  // @differentiable(wrt: (self, .0, .1), adjoint: _adjointAddingProduct)
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
     addend.addProduct(lhs, rhs)

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -27,7 +27,7 @@ _ = gradient(at: 0, in: one_to_one_0) // okay!
 // expected-note @+3 {{differentiating generic functions is not supported yet}}
 // expected-error @+2 {{function is not differentiable}}
 @differentiable()
-func generic<T: FloatingPoint>(_ x: T) -> T {
+func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
   return x + 1
 }
 

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -25,20 +25,20 @@ public func dfoo(_ seed: Float, partial: Float, _ x: Float, _ y: Float) -> (Floa
 
 @_silgen_name("foo_indir_ret")
 @differentiable(adjoint: dfoo_indir_ret)
-public func foo_indir_ret<T>(_ x: Float, _ y: T) -> T {
+public func foo_indir_ret<T: Differentiable>(_ x: Float, _ y: T) -> T {
   return y
 }
 
-// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 primal @foo_indir_ret adjoint @dfoo_indir_ret primitive] @foo_indir_ret : $@convention(thin) <T> (Float, @in_guaranteed T) -> @out T {
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 primal @foo_indir_ret adjoint @dfoo_indir_ret primitive] @foo_indir_ret : $@convention(thin) <T where T : Differentiable> (Float, @in_guaranteed T) -> @out T {
 // CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $Float, %2 : @trivial $*T):
 
 @_silgen_name("dfoo_indir_ret")
-public func dfoo_indir_ret<T>(_ seed: T, _ partial: T, _ x: Float, _ y: T) -> (Float, T) {
-  return (x, y)
+public func dfoo_indir_ret<T: Differentiable>(_ seed: T.CotangentVector, _ partial: T, _ x: Float, _ y: T) -> (Float, T.CotangentVector) {
+  return (x, seed)
 }
 
-// CHECK-LABEL: sil @dfoo_indir_ret : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T, Float, @in_guaranteed T) -> (Float, @out T) {
-// CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @trivial $*T, %3 : @trivial $Float, %4 : @trivial $*T):
+// CHECK-LABEL: sil @dfoo_indir_ret : $@convention(thin) <T where T : Differentiable> (@in_guaranteed T.CotangentVector, @in_guaranteed T, Float, @in_guaranteed T) -> (Float, @out T.CotangentVector) {
+// CHECK: bb0(%0 : @trivial $*T.CotangentVector, %1 : @trivial $*T.CotangentVector, %2 : @trivial $*T, %3 : @trivial $Float, %4 : @trivial $*T):
 
 //===----------------------------------------------------------------------===//
 // Flattened types


### PR DESCRIPTION
There is a general problem that some of the autodiff code still isn't aware of TangentVector/CotangentVector. This PR fixes part of that problem by making the adjoint type use CotangentVector for its seed and results. (Previously, it just used the original result types and parameter types.)

I had to strengthen TypeCheckAttr to always require that wrt params and results are Differentiable (or tuple of Differentiable), because that's necessary for the CotangentVector lookup to succeed.

I also factored `getAutoDiffAssociatedType` out into a function on `TypeBase` because it's now being used in 5 different places. (Previously, it was duplicatively implemented in 2 places: `AnyFunctionType::getAutoDiffAssociatedFunctionType` and `SILFunctionType::getAutoDiffAssociatedFunctionType`.)

The reason I did this now is that all my experiments with differentiable properties are running into this problem, which makes it difficult to experiment with differentiable properties.