### PR TITLE
[API] Derive conformances for `AdditiveArithmetic` and `VectorNumeric`.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2417,6 +2417,10 @@ ERROR(parameterized_no_parameters_struct,none,
 ERROR(parameterized_invalid_parameters_struct,none,
       "cannot automatically synthesize %0 because 'Parameters' struct is "
       "invalid", (Type))
+ERROR(broken_additive_arithmetic_requirement,none,
+      "AdditiveArithmetic protocol is broken: unexpected requirement", ())
+ERROR(broken_vector_numeric_requirement,none,
+      "VectorNumeric protocol is broken: unexpected requirement", ())
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -117,18 +117,23 @@ IDENTIFIER_WITH_NAME(value_, "_value")
 IDENTIFIER(with)
 
 // SWIFT_ENABLE_TENSORFLOW
+IDENTIFIER(TensorFlow)
+// KeyPathIterable
 IDENTIFIER(AllKeyPaths)
 IDENTIFIER(allKeyPaths)
 IDENTIFIER(recursivelyAllKeyPaths)
 IDENTIFIER(allWritableKeyPaths)
 IDENTIFIER(recursivelyAllWritableKeyPaths)
+// AdditiveArithmetic, VectorNumeric
+IDENTIFIER(zero)
+IDENTIFIER(Scalar)
+// ParameterGroup, Parameterized
 IDENTIFIER(allParameters)
 IDENTIFIER(Parameter)
 IDENTIFIER(Parameters)
-IDENTIFIER(TensorFlow)
+// Differentiable
 IDENTIFIER(CotangentVector)
 IDENTIFIER(TangentVector)
-IDENTIFIER(zero)
 
 // Kinds of layout constraints
 IDENTIFIER_WITH_NAME(UnknownLayout, "_UnknownLayout")

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -27,9 +27,11 @@ add_swift_host_library(swiftSema STATIC
   DerivedConformanceEquatableHashable.cpp
   DerivedConformanceError.cpp
   # SWIFT_ENABLE_TENSORFLOW
+  DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
   DerivedConformanceKeyPathIterable.cpp
   DerivedConformanceParameterGroup.cpp
   DerivedConformanceParameterized.cpp
+  # SWIFT_ENABLE_TENSORFLOW END
   DerivedConformanceRawRepresentable.cpp
   DerivedConformances.cpp
   InstrumenterSupport.cpp

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -1,0 +1,461 @@
+//===--- DerivedConformanceAdditiveArithmeticVectorNumeric.cpp ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements explicit derivation of the AdditiveArithmetic and
+// VectorNumeric protocols for struct types.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CodeSynthesis.h"
+#include "TypeChecker.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Stmt.h"
+#include "swift/AST/Types.h"
+#include "DerivedConformances.h"
+
+using namespace swift;
+
+// Represents synthesizable math operators.
+enum MathOperator {
+  // `+(Self, Self)`, `AdditiveArithmetic` requirement
+  Add,
+  // `-(Self, Self)`, `AdditiveArithmetic` requirement
+  Subtract,
+  // `*(Scalar, Self)`, `VectorNumeric` requirement
+  ScalarMultiply
+};
+
+static StringRef getMathOperatorName(MathOperator op) {
+  switch (op) {
+  case Add:
+    return "+";
+  case Subtract:
+    return "-";
+  case ScalarMultiply:
+    return "*";
+  }
+}
+
+// Return the protocol associated with a math operator.
+static ProtocolDecl *getAssociatedProtocol(MathOperator op, ASTContext &C) {
+  switch (op) {
+  case Add:
+  case Subtract:
+    return C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
+  case ScalarMultiply:
+    return C.getProtocol(KnownProtocolKind::VectorNumeric);
+  }
+}
+
+// Return the protocol requirement with the specified name.
+static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
+  auto lookup = proto->lookupDirect(name);
+  lookup.erase(std::remove_if(lookup.begin(), lookup.end(),
+                              [](ValueDecl *v) {
+                                return !isa<ProtocolDecl>(
+                                           v->getDeclContext()) ||
+                                       !v->isProtocolRequirement();
+                              }),
+               lookup.end());
+  assert(lookup.size() == 1 && "Ambiguous protocol requirement");
+  return lookup[0];
+}
+
+// Get memberwise initializer for a nominal type.
+static ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal) {
+  ConstructorDecl *memberwiseInitDecl = nullptr;
+  for (auto member : nominal->getMembers()) {
+    // Find memberwise initializer.
+    if (!memberwiseInitDecl) {
+      auto initDecl = dyn_cast<ConstructorDecl>(member);
+      if (!initDecl || !initDecl->isMemberwiseInitializer())
+        continue;
+      assert(!memberwiseInitDecl && "Memberwise initializer already found");
+      memberwiseInitDecl = initDecl;
+    }
+  }
+  return memberwiseInitDecl;
+}
+
+// Return the `Scalar` associated type for a ValueDecl if it conforms to
+// `VectorNumeric`.
+// If the decl does not conform to `VectorNumeric`, return a null `Type`.
+static Type getVectorNumericScalarAssocType(ValueDecl *decl) {
+  auto &C = decl->getASTContext();
+  auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
+  auto declType =
+      decl->getDeclContext()->mapTypeIntoContext(decl->getInterfaceType());
+  auto conf = TypeChecker::conformsToProtocol(declType, vectorNumericProto,
+                                              decl->getDeclContext(),
+                                              ConformanceCheckFlags::Used);
+  if (!conf)
+    return Type();
+  Type scalarType = ProtocolConformanceRef::getTypeWitnessByName(
+      decl->getInterfaceType(), *conf, C.Id_Scalar, C.getLazyResolver());
+  assert(scalarType && "'Scalar' associated type not found");
+  return scalarType;
+}
+
+static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal) {
+  // Must be a struct type.
+  auto *structDecl = dyn_cast<StructDecl>(nominal);
+  if (!structDecl)
+    return Type();
+  // Struct must have at least one stored property.
+  if (structDecl->getStoredProperties().empty())
+    return Type();
+  // If all stored properties conform to `VectorNumeric` and have the same
+  // `Scalar` associated type, return that `Scalar` associated type.
+  // Otherwise, the `Scalar` type cannot be derived.
+  Type sameScalarType;
+  for (auto member : structDecl->getStoredProperties()) {
+    auto scalarType = getVectorNumericScalarAssocType(member);
+    // If stored property does not conform to `VectorNumeric`, return null
+    // `Type`.
+    if (!scalarType)
+      return Type();
+    // If same `Scalar` type has not been set, set it for the first time.
+    if (!sameScalarType) {
+      sameScalarType = scalarType;
+      continue;
+    }
+    // If stored property `Scalar` types do not match, return null `Type`.
+    if (!scalarType->isEqual(sameScalarType))
+      return Type();
+  }
+  return sameScalarType;
+}
+
+bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal) {
+  // Must be a struct type.
+  auto *structDecl = dyn_cast<StructDecl>(nominal);
+  if (!structDecl)
+    return false;
+  // Struct must have at least one stored property.
+  if (structDecl->getStoredProperties().empty())
+    return false;
+  // All stored properties must conform to `AdditiveArithmetic`.
+  auto &C = nominal->getASTContext();
+  auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
+  return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
+    auto conf = TypeChecker::conformsToProtocol(v->getType(), addArithProto,
+                                                v->getDeclContext(),
+                                                ConformanceCheckFlags::Used);
+    return (bool)conf;
+  });
+}
+
+bool DerivedConformance::canDeriveVectorNumeric(NominalTypeDecl *nominal) {
+  return bool(deriveVectorNumeric_Scalar(nominal));
+}
+
+// Synthesize body for the given math operator.
+static void deriveBodyMathOperator(AbstractFunctionDecl *funcDecl,
+                                   MathOperator op) {
+  auto *nominal = funcDecl->getDeclContext()->getSelfNominalTypeDecl();
+  auto &C = nominal->getASTContext();
+
+  // Create memberwise initializer: `Nominal.init(...)`.
+  auto *memberwiseInitDecl = getMemberwiseInitializer(nominal);
+  auto *initDRE =
+      new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
+  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+  auto *nominalTypeExpr = TypeExpr::createForDecl(SourceLoc(), nominal,
+                                                  funcDecl, /*Implicit*/ true);
+  auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, nominalTypeExpr);
+
+  // Get operator protocol requirement.
+  auto *proto = getAssociatedProtocol(op, C);
+  auto operatorId = C.getIdentifier(getMathOperatorName(op));
+  auto *operatorReq = getProtocolRequirement(proto, operatorId);
+
+  // Create reference to operator parameters: lhs and rhs.
+  auto params = funcDecl->getParameters();
+  auto *lhsDRE =
+      new (C) DeclRefExpr(params->get(0), DeclNameLoc(), /*Implicit*/ true);
+  auto *rhsDRE =
+      new (C) DeclRefExpr(params->get(1), DeclNameLoc(), /*Implicit*/ true);
+
+  // Create expression combining lhs and rhs members using member operator.
+  auto createMemberOpExpr = [&](VarDecl *member) -> Expr * {
+    auto module = nominal->getModuleContext();
+    auto confRef = module->lookupConformance(member->getType(), proto);
+    assert(confRef && "Member does not conform to math protocol");
+
+    // Get member type's math operator, e.g. `Member.+`.
+    // Use protocol requirement declaration for the operator by default: this
+    // will be dynamically dispatched.
+    ValueDecl *memberOpDecl = operatorReq;
+    // If conformance reference is concrete, then use concrete witness
+    // declaration for the operator.
+    if (confRef->isConcrete())
+      memberOpDecl =
+          confRef->getConcrete()->getWitnessDecl(operatorReq, nullptr);
+    auto memberOpDRE =
+        new (C) DeclRefExpr(memberOpDecl, DeclNameLoc(), /*Implicit*/ true);
+    auto *memberTypeExpr = TypeExpr::createImplicit(member->getType(), C);
+    auto memberOpExpr =
+        new (C) DotSyntaxCallExpr(memberOpDRE, SourceLoc(), memberTypeExpr);
+
+    // Create lhs argument.
+    // For `AdditiveArithmetic` operators: use `lhs.member`.
+    // For `VectorNumeric.*`: use `lhs` directly.
+    Expr *lhsArg = nullptr;
+    switch (op) {
+    case Add:
+    case Subtract:
+      lhsArg = new (C) MemberRefExpr(lhsDRE, SourceLoc(), member, DeclNameLoc(),
+                                     /*Implicit*/ true);
+      break;
+    case ScalarMultiply:
+      lhsArg = lhsDRE;
+      break;
+    }
+    // Create rhs argument: `rhs.member`.
+    auto *rhsArg = new (C) MemberRefExpr(rhsDRE, SourceLoc(), member,
+                                         DeclNameLoc(), /*Implicit*/ true);
+    // Create expression `lhsArg <op> rhsArg`.
+    auto *memberOpArgs =
+        TupleExpr::create(C, SourceLoc(), {lhsArg, rhsArg}, {}, {}, SourceLoc(),
+                          /*HasTrailingClosure*/ false,
+                          /*Implicit*/ true);
+    auto *memberOpCallExpr =
+        new (C) BinaryExpr(memberOpExpr, memberOpArgs, /*Implicit*/ true);
+    return memberOpCallExpr;
+  };
+
+  // Create array of member operator call expressions.
+  llvm::SmallVector<Expr *, 2> memberOpExprs;
+  llvm::SmallVector<Identifier, 2> memberNames;
+  for (auto member : nominal->getStoredProperties()) {
+    memberOpExprs.push_back(createMemberOpExpr(member));
+    memberNames.push_back(member->getName());
+  }
+  // Call memberwise initialier with member operator call expressions.
+  auto *callExpr =
+      CallExpr::createImplicit(C, initExpr, memberOpExprs, memberNames);
+  ASTNode returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr, true);
+  funcDecl->setBody(
+      BraceStmt::create(C, SourceLoc(), returnStmt, SourceLoc(), true));
+}
+
+// Synthesize body for `AdditiveArithmetic.+` operator.
+static void deriveBodyAdditiveArithmetic_add(AbstractFunctionDecl *funcDecl) {
+  deriveBodyMathOperator(funcDecl, Add);
+}
+
+// Synthesize body for `AdditiveArithmetic.-` operator.
+static void
+deriveBodyAdditiveArithmetic_subtract(AbstractFunctionDecl *funcDecl) {
+  deriveBodyMathOperator(funcDecl, Subtract);
+}
+
+// Synthesize body for `VectorNumeric.*` operator.
+static void
+deriveBodyVectorNumeric_scalarMultiply(AbstractFunctionDecl *funcDecl) {
+  deriveBodyMathOperator(funcDecl, ScalarMultiply);
+}
+
+// Synthesize the function declaration for the given math operator.
+static ValueDecl *deriveMathOperator(DerivedConformance &derived,
+                                     MathOperator op) {
+  auto nominal = derived.Nominal;
+  auto &C = derived.TC.Context;
+  auto parentDC = derived.getConformanceContext();
+  auto selfInterfaceType = parentDC->getDeclaredInterfaceType();
+
+  // Return tuple of the lhs and rhs parameter types for the given math
+  // operator.
+  auto getParameterTypes = [&](MathOperator op) -> std::pair<Type, Type> {
+    switch (op) {
+    case Add:
+    case Subtract:
+      return std::make_pair(selfInterfaceType, selfInterfaceType);
+    case ScalarMultiply:
+      return std::make_pair(deriveVectorNumeric_Scalar(nominal),
+                            selfInterfaceType);
+    }
+  };
+
+  // Create parameter declaration with the given name and type.
+  auto createParamDecl = [&](StringRef name, Type type) -> ParamDecl * {
+    auto *param = new (C)
+        ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
+                  Identifier(), SourceLoc(), C.getIdentifier(name), parentDC);
+    param->setInterfaceType(type);
+    return param;
+  };
+
+  auto paramTypes = getParameterTypes(op);
+  ParameterList *params =
+      ParameterList::create(C, {createParamDecl("lhs", paramTypes.first),
+                                createParamDecl("rhs", paramTypes.second)});
+
+  Identifier operatorId = C.getIdentifier(getMathOperatorName(op));
+  DeclName operatorDeclName(C, operatorId, params);
+  auto operatorDecl =
+      FuncDecl::create(C, SourceLoc(), StaticSpellingKind::KeywordStatic,
+                       SourceLoc(), operatorDeclName, SourceLoc(),
+                       /*Throws*/ false, SourceLoc(),
+                       /*GenericParams=*/nullptr, params,
+                       TypeLoc::withoutLoc(selfInterfaceType), parentDC);
+  operatorDecl->setImplicit();
+  switch (op) {
+  case Add:
+    operatorDecl->setBodySynthesizer(deriveBodyAdditiveArithmetic_add);
+    break;
+  case Subtract:
+    operatorDecl->setBodySynthesizer(deriveBodyAdditiveArithmetic_subtract);
+    break;
+  case ScalarMultiply:
+    operatorDecl->setBodySynthesizer(deriveBodyVectorNumeric_scalarMultiply);
+    break;
+  }
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    operatorDecl->setGenericEnvironment(env);
+  operatorDecl->computeType();
+  operatorDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
+  operatorDecl->setValidationToChecked();
+
+  derived.addMembersToConformanceContext({operatorDecl});
+  C.addSynthesizedDecl(operatorDecl);
+
+  return operatorDecl;
+}
+
+// Synthesize body for the `AdditiveArithmetic.zero` computed property getter.
+static void deriveBodyAdditiveArithmetic_zero(AbstractFunctionDecl *funcDecl) {
+  auto *nominal = funcDecl->getDeclContext()->getSelfNominalTypeDecl();
+  auto &C = nominal->getASTContext();
+
+  auto *memberwiseInitDecl = getMemberwiseInitializer(nominal);
+  auto *initDRE =
+      new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
+  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+
+  auto *nominalTypeExpr = TypeExpr::createForDecl(SourceLoc(), nominal,
+                                                  funcDecl, /*Implicit*/ true);
+  auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, nominalTypeExpr);
+
+  auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
+  auto *zeroReq = getProtocolRequirement(addArithProto, C.Id_zero);
+
+  auto createMemberZeroExpr = [&](VarDecl *member) -> Expr * {
+    auto *memberTypeExpr = TypeExpr::createImplicit(member->getType(), C);
+    auto module = nominal->getModuleContext();
+    auto confRef = module->lookupConformance(member->getType(), addArithProto);
+    assert(confRef && "Member does not conform to 'AdditiveArithmetic'");
+    // If conformance reference is not concrete, then concrete witness
+    // declaration for `zero` cannot be resolved. Return reference to `zero`
+    // protocol requirement: this will be dynamically dispatched.
+    if (!confRef->isConcrete()) {
+      return new (C) MemberRefExpr(memberTypeExpr, SourceLoc(), zeroReq,
+                                   DeclNameLoc(), /*Implicit*/ true);
+    }
+    // Otherwise,return reference to concrete witness declaration for `zero`.
+    auto conf = confRef->getConcrete();
+    auto zeroDecl = conf->getWitnessDecl(zeroReq, nullptr);
+    return new (C) MemberRefExpr(memberTypeExpr, SourceLoc(), zeroDecl,
+                                 DeclNameLoc(), /*Implicit*/ true);
+  };
+
+  // Create array of `member.zero` expressions.
+  llvm::SmallVector<Expr *, 2> memberZeroExprs;
+  llvm::SmallVector<Identifier, 2> memberNames;
+  for (auto member : nominal->getStoredProperties()) {
+    memberZeroExprs.push_back(createMemberZeroExpr(member));
+    memberNames.push_back(member->getName());
+  }
+  // Call memberwise initialier with member zero expressions.
+  auto *callExpr =
+      CallExpr::createImplicit(C, initExpr, memberZeroExprs, memberNames);
+  ASTNode returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr, true);
+  funcDecl->setBody(
+      BraceStmt::create(C, SourceLoc(), returnStmt, SourceLoc(), true));
+}
+
+// Synthesize the static property declaration for `AdditiveArithmetic.zero`.
+static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
+  auto nominal = derived.Nominal;
+  auto &TC = derived.TC;
+  auto &C = TC.Context;
+
+  // The implicit memberwise constructor must be explicitly created so that it
+  // can called when synthesizing the `zero` property getter. Normally, the
+  // memberwise constructor is synthesized during SILGen, which is too late.
+  if (!getMemberwiseInitializer(nominal)) {
+    auto *initDecl = createImplicitConstructor(
+        TC, nominal, ImplicitConstructorKind::Memberwise);
+    nominal->addMember(initDecl);
+    C.addSynthesizedDecl(initDecl);
+  }
+
+  auto returnInterfaceTy = nominal->getDeclaredInterfaceType();
+  auto returnTy =
+      derived.getConformanceContext()->mapTypeIntoContext(returnInterfaceTy);
+
+  // Create `zero` static property declaration.
+  VarDecl *zeroDecl;
+  PatternBindingDecl *pbDecl;
+  std::tie(zeroDecl, pbDecl) = derived.declareDerivedProperty(
+      C.Id_zero, returnInterfaceTy, returnTy, /*isStatic*/ true,
+      /*isFinal*/ true);
+
+  // Create `zero` getter.
+  auto *getterDecl =
+      derived.declareDerivedPropertyGetter(TC, zeroDecl, returnTy);
+  getterDecl->setBodySynthesizer(deriveBodyAdditiveArithmetic_zero);
+  zeroDecl->setAccessors(StorageImplInfo::getImmutableComputed(), SourceLoc(),
+                         {getterDecl}, SourceLoc());
+  derived.addMembersToConformanceContext({getterDecl, zeroDecl, pbDecl});
+
+  return zeroDecl;
+}
+
+ValueDecl *
+DerivedConformance::deriveAdditiveArithmetic(ValueDecl *requirement) {
+  if (requirement->getBaseName() == TC.Context.getIdentifier("+")) {
+    return deriveMathOperator(*this, Add);
+  }
+  if (requirement->getBaseName() == TC.Context.getIdentifier("-")) {
+    return deriveMathOperator(*this, Subtract);
+  }
+  if (requirement->getBaseName() == TC.Context.Id_zero) {
+    return deriveAdditiveArithmetic_zero(*this);
+  }
+  TC.diagnose(requirement->getLoc(),
+              diag::broken_additive_arithmetic_requirement);
+  return nullptr;
+}
+
+ValueDecl *DerivedConformance::deriveVectorNumeric(ValueDecl *requirement) {
+  if (requirement->getBaseName() == TC.Context.getIdentifier("*")) {
+    return deriveMathOperator(*this, ScalarMultiply);
+  }
+  TC.diagnose(requirement->getLoc(), diag::broken_vector_numeric_requirement);
+  return nullptr;
+}
+
+Type DerivedConformance::deriveVectorNumeric(AssociatedTypeDecl *requirement) {
+  if (requirement->getBaseName() == TC.Context.Id_Scalar) {
+    auto rawType = deriveVectorNumeric_Scalar(Nominal);
+    return getConformanceContext()->mapTypeIntoContext(rawType);
+  }
+  TC.diagnose(requirement->getLoc(), diag::broken_vector_numeric_requirement);
+  return nullptr;
+}

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -207,6 +207,32 @@ public:
   /// \returns the derived member, which will also be added to the type.
   Type deriveParameterGroup(AssociatedTypeDecl *assocType);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Determine if an AdditiveArithmetic requirement can be derived for a type.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveAdditiveArithmetic(NominalTypeDecl *type);
