### PR TITLE
[AutoDiff] Make `@autodiff` functions callable.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3519,9 +3519,13 @@ void IRGenSILFunction::visitTryApplyInst(swift::TryApplyInst *i) {
 
 void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   const LoweredValue &calleeLV = getLoweredValue(site.getCallee());
-  
+
   auto origCalleeType = site.getOrigCalleeType();
   auto substCalleeType = site.getSubstCalleeType();
+
+  // SWIFT_ENABLE_TENSORFLOW
+  assert(!origCalleeType->isDifferentiable() && "Differentiable functions "
+         "should not reach here");
   
   auto args = site.getArguments();
   SILFunctionConventions origConv(origCalleeType, getSILModule());

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3519,7 +3519,7 @@ void IRGenSILFunction::visitTryApplyInst(swift::TryApplyInst *i) {
 
 void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   const LoweredValue &calleeLV = getLoweredValue(site.getCallee());
-
+  
   auto origCalleeType = site.getOrigCalleeType();
   auto substCalleeType = site.getSubstCalleeType();
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7457,7 +7457,17 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
       return special;
     }
   }
-  
+
+  // SWIFT_ENABLE_TENSORFLOW
+  if (auto *fnTy = cs.getType(fn)->getAs<AnyFunctionType>()) {
+    if (fnTy->isDifferentiable()) {
+      auto fnTyNoDiff =
+          fnTy->withExtInfo(fnTy->getExtInfo().withDifferentiable(false));
+      fn = new (tc.Context) AutoDiffFunctionExtractOriginalExpr(fn, fnTyNoDiff);
+      cs.setType(fn, fnTyNoDiff);
+      cs.cacheExprTypes(fn);
+    }
+  }
 
   bool unwrapResult = false;
   if (auto *IUOFnTy = dyn_cast<ImplicitlyUnwrappedFunctionConversionExpr>(fn)) {


### PR DESCRIPTION
Any `@autodiff` function should be callable as if `@autodiff` did not exist. This makes it so.