### PR TITLE
conform Unsafe(Mutable)RawBufferPointer conform to _HasContiguousBytes

### DIFF
--- a/stdlib/public/core/ContiguouslyStored.swift
+++ b/stdlib/public/core/ContiguouslyStored.swift
@@ -57,6 +57,22 @@ extension UnsafeMutableBufferPointer: _HasContiguousBytes {
     return try body(UnsafeRawBufferPointer(start: ptr, count: len))
   }
 }
+extension UnsafeRawBufferPointer: _HasContiguousBytes {
+  @inlinable @inline(__always)
+  func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try body(self)
+  }
+}
+extension UnsafeMutableRawBufferPointer: _HasContiguousBytes {
+  @inlinable @inline(__always)
+  func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try body(UnsafeRawBufferPointer(self))
+  }
+}
 extension String: _HasContiguousBytes {
   @inlinable
   internal var _providesContiguousBytesNoCopy: Bool {


### PR DESCRIPTION
This makes `Unsafe(Mutable)RawBufferPointer` conform to `_HasContiguousBytes` which is important to hit the fast path for `String(decoding:as:)`.

CC @milseman 

(I haven't compiled this locally yet, still compiling llvm and friends and need to leave soon ;) )