+
+  /// Derive an AdditiveArithmetic requirement for a nominal type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveAdditiveArithmetic(ValueDecl *requirement);
+
+  /// Determine if a VectorNumeric requirement can be derived for a type.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveVectorNumeric(NominalTypeDecl *type);
+
+  /// Derive a VectorNumeric requirement for a nominal type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveVectorNumeric(ValueDecl *requirement);
+
+  /// Derive a VectorNumeric type witness for a nominal type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  Type deriveVectorNumeric(AssociatedTypeDecl *assocType);
+
   /// Declare a read-only property.
   std::pair<VarDecl *, PatternBindingDecl *>
   declareDerivedProperty(Identifier name, Type propertyInterfaceType,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5288,6 +5288,14 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   case KnownProtocolKind::ParameterGroup:
     return derived.deriveParameterGroup(Requirement);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  case KnownProtocolKind::AdditiveArithmetic:
+    return derived.deriveAdditiveArithmetic(Requirement);
+
+  // SWIFT_ENABLE_TENSORFLOW
+  case KnownProtocolKind::VectorNumeric:
+    return derived.deriveVectorNumeric(Requirement);
+
   default:
     return nullptr;
   }
@@ -5318,6 +5326,8 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
     return derived.deriveParameterized(AssocType);
   case KnownProtocolKind::ParameterGroup:
     return derived.deriveParameterGroup(AssocType);
