### PR TITLE
[AutoDiff] Make activity analysis work on side effecting code.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -376,6 +376,8 @@ ERROR(autodiff_function_not_differentiable,none,
       "function is not differentiable", ())
 ERROR(autodiff_property_not_differentiable,none,
       "property is not differentiable", ())
+ERROR(autodiff_expression_is_not_differentiable_error,none,
+      "expression is not differentiable", ())
 NOTE(autodiff_function_generic_functions_unsupported,none,
      "differentiating generic functions is not supported yet", ())
 NOTE(autodiff_value_defined_here,none,

--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -96,10 +96,12 @@ public:
 ///     domOrder.pushChildren(block);
 ///   }
 /// \endcode
-class DominanceOrder {
+// SWIFT_ENABLE_TENSORFLOW
+template <class DomInfo>
+class DominanceOrderBase {
   
   SmallVector<SILBasicBlock *, 16> buffer;
-  DominanceInfo *DT;
+  DomInfo *DT;
   size_t srcIdx = 0;
   
 public:
@@ -109,7 +111,8 @@ public:
   /// \p DT The dominance info of the function.
   /// \p capacity Should be the number of basic blocks in the dominator tree to
   ///             reduce memory allocation.
-  DominanceOrder(SILBasicBlock *root, DominanceInfo *DT, int capacity = 0) :
+  // SWIFT_ENABLE_TENSORFLOW
+  DominanceOrderBase(SILBasicBlock *root, DomInfo *DT, int capacity = 0) :
             DT(DT) {
      buffer.reserve(capacity);
      buffer.push_back(root);
@@ -183,6 +186,9 @@ public:
   using super::properlyDominates;
 };
 
+// SWIFT_ENABLE_TENSORFLOW
+using DominanceOrder = DominanceOrderBase<DominanceInfo>;
+using PostDominanceOrder = DominanceOrderBase<PostDominanceInfo>;
 
 } // end namespace swift
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -662,6 +662,10 @@ public:
     DifferentiableAttrs.push_back(attr);
   }
 
+  void removeDifferentiableAttr(SILDifferentiableAttr *attr) {
+    std::remove(DifferentiableAttrs.begin(), DifferentiableAttrs.end(), attr);
+  }
+
   /// Get this function's optimization mode or OptimizationMode::NotSet if it is
   /// not set for this specific function.
   OptimizationMode getOptimizationMode() const { return OptMode; }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -497,6 +497,10 @@ public:
   /// formal type. Meant for verification purposes/assertions.
   bool isLoweringOf(SILModule &M, CanType formalType);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Returns true if this SILType is a differentiable type.
+  bool isDifferentiable(SILModule &M) const;
+
   /// Returns the hash code for the SILType.
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(*this);

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -598,3 +598,11 @@ bool SILType::isLoweringOf(SILModule &Mod, CanType formalType) {
   // Other types are preserved through lowering.
   return loweredType.getASTType() == formalType;
 }
+
+// SWIFT_ENABLE_TENSORFLOW
+/// Returns true if this SILType is a differentiable type.
+bool SILType::isDifferentiable(SILModule &M) const {
+  return getASTType()->getAutoDiffAssociatedVectorSpace(
+      AutoDiffAssociatedVectorSpaceKind::Tangent,
+      LookUpConformanceInModule(M.getSwiftModule())).hasValue();
+}

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -1031,6 +1031,20 @@ public:
     return cachedPlusFn;
   }
 
+  void clearTask(DifferentiationTask *task) {
+    LLVM_DEBUG(getADDebugStream() << "Clearing differentiation task for "
+               << task->original->getName() << '\n');
+    transform.notifyWillDeleteFunction(task->primal);
+    module.eraseFunction(task->primal);
+    transform.notifyWillDeleteFunction(task->adjoint);
+    module.eraseFunction(task->adjoint);
+    transform.notifyWillDeleteFunction(task->jvp);
+    module.eraseFunction(task->jvp);
+    transform.notifyWillDeleteFunction(task->vjp);
+    module.eraseFunction(task->vjp);
+    task->original->removeDifferentiableAttr(task->attr);
+  }
+
   /// Retrieves the file unit that contains implicit declarations in the
   /// current Swift module. If it does not exist, create one.
   ///
