### PR TITLE
[AutoDiff] Allow `@differentiable` without parentheses.

### DIFF
--- a/test/AutoDiff/differentiable_attr_parse.swift
+++ b/test/AutoDiff/differentiable_attr_parse.swift
@@ -22,13 +22,13 @@ func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
-@differentiable() // okay
+@differentiable // okay
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
 @_transparent
-@differentiable() // okay
+@differentiable // okay
 @inlinable
 func playWellWithOtherAttrs(_ x: Float, _: Float) -> Float {
   return 1 + x

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -60,7 +60,7 @@ public func dfoo_tuple(_ seed: Float, partial: Float, _ x: ((Float, (Float, Floa
 // CHECK-LABEL: sil @dfoo_tuple : $@convention(thin) (Float, Float, Float, Float, Float, Float, Float, Float) -> (Float, Float, Float, Float, Float, Float)
 
 @_silgen_name("no_prim_or_adj")
-@differentiable() // ok!
+@differentiable // ok!
 public func no_prim_or_adj(_ x: Float) -> Float {
   return x * x
 }

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -43,6 +43,7 @@ ATTRIBUTE_NODES = [
                        Child('ObjCName', kind='ObjCSelector'),
                        Child('ImplementsArguments', 
                              kind='ImplementsAttributeArguments'),
+                       # SWIFT_ENABLE_TENSORFLOW
                        Child('DifferentiableArguments',
                              kind='DifferentiableAttributeArguments'),
                    ], description='''


### PR DESCRIPTION
When there's no extra configurations, write `@differentiable`, not `@differentiable()`.