### PR TITLE
[API] Start deriving conformances for `Differentiable`.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2421,6 +2421,14 @@ ERROR(broken_additive_arithmetic_requirement,none,
       "AdditiveArithmetic protocol is broken: unexpected requirement", ())
 ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
+ERROR(broken_differentiable_requirement,none,
+      "Differentiable protocol is broken: unexpected requirement", ())
+ERROR(differentiable_no_vector_space_struct,none,
+      "cannot automatically synthesize %0 because '%1' struct does not exist",
+      (Type, Identifier))
+ERROR(differentiable_invalid_vector_space_struct,none,
+      "cannot automatically synthesize %0 because '%1' struct is invalid",
+      (Type, Identifier))
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2423,12 +2423,6 @@ ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
-ERROR(differentiable_no_vector_space_struct,none,
-      "cannot automatically synthesize %0 because '%1' struct does not exist",
-      (Type, Identifier))
-ERROR(differentiable_invalid_vector_space_struct,none,
-      "cannot automatically synthesize %0 because '%1' struct is invalid",
-      (Type, Identifier))
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -134,6 +134,8 @@ IDENTIFIER(Parameters)
 // Differentiable
 IDENTIFIER(CotangentVector)
 IDENTIFIER(TangentVector)
+IDENTIFIER(moved)
+IDENTIFIER(tangentVector)
 
 // Kinds of layout constraints
 IDENTIFIER_WITH_NAME(UnknownLayout, "_UnknownLayout")

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_host_library(swiftSema STATIC
   DerivedConformanceError.cpp
   # SWIFT_ENABLE_TENSORFLOW
   DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+  DerivedConformanceDifferentiable.cpp
   DerivedConformanceKeyPathIterable.cpp
   DerivedConformanceParameterGroup.cpp
   DerivedConformanceParameterized.cpp

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -1,0 +1,524 @@
+//===--- DerivedConformanceDifferentiable.cpp - Derived Differentiable ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// SWIFT_ENABLE_TENSORFLOW
+//
+// This file implements explicit derivation of the Differentiable protocol for
+// struct types.
+//
+//===----------------------------------------------------------------------===//
+
+// TODO:
+// - Support synthesis when non-synthesized `TangentVector` or `CotangentVector`
+//   struct does not have implicit memberwise initializer. Currently,
+//   user-defined memberwise initializers do not work.
+
+#include "CodeSynthesis.h"
+#include "TypeChecker.h"
+#include "swift/AST/AutoDiff.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Stmt.h"
+#include "swift/AST/Types.h"
+#include "DerivedConformances.h"
+
+using namespace swift;
+
+// Represents the possible outcomes of checking whether the `TangentVector` or
+// `CotangentVector` struct exists.
+enum VectorSpaceStructStatus {
+  Valid,
+  Invalid,
+  DoesNotExist
+};
+
+static Identifier
+getVectorSpaceIdentifier(AutoDiffAssociatedVectorSpaceKind kind,
+                         ASTContext &C) {
+  switch (kind) {
+  case AutoDiffAssociatedVectorSpaceKind::Tangent:
+    return C.Id_TangentVector;
+  case AutoDiffAssociatedVectorSpaceKind::Cotangent:
+    return C.Id_CotangentVector;
+  }
+}
+
+// Return the protocol requirement with the specified name.
+// TODO: Move function to shared place for use with other derived conformances.
+static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
+  auto lookup = proto->lookupDirect(name);
+  // Erase declarations that are not protocol requirements.
+  // This is important for removing default implementations of the same name.
+  lookup.erase(std::remove_if(lookup.begin(), lookup.end(),
+                              [](ValueDecl *v) {
+                                return !isa<ProtocolDecl>(
+                                           v->getDeclContext()) ||
+                                       !v->isProtocolRequirement();
+                              }),
+               lookup.end());
+  assert(lookup.size() == 1 && "Ambiguous protocol requirement");
+  return lookup[0];
+}
+
+bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal) {
+  // Nominal type must be a struct with at least one stored property.
+  auto *structDecl = dyn_cast<StructDecl>(nominal);
+  if (!structDecl || structDecl->getStoredProperties().empty())
+    return false;
+  auto &C = nominal->getASTContext();
+  auto *lazyResolver = C.getLazyResolver();
+  auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
+
+  // Nominal type must conform to `VectorNumeric`.
+  // TODO: Lift this restriction.
+  auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
+  if (!TypeChecker::conformsToProtocol(
+          nominal->getDeclaredInterfaceType(), vectorNumericProto,
+          nominal->getDeclContext(), ConformanceCheckFlags::Used))
+    return false;
+
+  // All stored properties must conform to `Differentiable`.
+  // Currently, all stored properties must also have
+  // `Self == TangentVector == CotangentVector`.
+  // TODO: Lift this restriction.
+  return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
+    if (!v->hasType())
+      lazyResolver->resolveDeclSignature(v);
+    if (!v->hasType())
+      return false;
+    auto conf = TypeChecker::conformsToProtocol(v->getType(), diffableProto,
+                                                v->getDeclContext(),
+                                                ConformanceCheckFlags::Used);
+    if (!conf)
+      return false;
+
+    Type memberTangentType = ProtocolConformanceRef::getTypeWitnessByName(
+        v->getType(), *conf, C.Id_TangentVector, lazyResolver);
+    Type memberCotangentType = ProtocolConformanceRef::getTypeWitnessByName(
+        v->getType(), *conf, C.Id_CotangentVector, lazyResolver);
+    return memberTangentType->isEqual(v->getType()) &&
+           memberCotangentType->isEqual(v->getType());
+  });
+}
+
+// Get the specified vector space associated type for the given declaration.
+// TODO: Generalize and move function to shared place for use with other derived
+// conformances.
+static Type getVectorSpaceType(ValueDecl *decl,
+                               AutoDiffAssociatedVectorSpaceKind kind) {
+  auto &C = decl->getASTContext();
+  auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
+  auto declType =
+      decl->getDeclContext()->mapTypeIntoContext(decl->getInterfaceType());
+  auto conf = TypeChecker::conformsToProtocol(declType, diffableProto,
+                                              decl->getDeclContext(),
+                                              ConformanceCheckFlags::Used);
+  if (!conf)
+    return Type();
+  auto vectorSpaceId = getVectorSpaceIdentifier(kind, C);
+  Type vectorSpaceType = ProtocolConformanceRef::getTypeWitnessByName(
+      declType, *conf, vectorSpaceId, C.getLazyResolver());
+  assert(vectorSpaceType &&
+         "Differentiable protocol vector space type not found");
+  return vectorSpaceType->mapTypeOutOfContext();
+}
+
+// Return true if `vectorSpaceDecl` is a valid vector space struct for the given
+// nominal type.
+static bool isValidVectorSpaceStruct(NominalTypeDecl *nominal,
+                                     StructDecl *vectorSpaceDecl) {
+  // Add all stored properties of the vector space struct to a map.
+  // Also, check that vector space struct has a memberwise initializer.
+  llvm::DenseMap<Identifier, VarDecl *> members;
+  ConstructorDecl *memberwiseInitDecl = nullptr;
+  for (auto member : vectorSpaceDecl->getMembers()) {
+    // Find memberwise initializer.
+    if (!memberwiseInitDecl) {
+      auto initDecl = dyn_cast<ConstructorDecl>(member);
+      if (initDecl && initDecl->isMemberwiseInitializer())
+        memberwiseInitDecl = initDecl;
+    }
+    // Add `members` struct stored properties to map.
+    auto varDecl = dyn_cast<VarDecl>(member);
+    if (!varDecl || varDecl->isStatic() || !varDecl->hasStorage())
+      continue;
+    members[varDecl->getName()] = varDecl;
+  }
+  if (!memberwiseInitDecl)
+    return false;
+
+  // Check that each member of the nominal type maps to a stored property in
+  // the vector space struct.
+  for (auto member : nominal->getStoredProperties()) {
+    auto it = members.find(member->getName());
+    if (it == members.end() ||
+        !it->second->getType()->isEqual(member->getType())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Attempt to find a vector space associated type for the given nominal type.
+static std::pair<StructDecl *, VectorSpaceStructStatus>
+getVectorSpaceStructDecl(NominalTypeDecl *nominal,
+                         AutoDiffAssociatedVectorSpaceKind kind) {
+  auto &ctx = nominal->getASTContext();
+  auto vectorSpaceId = getVectorSpaceIdentifier(kind, ctx);
+
+  VectorSpaceStructStatus status = DoesNotExist;
+  StructDecl *vectorSpaceStructDecl = nullptr;
+
+  for (auto member : nominal->getMembers()) {
+    // If member is a typealias declaration with matching name and underlying
+    // struct type, use the struct type.
+    if (auto aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
+      if (aliasDecl->getName() != vectorSpaceId)
+        continue;
+      auto underlyingType = aliasDecl->getUnderlyingTypeLoc().getType();
+      vectorSpaceStructDecl =
+          dyn_cast<StructDecl>(underlyingType->getAnyNominal());
+    }
+    // If member is a struct declaration with matching name, use it.
+    else if (auto structDecl = dyn_cast<StructDecl>(member)) {
+      if (structDecl->getName() != vectorSpaceId)
+        continue;
+      vectorSpaceStructDecl = structDecl;
+    }
+    if (!vectorSpaceStructDecl)
+      continue;
+    if (isValidVectorSpaceStruct(nominal, vectorSpaceStructDecl))
+      return std::make_pair(vectorSpaceStructDecl, Valid);
+    else
+      status = Invalid;
+  }
+  return std::make_pair(vectorSpaceStructDecl, status);
+}
+
+// Get memberwise initializer for a nominal type.
+static ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal) {
+  ConstructorDecl *memberwiseInitDecl = nullptr;
+  for (auto member : nominal->getMembers()) {
+    // Find memberwise initializer.
+    if (!memberwiseInitDecl) {
+      auto initDecl = dyn_cast<ConstructorDecl>(member);
+      if (!initDecl || !initDecl->isMemberwiseInitializer())
+        continue;
+      assert(!memberwiseInitDecl && "Memberwise initializer already found");
+      memberwiseInitDecl = initDecl;
+    }
+  }
+  return memberwiseInitDecl;
+}
+
+// Synthesize body for a `Differentiable` method requirement.
+static void deriveBodyDifferentiable_method(AbstractFunctionDecl *funcDecl,
+                                            Identifier methodName,
+                                            Identifier methodParamLabel) {
+  // NominalTypeDecl *returnedNominal) {
+  auto *nominal = funcDecl->getDeclContext()->getSelfNominalTypeDecl();
+  auto &C = nominal->getASTContext();
+
+  // Create memberwise initializer for the returned nominal type:
+  // `Nominal.init(...)`.
+  auto retNominalInterfaceType =
+      funcDecl->getMethodInterfaceType()->getAs<AnyFunctionType>()->getResult();
+  auto *retNominal = retNominalInterfaceType->getAnyNominal();
+  auto retNominalType = funcDecl->mapTypeIntoContext(retNominalInterfaceType);
+  auto *retNominalTypeExpr = TypeExpr::createImplicit(retNominalType, C);
+  auto *memberwiseInitDecl = getMemberwiseInitializer(retNominal);
+  auto *initDRE =
+      new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
+  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+  auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, retNominalTypeExpr);
+
+  // Get method protocol requirement.
+  auto *diffProto = C.getProtocol(KnownProtocolKind::Differentiable);
+  auto *methodReq = getProtocolRequirement(diffProto, methodName);
+
+  // Get references to `self` and parameter declarations.
+  auto *selfDecl = funcDecl->getImplicitSelfDecl();
+  auto *selfDRE =
+      new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
+  auto *paramDecl = funcDecl->getParameters()->get(0);
+  auto *paramDRE =
+      new (C) DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit*/ true);
+
+  // Create call expression applying a member method to a parameter member.
+  // Format: `<member>.method(<parameter>.<member>)`.
+  // Example: `x.moved(along: direction.x)`.
+  auto createMemberMethodCallExpr = [&](VarDecl *member) -> Expr * {
+    auto module = nominal->getModuleContext();
+    auto confRef = module->lookupConformance(member->getType(), diffProto);
+    assert(confRef && "Member does not conform to 'Differentiable'");
+
+    // Get member type's method, e.g. `Member.moved(along:)`.
+    // Use protocol requirement declaration for the method by default: this
+    // will be dynamically dispatched.
+    ValueDecl *memberMethodDecl = methodReq;
+    // If conformance reference is concrete, then use concrete witness
+    // declaration for the operator.
+    if (confRef->isConcrete())
+      memberMethodDecl =
+          confRef->getConcrete()->getWitnessDecl(methodReq, nullptr);
+    auto memberMethodDRE =
+        new (C) DeclRefExpr(memberMethodDecl, DeclNameLoc(), /*Implicit*/ true);
+    memberMethodDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+
+    // Create reference to member method: `x.moved(along:)`.
+    auto memberExpr =
+        new (C) MemberRefExpr(selfDRE, SourceLoc(), member, DeclNameLoc(),
+                              /*Implicit*/ true);
+    auto memberMethodExpr =
+        new (C) DotSyntaxCallExpr(memberMethodDRE, SourceLoc(), memberExpr);
+
+    // Create reference to parameter member: `direction.x`.
+    VarDecl *paramMember = nullptr;
+    auto paramNominal = paramDecl->getType()->getAnyNominal();
+    assert(paramNominal && "Parameter should have a nominal type");
+    // Find parameter member corresponding to nominal member.
+    // TODO: make more efficient using `lookupDirect` or a map of members.
+    for (auto candidate : paramNominal->getStoredProperties()) {
+      if (candidate->getName() == member->getName() &&
+          candidate->getType()->isEqual(member->getType())) {
+        paramMember = candidate;
+        break;
+      }
+    }
+    assert(paramMember && "Could not find corresponding parameter member");
+    auto paramMemberExpr =
+        new (C) MemberRefExpr(paramDRE, SourceLoc(), paramMember, DeclNameLoc(),
+                              /*Implicit*/ true);
+    // Create expression: `x.moved(along: direction.x)`.
+    return CallExpr::createImplicit(C, memberMethodExpr, {paramMemberExpr},
+                                    {methodParamLabel});
+  };
+
+  // Create array of member method call expressions.
+  llvm::SmallVector<Expr *, 2> memberMethodCallExprs;
+  llvm::SmallVector<Identifier, 2> memberNames;
+  for (auto member : nominal->getStoredProperties()) {
+    memberMethodCallExprs.push_back(createMemberMethodCallExpr(member));
+    memberNames.push_back(member->getName());
+  }
+  // Call memberwise initialier with member method call expressions.
+  auto *callExpr =
+      CallExpr::createImplicit(C, initExpr, memberMethodCallExprs, memberNames);
+  ASTNode returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr, true);
+  funcDecl->setBody(
+      BraceStmt::create(C, SourceLoc(), returnStmt, SourceLoc(), true));
+}
+
+// Synthesize body for `moved(along:)`.
+static void deriveBodyDifferentiable_moved(AbstractFunctionDecl *funcDecl) {
+  auto &C = funcDecl->getASTContext();
+  deriveBodyDifferentiable_method(funcDecl, C.Id_moved,
+                                  C.getIdentifier("along"));
+}
+
+// Synthesize body for `tangentVector(from:)`.
+static void
+deriveBodyDifferentiable_tangentVector(AbstractFunctionDecl *funcDecl) {
+  auto &C = funcDecl->getASTContext();
+  deriveBodyDifferentiable_method(funcDecl, C.Id_tangentVector,
+                                  C.getIdentifier("from"));
+}
+
+// Synthesize the `moved(along:)` function declaration.
+static ValueDecl *deriveDifferentiable_moved(DerivedConformance &derived) {
+  auto nominal = derived.Nominal;
+  auto &TC = derived.TC;
+  auto &C = derived.TC.Context;
+  auto parentDC = derived.getConformanceContext();
+  auto selfInterfaceType = parentDC->getDeclaredInterfaceType();
+
+  StructDecl *tangentDecl;
+  VectorSpaceStructStatus tangentStatus;
+  std::tie(tangentDecl, tangentStatus) = getVectorSpaceStructDecl(
+      nominal, AutoDiffAssociatedVectorSpaceKind::Tangent);
+  switch (tangentStatus) {
+  case DoesNotExist:
+    TC.diagnose(derived.ConformanceDecl->getLoc(),
+                diag::differentiable_no_vector_space_struct,
+                derived.getProtocolType(), C.Id_TangentVector);
+    return nullptr;
+  case Invalid:
+    TC.diagnose(tangentDecl, diag::differentiable_invalid_vector_space_struct,
+                derived.getProtocolType(), C.Id_TangentVector);
+    return nullptr;
+  case Valid:
+    break;
+  }
+  auto tangentType = tangentDecl->getDeclaredInterfaceType();
+
+  auto *param =
+      new (C) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
+                        C.getIdentifier("along"), SourceLoc(),
+                        C.getIdentifier("direction"), parentDC);
+  param->setInterfaceType(tangentType);
+  ParameterList *params = ParameterList::create(C, {param});
+
+  DeclName declName(C, C.Id_moved, params);
+  auto funcDecl =
+      FuncDecl::create(C, SourceLoc(), StaticSpellingKind::None, SourceLoc(),
+                       declName, SourceLoc(),
+                       /*Throws*/ false, SourceLoc(),
+                       /*GenericParams=*/nullptr, params,
+                       TypeLoc::withoutLoc(selfInterfaceType), parentDC);
+  funcDecl->setImplicit();
+  funcDecl->setBodySynthesizer(deriveBodyDifferentiable_moved);
+
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    funcDecl->setGenericEnvironment(env);
+  funcDecl->computeType();
+  funcDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
+  funcDecl->setValidationToChecked();
+
+  derived.addMembersToConformanceContext({funcDecl});
+  C.addSynthesizedDecl(funcDecl);
+
+  return funcDecl;
+}
+
+// Synthesize the `tangentVector(from:)` function declaration.
+static ValueDecl *
+deriveDifferentiable_tangentVector(DerivedConformance &derived) {
+  auto nominal = derived.Nominal;
+  auto &TC = derived.TC;
+  auto &C = derived.TC.Context;
+  auto parentDC = derived.getConformanceContext();
+
+  StructDecl *tangentDecl;
+  VectorSpaceStructStatus tangentStatus;
+  std::tie(tangentDecl, tangentStatus) = getVectorSpaceStructDecl(
+      nominal, AutoDiffAssociatedVectorSpaceKind::Tangent);
+  switch (tangentStatus) {
+  case DoesNotExist:
+    TC.diagnose(derived.ConformanceDecl->getLoc(),
+                diag::differentiable_no_vector_space_struct,
+                derived.getProtocolType(), C.Id_TangentVector);
+    return nullptr;
+  case Invalid:
+    TC.diagnose(tangentDecl, diag::differentiable_invalid_vector_space_struct,
+                derived.getProtocolType(), C.Id_TangentVector);
+    return nullptr;
+  case Valid:
+    break;
+  }
+  auto tangentType = tangentDecl->getDeclaredInterfaceType();
+
+  StructDecl *cotangentDecl;
+  VectorSpaceStructStatus cotangentStatus;
+  std::tie(cotangentDecl, cotangentStatus) = getVectorSpaceStructDecl(
+      nominal, AutoDiffAssociatedVectorSpaceKind::Cotangent);
+  switch (cotangentStatus) {
+  case DoesNotExist:
+    TC.diagnose(derived.ConformanceDecl->getLoc(),
+                diag::differentiable_no_vector_space_struct,
+                derived.getProtocolType(), C.Id_CotangentVector);
+    return nullptr;
+  case Invalid:
+    TC.diagnose(cotangentDecl, diag::differentiable_invalid_vector_space_struct,
+                derived.getProtocolType(), C.Id_CotangentVector);
+    return nullptr;
+  case Valid:
+    break;
+  }
+  auto cotangentType = cotangentDecl->getDeclaredInterfaceType();
+
+  auto *param =
+      new (C) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
+                        C.getIdentifier("from"), SourceLoc(),
+                        C.getIdentifier("cotangent"), parentDC);
+  param->setInterfaceType(cotangentType);
+  ParameterList *params = ParameterList::create(C, {param});
+
+  DeclName declName(C, C.Id_tangentVector, params);
+  auto funcDecl = FuncDecl::create(C, SourceLoc(), StaticSpellingKind::None,
+                                   SourceLoc(), declName, SourceLoc(),
+                                   /*Throws*/ false, SourceLoc(),
+                                   /*GenericParams=*/nullptr, params,
+                                   TypeLoc::withoutLoc(tangentType), parentDC);
+  funcDecl->setImplicit();
+  funcDecl->setBodySynthesizer(deriveBodyDifferentiable_tangentVector);
+
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    funcDecl->setGenericEnvironment(env);
+  funcDecl->computeType();
+  funcDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
+  funcDecl->setValidationToChecked();
+
+  derived.addMembersToConformanceContext({funcDecl});
+  C.addSynthesizedDecl(funcDecl);
+
+  return funcDecl;
+}
+
+// Synthesize a vector space associated type (either 'TangentVector' or
+// 'CotangentVector').
+static Type
+deriveDifferentiable_VectorSpace(DerivedConformance &derived,
+                                 AutoDiffAssociatedVectorSpaceKind kind) {
+  auto &TC = derived.TC;
+  auto parentDC = derived.getConformanceContext();
+  auto nominal = derived.Nominal;
+  auto &C = nominal->getASTContext();
+
+  // Check if all members have vector space associated types equal to `Self`.
+  bool allMembersVectorSpaceEqualsSelf =
+      llvm::all_of(nominal->getStoredProperties(), [&](VarDecl *member) {
+        auto memberAssocType =
+            nominal->mapTypeIntoContext(getVectorSpaceType(member, kind));
+        return member->getType()->isEqual(memberAssocType);
+      });
+  // Check if nominal type conforms to `VectorNumeric`.
+  // This is important because nominal type must conform to `VectorNumeric` in
+  // order to be a valid vector space type.
+  auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
+  auto nominalConformsToVectorNumeric = TC.conformsToProtocol(
+      nominal->getDeclaredInterfaceType(), vectorNumericProto, parentDC,
+      ConformanceCheckFlags::Used);
+  // Return `Self` if conditions are met.
+  if (allMembersVectorSpaceEqualsSelf && nominalConformsToVectorNumeric)
+    return nominal->getDeclaredInterfaceType();
+
+  // Otherwise, synthesis is not currently supported.
+  return nullptr;
+}
+
+ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
+  if (requirement->getBaseName() == TC.Context.Id_moved)
+    return deriveDifferentiable_moved(*this);
+  if (requirement->getBaseName() == TC.Context.Id_tangentVector)
+    return deriveDifferentiable_tangentVector(*this);
+  TC.diagnose(requirement->getLoc(), diag::broken_differentiable_requirement);
+  return nullptr;
+}
+
+Type DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
+  if (requirement->getBaseName() == TC.Context.Id_TangentVector) {
+    auto rawType = deriveDifferentiable_VectorSpace(
+        *this, AutoDiffAssociatedVectorSpaceKind::Tangent);
+    return getConformanceContext()->mapTypeIntoContext(rawType);
+  }
+  if (requirement->getBaseName() == TC.Context.Id_CotangentVector) {
+    auto rawType = deriveDifferentiable_VectorSpace(
+        *this, AutoDiffAssociatedVectorSpaceKind::Cotangent);
+    return getConformanceContext()->mapTypeIntoContext(rawType);
+  }
+  TC.diagnose(requirement->getLoc(), diag::broken_differentiable_requirement);
+  return nullptr;
+}

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -75,6 +75,10 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
     return canDeriveVectorNumeric(Nominal);
 
   // SWIFT_ENABLE_TENSORFLOW
