### PR TITLE
constant interpreter: split getSingleWriterAddressValue

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -268,6 +268,9 @@ public:
   SymbolicValueMemoryObject *
   getAddressValue(SmallVectorImpl<unsigned> &accessPath) const;
 
+  /// Return just the memory object for an address value.
+  SymbolicValueMemoryObject *getAddressValueMemoryObject() const;
+
   //===--------------------------------------------------------------------===//
   // Helpers
 
@@ -311,6 +314,24 @@ struct SymbolicValueMemoryObject {
   /// Create a new memory object whose overall type is as specified.
   static SymbolicValueMemoryObject *create(Type type, SymbolicValue value,
                                            ASTContext &astContext);
+
+  /// Given that this memory object contains an aggregate value like
+  /// {{1, 2}, 3}, and given an access path like [0,1], return the indexed
+  /// element, e.g. "2" in this case.
+  ///
+  /// Returns uninit memory if the access path points at or into uninit memory.
+  ///
+  /// Precondition: The access path must be valid for this memory object's type.
+  SymbolicValue getIndexedElement(ArrayRef<unsigned> accessPath);
+
+  /// Given that this memory object contains an aggregate value like
+  /// {{1, 2}, 3}, given an access path like [0,1], and given a scalar like "4",
+  /// set the indexed element to the specified scalar, producing {{1, 4}, 3} in
+  /// this case.
+  ///
+  /// Precondition: The access path must be valid for this memory object's type.
+  void setIndexedElement(ArrayRef<unsigned> accessPath, SymbolicValue scalar,
+                         ASTContext &astCtx);
 
 private:
   const Type type;

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -404,6 +404,14 @@ SymbolicValue::getAddressValue(SmallVectorImpl<unsigned> &accessPath) const {
   return dav->memoryObject;
 }
 
+/// Return just the memory object for an address value.
+SymbolicValueMemoryObject *SymbolicValue::getAddressValueMemoryObject() const {
+  if (representationKind == RK_DirectAddress)
+    return value.directAddress;
+  assert(representationKind == RK_DerivedAddress);
+  return value.derivedAddress->memoryObject;
+}
+
 //===----------------------------------------------------------------------===//
 // Higher level code
 //===----------------------------------------------------------------------===//
@@ -520,4 +528,125 @@ void SymbolicValue::emitUnknownDiagnosticNotes(SILLocation fallbackLoc) {
     diagnose(module.getASTContext(), sourceLoc, diag);
     emittedFirstNote = true;
   }
+}
+
+/// Returns the element of `aggregate` specified by the access path.
+///
+/// This is a helper for `SymbolicValueMemoryObject::getIndexedElement`. See
+/// there for more detailed documentation.
+static SymbolicValue getIndexedElement(SymbolicValue aggregate,
+                                       ArrayRef<unsigned> accessPath,
+                                       Type type) {
+  // We're done if we've run out of access path.
+  if (accessPath.empty())
+    return aggregate;
+
+  // Everything inside uninit memory is uninit memory.
+  if (aggregate.getKind() == SymbolicValue::UninitMemory)
+    return SymbolicValue::getUninitMemory();
+
+  assert(aggregate.getKind() == SymbolicValue::Aggregate &&
+         "the accessPath is invalid for this type");
+
+  unsigned elementNo = accessPath.front();
+
+  SymbolicValue elt = aggregate.getAggregateValue()[elementNo];
+  Type eltType;
+  if (auto *decl = type->getStructOrBoundGenericStruct()) {
+    auto it = decl->getStoredProperties().begin();
+    std::advance(it, elementNo);
+    eltType = (*it)->getType();
+  } else if (auto tuple = type->getAs<TupleType>()) {
+    assert(elementNo < tuple->getNumElements() && "invalid index");
+    eltType = tuple->getElement(elementNo).getType();
+  } else {
+    llvm_unreachable("the accessPath is invalid for this type");
+  }
+
+  return getIndexedElement(elt, accessPath.drop_front(), eltType);
+}
+
+/// Given that this memory object contains an aggregate value like
+/// {{1, 2}, 3}, and given an access path like [0,1], return the indexed
+/// element, e.g. "2" in this case.
+///
+/// Returns uninit memory if the access path points at or into uninit memory.
+///
+/// Precondition: The access path must be valid for this memory object's type.
+SymbolicValue
+SymbolicValueMemoryObject::getIndexedElement(ArrayRef<unsigned> accessPath) {
+  return ::getIndexedElement(value, accessPath, type);
+}
+
+/// Returns `aggregate` with the element specified by the access path set to
+/// `scalar`.
+///
+/// This is a helper for `SymbolicValueMemoryObject::setIndexedElement`. See
+/// there for more detailed documentation.
+static SymbolicValue setIndexedElement(SymbolicValue aggregate,
+                                       ArrayRef<unsigned> accessPath,
+                                       SymbolicValue scalar, Type type,
+                                       ASTContext &astCtx) {
+  // We're done if we've run out of access path.
+  if (accessPath.empty())
+    return scalar;
+
+  // If we have an uninit memory, then scalarize it into an aggregate to
+  // continue.  This happens when memory objects are initialized piecewise.
+  if (aggregate.getKind() == SymbolicValue::UninitMemory) {
+    unsigned numMembers;
+    // We need to have either a struct or a tuple type.
+    if (auto *decl = type->getStructOrBoundGenericStruct()) {
+      numMembers = std::distance(decl->getStoredProperties().begin(),
+                                 decl->getStoredProperties().end());
+    } else if (auto tuple = type->getAs<TupleType>()) {
+      numMembers = tuple->getNumElements();
+    } else {
+      llvm_unreachable("the accessPath is invalid for this type");
+    }
+
+    SmallVector<SymbolicValue, 4> newElts(numMembers,
+                                          SymbolicValue::getUninitMemory());
+    aggregate = SymbolicValue::getAggregate(newElts, astCtx);
+  }
+
+  assert(aggregate.getKind() == SymbolicValue::Aggregate &&
+         "the accessPath is invalid for this type");
+
+  unsigned elementNo = accessPath.front();
+
+  ArrayRef<SymbolicValue> oldElts = aggregate.getAggregateValue();
+  Type eltType;
+  if (auto *decl = type->getStructOrBoundGenericStruct()) {
+    auto it = decl->getStoredProperties().begin();
+    std::advance(it, elementNo);
+    eltType = (*it)->getType();
+  } else if (auto tuple = type->getAs<TupleType>()) {
+    assert(elementNo < tuple->getNumElements() && "invalid index");
+    eltType = tuple->getElement(elementNo).getType();
+  } else {
+    llvm_unreachable("the accessPath is invalid for this type");
+  }
+
+  // Update the indexed element of the aggregate.
+  SmallVector<SymbolicValue, 4> newElts(oldElts.begin(), oldElts.end());
+  newElts[elementNo] = setIndexedElement(newElts[elementNo],
+                                         accessPath.drop_front(), scalar,
+                                         eltType, astCtx);
+
+  aggregate = SymbolicValue::getAggregate(newElts, astCtx);
+
+  return aggregate;
+}
+
+/// Given that this memory object contains an aggregate value like
+/// {{1, 2}, 3}, given an access path like [0,1], and given a scalar like "4",
+/// set the indexed element to the specified scalar, producing {{1, 4}, 3} in
+/// this case.
+///
+/// Precondition: The access path must be valid for this memory object's type.
+void SymbolicValueMemoryObject::setIndexedElement(
+    ArrayRef<unsigned> accessPath, SymbolicValue scalar,
+    ASTContext &astCtx) {
+  value = ::setIndexedElement(value, accessPath, scalar, type, astCtx);
 }

