### PR TITLE
GlobalOpt: optimize static properties with resilient types.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -677,7 +677,7 @@ public:
            !hasOwnership() && "Unqualified inst in qualified function");
     assert((Qualifier == LoadOwnershipQualifier::Unqualified) ||
            hasOwnership() && "Qualified inst in unqualified function");
-    assert(LV->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(LV->getType()));
     return insert(new (getModule())
                       LoadInst(getSILDebugLocation(Loc), LV, Qualifier));
   }
@@ -696,13 +696,13 @@ public:
   /// non-address values.
   SILValue emitLoadValueOperation(SILLocation Loc, SILValue LV,
                                   LoadOwnershipQualifier Qualifier) {
-    assert(LV->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(LV->getType()));
     const auto &lowering = getTypeLowering(LV->getType());
     return lowering.emitLoad(*this, Loc, LV, Qualifier);
   }
 
   LoadBorrowInst *createLoadBorrow(SILLocation Loc, SILValue LV) {
-    assert(LV->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(LV->getType()));
     return insert(new (getModule())
                       LoadBorrowInst(getSILDebugLocation(Loc), LV));
   }
@@ -1069,7 +1069,7 @@ public:
   }
 
   DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand) {
-    assert(operand->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule())
                       DestroyValueInst(getSILDebugLocation(Loc), operand));
   }
@@ -1100,7 +1100,7 @@ public:
   RetainValueInst *createRetainValue(SILLocation Loc, SILValue operand,
                                      Atomicity atomicity) {
     assert(!hasOwnership());
-    assert(operand->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) RetainValueInst(getSILDebugLocation(Loc),
                                                       operand, atomicity));
   }
@@ -1115,7 +1115,7 @@ public:
   ReleaseValueInst *createReleaseValue(SILLocation Loc, SILValue operand,
                                        Atomicity atomicity) {
     assert(!hasOwnership());
-    assert(operand->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) ReleaseValueInst(getSILDebugLocation(Loc),
                                                        operand, atomicity));
   }
@@ -1132,7 +1132,7 @@ public:
                                                        SILValue operand,
                                                        Atomicity atomicity) {
     assert(hasOwnership());
-    assert(operand->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) UnmanagedRetainValueInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1141,7 +1141,7 @@ public:
                                                          SILValue operand,
                                                          Atomicity atomicity) {
     assert(hasOwnership());
-    assert(operand->getType().isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) UnmanagedReleaseValueInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1177,14 +1177,14 @@ public:
 
   StructInst *createStruct(SILLocation Loc, SILType Ty,
                            ArrayRef<SILValue> Elements) {
-    assert(Ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(Ty));
     return insert(StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
                                      getModule(), hasOwnership()));
   }
 
   TupleInst *createTuple(SILLocation Loc, SILType Ty,
                          ArrayRef<SILValue> Elements) {
-    assert(Ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(Ty));
     return insert(TupleInst::create(getSILDebugLocation(Loc), Ty, Elements,
                                     getModule(), hasOwnership()));
   }
@@ -1193,21 +1193,21 @@ public:
 
   EnumInst *createEnum(SILLocation Loc, SILValue Operand,
                        EnumElementDecl *Element, SILType Ty) {
-    assert(Ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(Ty));
     return insert(new (getModule()) EnumInst(getSILDebugLocation(Loc),
                                                Operand, Element, Ty));
   }
 
   /// Inject a loadable value into the corresponding optional type.
   EnumInst *createOptionalSome(SILLocation Loc, SILValue operand, SILType ty) {
-    assert(ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(ty));
     auto someDecl = getModule().getASTContext().getOptionalSomeDecl();
     return createEnum(Loc, operand, someDecl, ty);
   }
 
   /// Create the nil value of a loadable optional type.
   EnumInst *createOptionalNone(SILLocation Loc, SILType ty) {
-    assert(ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(ty));
     auto noneDecl = getModule().getASTContext().getOptionalNoneDecl();
     return createEnum(Loc, nullptr, noneDecl, ty);
   }
