### PR TITLE
[Sema][AST][WIP] Support existentials with concrete assoc. types

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -789,6 +789,7 @@ class CompositionTypeRepr final : public TypeRepr,
     private llvm::TrailingObjects<CompositionTypeRepr, TypeRepr*> {
   friend TrailingObjects;
   SourceLoc FirstTypeLoc;
+  Type ResolvedType;
   SourceRange CompositionRange;
 
   CompositionTypeRepr(ArrayRef<TypeRepr *> Types,
@@ -807,6 +808,9 @@ public:
   }
   SourceLoc getSourceLoc() const { return FirstTypeLoc; }
   SourceRange getCompositionRange() const { return CompositionRange; }
+  Type getResolvedType() const { return ResolvedType; }
+
+  void setResolvedType(Type ty) { ResolvedType = ty; }
 
   static CompositionTypeRepr *create(const ASTContext &C,
                                      ArrayRef<TypeRepr*> Protocols,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -403,6 +403,15 @@ using AccessLevelField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
+enum class ExistentialSupportKind : uint8_t {
+  Supported = 0,
+  UnsupportedSelf,
+  UnsupportedAssoc,
+};
+using ExistentialSupportKindField = BCFixed<2>;
+
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
 enum class OptionalTypeKind : uint8_t {
   None,
   Optional,
@@ -952,7 +961,7 @@ namespace decls_block {
     BCFixed<1>,             // implicit flag
     BCFixed<1>,             // class-bounded?
     BCFixed<1>,             // objc?
-    BCFixed<1>,             // existential-type-supported?
+    ExistentialSupportKindField, // existential-type-supported?
     GenericEnvironmentIDField, // generic environment
     TypeIDField,            // superclass
     AccessLevelField,       // access level

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3413,7 +3413,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       // match that of the subtype. For example, an inheriting protocol could
       // introduce an associated type or, conversely, specialize an inherited
       // associated type that would otherwise prevent the protocol from
-      // being supported.
+      // being supported. Similarly, a supported protocol does not
+      // always imply that a composition type containing said protocol is
+      // also supported, and vice versa.
 
       // Make sure the candidate belongs to a protocol.
       if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
@@ -3421,6 +3423,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         if (auto *protoTy = outerBaseTy->getAs<ProtocolType>()) {
           supported = protoTy->getDecl()->existentialTypeSupported(&TC)
               == ExistentialSupportKind::Supported;
+        } else if (auto *comp = outerBaseTy->getAs<ProtocolCompositionType>()) {
+          supported = comp->existentialTypeSupported(&TC);
         }
         supported = proto->isAvailableInExistential(
                                decl, /*skipAssocTypes=*/supported);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1347,24 +1347,24 @@ ConstraintSystem::getTypeOfMemberReference(
   // When accessing protocol members with an existential base, replace
   // the 'Self' type parameter with the existential type, since formally
   // the access will operate on existentials and not type parameters.
-  if (!isDynamicResult &&
-      baseObjTy->isExistentialType() &&
-      outerDC->getSelfProtocolDecl()) {
-    auto selfTy = replacements[
-      cast<GenericTypeParamType>(outerDC->getSelfInterfaceType()
-                                 ->getCanonicalType())];
-    type = type.transform([&](Type t) -> Type {
-      if (auto *selfTy = t->getAs<DynamicSelfType>())
-        t = selfTy->getSelfType();
-      if (t->is<TypeVariableType>())
-        if (t->isEqual(selfTy))
-          return baseObjTy;
-      if (auto *metatypeTy = t->getAs<MetatypeType>())
-        if (metatypeTy->getInstanceType()->isEqual(selfTy))
-          return ExistentialMetatypeType::get(baseObjTy);
-      return t;
-    });
-  }
+//  if (!isDynamicResult &&
+//      baseObjTy->isExistentialType() &&
+//      outerDC->getSelfProtocolDecl()) {
+//    auto selfTy = replacements[
+//      cast<GenericTypeParamType>(outerDC->getSelfInterfaceType()
+//                                 ->getCanonicalType())];
+//    type = type.transform([&](Type t) -> Type {
+//      if (auto *selfTy = t->getAs<DynamicSelfType>())
+//        t = selfTy->getSelfType();
+//      if (t->is<TypeVariableType>())
+//        if (t->isEqual(selfTy))
+//          return baseObjTy;
+//      if (auto *metatypeTy = t->getAs<MetatypeType>())
+//        if (metatypeTy->getInstanceType()->isEqual(selfTy))
+//          return ExistentialMetatypeType::get(baseObjTy);
+//      return t;
+//    });
+//  }
 
   // If we opened up any type variables, record the replacements.
   recordOpenedTypes(locator, replacements);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1190,16 +1190,15 @@ ConstraintSystem::getTypeOfMemberReference(
 
   FunctionType::Param baseObjParam(baseObjTy);
 
-  // Don't open existentials when accessing typealias members of
-  // protocols.
   if (auto *alias = dyn_cast<TypeAliasDecl>(value)) {
     if (baseObjTy->isExistentialType()) {
       auto memberTy = alias->getInterfaceType();
-      // If we end up with a protocol typealias here, it's underlying
-      // type must be fully concrete.
-      assert(!memberTy->hasTypeParameter());
-      auto openedType = FunctionType::get({baseObjParam}, memberTy);
-      return { openedType, memberTy };
+      // Only proceed to opening existentials when the protocol typealias
+      // has type parameters.
+      if (!memberTy->hasTypeParameter()) {
+        auto openedType = FunctionType::get({baseObjParam}, memberTy);
+        return { openedType, memberTy };
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3305,7 +3305,8 @@ public:
     
     auto comp = T->getComponentRange().back();
     if (auto *proto = dyn_cast_or_null<ProtocolDecl>(comp->getBoundDecl())) {
-      if (!proto->existentialTypeSupported(&TC)) {
+      if (proto->existentialTypeSupported(&TC) !=
+          ExistentialSupportKind::Supported) {
         TC.diagnose(comp->getIdLoc(), diag::unsupported_existential_type,
                     proto->getName());
         T->setInvalid();
@@ -3322,7 +3323,8 @@ public:
           for (auto *proto : layout.getProtocols()) {
             auto *protoDecl = proto->getDecl();
 
-            if (protoDecl->existentialTypeSupported(&TC))
+            if (protoDecl->existentialTypeSupported(&TC) ==
+                ExistentialSupportKind::Supported)
               continue;
             
             TC.diagnose(comp->getIdLoc(), diag::unsupported_existential_type,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1381,7 +1381,7 @@ static Type resolveNestedIdentTypeComponent(
   auto maybeDiagnoseBadMemberType = [&](TypeDecl *member, Type memberType,
                                         AssociatedTypeDecl *inferredAssocType) {
     // Diagnose invalid cases.
-    if (TypeChecker::isUnsupportedMemberTypeAccess(parentTy, member)) {
+    if (TypeChecker::isUnsupportedMemberTypeAccess(parentTy, member, memberType)) {
       if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
         if (parentTy->is<UnboundGenericType>())
           diagnoseUnboundGenericType(parentTy, parentRange.End);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1816,7 +1816,8 @@ public:
 
   /// Check whether the given declaration can be written as a
   /// member of the given base type.
-  static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
+  static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl,
+                                            Type replacementTy);
 
   /// Look up a member type within the given type.
   ///

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -215,7 +215,27 @@ func testExistential11(arg: EdgeCaseSub1) {}
 typealias Comp = EdgeCaseSub2 & EdgeCase1 & ProtAssoc
 
 func testExistential12(arg1: EdgeCaseSub2, arg2: Comp & ProtAssoc2) {
+  print(EdgeCaseSub2.Assoc.self)
+  print(EdgeCaseSub2.SimpleAlias.self)
+  print(EdgeCaseSub2.ComplexAlias.self)
+  print(Comp.Assoc.self)
+  print(Comp.SimpleAlias.self)
+  print(Comp.ComplexAlias.self)
+  print((EdgeCaseSub2 & EdgeCase1).Assoc.self)
+  print((EdgeCaseSub2 & EdgeCase1).SimpleAlias.self)
+  print((EdgeCaseSub2 & EdgeCase1).ComplexAlias.self)
 
   let _: Conforming = arg1.simpleAliasToAssoc(arg: Conforming())
   let _: Conforming = arg2.simpleAliasToAssoc(arg: Conforming())
+}
+
+func testExistentialMetatype(meta1: EdgeCaseSub2.Protocol,
+                             meta2: (EdgeCaseSub2 & EdgeCase1).Protocol,
+                             meta3: Comp.Protocol) {
+  print(meta1.Assoc.self)
+  print(meta1.ComplexAlias.self)
+  print(meta2.Assoc.self)
+  print(meta2.ComplexAlias.self)
+  print(meta3.Assoc.self)
+  print(meta3.ComplexAlias.self)
 }

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -168,12 +168,26 @@ protocol ProtAssoc2 {
 }
 protocol ProtMergeAssocInt: ProtAssocInt, ProtAssoc2 {}
 
+typealias Composition1 = ProtAssocConcreteHasSelf & TrivialProto
+typealias Composition2 = Composition1 & ProtAssoc2
+
 func testExistential1(arg: ProtAssocInt) {} // Ok
 func testExistential2(arg: ProtAssocBssocConcrete) {} // Ok
 func testExistential3(arg: ProtMergeAssocInt) {} // Ok
+func testExistential4(arg: TrivialClass & ProtAssoc2 & ProtAssocInt) {} // Ok
+func testExistential5(arg: TrivialProto & ProtAssocBssocConcrete & ProtAssoc2) {} // Ok
 
-func testExistential4(arg: ProtAssocConcreteHasSelf) {}
+func testExistential6(arg: ProtAssocConcreteHasSelf) {}
 // expected-error@-1 {{protocol 'ProtAssocConcreteHasSelf' can only be used}}
+func testExistential7(arg: ProtAssocInt & ProtAssocHasSelf & TrivialClass) {}
+// expected-error@-1 {{protocol 'ProtAssocHasSelf' can only be used}}
+func testExistential8(arg: ProtAssocConcreteHasSelf & TrivialProto & ProtAssoc2) {}
+// expected-error@-1 {{protocol 'ProtAssocConcreteHasSelf' can only be used}}
+func testExistential9(arg: Composition2) {}
+// expected-error@-1 {{protocol 'ProtAssocConcreteHasSelf' can only be used}}
+func testExistential10(arg: ProtAssoc & ProtAssoc2) {}
+// expected-error@-1 {{protocol 'ProtAssoc' can only be used}}
+// expected-error@-2 {{protocol 'ProtAssoc2' can only be used}}
 
 // Test various edge cases and expressions.
 class Conforming: EdgeCase1, EdgeCase2 {
@@ -197,7 +211,11 @@ protocol EdgeCaseSub2: EdgeCase2 where Assoc.Assoc == Conforming {}
 
 func testExistential11(arg: EdgeCaseSub1) {}
 // expected-error@-1 {{protocol 'EdgeCaseSub1' can only be used}}
-func testExistential12(arg1: EdgeCaseSub2) {
+
+typealias Comp = EdgeCaseSub2 & EdgeCase1 & ProtAssoc
+
+func testExistential12(arg1: EdgeCaseSub2, arg2: Comp & ProtAssoc2) {
 
   let _: Conforming = arg1.simpleAliasToAssoc(arg: Conforming())
+  let _: Conforming = arg2.simpleAliasToAssoc(arg: Conforming())
 }


### PR DESCRIPTION
Resolving [SR-4758](https://bugs.swift.org/browse/SR-4758).

This still needs corrections and I might have touched ABI sensitive stuff I shouldn't have, I'm not sure.

Anyway, I would like to hear your overall opinion, @slavapestov. Please be strict 🙂

Happy new year!

### TODO
- [x] Handle the edge case `Assoc.Assoc == Concrete`. 
- [x] Handle concrete associated type references in expression position, i.e.
  * `print(Proto.ConcreteAssoc.self)`, 
  * `print((A & B).ConcreteAssoc.self)`
  * `print(Proto.TypeAliasReferencingConcreteAssoc.self)`
  * ```swift
    func foo(meta1: Proto.Protocol, meta2: (A & B).Protocol) {
      print(meta1.ConcreteAssocOrTypeAliasWithTypeParameters.self)
      print(meta2.ConcreteAssocOrTypeAliasWithTypeParameters.self)
    }
    ```
- [x] Make sure we cannot access type aliases that contain `Self`.
- [x] Make sure compositions with conflicting concrete associated types get diagnosed.
- [ ] Decide on how to avoid creating generic environments for composition types each time a nested type has to be resolved.
- [ ] Handle the edge case `Assoc == Self`.
