### PR TITLE
[pmo] Move handling of releases: ElementUseCollector::{collectFrom,co…

### DIFF
--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -43,6 +43,63 @@ bb0(%0 : $Int):
   return %d : $Int
 }
 
+// In this example we create two boxes. The first box is initialized and then
+// taken from to initialize the second box. This means that the first box must
+// be dealloc_boxed (since its underlying memory is considered invalid). In
+// contrast, the 2nd box must be released so that we destroy the underlying
+// input object.
+//
+// CHECK-LABEL: sil @simple_reg_promotion_nontrivial_memory : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: strong_release
+// CHECK-NOT: dealloc_box
+// CHECK: } // end sil function 'simple_reg_promotion_nontrivial_memory'
+sil @simple_reg_promotion_nontrivial_memory : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>, 0
+  store %0 to %1a : $*Builtin.NativeObject
+
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>, 0
+  %4 = load %1a : $*Builtin.NativeObject
+  store %4 to %3a : $*Builtin.NativeObject
+  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+  dealloc_box %1 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Same as the last test but with release_value to be defensive in the cast that
+// someone passes us such SIL.
+//
+// CHECK-LABEL: sil @simple_reg_promotion_nontrivial_memory_release_value : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// The retain value is on the dealloc_box.
+// CHECK-NOT: retain_value
+// CHECK: release_value
+// CHECK-NOT: dealloc_box
+// CHECK: } // end sil function 'simple_reg_promotion_nontrivial_memory_release_value'
+sil @simple_reg_promotion_nontrivial_memory_release_value : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>, 0
+  store %0 to %1a : $*Builtin.NativeObject
+
+  // Also verify that we skip a retain_value on the dealloc_box.
+  retain_value %1 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>, 0
+  %4 = load %1a : $*Builtin.NativeObject
+  store %4 to %3a : $*Builtin.NativeObject
+  release_value %3 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+  dealloc_box %1 : $<τ_0_0> { var τ_0_0 } <Builtin.NativeObject>
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+
 sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
 sil @takes_NativeObject_inout : $@convention(thin) (@inout Builtin.NativeObject) -> ()
 


### PR DESCRIPTION
…llectContainerUses}()

Since:

1. We only handle alloc_stack, alloc_box in predictable memopts.
2. alloc_stack can not be released.

We know that the release collecting in collectFrom can just be done in
collectContainerUses() [which only processes alloc_box].

This also let me simplify some code as well and add a defensive check in case
for some reason we are passed a release_value on the box. NOTE: I verified that
previously this did not result in a bug since we would consider the
release_value to be an escape of the underlying value even though we didn't
handle it in collectFrom. But the proper way to handle release_value is like
strong_release, so I added code to do that as well.
