### PR TITLE
[pmo] Change MemoryInst to be an AllocationInst since it will always …

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -70,9 +70,9 @@ class SILBuilder;
 /// not super.init() has been called or not.
 class PMOMemoryObjectInfo {
 public:
-  /// This is the instruction that represents the memory.  It is either an
-  /// allocation (alloc_box, alloc_stack) or a mark_uninitialized.
-  SingleValueInstruction *MemoryInst;
+  /// This is the instruction that represents the memory. It is either an
+  /// alloc_box or alloc_stack.
+  AllocationInst *MemoryInst;
 
   /// This is the base type of the memory allocation.
   SILType MemorySILType;
@@ -87,7 +87,7 @@ public:
   unsigned NumElements;
 
 public:
-  PMOMemoryObjectInfo(SingleValueInstruction *MemoryInst);
+  PMOMemoryObjectInfo(AllocationInst *MemoryInst);
 
   SILLocation getLoc() const { return MemoryInst->getLoc(); }
   SILFunction &getFunction() const { return *MemoryInst->getFunction(); }


### PR DESCRIPTION
…be so.

Just a part of a series of small cleanups I found over the break in PMO that I
am landing in preparation for landing patches that fix PMO for ownership.