@@ -1219,10 +1233,13 @@ void ADContext::emitNondifferentiabilityError(SILInstruction *inst,
   // Location of the instruction.
   auto opLoc = inst->getLoc().getSourceLoc();
   auto invoker = task->getInvoker();
-  LLVM_DEBUG(getADDebugStream()
-             << "Diagnosing non-differentiability for value \n\t" << *inst
-             << "\n"
-             << "while performing differentiation task\n\t" << task << '\n');
+  LLVM_DEBUG({
+    auto &s = getADDebugStream()
+        << "Diagnosing non-differentiability for value \n\t" << *inst
+        << "\nwhile performing differentiation task\n\t";
+    task->print(s);
+    s << '\n';
+  });
   switch (invoker.getKind()) {
   // For a `autodiff_function` instruction or a `[differentiable]` attribute
   // that is not associated with any source location, we emit a diagnostic at
@@ -1406,6 +1423,11 @@ private:
   /// Perform analysis and populate sets.
   void analyze(DominanceInfo *di, PostDominanceInfo *pdi);
 
+  void setVariedIfDifferentiable(SILValue value,
+                                 unsigned independentVariableIndex);
+  void setUsefulIfDifferentiable(SILValue value,
+                                 unsigned dependentVariableIndex);
+
 public:
   explicit DifferentiableActivityInfo(SILFunction &f,
                                       DominanceInfo *di,
@@ -1458,9 +1480,8 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
              << "Running activity analysis on @" << function.getName() << '\n');
   // Inputs are just function's arguments, count `n`.
   auto paramArgs = function.getArgumentsWithoutIndirectResults();
-  for (auto valueAndIndex : enumerate(paramArgs)) {
-    inputValues.push_back(valueAndIndex.first);
-  }
+  for (auto value : paramArgs)
+    inputValues.push_back(value);
   LLVM_DEBUG({
     auto &s = getADDebugStream();
     s << "Inputs in @" << function.getName() << ":\n";
@@ -1476,37 +1497,109 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
       s << val << '\n';
   });
 
+  auto &module = function.getModule();
   // Mark inputs as varied.
   assert(variedValueSets.empty());
-  for (auto input : inputValues)
-    variedValueSets.push_back({input});
+  for (auto input : inputValues) {
+    variedValueSets.push_back({});
+    if (input->getType().isDifferentiable(module))
+      variedValueSets.back().insert(input);
+  }
   // Propagate varied-ness through the function in dominance order.
   DominanceOrder domOrder(function.getEntryBlock(), di);
   while (auto *block = domOrder.getNext()) {
-    for (auto &inst : *block)
-      for (auto &op : inst.getAllOperands())
-        for (auto i : indices(inputValues))
-          if (isVaried(op.get(), i))
-            for (auto result : inst.getResults())
-              variedValueSets[i].insert(result);
+    for (auto &inst : *block) {
+      for (auto i : indices(inputValues)) {
+        // Handle `apply`.
+        if (auto *ai = dyn_cast<ApplyInst>(&inst)) {
+          for (auto arg : ai->getArgumentsWithoutIndirectResults()) {
+            if (isVaried(arg, i)) {
+              for (auto indRes : ai->getIndirectSILResults())
+                setVariedIfDifferentiable(indRes, i);
+              for (auto dirRes : ai->getResults())
+                setVariedIfDifferentiable(dirRes, i);
+            }
+          }
+        }
+        // Handle `store`.
+        else if (auto *si = dyn_cast<StoreInst>(&inst)) {
+          if (isVaried(si->getSrc(), i))
+            setVariedIfDifferentiable(si->getDest(), i);
+        }
+        // Handle everything else.
+        else {
+          for (auto &op : inst.getAllOperands())
+            if (isVaried(op.get(), i))
+              for (auto result : inst.getResults())
+                setVariedIfDifferentiable(result, i);
+        }
+      }
+    }
     domOrder.pushChildren(block);
   }
 
-  // Mark outputs as useful.
+  // Mark differentiable outputs as useful.
   assert(usefulValueSets.empty());
-  for (auto output : outputValues)
-    usefulValueSets.push_back({output});
+  for (auto output : outputValues) {
+    usefulValueSets.push_back({});
+    if (output->getType().isDifferentiable(module))
+      usefulValueSets.back().insert(output);
+  }
   // Propagate usefulness through the function in post-dominance order.
   PostDominanceOrder postDomOrder(&*function.findReturnBB(), pdi);
   while (auto *block = postDomOrder.getNext()) {
-    for (auto &inst : reversed(*block))
-      for (auto result : inst.getResults())
-        for (auto i : indices(outputValues))
-          if (isUseful(result, i))
-            for (auto &op : inst.getAllOperands())
-              usefulValueSets[i].insert(op.get());
+    for (auto &inst : reversed(*block)) {
+      for (auto i : indices(outputValues)) {
+        // Handle indirect results in `apply`.
+        if (auto *ai = dyn_cast<ApplyInst>(&inst)) {
+          auto checkAndSetUseful = [&](SILValue res) {
+            if (isUseful(res, i))
+              for (auto arg : ai->getArgumentsWithoutIndirectResults())
+                setUsefulIfDifferentiable(arg, i);
+          };
+          for (auto dirRes : ai->getResults())
+            checkAndSetUseful(dirRes);
+          for (auto indRes : ai->getIndirectSILResults())
+            checkAndSetUseful(indRes);
+        }
+        // Handle `store`.
+        else if (auto *si = dyn_cast<StoreInst>(&inst)) {
+          if (isUseful(si->getDest(), i))
+            setUsefulIfDifferentiable(si->getSrc(), i);
+        }
+        // Handle side-effecting operations.
+        else if (inst.mayHaveSideEffects()) {
+          for (auto &op : inst.getAllOperands())
+            if (op.get()->getType().isAddress())
+              setUsefulIfDifferentiable(op.get(), i);
+          for (auto result : inst.getResults())
+            setUsefulIfDifferentiable(result, i);
+        }
+        // Handle everything else.
+        else {
+          for (auto result : inst.getResults())
+            if (isUseful(result, i))
+              for (auto &op : inst.getAllOperands())
+                setUsefulIfDifferentiable(op.get(), i);
+        }
+      }
+    }
     postDomOrder.pushChildren(block);
   }
+}
+
+void DifferentiableActivityInfo::setVariedIfDifferentiable(
+    SILValue value, unsigned independentVariableIndex) {
+  if (!value->getType().isDifferentiable(function.getModule()))
+    return;
+  variedValueSets[independentVariableIndex].insert(value);
+}
+
+void DifferentiableActivityInfo::setUsefulIfDifferentiable(
+    SILValue value, unsigned dependentVariableIndex) {
+  if (!value->getType().isDifferentiable(function.getModule()))
+    return;
+  usefulValueSets[dependentVariableIndex].insert(value);
 }
 
 bool DifferentiableActivityInfo::isIndependent(
@@ -2180,11 +2273,8 @@ public:
     // Clone.
     cloneFunctionBody(original, entry, entryArgs);
     // If errors occurred, back out.
-    if (errorOccurred) {
-      // Delete the body so that later passes don't get confused by invalid SIL.
-      getPrimal()->getBlocks().clear();
+    if (errorOccurred)
       return true;
-    }
     auto *origExit = &*original->findReturnBB();
     auto *exit = BBMap.lookup(origExit);
     assert(exit->getParent() == getPrimal());
@@ -2248,7 +2338,15 @@ public:
       return;
     SILClonerWithScopes::visit(inst);
   }
-  
+
+  void visitSILInstruction(SILInstruction *inst) {
+    // TODO: Change this to a note when we emit an error at the @autodiff
+    // function conversion location.
+    getContext().emitNondifferentiabilityError(inst, getDifferentiationTask(),
+        diag::autodiff_expression_is_not_differentiable_error);
+    errorOccurred = true;
+  }
+
   void visitReturnInst(ReturnInst *ri) {
     // The original return is not to be cloned.
     return;
@@ -2701,6 +2799,7 @@ bool PrimalGen::performSynthesis(FunctionSynthesisItem item) {
   // Synthesize primal.
   PrimalGenCloner cloner(item, activityInfo, domInfo, pdomInfo, loopInfo, *this,
                          context);
+  // Run the cloner.
   return cloner.run();
 }
 
@@ -2723,7 +2822,10 @@ bool PrimalGen::run() {
   while (!worklist.empty()) {
     auto synthesis = worklist.back();
     worklist.pop_back();
-    errorOccurred |= performSynthesis(synthesis);
+    if (performSynthesis(synthesis)) {
+      context.clearTask(synthesis.task);
+      errorOccurred = true;
+    }
     synthesis.task->getPrimalInfo()->computePrimalValueStructType();
     synthesis.task->setPrimalSynthesisState(FunctionSynthesisState::Done);
   }
@@ -2779,7 +2881,10 @@ bool AdjointGen::run() {
   while (!worklist.empty()) {
     auto synthesis = worklist.back();
     worklist.pop_back();
-    errorOccurred |= performSynthesis(synthesis);
+    if (performSynthesis(synthesis)) {
+      context.clearTask(synthesis.task);
+      errorOccurred = true;
+    }
     synthesis.task->setAdjointSynthesisState(FunctionSynthesisState::Done);
   }
   return errorOccurred;
@@ -3242,6 +3347,8 @@ public:
           continue;
         // Differentiate instruction.
         visit(&inst);
+        if (errorOccurred)
+          return true;
       }
     }
     
@@ -3321,7 +3428,11 @@ public:
   }
 
   void visitSILInstruction(SILInstruction *inst) {
-    llvm_unreachable("Unsupport instruction visited");
+    // TODO: Change this to a note when we emit an error at the @autodiff
+    // function conversion location.
+    getContext().emitNondifferentiabilityError(inst, getDifferentiationTask(),
+        diag::autodiff_expression_is_not_differentiable_error);
+    errorOccurred = true;
   }
 
   SILLocation remapLocation(SILLocation loc) { return loc; }
@@ -4325,6 +4436,7 @@ bool AdjointGen::performSynthesis(FunctionSynthesisItem item) {
                          *domAnalysis->get(item.original),
                          *pdomAnalysis->get(item.original),
                          *loopAnalysis->get(item.original), *this);
+  // Run the adjoint emitter.
   return emitter.run();
 }
 