+  case KnownProtocolKind::VectorNumeric:
+    return derived.deriveVectorNumeric(AssocType);
   default:
     return nullptr;
   }

--- a/test/Sema/struct_additive_arithmetic.swift
+++ b/test/Sema/struct_additive_arithmetic.swift
@@ -1,0 +1,61 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-frontend -typecheck -verify %s -verify-ignore-unknown
+
+func testAdditiveArithmetic<T : AdditiveArithmetic>(
+  _ x: inout T
+) {
+  // Test `AdditiveArithmetic` requirements: `zero`, `+`, `-`.
+  let zero = T.zero
+  x += x + zero
+  x -= x - zero
+}
+
+struct Int2: AdditiveArithmetic {
+  var a: Int
+  var b: Int
+}
+var int2 = Int2(a: 1, b: 1)
+testAdditiveArithmetic(&int2)
+
+// Test generic type.
+struct Vector2<T : AdditiveArithmetic>: AdditiveArithmetic {
+  var x: T
+  var y: T
+}
+var vec2 = Vector2<Double>(x: 1, y: 1)
+testAdditiveArithmetic(&vec2)
+
+// Test nested type.
+struct Nested: AdditiveArithmetic {
+  var int2: Int2
+  var int: Int
+}
+var nested = Nested(int2: int2, int: 1)
+testAdditiveArithmetic(&nested)
+
+// Test mixed type.
+// Note: `Numeric` refines `AdditiveArithmetic`.
+struct Mixed: AdditiveArithmetic {
+  var nested: Nested
+  var float: Float
+  var uint8: UInt8
+}
+var mixed = Mixed(nested: nested, float: 1, uint8: 1)
+testAdditiveArithmetic(&mixed)
+
+// Test type in generic context.
+struct A<T> {
+  struct B<U, V> {
+    struct GenericContextNested : AdditiveArithmetic {
+      var nested: Nested
+      var float: Float
+      var uint8: UInt8
+    }
+  }
+}
+func testGenericContext<T, U, V>() -> A<T>.B<U, V>.GenericContextNested {
+  var genericNested =
+    A<T>.B<U, V>.GenericContextNested(nested: nested, float: 1, uint8: 1)
+  testAdditiveArithmetic(&genericNested)
+  return genericNested
+}

