### PR TITLE
SwiftShims: always define TARGET_IS_SIMULATOR

### DIFF
--- a/stdlib/public/SwiftShims/Target.h
+++ b/stdlib/public/SwiftShims/Target.h
@@ -26,6 +26,8 @@
 #if __has_builtin(__is_target_environment)
 # if __is_target_environment(simulator)
 #  define SWIFT_TARGET_OS_SIMULATOR 1
+# else
+#  define SWIFT_TARGET_OS_SIMULATOR 0
 # endif
 #endif
 


### PR DESCRIPTION
This is used as a conditional guard rather than checked for a
definition.  Ensure that a value is always defined.  Silences a -Wundef
warning.  NFC

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
