### PR TITLE
[Type checker] Array/dictionary literals define to Swift.(Array|Dictionary)

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -658,6 +658,7 @@ static Type lookupDefaultLiteralType(TypeChecker &TC, DeclContext *dc,
 Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {
   Type *type = nullptr;
   const char *name = nullptr;
+  bool performLocalLookup = true;
 
   // ExpressibleByUnicodeScalarLiteral -> UnicodeScalarType
   if (protocol ==
@@ -711,6 +712,7 @@ Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {
                                    KnownProtocolKind::ExpressibleByArrayLiteral)){
     type = &ArrayLiteralType;
     name = "Array";
+    performLocalLookup = false;
   }
   // ExpressibleByDictionaryLiteral -> Dictionary
   else if (protocol == getProtocol(
@@ -718,6 +720,7 @@ Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {
                          KnownProtocolKind::ExpressibleByDictionaryLiteral)) {
     type = &DictionaryLiteralType;
     name = "Dictionary";
+    performLocalLookup = false;
   }
   // _ExpressibleByColorLiteral -> _ColorLiteralType
   else if (protocol == getProtocol(
@@ -746,7 +749,8 @@ Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {
 
   // If we haven't found the type yet, look for it now.
   if (!*type) {
-    *type = lookupDefaultLiteralType(*this, dc, name);
+    if (performLocalLookup)
+      *type = lookupDefaultLiteralType(*this, dc, name);
 
     if (!*type)
       *type = lookupDefaultLiteralType(*this, getStdlibModule(dc), name);

--- a/test/Constraints/array_literal_local_array.swift
+++ b/test/Constraints/array_literal_local_array.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-9611: Array type locally interfers with array literals.
+struct Array { }
+
+func foo() {
+  _ = ["a", "b", "c"]
+}

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -6,14 +6,14 @@ final class DictStringInt : ExpressibleByDictionaryLiteral {
   init(dictionaryLiteral elements: (String, Int)...) { }
 }
 
-final class Dictionary<K, V> : ExpressibleByDictionaryLiteral {
+final class MyDictionary<K, V> : ExpressibleByDictionaryLiteral {
   typealias Key = K
   typealias Value = V
   init(dictionaryLiteral elements: (K, V)...) { }
 }
 
 func useDictStringInt(_ d: DictStringInt) {}
-func useDict<K, V>(_ d: Dictionary<K,V>) {}
+func useDict<K, V>(_ d: MyDictionary<K,V>) {}
 
 // Concrete dictionary literals.
 useDictStringInt(["Hello" : 1])
@@ -30,7 +30,7 @@ useDictStringInt(["Hello" : nil])
 // expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'Int'}}
 
 typealias FuncBoolToInt = (Bool) -> Int
-let dict1: Dictionary<String, FuncBoolToInt> = ["Hello": nil]
+let dict1: MyDictionary<String, FuncBoolToInt> = ["Hello": nil]
 // expected-error@-1 {{'nil' is not compatible with expected dictionary value type '(Bool) -> Int'}}
 
 // Generic dictionary literals.
@@ -39,7 +39,7 @@ useDict(["Hello" : 1, "World" : 2])
 useDict(["Hello" : 1.5, "World" : 2])
 useDict([1 : 1.5, 3 : 2.5])
 
-// Fall back to Dictionary<K, V> if no context is otherwise available.
+// Fall back to Swift.Dictionary<K, V> if no context is otherwise available.
 var a = ["Hello" : 1, "World" : 2]
 var a2 : Dictionary<String, Int> = a
 var a3 = ["Hello" : 1]
@@ -52,20 +52,20 @@ var b3 = [1 : 2.5]
 // <rdar://problem/22584076> QoI: Using array literal init with dictionary produces bogus error
 
 // expected-note @+1 {{did you mean to use a dictionary literal instead?}}
-var _: Dictionary<String, (Int) -> Int>? = [  // expected-error {{dictionary of type 'Dictionary<String, (Int) -> Int>' cannot be initialized with array literal}}
+var _: MyDictionary<String, (Int) -> Int>? = [  // expected-error {{dictionary of type 'MyDictionary<String, (Int) -> Int>' cannot be initialized with array literal}}
   "closure_1" as String, {(Int) -> Int in 0},
   "closure_2", {(Int) -> Int in 0}]
 
 
-var _: Dictionary<String, Int>? = ["foo", 1]  // expected-error {{dictionary of type 'Dictionary<String, Int>' cannot be initialized with array literal}}
-// expected-note @-1 {{did you mean to use a dictionary literal instead?}} {{41-42=:}}
+var _: MyDictionary<String, Int>? = ["foo", 1]  // expected-error {{dictionary of type 'MyDictionary<String, Int>' cannot be initialized with array literal}}
+// expected-note @-1 {{did you mean to use a dictionary literal instead?}} {{43-44=:}}
 
-var _: Dictionary<String, Int>? = ["foo", 1, "bar", 42]  // expected-error {{dictionary of type 'Dictionary<String, Int>' cannot be initialized with array literal}}
-// expected-note @-1 {{did you mean to use a dictionary literal instead?}} {{41-42=:}} {{51-52=:}}
+var _: MyDictionary<String, Int>? = ["foo", 1, "bar", 42]  // expected-error {{dictionary of type 'MyDictionary<String, Int>' cannot be initialized with array literal}}
+// expected-note @-1 {{did you mean to use a dictionary literal instead?}} {{43-44=:}} {{53-54=:}}
 
-var _: Dictionary<String, Int>? = ["foo", 1.0, 2]  // expected-error {{cannot convert value of type '[Any]' to specified type 'Dictionary<String, Int>?'}}
+var _: MyDictionary<String, Int>? = ["foo", 1.0, 2]  // expected-error {{cannot convert value of type '[Any]' to specified type 'MyDictionary<String, Int>?'}}
 
-var _: Dictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
+var _: MyDictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
 
 
 // <rdar://problem/24058895> QoI: Should handle [] in dictionary contexts better
@@ -78,33 +78,33 @@ class C : A { }
 
 func testDefaultExistentials() {
   let _ = ["a" : 1, "b" : 2.5, "c" : "hello"]
-  // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<String, Any>'; add explicit type annotation if this is intentional}}{{46-46= as Dictionary<String, Any>}}
+  // expected-error@-1{{heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional}}{{46-46= as [String : Any]}}
 
   let _: [String : Any] = ["a" : 1, "b" : 2.5, "c" : "hello"]
 
   let _ = ["a" : 1, "b" : nil, "c" : "hello"]
-  // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<String, Any?>'; add explicit type annotation if this is intentional}}{{46-46= as Dictionary<String, Any?>}}
+  // expected-error@-1{{heterogeneous collection literal could only be inferred to '[String : Any?]'; add explicit type annotation if this is intentional}}{{46-46= as [String : Any?]}}
 
   let _: [String : Any?] = ["a" : 1, "b" : nil, "c" : "hello"]
 
   let d2 = [:]
   // expected-error@-1{{empty collection literal requires an explicit type}}
 
-  let _: Int = d2 // expected-error{{value of type 'Dictionary<AnyHashable, Any>'}}
+  let _: Int = d2 // expected-error{{value of type '[AnyHashable : Any]'}}
 
   let _ = ["a": 1,
            "b": ["a", 2, 3.14159],
            "c": ["a": 2, "b": 3.5]]
-  // expected-error@-3{{heterogeneous collection literal could only be inferred to 'Dictionary<String, Any>'; add explicit type annotation if this is intentional}}
+  // expected-error@-3{{heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional}}
 
   let d3 = ["b" : B(), "c" : C()]
-  let _: Int = d3 // expected-error{{value of type 'Dictionary<String, A>'}}
+  let _: Int = d3 // expected-error{{value of type '[String : A]'}}
 
   let _ = ["a" : B(), 17 : "seventeen", 3.14159 : "Pi"]
-  // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<AnyHashable, Any>'}}
+  // expected-error@-1{{heterogeneous collection literal could only be inferred to '[AnyHashable : Any]'}}
 
   let _ = ["a" : "hello", 17 : "string"]
-  // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<AnyHashable, String>'}}
+  // expected-error@-1{{heterogeneous collection literal could only be inferred to '[AnyHashable : String]'}}
 }
 
 // SR-4952, rdar://problem/32330004 - Assertion failure during swift::ASTVisitor<::FailureDiagnosis,...>::visit


### PR DESCRIPTION
The type checker was performing local name lookup to find the Array and
Dictionary types to use as defaults for array and dictionary
literals. Make sure we only look for Swift.Array and Swift.Dictionary.

Fixes SR-9611 / rdar://problem/47085684.