@@ -1224,7 +1224,7 @@ public:
                                                  SILValue Operand,
                                                  EnumElementDecl *Element,
                                                  SILType Ty) {
-    assert(Ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(Ty));
     return insert(new (getModule()) UncheckedEnumDataInst(
         getSILDebugLocation(Loc), Operand, Element, Ty));
   }
@@ -1264,7 +1264,7 @@ public:
                    ArrayRef<std::pair<EnumElementDecl *, SILValue>> CaseValues,
                    Optional<ArrayRef<ProfileCounter>> CaseCounts = None,
                    ProfileCounter DefaultCount = ProfileCounter()) {
-    assert(Ty.isLoadableOrOpaque(getModule()));
+    assert(isLoadableOrOpaque(Ty));
     return insert(SelectEnumInst::create(
         getSILDebugLocation(Loc), Operand, Ty, DefaultValue, CaseValues,
         getModule(), CaseCounts, DefaultCount, hasOwnership()));
@@ -2123,6 +2123,15 @@ private:
 #ifndef NDEBUG
     TheInst->verifyOperandOwnership();
 #endif
+  }
+
+  bool isLoadableOrOpaque(SILType Ty) {
+    if (!F) {
+      // We are inserting into the static initializer of a SILGlobalVariable.
+      // All types used there are loadable by definition.
+      return true;
+    }
+    return Ty.isLoadableOrOpaque(F);
   }
 
   void appendOperandTypeName(SILType OpdTy, llvm::SmallString<16> &Name) {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -316,8 +316,10 @@ public:
   mutable Lowering::TypeConverter Types;
 
   /// Look up the TypeLowering for a SILType.
-  const Lowering::TypeLowering &getTypeLowering(SILType t) {
-    return Types.getTypeLowering(t);
+  const Lowering::TypeLowering &
+  getTypeLowering(SILType t, ResilienceExpansion expansion =
+                               ResilienceExpansion::Minimal) {
+    return Types.getTypeLowering(t, expansion);
   }
 
   /// Invalidate cached entries in SIL Loader.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -257,13 +257,34 @@ public:
   bool isLoadable(SILModule &M) const {
     return !isAddressOnly(M);
   }
+
+  /// Like isLoadable(SILModule), but specific to a function.
+  ///
+  /// This takes the resilience expansion of the function into account. If the
+  /// type is not loadable in general (because it's resilient), it still might
+  /// be loadable inside a resilient function in the module.
+  /// In other words: isLoadable(SILModule) is the conservative default, whereas
+  /// isLoadable(SILFunction) might give a more optimistic result.
+  bool isLoadable(SILFunction *inFunction) const {
+    return !isAddressOnly(inFunction);
+  }
+
   /// True if either:
   /// 1) The type, or the referenced type of an address type, is loadable.
   /// 2) The SIL Module conventions uses lowered addresses
   bool isLoadableOrOpaque(SILModule &M) const;
+
+  /// Like isLoadableOrOpaque(SILModule), but takes the resilience expansion of
+  /// \p inFunction into account (see isLoadable(SILFunction)).
+  bool isLoadableOrOpaque(SILFunction *inFunction) const;
+
   /// True if the type, or the referenced type of an address type, is
   /// address-only. This is the opposite of isLoadable.
   bool isAddressOnly(SILModule &M) const;
+
+  /// Like isAddressOnly(SILModule), but takes the resilience expansion of
+  /// \p inFunction into account (see isLoadable(SILFunction)).
+  bool isAddressOnly(SILFunction *inFunction) const;
 
   /// True if the type, or the referenced type of an address type, is trivial.
   bool isTrivial(SILModule &M) const;

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -120,7 +120,7 @@ SILBuilder::createClassifyBridgeObject(SILLocation Loc, SILValue value) {
 // Create the appropriate cast instruction based on result type.
 SingleValueInstruction *
 SILBuilder::createUncheckedBitCast(SILLocation Loc, SILValue Op, SILType Ty) {
-  assert(Ty.isLoadableOrOpaque(getModule()));
+  assert(isLoadableOrOpaque(Ty));
   if (Ty.isTrivial(getModule()))
     return insert(UncheckedTrivialBitCastInst::create(
         getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes));
@@ -552,7 +552,7 @@ void SILBuilder::emitShallowDestructureAddressOperation(
 
 DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                              SILDebugVariable Var) {
-  assert(src->getType().isLoadableOrOpaque(getModule()));
+  assert(isLoadableOrOpaque(src->getType()));
   // Debug location overrides cannot apply to debug value instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
   return insert(

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -175,11 +175,22 @@ bool SILType::isLoadableOrOpaque(SILModule &M) const {
   return isLoadable(M) || !SILModuleConventions(M).useLoweredAddresses();
 }
 
+bool SILType::isLoadableOrOpaque(SILFunction *inFunction) const {
+  SILModule &M = inFunction->getModule();
+  return isLoadable(inFunction) ||
+         !SILModuleConventions(M).useLoweredAddresses();
+}
+
 /// True if the type, or the referenced type of an address type, is
 /// address-only. For example, it could be a resilient struct or something of
 /// unknown size.
 bool SILType::isAddressOnly(SILModule &M) const {
   return M.getTypeLowering(*this).isAddressOnly();
+}
+
+bool SILType::isAddressOnly(SILFunction *inFunction) const {
+  return inFunction->getModule().getTypeLowering(*this,
+                        inFunction->getResilienceExpansion()).isAddressOnly();
 }
 
 SILType SILType::substGenericArgs(SILModule &M,

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1534,7 +1534,7 @@ public:
   void checkLoadInst(LoadInst *LI) {
     require(LI->getType().isObject(), "Result of load must be an object");
     require(!fnConv.useLoweredAddresses()
-                || LI->getType().isLoadable(LI->getModule()),
+                || LI->getType().isLoadable(LI->getFunction()),
             "Load must have a loadable type");
     require(LI->getOperand()->getType().isAddress(),
             "Load operand must be an address");
@@ -1573,7 +1573,7 @@ public:
         "Inst with qualified ownership in a function that is not qualified");
     require(LBI->getType().isObject(), "Result of load must be an object");
     require(!fnConv.useLoweredAddresses()
-            || LBI->getType().isLoadable(LBI->getModule()),
+            || LBI->getType().isLoadable(LBI->getFunction()),
             "Load must have a loadable type");
     require(LBI->getOperand()->getType().isAddress(),
             "Load operand must be an address");
@@ -1691,7 +1691,7 @@ public:
     require(SI->getSrc()->getType().isObject(),
             "Can't store from an address source");
     require(!fnConv.useLoweredAddresses()
-                || SI->getSrc()->getType().isLoadable(SI->getModule()),
+                || SI->getSrc()->getType().isLoadable(SI->getFunction()),
             "Can't store a non loadable type");
     require(SI->getDest()->getType().isAddress(),
             "Must store to an address dest");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1139,7 +1139,7 @@ namespace {
   /// Build the appropriate TypeLowering subclass for the given type,
   /// which is assumed to already have been lowered.
   class LowerType
-    : public TypeClassifierBase<LowerType, const TypeLowering *>
+    : public TypeClassifierBase<LowerType, TypeLowering *>
   {
     TypeConverter &TC;
     IsDependent_t Dependent;
@@ -1149,18 +1149,18 @@ namespace {
       : TypeClassifierBase(TC.M, Sig, Expansion),
         TC(TC), Dependent(Dependent) {}
 
-    const TypeLowering *
+    TypeLowering *
     handleTrivial(CanType type) {
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC, Dependent) TrivialTypeLowering(silType);
     }
 
-    const TypeLowering *handleReference(CanType type) {
+    TypeLowering *handleReference(CanType type) {
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC, Dependent) ReferenceTypeLowering(silType);
     }
 
-    const TypeLowering *handleAddressOnly(CanType type, 
+    TypeLowering *handleAddressOnly(CanType type,
                                           RecursiveProperties properties) {
       if (SILModuleConventions(M).useLoweredAddresses()) {
         auto silType = SILType::getPrimitiveAddressType(type);
@@ -1171,20 +1171,20 @@ namespace {
     }
 
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    const TypeLowering * \
+    TypeLowering * \
     visitLoadable##Name##StorageType(Can##Name##StorageType type) { \
       return new (TC, Dependent) Loadable##Name##TypeLowering( \
                                   SILType::getPrimitiveObjectType(type)); \
     }
 #include "swift/AST/ReferenceStorage.def"
 
-    const TypeLowering *
+    TypeLowering *
     visitBuiltinUnsafeValueBufferType(CanBuiltinUnsafeValueBufferType type) {
       auto silType = SILType::getPrimitiveAddressType(type);
       return new (TC, Dependent) UnsafeValueBufferTypeLowering(silType);
     }
 
-    const TypeLowering *visitTupleType(CanTupleType tupleType) {
+    TypeLowering *visitTupleType(CanTupleType tupleType) {
       RecursiveProperties properties;
       for (auto eltType : tupleType.getElementTypes()) {
         auto &lowering = TC.getTypeLowering(eltType);
@@ -1195,13 +1195,13 @@ namespace {
                                                                     properties);
     }
 
-    const TypeLowering *visitAnyStructType(CanType structType, StructDecl *D) {
+    TypeLowering *visitAnyStructType(CanType structType, StructDecl *D) {
 
       // For now, if the type does not have a fixed layout in all resilience
       // domains, we will treat it as address-only in SIL.
       if (D->isResilient(M.getSwiftModule(), Expansion))
         return handleAddressOnly(structType,
-                                 RecursiveProperties::forOpaque());
+                                 RecursiveProperties::forResilient());
 
       // Classify the type according to its stored properties.
       RecursiveProperties properties;
@@ -1216,11 +1216,11 @@ namespace {
                                                                     properties);
     }
         
-    const TypeLowering *visitAnyEnumType(CanType enumType, EnumDecl *D) {
+    TypeLowering *visitAnyEnumType(CanType enumType, EnumDecl *D) {
       // For now, if the type does not have a fixed layout in all resilience
       // domains, we will treat it as address-only in SIL.
       if (D->isResilient(M.getSwiftModule(), Expansion))
-        return handleAddressOnly(enumType, RecursiveProperties::forOpaque());
+        return handleAddressOnly(enumType, RecursiveProperties::forResilient());
 
       // If the whole enum is indirect, we lower it as if all payload
       // cases were indirect. This means a fixed-layout indirect enum
@@ -1257,7 +1257,7 @@ namespace {
     }
 
     template <class LoadableLoweringClass>
-    const TypeLowering *handleAggregateByProperties(CanType type,
+    TypeLowering *handleAggregateByProperties(CanType type,
                                                     RecursiveProperties props) {
       if (props.isAddressOnly()) {
         return handleAddressOnly(type, props);
@@ -1451,7 +1451,8 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
     AbstractionPattern(getCurGenericContext(), loweredSubstType);
   auto loweredKey = getTypeKey(origTypeForCaching, loweredSubstType);
 
-  auto &lowering = getTypeLoweringForLoweredType(loweredKey);
+  auto &lowering = getTypeLoweringForLoweredType(loweredKey,
+                                                 ResilienceExpansion::Minimal);
   insert(key, &lowering);
   return lowering;
 }
@@ -1565,16 +1566,18 @@ CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
   return substType;
 }
 
-const TypeLowering &TypeConverter::getTypeLowering(SILType type) {
+const TypeLowering &
+TypeConverter::getTypeLowering(SILType type, ResilienceExpansion forExpansion) {
   auto loweredType = type.getASTType();
   auto key = getTypeKey(AbstractionPattern(getCurGenericContext(), loweredType),
                         loweredType);
 
-  return getTypeLoweringForLoweredType(key);
+  return getTypeLoweringForLoweredType(key, forExpansion);
 }
 
 const TypeLowering &
-TypeConverter::getTypeLoweringForLoweredType(TypeKey key) {
+TypeConverter::getTypeLoweringForLoweredType(TypeKey key,
+                                             ResilienceExpansion forExpansion) {
   auto type = key.SubstType;
   assert(type->isLegalSILType() && "type is not lowered!");
   (void)type;
@@ -1582,10 +1585,39 @@ TypeConverter::getTypeLoweringForLoweredType(TypeKey key) {
   // Re-using uncurry level 0 is reasonable because our uncurrying
   // transforms are idempotent at this level.  This means we don't
   // need a ton of redundant entries in the map.
-  if (auto existing = find(key))
-    return *existing;
+  const TypeLowering *lowering = find(key);
+  if (!lowering) {
+    lowering = &getTypeLoweringForUncachedLoweredType(key);
+  }
+  assert(lowering->forExpansion == ResilienceExpansion::Minimal &&
+         "the first lowering in the list must be for minimal expansion");
 
-  return getTypeLoweringForUncachedLoweredType(key);
+  if (key.isDependent() || !lowering->isResilient()) {
+    // Don't try to refine the lowering for other resilience expansions if
+    // we don't expect to get a different lowering anyway.
+    return *lowering;
+  }
+
+  // Search for a matching lowering in the linked list of lowerings.
+  while (true) {
+    if (lowering->forExpansion == forExpansion)
+      return *lowering;
+    if (lowering->nextExpansion) {
+      // Continue searching.
+      lowering = lowering->nextExpansion;
+      continue;
+    }
+
+    // Create a new lowering for the resilience expansion.
+    TypeLowering *theInfo = LowerType(*this,
+                              CanGenericSignature(),
+                              forExpansion,
+                              key.isDependent()).visit(key.SubstType);
+
+    lowering->nextExpansion = theInfo;
+    theInfo->forExpansion = forExpansion;
+    return *theInfo;
+  }
 }
 
 /// Do type-lowering for a lowered type which is not already in the cache,

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -137,6 +137,9 @@ protected:
   /// can be statically initialized.
   void optimizeInitializer(SILFunction *AddrF, GlobalInitCalls &Calls);
 
+  /// Perform peephole optimizations on the initializer list.
+  void peepholeInitializer(SILFunction *InitFunc);
+
   /// Optimize access to the global variable, which is known to have a constant
   /// value. Replace all loads from the global address by invocations of a
   /// getter that returns the value of this variable.
@@ -253,12 +256,14 @@ static SILFunction *getGlobalGetterFunction(SILOptFunctionBuilder &FunctionBuild
   if (auto *F = M.lookUpFunction(getterNameTmp))
     return F;
 
-  auto Linkage = (varDecl->getEffectiveAccess() >= AccessLevel::Public
-                  ? SILLinkage::PublicNonABI
-                  : SILLinkage::Private);
-  auto Serialized = (varDecl->getEffectiveAccess() >= AccessLevel::Public
-                     ? IsSerialized
-                     : IsNotSerialized);
+  auto Linkage = SILLinkage::Private;
+  auto Serialized = IsNotSerialized;
+
+  if (varDecl->getEffectiveAccess() >= AccessLevel::Public &&
+      !varDecl->isResilient()) {
+    Linkage = SILLinkage::PublicNonABI;
+    Serialized = IsSerialized;
+  }
 
   auto refType = M.Types.getLoweredType(varDecl->getInterfaceType());
 
@@ -690,7 +695,17 @@ replaceLoadsByKnownValue(BuiltinInst *CallToOnce, SILFunction *AddrF,
       auto *PTAI = dyn_cast<PointerToAddressInst>(Use->getUser());
       assert(PTAI && "All uses should be pointer_to_address");
       for (auto PTAIUse : PTAI->getUses()) {
-        replaceLoadSequence(PTAIUse->getUser(), NewAI, B);
+        SILInstruction *Load = PTAIUse->getUser();
+        if (auto *CA = dyn_cast<CopyAddrInst>(Load)) {
+          // The result of the initializer is stored to another location.
+          SILBuilder B(CA);
+          B.createStore(CA->getLoc(), NewAI, CA->getDest(),
+                        StoreOwnershipQualifier::Unqualified);
+          CA->eraseFromParent();
+        } else {
+          // The result of the initializer is used as a value.
+          replaceLoadSequence(Load, NewAI, B);
+        }
       }
     }
 
@@ -721,6 +736,8 @@ void SILGlobalOpt::optimizeInitializer(SILFunction *AddrF,
       InitializerCount[InitF] > 1)
     return;
 
+  peepholeInitializer(InitF);
+
   // If the globalinit_func is trivial, continue; otherwise bail.
   SingleValueInstruction *InitVal;
   SILGlobalVariable *SILG = getVariableOfStaticInitializer(InitF, InitVal);
@@ -741,6 +758,58 @@ void SILGlobalOpt::optimizeInitializer(SILFunction *AddrF,
 
   replaceLoadsByKnownValue(CallToOnce, AddrF, InitF, SILG, InitVal, Calls);
   HasChanged = true;
+}
+
+void SILGlobalOpt::peepholeInitializer(SILFunction *InitFunc) {
+  if (InitFunc->size() != 1)
+    return;
+  SILBasicBlock *BB = &InitFunc->front();
+
+  for (auto &I : *BB) {
+    if (auto *SI = dyn_cast<StoreInst>(&I)) {
+
+      // If struct S has a single field, replace
+      //   %a = struct_element_addr %s : $*S
+      //   store %x to %a
+      // with
+      //   %y = struct $S (%x)
+      //   store %y to %s
+      //
+      // This pattern occurs with resilient static properties, like
+      // struct ResilientStruct {
+      //   var singleField: Int
+      //   public static let x = ResilientStruct(singleField: 27)
+      // }
+      //
+      // TODO: handle structs with multiple fields.
+      SILValue Addr = SI->getDest();
+      auto *SEA = dyn_cast<StructElementAddrInst>(Addr);
+      if (!SEA)
+        continue;
+
+      if (SEA->getOperand()->getType().isAddressOnly(InitFunc))
+        continue;
+
+      StructDecl *Decl = SEA->getStructDecl();
+      auto beginProp = Decl->getStoredProperties().begin();
+      if (std::next(beginProp) != Decl->getStoredProperties().end())
+        continue;
+
+      assert(*beginProp == SEA->getField());
+
+      SILBuilder B(SI);
+      SILValue StructAddr = SEA->getOperand();
+      StructInst *Struct = B.createStruct(SEA->getLoc(),
+                                          StructAddr->getType().getObjectType(),
+                                          { SI->getSrc() });
+      SI->setOperand(StoreInst::Src, Struct);
+      SI->setOperand(StoreInst::Dest, StructAddr);
+      if (SEA->use_empty()) {
+        SEA->eraseFromParent();
+      }
+      HasChanged = true;
+    }
+  }
 }
 
 static bool canBeChangedExternally(SILGlobalVariable *SILG) {

--- a/test/SILOptimizer/globalopt_resilience.swift
+++ b/test/SILOptimizer/globalopt_resilience.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend  -O -module-name=test -enable-resilience -emit-sil -primary-file %s | %FileCheck %s
+
+// Check if GlobalOpt generates the optimal getter for a static property with a resilient type.
+// The (resilient) getter should just return the literal (and not lazily initialize a global variable).
+
+// CHECK-LABEL: sil @$s4test15ResilientStructV9staticValACvgZ :
+// CHECK:     bb0(%0 : $*ResilientStruct{{.*}}):
+// CHECK:       [[L:%[0-9]+]] = integer_literal {{.*}}, 27
+// CHECK:       [[I:%[0-9]+]] = struct $Int ([[L]] : {{.*}})
+// CHECK:       [[S:%[0-9]+]] = struct $ResilientStruct ([[I]] : $Int)
+// CHECK:       store [[S]] to %0
+// CHECK:       return
+
+public struct ResilientStruct {
+  var rawValue: Int
+
+  public static let staticVal = ResilientStruct(rawValue: 27)
+}
+


### PR DESCRIPTION
For example:
```
struct ResilientStruct {
  var singleField: Int
  public static let x = ResilientStruct(singleField: 27)
}
```

The generated (resilient) getter for x should just return a 27 (wrapped in a struct) and not lazily initialize a global variable.

The main SIL infrastructure change for this is to store type lowerings for multiple resilience expansions.
This lets the SIL optimizer reason about types (e.g. if a type is loadable) in specific functions.
For example, a type might be loadable in a resilient function, but not in an inlinable function.

rdar://problem/46712028