### PR TITLE
[Sema] Fix crasher in AdditiveArithmetic & VectorNumeric derived conformances

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -98,6 +98,8 @@ static ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal) {
 static Type getVectorNumericScalarAssocType(ValueDecl *decl) {
   auto &C = decl->getASTContext();
   auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
+  if (!decl->hasInterfaceType())
+    return Type();
   auto declType =
       decl->getDeclContext()->mapTypeIntoContext(decl->getInterfaceType());
   auto conf = TypeChecker::conformsToProtocol(declType, vectorNumericProto,
@@ -153,6 +155,8 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal) {
   auto &C = nominal->getASTContext();
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
   return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
+    if (!v->hasInterfaceType())
+      return false;
     auto conf = TypeChecker::conformsToProtocol(v->getType(), addArithProto,
                                                 v->getDeclContext(),
                                                 ConformanceCheckFlags::Used);

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -98,8 +98,6 @@ static ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal) {
 static Type getVectorNumericScalarAssocType(ValueDecl *decl) {
   auto &C = decl->getASTContext();
   auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
-  if (!decl->hasInterfaceType())
-    return Type();
   auto declType =
       decl->getDeclContext()->mapTypeIntoContext(decl->getInterfaceType());
   auto conf = TypeChecker::conformsToProtocol(declType, vectorNumericProto,
@@ -116,6 +114,7 @@ static Type getVectorNumericScalarAssocType(ValueDecl *decl) {
 static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal) {
   // Must be a struct type.
   auto *structDecl = dyn_cast<StructDecl>(nominal);
+  auto &C = nominal->getASTContext();
   if (!structDecl)
     return Type();
   // Struct must have at least one stored property.
@@ -126,6 +125,10 @@ static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal) {
   // Otherwise, the `Scalar` type cannot be derived.
   Type sameScalarType;
   for (auto member : structDecl->getStoredProperties()) {
+    if (!member->hasInterfaceType())
+      C.getLazyResolver()->resolveDeclSignature(member);
+    if (!member->hasInterfaceType())
+      return Type();
     auto scalarType = getVectorNumericScalarAssocType(member);
     // If stored property does not conform to `VectorNumeric`, return null
     // `Type`.
@@ -155,6 +158,8 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal) {
   auto &C = nominal->getASTContext();
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
   return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
+    if (!v->hasInterfaceType())
+      C.getLazyResolver()->resolveDeclSignature(v);
     if (!v->hasInterfaceType())
       return false;
     auto conf = TypeChecker::conformsToProtocol(v->getType(), addArithProto,


### PR DESCRIPTION
When stored properties do not have an interface type, `canDeriveAdditiveArithmetic` and `canDeriveVectorNumeric` crash in a lot of random places, even when there's no nominal type declarations at all (just a generic function can trigger it).  This makes whoever calls `getInterfaceType()` check `hasInterfaceType()` first.