### PR TITLE
Platform: extend WinSDK module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -54,6 +54,12 @@ module WinSDK [system] [extern_c] {
       export *
     }
 
+    // api-ms-win-core-Path-l1-0.dll
+    module path {
+      header "PathCch.h"
+      export *
+    }
+
     // api-ms-win-core-processthreads-l1-1-2.dll
     module processthreads {
       header "processthreadsapi.h"
@@ -79,5 +85,9 @@ module WinSDK [system] [extern_c] {
     }
   }
 
+  module Shell {
+    header "ShlObj.h"
+    export *
+  }
 }
 


### PR DESCRIPTION
Update the module definitions to include ShellAPI and Path API Set.
These are used by Foundation for FileManager.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
