### PR TITLE
[5.0]  [Runtime] Correctly match demangle tree for generic Objective-C classes.

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -163,9 +163,15 @@ class TypeDecoder {
     case NodeKind::BoundGenericClass:
     {
 #if SWIFT_OBJC_INTEROP
-      if (Node->getNumChildren() == 2)
-        if (auto mangledName = getObjCClassOrProtocolName(Node->getChild(0)))
+      if (Node->getNumChildren() == 2) {
+        auto ChildNode = Node->getChild(0);
+        if (ChildNode->getKind() == NodeKind::Type &&
+            ChildNode->getNumChildren() > 0)
+          ChildNode = ChildNode->getChild(0);
+
+        if (auto mangledName = getObjCClassOrProtocolName(ChildNode))
           return Builder.createObjCClassType(mangledName->str());
+      }
 #endif
       LLVM_FALLTHROUGH;
     }

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -163,7 +163,7 @@ class TypeDecoder {
     case NodeKind::BoundGenericClass:
     {
 #if SWIFT_OBJC_INTEROP
-      if (Node->getNumChildren() == 2) {
+      if (Node->getNumChildren() >= 2) {
         auto ChildNode = Node->getChild(0);
         if (ChildNode->getKind() == NodeKind::Type &&
             ChildNode->getNumChildren() > 0)

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -108,5 +108,9 @@ DemangleToMetadataTests.test("runtime conformance check for @objc protocol inher
   expectEqual(F<P3>.self, _typeByName("4main1FCyAA2P3PG")!)
 }
 
+DemangleToMetadataTests.test("Objective-C generics") {
+  expectEqual(NSArray.self, _typeByName("So7NSArrayCySo8NSStringCG")!)
+}
+
 runAllTests()
 


### PR DESCRIPTION
When we encounter the demangle tree for a bound generic class type, look
through the "Type" node of the child tree before checking whether we
have an Objective-C class name. If we do have an Objective-C class name,
there is no way to preserve the generic arguments, so we ignore them and
return the (non-generic) class type.

Fixes rdar://problem/47028102.