### PR TITLE
[AutoDiff] NFC: Refactor TangentSpace

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -104,7 +104,7 @@ namespace swift {
   class VarDecl;
   class UnifiedStatsReporter;
   // SWIFT_ENABLE_TENSORFLOW
-  class TangentSpace;
+  class VectorSpace;
 
   enum class KnownProtocolKind : uint8_t;
 
@@ -955,7 +955,7 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   /// Compute the tangent space of this manifold, if the given type represents a
   /// differentiable manifold.
-  Optional<TangentSpace> getTangentSpace(CanType type, ModuleDecl *module);
+  Optional<VectorSpace> getTangentSpace(CanType type, ModuleDecl *module);
 
 private:
   friend Decl;

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -357,24 +357,21 @@ class StructDecl;
 class TupleType;
 class EnumDecl;
 
-/// A type that represents the tangent space of a differentiable type.
-class TangentSpace {
+/// A type that represents a vector space.
+class VectorSpace {
 public:
   /// A tangent space kind.
   enum class Kind {
     /// `Builtin.FP<...>`.
-    BuiltinRealScalar,
-    /// A type that conforms to `FloatingPoint`.
-    RealScalar,
-    /// A type that conforms to `VectorNumeric` where the associated
-    /// `ScalarElement` conforms to `FloatingPoint`.
-    RealVector,
-    /// A product of tangent spaces as a struct.
-    ProductStruct,
-    /// A product of tangent spaces as a tuple.
-    ProductTuple,
-    /// A sum of tangent spaces.
-    Sum
+    BuiltinFloat,
+    /// A type that conforms to `VectorNumeric`.
+    Vector,
+    /// A product of vector spaces as a struct.
+    Struct,
+    /// A product of vector spaces as a tuple.
+    Tuple,
+    /// A union of vector spaces.
+    Enum
   };
 
 private:
@@ -382,7 +379,7 @@ private:
   union Value {
     // BuiltinRealScalar
     BuiltinFloatType *builtinFPType;
-    // RealScalar or RealVector
+    // RealVector
     NominalTypeDecl *realNominalType;
     // ProductStruct
     StructDecl *structDecl;
@@ -398,67 +395,55 @@ private:
     Value(EnumDecl *enumDecl) : enumDecl(enumDecl) {}
   } value;
 
-  TangentSpace(Kind kind, Value value)
+  VectorSpace(Kind kind, Value value)
       : kind(kind), value(value) {}
 
 public:
-  TangentSpace() = delete;
+  VectorSpace() = delete;
 
-  static TangentSpace
+  static VectorSpace
   getBuiltinRealScalarSpace(BuiltinFloatType *builtinFP) {
-    return {Kind::BuiltinRealScalar, builtinFP};
+    return {Kind::BuiltinFloat, builtinFP};
   }
-  static TangentSpace getRealScalarSpace(NominalTypeDecl *typeDecl) {
-    return {Kind::RealScalar, typeDecl};
+  static VectorSpace getRealVectorSpace(NominalTypeDecl *typeDecl) {
+    return {Kind::Vector, typeDecl};
   }
-  static TangentSpace getRealVectorSpace(NominalTypeDecl *typeDecl) {
-    return {Kind::RealVector, typeDecl};
+  static VectorSpace getStruct(StructDecl *structDecl) {
+    return {Kind::Struct, structDecl};
   }
-  static TangentSpace getProductStruct(StructDecl *structDecl) {
-    return {Kind::ProductStruct, structDecl};
+  static VectorSpace getTuple(TupleType *tupleTy) {
+    return {Kind::Tuple, tupleTy};
   }
-  static TangentSpace getProductTuple(TupleType *tupleTy) {
-    return {Kind::ProductTuple, tupleTy};
-  }
-  static TangentSpace getSum(EnumDecl *enumDecl) {
-    return {Kind::Sum, enumDecl};
+  static VectorSpace getEnum(EnumDecl *enumDecl) {
+    return {Kind::Enum, enumDecl};
   }
 
-  bool isBuiltinRealScalarSpace() const {
-    return kind == Kind::BuiltinRealScalar;
+  bool isBuiltinFloat() const {
+    return kind == Kind::BuiltinFloat;
   }
-  bool isRealScalarSpace() const { return kind == Kind::RealScalar; }
-  bool isRealVectorSpace() const { return kind == Kind::RealVector; }
-  bool isProductStruct() const { return kind == Kind::ProductStruct; }
-  bool isProductTuple() const { return kind == Kind::ProductTuple; }
+  bool isVector() const { return kind == Kind::Vector; }
+  bool isStruct() const { return kind == Kind::Struct; }
+  bool isTuple() const { return kind == Kind::Tuple; }
 
   Kind getKind() const { return kind; }
-  BuiltinFloatType *getBuiltinRealScalarSpace() const {
-    assert(kind == Kind::BuiltinRealScalar);
+  BuiltinFloatType *getBuiltinFloat() const {
+    assert(kind == Kind::BuiltinFloat);
     return value.builtinFPType;
   }
-  NominalTypeDecl *getRealScalarSpace() const {
-    assert(kind == Kind::RealScalar);
+  NominalTypeDecl *getVector() const {
+    assert(kind == Kind::Vector);
     return value.realNominalType;
   }
-  NominalTypeDecl *getRealVectorSpace() const {
-    assert(kind == Kind::RealVector);
-    return value.realNominalType;
-  }
-  NominalTypeDecl *getRealScalarOrVectorSpace() const {
-    assert(kind == Kind::RealScalar || kind == Kind::RealVector);
-    return value.realNominalType;
-  }
-  StructDecl *getProductStruct() const {
-    assert(kind == Kind::ProductStruct);
+  StructDecl *getStruct() const {
+    assert(kind == Kind::Struct);
     return value.structDecl;
   }
-  TupleType *getProductTuple() const {
-    assert(kind == Kind::ProductTuple);
+  TupleType *getTuple() const {
+    assert(kind == Kind::Tuple);
     return value.tupleType;
   }
-  EnumDecl *getSum() const {
-    assert(kind == Kind::Sum);
+  EnumDecl *getEnum() const {
+    assert(kind == Kind::Enum);
     return value.enumDecl;
   }
 };

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -2287,8 +2287,7 @@ public:
     auto *vjpCall = getBuilder().createApply(ai->getLoc(), vjp,
                                              ai->getSubstitutionMap(), newArgs,
                                              ai->isNonThrowing());
-    LLVM_DEBUG(getADDebugStream()
-               << "Applied vjp function\n" << *vjpCall);
+    LLVM_DEBUG(getADDebugStream() << "Applied vjp function\n" << *vjpCall);
 
     // Get the VJP results (original results and pullback).
     SmallVector<SILValue, 8> vjpDirectResults;
@@ -3743,13 +3742,8 @@ SILValue AdjointEmitter::materializeZeroDirect(CanType type, SILLocation loc) {
 
 SILValue AdjointEmitter::materializeAdjointDirect(AdjointValue val,
                                                   SILLocation loc) {
-  auto &ctx = getContext();
-  auto *swiftMod = ctx.getModule().getSwiftModule();
   LLVM_DEBUG(getADDebugStream() <<
              "Materializing adjoints for " << val << '\n');
-  auto tangentSpace =
-      getASTContext().getTangentSpace(val.getType().getASTType(), swiftMod);
-  assert(tangentSpace && "No tangent space for this type");
   switch (val.getKind()) {
   case AdjointValue::Kind::Zero:
     return materializeZeroDirect(val.getSwiftType(), loc);
@@ -3916,90 +3910,89 @@ SILValue AdjointEmitter::accumulateMaterializedAdjointsDirect(SILValue lhs,
   auto tangentSpace = astCtx.getTangentSpace(adjointASTTy, swiftMod);
   assert(tangentSpace && "No tangent space for this type");
   switch (tangentSpace->getKind()) {
-  case TangentSpace::Kind::BuiltinRealScalar:
+  case VectorSpace::Kind::BuiltinFloat:
     return builder.createBuiltinBinaryFunction(
         loc, "fadd", adjointTy, adjointTy, {lhs, rhs});
-    case TangentSpace::Kind::RealScalar:
-    case TangentSpace::Kind::RealVector: {
-      // Handle any nominal type value.
+  case VectorSpace::Kind::Vector: {
+    // Handle any nominal type value.
 
-      // Allocate buffers for inputs and output.
-      auto *resultBuf = builder.createAllocStack(loc, adjointTy);
-      auto *lhsBuf = builder.createAllocStack(loc, adjointTy);
-      auto *rhsBuf = builder.createAllocStack(loc, adjointTy);
+    // Allocate buffers for inputs and output.
+    auto *resultBuf = builder.createAllocStack(loc, adjointTy);
+    auto *lhsBuf = builder.createAllocStack(loc, adjointTy);
+    auto *rhsBuf = builder.createAllocStack(loc, adjointTy);
 
-      // Initialize input buffers.
-      auto *lhsBufInitAccess = builder.createBeginAccess(
-          loc, lhsBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
-          /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      auto *rhsBufInitAccess = builder.createBeginAccess(
-          loc, rhsBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
-          /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      builder.createStore(loc, lhs, lhsBufInitAccess,
-                          getBufferSOQ(adjointASTTy, getAdjoint()));
-      builder.createStore(loc, rhs, rhsBufInitAccess,
-                          getBufferSOQ(adjointASTTy, getAdjoint()));
-      builder.createEndAccess(loc, lhsBufInitAccess, /*aborted*/ false);
-      builder.createEndAccess(loc, rhsBufInitAccess, /*aborted*/ false);
+    // Initialize input buffers.
+    auto *lhsBufInitAccess = builder.createBeginAccess(
+        loc, lhsBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    auto *rhsBufInitAccess = builder.createBeginAccess(
+        loc, rhsBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    builder.createStore(loc, lhs, lhsBufInitAccess,
+                        getBufferSOQ(adjointASTTy, getAdjoint()));
+    builder.createStore(loc, rhs, rhsBufInitAccess,
+                        getBufferSOQ(adjointASTTy, getAdjoint()));
+    builder.createEndAccess(loc, lhsBufInitAccess, /*aborted*/ false);
+    builder.createEndAccess(loc, rhsBufInitAccess, /*aborted*/ false);
 
-      // Accumulate the adjoints.
-      auto *resultBufAccess = builder.createBeginAccess(
-          loc, resultBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
-          /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      auto *lhsBufReadAccess = builder.createBeginAccess(loc, lhsBuf,
-          SILAccessKind::Read, SILAccessEnforcement::Static,
-          /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      auto *rhsBufReadAccess = builder.createBeginAccess(loc, rhsBuf,
-          SILAccessKind::Read, SILAccessEnforcement::Static,
-          /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      accumulateMaterializedAdjointsIndirect(lhsBufReadAccess, rhsBufReadAccess,
-                                             resultBufAccess);
-      builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
-      builder.createEndAccess(loc, rhsBufReadAccess, /*aborted*/ false);
-      builder.createEndAccess(loc, lhsBufReadAccess, /*aborted*/ false);
+    // Accumulate the adjoints.
+    auto *resultBufAccess = builder.createBeginAccess(
+        loc, resultBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    auto *lhsBufReadAccess = builder.createBeginAccess(loc, lhsBuf,
+        SILAccessKind::Read, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    auto *rhsBufReadAccess = builder.createBeginAccess(loc, rhsBuf,
+        SILAccessKind::Read, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    accumulateMaterializedAdjointsIndirect(lhsBufReadAccess, rhsBufReadAccess,
+                                           resultBufAccess);
+    builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
+    builder.createEndAccess(loc, rhsBufReadAccess, /*aborted*/ false);
+    builder.createEndAccess(loc, lhsBufReadAccess, /*aborted*/ false);
 
-      // Deallocate input buffers.
-      builder.createDeallocStack(loc, rhsBuf);
-      builder.createDeallocStack(loc, lhsBuf);
+    // Deallocate input buffers.
+    builder.createDeallocStack(loc, rhsBuf);
+    builder.createDeallocStack(loc, lhsBuf);
 
-      // Load result.
-      resultBufAccess = builder.createBeginAccess(loc, resultBuf,
-          SILAccessKind::Read, SILAccessEnforcement::Static,
-          /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      auto val = builder.createLoad(loc, resultBufAccess,
-          getBufferLOQ(lhs->getType().getASTType(), getAdjoint()));
-      builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
+    // Load result.
+    resultBufAccess = builder.createBeginAccess(loc, resultBuf,
+        SILAccessKind::Read, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    auto val = builder.createLoad(loc, resultBufAccess,
+        getBufferLOQ(lhs->getType().getASTType(), getAdjoint()));
+    builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
 
-      // Deallocate result buffer.
-      builder.createDeallocStack(loc, resultBuf);
+    // Deallocate result buffer.
+    builder.createDeallocStack(loc, resultBuf);
 
-      return val;
+    return val;
+  }
+  case VectorSpace::Kind::Struct: {
+    auto *structDecl = tangentSpace->getStruct();
+    SmallVector<SILValue, 8> adjElements;
+    for (auto *field : structDecl->getStoredProperties()) {
+      auto *eltLHS = builder.createStructExtract(loc, lhs, field);
+      auto *eltRHS = builder.createStructExtract(loc, rhs, field);
+      adjElements.push_back(
+          accumulateMaterializedAdjointsDirect(eltLHS, eltRHS));
     }
-    case TangentSpace::Kind::ProductStruct: {
-      auto *structDecl = tangentSpace->getProductStruct();
-      SmallVector<SILValue, 8> adjElements;
-      for (auto *field : structDecl->getStoredProperties()) {
-        auto *eltLHS = builder.createStructExtract(loc, lhs, field);
-        auto *eltRHS = builder.createStructExtract(loc, rhs, field);
-        adjElements.push_back(
-            accumulateMaterializedAdjointsDirect(eltLHS, eltRHS));
-      }
-      return builder.createStruct(loc, adjointTy, adjElements);
+    return builder.createStruct(loc, adjointTy, adjElements);
+  }
+  case VectorSpace::Kind::Tuple: {
+    auto tupleType = tangentSpace->getTuple();
+    SmallVector<SILValue, 8> adjElements;
+    for (unsigned i : range(tupleType->getNumElements())) {
+      auto *eltLHS = builder.createTupleExtract(loc, lhs, i);
+      auto *eltRHS = builder.createTupleExtract(loc, rhs, i);
+      adjElements.push_back(
+          accumulateMaterializedAdjointsDirect(eltLHS, eltRHS));
     }
-    case TangentSpace::Kind::ProductTuple: {
-      auto tupleType = tangentSpace->getProductTuple();
-      SmallVector<SILValue, 8> adjElements;
-      for (unsigned i : range(tupleType->getNumElements())) {
-        auto *eltLHS = builder.createTupleExtract(loc, lhs, i);
-        auto *eltRHS = builder.createTupleExtract(loc, rhs, i);
-        adjElements.push_back(
-            accumulateMaterializedAdjointsDirect(eltLHS, eltRHS));
-      }
-      return builder.createTuple(loc, adjointTy, adjElements);
-    }
-    case TangentSpace::Kind::Sum: {
-      llvm_unreachable("Differentiating sum types is not supported yet");
-    }
+    return builder.createTuple(loc, adjointTy, adjElements);
+  }
+  case VectorSpace::Kind::Enum: {
+    llvm_unreachable("Differentiating sum types is not supported yet");
+  }
   }
 }
 
@@ -4020,7 +4013,7 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
   auto tangentSpace = astCtx.getTangentSpace(adjointASTTy, swiftMod);
   assert(tangentSpace && "No tangent space for this type");
   switch (tangentSpace->getKind()) {
-  case TangentSpace::Kind::BuiltinRealScalar: {
+  case VectorSpace::Kind::BuiltinFloat: {
     auto *sum = builder.createBuiltinBinaryFunction(
         loc, "fadd", lhsBufAccess->getType(), lhsBufAccess->getType(),
         {lhsBufAccess, rhsBufAccess});
@@ -4029,9 +4022,8 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
     return;
   }
-  case TangentSpace::Kind::RealScalar:
-  case TangentSpace::Kind::RealVector: {
-    auto *adjointTyDecl = tangentSpace->getRealScalarOrVectorSpace();
+  case VectorSpace::Kind::Vector: {
+    auto *adjointTyDecl = tangentSpace->getVector();
     auto *proto = getContext().getAdditiveArithmeticProtocol();
     auto *combinerFuncDecl = getContext().getPlusDecl();
     // Call the combiner function and return.
@@ -4057,8 +4049,8 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
                         /*isNonThrowing*/ false);
     return;
   }
-  case TangentSpace::Kind::ProductTuple: {
-    auto tupleType = tangentSpace->getProductTuple();
+  case VectorSpace::Kind::Tuple: {
+    auto tupleType = tangentSpace->getTuple();
     for (unsigned i : range(tupleType->getNumElements())) {
       auto *eltAddrLHS = builder.createTupleElementAddr(loc, lhsBufAccess, i);
       auto *eltAddrRHS = builder.createTupleElementAddr(loc, rhsBufAccess, i);
@@ -4067,8 +4059,8 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     }
     return;
   }
-  case TangentSpace::Kind::ProductStruct: {
-    auto *structDecl = tangentSpace->getProductStruct();
+  case VectorSpace::Kind::Struct: {
+    auto *structDecl = tangentSpace->getStruct();
     for (auto *field : structDecl->getStoredProperties()) {
       auto *eltAddrLHS =
           builder.createStructElementAddr(loc, lhsBufAccess, field);
@@ -4080,7 +4072,7 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     }
     return;
   }
-  case TangentSpace::Kind::Sum: {
+  case VectorSpace::Kind::Enum: {
     llvm_unreachable("Differentiating a sum type is not supported yet");
   }
   }

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -2723,8 +2723,7 @@ public:
 
 private:
   static bool isLegalAggregate(ArrayRef<AdjointValue> elements, SILType type) {
-    if (auto *structDecl =
-            dyn_cast_or_null<StructDecl>(type.getASTType()->getAnyNominal())) {
+    if (auto *structDecl = type.getASTType()->getStructOrBoundGenericStruct()) {
       // TODO: Check whether this struct is @_fixed_layout and ABI public.
       for (auto pair : llvm::zip(structDecl->getStoredProperties(), elements))
         if (!std::get<0>(pair)->getType()->getCanonicalType()
@@ -2748,8 +2747,7 @@ public:
       break;
     case Kind::Aggregate:
       s << "Aggregate<";
-      if (auto *decl = dyn_cast_or_null<StructDecl>(
-              type.getASTType()->getAnyNominal())) {
+      if (auto *decl = type.getASTType()->getStructOrBoundGenericStruct()) {
         s << "Struct>(";
         interleave(llvm::zip(decl->getStoredProperties(),
                              getAggregateElements()),
@@ -3809,8 +3807,8 @@ void AdjointEmitter::materializeAdjointIndirectHelper(
             builder.createTupleElementAddr(loc, destBufferAccess, idx, eltTy);
         materializeAdjointIndirectHelper(eltAndIdx.value(), eltBuf);
       }
-    } else if (auto *structDecl = dyn_cast_or_null<StructDecl>(
-                   val.getSwiftType()->getAnyNominal())) {
+    } else if (auto *structDecl =
+                   val.getSwiftType()->getStructOrBoundGenericStruct()) {
       for (auto eltAndField : zip(val.getAggregateElements(),
                                   structDecl->getStoredProperties())) {
         auto elt = std::get<0>(eltAndField);


### PR DESCRIPTION
Refactors `TangentSpace` so that it uses shorter case names like "vector", "struct" and "enum" and `ASTContext::getTangentSpace` uses `TypeBase::getAutoDiffAssociatedType` to get the tangent space. I'll start another patch to move `ASTContext::getTangentSpace` under `TypeBase`. 

Also fixes SR-8770.