### PR TITLE
[5.0] [Type checker] Don't implicitly propagate @objc to read/modify accessors

### DIFF
--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2312,3 +2312,18 @@ protocol ObjCProtocolWithWeakProperty {
 protocol ObjCProtocolWithUnownedProperty {
    unowned var unownedProp: AnyObject { get set } // okay
 }
+
+// rdar://problem/46699152: errors about read/modify accessors being implicitly
+// marked @objc.
+@objc class MyObjCClass: NSObject {}
+
+@objc
+extension MyObjCClass {
+    @objc
+    static var objCVarInObjCExtension: Bool {
+        get {
+            return true
+        }
+        set {}
+    }
+}


### PR DESCRIPTION
Fixes rdar://problem/46699152.
