### PR TITLE
Add inline(always) to AnyCollection routines like _suffix, _prefix, _drop, ...

### DIFF
--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -503,30 +503,36 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
     return _base.suffix(maxLength)
   }
 %   else:
+  @inline(__always)
   @inlinable
   internal override func _drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     return try _${Kind}Box<S.SubSequence>(_base: _base.drop(while: predicate))
   }
+  @inline(__always)
   @inlinable
   internal override func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.dropFirst(n))
   }
+  @inline(__always)
   @inlinable
   internal override func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.dropLast(n))
   }
+  @inline(__always)
   @inlinable
   internal override func _prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     return try _${Kind}Box<S.SubSequence>(_base: _base.prefix(while: predicate))
   }
+  @inline(__always)
   @inlinable
   internal override func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.prefix(maxLength))
   }
+  @inline(__always)
   @inlinable
   internal override func _suffix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.suffix(maxLength))


### PR DESCRIPTION
This causes regression as in https://github.com/apple/swift/pull/19820. By adding __inline(always) fixes the problem.
