### PR TITLE
Fix test builtin_bridge_object.swift

### DIFF
--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -30,7 +30,7 @@ let OBJC_TAGGED_POINTER_BITS: UInt = 0x8000_0000_0000_0001
 #elseif arch(arm64)
 
 // We have ObjC tagged pointers in the highest bit
-let NATIVE_SPARE_BITS: UInt = 0x7F00_0000_0000_0007
+let NATIVE_SPARE_BITS: UInt = 0x7000_0000_0000_0007
 let OBJC_TAGGED_POINTER_BITS: UInt = 0x8000_0000_0000_0000
 
 #elseif arch(powerpc64) || arch(powerpc64le)


### PR DESCRIPTION
The bottom 4 bits of the top byte are now reserved on arm64