### PR TITLE
[TF API] Make Tensor reduction ops return a Tensor.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -909,17 +909,17 @@ public extension Tensor where Scalar : Numeric & Comparable {
   // NOTE: This overload is necessary, otherwise `min()` would refer
   // to the variadic method `min(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func min() -> Scalar {
+  func min() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.min(self, reductionIndices: axes).handle)
+    return Raw.min(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `max()` would refer
   // to the variadic method `max(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func max() -> Scalar {
+  func max() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.max(self, reductionIndices: axes).handle)
+    return Raw.max(self, reductionIndices: axes)
   }
 
   /// Returns the maximum values along the specified axes. The reduced
@@ -978,14 +978,14 @@ public extension Tensor where Scalar : Numeric & Comparable {
 
   /// Returns the index of the maximum value of the flattened scalars.
   @inlinable @inline(__always)
-  func argmax() -> Int32 {
-    return _TFGetScalarOrDie(flattened().argmax(squeezingAxis: 0).handle)
+  func argmax() -> Tensor<Int32> {
+    return flattened().argmax(squeezingAxis: 0)
   }
 
   /// Returns the index of the minimum value of the flattened scalars.
   @inlinable @inline(__always)
-  func argmin() -> Int32 {
-    return _TFGetScalarOrDie(flattened().argmin(squeezingAxis: 0).handle)
+  func argmin() -> Tensor<Int32> {
+    return flattened().argmin(squeezingAxis: 0)
   }
 }
 
@@ -993,25 +993,25 @@ public extension Tensor where Scalar : Numeric {
   // NOTE: This overload is necessary, otherwise `mean()` would refer
   // to the variadic method `mean(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func mean() -> Scalar {
+  func mean() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.mean(self, reductionIndices: axes).handle)
+    return Raw.mean(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func sum() -> Scalar {
+  func sum() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.sum(self, reductionIndices: axes).handle)
+    return Raw.sum(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func product() -> Scalar {
+  func product() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.prod(self, reductionIndices: axes).handle)
+    return Raw.prod(self, reductionIndices: axes)
   }
 
   /// Returns the arithmetic mean along the specified axes. The reduced

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -141,7 +141,7 @@ public func sinkTensorToScalarCrash() {
 
   for _ in 0...10000 {
     w2 -= w1
-    loss = w2.mean()
+    loss = w2.mean().scalarized()
   }
 
   opaqueGenericFunction(loss)

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -75,8 +75,8 @@ public func testSigmoid(x: Tensor<Float>, y: Tensor<Float>) -> (Tensor<Float>, T
 // Likewise, mean and max shouldn't cause send/receive errors.
 public func testMeanMax(x: Tensor<Float>) -> Float {
   let y = x.toAccelerator()
-  let a = y.mean()
-  let b = y.max()
+  let a = y.mean().scalarized()
+  let b = y.max().scalarized()
   return a+b
 }
 
@@ -96,12 +96,12 @@ public func randomUniformHoisting() -> Tensor<Float> {
   return (x+y+z).toHost()
 }
 
-// Here ".mean()" contains a tensor2scalar operation, and we then convert that
-// scalar back to a tensor.  This checks to make sure that tf-partition can pull
-// this whole mess in graph without leaving anything on the host that will cause
-// a send/receive.
+// Here ".mean().scalarized()" contains a tensor2scalar operation, and we then 
+// convert that scalar back to a tensor.  This checks to make sure that tf-partition 
+// can pull this whole mess in graph without leaving anything on the host that will 
+// cause a send/receive.
 public func tensorToScalarToTensor(a: Tensor<Int32>) -> Tensor<Int32> {
-  let scalar = a.toAccelerator().mean()
+  let scalar = a.toAccelerator().mean().scalarized()
   let b = Tensor(scalar)
   return (b+b).toHost()
 }

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -255,7 +255,7 @@ TensorTests.testAllBackends("ArgMax") {
   let scalarsArgmax = x.argmax()
   expectEqual(ShapedArray(shape: [3], scalars: [1, 1, 1]), argmax0.array)
   expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), argmax1.array)
-  expectEqual(5, scalarsArgmax)
+  expectEqual(ShapedArray(shape: [], scalars: [5]), scalarsArgmax.array)
 }
 
 TensorTests.testAllBackends("CeilFloor") {


### PR DESCRIPTION
@lattner requested that `Tensor` reduction ops return a `Tensor` so that execution can be more easily traced.