### PR TITLE
stubs: add workaround for Windows c++ runtime behaviour

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -371,6 +371,47 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   return nptr + pos;
 }
 
+#if defined(_WIN32)
+template <>
+static const char *
+_swift_stdlib_strtoX_clocale_impl<float>(const char *str, float *result) {
+  if (swift_stringIsSignalingNaN(str)) {
+    *result = std::numeric_limits<float>::signaling_NaN();
+    return str + std::strlen(str);
+  }
+
+  char *end;
+  *result = std::strtof(str, &end);
+  return end;
+}
+
+template <>
+static const char *
+_swift_stdlib_strtoX_clocale_impl<double>(const char *str, double *result) {
+  if (swift_stringIsSignalingNaN(str)) {
+    *result = std::numeric_limits<double>::signaling_NaN();
+    return str + std::strlen(str);
+  }
+
+  char *end;
+  *result = std::strtod(str, &end);
+  return end;
+}
+
+template <>
+static const char *
+_swift_stdlib_strtoX_clocale_impl<long double>(const char *str, long double *result) {
+  if (swift_stringIsSignalingNaN(str)) {
+    *result = std::numeric_limits<long double>::signaling_NaN();
+    return str + std::strlen(str);
+  }
+
+  char *end;
+  *result = std::strtold(str, &end);
+  return end;
+}
+#endif
+
 const char *swift::_swift_stdlib_strtold_clocale(
     const char *nptr, void *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(


### PR DESCRIPTION
The conversion routines in MSVCPRT return "0" for the conversion of
"-inf" et al.  Provde template specializations for `float`, `double`,
and `long double` to use `strtof`, `strtod`, and `strtold` respectively.
This fixes the lossless conversion of floating point constants.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
