### PR TITLE
Add @inline(__always) to stdlib function for performance parity

### DIFF
--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -984,6 +984,7 @@ extension ${Self}: ${SelfProtocol} {
   /// - Parameter base: The collection to wrap.
   ///
   /// - Complexity: O(1).
+  @inline(__always)
   @inlinable
   public init<C : ${SubProtocol}>(_ base: C) where C.Element == Element {
     // Traversal: ${Traversal}


### PR DESCRIPTION
For https://github.com/apple/swift/pull/19820, this PR addresses the performance regression of `ReversedBidirectional` in `-Osize`. 