### PR TITLE
Tweak help for the `--line-directive` option

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1237,7 +1237,10 @@ def main():
              Line directive format string, which will be
              provided 2 substitutions, `%%(line)d` and `%%(file)s`.
 
-             Example: `// #sourceLocation(file: "%%(file)s", line: %%(line)d)`
+             Example: `// ###sourceLocation(file: "%%(file)s", line: %%(line)d)`
+             
+             The default works automatically with the `line-directive` tool, 
+             which see for more information.
              ''')
 
     args = parser.parse_args(sys.argv[1:])

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1237,8 +1237,8 @@ def main():
              Line directive format string, which will be
              provided 2 substitutions, `%%(line)d` and `%%(file)s`.
 
-             Example: `// ###sourceLocation(file: "%%(file)s", line: %%(line)d)`
-             
+             Example: `#sourceLocation(file: "%%(file)s", line: %%(line)d)`
+
              The default works automatically with the `line-directive` tool, 
              which see for more information.
              ''')


### PR DESCRIPTION
Most people don't know what this is for and set it to "", robbing themselves of usability benefits.  I'm going to add more help text to line-directive to explain that.
