### PR TITLE
[pmo] Eliminate dynamically dead code paths.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -260,13 +260,12 @@ bool ElementUseCollector::collectFrom() {
     return false;
 
   // Collect information about the retain count result as well.
-  for (auto UI : TheMemory.MemoryInst->getUses()) {
-    auto *User = UI->getUser();
+  for (auto *op : TheMemory.MemoryInst->getUses()) {
+    auto *user = op->getUser();
 
-    // If this is a release or dealloc_stack, then remember it as such.
-    if (isa<StrongReleaseInst>(User) || isa<DeallocStackInst>(User) ||
-        isa<DeallocBoxInst>(User)) {
-      Releases.push_back(User);
+    // If this is a strong_release, stash it.
+    if (isa<StrongReleaseInst>(user)) {
+      Releases.push_back(user);
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1282,7 +1282,7 @@ bool AllocOptimize::tryToRemoveDeadAllocation() {
   if (!MemoryType.isTrivial(Module)) {
     for (auto P : llvm::enumerate(Releases)) {
       auto *R = P.value();
-      if (R == nullptr || isa<DeallocStackInst>(R) || isa<DeallocBoxInst>(R))
+      if (R == nullptr)
         continue;
 
       // We stash all of the destroy_addr that we see.


### PR DESCRIPTION
Specifically, we are putting dealloc_stack, destroy_box into the Releases array
in PMOMemoryUseCollector only to ignore them in the only place that we use the
Releases array in PredictableMemOpts.
