### PR TITLE
[Type checker] Allow unowned/unowned(unsafe) optional lets.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2403,9 +2403,7 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
     }
     break;
   case ReferenceOwnershipOptionality::Allowed:
-    if (!isOptional)
-      break;
-    LLVM_FALLTHROUGH;
+    break;
   case ReferenceOwnershipOptionality::Required:
     if (var->isLet()) {
       diagnose(var->getStartLoc(), diag::invalid_ownership_is_let,

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -273,3 +273,12 @@ class HasStorage {
 @_invalid_attribute_ // expected-error {{unknown attribute '_invalid_attribute_'}}
 @inline(__always)
 public func sillyFunction() {}
+
+// rdar://problem/45732251: unowned/unowned(unsafe) optional lets are permitted
+func unownedOptionals(x: C) {
+  unowned let y: C? = x
+  unowned(unsafe) let y2: C? = x
+
+  _ = y
+  _ = y2
+}


### PR DESCRIPTION
Unlike weak values of optional type, an unowned or unowned(unsafe)
value of optional type will not silently become 'nil' when the
referenced instance goes away: rather, the program will trap. Don't
reject unowned or unowned(unsafe) optional lets.

Fixes rdar://problem/45732251.
