### PR TITLE
 enable @differentiable on stored and computed properties

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -386,7 +386,7 @@ SIMPLE_DECL_ATTR(_nonoverride, NonOverride,
 
 // SWIFT_ENABLE_TENSORFLOW
 DECL_ATTR(differentiable, Differentiable,
-          OnFunc | LongAttribute, 80)
+          OnAccessor | OnFunc | OnVar | LongAttribute, 80)
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
                  OnAccessor | OnFunc | OnConstructor | OnSubscript,
                  /* Not serialized */ 81)

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -719,51 +719,62 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  // [differentiable] attributes only make sense on functions with
-  // bodies, because [differentiable] attributes declare actual primals
-  // and adjoints corresponding to the function body.
+  // [differentiable] attributes only make sense on functions with bodies,
+  // because [differentiable] attributes declare actual associated functions
+  // corresponding to the function body.
   if (!AFD->hasBody())
     return;
 
-  // If the declaration has a @differentiable(reverse) attribute, turn it into a
-  // SIL [differentiable] attribute with lowered associated function names and
-  // lowered differentiation parameter indices.
-  //
+  // Look for a @differentiable attribute on the decl.
   // FIXME: Handle multiple @differentiable attributes.
-  if (auto *diffAttr = cast_or_null<DifferentiableAttr>(
-        AFD->getAttrs().getAttribute(DeclAttrKind::DAK_Differentiable))) {
-    auto silOriginalFn = getFunction(SILDeclRef(AFD), ForDefinition);
-    // Either only adjoint is specified, or both primal and adjoint are
-    // spcified.
-    StringRef primName, adjName, jvpName, vjpName;
-    bool hasPrimitiveAdjoint = false;
-    if (auto *primFn = diffAttr->getPrimalFunction())
-      primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
-    if (auto *adjointFn = diffAttr->getAdjointFunction()) {
-      // If the adjoint is specified but the primal is not, then we treat the
-      // original as the primal.
-      if (primName.empty())
-        primName = silOriginalFn->getName();
-      adjName = getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
-      hasPrimitiveAdjoint = true;
+  DifferentiableAttr *diffAttr = nullptr;
+  if (AFD->getAttrs().hasAttribute<DifferentiableAttr>())
+    diffAttr = AFD->getAttrs().getAttribute<DifferentiableAttr>();
+  // If the AFD is the getter for a storage decl, also look for a
+  // @differentiable attribute on the storage decl, because @differentiable
+  // attributes on storage decls modify the getter.
+  if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
+    if (accessor->isGetter()) {
+      auto &storageAttrs = accessor->getStorage()->getAttrs();
+      if (storageAttrs.hasAttribute<DifferentiableAttr>())
+        diffAttr = storageAttrs.getAttribute<DifferentiableAttr>();
     }
-    else {
-      assert(primName.empty() &&
-             "Primal cannot be present if adjoint is not");
-    }
-    if (auto *jvpFn = diffAttr->getJVPFunction())
-      jvpName = getFunction(SILDeclRef(jvpFn), ForDefinition)->getName();
-    if (auto *vjpFn = diffAttr->getVJPFunction())
-      vjpName = getFunction(SILDeclRef(vjpFn), ForDefinition)->getName();
-    // Get lowered argument indices.
-    auto paramIndices = diffAttr->getCheckedParameterIndices()->getLowered(
-        AFD->getInterfaceType()->castTo<AnyFunctionType>());
-    SILAutoDiffIndices indices(/*source*/ 0, paramIndices);
-    silOriginalFn->addDifferentiableAttr(
-        SILDifferentiableAttr::create(
-            M, indices, primName, adjName,
-            /*primitive*/ hasPrimitiveAdjoint, jvpName, vjpName));
   }
+
+  if (!diffAttr)
+    return;
+
+  // The declaration (or its storage decl) has a @differentiable attribute, so
+  // turn it into a SIL [differentiable] attribute with lowered associated
+  // function names and lowered differentiation parameter indices.
+  auto silOriginalFn = getFunction(SILDeclRef(AFD), ForDefinition);
+  // Either only adjoint is specified, or both primal and adjoint are
+  // spcified.
+  StringRef primName, adjName, jvpName, vjpName;
+  bool hasPrimitiveAdjoint = false;
+  if (auto *primFn = diffAttr->getPrimalFunction())
+    primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
+  if (auto *adjointFn = diffAttr->getAdjointFunction()) {
+    // If the adjoint is specified but the primal is not, then we treat the
+    // original as the primal.
+    if (primName.empty())
+      primName = silOriginalFn->getName();
+    adjName = getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
+    hasPrimitiveAdjoint = true;
+  } else {
+    assert(primName.empty() && "Primal cannot be present if adjoint is not");
+  }
+  if (auto *jvpFn = diffAttr->getJVPFunction())
+    jvpName = getFunction(SILDeclRef(jvpFn), ForDefinition)->getName();
+  if (auto *vjpFn = diffAttr->getVJPFunction())
+    vjpName = getFunction(SILDeclRef(vjpFn), ForDefinition)->getName();
+  // Get lowered argument indices.
+  auto paramIndices = diffAttr->getCheckedParameterIndices()->getLowered(
+      AFD->getInterfaceType()->castTo<AnyFunctionType>());
+  SILAutoDiffIndices indices(/*source*/ 0, paramIndices);
+  silOriginalFn->addDifferentiableAttr(SILDifferentiableAttr::create(
+      M, indices, primName, adjName,
+      /*primitive*/ hasPrimitiveAdjoint, jvpName, vjpName));
 }
 
 void SILGenModule::emitFunction(FuncDecl *fd) {

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -104,3 +104,87 @@ public func dhasvjp(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)
 }
 
 // CHECK-LABEL: sil @dhasvjp
