### PR TITLE
stdlib: disable abort reporting on Windows

### DIFF
--- a/stdlib/private/StdlibUnittest/InterceptTraps.cpp
+++ b/stdlib/private/StdlibUnittest/InterceptTraps.cpp
@@ -71,7 +71,7 @@ void installTrapInterceptor() {
   setbuf(stdout, 0);
 
 #if defined(_WIN32)
-  _set_abort_behavior(1, _WRITE_ABORT_MSG);
+  _set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif
 
   signal(SIGILL,  CrashCatcher);


### PR DESCRIPTION
Avoid the dialog when an assertion fails on Windows.  This is important to
ensure that the tests do not create a large number of prompts.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
