### PR TITLE
[SourceKit] Use diagnostics for arg parsing

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -596,6 +596,12 @@ namespace swift {
       Consumers.push_back(&Consumer);
     }
 
+    /// Remove a specific DiagnosticConsumer.
+    void removeConsumer(DiagnosticConsumer &Consumer) {
+      Consumers.erase(
+          std::remove(Consumers.begin(), Consumers.end(), &Consumer));
+    }
+
     /// Remove and return all \c DiagnosticConsumers.
     std::vector<DiagnosticConsumer *> takeConsumers() {
       auto Result = std::vector<DiagnosticConsumer*>(Consumers.begin(),

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -448,6 +448,13 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
     return Invocation.parseArgs(FrontendArgs, Diags);
   });
 
+  // Remove the StreamDiagConsumer as it's no longer needed.
+  std::vector<DiagnosticConsumer *> OldC = Diags.takeConsumers();
+  OldC.erase(std::remove(OldC.begin(), OldC.end(), &DiagConsumer));
+  for (DiagnosticConsumer *Consumer : OldC) {
+    Diags.addConsumer(*Consumer);
+  }
+
   if (HadError) {
     Error = ErrOS.str();
     return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -449,11 +449,7 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
   });
 
   // Remove the StreamDiagConsumer as it's no longer needed.
-  std::vector<DiagnosticConsumer *> OldC = Diags.takeConsumers();
-  OldC.erase(std::remove(OldC.begin(), OldC.end(), &DiagConsumer));
-  for (DiagnosticConsumer *Consumer : OldC) {
-    Diags.addConsumer(*Consumer);
-  }
+  Diags.removeConsumer(DiagConsumer);
 
   if (HadError) {
     Error = ErrOS.str();


### PR DESCRIPTION
With this change, you will no longer receive `error when parsing the compiler arguments` when SourceKit fails to parse the invocation arguments.

Instead, you will receive the underlying error, like `error: unable to load output file map 'output_file_map.json': No such file or directory`

<!-- What's in this pull request? -->
This is helpful to figure out which arguments in the compiler invocation are considered invalid (as opposed to a generic error).