--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -debug-only=differentiation %s 2>&1 | %FileCheck %s
+
+func simpleStoreLoad(x: Float) -> Float {
+  var y = x
+  y = x + 1
+  // expected-error @+1 {{expression is not differentiable}}
+  return y
+}
+let _: @autodiff (Float) -> Float = simpleStoreLoad(x:)
+
+// CHECK-LABEL: [AD] Activity info for ${{.*}}simpleStoreLoad{{.*}} at (source=0 parameters=(0))
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Float
+// CHECK: [ACTIVE]   %2 = alloc_stack $Float, var, name "y"
+// CHECK: [NONE]   %4 = metatype $@thin Float.Type
+// CHECK: [NONE]   %5 = metatype $@thin Float.Type
+// CHECK: [NONE]   %6 = integer_literal $Builtin.IntLiteral, 1
+// CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)
+// CHECK:   %7 = function_ref @$sSf22_builtinIntegerLiteralSfBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float
+// CHECK: [USEFUL]   %8 = apply %7(%6, %5) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float // user: %10
+// CHECK: [NONE]   // function_ref static Float.+ infix(_:_:)
+// CHECK:   %9 = function_ref @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [ACTIVE]   %10 = apply %9(%0, %8, %4) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [ACTIVE]   %11 = begin_access [modify] [static] %2 : $*Float
+// CHECK: [ACTIVE]   %14 = begin_access [read] [static] %2 : $*Float
+// CHECK: [ACTIVE]   %15 = load %14 : $*Float

