### PR TITLE
[pred-memopts] Eliminate dynamically dead code.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -211,7 +211,7 @@ struct PMOMemoryUse {
 LLVM_NODISCARD bool
 collectPMOElementUsesFrom(const PMOMemoryObjectInfo &MemoryInfo,
                           SmallVectorImpl<PMOMemoryUse> &Uses,
-                          SmallVectorImpl<SILInstruction *> &Releases);
+                          SmallVectorImpl<DestroyAddrInst *> &Destroys);
 
 } // end namespace swift
 


### PR DESCRIPTION
pred mem opts and definite init used to use the same code. To split them, I
copied potentially dead code so that the two pieces of code could evolve
independently of each other and allow for logic to be disentangled over time by
eliminating that code as we simplified it. This commit disentangles some of that
by renaming the "Releases" array to "Destroys" and eliminating all of the places
we assign nullptrs into it or add non-destroy_addr to it.

This is safe to do since:

1. We were appending the non-destroy_addr to the releases array in
PMOMemoryUseCollector and only then ignoring them in PredictableMemOpts.

2. We were when working with the releases array working with it as if it could
contain null pointers, but we only assigned null pointers into it /after/ we
know that we would never access that specific element again.

Using this simplification I was able to eliminate a bunch of dead code and also
simplify how we promoted destroy_addr to use far less state in a more straight
forward way.
