### PR TITLE
[Exclusivity] Change the exclusivity checks inline heuristic threshold

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -105,7 +105,7 @@ class SILPerformanceInliner {
     /// The benefit of inlining an exclusivity-containing callee.
     /// The exclusivity needs to be: dynamic,
     /// has no nested conflict and addresses known storage
-    ExclusivityBenefit = RemovedCallBenefit + 300,
+    ExclusivityBenefit = RemovedCallBenefit + 125,
 
     /// The benefit of inlining class methods with -Osize.
     /// We only inline very small class methods with -Osize.


### PR DESCRIPTION
radar rdar://problem/46783598

This PR reduces the aggressiveness of the exclusivity checks inline heuristic: based on local testing, I believe I found a sweet-spot between maintaining -O performance and making sure we do not increase the code size (too much) - will use this PR to test on the bots before committing.