--- a/test/Sema/struct_vector_numeric.swift
+++ b/test/Sema/struct_vector_numeric.swift
@@ -1,0 +1,75 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-frontend -typecheck -verify %s -verify-ignore-unknown
+
+func testVectorNumeric<T : VectorNumeric>(
+_ x: inout T, scalar: T.Scalar
+) {
+  // Test `AdditiveArithmetic` requirements: `zero`, `+`, `-`.
+  let zero = T.zero
+  x += x + zero
+  x -= x - zero
+  // Test `VectorNumeric` requirements: `Scalar`, `*`.
+  x *= scalar
+  _ = scalar * x
+  _ = x * scalar
+}
+
+struct Float2: VectorNumeric {
+  var x: Float
+  var y: Float
+}
+var float2 = Float2(x: 1, y: 1)
+testVectorNumeric(&float2, scalar: 1)
+
+// Test generic type.
+struct Vector2<T : VectorNumeric>: VectorNumeric {
+  var x: T
+  var y: T
+}
+_ = Vector2<Double>(x: 1, y: 1)
+_ = Vector2<Float2>(x: float2, y: float2)
+func testGeneric<T : VectorNumeric>(vec2: inout Vector2<T>, scalar: T.Scalar) {
+  testVectorNumeric(&vec2, scalar: scalar)
+}
+
+// Test nested types.
+struct Nested: VectorNumeric {
+  var float2: Float2
+  var float: Float
+}
+var nested = Nested(float2: float2, float: 1)
+testVectorNumeric(&nested, scalar: 1)
+
+struct NestedGeneric: VectorNumeric {
+  var vec2: Vector2<Float>
+  var float2: Float2
+  var float: Float
+}
+var nestedGeneric = NestedGeneric(vec2: Vector2<Float>(x: 1, y: 1),
+                                  float2: float2, float: 1)
+testVectorNumeric(&nestedGeneric, scalar: 1)
+
+// Test type in generic context.
+struct A<T> {
+  struct B<U, V> {
+    struct GenericContextNested : VectorNumeric {
+      var float2: Float2
+      var float: Float
+    }
+  }
+}
+func testGenericContext<T, U, V>() -> A<T>.B<U, V>.GenericContextNested {
+  var genericNested =
+    A<T>.B<U, V>.GenericContextNested(float2: float2, float: 1)
+  testVectorNumeric(&genericNested, scalar: 1)
+  return genericNested
+}
+
+// Test errors.
+
+// Test type whose members conform to `VectorNumeric`
+// but have different `Scalar` associated type.
+struct InvalidMixedScalar: VectorNumeric { // expected-error {{type 'InvalidMixedScalar' does not conform to protocol 'VectorNumeric'}}
+  var float: Float
+  var double: Double
+}


