### PR TITLE
[stdlib] [AutoDiff] More differential operators and utilities

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4893,6 +4893,7 @@ bool Differentiation::processAutoDiffFunctionInst(AutoDiffFunctionInst *adfi,
   SILFunction *parent = adfi->getFunction();
   auto origFnOperand = adfi->getOriginalFunction();
   SILBuilder builder(adfi);
+  auto loc = parent->getLocation();
 
   SmallVector<SILValue, 2> assocFns;
   for (auto assocFnKind : {AutoDiffAssociatedFunctionKind::JVP,
@@ -4915,10 +4916,11 @@ bool Differentiation::processAutoDiffFunctionInst(AutoDiffFunctionInst *adfi,
     assert(assocFnAndIndices->second == desiredIndices &&
            "FIXME: We could emit a thunk that converts the VJP to have the "
            "desired indices.");
+    auto assocFn = assocFnAndIndices->first;
+    builder.createRetainValue(loc, assocFn, builder.getDefaultAtomicity());
     assocFns.push_back(assocFnAndIndices->first);
   }
 
-  auto loc = parent->getLocation();
   auto *newADFI = builder.createAutoDiffFunction(
       loc, adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
       origFnOperand, assocFns);

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -158,9 +158,9 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
   auto &C = nominal->getASTContext();
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
   return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
-    if (!v->getType())
+    if (!v->hasInterfaceType() || !v->getType())
       C.getLazyResolver()->resolveDeclSignature(v);
-    if (!v->getType())
+    if (!v->hasInterfaceType() || !v->getType())
       return false;
     auto declType = v->getType()->hasArchetype()
                         ? v->getType()

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -1,0 +1,27 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if os(macOS)
+import Darwin.C
+#else
+import Glibc
+#endif
+
+var CustomDerivativesTests = TestSuite("CustomDerivatives")
+
+// Not differentiable!
+func foo(_ x: Float) -> Float {
+  var x = x
+  x *= 2
+  return x
+}
+
+CustomDerivativesTests.test("Make a differentiable function") {
+  let diffableFoo = differentiableFunction { x in
+    (value: foo(x), pullback: { v in v * x * 2 })
+  }
+  expectEqual(20, gradient(at: 10, in: diffableFoo))
+}
+
+runAllTests()

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -5,7 +5,7 @@ import StdlibUnittest
 
 var ProtocolRequirementAutodiffTests = TestSuite("ProtocolRequirementAutodiff")
 
-func pullback<T, U, R>(
+func _pullback<T, U, R>(
   at x: (T, U), in f: @autodiff (T) -> (U) -> R
 ) -> (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable, R : Differentiable {
@@ -19,7 +19,7 @@ protocol DiffReq : Differentiable {
 
 extension DiffReq {
   func gradF(at x: Float) -> (Self.CotangentVector, Float) {
-    return pullback(at: (self, x), in: Self.f)(1)
+    return _pullback(at: (self, x), in: Self.f)(1)
   }
 }
 

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -107,7 +107,7 @@ SimpleModelTests.test("gradient") {
   let model = Model(l1: layer, l2: layer, l3: layer)
   let label: Float = 3
   let input: Float = 1
-  let gradModel = gradient(at: model) { (model: Model) -> Float in
+  let gradModel = model.gradient { model -> Float in
     let pred = model.prediction(for: input)
     return model.loss(of: pred, from: label)
   }


### PR DESCRIPTION
### 1. VJP to `@autodiff` functions

Primitive registration requires function declarations, which are cumbersome for stdlib functions and for closures.  This PR introduces `differentiableFunction(from:)`, which takes a VJP and returns a differentiable `@autodiff` function, which one can use in the middle of any code that is to be differentiated.

The implementation of `differentiableFunction(from:)` is incredibly simple: it's just a wrapper around a pair of primitive registration function declarations.

```swift
@inlinable
public func differentiableFunction<T : Differentiable, R : Differentiable>(
  from vjp: @escaping (T)
           -> (value: R, pullback: (R.CotangentVector) -> T.CotangentVector)
) -> @autodiff (T) -> R {
  @differentiable(vjp: _vjp)
  func original(_ x: T) -> R {
    return vjp(x).value
  }
  func _vjp(_ x: T) -> (R, (R.CotangentVector) -> T.CotangentVector) {
    return vjp(x)
  }
  return original
}
```

It's also super easy to use:

```swift
let diffableFoo: @autodiff (Float) -> Float = differentiableFunction { x in
  return (value: foo(x), pullback: { v in v * x * 2 })
}
```

### 2. Differential operators as methods under `Differentiable`

Top-level differential operators `valueWithPullback(at:in:)`, `pullback(at:in:)`, `valueWithGradient(at:in:)`, and `gradient(at:in:)` have been overloaded for unary up to ternary functions. However, there are cases where the type checker can't infer which differential operator to use even when the trailing closure has a clear arity with concrete types. To ease this tension, we add two sets of differential operators as methods under `Differentiable`:
* `valueWithPullback|pullback|valueWithGradient|gradient(in:)`: This acts as a unary differential operator where the parameter is `self`.
* `valueWithPullback|pullback|valueWithGradient|gradient(at:in:)`: This acts as a binary differential operator where the parameters are `self` and the argument passed in the `at:` position.

### 3. Bug fixes

This patch also fixes the following bugs:
- A crasher in `AdditiveArithmetic` derived conformances. The fix is to check for `hasInterfaceType()` before calling `getType()`.
- A segfault where the autodiff-associated functions are used after free. The fix is to retain associated functions when we fill in an `autodiff_function` instruction in the differentiation transform.