### PR TITLE
[stdlib] Add String initializer from StaticString

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -842,3 +842,11 @@ extension String {
     }
   }
 }
+
+extension String {
+    /// Creates a String instance from a StaticString
+    @inlinable @inline(__always)
+    public init(_ staticString: StaticString) {
+        self = staticString.withUTF8Buffer { String._uncheckedFromUTF8($0) }
+    }
+}

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2105,6 +2105,10 @@ let comparisonTestCases = [
   ComparisonTestCase(["abcdefg", "abcdefg"], .equal),
   ComparisonTestCase(["", "Z", "a", "b", "c", "\u{00c5}", "á"], .less),
 
+  ComparisonTestCase([String(StaticString("a")), "a"], .equal),
+  ComparisonTestCase([String(StaticString("abcdefg")), "abcdefg"], .equal),
+  ComparisonTestCase([String(StaticString("😀 \u{2f9df}")), "😀 \u{2f9df}"], .equal),
+
   ComparisonTestCase(["ábcdefg", "ábcdefgh", "ábcdefghi"], .less),
   ComparisonTestCase(["abcdefg", "abcdefgh", "abcdefghi"], .less),
 


### PR DESCRIPTION
Add String(_: StaticString) initializer to allow String initialization from a StaticString. 

Resolves https://bugs.swift.org/browse/SR-2257