### PR DESCRIPTION
Implement `AdditiveArithmetic` and `VectorNumeric` derived conformances for
struct types.

* `AdditiveArithmetic` conformances can be derived for struct types whose
  members all conform to `AdditiveArithmetic`.
* `VectorNumeric` conformances can be derived for struct types whose members
  all conform to `VectorNumeric` and all share the same `Scalar` associated
  type.

Derived conformances improve the usability of these math protocols for
user-defined types.
Derived conformances can be extended for enum types in the future.

Examples:
```swift
struct IntFloat: AdditiveArithmetic {
  // Synthesis requirement: all members must conform to `AdditiveArithmetic`.
  var int: Int
  var float: Float

  // Compiler synthesizes:
  // static var zero: IntFloat {
  //   return IntFloat(int: Int.zero, float: Float.zero)
  // }
  // static func + (lhs: IntFloat, rhs: IntFloat) -> IntFloat {
  //   return IntFloat(int: lhs.int + rhs.int, float: lhs.float + rhs.float)
  // }
  // static func - (lhs: IntFloat, rhs: IntFloat) -> IntFloat {
  //   return IntFloat(int: lhs.int - rhs.int, float: lhs.float - rhs.float)
  // }
}

// Generic type.
struct Vector2<T : VectorNumeric>: VectorNumeric {
  // Synthesis requirement: all members must conform to `VectorNumeric`
  // and share the same `Scalar` type.
  var x: T
  var y: T

  // Compiler synthesizes:
  // <all three `AdditiveArithmetic` requirements from above>
  // typealias Scalar = T.Scalar
  // static func * (lhs: Scalar, rhs: Vector2) -> Vector2 {
  //   return Vector2(x: lhs * rhs.x, y: lhs * rhs.y)
  // }
}

// Nested generic type.
struct NestedGeneric: VectorNumeric {
  var vec2: Vector2<Float>
  var float: Float

  // Compiler synthesizes:
  // typealias Scalar = Float
  // <all other `VectorNumeric` requirements from above>
}
```