### PR TITLE
test: port most of the stdlib tests to Windows

### DIFF
--- a/test/stdlib/CastTraps.swift.gyb
+++ b/test/stdlib/CastTraps.swift.gyb
@@ -5,7 +5,7 @@
 // FIXME: Casting.cpp has dozens of places to fail a cast. This test does not
 // attempt to enumerate them all.
 
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import StdlibUnittest
 

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -o %t/Error -DPTR_SIZE_%target-ptrsize -module-name main %s
+// RUN: %target-build-swift -o %t/Error -DPTR_SIZE_%target-ptrsize -module-name main %/s
 // RUN: %target-run %t/Error
 // REQUIRES: executable_test
 

--- a/test/stdlib/FloatConstants.swift
+++ b/test/stdlib/FloatConstants.swift
@@ -4,6 +4,8 @@
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #endif
 
 _ = FLT_RADIX // expected-warning {{is deprecated}}

--- a/test/stdlib/FloatingPointIR.swift
+++ b/test/stdlib/FloatingPointIR.swift
@@ -4,9 +4,6 @@
 
 var globalFloat32 : Float32 = 0.0
 var globalFloat64 : Float64 = 0.0
-#if arch(i386) || arch(x86_64)
-var globalFloat80 : Float80 = 0.0
-#endif
 
 @inline(never)
 func acceptFloat32(_ a: Float32) {
@@ -18,28 +15,16 @@ func acceptFloat64(_ a: Float64) {
   globalFloat64 = a
 }
 
-#if arch(i386) || arch(x86_64)
-@inline(never)
-func acceptFloat80(_ a: Float80) {
-  globalFloat80 = a
-}
-#endif
-
 func testConstantFoldFloatLiterals() {
   acceptFloat32(1.0)
   acceptFloat64(1.0)
-#if arch(i386) || arch(x86_64)
-  acceptFloat80(1.0)
-#endif
 }
 
 // i386: call swiftcc void @"$s15FloatingPointIR13acceptFloat32yySfF{{.*}}"(float 1.000000e+00)
 // i386: call swiftcc void @"$s15FloatingPointIR13acceptFloat64yySdF{{.*}}"(double 1.000000e+00)
-// i386: call swiftcc void @"$s15FloatingPointIR13acceptFloat80yys0E0VF{{.*}}"(x86_fp80 0xK3FFF8000000000000000)
 
 // x86_64: call swiftcc void @"$s15FloatingPointIR13acceptFloat32yySfF{{.*}}"(float 1.000000e+00)
 // x86_64: call swiftcc void @"$s15FloatingPointIR13acceptFloat64yySdF{{.*}}"(double 1.000000e+00)
-// x86_64: call swiftcc void @"$s15FloatingPointIR13acceptFloat80yys0E0VF{{.*}}"(x86_fp80 0xK3FFF8000000000000000)
 
 // armv7: call swiftcc void @"$s15FloatingPointIR13acceptFloat32yySfF{{.*}}"(float 1.000000e+00)
 // armv7: call swiftcc void @"$s15FloatingPointIR13acceptFloat64yySdF{{.*}}"(double 1.000000e+00)

--- a/test/stdlib/FloatingPointIR_FP80.swift
+++ b/test/stdlib/FloatingPointIR_FP80.swift
@@ -1,0 +1,20 @@
+// RUN: %target-build-swift -emit-ir %s | %FileCheck -check-prefix=%target-cpu %s
+// RUN: %target-build-swift -O -emit-ir %s | %FileCheck -check-prefix=%target-cpu %s
+// RUN: %target-build-swift -Ounchecked -emit-ir %s | %FileCheck -check-prefix=%target-cpu %s
+
+// REQUIRES: CPU=i386 || CPU=x86_64
+// UNSUPPORTED: OS=windows-msvc
+
+var globalFloat80 : Float80 = 0.0
+
+@inline(never)
+func acceptFloat80(_ a: Float80) {
+  globalFloat80 = a
+}
+
+func testConstantFoldFloatLiterals() {
+  acceptFloat80(1.0)
+}
+
+// i386: call swiftcc void @"$s20FloatingPointIR_FP8013acceptFloat80yys0F0VF{{.*}}"(x86_fp80 0xK3FFF8000000000000000)
+// x86_64: call swiftcc void @"$s20FloatingPointIR_FP8013acceptFloat80yys0F0VF{{.*}}"(x86_fp80 0xK3FFF8000000000000000)

--- a/test/stdlib/MathConstants.swift
+++ b/test/stdlib/MathConstants.swift
@@ -4,6 +4,8 @@
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #endif
 
 _ = M_PI // expected-warning {{is deprecated}}

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -21,7 +21,9 @@
 // RUN: fi
 // RUN: %target-codesign %t/Mirror
 // RUN: %target-run %t/Mirror
+
 // REQUIRES: executable_test
+// REQUIRES: shell
 
 import StdlibUnittest
 

--- a/test/stdlib/Nil.swift
+++ b/test/stdlib/Nil.swift
@@ -2,7 +2,7 @@
 // REQUIRES: executable_test
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -134,7 +134,7 @@ tests.test("FixedWidthInteger/maxUInt64") {
 % for Self in 'Float', 'Double', 'Float80':
 
 % if Self == 'Float80':
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 % end
 
 tests.test("${Self}/Basics") {

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=windows-msvc
 
 import StdlibUnittest
 #if os(Linux) || os(Android)

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -9,8 +9,10 @@
 import StdlibUnittest
 #if os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
   import Glibc
-#else
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   import Darwin
+#elseif os(Windows)
+  import MSVCRT
 #endif
 
 // It takes about an hour to run the Float formatter over all 2 billion

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -14,6 +14,9 @@ import SwiftShims
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
+import WinSDK
 #endif
 
 @_silgen_name("swift_demangle")
@@ -566,14 +569,27 @@ Runtime.test("SwiftError layout constants for LLDB") {
   #else
     _UnimplementedError()
   #endif
+#elseif os(Windows)
+  let hStdlibCore: HMODULE = GetModuleHandleA("swiftCore.dll")!
 #else
   _UnimplementedError()
 #endif
 
+#if os(Windows)
+  let offsetof_SwiftError_typeMetadata: UnsafeRawPointer =
+      unsafeBitCast(GetProcAddress(hStdlibCore,
+                                   "_swift_lldb_offsetof_SwiftError_typeMetadata")!,
+                    to: UnsafeRawPointer.self)
+  let sizeof_SwiftError: UnsafeRawPointer =
+      unsafeBitCast(GetProcAddress(hStdlibCore,
+                                   "_swift_lldb_sizeof_SwiftError")!,
+                    to: UnsafeRawPointer.self)
+#else
   let offsetof_SwiftError_typeMetadata =
     dlsym(RTLD_DEFAULT, "_swift_lldb_offsetof_SwiftError_typeMetadata")!
   let sizeof_SwiftError =
     dlsym(RTLD_DEFAULT, "_swift_lldb_sizeof_SwiftError")!
+#endif
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 #if arch(i386) || arch(arm)
   expectEqual(20, offsetof_SwiftError_typeMetadata.load(as: UInt.self))
@@ -582,7 +598,7 @@ Runtime.test("SwiftError layout constants for LLDB") {
   expectEqual(40, offsetof_SwiftError_typeMetadata.load(as: UInt.self))
   expectEqual(72, sizeof_SwiftError.load(as: UInt.self))
 #endif
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(Android) || os(Windows)
   expectEqual(16, offsetof_SwiftError_typeMetadata.load(as: UInt.self))
   expectEqual(32, sizeof_SwiftError.load(as: UInt.self))
 #else

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -6,9 +6,16 @@ import Swift
 #if _runtime(_ObjC)
 import Darwin
 import CoreGraphics
-#else
+#elseif os(Linux) || os(FreeBSD) || os(Android) || os(Haiku) || os(PS4)
 import Glibc
 typealias CGFloat = Double
+#elseif os(Windows)
+import MSVCRT
+#if arch(x86_64) || arch(arm64)
+typealias CGFloat = Double
+#else
+typealias CGFloat = Float
+#endif
 #endif
 
 func my_printf(_ format: String, _ arguments: CVarArg...) {

--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -20,7 +20,9 @@
 // RUN: fi
 // RUN: %target-codesign %t/Mirror
 // RUN: %target-run %t/Mirror
+
 // REQUIRES: executable_test
+// REQUIRES: shell
 
 import StdlibUnittest
 

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=windows-msvc
 
 import StdlibUnittest
 #if os(Linux) || os(Android)

--- a/test/stdlib/simd.swift.gyb
+++ b/test/stdlib/simd.swift.gyb
@@ -2,7 +2,7 @@
 // REQUIRES: executable_test
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: linux
+// XFAIL: linux, windows
 
 import simd
 import StdlibUnittest

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: linux
+// XFAIL: linux, windows
 
 import simd
 

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -17,10 +17,12 @@
 // RUN: %line-directive %t/tgmath.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
-#if canImport(Darwin)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   import Darwin.C.tgmath
-#else
+#elseif os(Linux) || os(android) || os(FreeBSD) || os(Haiku) || os(PS4)
   import Glibc
+#elseif os(Windows)
+  import MSVCRT
 #endif
 
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
@@ -77,7 +79,9 @@ internal protocol TGMath: BinaryFloatingPoint {
 %end
   static func _remquo(_ x: Self, _ y: Self) -> (Self, Int)
   static func _fma(_ x: Self, _ y: Self, _ z: Self) -> Self
+#if !os(Windows)
   static func _lgamma(_ x: Self) -> (Self, Int)
+#endif
   static func _modf(_ x: Self) -> (Self, Self)
   static func _scalbn(_ x: Self, _ n: Int) -> Self
   static func _frexp(_ x: Self) -> (Self, Int)
@@ -116,8 +120,10 @@ internal extension TGMath {
     expectEqualWithTolerance(0.4041169094348222983238250859191217675, Self._erf(0.375))
     expectEqualWithTolerance(0.5958830905651777016761749140808782324, Self._erfc(0.375))
     expectEqualWithTolerance(2.3704361844166009086464735041766525098, Self._tgamma(0.375))
+#if !os(Windows)
     expectEqualWithTolerance( -0.11775527074107877445136203331798850, Self._lgamma(1.375).0, ulps: 16)
     expectEqual(1, Self._lgamma(1.375).1)
+#endif
     expectEqual(1, Self._ceil(0.375))
     expectEqual(0, Self._floor(0.375))
     expectEqual(0, Self._nearbyint(0.375))
@@ -181,7 +187,9 @@ extension ${T}: TGMath {
 %end
   static func _remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) { return remquo(x, y) }
   static func _fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} { return fma(x, y, z) }
+#if !os(Windows)
   static func _lgamma(_ x: ${T}) -> (${T}, Int) { return lgamma(x) }
+#endif
   static func _modf(_ x: ${T}) -> (${T}, ${T}) { return modf(x) }
   static func _scalbn(_ x: ${T}, _ n: Int) -> ${T} { return scalbn(x, n) }
   static func _frexp(_ x: ${T}) -> (${T}, Int) { return frexp(x) }

--- a/test/stdlib/tgmath_optimized.swift
+++ b/test/stdlib/tgmath_optimized.swift
@@ -6,8 +6,10 @@
 
 #if os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
   import Glibc
-#else
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   import Darwin
+#elseif os(Windows)
+  import MSVCRT
 #endif
 import StdlibUnittest
 


### PR DESCRIPTION
This adjusts the standard library test suite to mostly pass on Windows.
The remaining failures are due to various cases:
- memory corruption (unresolved)
- unresolved symbols (keypath metadata is not exported?)
- withVAList failure (unresolved)
- heap corruption (unresolved)
- #import vs #include for ClangImporter

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
