### PR TITLE
[AutoDiff] Fix serialization of @differentiable attribute.

### DIFF
--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -420,8 +420,12 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       parameters.push_back(indices.parameters[i]);
     SILDifferentiableAttrLayout::emitRecord(
         Out, ScratchRecord, differentiableAttrAbbrCode,
-        S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getPrimalName())),
-        S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getAdjointName())),
+        DA->hasPrimal()
+            ? S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getPrimalName()))
+            : IdentifierID(),
+        DA->hasAdjoint()
+            ? S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getAdjointName()))
+            : IdentifierID(),
         DA->isAdjointPrimitive(),
         // TODO: Once we add synthesis for JVP and VJP, serialized
         // [differentiable] attrs should always have JVP and VJP, so we should

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -90,13 +90,14 @@ public func dhasjvp(_ x: Float, _ y: Float) -> (Float, (Float, Float) -> Float) 
 // VJP
 //===----------------------------------------------------------------------===//
 
+@inlinable
 @_silgen_name("hasvjp")
 @differentiable(vjp: dhasvjp)
 public func hasvjp(_ x: Float, _ y: Float) -> Float {
   return 1
 }
 
-// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @dhasvjp] @hasvjp
+// CHECK-LABEL: sil [serialized] [differentiable source 0 wrt 0, 1 vjp @dhasvjp] @hasvjp
 
 @_silgen_name("dhasvjp")
 public func dhasvjp(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)) {


### PR DESCRIPTION
Fixes a crasher in serialization. When primal/adjoint do not exist, do not get their names.