### PR TITLE
[stdlib] Use ContiguousArray internally in Sequence dropLast, prefix, suffix

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -906,8 +906,7 @@ extension Sequence {
         ringBuffer.append(element)
       } else {
         ringBuffer[i] = element
-        i += 1
-        i %= maxLength
+        i = (i + 1) % maxLength
       }
     }
 
@@ -986,8 +985,7 @@ extension Sequence {
       } else {
         result.append(ringBuffer[i])
         ringBuffer[i] = element
-        i += 1
-        i %= k
+        i = (i + 1) % k
       }
     }
     return result

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -893,10 +893,9 @@ extension Sequence {
 
     // FIXME: <rdar://problem/21885650> Create reusable RingBuffer<T>
     // Put incoming elements into a ring buffer to save space. Once all
-    // elements are consumed, reorder the ring buffer into an `Array`
-    // and return it. This saves memory for sequences particularly longer
-    // than `maxLength`.
-    var ringBuffer: [Element] = []
+    // elements are consumed, reorder the ring buffer into a copy and return it.
+    // This saves memory for sequences particularly longer than `maxLength`.
+    var ringBuffer = ContiguousArray<Element>()
     ringBuffer.reserveCapacity(Swift.min(maxLength, underestimatedCount))
 
     var i = 0
@@ -911,13 +910,13 @@ extension Sequence {
     }
 
     if i != ringBuffer.startIndex {
-      var rotated: [Element] = []
+      var rotated = ContiguousArray<Element>()
       rotated.reserveCapacity(ringBuffer.count)
       rotated += ringBuffer[i..<ringBuffer.endIndex]
       rotated += ringBuffer[0..<i]
-      return rotated
-    } else {      
-      return ringBuffer
+      return Array(rotated)
+    } else {
+      return Array(ringBuffer)
     }
   }
 
@@ -975,8 +974,8 @@ extension Sequence {
     // holding tank into the result, an `Array`. This saves
     // `k` * sizeof(Element) of memory, because slices keep the entire
     // memory of an `Array` alive.
-    var result: [Element] = []
-    var ringBuffer: [Element] = []
+    var result = ContiguousArray<Element>()
+    var ringBuffer = ContiguousArray<Element>()
     var i = ringBuffer.startIndex
 
     for element in self {
@@ -988,7 +987,7 @@ extension Sequence {
         i = (i + 1) % k
       }
     }
-    return result
+    return Array(result)
   }
 
   /// Returns a sequence by skipping the initial, consecutive elements that
@@ -1070,7 +1069,7 @@ extension Sequence {
   public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> [Element] {
-    var result: [Element] = []
+    var result = ContiguousArray<Element>()
 
     for element in self {
       guard try predicate(element) else {
@@ -1078,7 +1077,7 @@ extension Sequence {
       }
       result.append(element)
     }
-    return result
+    return Array(result)
   }
 }
 


### PR DESCRIPTION
Following the implementation template used in methods `map` and `_filter`, use  the `ContiguousArray` internally in default implementations of  `dropLast`, `prefix` and `suffix`. This is converted into an `Array` on return in a constant time. In addition to increased consistency of the internal implementation, this noticeably improves the performance of these methods for `UnfoldSequence` benchmark variants in the unoptimized build.

This PR is based on discussion in https://github.com/apple/swift/pull/20221#pullrequestreview-174666315 and was split off from an experiment in #20758.

