### PR TITLE
[TF API] Align TF comparison/equality operators with SE-0229 (SIMD).

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -87,9 +87,9 @@ extension Tensor where Scalar : Numeric {
 func _adjointMinMax<T : Numeric & Comparable>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
-  let denom = 1 + Tensor<T>(x.elementsEqual(y))
-  let dfdx = seed * Tensor<T>(x.elementsEqual(originalValue)) / denom
-  let dfdy = seed * Tensor<T>(y.elementsEqual(originalValue)) / denom
+  let denom = 1 + Tensor<T>(x .== y)
+  let dfdx = seed * Tensor<T>(x .== originalValue) / denom
+  let dfdy = seed * Tensor<T>(y .== originalValue) / denom
   return (dfdx.unbroadcast(like: x), dfdy.unbroadcast(like: y))
 }
 
@@ -451,5 +451,5 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 func _adjointRelu<T : BinaryFloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
-  return Tensor(x.elementsGreater(0)) * seed
+  return Tensor(x .> 0) * seed
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -909,17 +909,17 @@ public extension Tensor where Scalar : Numeric & Comparable {
   // NOTE: This overload is necessary, otherwise `min()` would refer
   // to the variadic method `min(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func min() -> Scalar {
+  func min() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.min(self, reductionIndices: axes).handle)
+    return Raw.min(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `max()` would refer
   // to the variadic method `max(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func max() -> Scalar {
+  func max() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.max(self, reductionIndices: axes).handle)
+    return Raw.max(self, reductionIndices: axes)
   }
 
   /// Returns the maximum values along the specified axes. The reduced
