### PR TITLE
[5.0 backport] conform Unsafe(Mutable)RawBufferPointer conform to _HasContiguousBytes

### DIFF
--- a/stdlib/public/core/ContiguouslyStored.swift
+++ b/stdlib/public/core/ContiguouslyStored.swift
@@ -57,6 +57,22 @@ extension UnsafeMutableBufferPointer: _HasContiguousBytes {
     return try body(UnsafeRawBufferPointer(start: ptr, count: len))
   }
 }
+extension UnsafeRawBufferPointer: _HasContiguousBytes {
+  @inlinable @inline(__always)
+  func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try body(self)
+  }
+}
+extension UnsafeMutableRawBufferPointer: _HasContiguousBytes {
+  @inlinable @inline(__always)
+  func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try body(UnsafeRawBufferPointer(self))
+  }
+}
 extension String: _HasContiguousBytes {
   @inlinable
   internal var _providesContiguousBytesNoCopy: Bool {


### PR DESCRIPTION
(cherry picked from commit f87ffd20772f6aa7226901037beb55858fbda736)

backport of #21611 to `swift-5.0-branch`