### PR TITLE
[Sema] [AutoDiff] Mark stored properties as `@differentiable` when they get added to associated vector spaces.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -474,6 +474,8 @@ getOrSynthesizeVectorSpaceStruct(DerivedConformance &derived,
     // Skip members with `@noDerivative`.
     if (member->getAttrs().hasAttribute<NoDerivativeAttr>())
       continue;
+    // Add this member's corresponding vector space to the parent's vector space
+    // struct.
     auto memberAssocType = getVectorSpaceType(member, nominal, kind);
     auto newMember = new (C) VarDecl(
         member->isStatic(), member->getSpecifier(), member->isCaptureList(),
@@ -491,6 +493,23 @@ getOrSynthesizeVectorSpaceStruct(DerivedConformance &derived,
     newMember->setValidationToChecked();
     newMember->setSetterAccess(member->getFormalAccess());
     C.addSynthesizedDecl(newMember);
+
+    // Now that this member is in the associated vector space, it should be
+    // marked `@differentiable` so that the differentition transform will
+    // synthesize associated functions for it. We only add this to public
+    // functions, because they are the only ones whose access go through
+    if (member->getEffectiveAccess() > AccessLevel::Internal &&
+        !member->getAttrs().hasAttribute<DifferentiableAttr>()) {
+      auto *diffableAttr = DifferentiableAttr::create(
+          C, SourceLoc(), SourceLoc(), ArrayRef<AutoDiffParameter>(), None,
+          None, None, None, nullptr);
+      member->getAttrs().add(diffableAttr);
+      auto *getterType =
+          member->getGetter()->getInterfaceType()->castTo<AnyFunctionType>();
+      AutoDiffParameterIndicesBuilder builder(getterType);
+      builder.setParameter(0);
+      diffableAttr->setCheckedParameterIndices(builder.build(C));
+    }
   }
 
   // The implicit memberwise constructor must be explicitly created so that it

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+public struct Foo : Differentiable {
+  public var a: Float
+}
+
+// CHECK-LABEL: public struct Foo : Differentiable {
+// CHECK:   @sil_stored @differentiable()
+// CHECK:   public var a: Float { get set }
+
+// CHECK-LABEL: // Foo.a.getter
+// CHECK: sil [transparent] [serialized] [differentiable source 0 wrt 0] @$s33derived_differentiable_properties3FooV1aSfvg : $@convention(method) (Foo) -> Float
+
+


### PR DESCRIPTION
In `Differentiable` derived conformances, when a stored property is added to the tangent/cotangent space and has public effective access, add a `@differentiable` attribute to the property so that the differentiation transform will synthesize a JVP and a VJP for it in order for cross-module differentiation through stored property accesses to work.