### PR TITLE
stdlib: remove some static assertions which may not hold

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -102,13 +102,6 @@ static_assert(
     4 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
   "_SwiftSetBodyStorage has unexpected size");
 
-static_assert(std::is_pod<_SwiftEmptyArrayStorage>::value,
-              "empty array type should be POD");
-static_assert(std::is_pod<_SwiftEmptyDictionarySingleton>::value,
-              "empty dictionary type should be POD");
-static_assert(std::is_pod<_SwiftEmptySetSingleton>::value,
-              "empty set type should be POD");
-
 }} // extern "C", namespace swift
 #endif
 

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -93,8 +93,6 @@ __swift_size_t swift_weakRetainCount(HeapObject *obj);
 #endif
 
 #ifdef __cplusplus
-static_assert(swift::IsTriviallyConstructible<HeapObject>::value,
-              "HeapObject must be trivially initializable");
 static_assert(std::is_trivially_destructible<HeapObject>::value,
               "HeapObject must be trivially destructible");
 

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1188,8 +1188,6 @@ class RefCounts {
 typedef RefCounts<InlineRefCountBits> InlineRefCounts;
 typedef RefCounts<SideTableRefCountBits> SideTableRefCounts;
 
-static_assert(swift::IsTriviallyConstructible<InlineRefCounts>::value,
-              "InlineRefCounts must be trivially initializable");
 static_assert(std::is_trivially_destructible<InlineRefCounts>::value,
               "InlineRefCounts must be trivially destructible");
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -84,9 +84,11 @@ static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
   assert(isAlignmentMask(requiredAlignmentMask));
   auto object = reinterpret_cast<HeapObject *>(
       swift_slowAlloc(requiredSize, requiredAlignmentMask));
-  // FIXME: this should be a placement new but that adds a null check
-  object->metadata = metadata;
-  object->refCounts.init();
+
+  // NOTE: this relies on the C++17 guaranteed semantics of no null-pointer
+  // check on the placement new allocator which we have observed on Windows,
+  // Linux, and macOS.
+  new (object) HeapObject(metadata);
 
   // If leak tracking is enabled, start tracking this object.
   SWIFT_LEAKS_START_TRACKING_OBJECT(object);


### PR DESCRIPTION
These are based around the idea that `std::atomic` is trivially
constructible, which is not a guarantee that the standard fully
provides.  The default initialization of the `std::atomic` type
may leave it in an undetermined state.  These were caught using
the Visual C++ preview runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
