### PR TITLE
fix bug where AD is not always seeing custom [differentiable] attrs

### DIFF
--- a/test/AutoDiff/superset_adjoint_loaded.swift
+++ b/test/AutoDiff/superset_adjoint_loaded.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+// Do not add other tests to this file, because differentiating other things
+// can hide this bug.
+
+// There was a bug where the AD pass would not see the custom [differentiable]
+// attribute on `Float.*` wrt both parameters until after the AD pass generated
+// its own adjoint for `Float.*` wrt the second parameter. This test verifies
+// that the AD pass uses the custom adjoint defined on `Float.*`.
+
+func mul3(_ x: Float) -> Float {
+  return 3 * x
+}
+
+let _ = gradient(at: 0, in: mul3)
+
+// CHECK-LABEL: sil{{.*}} @AD__{{.*}}mul3{{.*}}__primal{{.*}}
+// CHECK: function_ref static Float._adjointMultiply(_:_:_:_:)
+// CHECK: } // end sil function 'AD__{{.*}}mul3{{.*}}__primal{{.*}}'


### PR DESCRIPTION
When SILGen generates SIL for an expression like `3 * x` it creates a `SILFunciton` for `Float.*` but does not populate that `SILFunction` with data like the list of `[differentiable]` attrs. The AD pass does not load this data until after running `lookUpMinimalDifferentiationTask`, so `lookUpMinimalDifferentiationTask` does not find the custom adjoint. So AD differentiates `Float.*` wrt the second parameter instead of using the custom adjoint.

The `struct_extract` differentiation patch that I am working on exposes this, so I split this fix out into its own PR.