### PR TITLE
[5.0][Parse] Eliminate backtracking in collection expression parsing

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1333,8 +1333,7 @@ public:
   ParserResult<Expr> parseExprCallSuffix(ParserResult<Expr> fn,
                                          bool isExprBasic);
   ParserResult<Expr> parseExprCollection();
-  ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc);
-  ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc);
+  ParserResult<Expr> parseExprCollectionElement(Optional<bool> &isDictionary);
   ParserResult<Expr> parseExprPoundAssert();
   ParserResult<Expr> parseExprPoundUnknown(SourceLoc LSquareLoc);
   ParserResult<Expr>

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -110,7 +110,7 @@ func testDefaultExistentials() {
 // SR-4952, rdar://problem/32330004 - Assertion failure during swift::ASTVisitor<::FailureDiagnosis,...>::visit
 func rdar32330004_1() -> [String: Any] {
   return ["a""one": 1, "two": 2, "three": 3] // expected-note {{did you mean to use a dictionary literal instead?}}
-  // expected-error@-1 2 {{expected ',' separator}}
+  // expected-error@-1 {{expected ',' separator}}
   // expected-error@-2 {{dictionary of type '[String : Any]' cannot be used with array literal}}
 }
 

--- a/test/Profiler/coverage_closures.swift
+++ b/test/Profiler/coverage_closures.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_closures %s | %FileCheck %s
 
 func bar(arr: [(Int32) -> Int32]) {
-// CHECK-LABEL: sil_coverage_map {{.*}}// closure #2 (Swift.Int32) -> Swift.Int32 in coverage_closures.bar
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int32) -> Swift.Int32 in coverage_closures.bar
 // CHECK-NEXT:  [[@LINE+1]]:13 -> [[@LINE+1]]:42 : 0
   for a in [{ (b : Int32) -> Int32 in b }] {
     a(0)

--- a/test/SILGen/local_types.swift
+++ b/test/SILGen/local_types.swift
@@ -1,10 +1,22 @@
 // RUN: %target-swift-emit-silgen  -parse-as-library -enable-sil-ownership %s -verify | %FileCheck %s
 // RUN: %target-swift-emit-ir  -parse-as-library -enable-sil-ownership %s
 
-func function() {
+func function1() {
   return
 
   class UnreachableClass {} // expected-warning {{code after 'return' will never be executed}}
 }
+
+func function2() {
+  let _ = [
+    {
+      struct S {
+        var x = 0
+      }
+    }
+  ]
+}
+
+// CHECK-LABEL: sil private [transparent] @$s11local_types9function2yyFyycfU_1SL_V1xSivpfi : $@convention(thin) () -> Int
 
 // CHECK-LABEL: sil_vtable UnreachableClass

--- a/test/Syntax/diagnostics_verify.swift
+++ b/test/Syntax/diagnostics_verify.swift
@@ -9,7 +9,7 @@ if true {
 if false {
   [.]
   // expected-error@-1 {{expected identifier after '.' expression}}
-  // expected-error@-2 2 {{unknown expression syntax exists in the source}}
+  // expected-error@-2 {{unknown expression syntax exists in the source}}
 }
 
 class { // expected-error {{unknown declaration syntax exists in the source}}

--- a/validation-test/compiler_scale/parse_array_nested.swift.gyb
+++ b/validation-test/compiler_scale/parse_array_nested.swift.gyb
@@ -1,0 +1,9 @@
+// RUN: %scale-test -parse --begin 0 --end 10 --step 1 --select NumASTBytes %s
+
+ %for i in range(1, N + 1):
+ [
+ %end
+   1
+ %for i in range(1, N + 1):
+ ]
+ %end


### PR DESCRIPTION
(Cherry picked from #21487 )

Parsing collection literal expression used to take exponential time depending on the nesting level of the first element.

Stop using `parseList()` because using it complicates libSyntax parsing.

rdar://problem/45221238 / https://bugs.swift.org/browse/SR-9220
rdar://problem/38913395 / https://bugs.swift.org/browse/SR-7283