@@ -978,14 +978,14 @@ public extension Tensor where Scalar : Numeric & Comparable {
 
   /// Returns the index of the maximum value of the flattened scalars.
   @inlinable @inline(__always)
-  func argmax() -> Int32 {
-    return _TFGetScalarOrDie(flattened().argmax(squeezingAxis: 0).handle)
+  func argmax() -> Tensor<Int32> {
+    return flattened().argmax(squeezingAxis: 0)
   }
 
   /// Returns the index of the minimum value of the flattened scalars.
   @inlinable @inline(__always)
-  func argmin() -> Int32 {
-    return _TFGetScalarOrDie(flattened().argmin(squeezingAxis: 0).handle)
+  func argmin() -> Tensor<Int32> {
+    return flattened().argmin(squeezingAxis: 0)
   }
 }
 
@@ -993,25 +993,25 @@ public extension Tensor where Scalar : Numeric {
   // NOTE: This overload is necessary, otherwise `mean()` would refer
   // to the variadic method `mean(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func mean() -> Scalar {
+  func mean() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.mean(self, reductionIndices: axes).handle)
+    return Raw.mean(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func sum() -> Scalar {
+  func sum() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.sum(self, reductionIndices: axes).handle)
+    return Raw.sum(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
-  func product() -> Scalar {
+  func product() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.prod(self, reductionIndices: axes).handle)
+    return Raw.prod(self, reductionIndices: axes)
   }
 
   /// Returns the arithmetic mean along the specified axes. The reduced

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -40,6 +40,13 @@
 
 infix operator ++ : AdditionPrecedence
 
+infix operator .< : ComparisonPrecedence
+infix operator .<= : ComparisonPrecedence
+infix operator .>= : ComparisonPrecedence
+infix operator .> : ComparisonPrecedence
+infix operator .== : ComparisonPrecedence
+infix operator .!= : ComparisonPrecedence
+
 // TODO:
 // - Consider explicit broadcasting for elementwise binary ops when
 //   scalarization and rank getter are implemented.
@@ -104,6 +111,7 @@ extension Tensor : ShapedVectorNumeric where Scalar : Numeric {}
 extension Tensor : Differentiable where Scalar : FloatingPoint {
   public typealias TangentVector = Tensor
   public typealias CotangentVector = Tensor
+  @inlinable @inline(__always)
   public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
   }
@@ -307,52 +315,96 @@ public extension Tensor where Scalar : Numeric {
 //===----------------------------------------------------------------------===//
 
 public extension Tensor where Scalar : Numeric & Comparable {
-  /// Computes `self < other` element-wise.
+  /// Computes `lhs < rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
   @inlinable @inline(__always)
-  func elementsLess(_ other: Tensor) -> Tensor<Bool> {
-    return Raw.less(self, other)
+  static func .< (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.less(lhs, rhs)
   }
 
-  /// Computes `self < other`, broadcasting `other`.
+  /// Computes `lhs <= rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
   @inlinable @inline(__always)
-  func elementsLess(_ other: Scalar) -> Tensor<Bool> {
-    return elementsLess(Tensor(other))
+  static func .<= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.lessEqual(lhs, rhs)
   }
 
-  /// Computes `self <= other` element-wise.
+  /// Computes `lhs > rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
   @inlinable @inline(__always)
-  func elementsLessOrEqual(_ other: Tensor) -> Tensor<Bool> {
-    return Raw.lessEqual(self, other)
+  static func .> (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.greater(lhs, rhs)
   }
 
-  /// Computes `self <= other`, broadcasting `other`.
+  /// Computes `lhs >= rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
   @inlinable @inline(__always)
-  func elementsLessOrEqual(_ other: Scalar) -> Tensor<Bool> {
-    return elementsLessOrEqual(Tensor(other))
+  static func .>= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.greaterEqual(lhs, rhs)
   }
 
-  /// Computes `self > other` element-wise.
+  /// Computes `lhs < rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.<` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsGreater(_ other: Tensor) -> Tensor<Bool> {
-    return Raw.greater(self, other)
+  static func .< (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.less(Tensor(lhs), rhs)
   }
 
-  /// Computes `self > other`, broadcasting `other`.
+  /// Computes `lhs <= rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.<=` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsGreater(_ other: Scalar) -> Tensor<Bool> {
-    return elementsGreater(Tensor(other))
+  static func .<= (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.lessEqual(Tensor(lhs), rhs)
   }
 
-  /// Computes `self >= other` element-wise.
+  /// Computes `lhs > rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.>` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsGreaterOrEqual(_ other: Tensor) -> Tensor<Bool> {
-    return Raw.greaterEqual(self, other)
+  static func .> (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.greater(Tensor(lhs), rhs)
   }
 
-  /// Computes `self >= other`, broadcasting `other`.
+  /// Computes `lhs >= rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.>=` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsGreaterOrEqual(_ other: Scalar) -> Tensor<Bool> {
-    return elementsGreaterOrEqual(Tensor(other))
+  static func .>= (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.greaterEqual(Tensor(lhs), rhs)
+  }
+
+  /// Computes `lhs < rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.<` supports broadcasting.
+  @inlinable @inline(__always)
+  static func .< (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
+    return Raw.less(lhs, Tensor(rhs))
+  }
+
+  /// Computes `lhs <= rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.<=` supports broadcasting.
+  @inlinable @inline(__always)
+  static func .<= (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
+    return Raw.lessEqual(lhs, Tensor(rhs))
+  }
+
+  /// Computes `lhs > rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.>` supports broadcasting.
+  @inlinable @inline(__always)
+  static func .> (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
+    return Raw.greater(lhs, Tensor(rhs))
+  }
+
+  /// Computes `lhs >= rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.>=` supports broadcasting.
+  @inlinable @inline(__always)
+  static func .>= (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
+    return Raw.greaterEqual(lhs, Tensor(rhs))
   }
 }
 
@@ -361,28 +413,28 @@ extension Tensor : Comparable where Scalar : Numeric & Comparable {
   /// is lexicographically less than that of the second argument.
   @inlinable @inline(__always)
   public static func < (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsLess(rhs).all()
+    return (lhs .< rhs).all()
   }
 
   /// Returns a Boolean value indicating whether the value of the first argument
   /// is lexicographically less than or equal to that of the second argument.
   @inlinable @inline(__always)
   public static func <= (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsLessOrEqual(rhs).all()
+    return (lhs .<= rhs).all()
   }
 
   /// Returns a Boolean value indicating whether the value of the first argument
   /// is lexicographically greater than that of the second argument.
   @inlinable @inline(__always)
   public static func > (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsGreater(rhs).all()
+    return (lhs .> rhs).all()
   }
 
   /// Returns a Boolean value indicating whether the value of the first argument
   /// is lexicographically greater than or equal to that of the second argument.
   @inlinable @inline(__always)
   public static func >= (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsGreaterOrEqual(rhs).all()
+    return (lhs .>= rhs).all()
   }
 }
 
@@ -391,56 +443,78 @@ public extension Tensor where Scalar : Numeric & Comparable {
   /// is lexicographically less than that of the second argument.
   @inlinable @inline(__always)
   static func < (lhs: Tensor, rhs: Scalar) -> Bool {
-    return lhs.elementsLess(rhs).all()
+    return (lhs .< rhs).all()
   }
 
   /// Returns a Boolean value indicating whether the value of the first argument
   /// is lexicographically less than or equal to that of the second argument.
   @inlinable @inline(__always)
   static func <= (lhs: Tensor, rhs: Scalar) -> Bool {
-    return lhs.elementsLessOrEqual(rhs).all()
+    return (lhs .<= rhs).all()
   }
 
   /// Returns a Boolean value indicating whether the value of the first argument
   /// is lexicographically greater than that of the second argument.
   @inlinable @inline(__always)
   static func > (lhs: Tensor, rhs: Scalar) -> Bool {
-    return lhs.elementsGreater(rhs).all()
+    return (lhs .> rhs).all()
   }
 
   /// Returns a Boolean value indicating whether the value of the first argument
   /// is lexicographically greater than or equal to that of the second argument.
   @inlinable @inline(__always)
   static func >= (lhs: Tensor, rhs: Scalar) -> Bool {
-    return lhs.elementsGreaterOrEqual(rhs).all()
+    return (lhs .>= rhs).all()
   }
 }
 
 public extension Tensor where Scalar : Equatable {
-  /// Computes `self == other` element-wise.
-  /// - Note: `elementsEqual` supports broadcasting.
+  /// Computes `lhs != rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.==` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsEqual(_ other: Tensor) -> Tensor<Bool> {
-    return Raw.equal(self, other)
+  static func .==(lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.equal(lhs, rhs)
   }
 
-  /// Computes `self == other` element-wise, broadcasting `other`.
+  /// Computes `lhs != rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.!=` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsEqual(_ other: Scalar) -> Tensor<Bool> {
-    return elementsEqual(Tensor(other))
+  static func .!=(lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
+    return Raw.notEqual(lhs, rhs)
   }
 
-  /// Computes `self != other` element-wise.
-  /// - Note: `elementsNotEqual` supports broadcasting.
+  /// Computes `lhs == rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.==` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsNotEqual(_ other: Tensor) -> Tensor<Bool> {
-    return Raw.notEqual(self, other)
+  static func .==(lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
+    return Tensor(lhs) .== rhs
   }
 
-  /// Computes `self != other` element-wise, broadcasting `other`.
+  /// Computes `lhs != rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.!=` supports broadcasting.
   @inlinable @inline(__always)
-  func elementsNotEqual(_ other: Scalar) -> Tensor<Bool> {
-    return elementsNotEqual(Tensor(other))
+  static func .!=(lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
+    return Tensor(lhs) .!= rhs
+  }
+
+  /// Computes `lhs == rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.==` supports broadcasting.
+  @inlinable @inline(__always)
+  static func .==(lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
+    return lhs .== Tensor(rhs)
+  }
+
+  /// Computes `lhs != rhs` element-wise and returns a `Tensor` of Boolean
+  /// scalars.
+  /// - Note: `.!=` supports broadcasting.
+  @inlinable @inline(__always)
+  static func .!=(lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
+    return lhs .!= Tensor(rhs)
   }
 }
 
@@ -1133,7 +1207,7 @@ public extension Tensor where Scalar : Numeric {
     let rankDiff = (rankTensor - otherShape.scalarCountTensor).rankLifted()
     let ones: Tensor<Int32> = Raw.fill(dims: rankDiff, value: Tensor<Int32>(1))
     let paddedShape = ones ++ otherShape
-    let nonEqualIndices = paddedShape.elementsNotEqual(shapeTensor)
+    let nonEqualIndices = paddedShape .!= shapeTensor
     let broadcastIndices = Raw.where_(nonEqualIndices).flattened()
     let unbroadcasted: Tensor = Raw.sum(
       self, reductionIndices: Tensor<Int32>(broadcastIndices), keepDims: false)

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -886,12 +886,12 @@ public extension TensorFlowScalar {
 extension Tensor : Equatable where Scalar : Equatable {
   @inlinable @inline(__always)
   public static func == (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsEqual(rhs).all()
+    return (lhs .== rhs).all()
   }
 
   @inlinable @inline(__always)
   public static func != (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsNotEqual(rhs).any()
+    return (lhs .== rhs).any()
   }
 }
 

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -141,7 +141,7 @@ public func sinkTensorToScalarCrash() {
 
   for _ in 0...10000 {
     w2 -= w1
-    loss = w2.mean()
+    loss = w2.mean().scalarized()
   }
 
   opaqueGenericFunction(loss)

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -199,7 +199,7 @@ public func testShapeList2() {
 
 @TensorFlowGraph
 func isZero(_ x: Tensor<Float>) -> Tensor<Bool> {
-  return x.elementsEqual(Tensor<Float>(0));
+  return x .== Tensor<Float>(0)
 }
 
 public func noescapeFuncAsAttr(_ f: @convention(tensorflow) (Tensor<Float>) -> Tensor<Bool>) {

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -75,8 +75,8 @@ public func testSigmoid(x: Tensor<Float>, y: Tensor<Float>) -> (Tensor<Float>, T
 // Likewise, mean and max shouldn't cause send/receive errors.
 public func testMeanMax(x: Tensor<Float>) -> Float {
   let y = x.toAccelerator()
-  let a = y.mean()
-  let b = y.max()
+  let a = y.mean().scalarized()
+  let b = y.max().scalarized()
   return a+b
 }
 
@@ -96,12 +96,12 @@ public func randomUniformHoisting() -> Tensor<Float> {
   return (x+y+z).toHost()
 }
 
-// Here ".mean()" contains a tensor2scalar operation, and we then convert that
-// scalar back to a tensor.  This checks to make sure that tf-partition can pull
-// this whole mess in graph without leaving anything on the host that will cause
-// a send/receive.
+// Here ".mean().scalarized()" contains a tensor2scalar operation, and we then 
+// convert that scalar back to a tensor.  This checks to make sure that tf-partition 
+// can pull this whole mess in graph without leaving anything on the host that will 
+// cause a send/receive.
 public func tensorToScalarToTensor(a: Tensor<Int32>) -> Tensor<Int32> {
-  let scalar = a.toAccelerator().mean()
+  let scalar = a.toAccelerator().mean().scalarized()
   let b = Tensor(scalar)
   return (b+b).toHost()
 }

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -255,7 +255,7 @@ TensorTests.testAllBackends("ArgMax") {
   let scalarsArgmax = x.argmax()
   expectEqual(ShapedArray(shape: [3], scalars: [1, 1, 1]), argmax0.array)
   expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), argmax1.array)
-  expectEqual(5, scalarsArgmax)
+  expectEqual(ShapedArray(shape: [], scalars: [5]), scalarsArgmax.array)
 }
 
 TensorTests.testAllBackends("CeilFloor") {

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -238,7 +238,7 @@ TensorTests.testAllBackends("Concatenation") {
 TensorTests.test("EwiseComparison") {
   let x = Tensor<Float>([0, 1, 2])
   let y = Tensor<Float>([2, 1, 3])
-  expectEqual(x.elementsLess(y).scalars, [true, false, true])
+  expectEqual((x .< y).scalars, [true, false, true])
 }
 
 TensorTests.test("LexicographicalComparison") {


### PR DESCRIPTION
A while ago in #18440, we changed normal comparison operators and equality operators (`<`, `<=`, etc) to methods like `elementsLess(_:)` to align normal comparison opreators with programmers' mental model and to wait for a community decision on what operators we should use for elementwise comparison and equality. Obviously, that decision has been made via the acceptance of [SE-0229](https://github.com/apple/swift-evolution/blob/master/proposals/0229-simd.md).

This patch changes those methods to dot-prefixed operators (`.<`, `.<=`, etc) to follow the naming convention of official Swift vector libraries.