--- a/test/SILOptimizer/pound_assert.sil
+++ b/test/SILOptimizer/pound_assert.sil
@@ -229,7 +229,6 @@ sil @doubleWriteTopLevel : $@convention(thin) () -> () {
 sil @doubleWriteTupleElement : $@convention(thin) (Int64) -> () {
 bb0(%arg : $Int64):
   // Allocate and initialize the tuple to (1, 2).
-  // expected-note @+1 {{could not fold operation}}
   %0 = alloc_stack $(Int64, Int64), var, name "tup"
   %1 = tuple_element_addr %0 : $*(Int64, Int64), 0
   %2 = tuple_element_addr %0 : $*(Int64, Int64), 1
@@ -241,6 +240,7 @@ bb0(%arg : $Int64):
   store %7 to %2 : $*Int64
 
   // Store %arg, whose value is unknown, to the first element of the tuple.
+  // expected-note @+1 {{could not fold operation}}
   %addr = tuple_element_addr %0 : $*(Int64, Int64), 0
   store %arg to %addr : $*Int64
 


### PR DESCRIPTION
This splits `getSingleWriterAddressValue` into two functions:
* a wrapper `getSingleWriterAddressValue` responsible for allocating the memory
* a helper `initializeAddressFromSingleWriter` responsible for initializing the memory (possibly recursively)

This eliminates some wasteful and confusing redundant memory allocations that happen when a single function responsible for allocating and initializing the memory recurses on itself. (e.g. when it's initializing an `(Int, Int)`, the top call allocates space for `(Int, Int)`, then the inner call allocates space for `Int` and initializes it, and then the outer call copies the value into its `(Int, Int)` memory).

We had some confusing bugs in the tensorflow branch where the different memory objects somehow got out of sync. I think that we managed to squash all of them by being very careful. But then we did this refactoring which should make them a lot less likely to reoccur.