### PR TITLE
[Type checker] Protect against an extension having no nominal declaration

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1600,6 +1600,13 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
     }
 
     NominalTypeDecl *nominal = extension->getExtendedNominal();
+
+    // Extension is ill-formed; suppress the attribute.
+    if (!nominal) {
+      attr->setInvalid();
+      return;
+    }
+
     AccessLevel typeAccess = nominal->getFormalAccess();
     if (attr->getAccess() > typeAccess) {
       TC.diagnose(attr->getLocation(), diag::access_control_extension_more,


### PR DESCRIPTION
Couldn't come up with a test case, but this should fix the crash in
rdar://problem/46817639.
