### PR TITLE
[Stdlib] Add Missing Implementations of underestimatedCount

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -157,4 +157,9 @@ extension EnumeratedSequence: Sequence {
   public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
+
+  @inlinable
+  public var underestimatedCount: Int {
+    return _base.underestimatedCount
+  }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -128,6 +128,11 @@ extension IndexingIterator: IteratorProtocol, Sequence {
     _elements.formIndex(after: &_position)
     return element
   }
+
+  @inlinable
+  public var underestimatedCount: Int {
+    return _elements.underestimatedCount
+  }
 }
 
 /// A sequence whose elements can be traversed multiple times,

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -93,6 +93,11 @@ extension ReversedCollection.Iterator: IteratorProtocol, Sequence {
     _base.formIndex(before: &_position)
     return _base[_position]
   }
+
+  @inlinable
+  public var underestimatedCount: Int {
+    return _base.underestimatedCount
+  }
 }
 
 extension ReversedCollection: Sequence {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -427,6 +427,11 @@ extension DropFirstSequence: Sequence {
     // [1,2,3,4].dropFirst(2).
     return DropFirstSequence(_base, dropping: _limit + k)
   }
+
+  @inlinable
+  public var underestimatedCount: Int {
+    return Swift.max(0, _base.underestimatedCount - _limit)
+  }
 }
 
 /// A sequence that only consumes up to `n` elements from an underlying

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -494,6 +494,11 @@ extension PrefixSequence: Sequence {
     let length = Swift.min(maxLength, self._maxLength)
     return PrefixSequence(_base, maxLength: length)
   }
+
+  @inlinable
+  public var underestimatedCount: Int {
+    return Swift.min(_base.underestimatedCount, _maxLength)
+  }
 }
 
 


### PR DESCRIPTION

Fixes [SR-9570](https://bugs.swift.org/browse/SR-9570).

The following types, which, to my knowledge, are all `Sequence`s from the Standard Library, have been checked:

- `AnyBidirectionalCollection`
- `AnyCollection`
- `AnyIterator`
- `AnyRandomAccessCollection`
- `AnySequence`
- `Array`
- `ArraySlice`
- `ClosedRange`
- `CollectionOfOne`
- `ContiguousArray`
- `DefaultIndices`
- `Dictionary`
- `DropFirstSequence`
- `DropWhileSequence`
- `EmptyCollection`
- `EmptyCollection.Iterator`
- `EnumeratedSequence`
- `EnumeratedSequence.Iterator`
- `FlattenSequence`
- `FlattenSequence.Iterator`
- `IndexingIterator`
- `IteratorSequence`
- `JoinedSequence`
- `KeyValuePairs`
- `LazyDropWhileSequence`
- `LazyFilterSequence`
- `LazyMapSequence`
- `LazyPrefixWhileSequence`
- `LazySequence`
- `LazyFilterSequence.Iterator`
- `LazyPrefixWhileSequence.Iterator`
- `LazyMapSequence.Iterator`
- `PartialRangeFrom`
- `PrefixSequence`
- `Range`
- `Repeated`
- `ReversedCollection`
- `ReversedCollection.Iterator`
- `Set`
- `Slice`
- `StrideThrough`
- `StrideTo`
- `String`
- `String.UnicodeScalarView`
- `String.UTF16View`
- `String.UTF8View`
- `Substring`
- `Substring.UnicodeScalarView`
- `Substring.UTF16View`
- `Substring.UTF8View`
- `UnfoldSequence`
- `Unicode.Scalar.UTF16View`
- `UnsafeBufferPointer`
- `UnsafeMutableBufferPointer`
- `UnsafeMutableRawBufferPointer`
- `UnsafeRawBufferPointer`
- `UnsafeRawBufferPointer.Iterator`
- `Zip2Sequence`

Please test and review.