--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -debug-only=differentiation %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -debug-only=differentiation %s 2>&1 || exit 0 | %FileCheck %s
 
 func simpleStoreLoad(x: Float) -> Float {
   var y = x

--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -debug-only=differentiation %s 2>&1 || exit 0 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
 
 func simpleStoreLoad(x: Float) -> Float {
   var y = x
@@ -8,18 +8,4 @@ func simpleStoreLoad(x: Float) -> Float {
 }
 let _: @autodiff (Float) -> Float = simpleStoreLoad(x:)
 
-// CHECK-LABEL: [AD] Activity info for ${{.*}}simpleStoreLoad{{.*}} at (source=0 parameters=(0))
-// CHECK: [ACTIVE] %0 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %2 = alloc_stack $Float, var, name "y"
-// CHECK: [NONE]   %4 = metatype $@thin Float.Type
-// CHECK: [NONE]   %5 = metatype $@thin Float.Type
-// CHECK: [NONE]   %6 = integer_literal $Builtin.IntLiteral, 1
-// CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)
-// CHECK:   %7 = function_ref @$sSf22_builtinIntegerLiteralSfBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float
-// CHECK: [USEFUL]   %8 = apply %7(%6, %5) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float // user: %10
-// CHECK: [NONE]   // function_ref static Float.+ infix(_:_:)
-// CHECK:   %9 = function_ref @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK: [ACTIVE]   %10 = apply %9(%0, %8, %4) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK: [ACTIVE]   %11 = begin_access [modify] [static] %2 : $*Float
-// CHECK: [ACTIVE]   %14 = begin_access [read] [static] %2 : $*Float
-// CHECK: [ACTIVE]   %15 = load %14 : $*Float
+// TODO: Add file checks.


### PR DESCRIPTION
* Make activity analysis only track values whose types are differentiable.
* Extend the original data flow analysis to propagate `VARIED` and `USEFUL` though `apply` (with indirect results), `store` and other side-effecting operations.
* When primal or adjoint synthesis fails, erase all generated functions for that differentiation task to avoid unexpected verification failures.

Note: This patch does not make differentiating through loads and stores work. That will be done in my next patch.