+  if (*knownProtocol == KnownProtocolKind::Differentiable)
+    return canDeriveDifferentiable(Nominal);
+
+  // SWIFT_ENABLE_TENSORFLOW
   // The only requirement for deriving Parameterized is that there exist some
   // stored properties marked with @TFParameter. The `Parameters` struct can
   // always be derived, even if parameters have different types.
@@ -275,6 +279,28 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
     }
 
     // SWIFT_ENABLE_TENSORFLOW
+    // Differentiable.moved(along:)
+    if (name.isCompoundName() &&
+        name.getBaseName() == ctx.Id_moved) {
+      auto argumentNames = name.getArgumentNames();
+      if (argumentNames.size() == 1 &&
+          argumentNames[0] == ctx.getIdentifier("along")) {
+        return getRequirement(KnownProtocolKind::Differentiable);
+      }
+    }
+
+    // SWIFT_ENABLE_TENSORFLOW
+    // Differentiable.tangentVector(from:)
+    if (name.isCompoundName() &&
+        name.getBaseName() == ctx.Id_tangentVector) {
+      auto argumentNames = name.getArgumentNames();
+      if (argumentNames.size() == 1 &&
+          argumentNames[0] == ctx.getIdentifier("from")) {
+        return getRequirement(KnownProtocolKind::Differentiable);
+      }
+    }
+
+    // SWIFT_ENABLE_TENSORFLOW
     // ParameterGroup.update(withGradients:_:)
     if (name.isCompoundName() &&
         name.getBaseName() == ctx.getIdentifier("update")) {
@@ -324,6 +350,13 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
     // KeyPathIterable.AllKeyPaths
     if (name.isSimpleName(ctx.Id_AllKeyPaths))
       return getRequirement(KnownProtocolKind::KeyPathIterable);
+
+    // SWIFT_ENABLE_TENSORFLOW
+    // Differentiable.TangentVector
+    // Differentiable.CotangentVector
+    if (name.isSimpleName(ctx.Id_TangentVector) ||
+        name.isSimpleName(ctx.Id_CotangentVector))
+      return getRequirement(KnownProtocolKind::Differentiable);
 
     // SWIFT_ENABLE_TENSORFLOW
     // Parameterized.Parameters

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -233,6 +233,22 @@ public:
   /// \returns the derived member, which will also be added to the type.
   Type deriveVectorNumeric(AssociatedTypeDecl *assocType);
 
+  /// Determine if a Differentiable requirement can be derived for a type.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveDifferentiable(NominalTypeDecl *type);
+
+  /// Derive a Differentiable requirement for a nominal type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveDifferentiable(ValueDecl *requirement);
+
+  /// Derive a Differentiable type witness for a nominal type, if it has
+  /// parameters (stored properties marked with @TFParameter).
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  Type deriveDifferentiable(AssociatedTypeDecl *assocType);
+
   /// Declare a read-only property.
   std::pair<VarDecl *, PatternBindingDecl *>
   declareDerivedProperty(Identifier name, Type propertyInterfaceType,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2385,10 +2385,10 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
   // Predicate checking if a type has associated tangent and cotangent spaces.
   auto hasAssociatedSpaces = [&](Type type) -> bool {
-    // No need to check for cotangent space because every type with a tangent
-    // space also has a cotangent space.
     return (bool)type->getAutoDiffAssociatedVectorSpace(
-        AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance);
+               AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance) &&
+           (bool)type->getAutoDiffAssociatedVectorSpace(
+               AutoDiffAssociatedVectorSpaceKind::Cotangent, lookupConformance);
   };
 
   // Check that the user has only selected wrt params with allowed types.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5296,6 +5296,10 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   case KnownProtocolKind::VectorNumeric:
     return derived.deriveVectorNumeric(Requirement);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  case KnownProtocolKind::Differentiable:
+    return derived.deriveDifferentiable(Requirement);
+
   default:
     return nullptr;
   }
