### PR TITLE
vim: detect `prefix` modifier

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -42,6 +42,7 @@ syn keyword swiftDefinitionModifier
       \ nonmutating
       \ open
       \ override
+      \ prefix
       \ private
       \ public
       \ required


### PR DESCRIPTION
THe `prefix` modifier applies to prefix operators.  This is used for the
operator definitions, detect the keyword appropriately.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
