### PR TITLE
[5.0 12/12] Revise documentation for Swift 5 stdlib additions (#21333)

### DIFF
--- a/stdlib/public/core/CharacterProperties.swift
+++ b/stdlib/public/core/CharacterProperties.swift
@@ -22,15 +22,31 @@ extension Character {
     ) == self.unicodeScalars.endIndex
   }
 
-  /// Whether this Character is ASCII.
+  /// A Boolean value indicating whether this is an ASCII character.
   @inlinable
   public var isASCII: Bool {
     return asciiValue != nil
   }
 
-  /// Returns the ASCII encoding value of this Character, if ASCII.
+  /// The ASCII encoding value of this character, if it is an ASCII character.
   ///
-  /// Note: "\r\n" (CR-LF) is normalized to "\n" (LF), which will return 0x0A
+  ///     let chars: [Character] = ["a", " ", "™"]
+  ///     for ch in chars {
+  ///         print(ch, "-->", ch.properties.numericValue)
+  ///     }
+  ///     // a --> 97
+  ///     //   --> 32
+  ///     // ™ --> nil
+  ///
+  /// A character with the value "\r\n" (CR-LF) is normalized to "\n" (LF) and
+  /// has an `asciiValue` property equal to 10.
+  ///
+  ///     let cr = "\r" as Character
+  ///     // cr.asciiValue == 13
+  ///     let lf = "\n" as Character
+  ///     // lf.asciiValue == 10
+  ///     let crlf = "\r\n" as Character
+  ///     // crlf.asciiValue == 10
   @inlinable
   public var asciiValue: UInt8? {
     if _slowPath(self == "\r\n") { return 0x000A /* LINE FEED (LF) */ }
@@ -38,30 +54,31 @@ extension Character {
     return UInt8(_firstScalar.value)
   }
 
-  /// Whether this Character represents whitespace, including newlines.
+  /// A Boolean value indicating whether this character represents whitespace,
+  /// including newlines.
   ///
-  /// Examples:
-  ///   * "\t" (U+0009 CHARACTER TABULATION)
-  ///   * " " (U+0020 SPACE)
-  ///   * U+2029 PARAGRAPH SEPARATOR
-  ///   * U+3000 IDEOGRAPHIC SPACE
+  /// For example, the following characters all represent whitespace:
   ///
+  /// - "\t" (U+0009 CHARACTER TABULATION)
+  /// - " " (U+0020 SPACE)
+  /// - U+2029 PARAGRAPH SEPARATOR
+  /// - U+3000 IDEOGRAPHIC SPACE
   public var isWhitespace: Bool {
     return _firstScalar.properties.isWhitespace
   }
 
-  /// Whether this Character represents a newline.
+  /// A Boolean value indicating whether this character represents a newline.
   ///
-  /// Examples:
-  ///   * "\n" (U+000A): LINE FEED (LF)
-  ///   * U+000B: LINE TABULATION (VT)
-  ///   * U+000C: FORM FEED (FF)
-  ///   * "\r" (U+000D): CARRIAGE RETURN (CR)
-  ///   * "\r\n" (U+000A U+000D): CR-LF
-  ///   * U+0085: NEXT LINE (NEL)
-  ///   * U+2028: LINE SEPARATOR
-  ///   * U+2029: PARAGRAPH SEPARATOR
+  /// For example, the following characters all represent newlines:
   ///
+  /// - "\n" (U+000A): LINE FEED (LF)
+  /// - U+000B: LINE TABULATION (VT)
+  /// - U+000C: FORM FEED (FF)
+  /// - "\r" (U+000D): CARRIAGE RETURN (CR)
+  /// - "\r\n" (U+000D U+000A): CR-LF
+  /// - U+0085: NEXT LINE (NEL)
+  /// - U+2028: LINE SEPARATOR
+  /// - U+2029: PARAGRAPH SEPARATOR
   @inlinable
   public var isNewline: Bool {
     switch _firstScalar.value {
@@ -73,54 +90,78 @@ extension Character {
     }
   }
 
-  /// Whether this Character represents a number.
+  /// A Boolean value indicating whether this character represents a number.
   ///
-  /// Examples:
-  ///   * "7" (U+0037 DIGIT SEVEN)
-  ///   * "⅚" (U+215A VULGAR FRACTION FIVE SIXTHS)
-  ///   * "㊈" (U+3288 CIRCLED IDEOGRAPH NINE)
-  ///   * "𝟠" (U+1D7E0 MATHEMATICAL DOUBLE-STRUCK DIGIT EIGHT)
-  ///   * "๒" (U+0E52 THAI DIGIT TWO)
+  /// For example, the following characters all represent numbers:
   ///
+  /// - "7" (U+0037 DIGIT SEVEN)
+  /// - "⅚" (U+215A VULGAR FRACTION FIVE SIXTHS)
+  /// - "㊈" (U+3288 CIRCLED IDEOGRAPH NINE)
+  /// - "𝟠" (U+1D7E0 MATHEMATICAL DOUBLE-STRUCK DIGIT EIGHT)
+  /// - "๒" (U+0E52 THAI DIGIT TWO)
   public var isNumber: Bool {
     return _firstScalar.properties.numericType != nil
   }
 
-  /// Whether this Character represents a whole number. See
-  /// `Character.wholeNumberValue`
+  /// A Boolean value indicating whether this character represents a whole
+  /// number.
+  ///
+  /// For example, the following characters all represent whole numbers:
+  ///
+  /// - "1" (U+0031 DIGIT ONE) => 1
+  /// - "५" (U+096B DEVANAGARI DIGIT FIVE) => 5
+  /// - "๙" (U+0E59 THAI DIGIT NINE) => 9
+  /// - "万" (U+4E07 CJK UNIFIED IDEOGRAPH-4E07) => 10_000
   @inlinable
   public var isWholeNumber: Bool {
     return wholeNumberValue != nil
   }
 
-  /// If this Character is a whole number, return the value it represents, else
-  /// nil.
+  /// The numeric value this character represents, if it represents a whole
+  /// number.
   ///
-  /// Examples:
-  ///   * "1" (U+0031 DIGIT ONE) => 1
-  ///   * "५" (U+096B DEVANAGARI DIGIT FIVE) => 5
-  ///   * "๙" (U+0E59 THAI DIGIT NINE) => 9
-  ///   * "万" (U+4E07 CJK UNIFIED IDEOGRAPH-4E07) => 10_000
+  /// If this character does not represent a whole number, or the value is too
+  /// large to represent as an `Int`, the value of this property is `nil`.
   ///
-  /// Note: Returns nil on 32-bit platforms if the result would overflow `Int`.
+  ///     let chars: [Character] = ["4", "④", "万", "a"]
+  ///     for ch in chars {
+  ///         print(ch, "-->", ch.properties.numericValue)
+  ///     }
+  ///     // 4 --> 4
+  ///     // ④ --> 4
+  ///     // 万 --> 10000
+  ///     // a --> nil
   public var wholeNumberValue: Int? {
     guard _isSingleScalar else { return nil }
     guard let value = _firstScalar.properties.numericValue else { return nil }
     return Int(exactly: value)
   }
 
-  /// Whether this Character represents a hexadecimal digit.
+  /// A Boolean value indicating whether this character represents a
+  /// hexadecimal digit.
   ///
   /// Hexadecimal digits include 0-9, Latin letters a-f and A-F, and their
-  /// fullwidth compatibility forms. To get their value, see
-  /// `Character.hexDigitValue`
+  /// fullwidth compatibility forms. To get the character's value, use the
+  /// `hexDigitValue` property.
   @inlinable
   public var isHexDigit: Bool {
     return hexDigitValue != nil
   }
 
-  /// If this Character is a hexadecimal digit, returns the value it represents,
-  /// else nil.
+  /// The numeric value this character represents, if it is a hexadecimal digit.
+  ///
+  /// Hexadecimal digits include 0-9, Latin letters a-f and A-F, and their
+  /// fullwidth compatibility forms. If the character does not represent a
+  /// hexadecimal digit, the value of this property is `nil`.
+  ///
+  ///     let chars: [Character] = ["1", "a", "Ｆ", "g"]
+  ///     for ch in chars {
+  ///         print(ch, "-->", ch.hexDigitValue)
+  ///     }
+  ///     // 1 --> 1
+  ///     // a --> 10
+  ///     // Ｆ --> 15
+  ///     // g --> nil
   public var hexDigitValue: Int? {
     guard _isSingleScalar else { return nil }
     let value = _firstScalar.value
@@ -142,48 +183,51 @@ extension Character {
     }
   }
 
-  /// Whether this Character is a letter.
+  /// A Boolean value indicating whether this character is a letter.
   ///
-  /// Examples:
-  ///   * "A" (U+0041 LATIN CAPITAL LETTER A)
-  ///   * "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///   * "ϴ" (U+03F4 GREEK CAPITAL THETA SYMBOL)
-  ///   * "ڈ" (U+0688 ARABIC LETTER DDAL)
-  ///   * "日" (U+65E5 CJK UNIFIED IDEOGRAPH-65E5)
-  ///   * "ᚨ" (U+16A8 RUNIC LETTER ANSUZ A)
+  /// For example, the following characters are all letters:
   ///
+  /// - "A" (U+0041 LATIN CAPITAL LETTER A)
+  /// - "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
+  /// - "ϴ" (U+03F4 GREEK CAPITAL THETA SYMBOL)
+  /// - "ڈ" (U+0688 ARABIC LETTER DDAL)
+  /// - "日" (U+65E5 CJK UNIFIED IDEOGRAPH-65E5)
+  /// - "ᚨ" (U+16A8 RUNIC LETTER ANSUZ A)
   public var isLetter: Bool {
     return _firstScalar.properties.isAlphabetic
   }
 
-  /// Perform case conversion to uppercase
+  /// Returns an uppercased version of this character.
   ///
-  /// Examples:
-  ///   * "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///     => "É" (U+0045 LATIN CAPITAL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///   * "и" (U+0438 CYRILLIC SMALL LETTER I)
-  ///     => "И" (U+0418 CYRILLIC CAPITAL LETTER I)
-  ///   * "π" (U+03C0 GREEK SMALL LETTER PI)
-  ///     => "Π" (U+03A0 GREEK CAPITAL LETTER PI)
-  ///   * "ß" (U+00DF LATIN SMALL LETTER SHARP S)
-  ///     => "SS" (U+0053 LATIN CAPITAL LETTER S, U+0053 LATIN CAPITAL LETTER S)
+  /// Because case conversion can result in multiple characters, the result
+  /// of `uppercased()` is a string.
   ///
-  /// Note: Returns a String as case conversion can result in multiple
-  /// Characters.
+  ///     let chars: [Character] = ["e", "é", "и", "π", "ß", "1"]
+  ///     for ch in chars {
+  ///         print(ch, "-->", ch.uppercased())
+  ///     }
+  ///     // e --> E
+  ///     // é --> É
+  ///     // и --> И
+  ///     // π --> Π
+  ///     // ß --> SS
+  ///     // 1 --> 1
   public func uppercased() -> String { return String(self).uppercased() }
 
-  /// Perform case conversion to lowercase
+  /// Returns a lowercased version of this character.
   ///
-  /// Examples:
-  ///   * "É" (U+0045 LATIN CAPITAL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///     => "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///   * "И" (U+0418 CYRILLIC CAPITAL LETTER I)
-  ///     => "и" (U+0438 CYRILLIC SMALL LETTER I)
-  ///   * "Π" (U+03A0 GREEK CAPITAL LETTER PI)
-  ///     => "π" (U+03C0 GREEK SMALL LETTER PI)
+  /// Because case conversion can result in multiple characters, the result
+  /// of `lowercased()` is a string.
   ///
-  /// Note: Returns a String as case conversion can result in multiple
-  /// Characters.
+  ///     let chars: [Character] = ["E", "É", "И", "Π", "1"]
+  ///     for ch in chars {
+  ///         print(ch, "-->", ch.lowercased())
+  ///     }
+  ///     // E --> e
+  ///     // É --> é
+  ///     // И --> и
+  ///     // Π --> π
+  ///     // 1 --> 1
   public func lowercased() -> String { return String(self).lowercased() }
 
   @usableFromInline
@@ -191,16 +235,14 @@ extension Character {
   @usableFromInline
   internal var _isLowercased: Bool { return String(self) == self.lowercased() }
 
-  /// Whether this Character is considered uppercase.
+  /// A Boolean value indicating whether this character is considered uppercase.
   ///
-  /// Uppercase Characters vary under case-conversion to lowercase, but not when
-  /// converted to uppercase.
+  /// Uppercase characters vary under case-conversion to lowercase, but not when
+  /// converted to uppercase. The following characters are all uppercase:
   ///
-  /// Examples:
-  ///   * "É" (U+0045 LATIN CAPITAL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///   * "И" (U+0418 CYRILLIC CAPITAL LETTER I)
-  ///   * "Π" (U+03A0 GREEK CAPITAL LETTER PI)
-  ///
+  /// - "É" (U+0045 LATIN CAPITAL LETTER E, U+0301 COMBINING ACUTE ACCENT)
+  /// - "И" (U+0418 CYRILLIC CAPITAL LETTER I)
+  /// - "Π" (U+03A0 GREEK CAPITAL LETTER PI)
   @inlinable
   public var isUppercase: Bool {
     if _fastPath(_isSingleScalar && _firstScalar.properties.isUppercase) {
@@ -209,16 +251,14 @@ extension Character {
     return _isUppercased && isCased
   }
 
-  /// Whether this Character is considered lowercase.
+  /// A Boolean value indicating whether this character is considered lowercase.
   ///
-  /// Lowercase Characters vary under case-conversion to uppercase, but not when
-  /// converted to lowercase.
+  /// Lowercase characters change when converted to uppercase, but not when
+  /// converted to lowercase. The following characters are all lowercase:
   ///
-  /// Examples:
-  ///   * "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
-  ///   * "и" (U+0438 CYRILLIC SMALL LETTER I)
-  ///   * "π" (U+03C0 GREEK SMALL LETTER PI)
-  ///
+  /// - "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
+  /// - "и" (U+0438 CYRILLIC SMALL LETTER I)
+  /// - "π" (U+03C0 GREEK SMALL LETTER PI)
   @inlinable
   public var isLowercase: Bool {
     if _fastPath(_isSingleScalar && _firstScalar.properties.isLowercase) {
@@ -227,7 +267,8 @@ extension Character {
     return _isLowercased && isCased
   }
 
-  /// Whether this Character changes under any form of case conversion.
+  /// A Boolean value indicating whether this character changes under any form
+  /// of case conversion.
   @inlinable
   public var isCased: Bool {
     if _fastPath(_isSingleScalar && _firstScalar.properties.isCased) {
@@ -236,53 +277,64 @@ extension Character {
     return !_isUppercased || !_isLowercased
   }
 
-  /// Whether this Character represents a symbol
+  /// A Boolean value indicating whether this character represents a symbol.
   ///
-  /// Examples:
-  ///   * "®" (U+00AE REGISTERED SIGN)
-  ///   * "⌹" (U+2339 APL FUNCTIONAL SYMBOL QUAD DIVIDE)
-  ///   * "⡆" (U+2846 BRAILLE PATTERN DOTS-237)
+  /// This property is `true` only for characters composed of scalars in the
+  /// "Math_Symbol", "Currency_Symbol", "Modifier_Symbol", or "Other_Symbol"
+  /// categories in the
+  /// [Unicode Standard](https://unicode.org/reports/tr44/#General_Category_Values).
   ///
+  /// For example, the following characters all represent symbols:
+  ///
+  /// - "®" (U+00AE REGISTERED SIGN)
+  /// - "⌹" (U+2339 APL FUNCTIONAL SYMBOL QUAD DIVIDE)
+  /// - "⡆" (U+2846 BRAILLE PATTERN DOTS-237)
   public var isSymbol: Bool {
     return _firstScalar.properties.generalCategory._isSymbol
   }
 
-  /// Whether this Character represents a symbol used mathematical formulas
+  /// A Boolean value indicating whether this character represents a symbol
+  /// that naturally appears in mathematical contexts.
   ///
-  /// Examples:
-  ///   * "+" (U+002B PLUS SIGN)
-  ///   * "∫" (U+222B INTEGRAL)
-  ///   * "ϰ" (U+03F0 GREEK KAPPA SYMBOL)
+  /// For example, the following characters all represent math symbols:
   ///
-  /// Note: This is not a strict subset of isSymbol. This includes characters
-  /// used both as letters and commonly in mathematical formulas. For example,
-  /// "ϰ" (U+03F0 GREEK KAPPA SYMBOL) is considered a both mathematical symbol
-  /// and a letter.
+  /// - "+" (U+002B PLUS SIGN)
+  /// - "∫" (U+222B INTEGRAL)
+  /// - "ϰ" (U+03F0 GREEK KAPPA SYMBOL)
   ///
+  /// The set of characters that have an `isMathSymbol` value of `true` is not
+  /// a strict subset of those for which `isSymbol` is `true`. This includes
+  /// characters used both as letters and commonly in mathematical formulas.
+  /// For example, "ϰ" (U+03F0 GREEK KAPPA SYMBOL) is considered both a
+  /// mathematical symbol and a letter.
+  ///
+  /// This property corresponds to the "Math" property in the
+  /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isMathSymbol: Bool {
     return _firstScalar.properties.isMath
   }
 
-  /// Whether this Character represents a currency symbol
+  /// A Boolean value indicating whether this character represents a currency
+  /// symbol.
   ///
-  /// Examples:
-  ///   * "$" (U+0024 DOLLAR SIGN)
-  ///   * "¥" (U+00A5 YEN SIGN)
-  ///   * "€" (U+20AC EURO SIGN)
+  /// For example, the following characters all represent currency symbols:
   ///
+  /// - "$" (U+0024 DOLLAR SIGN)
+  /// - "¥" (U+00A5 YEN SIGN)
+  /// - "€" (U+20AC EURO SIGN)
   public var isCurrencySymbol: Bool {
     return _firstScalar.properties.generalCategory == .currencySymbol
   }
 
-  /// Whether this Character represents punctuation
+  /// A Boolean value indicating whether this character represents punctuation.
   ///
-  /// Examples:
-  ///   * "!" (U+0021 EXCLAMATION MARK)
-  ///   * "؟" (U+061F ARABIC QUESTION MARK)
-  ///   * "…" (U+2026 HORIZONTAL ELLIPSIS)
-  ///   * "—" (U+2014 EM DASH)
-  ///   * "“" (U+201C LEFT DOUBLE QUOTATION MARK)
+  /// For example, the following characters all represent punctuation:
   ///
+  /// - "!" (U+0021 EXCLAMATION MARK)
+  /// - "؟" (U+061F ARABIC QUESTION MARK)
+  /// - "…" (U+2026 HORIZONTAL ELLIPSIS)
+  /// - "—" (U+2014 EM DASH)
+  /// - "“" (U+201C LEFT DOUBLE QUOTATION MARK)
   public var isPunctuation: Bool {
     return _firstScalar.properties.generalCategory._isPunctuation
   }

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -709,45 +709,49 @@ public protocol ExpressibleByDictionaryLiteral {
 ///     print(message)
 ///     // Prints "One cookie: $2, 3 cookies: $6."
 /// 
-/// Extending default interpolation behavior
-/// ========================================
+/// Extending the Default Interpolation Behavior
+/// ============================================
 /// 
-/// Clients which want to add new interpolation behavior to existing types
-/// should extend `DefaultStringInterpolation`, the type which implements
-/// interpolation for types like `String` and `Substring`, to add an overload of
-/// `appendInterpolation(_:)` with their new behavior. See the
-/// `DefaultStringInterpolation` and `StringInterpolationProtocol` documentation
-/// for more details.
-/// 
-/// Creating a type which supports default string interpolation
-/// ===========================================================
-/// 
-/// Clients which want to create new types supporting string literals and
-/// interpolation, but which do not need any custom behavior, should conform
-/// their type to `ExpressibleByStringInterpolation` and implement an
-/// `init(stringLiteral: String)` method. Swift will automatically use
-/// `DefaultStringInterpolation` and provide an `init(stringInterpolation:)`
-/// implementation which passes the interpolated literal's contents to
-/// `init(stringLiteral:)`, so you won't need to implement anything special.
+/// Add new interpolation behavior to existing types by extending
+/// `DefaultStringInterpolation`, the type that implements interpolation for
+/// types like `String` and `Substring`, to add an overload of
+/// `appendInterpolation(_:)` with their new behavior.
 ///
-/// Creating a type which supports custom string interpolation
-/// ==========================================================
+/// For more information, see the `DefaultStringInterpolation` and
+/// `StringInterpolationProtocol` documentation.
 /// 
-/// If a conforming type wants to differentiate between literal and interpolated
-/// segments, restrict the types which can be interpolated into it, support
-/// different interpolators from the ones on `String`, or avoid constructing a
-/// `String` containing the data, it must specify a custom `StringInterpolation`
-/// associated type. This type must conform to `StringInterpolationProtocol` and
-/// must have a matching `StringLiteralType`.
+/// Creating a Type That Supports the Default String Interpolation
+/// ==============================================================
+/// 
+/// To create a new type that supports string literals and interpolation, but
+/// that doesn't need any custom behavior, conform the type to
+/// `ExpressibleByStringInterpolation` and implement the
+/// `init(stringLiteral: String)` initializer declared by the
+/// `ExpressibleByStringLiteral` protocol. Swift will automatically use
+/// `DefaultStringInterpolation` as the interpolation type and provide an
+/// implementation for `init(stringInterpolation:)` that passes the
+/// interpolated literal's contents to `init(stringLiteral:)`, so you don't
+/// need to implement anything specific to this protocol.
 ///
-/// See the `StringLiteralProtocol` documentation for more details about how to
-/// do this.
+/// Creating a Type That Supports Custom String Interpolation
+/// =========================================================
+///
+/// If you want a conforming type to differentiate between literal and
+/// interpolated segments, restrict the types that can be interpolated,
+/// support different interpolators from the ones on `String`, or avoid
+/// constructing a `String` containing the data, the type must specify a custom
+/// `StringInterpolation` associated type. This type must conform to
+/// `StringInterpolationProtocol` and have a matching `StringLiteralType`.
+///
+/// For more information, see the `StringInterpolationProtocol` documentation.
 public protocol ExpressibleByStringInterpolation
   : ExpressibleByStringLiteral {
   
   /// The type each segment of a string literal containing interpolations
-  /// should be appended to. Its `StringLiteralType` should match the
-  /// `StringLiteralType` of this type.
+  /// should be appended to.
+  ///
+  /// The `StringLiteralType` of an interpolation type must match the
+  /// `StringLiteralType` of the conforming type.
   associatedtype StringInterpolation : StringInterpolationProtocol
     = DefaultStringInterpolation
     where StringInterpolation.StringLiteralType == StringLiteralType
@@ -770,7 +774,7 @@ extension ExpressibleByStringInterpolation
   
   /// Creates a new instance from an interpolated string literal.
   /// 
-  /// Do not call this initializer directly. It is used by the compiler when
+  /// Don't call this initializer directly. It's used by the compiler when
   /// you create a string using string interpolation. Instead, use string
   /// interpolation to create a new string by including values, literals,
   /// variables, or expressions enclosed in parentheses, prefixed by a
@@ -782,14 +786,13 @@ extension ExpressibleByStringInterpolation
   ///                   If one cookie costs \(price) dollars, \
   ///                   \(number) cookies cost \(price * number) dollars.
   ///                   """
-  ///     print(message)
-  ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
+  ///     // message == "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   public init(stringInterpolation: DefaultStringInterpolation) {
     self.init(stringLiteral: stringInterpolation.make())
   }
 }
 
-/// Represents the contents of a string literal with interpolations while it is
+/// Represents the contents of a string literal with interpolations while it's
 /// being built up.
 /// 
 /// Each `ExpressibleByStringInterpolation` type has an associated
@@ -809,60 +812,78 @@ extension ExpressibleByStringInterpolation
 /// The `StringInterpolation` type is responsible for collecting the segments
 /// passed to its `appendLiteral(_:)` and `appendInterpolation` methods and
 /// assembling them into a whole, converting as necessary. Once all of the
-/// segments have been appended, the interpolation will be passed to an
+/// segments are appended, the interpolation is passed to an
 /// `init(stringInterpolation:)` initializer on the type being created, which
 /// must extract the accumulated data from the `StringInterpolation`.
 /// 
-/// In simple cases, types conforming to `ExpressibleByStringInterpolation`
-/// can use `DefaultStringInterpolation` instead of writing their own. All they
-/// must do is conform to `ExpressibleByStringInterpolation` and implement
-/// `init(stringLiteral: String)`; interpolated string literals will then go
-/// through that initializer just as any other string literal would.
+/// In simple cases, you can use `DefaultStringInterpolation` as the
+/// interpolation type for types that conform to the
+/// `ExpressibleByStringLiteral` protocol. To use the default interpolation,
+/// conform a type to `ExpressibleByStringInterpolation` and implement
+/// `init(stringLiteral: String)`. Values in interpolations are converted to
+/// strings, and then passed to that initializer just like any other string
+/// literal.
 /// 
-/// The `appendInterpolation` Method
-/// ================================
-/// 
-/// Each interpolated segment is translated into a call to a
-/// `StringInterpolationProtocol.appendInterpolation(...)` method, with the
-/// contents of the interpolation's parentheses treated as the call's argument
-/// list. That argument list can include multiple arguments and argument labels.
-/// For example:
-/// 
-/// | If you write... | Swift calls...                    |
-/// |---------------- | --------------------------------- |
-/// | `\(x)`          | `appendInterpolation(x)`          |
-/// | `\(x, y)`       | `appendInterpolation(x, y)`       |
-/// | `\(foo: x)`     | `appendInterpolation(foo: x)`     |
-/// | `\(x, foo: y)`  | `appendInterpolation(x, foo: y)`  |
-/// 
-/// `appendInterpolation` methods should return `Void` and should not be
-/// `static`. They otherwise support virtually all features of methods: they can
-/// have any number of parameters, can specify labels for any or all of them,
-/// can provide default values for parameters, can have variadic parameters, and
-/// can have parameters with generic types. Most importantly, they can be
-/// overloaded, so a `StringInterpolationProtocol`-conforming type can provide
-/// several different `appendInterpolation` methods with different behaviors.
-/// `appendInterpolation` methods can also throw; when a user uses one of these,
-/// they must mark the string literal with `try` or one of its variants.
+/// Handling String Interpolations
+/// ==============================
+///
+/// With a custom interpolation type, each interpolated segment is translated
+/// into a call to a special `appendInterpolation` method. The contents of
+/// the interpolation's parentheses are treated as the call's argument list.
+/// That argument list can include multiple arguments and argument labels.
+///
+/// The following examples show how string interpolations are translated into
+/// calls to `appendInterpolation`:
+///
+/// - `\(x)` translates to `appendInterpolation(x)`
+/// - `\(x, y)` translates to `appendInterpolation(x, y)`
+/// - `\(foo: x)` translates to `appendInterpolation(foo: x)`
+/// - `\(x, foo: y)` translates to `appendInterpolation(x, foo: y)`
+///
+/// The `appendInterpolation` methods in your custom type must be mutating
+/// instance methods that return `Void`. This code shows a custom interpolation
+/// type's declaration of an `appendInterpolation` method that provides special
+/// validation for user input:
+///
+///     extension MyString.StringInterpolation {
+///         mutating func appendInterpolation(validating input: String) {
+///             // Perform validation of `input` and store for later use
+///         }
+///     }
+///
+/// To use this interpolation method, create a string literal with an
+/// interpolation using the `validating` parameter label.
+///
+///     let userInput = readLine() ?? ""
+///     let myString = "The user typed '\(validating: userInput)'." as MyString
+///
+/// `appendInterpolation` methods support virtually all features of methods:
+/// they can have any number of parameters, can specify labels for any or all
+/// of their parameters, can provide default values, can have variadic
+/// parameters, and can have parameters with generic types. Most importantly,
+/// they can be overloaded, so a type that conforms to
+/// `StringInterpolationProtocol` can provide several different
+/// `appendInterpolation` methods with different behaviors. An
+/// `appendInterpolation` method can also throw; when a user writes a literal
+/// with one of these interpolations, they must mark the string literal with
+/// `try` or one of its variants.
 public protocol StringInterpolationProtocol {
   /// The type that should be used for literal segments.
   associatedtype StringLiteralType : _ExpressibleByBuiltinStringLiteral
 
   /// Creates an empty instance ready to be filled with string literal content.
   /// 
-  /// Do not call this initializer directly. Instead, initialize a variable or
+  /// Don't call this initializer directly. Instead, initialize a variable or
   /// constant using a string literal with interpolated expressions.
   /// 
   /// Swift passes this initializer a pair of arguments specifying the size of
   /// the literal segments and the number of interpolated segments. Use this
-  /// information to estimate the amount of storage you will need and
-  /// pre-allocate it with a method like
-  /// `RangeReplaceableCollection.reserveCapacity(_:)`.
+  /// information to estimate the amount of storage you will need.
   /// 
   /// - Parameter literalCapacity: The approximate size of all literal segments
   ///   combined. This is meant to be passed to `String.reserveCapacity(_:)`;
-  ///   it may be slightly larger or smaller than the sum of `String.count`
-  ///   called on each literal segment.
+  ///   it may be slightly larger or smaller than the sum of the counts of each
+  ///   literal segment.
   /// - Parameter interpolationCount: The number of interpolations which will be
   ///   appended. Use this value to estimate how much additional capacity will
   ///   be needed for the interpolated segments.
@@ -870,15 +891,15 @@ public protocol StringInterpolationProtocol {
 
   /// Appends a literal segment to the interpolation.
   /// 
-  /// Do not call this method directly. Instead, initialize a variable or
+  /// Don't call this method directly. Instead, initialize a variable or
   /// constant using a string literal with interpolated expressions.
   /// 
-  /// Interpolated expressions do not pass through this method; instead, Swift
-  /// selects an overload of `appendInterpolation`. See the top-level
-  /// `StringInterpolationProtocol` documentation for more details.
+  /// Interpolated expressions don't pass through this method; instead, Swift
+  /// selects an overload of `appendInterpolation`. For more information, see
+  /// the top-level `StringInterpolationProtocol` documentation.
   /// 
   /// - Parameter literal: A string literal containing the characters
-  ///             that appear next in the string literal.
+  ///   that appear next in the string literal.
   mutating func appendLiteral(_ literal: StringLiteralType)
 
   // Informal requirement: Any desired appendInterpolation overloads, e.g.:

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -921,10 +921,10 @@ extension Dictionary {
   }
 
   /// Returns a new dictionary containing only the key-value pairs that have
-  /// non-`nil` values as the result from the transform by the given closure.
+  /// non-`nil` values as the result of transformation by the given closure.
   ///
-  /// Use this method to receive a dictionary of non-optional values when your
-  /// transformation can produce an optional value.
+  /// Use this method to receive a dictionary with non-optional values when
+  /// your transformation produces optional values.
   ///
   /// In this example, note the difference in the result of using `mapValues`
   /// and `compactMapValues` with a transformation that returns an optional

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -27,12 +27,45 @@ extension ExpressibleByIntegerLiteral
 //===--- AdditiveArithmetic -----------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-// FIXME: Add doc comment.
+/// A type with values that support addition and subtraction.
+///
+/// The `AdditiveArithmetic` protocol provides a suitable basis for additive
+/// arithmetic on scalar values, such as integers and floating-point numbers,
+/// or vectors. You can write generic methods that operate on any numeric type
+/// in the standard library by using the `AdditiveArithmetic` protocol as a
+/// generic constraint.
+///
+/// The following code declares a method that calculates the total of any
+/// sequence with `Numeric` elements.
+///
+///     extension Sequence where Element: AdditiveArithmetic {
+///         func sum() -> Element {
+///             return reduce(.zero, +)
+///         }
+///     }
+///
+/// The `sum()` method is now available on any sequence with values that
+/// conform to `AdditiveArithmetic`, whether it is an array of `Double` or a
+/// range of `Int`.
+///
+///     let arraySum = [1.1, 2.2, 3.3, 4.4, 5.5].sum()
+///     // arraySum == 16.5
+///
+///     let rangeSum = (1..<10).sum()
+///     // rangeSum == 45
+///
+/// Conforming to the AdditiveArithmetic Protocol
+/// =============================================
+///
+/// To add `AdditiveArithmetic` protocol conformance to your own custom type,
+/// implement the required operators, and provide a static `zero` property
+/// using a type that can represent the magnitude of any value of your custom
+/// type.
 public protocol AdditiveArithmetic : Equatable {
   /// The zero value.
   ///
-  /// - Note: Zero is the identity element for addition; for any value,
-  ///   `x + .zero == x` and `.zero + x == x`.
+  /// Zero is the identity element for addition. For any value,
+  /// `x + .zero == x` and `.zero + x == x`.
   static var zero: Self { get }
 
   /// Adds two values and produces their sum.
@@ -96,6 +129,10 @@ public protocol AdditiveArithmetic : Equatable {
 }
 
 public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
+  /// The zero value.
+  ///
+  /// Zero is the identity element for addition. For any value,
+  /// `x + .zero == x` and `.zero + x == x`.
   static var zero: Self {
     return 0
   }
@@ -105,41 +142,41 @@ public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
 //===--- Numeric ----------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-// FIXME: Update comment based on the `AdditiveArithmetic` change.
-/// Declares methods backing binary arithmetic operators--such as `+`, `-` and
-/// `*`--and their mutating counterparts.
+/// A type with values that support multiplication.
 ///
 /// The `Numeric` protocol provides a suitable basis for arithmetic on
 /// scalar values, such as integers and floating-point numbers. You can write
 /// generic methods that operate on any numeric type in the standard library
 /// by using the `Numeric` protocol as a generic constraint.
 ///
-/// The following example declares a method that calculates the total of any
-/// sequence with `Numeric` elements.
+/// The following example extends `Sequence` with a method that returns an
+/// array with the sequence's values multiplied by two.
 ///
 ///     extension Sequence where Element: Numeric {
-///         func sum() -> Element {
-///             return reduce(0, +)
+///         func doublingAll() -> [Element] {
+///             return map { $0 * 2 }
 ///         }
 ///     }
 ///
-/// The `sum()` method is now available on any sequence or collection with
-/// numeric values, whether it is an array of `Double` or a countable range of
-/// `Int`.
+/// With this extension, any sequence with elements that conform to `Numeric`
+/// has the `doublingAll()` method. For example, you can double the elements of
+/// an array of doubles or a range of integers:
 ///
-///     let arraySum = [1.1, 2.2, 3.3, 4.4, 5.5].sum()
-///     // arraySum == 16.5
+///     let observations = [1.5, 2.0, 3.25, 4.875, 5.5]
+///     let doubledObservations = observations.doublingAll()
+///     // doubledObservations == [3.0, 4.0, 6.5, 9.75, 11.0]
 ///
-///     let rangeSum = (1..<10).sum()
-///     // rangeSum == 45
+///     let integers = 0..<8
+///     let doubledIntegers = integers.doublingAll()
+///     // doubledIntegers == [0, 2, 4, 6, 8, 10, 12, 14]
 ///
 /// Conforming to the Numeric Protocol
-/// =====================================
+/// ==================================
 ///
 /// To add `Numeric` protocol conformance to your own custom type, implement
-/// the required mutating methods. Extensions to `Numeric` provide default
-/// implementations for the protocol's nonmutating methods based on the
-/// mutating variants.
+/// the required initializer and operators, and provide a `magnitude` property
+/// using a type that can represent the magnitude of any value of your custom
+/// type.
 public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// Creates a new instance from the given integer, if it can be represented
   /// exactly.
@@ -216,7 +253,7 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
 /// `Numeric` protocol to include a value's additive inverse.
 ///
 /// Conforming to the SignedNumeric Protocol
-/// ===========================================
+/// ========================================
 ///
 /// Because the `SignedNumeric` protocol provides default implementations of
 /// both of its required methods, you don't need to do anything beyond
@@ -1163,19 +1200,20 @@ public protocol BinaryInteger :
   func quotientAndRemainder(dividingBy rhs: Self)
     -> (quotient: Self, remainder: Self)
 
-  /// Returns true if this value is a multiple of `other`, and false otherwise.
+  /// Returns `true` if this value is a multiple of the given value, and `false`
+  /// otherwise.
   ///
-  /// For two integers a and b, a is a multiple of b if there exists a third
-  /// integer q such that a = q*b. For example, 6 is a multiple of 3, because
-  /// 6 = 2*3, and zero is a multiple of everything, because 0 = 0*x, for any
-  /// integer x.
+  /// For two integers *a* and *b*, *a* is a multiple of *b* if there exists a
+  /// third integer *q* such that _a = q*b_. For example, *6* is a multiple of
+  /// *3* because _6 = 2*3_. Zero is a multiple of everything because _0 = 0*x_
+  /// for any integer *x*.
   ///
   /// Two edge cases are worth particular attention:
   /// - `x.isMultiple(of: 0)` is `true` if `x` is zero and `false` otherwise.
   /// - `T.min.isMultiple(of: -1)` is `true` for signed integer `T`, even
-  ///   though the quotient `T.min / -1` is not representable in type `T`.
+  ///   though the quotient `T.min / -1` isn't representable in type `T`.
   ///
-  /// - Parameter other: the value to test.
+  /// - Parameter other: The value to test.
   func isMultiple(of other: Self) -> Bool
 
   /// Returns `-1` if this value is negative and `1` if it's positive;

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -15,25 +15,30 @@ infix operator .^= : AssignmentPrecedence
 infix operator .|= : AssignmentPrecedence
 prefix operator .!
 
-/// A SIMD vector type that may not have any computational operations.
+/// A type that provides storage for a SIMD vector type.
 ///
-/// This protocol only defines a storage layout and provides elementwise
-/// accesses. Computational operations are defined on SIMDVector, which
-/// refines this protocol, or on the concrete types that conform.
+/// The `SIMDStorage` protocol defines a storage layout and provides
+/// elementwise accesses. Computational operations are defined on the `SIMD`
+/// protocol, which refines this protocol, and on the concrete types that
+/// conform to `SIMD`.
 public protocol SIMDStorage {
   /// The type of scalars in the vector space.
   associatedtype Scalar : Hashable
   
-  /// The number of scalars/elements in the vector.
+  /// The number of scalars, or elements, in the vector.
   var scalarCount: Int { get }
   
-  /// A vector with zero in all lanes.
+  /// Creates a vector with zero in all lanes.
   init()
   
-  /// Element access to the vector.
+  /// Accesses the element at the specified index.
+  ///
+  /// - Parameter index: The index of the element to access. `index` must be in
+  ///   the range `0..<scalarCount`.
   subscript(index: Int) -> Scalar { get set }
 }
 
+/// A type that can be used as an element in a SIMD vector.
 public protocol SIMDScalar {
   associatedtype SIMDMaskScalar : SIMDScalar & FixedWidthInteger & SignedInteger
   associatedtype SIMD2Storage : SIMDStorage where SIMD2Storage.Scalar == Self
@@ -44,6 +49,7 @@ public protocol SIMDScalar {
   associatedtype SIMD64Storage : SIMDStorage where SIMD64Storage.Scalar == Self
 }
 
+/// A SIMD vector of a fixed number of elements.
 public protocol SIMD : SIMDStorage,
                        Hashable,
                        CustomStringConvertible,
@@ -58,14 +64,14 @@ public extension SIMD {
   @_transparent
   var indices: Range<Int> { return 0 ..< scalarCount }
   
-  /// A vector with value in all lanes.
+  /// A vector with the specified value in all lanes.
   @_transparent
   init(repeating value: Scalar) {
     self.init()
     for i in indices { self[i] = value }
   }
   
-  /// Conformance to Equatable
+  /// Returns a Boolean value indicating whether two vectors are equal.
   @_transparent
   static func ==(lhs: Self, rhs: Self) -> Bool {
     var result = true
@@ -73,20 +79,20 @@ public extension SIMD {
     return result
   }
   
-  /// Conformance to Hashable
+  /// Hashes the elements of the vector using the given hasher.
   @inlinable
   func hash(into hasher: inout Hasher) {
     for i in indices { hasher.combine(self[i]) }
   }
   
-  /// Conformance to CustomStringConvertible
+  /// A textual description of the vector.
   var description: String {
     get {
       return "\(Self.self)(" + indices.map({"\(self[$0])"}).joined(separator: ", ") + ")"
     }
   }
   
-  /// Pointwise equality
+  /// Returns a vector mask with the result of a pointwise equality comparison.
   @_transparent
   static func .==(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -94,6 +100,8 @@ public extension SIMD {
     return result
   }
   
+  /// Returns a vector mask with the result of a pointwise inequality
+  /// comparison.
   @_transparent
   static func .!=(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -101,18 +109,26 @@ public extension SIMD {
     return result
   }
   
-  /// Replaces elements of this vector with `other` in the lanes where
-  /// `mask` is `true`.
+  /// Replaces elements of this vector with elements of `other` in the lanes
+  /// where `mask` is `true`.
   @_transparent
   mutating func replace(with other: Self, where mask: SIMDMask<MaskStorage>) {
     for i in indices { self[i] = mask[i] ? other[i] : self[i] }
   }
   
+  /// Creates a vector from the specified elements.
+  ///
+  /// - Parameter scalars: The elements to use in the vector. `scalars` must
+  ///   have the same number of elements as the vector type.
   @inlinable
   init(arrayLiteral scalars: Scalar...) {
     self.init(scalars)
   }
   
+  /// Creates a vector from the given sequence.
+  ///
+  /// - Parameter scalars: The elements to use in the vector. `scalars` must
+  ///   have the same number of elements as the vector type.
   @inlinable
   init<S: Sequence>(_ scalars: S) where S.Element == Scalar {
     self.init()
@@ -133,7 +149,8 @@ public extension SIMD {
 //  Implementations of comparison operations. These should eventually all
 //  be replaced with @_semantics to lower directly to vector IR nodes.
 public extension SIMD where Scalar : Comparable {
-  /// Pointwise less than
+  /// Returns a vector mask with the result of a pointwise less than
+  /// comparison.
   @_transparent
   static func .<(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -141,7 +158,8 @@ public extension SIMD where Scalar : Comparable {
     return result
   }
   
-  /// Pointwise less than or equal to
+  /// Returns a vector mask with the result of a pointwise less than or equal
+  /// comparison.
   @_transparent
   static func .<=(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -153,16 +171,27 @@ public extension SIMD where Scalar : Comparable {
 //  These operations should never need @_semantics; they should be trivial
 //  wrappers around the core operations defined above.
 public extension SIMD {
+  /// Returns a vector mask with the result of a pointwise equality comparison.
   @_transparent static func .==(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> { return Self(repeating: lhs) .== rhs }
+
+  /// Returns a vector mask with the result of a pointwise inequality comparison.
   @_transparent static func .!=(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> { return Self(repeating: lhs) .!= rhs }
+
+  /// Returns a vector mask with the result of a pointwise equality comparison.
   @_transparent static func .==(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> { return lhs .== Self(repeating: rhs) }
+
+  /// Returns a vector mask with the result of a pointwise inequality comparison.
   @_transparent static func .!=(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> { return lhs .!= Self(repeating: rhs) }
   
+  /// Replaces elements of this vector with `other` in the lanes where `mask`
+  /// is `true`.
   @_transparent
   mutating func replace(with other: Scalar, where mask: SIMDMask<MaskStorage>) {
     replace(with: Self(repeating: other), where: mask)
   }
   
+  /// Returns a copy of this vector, with elements replaced by elements of
+  /// `other` in the lanes where `mask` is `true`.
   @_transparent
   func replacing(with other: Self, where mask: SIMDMask<MaskStorage>) -> Self {
     var result = self
@@ -170,6 +199,8 @@ public extension SIMD {
     return result
   }
   
+  /// Returns a copy of this vector, with elements `other` in the lanes where
+  /// `mask` is `true`.
   @_transparent
   func replacing(with other: Scalar, where mask: SIMDMask<MaskStorage>) -> Self {
     return replacing(with: Self(repeating: other), where: mask)
@@ -177,21 +208,51 @@ public extension SIMD {
 }
 
 public extension SIMD where Scalar : Comparable {
+  /// Returns a vector mask with the result of a pointwise greater than or
+  /// equal comparison.
   @_transparent static func .>=(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> { return rhs .<= lhs }
+
+  /// Returns a vector mask with the result of a pointwise greater than
+  /// comparison.
   @_transparent static func .>(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> { return rhs .< lhs }
+
+  /// Returns a vector mask with the result of a pointwise less than comparison.
   @_transparent static func .<(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> { return Self(repeating: lhs) .< rhs }
+
+  /// Returns a vector mask with the result of a pointwise less than or equal
+  /// comparison.
   @_transparent static func .<=(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> { return Self(repeating: lhs) .<= rhs }
+
+  /// Returns a vector mask with the result of a pointwise greater than or
+  /// equal comparison.
   @_transparent static func .>=(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> { return Self(repeating: lhs) .>= rhs }
+
+  /// Returns a vector mask with the result of a pointwise greater than
+  /// comparison.
   @_transparent static func .>(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> { return Self(repeating: lhs) .> rhs }
+
+  /// Returns a vector mask with the result of a pointwise less than comparison.
   @_transparent static func .<(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> { return lhs .< Self(repeating: rhs) }
+
+  /// Returns a vector mask with the result of a pointwise less than or equal
+  /// comparison.
   @_transparent static func .<=(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> { return lhs .<= Self(repeating: rhs) }
+
+  /// Returns a vector mask with the result of a pointwise greater than or
+  /// equal comparison.
   @_transparent static func .>=(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> { return lhs .>= Self(repeating: rhs) }
+
+  /// Returns a vector mask with the result of a pointwise greater than
+  /// comparison.
   @_transparent static func .>(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> { return lhs .> Self(repeating: rhs) }
 }
 
 public extension SIMD where Scalar : FixedWidthInteger {
+  /// A vector with zero in all lanes.
   @_transparent static var zero: Self { return Self() }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes, using the given generator as a source for randomness.
   @inlinable
   static func random<T: RandomNumberGenerator>(
     in range: Range<Scalar>,
@@ -204,12 +265,16 @@ public extension SIMD where Scalar : FixedWidthInteger {
     return result
   }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes.
   @inlinable
   static func random(in range: Range<Scalar>) -> Self {
     var g = SystemRandomNumberGenerator()
     return Self.random(in: range, using: &g)
   }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes, using the given generator as a source for randomness.
   @inlinable
   static func random<T: RandomNumberGenerator>(
     in range: ClosedRange<Scalar>,
@@ -222,6 +287,8 @@ public extension SIMD where Scalar : FixedWidthInteger {
     return result
   }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes.
   @inlinable
   static func random(in range: ClosedRange<Scalar>) -> Self {
     var g = SystemRandomNumberGenerator()
@@ -230,11 +297,14 @@ public extension SIMD where Scalar : FixedWidthInteger {
 }
 
 public extension SIMD where Scalar : FloatingPoint {
+  /// A vector with zero in all lanes.
   @_transparent static var zero: Self { return Self() }
 }
 
 public extension SIMD
 where Scalar : BinaryFloatingPoint, Scalar.RawSignificand : FixedWidthInteger {
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes, using the given generator as a source for randomness.
   @inlinable
   static func random<T: RandomNumberGenerator>(
     in range: Range<Scalar>,
@@ -247,12 +317,16 @@ where Scalar : BinaryFloatingPoint, Scalar.RawSignificand : FixedWidthInteger {
     return result
   }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes.
   @inlinable
   static func random(in range: Range<Scalar>) -> Self {
     var g = SystemRandomNumberGenerator()
     return Self.random(in: range, using: &g)
   }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes, using the given generator as a source for randomness.
   @inlinable
   static func random<T: RandomNumberGenerator>(
     in range: ClosedRange<Scalar>,
@@ -265,6 +339,8 @@ where Scalar : BinaryFloatingPoint, Scalar.RawSignificand : FixedWidthInteger {
     return result
   }
   
+  /// Returns a vector with random values from within the specified range in
+  /// all lanes.
   @inlinable
   static func random(in range: ClosedRange<Scalar>) -> Self {
     var g = SystemRandomNumberGenerator()
@@ -313,6 +389,8 @@ public struct SIMDMask<Storage> : SIMD
 }
 
 public extension SIMDMask {
+  /// Returns a vector mask with `true` or `false` randomly assigned in each
+  /// lane, using the given generator as a source for randomness.
   @inlinable
   static func random<T: RandomNumberGenerator>(using generator: inout T) -> SIMDMask {
     var result = SIMDMask()
@@ -320,6 +398,8 @@ public extension SIMDMask {
     return result
   }
   
+  /// Returns a vector mask with `true` or `false` randomly assigned in each
+  /// lane.
   @inlinable
   static func random() -> SIMDMask {
     var g = SystemRandomNumberGenerator()

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -3,10 +3,16 @@ from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 storagescalarCounts = [2,4,8,16,32,64]
 vectorscalarCounts = storagescalarCounts + [3]
+spelledNumbers = {
+  2: 'two', 4: 'four', 8: 'eight', 16: '16', 32: '32', 64: '64',
+  3: 'three'
+}
+ordinalPositions = ['first', 'second', 'third', 'fourth']
 }%
 
 %for n in vectorscalarCounts:
 % storageN = 4 if n == 3 else n
+/// A vector of ${spelledNumbers[n]} scalar values.
 @_fixed_layout
 public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 
@@ -14,16 +20,19 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 
   public typealias MaskStorage = SIMD${n}<Scalar.SIMDMaskScalar>
 
+  /// The number of scalars in the vector.
   @_transparent
   public var scalarCount: Int {
     return ${n}
   }
 
+  /// Creates a vector with zero in all lanes.
   @_transparent
   public init() {
     _storage = Scalar.SIMD${storageN}Storage()
   }
 
+  /// Accesses the scalar at the specified position.
   public subscript(index: Int) -> Scalar {
     @_transparent get {
       _precondition(indices.contains(index))
@@ -35,6 +44,7 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
     }
   }
 
+  /// Creates a new vector from the given elements.
   @_transparent
   public init(${', '.join(['_ v' + str(i) + ': Scalar' for i in range(n)])}) {
     self.init()
@@ -44,12 +54,19 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
   }
 
 % if n <= 4:
+  /// Creates a new vector from the given elements.
+  ///
+  /// - Parameters:
+  %  for i in range(n):
+  ///   - ${'xyzw'[i]}: The ${ordinalPositions[i]} element of the vector.
+  %  end
   @_transparent
   public init(${', '.join([c + ': Scalar' for c in 'xyzw'[:n]])}) {
     self.init(${', '.join('xyzw'[:n])})
   }
 
 %  for i in range(n):
+  /// The ${ordinalPositions[i]} element of the vector.
   @_transparent
   public var ${'xyzw'[i]}: Scalar {
     @_transparent get { return self[${i}]}
@@ -59,6 +76,7 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 %  end
 % end
 % if n >= 4:
+  /// Creates a new vector from two half-length vectors.
   @_transparent
   public init(lowHalf: SIMD${n/2}<Scalar>, highHalf: SIMD${n/2}<Scalar>) {
     self.init()
@@ -67,6 +85,7 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
   }
 
 %  for (half,indx) in [('low','i'), ('high',str(n/2)+'+i'), ('even','2*i'), ('odd','2*i+1')]:
+  /// A half-length vector made up of the ${half} elements of the vector.
   public var ${half}Half: SIMD${n/2}<Scalar> {
     @inlinable get {
       var result = SIMD${n/2}<Scalar>()
@@ -83,6 +102,10 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 }
 
 public extension SIMD${n} where Scalar : FixedWidthInteger {
+  /// Creates a new vector from the given vector, truncating the bit patterns
+  /// of the given vector's elements if necessary.
+  ///
+  /// - Parameter other: The vector to convert.
   @inlinable
   init<Other>(truncatingIfNeeded other: SIMD${n}<Other>)
   where Other : FixedWidthInteger {
@@ -90,6 +113,10 @@ public extension SIMD${n} where Scalar : FixedWidthInteger {
     for i in indices { self[i] = Scalar(truncatingIfNeeded: other[i]) }
   }
 
+  /// Creates a new vector from the given vector, clamping the values of the
+  /// given vector's elements if necessary.
+  ///
+  /// - Parameter other: The vector to convert.
   @inlinable
   init<Other>(clamping other: SIMD${n}<Other>)
   where Other : FixedWidthInteger {
@@ -97,6 +124,13 @@ public extension SIMD${n} where Scalar : FixedWidthInteger {
     for i in indices { self[i] = Scalar(clamping: other[i]) }
   }
 
+  /// Creates a new vector from the given vector, rounding the given vector's
+  /// of elements using the specified rounding rule.
+  ///
+  /// - Parameters:
+  ///   - other: The vector to convert.
+  ///   - rule: The round rule to use when converting elements of `other.` The
+  ///     default is `.towardZero`.
   @inlinable
   init<Other>(
     _ other: SIMD${n}<Other>,
@@ -111,6 +145,9 @@ public extension SIMD${n} where Scalar : FixedWidthInteger {
 
 
 public extension SIMD${n} where Scalar : BinaryFloatingPoint {
+  /// Creates a new vector from the given vector of integers.
+  ///
+  /// - Parameter other: The vector to convert.
   @inlinable
   init<Other>(_ other: SIMD${n}<Other>)
   where Other : FixedWidthInteger {
@@ -118,6 +155,9 @@ public extension SIMD${n} where Scalar : BinaryFloatingPoint {
     for i in indices { self[i] = Scalar(other[i]) }
   }
 
+  /// Creates a new vector from the given vector of floating-point values.
+  ///
+  /// - Parameter other: The vector to convert.
   @inlinable
   init<Other>(_ other: SIMD${n}<Other>)
   where Other : BinaryFloatingPoint {
@@ -138,6 +178,7 @@ extension ${Self} : SIMDScalar {
 
 % for n in storagescalarCounts:
 %  bytes = n * self_type.bits / 8
+  /// Storage for a vector of ${spelledNumbers[n]} integers.
   @_fixed_layout
   @_alignment(${bytes if bytes <= 16 else 16})
   public struct SIMD${n}Storage : SIMDStorage {
@@ -182,6 +223,7 @@ extension ${Self} : SIMDScalar {
 
 % for n in storagescalarCounts:
 %  bytes = n * bits / 8
+  /// Storage for a vector of ${spelledNumbers[n]} floating-point values.
   @_fixed_layout
   @_alignment(${bytes if bytes <= 16 else 16})
   public struct SIMD${n}Storage : SIMDStorage {

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -581,7 +581,7 @@ extension Sequence {
   /// predicate.
   ///
   /// You can use this method to count the number of elements that pass a test.
-  /// For example, this code finds the number of names that are fewer than
+  /// The following example finds the number of names that are fewer than
   /// five characters long:
   ///
   ///     let names = ["Jacqueline", "Ian", "Amy", "Juan", "Soroush", "Tiffany"]
@@ -589,7 +589,7 @@ extension Sequence {
   ///     // shortNameCount == 3
   ///
   /// To find the number of times a specific element appears in the sequence,
-  /// use the equal-to operator (`==`) in the closure to test for a match.
+  /// use the equal to operator (`==`) in the closure to test for a match.
   ///
   ///     let birds = ["duck", "duck", "duck", "duck", "goose"]
   ///     let duckCount = birds.count(where: { $0 == "duck" })

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -19,7 +19,6 @@ extension Unicode.Scalar {
 
   /// A value that provides access to properties of a Unicode scalar that are
   /// defined by the Unicode standard.
-
   public struct Properties {
     @usableFromInline
     internal var _scalar: Unicode.Scalar
@@ -34,8 +33,17 @@ extension Unicode.Scalar {
     }
   }
 
-  /// A value that provides access to properties of the Unicode scalar that are
-  /// defined by the Unicode standard.
+  /// Properties of this scalar defined by the Unicode standard.
+  ///
+  /// Use this property to access the Unicode properties of a Unicode scalar
+  /// value. The following code tests whether a string contains any math
+  /// symbols:
+  ///
+  ///     let question = "Which is larger, 3 * 3 * 3 or 10 + 10 + 10?"
+  ///     let hasMathSymbols = question.unicodeScalars.contains(where: {
+  ///         $0.properties.isMath
+  ///     })
+  ///     // hasMathSymbols == true
   public var properties: Properties {
     return Properties(self)
   }
@@ -50,61 +58,61 @@ extension Unicode.Scalar.Properties {
     return __swift_stdlib_u_hasBinaryProperty(icuValue, property) != 0
   }
 
-  /// A Boolean property indicating whether the scalar is alphabetic.
+  /// A Boolean value indicating whether the scalar is alphabetic.
   ///
   /// Alphabetic scalars are the primary units of alphabets and/or syllabaries.
   ///
-  /// This property corresponds to the `Alphabetic` property in the
+  /// This property corresponds to the "Alphabetic" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isAlphabetic: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_ALPHABETIC)
   }
 
-  /// A Boolean property indicating whether the scalar is an ASCII character
+  /// A Boolean value indicating whether the scalar is an ASCII character
   /// commonly used for the representation of hexadecimal numbers.
   ///
-  /// The only scalars for which this property is true are:
+  /// The only scalars for which this property is `true` are:
   ///
   /// * U+0030...U+0039: DIGIT ZERO...DIGIT NINE
   /// * U+0041...U+0046: LATIN CAPITAL LETTER A...LATIN CAPITAL LETTER F
   /// * U+0061...U+0066: LATIN SMALL LETTER A...LATIN SMALL LETTER F
   ///
-  /// This property corresponds to the `ASCII_Hex_Digit` property in the
+  /// This property corresponds to the "ASCII_Hex_Digit" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isASCIIHexDigit: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_ASCII_HEX_DIGIT)
   }
 
-  /// A Boolean property indicating whether the scalar is a format control
+  /// A Boolean value indicating whether the scalar is a format control
   /// character that has a specific function in the Unicode Bidrectional
   /// Algorithm.
   ///
-  /// This property corresponds to the `Bidi_Control` property in the
+  /// This property corresponds to the "Bidi_Control" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isBidiControl: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_BIDI_CONTROL)
   }
 
-  /// A Boolean property indicating whether the scalar is mirrored in
+  /// A Boolean value indicating whether the scalar is mirrored in
   /// bidirectional text.
   ///
-  /// This property corresponds to the `Bidi_Mirrored` property in the
+  /// This property corresponds to the "Bidi_Mirrored" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isBidiMirrored: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_BIDI_MIRRORED)
   }
 
-  /// A Boolean property indicating whether the scalar is a punctuation
+  /// A Boolean value indicating whether the scalar is a punctuation
   /// symbol explicitly called out as a dash in the Unicode Standard or a
   /// compatibility equivalent.
   ///
-  /// This property corresponds to the `Dash` property in the
+  /// This property corresponds to the "Dash" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isDash: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_DASH)
   }
 
-  /// A Boolean property indicating whether the scalar is a default-ignorable
+  /// A Boolean value indicating whether the scalar is a default-ignorable
   /// code point.
   ///
   /// Default-ignorable code points are those that should be ignored by default
@@ -112,100 +120,103 @@ extension Unicode.Scalar.Properties {
   /// advance width in and of themselves, although they may affect the display,
   /// positioning, or adornment of adjacent or surrounding characters.
   ///
-  /// This property corresponds to the `Default_Ignorable_Code_Point` property
+  /// This property corresponds to the "Default_Ignorable_Code_Point" property
   /// in the [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isDefaultIgnorableCodePoint: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_DEFAULT_IGNORABLE_CODE_POINT)
   }
 
-  /// A Boolean property indicating whether the scalar is deprecated.
+  /// A Boolean value indicating whether the scalar is deprecated.
   ///
   /// Scalars are never removed from the Unicode Standard, but the usage of
   /// deprecated scalars is strongly discouraged.
   ///
-  /// This property corresponds to the `Deprecated` property in the
+  /// This property corresponds to the "Deprecated" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isDeprecated: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_DEPRECATED)
   }
 
-  /// A Boolean property indicating whether the scalar is a diacritic.
+  /// A Boolean value indicating whether the scalar is a diacritic.
   ///
   /// Diacritics are scalars that linguistically modify the meaning of another
-  /// scalar to which they apply. Scalars for which this property is true are
+  /// scalar to which they apply. Scalars for which this property is `true` are
   /// frequently, but not always, combining marks or modifiers.
   ///
-  /// This property corresponds to the `Diacritic` property in the
+  /// This property corresponds to the "Diacritic" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isDiacritic: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_DIACRITIC)
   }
 
-  /// A Boolean property indicating whether the scalar's principal function is
+  /// A Boolean value indicating whether the scalar's principal function is
   /// to extend the value or shape of a preceding alphabetic scalar.
   ///
   /// Typical extenders are length and iteration marks.
   ///
-  /// This property corresponds to the `Extender` property in the
+  /// This property corresponds to the "Extender" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isExtender: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EXTENDER)
   }
 
-  /// A Boolean property indicating whether the scalar is excluded from
+  /// A Boolean value indicating whether the scalar is excluded from
   /// composition when performing Unicode normalization.
   ///
-  /// This property corresponds to the `Full_Composition_Exclusion` property in
+  /// This property corresponds to the "Full_Composition_Exclusion" property in
   /// the [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isFullCompositionExclusion: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_FULL_COMPOSITION_EXCLUSION)
   }
 
-  /// A Boolean property indicating whether the scalar is a grapheme base.
+  /// A Boolean value indicating whether the scalar is a grapheme base.
   ///
   /// A grapheme base can be thought of as a space-occupying glyph above or
   /// below which other non-spacing modifying glyphs can be applied. For
-  /// example, when the character `é` is represented in NFD form, the grapheme
-  /// base is "e" (U+0065 LATIN SMALL LETTER E) and it is followed by a single
-  /// grapheme extender, U+0301 COMBINING ACUTE ACCENT.
+  /// example, when the character `é` is represented in its decomposed form,
+  /// the grapheme base is "e" (U+0065 LATIN SMALL LETTER E) and it is followed
+  /// by a single grapheme extender, U+0301 COMBINING ACUTE ACCENT.
   ///
-  /// The set of scalars for which `isGraphemeBase` is true is disjoint by
-  /// definition from the set for which `isGraphemeExtend` is true.
+  /// The set of scalars for which `isGraphemeBase` is `true` is disjoint by
+  /// definition from the set for which `isGraphemeExtend` is `true`.
   ///
-  /// This property corresponds to the `Grapheme_Base` property in the
+  /// This property corresponds to the "Grapheme_Base" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isGraphemeBase: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_GRAPHEME_BASE)
   }
 
-  /// A Boolean property indicating whether the scalar is a grapheme extender.
+  /// A Boolean value indicating whether the scalar is a grapheme extender.
   ///
   /// A grapheme extender can be thought of primarily as a non-spacing glyph
-  /// that is applied above or below another glyph.
+  /// that is applied above or below another glyph. For example, when the
+  /// character `é` is represented in its decomposed form, the grapheme base is
+  /// "e" (U+0065 LATIN SMALL LETTER E) and it is followed by a single grapheme
+  /// extender, U+0301 COMBINING ACUTE ACCENT.
   ///
-  /// The set of scalars for which `isGraphemeExtend` is true is disjoint by
-  /// definition from the set for which `isGraphemeBase` is true.
+  /// The set of scalars for which `isGraphemeExtend` is `true` is disjoint by
+  /// definition from the set for which `isGraphemeBase` is `true`.
   ///
-  /// This property corresponds to the `Grapheme_Extend` property in the
+  /// This property corresponds to the "Grapheme_Extend" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isGraphemeExtend: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_GRAPHEME_EXTEND)
   }
 
-  /// A Boolean property indicating whether the scalar is one that is commonly
+  /// A Boolean value indicating whether the scalar is one that is commonly
   /// used for the representation of hexadecimal numbers or a compatibility
   /// equivalent.
   ///
-  /// This property is true for all scalars for which `isASCIIHexDigit` is true
-  /// as well as for their CJK halfwidth and fullwidth variants.
+  /// This property is `true` for all scalars for which `isASCIIHexDigit` is
+  /// `true` as well as for their CJK halfwidth and fullwidth variants.
   ///
-  /// This property corresponds to the `Hex_Digit` property in the
+  /// This property corresponds to the "Hex_Digit" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isHexDigit: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_HEX_DIGIT)
   }
 
-  /// A Boolean property indicating whether the scalar is one which is
+  /// A Boolean value indicating whether the scalar is one which is
   /// recommended to be allowed to appear in a non-starting position in a
   /// programming language identifier.
   ///
@@ -213,13 +224,13 @@ extension Unicode.Scalar.Properties {
   /// use `isXIDContinue` to check whether a scalar is a valid identifier
   /// character.
   ///
-  /// This property corresponds to the `ID_Continue` property in the
+  /// This property corresponds to the "ID_Continue" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isIDContinue: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_ID_CONTINUE)
   }
 
-  /// A Boolean property indicating whether the scalar is one which is
+  /// A Boolean value indicating whether the scalar is one which is
   /// recommended to be allowed to appear in a starting position in a
   /// programming language identifier.
   ///
@@ -227,13 +238,13 @@ extension Unicode.Scalar.Properties {
   /// use `isXIDStart` to check whether a scalar is a valid identifier
   /// character.
   ///
-  /// This property corresponds to the `ID_Start` property in the
+  /// This property corresponds to the "ID_Start" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isIDStart: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_ID_START)
   }
 
-  /// A Boolean property indicating whether the scalar is considered to be a
+  /// A Boolean value indicating whether the scalar is considered to be a
   /// CJKV (Chinese, Japanese, Korean, and Vietnamese) or other siniform
   /// (Chinese writing-related) ideograph.
   ///
@@ -241,13 +252,13 @@ extension Unicode.Scalar.Properties {
   /// not include characters of other logographic scripts such as Cuneiform or
   /// Egyptian Hieroglyphs.
   ///
-  /// This property corresponds to the `Ideographic` property in the
+  /// This property corresponds to the "Ideographic" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isIdeographic: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_IDEOGRAPHIC)
   }
 
-  /// A Boolean property indicating whether the scalar is an ideographic
+  /// A Boolean value indicating whether the scalar is an ideographic
   /// description character that determines how the two ideographic characters
   /// or ideographic description sequences that follow it are to be combined to
   /// form a single character.
@@ -256,13 +267,13 @@ extension Unicode.Scalar.Properties {
   /// but advanced rendering engines may use them to approximate ideographs that
   /// are otherwise unrepresentable.
   ///
-  /// This property corresponds to the `IDS_Binary_Operator` property in the
+  /// This property corresponds to the "IDS_Binary_Operator" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isIDSBinaryOperator: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_IDS_BINARY_OPERATOR)
   }
 
-  /// A Boolean property indicating whether the scalar is an ideographic
+  /// A Boolean value indicating whether the scalar is an ideographic
   /// description character that determines how the three ideographic characters
   /// or ideographic description sequences that follow it are to be combined to
   /// form a single character.
@@ -271,17 +282,17 @@ extension Unicode.Scalar.Properties {
   /// but advanced rendering engines may use them to approximate ideographs that
   /// are otherwise unrepresentable.
   ///
-  /// This property corresponds to the `IDS_Trinary_Operator` property in the
+  /// This property corresponds to the "IDS_Trinary_Operator" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isIDSTrinaryOperator: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_IDS_TRINARY_OPERATOR)
   }
 
-  /// A Boolean property indicating whether the scalar is a format control
+  /// A Boolean value indicating whether the scalar is a format control
   /// character that has a specific function in controlling cursive joining and
   /// ligation.
   ///
-  /// There are two scalars for which this property is true:
+  /// There are two scalars for which this property is `true`:
   ///
   /// * When U+200C ZERO WIDTH NON-JOINER is inserted between two characters, it
   ///   directs the rendering engine to render them separately/disconnected when
@@ -297,13 +308,13 @@ extension Unicode.Scalar.Properties {
   ///   For example, the various "family" emoji are encoded as sequences of man,
   ///   woman, or child emoji that are interleaved with zero width joiners.
   ///
-  /// This property corresponds to the `Join_Control` property in the
+  /// This property corresponds to the "Join_Control" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isJoinControl: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_JOIN_CONTROL)
   }
 
-  /// A Boolean property indicating whether the scalar requires special handling
+  /// A Boolean value indicating whether the scalar requires special handling
   /// for operations involving ordering, such as sorting and searching.
   ///
   /// This property applies to a small number of spacing vowel letters occurring
@@ -311,125 +322,125 @@ extension Unicode.Scalar.Properties {
   /// order display model. Such letters are stored in text ahead of
   /// syllable-initial consonants.
   ///
-  /// This property corresponds to the `Logical_Order_Exception` property in the
+  /// This property corresponds to the "Logical_Order_Exception" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isLogicalOrderException: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_LOGICAL_ORDER_EXCEPTION)
   }
 
-  /// A Boolean property indicating whether the scalar's letterform is
+  /// A Boolean value indicating whether the scalar's letterform is
   /// considered lowercase.
   ///
-  /// This property corresponds to the `Lowercase` property in the
+  /// This property corresponds to the "Lowercase" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isLowercase: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_LOWERCASE)
   }
 
-  /// A Boolean property indicating whether the scalar is one that naturally
+  /// A Boolean value indicating whether the scalar is one that naturally
   /// appears in mathematical contexts.
   ///
-  /// The set of scalars for which this property is true includes mathematical
+  /// The set of scalars for which this property is `true` includes mathematical
   /// operators and symbols as well as specific Greek and Hebrew letter
   /// variants that are categorized as symbols. Notably, it does _not_ contain
   /// the standard digits or Latin/Greek letter blocks; instead, it contains the
   /// mathematical Latin, Greek, and Arabic letters and numbers defined in the
   /// Supplemental Multilingual Plane.
   ///
-  /// This property corresponds to the `Math` property in the
+  /// This property corresponds to the "Math" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isMath: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_MATH)
   }
 
-  /// A Boolean property indicating whether the scalar is permanently reserved
+  /// A Boolean value indicating whether the scalar is permanently reserved
   /// for internal use.
   ///
-  /// This property corresponds to the `Noncharacter_Code_Point` property in the
+  /// This property corresponds to the "Noncharacter_Code_Point" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isNoncharacterCodePoint: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_NONCHARACTER_CODE_POINT)
   }
 
-  /// A Boolean property indicating whether the scalar is one that is used in
+  /// A Boolean value indicating whether the scalar is one that is used in
   /// writing to surround quoted text.
   ///
-  /// This property corresponds to the `Quotation_Mark` property in the
+  /// This property corresponds to the "Quotation_Mark" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isQuotationMark: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_QUOTATION_MARK)
   }
 
-  /// A Boolean property indicating whether the scalar is a radical component of
+  /// A Boolean value indicating whether the scalar is a radical component of
   /// CJK characters, Tangut characters, or Yi syllables.
   ///
   /// These scalars are often the components of ideographic description
   /// sequences, as defined by the `isIDSBinaryOperator` and
   /// `isIDSTrinaryOperator` properties.
   ///
-  /// This property corresponds to the `Radical` property in the
+  /// This property corresponds to the "Radical" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isRadical: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_RADICAL)
   }
 
-  /// A Boolean property indicating whether the scalar has a "soft dot" that
+  /// A Boolean value indicating whether the scalar has a "soft dot" that
   /// disappears when a diacritic is placed over the scalar.
   ///
   /// For example, "i" is soft dotted because the dot disappears when adding an
   /// accent mark, as in "í".
   ///
-  /// This property corresponds to the `Soft_Dotted` property in the
+  /// This property corresponds to the "Soft_Dotted" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isSoftDotted: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_SOFT_DOTTED)
   }
 
-  /// A Boolean property indicating whether the scalar is a punctuation symbol
+  /// A Boolean value indicating whether the scalar is a punctuation symbol
   /// that typically marks the end of a textual unit.
   ///
-  /// This property corresponds to the `Terminal_Punctuation` property in the
+  /// This property corresponds to the "Terminal_Punctuation" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isTerminalPunctuation: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_TERMINAL_PUNCTUATION)
   }
 
-  /// A Boolean property indicating whether the scalar is one of the unified
+  /// A Boolean value indicating whether the scalar is one of the unified
   /// CJK ideographs in the Unicode Standard.
   ///
   /// This property is false for CJK punctuation and symbols, as well as for
   /// compatibility ideographs (which canonically decompose to unified
   /// ideographs).
   ///
-  /// This property corresponds to the `Unified_Ideograph` property in the
+  /// This property corresponds to the "Unified_Ideograph" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isUnifiedIdeograph: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_UNIFIED_IDEOGRAPH)
   }
 
-  /// A Boolean property indicating whether the scalar's letterform is
+  /// A Boolean value indicating whether the scalar's letterform is
   /// considered uppercase.
   ///
-  /// This property corresponds to the `Uppercase` property in the
+  /// This property corresponds to the "Uppercase" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isUppercase: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_UPPERCASE)
   }
 
-  /// A Boolean property indicating whether the scalar is a whitespace
+  /// A Boolean value indicating whether the scalar is a whitespace
   /// character.
   ///
-  /// This property is true for scalars that are spaces, separator characters,
+  /// This property is `true` for scalars that are spaces, separator characters,
   /// and other control characters that should be treated as whitespace for the
   /// purposes of parsing text elements.
   ///
-  /// This property corresponds to the `White_Space` property in the
+  /// This property corresponds to the "White_Space" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isWhitespace: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_WHITE_SPACE)
   }
 
-  /// A Boolean property indicating whether the scalar is one which is
+  /// A Boolean value indicating whether the scalar is one which is
   /// recommended to be allowed to appear in a non-starting position in a
   /// programming language identifier, with adjustments made for NFKC normalized
   /// form.
@@ -438,13 +449,13 @@ extension Unicode.Scalar.Properties {
   /// under NFKC normalization by removing any scalars whose normalized form is
   /// not of the form `[:ID_Continue:]*`.
   ///
-  /// This property corresponds to the `XID_Continue` property in the
+  /// This property corresponds to the "XID_Continue" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isXIDContinue: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_XID_CONTINUE)
   }
 
-  /// A Boolean property indicating whether the scalar is one which is
+  /// A Boolean value indicating whether the scalar is one which is
   /// recommended to be allowed to appear in a starting position in a
   /// programming language identifier, with adjustments made for NFKC normalized
   /// form.
@@ -453,132 +464,127 @@ extension Unicode.Scalar.Properties {
   /// NFKC normalization by removing any scalars whose normalized form is not of
   /// the form `[:ID_Start:] [:ID_Continue:]*`.
   ///
-  /// This property corresponds to the `XID_Start` property in the
+  /// This property corresponds to the "XID_Start" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isXIDStart: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_XID_START)
   }
 
-  /// A Boolean property indicating whether the scalar is a punctuation mark
+  /// A Boolean value indicating whether the scalar is a punctuation mark
   /// that generally marks the end of a sentence.
   ///
-  /// This property corresponds to the `Sentence_Terminal` property in the
+  /// This property corresponds to the "Sentence_Terminal" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isSentenceTerminal: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_S_TERM)
   }
 
-  /// A Boolean property indicating whether the scalar is a variation selector.
+  /// A Boolean value indicating whether the scalar is a variation selector.
   ///
   /// Variation selectors allow rendering engines that support them to choose
   /// different glyphs to display for a particular code point.
   ///
-  /// This property corresponds to the `Variation_Selector` property in the
+  /// This property corresponds to the "Variation_Selector" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isVariationSelector: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_VARIATION_SELECTOR)
   }
 
-  /// A Boolean property indicating whether the scalar is recommended to have
+  /// A Boolean value indicating whether the scalar is recommended to have
   /// syntactic usage in patterns represented in source code.
   ///
-  /// This property corresponds to the `Pattern_Syntax` property in the
+  /// This property corresponds to the "Pattern_Syntax" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isPatternSyntax: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_PATTERN_SYNTAX)
   }
 
-  /// A Boolean property indicating whether the scalar is recommended to be
+  /// A Boolean value indicating whether the scalar is recommended to be
   /// treated as whitespace when parsing patterns represented in source code.
   ///
-  /// This property corresponds to the `Pattern_White_Space` property in the
+  /// This property corresponds to the "Pattern_White_Space" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isPatternWhitespace: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_PATTERN_WHITE_SPACE)
   }
 
-  /// A Boolean property indicating whether the scalar is considered to be
+  /// A Boolean value indicating whether the scalar is considered to be
   /// either lowercase, uppercase, or titlecase.
   ///
-  /// Though similar in name, this property is _not_ equivalent to
-  /// `changesWhenCaseMapped`. The set of scalars for which `isCased` is true is
-  /// a superset of those for which `changesWhenCaseMapped` is true. An example
-  /// of scalars that only have `isCased` as true are the Latin small capitals
-  /// that are used by the International Phonetic Alphabet. These letters have a
-  /// case but do not change when they are mapped to any of the other cases.
+  /// Though similar in name, this property is *not* equivalent to
+  /// `changesWhenCaseMapped`. The set of scalars for which `isCased` is `true`
+  /// is a superset of those for which `changesWhenCaseMapped` is `true`. For
+  /// example, the Latin small capitals that are used by the International
+  /// Phonetic Alphabet have a case, but do not change when they are mapped to
+  /// any of the other cases.
   ///
-  /// This property corresponds to the `Cased` property in the
+  /// This property corresponds to the "Cased" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isCased: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CASED)
   }
 
-  /// A Boolean property indicating whether the scalar is ignored for casing
+  /// A Boolean value indicating whether the scalar is ignored for casing
   /// purposes.
   ///
-  /// This property corresponds to the `Case_Ignorable` property in the
+  /// This property corresponds to the "Case_Ignorable" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var isCaseIgnorable: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CASE_IGNORABLE)
   }
 
-  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// A Boolean value indicating whether the scalar's normalized form differs
   /// from the `lowercaseMapping` of each constituent scalar.
   ///
-  /// This property corresponds to the `Changes_When_Lowercased` property in the
+  /// This property corresponds to the "Changes_When_Lowercased" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var changesWhenLowercased: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_LOWERCASED)
   }
 
-  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// A Boolean value indicating whether the scalar's normalized form differs
   /// from the `uppercaseMapping` of each constituent scalar.
   ///
-  /// This property corresponds to the `Changes_When_Uppercased` property in the
+  /// This property corresponds to the "Changes_When_Uppercased" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var changesWhenUppercased: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_UPPERCASED)
   }
 
-  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// A Boolean value indicating whether the scalar's normalized form differs
   /// from the `titlecaseMapping` of each constituent scalar.
   ///
-  /// This property corresponds to the `Changes_When_Titlecased` property in the
+  /// This property corresponds to the "Changes_When_Titlecased" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var changesWhenTitlecased: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_TITLECASED)
   }
 
-  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// A Boolean value indicating whether the scalar's normalized form differs
   /// from the case-fold mapping of each constituent scalar.
   ///
-  /// This property corresponds to the `Changes_When_Casefolded` property in the
+  /// This property corresponds to the "Changes_When_Casefolded" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var changesWhenCaseFolded: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_CASEFOLDED)
   }
 
-  /// A Boolean property indicating whether the scalar may change when it
+  /// A Boolean value indicating whether the scalar may change when it
   /// undergoes case mapping.
   ///
-  /// For any scalar `s`, it holds by definition that
+  /// This property is `true` whenever one or more of `changesWhenLowercased`,
+  /// `changesWhenUppercased`, or `changesWhenTitlecased` are `true`.
   ///
-  /// ```
-  /// s.changesWhenCaseMapped = s.changesWhenLowercased ||
-  ///                           s.changesWhenUppercased ||
-  ///                           s.changesWhenTitlecased
-  /// ```
-  ///
-  /// This property corresponds to the `Changes_When_Casemapped` property in the
+  /// This property corresponds to the "Changes_When_Casemapped" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var changesWhenCaseMapped: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_CASEMAPPED)
   }
 
-  /// A Boolean property indicating whether the scalar is one that is not
+  /// A Boolean value indicating whether the scalar is one that is not
   /// identical to its NFKC case-fold mapping.
   ///
-  /// This property corresponds to the `Changes_When_NFKC_Casefolded` property
+  /// This property corresponds to the "Changes_When_NFKC_Casefolded" property
   /// in the [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var changesWhenNFKCCaseFolded: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_NFKC_CASEFOLDED)
@@ -590,7 +596,7 @@ extension Unicode.Scalar.Properties {
   // non-Darwin platforms for now; bundling ICU with the toolchain would resolve
   // this and other inconsistencies (https://bugs.swift.org/browse/SR-6076).
 
-  /// A Boolean property indicating whether the scalar has an emoji
+  /// A Boolean value indicating whether the scalar has an emoji
   /// presentation, whether or not it is the default.
   ///
   /// This property is true for scalars that are rendered as emoji by default
@@ -598,18 +604,13 @@ extension Unicode.Scalar.Properties {
   /// by U+FE0F VARIATION SELECTOR-16. This includes some scalars that are not
   /// typically considered to be emoji:
   ///
-  /// ```
-  /// let sunglasses: Unicode.Scalar = "😎"
-  /// let dollar: Unicode.Scalar = "$"
-  /// let zero: Unicode.Scalar = "0"
-  ///
-  /// print(sunglasses.isEmoji)
-  /// // Prints "true"
-  /// print(dollar.isEmoji)
-  /// // Prints "false"
-  /// print(zero.isEmoji)
-  /// // Prints "true"
-  /// ```
+  ///     let scalars: [Unicode.Scalar] = ["😎", "$", "0"]
+  ///     for s in scalars {
+  ///         print(s, "-->", s.isEmoji)
+  ///     }
+  ///     // 😎 --> true
+  ///     // $ --> false
+  ///     // 0 --> true
   ///
   /// The final result is true because the ASCII digits have non-default emoji
   /// presentations; some platforms render these with an alternate appearance.
@@ -622,48 +623,48 @@ extension Unicode.Scalar.Properties {
   /// determine whether it is followed by a variation selector that would modify
   /// the presentation.
   ///
-  /// This property corresponds to the `Emoji` property in the
+  /// This property corresponds to the "Emoji" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmoji: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI)
   }
 
-  /// A Boolean property indicating whether the scalar is one that should be
+  /// A Boolean value indicating whether the scalar is one that should be
   /// rendered with an emoji presentation, rather than a text presentation, by
   /// default.
   ///
-  /// Scalars that have emoji presentation by default can be followed by
+  /// Scalars that have default to emoji presentation can be followed by
   /// U+FE0E VARIATION SELECTOR-15 to request the text presentation of the
   /// scalar instead. Likewise, scalars that default to text presentation can
   /// be followed by U+FE0F VARIATION SELECTOR-16 to request the emoji
   /// presentation.
   ///
-  /// This property corresponds to the `Emoji_Presentation` property in the
+  /// This property corresponds to the "Emoji_Presentation" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmojiPresentation: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI_PRESENTATION)
   }
 
-  /// A Boolean property indicating whether the scalar is one that can modify
+  /// A Boolean value indicating whether the scalar is one that can modify
   /// a base emoji that precedes it.
   ///
   /// The Fitzpatrick skin types are examples of emoji modifiers; they change
   /// the appearance of the preceding emoji base (that is, a scalar for which
   /// `isEmojiModifierBase` is true) by rendering it with a different skin tone.
   ///
-  /// This property corresponds to the `Emoji_Modifier` property in the
+  /// This property corresponds to the "Emoji_Modifier" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmojiModifier: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI_MODIFIER)
   }
 
-  /// A Boolean property indicating whether the scalar is one whose appearance
+  /// A Boolean value indicating whether the scalar is one whose appearance
   /// can be changed by an emoji modifier that follows it.
   ///
-  /// This property corresponds to the `Emoji_Modifier_Base` property in the
+  /// This property corresponds to the "Emoji_Modifier_Base" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmojiModifierBase: Bool {
@@ -725,7 +726,7 @@ extension Unicode.Scalar.Properties {
   /// WITH DOT ABOVE) becomes two scalars (U+0069 LATIN SMALL LETTER I, U+0307
   /// COMBINING DOT ABOVE) when converted to lowercase.
   ///
-  /// This property corresponds to the `Lowercase_Mapping` property in the
+  /// This property corresponds to the "Lowercase_Mapping" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var lowercaseMapping: String {
     return _applyMapping(__swift_stdlib_u_strToLower)
@@ -739,7 +740,7 @@ extension Unicode.Scalar.Properties {
   /// becomes "Fi" (U+0046 LATIN CAPITAL LETTER F, U+0069 LATIN SMALL LETTER I)
   /// when converted to titlecase.
   ///
-  /// This property corresponds to the `Titlecase_Mapping` property in the
+  /// This property corresponds to the "Titlecase_Mapping" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var titlecaseMapping: String {
     return _applyMapping { ptr, cap, src, len, locale, err in
@@ -755,7 +756,7 @@ extension Unicode.Scalar.Properties {
   /// SHARP S) becomes "SS" (U+0053 LATIN CAPITAL LETTER S, U+0053 LATIN CAPITAL
   /// LETTER S) when converted to uppercase.
   ///
-  /// This property corresponds to the `Uppercase_Mapping` property in the
+  /// This property corresponds to the "Uppercase_Mapping" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var uppercaseMapping: String {
     return _applyMapping(__swift_stdlib_u_strToUpper)
@@ -764,7 +765,7 @@ extension Unicode.Scalar.Properties {
 
 extension Unicode {
 
-  /// A version of the Unicode Standard represented by its `major.minor`
+  /// A version of the Unicode Standard represented by its major and minor
   /// components.
   public typealias Version = (major: Int, minor: Int)
 }
@@ -774,9 +775,9 @@ extension Unicode.Scalar.Properties {
   /// The earliest version of the Unicode Standard in which the scalar was
   /// assigned.
   ///
-  /// This value will be nil for code points that have not yet been assigned.
+  /// This value is `nil` for code points that have not yet been assigned.
   ///
-  /// This property corresponds to the `Age` property in the
+  /// This property corresponds to the "Age" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var age: Unicode.Version? {
     var versionInfo: __swift_stdlib_UVersionInfo = (0, 0, 0, 0)
@@ -1074,7 +1075,7 @@ extension Unicode.Scalar.Properties {
 
   /// The general category (most usual classification) of the scalar.
   ///
-  /// This property corresponds to the `General_Category` property in the
+  /// This property corresponds to the "General_Category" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var generalCategory: Unicode.GeneralCategory {
     let rawValue = __swift_stdlib_UCharCategory(
@@ -1117,15 +1118,16 @@ extension Unicode.Scalar.Properties {
   /// The published name of the scalar.
   ///
   /// Some scalars, such as control characters, do not have a value for this
-  /// property in the UCD. For such scalars, this property will be nil.
+  /// property in the Unicode Character Database. For such scalars, this
+  /// property is `nil`.
   ///
-  /// This property corresponds to the `Name` property in the
+  /// This property corresponds to the "Name" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var name: String? {
     return _scalarName(__swift_stdlib_U_UNICODE_CHAR_NAME)
   }
 
-  /// The normative formal alias of the scalar, or nil if it has no alias.
+  /// The normative formal alias of the scalar.
   ///
   /// The name of a scalar is immutable and never changed in future versions of
   /// the Unicode Standard. The `nameAlias` property is provided to issue
@@ -1134,7 +1136,9 @@ extension Unicode.Scalar.Properties {
   /// (note that "BRACKET" is misspelled). The `nameAlias` property then
   /// contains the corrected name.
   ///
-  /// This property corresponds to the `Name_Alias` property in the
+  /// If a scalar has no alias, this property is `nil`.
+  ///
+  /// This property corresponds to the "Name_Alias" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var nameAlias: String? {
     return _scalarName(__swift_stdlib_U_CHAR_NAME_ALIAS)
@@ -1159,10 +1163,10 @@ extension Unicode {
   /// `"\u{0041}\u{0316}\u{0301}"`, so two strings that differ only by the
   /// ordering of those scalars would compare as equal:
   ///
-  /// ```
-  /// print("\u{0041}\u{0316}\u{0301}" == "\u{0041}\u{0301}\u{0316}")
-  /// // Prints "true"
-  /// ```
+  ///     let aboveBeforeBelow = "\u{0041}\u{0301}\u{0316}"
+  ///     let belowBeforeAbove = "\u{0041}\u{0316}\u{0301}"
+  ///     print(aboveBeforeBelow == belowBeforeAbove)
+  ///     // Prints "true"
   ///
   /// Named and Unnamed Combining Classes
   /// ===================================
@@ -1172,15 +1176,13 @@ extension Unicode {
   /// symbolic names to a subset of these combining classes.
   ///
   /// The `CanonicalCombiningClass` type conforms to `RawRepresentable` with a
-  /// raw value of type `UInt8`. Instances of the type can be created from the
-  /// actual numeric value using the `init(rawValue:)` initializer, and
-  /// combining classes with symbolic names can also be referenced using the
-  /// static members that share those names.
+  /// raw value of type `UInt8`. You can create instances of the type by using
+  /// the static members named after the symbolic names, or by using the
+  /// `init(rawValue:)` initializer.
   ///
-  /// ```
-  /// print(Unicode.CanonicalCombiningClass(rawValue: 1) == .overlay)
-  /// // Prints "true"
-  /// ```
+  ///     let overlayClass = Unicode.CanonicalCombiningClass(rawValue: 1)
+  ///     let overlayClassIsOverlay = overlayClass == .overlay
+  ///     // overlayClassIsOverlay == true
   public struct CanonicalCombiningClass:
     Comparable, Hashable, RawRepresentable
   {
@@ -1286,7 +1288,7 @@ extension Unicode.Scalar.Properties {
 
   /// The canonical combining class of the scalar.
   ///
-  /// This property corresponds to the `Canonical_Combining_Class` property in
+  /// This property corresponds to the "Canonical_Combining_Class" property in
   /// the [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var canonicalCombiningClass: Unicode.CanonicalCombiningClass {
     let rawValue = UInt8(__swift_stdlib_u_getIntPropertyValue(
@@ -1308,32 +1310,35 @@ extension Unicode {
   /// from incorrectly interpreting them as numbers in non-numeric contexts.
   public enum NumericType {
 
-    /// Digits that are commonly understood to form base-10 numbers.
+    /// A digit that is commonly understood to form base-10 numbers.
     ///
     /// Specifically, scalars have this numeric type if they occupy a contiguous
     /// range of code points representing numeric values `0...9`.
     case decimal
 
-    /// Decimal digits that otherwise do not meet the requirements of numeric
-    /// type `decimal`.
+    /// A digit that does not meet the requirements of the `decimal` numeric
+    /// type.
     ///
     /// Scalars with this numeric type are often those that represent a decimal
-    /// digit but would not typically be used to write a base-10 number, such as
-    /// "④" (U+2463 CIRCLED DIGIT FOUR).
+    /// digit but would not typically be used to write a base-10 number, such
+    /// as "④" (U+2463 CIRCLED DIGIT FOUR).
     ///
-    /// In practice, the distinction between `digit` and `numeric` has not
-    /// proven to be valuable. As of Unicode 6.3, any new scalars that represent
-    /// numbers but do not meet the requirements of `decimal` will have numeric
-    /// type `numeric`, and programs can treat `digit` and `numeric`
-    /// equivalently.
+    /// As of Unicode 6.3, any new scalars that represent numbers but do not
+    /// meet the requirements of `decimal` will have numeric type `numeric`,
+    /// and programs can treat `digit` and `numeric` equivalently.
     case digit
 
-    /// Numbers that are not decimal digits.
+    /// A digit that does not meet the requirements of the `decimal` numeric
+    /// type or a non-digit numeric value.
     ///
-    /// This numeric type includes fractions such as "⅕" (U+2155 VULGAR FRACITON
-    /// ONE FIFTH), numerical CJK ideographs like "兆" (U+5146 CJK UNIFIED
-    /// IDEOGRAPH-5146), and other scalars that are not decimal digits used
-    /// positionally in the writing of base-10 numbers.
+    /// This numeric type includes fractions such as "⅕" (U+2155 VULGAR
+    /// FRACITON ONE FIFTH), numerical CJK ideographs like "兆" (U+5146 CJK
+    /// UNIFIED IDEOGRAPH-5146), and other scalars that are not decimal digits
+    /// used positionally in the writing of base-10 numbers.
+    ///
+    /// As of Unicode 6.3, any new scalars that represent numbers but do not
+    /// meet the requirements of `decimal` will have numeric type `numeric`,
+    /// and programs can treat `digit` and `numeric` equivalently.
     case numeric
 
     internal init?(rawValue: __swift_stdlib_UNumericType) {
@@ -1353,21 +1358,19 @@ extension Unicode.Scalar.Properties {
 
   /// The numeric type of the scalar.
   ///
-  /// The value of this property is nil for scalars that do not represent a
-  /// number.
+  /// For scalars that represent a number, `numericType` is the numeric type
+  /// of the scalar. For all other scalars, this property is `nil`.
   ///
-  /// ```
-  /// print("X", ("X" as Unicode.Scalar).properties.numericType ?? "nil")
-  /// // Prints "X nil"
-  /// print("4", ("4" as Unicode.Scalar).properties.numericType ?? "nil")
-  /// // Prints "4 decimal"
-  /// print("\u{2463}", ("\u{2463}" as Unicode.Scalar).properties.numericType ?? "nil")
-  /// // Prints "④ digit"
-  /// print("\u{2155}", ("\u{2155}" as Unicode.Scalar).properties.numericType ?? "nil")
-  /// // Prints "⅕ numeric"
-  /// ```
+  ///     let scalars: [Unicode.Scalar] = ["4", "④", "⅕", "X"]
+  ///     for scalar in scalars {
+  ///         print(scalar, "-->", scalar.properties.numericType)
+  ///     }
+  ///     // 4 --> decimal
+  ///     // ④ --> digit
+  ///     // ⅕ --> numeric
+  ///     // X --> nil
   ///
-  /// This property corresponds to the `Numeric_Type` property in the
+  /// This property corresponds to the "Numeric_Type" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var numericType: Unicode.NumericType? {
     let rawValue = __swift_stdlib_UNumericType(
@@ -1379,25 +1382,20 @@ extension Unicode.Scalar.Properties {
 
   /// The numeric value of the scalar.
   ///
-  /// The value of this property is nil for scalars that do not represent a
-  /// number.
+  /// For scalars that represent a numeric value, `numericValue` is the whole
+  /// or fractional value. For all other scalars, this property is `nil`.
   ///
-  /// The numeric value of a scalar is represented as a `Double` because some
-  /// scalars represent fractions:
+  ///     let scalars: [Unicode.Scalar] = ["4", "④", "⅕", "X"]
+  ///     for scalar in scalars {
+  ///         print(scalar, "-->", scalar.properties.numericValue)
+  ///     }
+  ///     // 4 --> 4.0
+  ///     // ④ --> 4.0
+  ///     // ⅕ --> 0.2
+  ///     // X --> nil
   ///
-  /// ```
-  /// print("X", ("X" as Unicode.Scalar).properties.numericValue ?? "nil")
-  /// // Prints "X nil"
-  /// print("4", ("4" as Unicode.Scalar).properties.numericValue ?? "nil")
-  /// // Prints "4 4.0"
-  /// print("\u{2463}", ("\u{2463}" as Unicode.Scalar).properties.numericValue ?? "nil")
-  /// // Prints "④ 4.0"
-  /// print("\u{2155}", ("\u{2155}" as Unicode.Scalar).properties.numericValue ?? "nil")
-  /// // Prints "⅕ 0.2"
-  /// ```
-  ///
-  /// This property corresponds to the `Numeric_Value` property in the
-  /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  /// This property corresponds to the "Numeric_Value" property in the [Unicode
+  /// Standard](http://www.unicode.org/versions/latest/).
   public var numericValue: Double? {
     let icuNoNumericValue: Double = -123456789
     let result = __swift_stdlib_u_getNumericValue(icuValue)


### PR DESCRIPTION
Cherry pick from #21333.

Note: This cherry-pick drops the documentation revisions to the `Result` type, which isn't included on this branch.

**Explanation:** Documentation revisions for Swift 5 addditions to the standard library.
**Scope of Issue:** No code changes, these are documentation comments only. There is a small amount of additional gyb code added to support documenting the vector types, but the only changes to the rendered Swift files are documentation changes.
**Risk:** Minimal.
**Reviewer:** Ben Cohen @airspeedswift, Steve Canon @stephentyrone, Michael Ilseman @milseman
**Testing:** The standard test and validation suites.
**Radar:** rdar://problem/47055142