### PR TITLE
[AD] Serialize/type-check differentiable attribute trailing where clauses.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2688,8 +2688,6 @@ ERROR(differentiable_attr_specified_not_function,none,
 ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "ambiguous or overloaded identifier %0 cannot be used in @differentiable "
       "attribute", (DeclName))
-ERROR(differentiable_attr_forward_mode_unsupported,none,
-      "forward-mode automatic differentiation is not supported yet", ())
 ERROR(differentiable_attr_invalid_access,none,
       "associated differentiation function %0 is required to either be public "
       "or @usableFromInline because the original function %1 is public or "
@@ -2700,6 +2698,16 @@ ERROR(differentiable_attr_wrt_not_differentiable,none,
 ERROR(differentiable_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
+ERROR(differentiable_attr_empty_where_clause,none,
+      "empty 'where' clause in @differentiable attribute", ())
+ERROR(differentiable_attr_nongeneric_trailing_where,none,
+      "trailing 'where' clause in @differentiable attribute of non-generic function %0", (DeclName))
+ERROR(differentiable_attr_only_generic_param_req,none,
+      "only requirements on generic parameters are supported by @differentiable attribute", ())
+ERROR(differentiable_attr_non_protocol_type_constraint_req,none,
+      "only conformances to protocol types are supported by @differentiable attribute", ())
+ERROR(differentiable_attr_unsupported_req_kind,none,
+      "layout requirement are not supported by @differentiable attribute", ())
 
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -221,7 +221,10 @@ struct WhereClauseOwner {
 
   /// The source of the where clause, which can be a generic parameter list
   /// or a declaration that can have a where clause.
-  llvm::PointerUnion3<GenericParamList *, Decl *, SpecializeAttr *> source;
+  llvm::PointerUnion4<GenericParamList *, Decl *, SpecializeAttr *,
+                      // SWIFT_ENABLE_TENSORFLOW
+                      DifferentiableAttr *>
+      source;
 
   WhereClauseOwner(Decl *decl);
 
@@ -230,6 +233,10 @@ struct WhereClauseOwner {
 
   WhereClauseOwner(DeclContext *dc, SpecializeAttr *attr)
     : dc(dc), source(attr) { }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  WhereClauseOwner(DeclContext *dc, DifferentiableAttr *attr)
+    : dc(dc), source(attr) {}
 
   SourceLoc getLoc() const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3108,11 +3108,13 @@ public:
   AnyFunctionType *getAutoDiffAssociatedFunctionType(
       AutoDiffParameterIndices *indices, unsigned resultIndex,
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
-      LookupConformanceFn lookupConformance);
+      LookupConformanceFn lookupConformance,
+      GenericSignature *whereClauseGenericSignature = nullptr);
 
   AnyFunctionType *getAutoDiffAdjointFunctionType(
       AutoDiffParameterIndices *indices, const TupleType *primalResultTy,
-      LookupConformanceFn lookupConformance, bool isMethod);
+      LookupConformanceFn lookupConformance, bool isMethod,
+      GenericSignature *whereClauseGenericSignature = nullptr);
 
   /// \brief True if this type allows an implicit conversion from a function
   /// argument expression of type T to a function of type () -> T.
@@ -4175,7 +4177,8 @@ public:
   CanSILFunctionType getAutoDiffAssociatedFunctionType(
       const SmallBitVector &parameterIndices, unsigned resultIndex,
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
-      SILModule &module, LookupConformanceFn lookupConformance);
+      SILModule &module, LookupConformanceFn lookupConformance,
+      GenericSignature *whereClauseGenericSignature = nullptr);
 
   /// Returns a bit vector that specifices which parameters you can
   /// differentiate with respect to for this differentiable function type. (e.g.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -262,6 +262,7 @@ SourceLoc WhereClauseOwner::getLoc() const {
   if (auto attr = source.dyn_cast<SpecializeAttr *>())
     return attr->getLocation();
 
+  // SWIFT_ENABLE_TENSORFLOW
   if (auto attr = source.dyn_cast<DifferentiableAttr *>())
     return attr->getLocation();
 
@@ -300,7 +301,7 @@ RequirementRequest::getRequirements(WhereClauseOwner owner) {
   if (auto attr = owner.source.dyn_cast<SpecializeAttr *>()) {
     if (auto whereClause = attr->getTrailingWhereClause())
       return whereClause->getRequirements();
-
+    
     return { };
   }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -262,6 +262,9 @@ SourceLoc WhereClauseOwner::getLoc() const {
   if (auto attr = source.dyn_cast<SpecializeAttr *>())
     return attr->getLocation();
 
+  if (auto attr = source.dyn_cast<DifferentiableAttr *>())
+    return attr->getLocation();
+
   return source.get<GenericParamList *>()->getWhereLoc();
 }
 
@@ -297,8 +300,15 @@ RequirementRequest::getRequirements(WhereClauseOwner owner) {
   if (auto attr = owner.source.dyn_cast<SpecializeAttr *>()) {
     if (auto whereClause = attr->getTrailingWhereClause())
       return whereClause->getRequirements();
-    
+
     return { };
+  }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  if (auto attr = owner.source.dyn_cast<DifferentiableAttr *>()) {
+    if (auto whereClause = attr->getWhereClause())
+      return whereClause->getRequirements();
+    return {};
   }
 
   auto decl = owner.source.dyn_cast<Decl *>();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1079,7 +1079,7 @@ bool Parser::parseDifferentiableAttributeArguments(
     SmallVector<RequirementRepr, 4> requirements;
     bool firstTypeInComplete;
     parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete,
-                            /*AllowLayoutConstraints=*/true);
+                            /*AllowLayoutConstraints=*/false);
     whereClause = TrailingWhereClause::create(Context, whereLoc, requirements);
   }
   return false;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -180,10 +180,8 @@ namespace {
                                 GenericEnvironment *GenericEnv = nullptr,
                                 DeclContext *DC = nullptr);
 
-    /*
     void convertRequirements(SILFunction *F, ArrayRef<RequirementRepr> From,
                              SmallVectorImpl<Requirement> &To);
-     */
 
     ProtocolConformance *
     parseProtocolConformanceHelper(ProtocolDecl *&proto,
@@ -195,10 +193,6 @@ namespace {
         : P(P), SILMod(static_cast<SILParserTUState *>(P.SIL)->M),
           TUState(*static_cast<SILParserTUState *>(P.SIL)),
           ParsedTypeCallback([](Type ty) {}) {}
-
-    // SWIFT_ENABLE_TENSORFLOW
-    void convertRequirements(SILFunction *F, ArrayRef<RequirementRepr> From,
-                             SmallVectorImpl<Requirement> &To);
 
     /// diagnoseProblems - After a function is fully parse, emit any diagnostics
     /// for errors and return true if there were any.

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5952,8 +5952,11 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
 
       // SWIFT_ENABLE_TENSORFLOW
       for (auto &attr : DiffAttrs) {
+        // Resolve where clause requirements.
+        // If no where clause, continue.
+        if (!attr->getWhereClause())
+          continue;
         SmallVector<Requirement, 2> requirements;
-        // Resolve types and convert requirements.
         FunctionState.convertRequirements(
             FunctionState.F, attr->getWhereClause()->getRequirements(),
             requirements);

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -63,10 +63,26 @@ SILDifferentiableAttr(const SILAutoDiffIndices &indices,
                       StringRef adjointName,
                       bool adjointIsPrimitive,
                       StringRef jvpName,
-                      StringRef vjpName)
+                      StringRef vjpName,
+                      TrailingWhereClause *whereClause)
   : indices(indices), PrimalName(primalName), AdjointName(adjointName),
-    AdjointIsPrimitive(adjointIsPrimitive), JVPName(jvpName), VJPName(vjpName)
-    {}
+    AdjointIsPrimitive(adjointIsPrimitive), JVPName(jvpName), VJPName(vjpName),
+    WhereClause(whereClause),
+    NumRequirements(whereClause->getRequirements().size()) {}
+
+SILDifferentiableAttr::
+SILDifferentiableAttr(const SILAutoDiffIndices &indices,
+                      StringRef primalName,
+                      StringRef adjointName,
+                      bool adjointIsPrimitive,
+                      StringRef jvpName,
+                      StringRef vjpName,
+                      ArrayRef<Requirement> requirements)
+  : indices(indices), PrimalName(primalName), AdjointName(adjointName),
+    AdjointIsPrimitive(adjointIsPrimitive), JVPName(jvpName), VJPName(vjpName),
+    NumRequirements(requirements.size()) {
+  std::copy(requirements.begin(), requirements.end(), getRequirementsData());
+}
 
 SILDifferentiableAttr *
 SILDifferentiableAttr::create(SILModule &M,
@@ -75,12 +91,47 @@ SILDifferentiableAttr::create(SILModule &M,
                               StringRef adjointName,
                               bool adjointIsPrimitive,
                               StringRef jvpName,
-                              StringRef vjpName) {
-  void *mem = M.allocate(sizeof(SILDifferentiableAttr),
-                         alignof(SILDifferentiableAttr));
+                              StringRef vjpName,
+                              TrailingWhereClause *whereClause) {
+  unsigned size = sizeof(SILDifferentiableAttr) +
+      whereClause->getRequirements().size() * sizeof(Requirement);
+  void *mem = M.allocate(size, alignof(SILDifferentiableAttr));
   return ::new (mem)
       SILDifferentiableAttr(indices, primalName, adjointName,
-                            adjointIsPrimitive, jvpName, vjpName);
+                            adjointIsPrimitive, jvpName, vjpName, whereClause);
+}
+
+SILDifferentiableAttr *
+SILDifferentiableAttr::create(SILModule &M,
+                              const SILAutoDiffIndices &indices,
+                              ArrayRef<Requirement> requirements,
+                              StringRef primalName,
+                              StringRef adjointName,
+                              bool adjointIsPrimitive,
+                              StringRef jvpName,
+                              StringRef vjpName) {
+  unsigned size = sizeof(SILDifferentiableAttr) +
+      requirements.size() * sizeof(Requirement);
+  void *mem = M.allocate(size, alignof(SILDifferentiableAttr));
+  return ::new (mem)
+      SILDifferentiableAttr(indices, primalName, adjointName,
+                            adjointIsPrimitive, jvpName, vjpName, requirements);
+}
+
+void SILDifferentiableAttr::setRequirements(
+    ArrayRef<Requirement> requirements) {
+  unsigned numClauseRequirements =
+      WhereClause ? WhereClause->getRequirements().size() : 0;
+  assert(requirements.size() <= numClauseRequirements &&
+         "Requirements size must not exceed number of requirements used for "
+         "allocation");
+  NumRequirements = numClauseRequirements;
+  std::copy(requirements.begin(), requirements.end(), getRequirementsData());
+}
+
+void SILFunction::addDifferentiableAttr(SILDifferentiableAttr *attr) {
+  attr->Original = this;
+  DifferentiableAttrs.push_back(attr);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -68,7 +68,7 @@ SILDifferentiableAttr(const SILAutoDiffIndices &indices,
   : indices(indices), PrimalName(primalName), AdjointName(adjointName),
     AdjointIsPrimitive(adjointIsPrimitive), JVPName(jvpName), VJPName(vjpName),
     WhereClause(whereClause),
-    NumRequirements(whereClause->getRequirements().size()) {}
+    NumRequirements(whereClause ? whereClause->getRequirements().size() : 0) {}
 
 SILDifferentiableAttr::
 SILDifferentiableAttr(const SILAutoDiffIndices &indices,
@@ -93,12 +93,14 @@ SILDifferentiableAttr::create(SILModule &M,
                               StringRef jvpName,
                               StringRef vjpName,
                               TrailingWhereClause *whereClause) {
-  unsigned size = sizeof(SILDifferentiableAttr) +
-      whereClause->getRequirements().size() * sizeof(Requirement);
+  unsigned size = sizeof(SILDifferentiableAttr);
+  if (whereClause)
+    size += whereClause->getRequirements().size() * sizeof(Requirement);
   void *mem = M.allocate(size, alignof(SILDifferentiableAttr));
   return ::new (mem)
       SILDifferentiableAttr(indices, primalName, adjointName,
-                            adjointIsPrimitive, jvpName, vjpName, whereClause);
+                            adjointIsPrimitive, jvpName, vjpName,
+                            whereClause);
 }
 
 SILDifferentiableAttr *
@@ -115,7 +117,8 @@ SILDifferentiableAttr::create(SILModule &M,
   void *mem = M.allocate(size, alignof(SILDifferentiableAttr));
   return ::new (mem)
       SILDifferentiableAttr(indices, primalName, adjointName,
-                            adjointIsPrimitive, jvpName, vjpName, requirements);
+                            adjointIsPrimitive, jvpName, vjpName,
+                            requirements);
 }
 
 void SILDifferentiableAttr::setRequirements(

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3219,7 +3219,7 @@ void SILDifferentiableAttr::print(llvm::raw_ostream &OS) const {
          return;
       }
       // Use GenericEnvironment to produce user-friendly
-      // names instead of something like t_0_0.
+      // names instead of something like 't_0_0'.
       auto FirstTy = genericEnv->getSugaredType(req.getFirstType());
       if (req.getKind() != RequirementKind::Layout) {
         auto SecondTy =

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3207,6 +3207,34 @@ void SILDifferentiableAttr::print(llvm::raw_ostream &OS) const {
   if (!VJPName.empty()) {
     OS << " vjp @" << VJPName;
   }
+  if (!getRequirements().empty()) {
+    OS << " where ";
+    SILFunction *original = getOriginal();
+    assert(original);
+    auto genericEnv = original->getGenericEnvironment();
+    PrintOptions SubPrinter = PrintOptions::printSIL();
+    interleave(getRequirements(), [&](Requirement req) {
+      if (!genericEnv) {
+         req.print(OS, SubPrinter);
+         return;
+      }
+      // Use GenericEnvironment to produce user-friendly
+      // names instead of something like t_0_0.
+      auto FirstTy = genericEnv->getSugaredType(req.getFirstType());
+      if (req.getKind() != RequirementKind::Layout) {
+        auto SecondTy =
+        genericEnv->getSugaredType(req.getSecondType());
+        Requirement ReqWithDecls(req.getKind(), FirstTy, SecondTy);
+        ReqWithDecls.print(OS, SubPrinter);
+      } else {
+        Requirement ReqWithDecls(req.getKind(), FirstTy,
+                                 req.getLayoutConstraint());
+        ReqWithDecls.print(OS, SubPrinter);
+      }
+    }, [&] {
+      OS << ", ";
+    });
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -773,7 +773,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       AFD->getInterfaceType()->castTo<AnyFunctionType>());
   SILAutoDiffIndices indices(/*source*/ 0, paramIndices);
   silOriginalFn->addDifferentiableAttr(SILDifferentiableAttr::create(
-      M, indices, primName, adjName,
+      M, indices, diffAttr->getRequirements(), primName, adjName,
       /*primitive*/ hasPrimitiveAdjoint, jvpName, vjpName));
 }
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -247,6 +247,7 @@ void SILGenModule::emitCurryThunk(SILDeclRef constant) {
       fd->getInterfaceType()->castTo<AnyFunctionType>());
   auto *SILDA = SILDifferentiableAttr::create(
       M, SILAutoDiffIndices(/*source*/ 0, loweredParamIndices),
+      /*requirements*/ DA->getRequirements(),
       /*primalName*/ StringRef(),
       /*adjointName*/ StringRef(),
       /*adjointIsPrimitive*/ false,

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -4398,6 +4399,30 @@ DifferentiationTask::DifferentiationTask(ADContext &context,
   createVJP();
 }
 
+// Return the expected generic signature for autodiff associated functions given
+// a SILDifferentiableAttr. The expected generic signature is built from the
+// original generic signature and the attribute's requirements.
+static GenericSignature *
+getAutodiffAssociatedFunctionGenericSignature(SILDifferentiableAttr *attr) {
+  auto original = attr->getOriginal();
+  auto originalGenEnv = original->getGenericEnvironment();
+  if (!originalGenEnv)
+    return nullptr;
+  GenericSignatureBuilder builder(original->getASTContext());
+  // Add original generic signature.
+  builder.addGenericSignature(originalGenEnv->getGenericSignature());
+  // Add where clause requirements.
+  auto source =
+      GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
+  for (auto &req : attr->getRequirements())
+    builder.addRequirement(req, source, original->getModule().getSwiftModule());
+  auto canGenericSig = std::move(builder)
+                           .computeGenericSignature(
+                               SourceLoc(), /*allowConcreteGenericParams=*/true)
+                           ->getCanonicalSignature();
+  return canGenericSig;
+}
+
 void DifferentiationTask::createEmptyPrimal() {
   assert(primalSynthesisState == FunctionSynthesisState::Needed);
   assert(!primalInfo);
@@ -4410,6 +4435,7 @@ void DifferentiationTask::createEmptyPrimal() {
                         .getIdentifier("AD__" + original->getName().str() +
                                        "__primal_" + indices.mangle())
                         .str();
+  auto *primalGenericSig = getAutodiffAssociatedFunctionGenericSignature(attr);
   StructDecl *primalValueStructDecl = context.createPrimalValueStruct(this);
   primalInfo = std::unique_ptr<PrimalInfo>(
       new PrimalInfo(primalValueStructDecl, module));
@@ -4424,7 +4450,7 @@ void DifferentiationTask::createEmptyPrimal() {
   // Create result info for checkpoints.
   auto originalTy = original->getLoweredFunctionType();
   auto primalTy = SILFunctionType::get(
-      originalTy->getGenericSignature(), originalTy->getExtInfo(),
+      primalGenericSig, originalTy->getExtInfo(),
       originalTy->getCoroutineKind(), originalTy->getCalleeConvention(),
       originalTy->getParameters(), originalTy->getYields(), results,
       originalTy->getOptionalErrorResult(), context.getASTContext());
@@ -4549,10 +4575,15 @@ void DifferentiationTask::createEmptyAdjoint() {
                      .getIdentifier("AD__" + original->getName().str() +
                                     "__adjoint_" + getIndices().mangle())
                      .str();
+  auto *adjGenericSig = getAutodiffAssociatedFunctionGenericSignature(attr);
+  auto *adjGenericEnv = adjGenericSig
+      ? adjGenericSig->createGenericEnvironment()
+      : nullptr;
   auto adjType = SILFunctionType::get(
-      origTy->getGenericSignature(), origTy->getExtInfo(),
-      origTy->getCoroutineKind(), origTy->getCalleeConvention(), adjParams, {},
-      adjResults, None, original->getASTContext());
+      adjGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
+      origTy->getCalleeConvention(), adjParams, {}, adjResults, None,
+      original->getASTContext());
+
   SILOptFunctionBuilder fb(context.getTransform());
   // We set generated adjoint linkage to Hidden because generated adjoints are
   // never called cross-module in VJP mode: all cross-module calls to associated
@@ -4562,9 +4593,8 @@ void DifferentiationTask::createEmptyAdjoint() {
   // also need to update TBDGen to generate TBD entries for public adjoints.
   auto linkage = SILLinkage::Hidden;
   adjoint = fb.createFunction(
-      linkage, adjName, adjType, original->getGenericEnvironment(),
-      original->getLocation(), original->isBare(), IsNotTransparent,
-      original->isSerialized());
+      linkage, adjName, adjType, adjGenericEnv, original->getLocation(),
+      original->isBare(), IsNotTransparent, original->isSerialized());
   adjoint->setUnqualifiedOwnership();
   adjoint->setDebugScope(new (module)
                              SILDebugScope(original->getLocation(), adjoint));
@@ -4579,16 +4609,21 @@ void DifferentiationTask::createJVP() {
   // === Create an empty JVP. ===
   auto jvpName =
       "AD__" + original->getName().str() + "__jvp_" + getIndices().mangle();
+  auto *jvpGenericSig = getAutodiffAssociatedFunctionGenericSignature(attr);
+  auto *jvpGenericEnv = jvpGenericSig
+      ? jvpGenericSig->createGenericEnvironment()
+      : nullptr;
   auto jvpType = originalTy->getAutoDiffAssociatedFunctionType(
       getIndices().parameters, getIndices().source, 1,
       AutoDiffAssociatedFunctionKind::JVP, module,
-      LookUpConformanceInModule(module.getSwiftModule()));
+      LookUpConformanceInModule(module.getSwiftModule()),
+      jvpGenericSig);
 
   SILOptFunctionBuilder fb(context.getTransform());
   jvp = fb.createFunction(original->getLinkage(), jvpName, jvpType,
-                          original->getGenericEnvironment(),
-                          original->getLocation(), original->isBare(),
-                          IsNotTransparent, original->isSerialized());
+                          jvpGenericEnv, original->getLocation(),
+                          original->isBare(), IsNotTransparent,
+                          original->isSerialized());
   jvp->setUnqualifiedOwnership();
   jvp->setDebugScope(new (module) SILDebugScope(original->getLocation(), jvp));
   attr->setJVPName(jvp->getName());
@@ -4635,15 +4670,18 @@ void DifferentiationTask::createVJP() {
                      .getIdentifier("AD__" + original->getName().str() +
                                     "__vjp_" + getIndices().mangle())
                      .str();
+  auto *vjpGenericSig = getAutodiffAssociatedFunctionGenericSignature(attr);
+  auto *vjpGenericEnv = vjpGenericSig
+      ? vjpGenericSig->createGenericEnvironment()
+      : nullptr;
   auto vjpType = originalTy->getAutoDiffAssociatedFunctionType(
       getIndices().parameters, getIndices().source, 1,
       AutoDiffAssociatedFunctionKind::VJP, module,
-      LookUpConformanceInModule(module.getSwiftModule()));
+      LookUpConformanceInModule(module.getSwiftModule()), vjpGenericSig);
 
   SILOptFunctionBuilder fb(context.getTransform());
   auto linkage = getAutoDiffFunctionLinkage(original->getLinkage());
-  vjp = fb.createFunction(linkage, vjpName, vjpType,
-                          original->getGenericEnvironment(),
+  vjp = fb.createFunction(linkage, vjpName, vjpType, vjpGenericEnv,
                           original->getLocation(), original->isBare(),
                           IsNotTransparent, original->isSerialized());
   vjp->setUnqualifiedOwnership();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2193,6 +2193,23 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
   return candidate;
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+/// Require that the given type either not involve type parameters or be
+/// a type parameter.
+// TODO: Generalize function to take a `Diagnostic` and merge with
+// `diagnoseIndirectGenericTypeParam`.
+static bool diagnoseDifferentiableAttrIndirectGenericType(SourceLoc loc,
+                                                          Type type,
+                                                          TypeRepr *typeRepr) {
+  if (type->hasTypeParameter() && !type->is<GenericTypeParamType>()) {
+    type->getASTContext()
+        .Diags.diagnose(loc, diag::differentiable_attr_only_generic_param_req)
+        .highlight(typeRepr->getSourceRange());
+    return true;
+  }
+  return false;
+}
+
 void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto &ctx = TC.Context;
   auto lookupConformance =
@@ -2263,44 +2280,153 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
+  // Type-check 'where' clause.
+  GenericSignature *whereClauseGenSig = nullptr;
+  GenericEnvironment *whereClauseGenEnv = nullptr;
+  if (auto whereClause = attr->getWhereClause()) {
+    if (whereClause->getRequirements().empty()) {
+      // Report an empty where clause.
+      TC.diagnose(attr->getLocation(),
+                  diag::differentiable_attr_empty_where_clause);
+      attr->setInvalid();
+      return;
+    }
+
+    auto *genericSig = original->getGenericSignature();
+    if (!genericSig) {
+      // Only generic functions can have trailing where clauses.
+      TC.diagnose(attr->getLocation(),
+                  diag::differentiable_attr_nongeneric_trailing_where,
+                  original->getFullName())
+        .highlight(whereClause->getSourceRange());
+      attr->setInvalid();
+      return;
+    }
+
+    // Form a new generic signature.
+    GenericSignatureBuilder builder(ctx);
+    // First, add the old generic signature.
+    builder.addGenericSignature(genericSig);
+    // Go over the set of requirements, adding them to the builder.
+    SmallVector<Requirement, 4> convertedRequirements;
+
+    // Set where clause owner.
+    // Default to using @differentiable attribute as owner.
+    // If original function is declared on a protocol, use protocol's generic
+    // parameters instead.
+    WhereClauseOwner owner(original, attr);
+    if (auto nominal = original->getDeclContext()->getSelfNominalTypeDecl()) {
+      if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
+        auto DC = original->getDeclContext();
+        auto genericParams = proto->createGenericParams(DC);
+        TC.prepareGenericParamList(genericParams, DC);
+        genericParams->addTrailingWhereClause(ctx, whereClause->getWhereLoc(),
+                                              whereClause->getRequirements());
+        owner = WhereClauseOwner(original, genericParams);
+      }
+    }
+
+    using FloatingRequirementSource =
+    GenericSignatureBuilder::FloatingRequirementSource;
+
+    RequirementRequest::visitRequirements(
+      owner, TypeResolutionStage::Structural,
+      [&](const Requirement &req, RequirementRepr *reqRepr) {
+        // Check additional constraints.
+        // TODO: refine constraints.
+        switch (req.getKind()) {
+        case RequirementKind::SameType:
+        case RequirementKind::Superclass:
+          break;
+
+        // Layout requirements are not supported.
+        case RequirementKind::Layout:
+          TC.diagnose(attr->getLocation(),
+                      diag::differentiable_attr_unsupported_req_kind)
+            .highlight(reqRepr->getSourceRange());
+          return false;
+
+        // Conformance requirements are supported if:
+        // - The first type is a generic type parameter type.
+        // - The second type is a protocol type.
+        case RequirementKind::Conformance:
+          if (diagnoseDifferentiableAttrIndirectGenericType(
+                  attr->getLocation(), req.getFirstType(),
+                  reqRepr->getSubjectRepr()))
+            return false;
+
+          if (!req.getSecondType()->is<ProtocolType>()) {
+            TC.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_non_protocol_type_constraint_req)
+              .highlight(reqRepr->getSourceRange());
+            return false;
+          }
+          break;
+        }
+
+        // Add the requirement to the generic signature builder.
+        builder.addRequirement(req, reqRepr,
+                               FloatingRequirementSource::forExplicit(reqRepr),
+                               nullptr, original->getModuleContext());
+        convertedRequirements.push_back(getCanonicalRequirement(req));
+        return false;
+      });
+
+    // Store the converted requirements in the attribute.
+    attr->setRequirements(ctx, convertedRequirements);
+    whereClauseGenSig = std::move(builder).computeGenericSignature(
+        attr->getLocation(), /*allowConcreteGenericParams=*/true);
+    whereClauseGenEnv = whereClauseGenSig->createGenericEnvironment();
+    whereClauseGenEnv->setOwningDeclContext(original->getDeclContext());
+  }
+
   // Resolve the primal declaration, if it exists.
   FuncDecl *primal = nullptr;
   if (attr->getPrimal()) {
+    auto expectedPrimalParamTypes = originalParamsTy;
+    auto expectedPrimalResultTy = original->getResultInterfaceType();
+    if (whereClauseGenEnv) {
+      expectedPrimalParamTypes =
+          whereClauseGenEnv->mapTypeIntoContext(expectedPrimalParamTypes);
+      expectedPrimalResultTy =
+          whereClauseGenEnv->mapTypeIntoContext(expectedPrimalResultTy);
+    }
     auto isValidPrimal = [&](FuncDecl *primalCandidate) {
-      // Returns true if the primal candidate
-      // - has the same parameter types as the original function,
-      // - has the same generic signature as the original function, and
-      // - returns a 2-tuple where the second element type is the original
-      //   function's result type.
+      // Returns true if the primal candidate:
+      // - has the same parameter types as the original function.
+      // - has the same generic signature as the original function.
+      // - returns a 2-tuple where the second element type is the original.
       TC.validateDeclForNameLookup(primalCandidate);
       auto primalParams = primalCandidate->getParameters();
       auto primalParamTypes = map<SmallVector<TupleTypeElt, 8>>(
           primalParams->getArray(),
           [&](ParamDecl *decl) { return decl->getInterfaceType(); });
       auto primalParamsTy = TupleType::get(primalParamTypes, ctx);
-      if (!primalParamsTy->isEqual(originalParamsTy))
+      if (!primalParamsTy->isEqual(expectedPrimalParamTypes))
         return false;
-      auto originalCanGenSig = original->getGenericSignature()
+      auto expectedCanGenSig = original->getGenericSignature()
         ? original->getGenericSignature()->getCanonicalSignature()
         : CanGenericSignature();
+      if (whereClauseGenSig)
+        expectedCanGenSig = whereClauseGenSig->getCanonicalSignature();
       auto primalCanGenSig = primalCandidate->getGenericSignature()
         ? primalCandidate->getGenericSignature()->getCanonicalSignature()
         : CanGenericSignature();
-      if (primalCanGenSig != originalCanGenSig)
+      if (primalCanGenSig != expectedCanGenSig)
         return false;
-      auto origResultTy = original->getResultInterfaceType();
       auto resultTy = primalCandidate->getResultInterfaceType();
       auto *resultTupleTy = resultTy->getAs<TupleType>();
       if (!resultTupleTy ||
           resultTupleTy->getNumElements() != 2 ||
-          !resultTupleTy->getElement(1).getType()->isEqual(origResultTy))
+          !resultTupleTy->getElement(1).getType()->isEqual(expectedPrimalResultTy))
         return false;
       return true;
     };
 
     primal = resolveAutoDiffAssociatedFunction(TC, attr->getPrimal().getValue(),
                                                original, /*isPrimal*/ true,
-                                               originalParamsTy, isValidPrimal);
+                                               expectedPrimalParamTypes,
+                                               isValidPrimal);
 
     if (!primal) {
       attr->setInvalid();
@@ -2375,7 +2501,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto *checkedWrtParamIndices = autoDiffParameterIndicesBuilder.build(ctx);
 
   // This can happen when someone puts the attribute on an instance method with
-  // no paramters (other than the self parameter), and does not specify a wrt
+  // no parameters (other than the self parameter), and does not specify a wrt
   // list.
   if (checkedWrtParamIndices->isEmpty()) {
     TC.diagnose(attr->getLocation(), diag::differentiable_attr_wrt_nothing,
@@ -2416,6 +2542,13 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
     // We also require that all the wrt params have associated tangent/cotangent
     // spaces.
+    if (whereClauseGenEnv) {
+      auto wrtParamInterfaceType = !wrtParamType->hasTypeParameter() ?
+          wrtParamType->mapTypeOutOfContext() :
+          wrtParamType;
+      wrtParamType =
+          whereClauseGenEnv->mapTypeIntoContext(wrtParamInterfaceType);
+    }
     if (!hasAssociatedSpaces(wrtParamType)) {
       TC.diagnose(loc, diag::differentiable_attr_wrt_not_differentiable,
                   wrtParamType);
@@ -2431,8 +2564,14 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
       unwrapped = unwrapped->getResult()->castTo<AnyFunctionType>();
     Type originalResult = unwrapped->getResult();
     if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      for (auto &resultTupleElt : resultTuple->getElements()) {
-        if (!hasAssociatedSpaces(resultTupleElt.getType())) {
+      for (unsigned i : range(resultTuple->getNumElements())) {
+        auto &resultTupleElt = resultTuple->getElement(i);
+        auto resultTupleEltType = resultTupleElt.getType();
+        if (whereClauseGenEnv) {
+          resultTupleEltType = whereClauseGenEnv->mapTypeIntoContext(
+              resultTupleEltType->mapTypeOutOfContext());
+        }
+        if (!hasAssociatedSpaces(resultTupleEltType)) {
           TC.diagnose(attr->getLocation(),
                       diag::differentiable_attr_result_not_differentiable,
                       resultTupleElt.getType());
@@ -2441,6 +2580,13 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         }
       }
     } else {
+      if (whereClauseGenEnv) {
+        auto originalResultInterfaceType = !originalResult->hasTypeParameter()
+            ? originalResult->mapTypeOutOfContext()
+            : originalResult;
+        originalResult =
+            whereClauseGenEnv->mapTypeIntoContext(originalResultInterfaceType);
+      }
       if (!hasAssociatedSpaces(originalResult)) {
         TC.diagnose(attr->getLocation(),
                     diag::differentiable_attr_result_not_differentiable,
@@ -2499,7 +2645,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     AnyFunctionType *expectedAdjointFnTy =
         originalFnTy->getAutoDiffAdjointFunctionType(
             checkedWrtParamIndices, primalResultTy, lookupConformance,
-            isMethod);
+            isMethod, whereClauseGenSig);
 
     auto isValidAdjoint = [&](FuncDecl *adjointCandidate) {
       TC.validateDeclForNameLookup(adjointCandidate);
@@ -2526,7 +2672,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         originalFnTy->getAutoDiffAssociatedFunctionType(
             checkedWrtParamIndices, /*resultIndex*/ 0,
             /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP,
-            lookupConformance);
+            lookupConformance, whereClauseGenSig);
 
     auto isValidJVP = [&](FuncDecl *jvpCandidate) {
       TC.validateDeclForNameLookup(jvpCandidate);
@@ -2553,7 +2699,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         originalFnTy->getAutoDiffAssociatedFunctionType(
             checkedWrtParamIndices, /*resultIndex*/ 0,
             /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::VJP,
-            lookupConformance);
+            lookupConformance, whereClauseGenSig);
 
     auto isValidVJP = [&](FuncDecl *vjpCandidate) {
       TC.validateDeclForNameLookup(vjpCandidate);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2552,6 +2552,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
         uint64_t vjpNameId;
         DeclID vjpDeclId;
         ArrayRef<uint64_t> paramValues;
+        SmallVector<Requirement, 4> requirements;
 
         serialization::decls_block::DifferentiableDeclAttrLayout::readRecord(
             scratch, primalNameId, primalDeclId, adjointNameId, adjointDeclId,
@@ -2592,11 +2593,11 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
           parameters.push_back(parameter);
         }
         // TODO: Deserialize CheckedParameterIndices.
-        // TODO: Deserialize trailing where clause.
+        readGenericRequirements(requirements, DeclTypeCursor);
+
         auto diffAttr =
           DifferentiableAttr::create(ctx, loc, SourceRange(), parameters,
-                                     primal, adjoint, jvp, vjp,
-                                     /*TrailingWhereClause*/ nullptr);
+                                     primal, adjoint, jvp, vjp, requirements);
         diffAttr->setPrimalFunction(primalDecl);
         diffAttr->setAdjointFunction(adjointDecl);
         diffAttr->setJVPFunction(jvpDecl);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -647,9 +647,13 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
       parametersBitVector[i] = parameters[i];
     SILAutoDiffIndices indices(source, parametersBitVector);
 
-    auto *attr = SILDifferentiableAttr::create(SILMod, indices, primalName,
-                                               adjointName, adjointIsPrimitive,
-                                               jvpName, vjpName);
+    SmallVector<Requirement, 8> requirements;
+    MF->readGenericRequirements(requirements, SILCursor);
+
+    auto *attr = SILDifferentiableAttr::create(SILMod, indices, requirements,
+                                               primalName, adjointName,
+                                               adjointIsPrimitive, jvpName,
+                                               vjpName);
     fn->addDifferentiableAttr(attr);
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2387,9 +2387,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
       Out, ScratchRecord, abbrCode, primalName, primalRef, adjointName,
       adjointRef, jvpName, jvpRef, vjpName, vjpRef, parameters);
     // TODO: Serialize CheckedParameterIndices.
-    // TODO: Serialize trailing where clause.
-    // Type-checking where clause should be done first (mimicking the
-    // @_specialize attribute).
+    writeGenericRequirements(attr->getRequirements(), DeclTypeAbbrCodes);
     return;
   }
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -433,6 +433,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
             ? S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getVJPName()))
             : IdentifierID(),
         indices.source, parameters);
+    S.writeGenericRequirements(DA->getRequirements(), SILAbbrCodes);
   }
 
   // Assign a unique ID to each basic block of the SILFunction.

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -98,3 +98,66 @@ func vjpSimple(x: Float) -> Float {
 func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
 }
+
+/*
+// FIXME: 'where' clauses don't show up after round-trip serialization/deserialization.
+
+// HECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
+// HECK-DAG: func testWhereClause<T : Numeric>(x: T) -> T {
+@differentiable(vjp: vjpTestWhereClause where T : Differentiable)
+func testWhereClause<T : Numeric>(x: T) -> T {
+  return x
+}
+func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector)
+  where T : Numeric, T : Differentiable
+{
+  return (x, { v in v })
+}
+
+protocol P {}
+extension P {
+  // HECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
+  // HECK-DAG: func testWhereClause() -> Self {
+  @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
+  func testWhereClause() -> Self {
+    return self
+  }
+}
+extension P where Self : Differentiable {
+  func vjpTestWhereClause() -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
+    return (self, { v in v })
+  }
+}
+*/
+
+/*
+// NOTE: The failing tests involve where clauses with member type constraints.
+// They pass type-checking but crash during serialization.
+
+// HECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
+// HECK-DAG: func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
+@differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
+func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
+  return x
+}
+func vjpTestWhereClauseMemberTypeConstraint<T>(x: T) -> (T, (T) -> T)
+  where T : Numeric, T : Differentiable, T == T.CotangentVector
+{
+  return (x, { v in v })
+}
+
+protocol P {}
+extension P {
+  // HECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
+  // HECK-DAG: func testWhereClauseMemberTypeConstraint() -> Self {
+  @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
+  func testWhereClauseMemberTypeConstraint() -> Self {
+    return self
+  }
+}
+extension P where Self : Differentiable {
+  func vjpTestWhereClauseMemberTypeConstraint() -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
+    return (self, { v in v })
+  }
+}
+*/

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -1,5 +1,4 @@
 // SWIFT_ENABLE_TENSORFLOW
-// TODO: Handle trailing where clause in @differentiable attribute.
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -98,11 +98,8 @@ func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
 }
 
-/*
-// FIXME: 'where' clauses don't show up after round-trip serialization/deserialization.
-
-// HECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
-// HECK-DAG: func testWhereClause<T : Numeric>(x: T) -> T {
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
+// CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
 func testWhereClause<T : Numeric>(x: T) -> T {
   return x
@@ -115,8 +112,8 @@ func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector
 
 protocol P {}
 extension P {
-  // HECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
-  // HECK-DAG: func testWhereClause() -> Self {
+  // CHECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
+  // CHECK-DAG: func testWhereClause() -> Self
   @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
   func testWhereClause() -> Self {
     return self
@@ -127,7 +124,6 @@ extension P where Self : Differentiable {
     return (self, { v in v })
   }
 }
-*/
 
 /*
 // NOTE: The failing tests involve where clauses with member type constraints.


### PR DESCRIPTION
- Store where clause `Requirement`s in `DifferentiableAttr` and `SILDifferentiableAttr`.
- Implement serialization/deserialization logic for where clause requirements.
- Implement type-checking for where clauses.
  - The primal/adjoint/JVP/VJP generic signature is expected to be the union of the
    original function generic signature and the where clause generic signature.

Where clauses enable the definition of autodiff associated functions that are more
constrained than the original function. This is useful for `<Scalar : Numeric>`
operations, for example, which are differentiable only `where Scalar : FloatingPoint`.

TODOs:
- Fix where clauses with member type constraints `e.g. <Self == Self.CotangentVector>`,
  which type-check but crash at serialization.
- Add `where` clauses to `@differentiable` attributes in stdlib. (I've started this.)