+
+//===----------------------------------------------------------------------===//
+// Stored property
+//===----------------------------------------------------------------------===//
+
+struct DiffStoredProp {
+  @differentiable(wrt: (self), jvp: storedPropJVP, vjp: storedPropVJP)
+  let storedProp: Float
+
+  @_silgen_name("storedPropJVP")
+  func storedPropJVP() -> (Float, (DiffStoredProp) -> Float) {
+    fatalError("unimplemented")
+  }
+
+  @_silgen_name("storedPropVJP")
+  func storedPropVJP() -> (Float, (Float) -> DiffStoredProp) {
+    fatalError("unimplemented")
+  }
+}
+
+extension DiffStoredProp : VectorNumeric {
+  static var zero: DiffStoredProp { fatalError("unimplemented") }
+  static func + (lhs: DiffStoredProp, rhs: DiffStoredProp) -> DiffStoredProp {
+    fatalError("unimplemented")
+  }
+  static func - (lhs: DiffStoredProp, rhs: DiffStoredProp) -> DiffStoredProp {
+    fatalError("unimplemented")
+  }
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: DiffStoredProp) -> DiffStoredProp {
+    fatalError("unimplemented")
+  }
+}
+
+extension DiffStoredProp : Differentiable {
+  typealias TangentVector = DiffStoredProp
+  typealias CotangentVector = DiffStoredProp
+}
+
+// CHECK-LABEL: DiffStoredProp.storedProp.getter
+// CHECK-NEXT: sil {{.*}} [differentiable source 0 wrt 0 jvp @storedPropJVP vjp @storedPropVJP]
+
+//===----------------------------------------------------------------------===//
+// Computed property
+//===----------------------------------------------------------------------===//
+
+struct DiffComputedProp {
+  @differentiable(wrt: (self), jvp: computedPropJVP, vjp: computedPropVJP)
+  var computedProp: Float {
+    return 0
+  }
+
+  @_silgen_name("computedPropJVP")
+  func computedPropJVP() -> (Float, (DiffComputedProp) -> Float) {
+    fatalError("unimplemented")
+  }
+
+  @_silgen_name("computedPropVJP")
+  func computedPropVJP() -> (Float, (Float) -> DiffComputedProp) {
+    fatalError("unimplemented")
+  }
+}
+
+extension DiffComputedProp : VectorNumeric {
+  static var zero: DiffComputedProp { fatalError("unimplemented") }
+  static func + (lhs: DiffComputedProp, rhs: DiffComputedProp) -> DiffComputedProp {
+    fatalError("unimplemented")
+  }
+  static func - (lhs: DiffComputedProp, rhs: DiffComputedProp) -> DiffComputedProp {
+    fatalError("unimplemented")
+  }
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: DiffComputedProp) -> DiffComputedProp {
+    fatalError("unimplemented")
+  }
+}
+
+extension DiffComputedProp : Differentiable {
+  typealias TangentVector = DiffComputedProp
+  typealias CotangentVector = DiffComputedProp
+}
+
+// CHECK-LABEL: DiffComputedProp.computedProp.getter
+// CHECK-NEXT: sil {{.*}} [differentiable source 0 wrt 0 jvp @computedPropJVP vjp @computedPropVJP]

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -1,0 +1,90 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// An end-to-end test that we can differentiate property accesses, with custom
+// VJPs for the properties specified in various ways.
+
+import StdlibUnittest
+
+var E2EDifferentiablePropertyTests = TestSuite("E2EDifferentiableProperty")
+
+struct TangentSpace {
+  let dx, dy: Float
+}
+
+extension TangentSpace : Differentiable, VectorNumeric {
+  typealias TangentVector = TangentSpace
+  typealias CotangentVector = TangentSpace
+  typealias Scalar = Float
+  static var zero: TangentSpace {
+    return TangentSpace(dx: 0, dy: 0)
+  }
+  static func + (lhs: TangentSpace, rhs: TangentSpace) -> TangentSpace {
+    return TangentSpace(dx: lhs.dx + rhs.dx, dy: lhs.dy + rhs.dy)
+  }
+  static func - (lhs: TangentSpace, rhs: TangentSpace) -> TangentSpace {
+    return TangentSpace(dx: lhs.dx - rhs.dx, dy: lhs.dy - rhs.dy)
+  }
+  static func * (lhs: Float, rhs: TangentSpace) -> TangentSpace {
+    return TangentSpace(dx: lhs * rhs.dx, dy: lhs * rhs.dy)
+  }
+}
+
+struct Space {
+  /// `x` is a computed property with a custom vjp.
+  var x: Float {
+    @differentiable(wrt: (self), vjp: vjpX)
+    get {
+      return storedX
+    }
+  }
+
+  func vjpX() -> (Float, (Float) -> TangentSpace) {
+    return (x, { v in TangentSpace(dx: v, dy: 0) } )
+  }
+
+  private let storedX: Float
+
+  /// `y` is a stored property with a custom vjp for its getter.
+  @differentiable(wrt: (self), vjp: vjpY)
+  let y: Float
+
+  func vjpY() -> (Float, (Float) -> TangentSpace) {
+    return (y, { v in TangentSpace(dx: 0, dy: v) })
+  }
+
+  init(x: Float, y: Float) {
+    self.storedX = x
+    self.y = y
+  }
+}
+
+extension Space : Differentiable {
+  typealias TangentVector = TangentSpace
+  typealias CotangentVector = TangentSpace
+  func moved(along: TangentSpace) -> Space {
+    return Space(x: x + along.dx, y: y + along.dy)
+  }
+}
+
+E2EDifferentiablePropertyTests.test("computed property") {
+  let actualGrad = gradient(at: Space(x: 0, y: 0)) { (point: Space) -> Float in
+    return 2 * point.x
+  }
+  let expectedGrad = TangentSpace(dx: 2, dy: 0)
+  expectEqual(expectedGrad, actualGrad)
+}
+
+// FIXME: The AD pass cannot differentiate this because it sees
+// `struct_extract`s instead of calls to getters. This problem should fix
+// itself once we move the AD pass before mandatory inlining, and we should be
+// able to enable this test.
+// E2EDifferentiablePropertyTests.test("stored property") {
+//   let actualGrad = gradient(at: Space(x: 0, y: 0)) { (point: Space) -> Float in
+//     return 3 * point.y
+//   }
+//   let expectedGrad = TangentSpace(dx: 0, dy: 3)
+//   expectEqual(expectedGrad, actualGrad)
+// }
+
+runAllTests()


### PR DESCRIPTION
(Only look at the latest commit. The previous commit is from a previous PR that hasn't submitted yet.)

Enables @differentiable on stored and computed properties, and propagates them to SIL [differentiable] attributes on the getter SILFunctions.