### PR TITLE
[stdlib] [AutoDiff] FloatingPoint refines Differentiable

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -98,6 +98,8 @@ static ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal) {
 static Type getVectorNumericScalarAssocType(ValueDecl *decl) {
   auto &C = decl->getASTContext();
   auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
+  if (!decl->hasInterfaceType())
+    return Type();
   auto declType =
       decl->getDeclContext()->mapTypeIntoContext(decl->getInterfaceType());
   auto conf = TypeChecker::conformsToProtocol(declType, vectorNumericProto,
@@ -153,6 +155,8 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal) {
   auto &C = nominal->getASTContext();
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
   return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
+    if (!v->hasInterfaceType())
+      return false;
     auto conf = TypeChecker::conformsToProtocol(v->getType(), addArithProto,
                                                 v->getDeclContext(),
                                                 ConformanceCheckFlags::Used);

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -1168,6 +1168,10 @@ public extension PythonObject {
   }
 }
 
+extension PythonObject : VectorNumeric {
+  public typealias Scalar = PythonObject
+}
+
 extension PythonObject : SignedNumeric {
   public init<T : BinaryInteger>(exactly value: T) {
     self.init(Int(value))

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -1168,10 +1168,6 @@ public extension PythonObject {
   }
 }
 
-extension PythonObject : VectorNumeric {
-  public typealias Scalar = PythonObject
-}
-
 extension PythonObject : SignedNumeric {
   public init<T : BinaryInteger>(exactly value: T) {
     self.init(Int(value))

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -77,8 +77,6 @@ extension CGFloat : BinaryFloatingPoint {
 
   public typealias RawSignificand = UInt
   public typealias Exponent = Int
-  // SWIFT_ENABLE_TENSORFLOW
-  public typealias Scalar = CGFloat
 
   @_transparent
   public static var exponentBitCount: Int {

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -77,6 +77,8 @@ extension CGFloat : BinaryFloatingPoint {
 
   public typealias RawSignificand = UInt
   public typealias Exponent = Int
+  // SWIFT_ENABLE_TENSORFLOW
+  public typealias Scalar = CGFloat
 
   @_transparent
   public static var exponentBitCount: Int {

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -78,6 +78,10 @@ extension CGFloat : BinaryFloatingPoint {
   public typealias RawSignificand = UInt
   public typealias Exponent = Int
 
+  // SWIFT_ENABLE_TENSORFLOW
+  public typealias TangentVector = CGFloat
+  public typealias CotangentVector = CGFloat
+
   @_transparent
   public static var exponentBitCount: Int {
     return NativeType.exponentBitCount

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -18,6 +18,8 @@ import _SwiftCoreFoundationOverlayShims
 extension Decimal {
     public typealias RoundingMode = NSDecimalNumber.RoundingMode
     public typealias CalculationError = NSDecimalNumber.CalculationError
+    // SWIFT_ENABLE_TENSORFLOW
+    public typealias Scalar = Decimal
 
     public static let leastFiniteMagnitude = Decimal(_exponent: 127, _length: 8, _isNegative: 1, _isCompact: 1, _reserved: 0, _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff))
     public static let greatestFiniteMagnitude = Decimal(_exponent: 127, _length: 8, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff))

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -83,6 +83,70 @@ extension Tensor where Scalar : Numeric {
   }
 }
 
+/* FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+extension Tensor where Scalar : Numeric & Differentiable {
+  @inlinable
+  static func _vjp_add(
+    lhs: Tensor, rhs: Scalar
+  ) -> (value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)) {
+    return (value: lhs + rhs, pullback: { v in (v, v.sum()) })
+  }
+
+  @inlinable
+  static func _vjp_add(
+    lhs: Scalar, rhs: Tensor
+  ) -> (value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)) {
+    return (value: lhs + rhs, pullback: { v in (v.sum(), v) })
+  }
+
+  @inlinable
+  static func _vjp_sub(
+    lhs: Tensor, rhs: Scalar
+  ) -> (value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)) {
+    return (value: lhs - rhs, pullback: { v in (v, 0 - v.sum()) })
+  }
+
+  @inlinable
+  static func _vjp_sub(
+    lhs: Scalar, rhs: Tensor
+  ) -> (value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)) {
+    return (value: lhs - rhs, pullback: { v in (v.sum(), 0 - v) })
+  }
+
+  @inlinable
+  static func _vjp_mul(
+    lhs: Tensor, rhs: Scalar
+  ) -> (value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)) {
+    return (value: lhs + rhs, pullback: { v in (v * rhs, (v * lhs).sum()) })
+  }
+
+  @inlinable
+  static func _vjp_mul(
+    lhs: Scalar, rhs: Tensor
+  ) -> (value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)) {
+    return (value: lhs + rhs, pullback: { v in ((v * rhs).sum(), v * lhs) })
+  }
+
+  @inlinable
+  static func _vjp_div(
+    lhs: Tensor, rhs: Scalar
+  ) -> (value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)) {
+    return (value: lhs + rhs, pullback: { v in
+      (v / rhs, (v * (0 - lhs) / rhs.squared()).sum())
+    })
+  }
+
+  @inlinable
+  static func _vjp_div(
+    lhs: Scalar, rhs: Tensor
+  ) -> (value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)) {
+    return (value: lhs + rhs, pullback: { v in
+      ((v / rhs).sum(), v * (0 - lhs) / rhs.squared())
+    })
+  }
+}
+ */
+
 @inlinable
 func _adjointMinMax<T : Numeric & Comparable>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
@@ -266,7 +330,6 @@ extension Tensor {
 //===----------------------------------------------------------------------===//
 
 extension Tensor where Scalar : BinaryFloatingPoint,
-                       Scalar : Differentiable,
                        Scalar.CotangentVector == Scalar {
   // TODO: Verify that these calculations are correct.
   @inlinable

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -94,6 +94,8 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   /// Multiplies the scalar with every scalar of the tensor and produces the
   /// product.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_mul)
   public static func * (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) * rhs
   }
@@ -116,12 +118,16 @@ extension Tensor : Differentiable where Scalar : FloatingPoint {
 public extension Tensor where Scalar : Numeric {
   /// Adds the scalar to every scalar of the tensor and produces the sum.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_add)
   static func + (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) + rhs
   }
 
   /// Adds the scalar to every scalar of the tensor and produces the sum.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_add)
   static func + (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs + Tensor(rhs)
   }
@@ -129,6 +135,8 @@ public extension Tensor where Scalar : Numeric {
   /// Subtracts the scalar from every scalar of the tensor and produces the
   /// difference.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_sub)
   static func - (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) - rhs
   }
@@ -136,6 +144,8 @@ public extension Tensor where Scalar : Numeric {
   /// Subtracts the scalar from every scalar of the tensor and produces the
   /// difference.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_sub)
   static func - (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs - Tensor(rhs)
   }
@@ -172,7 +182,8 @@ public extension Tensor where Scalar : Numeric {
   /// Multiplies two tensors and produces their product.
   /// - Note: `*` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointMultiply(_:_:_:_:))
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(adjoint: _adjointMultiply(_:_:_:_:))
   static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.mul(lhs, rhs)
   }
@@ -180,6 +191,8 @@ public extension Tensor where Scalar : Numeric {
   /// Multiplies the scalar with every scalar of the tensor and produces the
   /// product.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_mul)
   static func * (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs * Tensor(rhs)
   }
@@ -200,7 +213,8 @@ public extension Tensor where Scalar : Numeric {
   /// Returns the quotient of dividing the first tensor by the second.
   /// - Note: `/` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointDivide(_:_:_:_:))
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(adjoint: _adjointDivide(_:_:_:_:))
   static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.div(lhs, rhs)
   }
@@ -208,6 +222,8 @@ public extension Tensor where Scalar : Numeric {
   /// Returns the quotient of dividing the scalar by the tensor, broadcasting
   /// the scalar.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_div)
   static func / (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) / rhs
   }
@@ -215,6 +231,8 @@ public extension Tensor where Scalar : Numeric {
   /// Returns the quotient of dividing the tensor by the scalar, broadcasting
   /// the scalar.
   @inlinable @inline(__always)
+  // FIXME(SR-9596): Uncomment when @differentiable 'where' clause is supported.
+  // @differentiable(vjp: _vjp_div)
   static func / (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs / Tensor(rhs)
   }
@@ -1319,7 +1337,6 @@ public extension Tensor {
 // we did that now, type checking for the adjoint would fail because it
 // doesn't see @differentiable attribute constraints.
 public extension Tensor where Scalar : BinaryFloatingPoint,
-                              Scalar : Differentiable,
                               Scalar.CotangentVector == Scalar {
   /// Computes the batch normalized tensor along the specified axis.
   ///

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -180,17 +180,17 @@ public func pullback<T, U, V, R>(
 public func derivative<T, R>(
   at x: T, in f: @autodiff (T) -> R
 ) -> R.TangentVector
-  where T : BinaryFloatingPoint & Differentiable, R : Differentiable,
+  where T : FloatingPoint, R : Differentiable,
         T.TangentVector == T {
   let (y, differential) = valueWithDifferential(at: x, in: f)
-  return differential(1)
+  return differential(R(1))
 }
 
 @inlinable
 public func derivative<T, R>(
   of f: @escaping @autodiff (T) -> R
 ) -> (T) -> R.TangentVector
-  where T : BinaryFloatingPoint & Differentiable, R : Differentiable,
+  where T : FloatingPoint, R : Differentiable,
         T.TangentVector == T {
   return { x in derivative(at: x, in: f) }
 }
@@ -202,10 +202,10 @@ public func derivative<T, R>(
 public func valueWithGradient<T, R>(
   at x: T, in f: @autodiff (T) -> R
 ) -> (value: R, gradient: T.CotangentVector)
-  where T : Differentiable, R : BinaryFloatingPoint & Differentiable,
+  where T : Differentiable, R : FloatingPoint,
         R.CotangentVector == R {
   let (y, pullback) = valueWithPullback(at: x, in: f)
-  return (y, pullback(1))
+  return (y, pullback(R(1)))
 }
 
 @inlinable
@@ -213,9 +213,9 @@ public func valueWithGradient<T, U, R>(
   at x: T, _ y: U, in f: @autodiff (T, U) -> R
 ) -> (value: R, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
-        R : BinaryFloatingPoint & Differentiable, R.CotangentVector == R {
+        R : FloatingPoint, R.CotangentVector == R {
   let (y, pullback) = valueWithPullback(at: x, y, in: f)
-  return (y, pullback(1))
+  return (y, pullback(R(1)))
 }
 
 @inlinable
@@ -224,9 +224,9 @@ public func valueWithGradient<T, U, V, R>(
 ) -> (value: R,
       gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : BinaryFloatingPoint & Differentiable, R.CotangentVector == R {
+        R : FloatingPoint, R.CotangentVector == R {
   let (y, pullback) = valueWithPullback(at: x, y, z, in: f)
-  return (y, pullback(1))
+  return (y, pullback(R(1)))
 }
 
 // Value with gradient (curried)
@@ -235,7 +235,7 @@ public func valueWithGradient<T, U, V, R>(
 public func valueWithGradient<T, R>(
   of f: @escaping @autodiff (T) -> R
 ) -> (T) -> (value: R, gradient: T.CotangentVector)
-  where T : Differentiable, R : BinaryFloatingPoint & Differentiable,
+  where T : Differentiable, R : FloatingPoint,
         R.CotangentVector == R {
   return { x in valueWithGradient(at: x, in: f) }
 }
@@ -245,7 +245,7 @@ public func valueWithGradient<T, U, R>(
   of f: @escaping @autodiff (T, U) -> R
 ) -> (T, U) -> (value: R, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
-        R : BinaryFloatingPoint & Differentiable,
+        R : FloatingPoint,
         R.CotangentVector == R {
   return { x, y in valueWithGradient(at: x, y, in: f) }
 }
@@ -257,7 +257,7 @@ public func valueWithGradient<T, U, V, R>(
     -> (value: R,
         gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : BinaryFloatingPoint & Differentiable,
+        R : FloatingPoint & Differentiable,
         R.CotangentVector == R {
   return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
 }
@@ -268,9 +268,9 @@ public func valueWithGradient<T, U, V, R>(
 public func gradient<T, R>(
   at x: T, in f: @autodiff (T) -> R
 ) -> T.CotangentVector
-  where T : Differentiable, R : BinaryFloatingPoint & Differentiable,
+  where T : Differentiable, R : FloatingPoint,
         R.CotangentVector == R {
-  return pullback(at: x, in: f)(1)
+  return pullback(at: x, in: f)(R(1))
 }
 
 @inlinable
@@ -278,8 +278,8 @@ public func gradient<T, U, R>(
   at x: T, _ y: U, in f: @autodiff (T, U) -> R
 ) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
-        R : BinaryFloatingPoint & Differentiable, R.CotangentVector == R {
-  return pullback(at: x, y, in: f)(1)
+        R : FloatingPoint, R.CotangentVector == R {
+  return pullback(at: x, y, in: f)(R(1))
 }
 
 @inlinable
@@ -287,8 +287,8 @@ public func gradient<T, U, V, R>(
   at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> R
 ) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : BinaryFloatingPoint & Differentiable, R.CotangentVector == R {
-  return pullback(at: x, y, z, in: f)(1)
+        R : FloatingPoint, R.CotangentVector == R {
+  return pullback(at: x, y, z, in: f)(R(1))
 }
 
 // Gradient (curried)
@@ -297,7 +297,7 @@ public func gradient<T, U, V, R>(
 public func gradient<T, R>(
   of f: @escaping @autodiff (T) -> R
 ) -> (T) -> T.CotangentVector
-  where T : Differentiable, R : BinaryFloatingPoint & Differentiable,
+  where T : Differentiable, R : FloatingPoint,
         R.CotangentVector == R {
   return { x in gradient(at: x, in: f) }
 }
@@ -307,8 +307,7 @@ public func gradient<T, U, R>(
   of f: @escaping @autodiff (T, U) -> R
 ) -> (T, U) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
-        R : BinaryFloatingPoint & Differentiable,
-        R.CotangentVector == R {
+        R : FloatingPoint, R.CotangentVector == R {
   return { x, y in gradient(at: x, y, in: f) }
 }
 
@@ -317,8 +316,7 @@ public func gradient<T, U, V, R>(
   of f: @escaping @autodiff (T, U, V) -> R
 ) -> (T, U, V) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : BinaryFloatingPoint & Differentiable,
-        R.CotangentVector == R {
+        R : FloatingPoint, R.CotangentVector == R {
   return { x, y, z in gradient(at: x, y, z, in: f) }
 }
 

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -158,7 +158,9 @@
 ///     print("Average: \(average)°F in \(validTemps.count) " +
 ///           "out of \(tempsFahrenheit.count) observations.")
 ///     // Prints "Average: 74.84°F in 5 out of 7 observations."
-public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
+// SWIFT_ENABLE_TENSORFLOW
+public protocol FloatingPoint : SignedNumeric, Strideable, Hashable,
+                                Differentiable
                                 where Magnitude == Self {
 
   /// A type that can represent any written exponent.

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1848,7 +1848,6 @@ extension ${Self} : Strideable {
 extension ${Self} : Differentiable {
   public typealias TangentVector = ${Self}
   public typealias CotangentVector = ${Self}
-  public typealias Scalar = ${Self}
   public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
   }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1842,16 +1842,13 @@ extension ${Self} : Strideable {
 
 // SWIFT_ENABLE_TENSORFLOW
 //===----------------------------------------------------------------------===//
-// VectorNumeric Conformance
+// Differentiable Conformance
 //===----------------------------------------------------------------------===//
-
-extension ${Self} : VectorNumeric {
-  public typealias Scalar = ${Self}
-}
 
 extension ${Self} : Differentiable {
   public typealias TangentVector = ${Self}
   public typealias CotangentVector = ${Self}
+  public typealias Scalar = ${Self}
   public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
   }

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1106,9 +1106,6 @@ public struct ${Self}
   /// A type that represents an integer literal.
   public typealias IntegerLiteralType = ${Self}
 
-  // SWIFT_ENABLE_TENSORFLOW
-  public typealias Scalar = ${Self}
-
   @_transparent
   public init(_builtinIntegerLiteral x: Builtin.IntLiteral) {
     _value = Builtin.s_to_${u}_checked_trunc_IntLiteral_${BuiltinName}(x).0

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1106,6 +1106,8 @@ public struct ${Self}
   /// A type that represents an integer literal.
   public typealias IntegerLiteralType = ${Self}
 
+  // SWIFT_ENABLE_TENSORFLOW
+  public typealias Scalar = ${Self}
 
   @_transparent
   public init(_builtinIntegerLiteral x: Builtin.IntLiteral) {

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -147,7 +147,8 @@ public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
 /// implementations for the protocol's nonmutating methods based on the
 /// mutating variants.
 // SWIFT_ENABLE_TENSORFLOW
-public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
+public protocol Numeric : VectorNumeric, ExpressibleByIntegerLiteral
+  where Scalar == Self {
   /// Creates a new instance from the given integer, if it can be represented
   /// exactly.
   ///
@@ -206,7 +207,7 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  static func *(lhs: Self, rhs: Self) -> Self
+  override static func *(lhs: Self, rhs: Self) -> Self
 
   /// Multiplies two values and stores the result in the left-hand-side
   /// variable.
@@ -214,7 +215,7 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  static func *=(lhs: inout Self, rhs: Self)
+  override static func *=(lhs: inout Self, rhs: Self)
 }
 
 /// A type that can represent both positive and negative values.

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -146,9 +146,7 @@ public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
 /// the required mutating methods. Extensions to `Numeric` provide default
 /// implementations for the protocol's nonmutating methods based on the
 /// mutating variants.
-// SWIFT_ENABLE_TENSORFLOW
-public protocol Numeric : VectorNumeric, ExpressibleByIntegerLiteral
-  where Scalar == Self {
+public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// Creates a new instance from the given integer, if it can be represented
   /// exactly.
   ///

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -205,7 +205,7 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  override static func *(lhs: Self, rhs: Self) -> Self
+  static func *(lhs: Self, rhs: Self) -> Self
 
   /// Multiplies two values and stores the result in the left-hand-side
   /// variable.
@@ -213,7 +213,7 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  override static func *=(lhs: inout Self, rhs: Self)
+  static func *=(lhs: inout Self, rhs: Self)
 }
 
 /// A type that can represent both positive and negative values.

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -393,7 +393,7 @@ func dbaz3<T : Differentiable & Numeric>(_ seed: T.CotangentVector, _ primal: T,
   return (seed, seed)
 }
 @differentiable(adjoint: dbaz3)
-// expected-error @-1 {{'dbaz3' does not have expected type '<T where T : Differentiable, T : FloatingPoint> (T.CotangentVector, T, T, T) -> (T.CotangentVector, T.CotangentVector)'}}
+// expected-error @-1 {{'dbaz3' does not have expected type '<T where T : FloatingPoint> (T.CotangentVector, T, T, T) -> (T.CotangentVector, T.CotangentVector)'}}
 func baz3<T : Differentiable & FloatingPoint>(_ x: T, _ y: T) -> T {
   return x + y
 }


### PR DESCRIPTION
(DO NOT MERGE)

This is an experimental patch that makes `Numeric` refine `VectorNumeric` and makes `FloatingPoint` refine `Differentiable`.  I'm not sure if ABI requirements will ever allow us to propose such a change in `master`, but this makes automatic differentiation work a lot better with generic code in stdlib and the user code simpler.

This patch also declares primitive VJPs for tensor arithmetic operators that take a scalar on one side. Unfortunately, this is blocked on the type checker support for the trailing `where` clause in `@differentiable` attributes ([SR-9596](https://bugs.swift.org/browse/SR-9596)), which should be fixed ASAP.