### PR TITLE
[AutoDiff] Make sure `AdjointValue`s are always in the cotangent space

### DIFF
--- a/test/AutoDiff/separate_cotangent_type.swift
+++ b/test/AutoDiff/separate_cotangent_type.swift
@@ -1,0 +1,72 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if os(macOS)
+import Darwin.C
+#else
+import Glibc
+#endif
+
+var SeparateCotangentTypeTests = TestSuite("SeparateCotangentType")
+
+struct DifferentiableSubset : Differentiable {
+  @differentiable(wrt: (self))
+  var w: Float
+  @differentiable(wrt: (self))
+  var b: Float
+  @noDerivative var flag: Bool
+
+  // @_fieldwiseProductSpace
+  struct TangentVector : Differentiable, VectorNumeric {
+    @_fieldwiseProductSpace
+    typealias TangentVector = DifferentiableSubset.TangentVector
+    @_fieldwiseProductSpace
+    typealias CotangentVector = DifferentiableSubset.CotangentVector
+    var w: Float
+    var b: Float
+    func tangentVector(from cotan: CotangentVector) -> TangentVector {
+      return TangentVector(w: cotan.w, b: cotan.b)
+    }
+  }
+  // @_fieldwiseProductSpace
+  struct CotangentVector : Differentiable, VectorNumeric {
+    @_fieldwiseProductSpace
+    typealias TangentVector = DifferentiableSubset.CotangentVector
+    @_fieldwiseProductSpace
+    typealias CotangentVector = DifferentiableSubset.TangentVector
+    var w: Float
+    var b: Float
+    func tangentVector(from cotan: CotangentVector) -> TangentVector {
+      return TangentVector(w: cotan.w, b: cotan.b)
+    }
+  }
+  func tangentVector(from cotan: CotangentVector) -> TangentVector {
+    return TangentVector(w: cotan.w, b: cotan.b)
+  }
+  func moved(along v: TangentVector) -> DifferentiableSubset {
+    return DifferentiableSubset(w: w.moved(along: v.w), b: b.moved(along: v.b), flag: flag)
+  }
+}
+
+SeparateCotangentTypeTests.test("Trivial") {
+  let x = DifferentiableSubset(w: 0, b: 1, flag: false)
+  let pb = pullback(at: x) { x in x }
+  expectEqual(pb(DifferentiableSubset.CotangentVector.zero), DifferentiableSubset.CotangentVector.zero)
+}
+
+SeparateCotangentTypeTests.test("Initialization") {
+  let x = DifferentiableSubset(w: 0, b: 1, flag: false)
+  let pb = pullback(at: x) { x in DifferentiableSubset(w: 1, b: 2, flag: true) }
+  expectEqual(pb(DifferentiableSubset.CotangentVector.zero), DifferentiableSubset.CotangentVector.zero)
+}
+
+// FIXME(SR-9602): If `CotangentVector` is not marked
+// `@_fieldwiseProductSpace`, call the VJP of the memberwise initializer.
+// SeparateCotangentTypeTests.test("SomeArithmetics") {
+//   let x = DifferentiableSubset(w: 0, b: 1, flag: false)
+//   let pb = pullback(at: x) { x in DifferentiableSubset(w: x.w * x.w, b: x.b * x.b, flag: true) }
+//   expectEqual(pb(DifferentiableSubset.CotangentVector.zero), DifferentiableSubset.CotangentVector.zero)
+// }
+
+runAllTests()

--- a/test/AutoDiff/superset_adjoint_loaded.swift
+++ b/test/AutoDiff/superset_adjoint_loaded.swift
@@ -15,5 +15,4 @@ func mul3(_ x: Float) -> Float {
 let _ = gradient(at: 0, in: mul3)
 
 // CHECK-LABEL: sil{{.*}} @AD__{{.*}}mul3{{.*}}__primal{{.*}}
-// CHECK: function_ref static Float._adjointMultiply(_:_:_:_:)
-// CHECK: } // end sil function 'AD__{{.*}}mul3{{.*}}__primal{{.*}}'
+// CHECK: function_ref AD__$sSf1moiyS2f_SftFZ__vjp_src_0_wrt_0_1


### PR DESCRIPTION
Long ago, we assumed adjoint values to have the same type as the original, but they now have the `CotangentVector` type which can be different from the original type. This patch fixes that by making sure `AdjointValue` is always created with a cotangent type.

This does not fully fix the following case:
```swift
let pb = pullback(at: x) { x in DifferentiableSubset(w: x.w * x.w, b: x.b * x.b, flag: true) }
```
In this example we need to be able to differentiate the memberwise initializer `DifferentiableSubset`, which is implemented in terms of the `struct` instruction. Need to change the logic there so that when `CotangentVector` is tagged `@_fieldwiseProductSpace`, the derivative is `struct_extract`, otherwise the derivative is a call to the VJP. ([SR-9602](https://bugs.swift.org/browse/SR-9602))