@@ -5328,6 +5332,8 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
     return derived.deriveParameterGroup(AssocType);
   case KnownProtocolKind::VectorNumeric:
     return derived.deriveVectorNumeric(AssocType);
+  case KnownProtocolKind::Differentiable:
+    return derived.deriveDifferentiable(AssocType);
   default:
     return nullptr;
   }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -104,6 +104,9 @@ extension Tensor : ShapedVectorNumeric where Scalar : Numeric {}
 extension Tensor : Differentiable where Scalar : FloatingPoint {
   public typealias TangentVector = Tensor
   public typealias CotangentVector = Tensor
+  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
+    return cotangent
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -87,11 +87,16 @@ public extension Differentiable
   }
 }
 
+// FIXME: This is currently commented because the where clause leads to
+// associated type inference which conflicts with `Differentiable` derived
+// conformances.
+/*
 public extension Differentiable where TangentVector == CotangentVector {
   func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
   }
 }
+*/
 
 //===----------------------------------------------------------------------===//
 // Differential Operators

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1852,6 +1852,9 @@ extension ${Self} : VectorNumeric {
 extension ${Self} : Differentiable {
   public typealias TangentVector = ${Self}
   public typealias CotangentVector = ${Self}
+  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
+    return cotangent
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -52,6 +52,9 @@ extension Space : Differentiable {
   func moved(along: TangentSpace) -> Space {
     return Space(x: x + along.dx, y: y + along.dy)
   }
+  func tangentVector(from cotangent: CotangentVector) -> TangentVector {
+    return cotangent
+  }
 }
 
 E2EDifferentiablePropertyTests.test("computed property") {
@@ -109,6 +112,9 @@ extension ProductSpaceOtherTangent : Differentiable {
   typealias CotangentVector = ProductSpaceOtherTangentTangentSpace
   func moved(along: ProductSpaceOtherTangentTangentSpace) -> ProductSpaceOtherTangent {
     return ProductSpaceOtherTangent(x: x + along.x, y: y + along.y)
+  }
+  func tangentVector(from cotangent: CotangentVector) -> TangentVector {
+    return cotangent
   }
 }
 

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -12,6 +12,8 @@ public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable, Equata
   public var y: Float
   public var nonTrivialStuff = NonTrivialStuff()
   public typealias TangentVector = Vector
+  public typealias CotangentVector = Vector
+  public func tangentVector(from cotangent: CotangentVector) -> TangentVector { return cotangent }
   public typealias Scalar = Float
   public static var zero: Vector { return Vector(0) }
   public init(_ scalar: Float) { self.x = scalar; self.y = scalar }

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -33,6 +33,14 @@ var generic = Generic<Double>(w: 1, b: 1)
 assert(generic.moved(along: generic) == generic + generic)
 assert(generic.tangentVector(from: generic) == generic)
 
+// Test type with manual definition of vector space types to `Self`.
+struct VectorSpacesEqualSelf : VectorNumeric, Differentiable {
+  var w: Float
+  var b: Float
+  typealias TangentVector = VectorSpacesEqualSelf
+  typealias CotangentVector = VectorSpacesEqualSelf
+}
+
 // TODO: Support the cases below after `Differentiable` derived conformances
 // limitations are lifted.
 
@@ -58,3 +66,24 @@ struct NotVectorNumeric : Differentiable {
   var b: Float
 }
 */
+
+// Test errors.
+
+// Test manually customizing vector space types.
+// Thees should fail. Synthesis is semantically unsupported if vector space
+// types are customized.
+struct VectorSpaceTypeAlias : VectorNumeric, Differentiable { // expected-error {{type 'VectorSpaceTypeAlias' does not conform to protocol 'Differentiable'}}
+  var w: Float
+  var b: Float
+  typealias TangentVector = Simple
+}
+struct VectorSpaceCustomStruct : VectorNumeric, Differentiable { // expected-error {{type 'VectorSpaceCustomStruct' does not conform to protocol 'Differentiable'}}
+  var w: Float
+  var b: Float
+  struct CotangentVector : VectorNumeric, Differentiable {
+    var w: Float.CotangentVector
+    var b: Float.CotangentVector
+    typealias TangentVector = VectorSpaceCustomStruct.CotangentVector
+    typealias CotangentVector = VectorSpaceCustomStruct.CotangentVector
+  }
+}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -1,0 +1,60 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-frontend -typecheck -verify %s -verify-ignore-unknown
+
+struct Simple : VectorNumeric, Differentiable {
+  var w: Float
+  var b: Float
+}
+var x = Simple(w: 1, b: 1)
+assert(x.moved(along: x) == x + x)
+assert(x.tangentVector(from: x) == x)
+
+// Test type with mixed members.
+struct Mixed : VectorNumeric, Differentiable {
+  var tensor: Tensor<Float>
+  var float: Float
+}
+var mixed = Mixed(tensor: Tensor(1), float: 1)
+assert(mixed.moved(along: mixed) == mixed + mixed)
+assert(mixed.tangentVector(from: mixed) == mixed)
+
+// Test type with generic members that conform to `Differentiable`.
+// Since `Member == Member.TangentVector == Member.CotangentVector`,
+// it's only necessary to synthesis typealiases:
+// `typealias TangentVector = Generic`
+// `typealias CotangentVector = Generic`
+struct Generic<Member> : VectorNumeric, Differentiable
+  where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
+{
+  var w: T
+  var b: T
+}
+var generic = Generic<Double>(w: 1, b: 1)
+assert(generic.moved(along: generic) == generic + generic)
+assert(generic.tangentVector(from: generic) == generic)
+
+// TODO: Support the cases below after `Differentiable` derived conformances
+// limitations are lifted.
+
+/*
+// Test type with generic members that conform to `Differentiable`.
+// Since it's not the case that
+// `Member == Member.TangentVector == Member.CotangentVector`,
+// it's necessary to synthesize new vector space struct types.
+struct GenericNeedsVectorSpaceStructs<T> : VectorNumeric, Differentiable
+  where T : VectorNumeric, T : Differentiable
+{
+  var w: T
+  var b: T
+}
+
+// Test type that doesn't conform to `VectorNumeric`.
+// Thus, `Self` cannot be used as `TangentVector` or `CotangentVector`.
+// Vector space structs types must be synthesized.
+// Note: it would be nice to emit a warning if conforming `Self` to
+// `VectorNumeric` is possible.
+struct NotVectorNumeric : Differentiable {
+  var w: Float
+  var b: Float
+}
+*/

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -5,25 +5,25 @@ struct Simple : VectorNumeric, Differentiable {
   var w: Float
   var b: Float
 }
-var x = Simple(w: 1, b: 1)
-assert(x.moved(along: x) == x + x)
-assert(x.tangentVector(from: x) == x)
+var simple = Simple(w: 1, b: 1)
+assert(simple.moved(along: simple) == simple + simple)
+assert(simple.tangentVector(from: simple) == simple)
 
 // Test type with mixed members.
 struct Mixed : VectorNumeric, Differentiable {
-  var tensor: Tensor<Float>
+  var simple: Simple
   var float: Float
 }
-var mixed = Mixed(tensor: Tensor(1), float: 1)
+var mixed = Mixed(simple: simple, float: 1)
 assert(mixed.moved(along: mixed) == mixed + mixed)
 assert(mixed.tangentVector(from: mixed) == mixed)
 
 // Test type with generic members that conform to `Differentiable`.
-// Since `Member == Member.TangentVector == Member.CotangentVector`,
+// Since `T == T.TangentVector == T.CotangentVector`,
 // it's only necessary to synthesis typealiases:
 // `typealias TangentVector = Generic`
 // `typealias CotangentVector = Generic`
-struct Generic<Member> : VectorNumeric, Differentiable
+struct Generic<T> : VectorNumeric, Differentiable
   where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
 {
   var w: T
@@ -39,7 +39,7 @@ assert(generic.tangentVector(from: generic) == generic)
 /*
 // Test type with generic members that conform to `Differentiable`.
 // Since it's not the case that
-// `Member == Member.TangentVector == Member.CotangentVector`,
+// `T == T.TangentVector == T.CotangentVector`,
 // it's necessary to synthesize new vector space struct types.
 struct GenericNeedsVectorSpaceStructs<T> : VectorNumeric, Differentiable
   where T : VectorNumeric, T : Differentiable


### PR DESCRIPTION
Implement `Differentiable` derived conformances for struct types.
This improves the usability of `Differentiable` for user-defined types.

`Differentiable` conformances can be derived for a struct type when all
stored properties conform to `Differentiable`.

Currently, synthesis also requires that the struct conforms to `VectorNumeric`
and that all members have `Self == TangentVector == CotangentVector`.
This limitation will be removed in a follow-up patch.

---

Examples:

```swift
struct Simple : VectorNumeric, Differentiable {
  var w: Float
  var b: Float
}
var x = Simple(w: 1, b: 1)
assert(x.moved(along: x) == x + x)
assert(x.tangentVector(from: x) == x)

// Type with mixed members.
struct Mixed : VectorNumeric, Differentiable {
  var tensor: Tensor<Float>
  var float: Float
}

// Type with generic members that conform to `Differentiable`.
struct Generic<Member> : VectorNumeric, Differentiable
  where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
{
  var w: T
  var b: T
}
var generic = Generic<Double>(w: 1, b: 1)
assert(generic.moved(along: generic) == generic + generic)
assert(generic.tangentVector(from: generic) == generic)
```

---

There are many todos:
- Lift aforementioned limitation and synthesize member `TangentVector`
  and `CotangentVector` structs. This is necessary when not all members
  have `Self == TangentVector == CotangentVector`.
  - Mark synthesized structs with `@_fieldwiseProductSpace`.
  - I'm mostly done implementing this, need to fix some bugs.
- Emit warning when deriving `Diffentiable` conformances for struct type
  that doesn't conform to `VectorNumeric` but could.
  - Warning: `'TangentVector' and 'CotangentVector' could be '<Self>' if
    '<Self>' conforms to 'VectorNumeric'`
- Support `Differentiable` synthesis for enums.