### PR TITLE
[AutoDiff] Update generic constraints in `Differentiable` protocol.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -58,18 +58,22 @@ public protocol ShapedVectorNumeric : VectorNumeric {
 
 /// A type that mathematically represents a differentiable manifold whose
 /// tangent spaces are finite-dimensional.
-///
-/// In automatic differentiation, differentiation will produce a Jacobian whose
-/// elements are of `Tangent` type.
 public protocol Differentiable {
   /// The tangent vector space of this differentiable manifold.
-  associatedtype TangentVector : Differentiable, VectorNumeric
-    where TangentVector.TangentVector == TangentVector,
-          TangentVector.Scalar : FloatingPoint
-  /// The cotangent space of this differentiable manifold.
-  associatedtype CotangentVector : Differentiable, VectorNumeric
-    where CotangentVector.CotangentVector == CotangentVector,
-          CotangentVector.Scalar : FloatingPoint
+  associatedtype TangentVector : Differentiable & VectorNumeric
+    // FIXME(SR-9595): Unexpected error when type checking constrained
+    // associated types.
+    where // TangentVector.Scalar : FloatingPoint,
+          TangentVector.TangentVector == TangentVector,
+          TangentVector.CotangentVector == CotangentVector
+
+  /// The cotangent vector space of this differentiable manifold.
+  associatedtype CotangentVector : Differentiable & VectorNumeric
+    // FIXME(SR-9595): Unexpected error when type checking constrained
+    // associated types.
+    where // CotangentVector.Scalar : FloatingPoint,
+          CotangentVector.TangentVector == CotangentVector,
+          CotangentVector.CotangentVector == TangentVector
 
   /// Returns `self` moved along the value space towards the given tangent
   /// vector. In Riemannian geometry (mathematics), this represents an
@@ -80,8 +84,11 @@ public protocol Differentiable {
   func tangentVector(from cotangent: CotangentVector) -> TangentVector
 }
 
+// FIXME: The `Self : VectorNumeric` constraint should be implied by
+// `TangentVector == Self`, but the type checker errors out when it does not
+// exist.
 public extension Differentiable
-  where Self : VectorNumeric, TangentVector == Self {
+  where TangentVector == Self, Self : VectorNumeric {
   func moved(along direction: TangentVector) -> Self {
     return self + direction
   }

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -23,7 +23,7 @@ assert(mixed.tangentVector(from: mixed) == mixed)
 // it's only necessary to synthesis typealiases:
 // `typealias TangentVector = Generic`
 // `typealias CotangentVector = Generic`
-struct Generic<T> : VectorNumeric, Differentiable
+struct Generic<T : VectorNumeric> : VectorNumeric, Differentiable
   where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
 {
   var w: T


### PR DESCRIPTION
`CotangentVector.CotangentVector == CotangentVector` is incorrect. It should be equal to `TangentVector`. So when we take the adjoint of a pullback `(U.CotangentVector) -> T.CotangentVector`, we get a differential of type `(T.CotangentVector.CotangentVector) -> U.CotangentVector.CotangentVector` (aka `T.TangentVector -> U.TangentVector`).

Concrete example:
```swift
func foo<T : Differentiable, U : Differentiable>(_ x: T) -> U { ... }
let pb = pullback(of: foo) // (U.CotangentVector) -> (T.CotangentVector)
let differential = pullback(at: .zero, in: pb) // (T.TangentVector) -> (U.TangentVector)
```

This patch does not enable higher-order differentiation nor is in the process of making that happen. It is to fix the semantics.

`TangentVector.Scalar` and `CotangentVector.Scalar` cannot be constrained because [SR-9595](https://bugs.swift.org/browse/SR-9595) got in the way. @DougGregor @rudkx, is there any workaround?