### PR TITLE
[pmo] Eliminate dead flat namespace tuple numbering from PMOMemoryUseCollector.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -98,15 +98,6 @@ public:
   AllocBoxInst *getContainer() const {
     return dyn_cast<AllocBoxInst>(MemoryInst);
   }
-
-  /// getElementType - Return the swift type of the specified element.
-  SILType getElementType(unsigned EltNo) const;
-
-  /// Push the symbolic path name to the specified element number onto the
-  /// specified std::string.  If the actual decl (or a subelement thereof) can
-  /// be determined, return it.  Otherwise, return null.
-  ValueDecl *getPathStringToElement(unsigned Element,
-                                    std::string &Result) const;
 };
 
 enum PMOUseKind {

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -516,8 +516,7 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType LoadTy,
   if (!Val) {
     auto *Load =
         B.createLoad(Loc, Address, LoadOwnershipQualifier::Unqualified);
-    Uses.push_back(PMOMemoryUse(Load, PMOUseKind::Load, FirstElt,
-                                getNumSubElements(Load->getType(), M)));
+    Uses.emplace_back(Load, PMOUseKind::Load);
     return Load;
   }
 


### PR DESCRIPTION
    TLDR: This does not eliminate the struct/tuple flat namespace from Predictable
    Mem Opts. Just the tuple specific flat namespace code from PMOMemoryUseCollector
    that we were computing and then throwing away. I explain below in more detail.
    
    First note that this is cruft from when def-init and pmo were one pass. What we
    were doing here was maintaing a flattened tuple namespace while we were
    collecting uses in PMOMemoryUseCollector. We never actually used them for
    anything since we recomputed this information including information about
    structs in PMO itself! So this information was truly completely dead.
    
    This commit removes that and related logic and from a maintenance standpoint
    makes PMOMemoryUseCollector a simple visitor that doesn't have any real special
    logic in it beyond the tuple scalarization.

----

NOTE: I split this commit into two parts. 7175e17 only removes the flat namespace tuple numbering to ease review, while 7b7ccdc removes additional code that becomes dead. I did this to ease review.