### PR TITLE
Restrict withUnsafeBytes to swift 5.0 or greater availability to avoid ambiguity

### DIFF
--- a/stdlib/public/Darwin/Foundation/ContiguousBytes.swift
+++ b/stdlib/public/Darwin/Foundation/ContiguousBytes.swift
@@ -21,32 +21,55 @@ public protocol ContiguousBytes {
     ///         the same buffer pointer will be passed in every time.
     /// - warning: The buffer argument to the body should not be stored or used
     ///            outside of the lifetime of the call to the closure.
-    func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+    func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+}
+
+extension Data {
+    @inlinable
+    @available(swift, introduced: 5)
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try withContiguousUnsafeBytes(body)
+    }
 }
 
 //===--- Collection Conformances ------------------------------------------===//
 
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
-extension Array : ContiguousBytes where Element == UInt8 { }
+extension Array : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try withUnsafeBytes(body)
+    }
+}
 
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
-extension ArraySlice : ContiguousBytes where Element == UInt8 { }
+extension ArraySlice : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try withUnsafeBytes(body)
+    }
+}
 
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
-extension ContiguousArray : ContiguousBytes where Element == UInt8 { }
+extension ContiguousArray : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try withUnsafeBytes(body)
+    }
+}
 
 //===--- Pointer Conformances ---------------------------------------------===//
 
 extension UnsafeRawBufferPointer : ContiguousBytes {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try body(self)
     }
 }
 
 extension UnsafeMutableRawBufferPointer : ContiguousBytes {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 }
@@ -54,7 +77,7 @@ extension UnsafeMutableRawBufferPointer : ContiguousBytes {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 }
@@ -62,7 +85,7 @@ extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 }
@@ -70,7 +93,7 @@ extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 extension EmptyCollection : ContiguousBytes where Element == UInt8 {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try body(UnsafeRawBufferPointer(start: nil, count: 0))
     }
 }
@@ -78,7 +101,7 @@ extension EmptyCollection : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withContiguousUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         let element = self.first!
         return try Swift.withUnsafeBytes(of: element) {
             return try body($0)
@@ -89,9 +112,9 @@ extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
 //===--- Conditional Conformances -----------------------------------------===//
 
 extension Slice : ContiguousBytes where Base : ContiguousBytes {
-    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+    public func withContiguousUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
         let offset = base.distance(from: base.startIndex, to: self.startIndex)
-        return try base.withUnsafeBytes { ptr in
+        return try base.withContiguousUnsafeBytes { ptr in
             let slicePtr = ptr.baseAddress?.advanced(by: offset)
             let sliceBuffer = UnsafeRawBufferPointer(start: slicePtr, count: self.count)
             return try body(sliceBuffer)

--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -313,9 +313,9 @@ internal final class _DataStorage {
     @inlinable
     func append(_ otherData: Data) {
         guard otherData.count > 0 else { return }
-        otherData.withUnsafeBytes {
-        append($0.baseAddress!, length: $0.count)
-    }
+        otherData.withContiguousUnsafeBytes {
+            append($0.baseAddress!, length: $0.count)
+        }
     }
     
     @inlinable
@@ -1950,7 +1950,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inlinable
     public init(repeating repeatedValue: UInt8, count: Int) {
         self.init(count: count)
-        withUnsafeMutableBytes { (buffer: UnsafeMutableRawBufferPointer) -> Void in
+        withContiguousUnsafeMutableBytes { (buffer: UnsafeMutableRawBufferPointer) -> Void in
             memset(buffer.baseAddress, Int32(repeatedValue), buffer.count)
         }
     }
@@ -2074,7 +2074,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public init<S: Sequence>(_ elements: S) where S.Element == UInt8 {
         // If the sequence is already contiguous, access the underlying raw memory directly.
         if let contiguous = elements as? ContiguousBytes {
-            _representation = contiguous.withUnsafeBytes { return _Representation($0) }
+            _representation = contiguous.withContiguousUnsafeBytes { return _Representation($0) }
             return
         }
 
@@ -2161,7 +2161,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// Access the bytes in the data.
     ///
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
-    @available(swift, deprecated: 5, message: "use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead")
+    @available(swift, deprecated: 5, message: "use `withContiguousUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead")
     public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         return try _representation.withUnsafeBytes {
             return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafePointer<ContentType>(bitPattern: 0xBAD0)!)
@@ -2169,7 +2169,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
     
     @inlinable
-    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+    public func withContiguousUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
         return try _representation.withUnsafeBytes(body)
     }
 
@@ -2177,7 +2177,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// This function assumes that you are mutating the contents.
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
-    @available(swift, deprecated: 5, message: "use `withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R` instead")
+    @available(swift, deprecated: 5, message: "use `withContiguousUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R` instead")
     public mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ body: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         return try _representation.withUnsafeMutableBytes {
             return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafeMutablePointer<ContentType>(bitPattern: 0xBAD0)!)
@@ -2185,7 +2185,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
 
     @inlinable
-    public mutating func withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+    public mutating func withContiguousUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
         return try _representation.withUnsafeMutableBytes(body)
     }
     
@@ -2334,7 +2334,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inlinable
     public mutating func append(_ other: Data) {
         guard other.count > 0 else { return }
-        other.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+        other.withContiguousUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
             _representation.append(contentsOf: buffer)
         }
     }
@@ -2358,7 +2358,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public mutating func append<S: Sequence>(contentsOf elements: S) where S.Element == Element {
         // If the sequence is already contiguous, access the underlying raw memory directly.
         if let contiguous = elements as? ContiguousBytes {
-            contiguous.withUnsafeBytes {
+            contiguous.withContiguousUnsafeBytes {
                 _representation.append(contentsOf: $0)
             }
 
@@ -2420,7 +2420,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter data: The replacement data.
     @inlinable
     public mutating func replaceSubrange(_ subrange: Range<Index>, with data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+        data.withContiguousUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
             _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: buffer.count)
         }
     }
@@ -2474,7 +2474,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         let slice = self[range]
 
-        return slice.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Data in
+        return slice.withContiguousUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Data in
             return Data(bytes: buffer.baseAddress!, count: buffer.count)
         }
     }
@@ -2517,7 +2517,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public func advanced(by amount: Int) -> Data {
         let length = count - amount
         precondition(length > 0)
-        return withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
+        return withContiguousUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
             return Data(bytes: ptr.baseAddress!.advanced(by: amount), count: length)
         }
     }
@@ -2612,7 +2612,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         guard !isEmpty else { return (makeIterator(), buffer.startIndex) }
         let cnt = Swift.min(count, buffer.count)
         
-        withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+        withContiguousUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
             _ = memcpy(UnsafeMutableRawPointer(buffer.baseAddress), bytes.baseAddress, cnt)
         }
         
@@ -2693,10 +2693,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         set { fatalError() }
     }
     
-    @available(*, unavailable, message: "use withUnsafeBytes instead")
+    @available(*, unavailable, message: "use withContiguousUnsafeBytes instead")
     public var bytes: UnsafeRawPointer { fatalError() }
     
-    @available(*, unavailable, message: "use withUnsafeMutableBytes instead")
+    @available(*, unavailable, message: "use withContiguousUnsafeMutableBytes instead")
     public var mutableBytes: UnsafeMutableRawPointer { fatalError() }
     
     /// Returns `true` if the two `Data` arguments are equal.
@@ -2707,8 +2707,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return false
         }
         if length1 > 0 {
-            return d1.withUnsafeBytes { (b1: UnsafeRawBufferPointer) in
-                return d2.withUnsafeBytes { (b2: UnsafeRawBufferPointer) in
+            return d1.withContiguousUnsafeBytes { (b1: UnsafeRawBufferPointer) in
+                return d2.withContiguousUnsafeBytes { (b2: UnsafeRawBufferPointer) in
                     return memcmp(b1.baseAddress!, b2.baseAddress!, b2.count) == 0
                 }
             }
@@ -2734,7 +2734,7 @@ extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomRe
         var children: [(label: String?, value: Any)] = []
         children.append((label: "count", value: nBytes))
         
-        self.withUnsafeBytes { (bytes : UnsafeRawBufferPointer) in
+        withContiguousUnsafeBytes { (bytes : UnsafeRawBufferPointer) in
             children.append((label: "pointer", value: bytes.baseAddress!))
         }
         
@@ -2816,7 +2816,7 @@ extension Data : Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
-        try withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+        try withContiguousUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
             try container.encode(contentsOf: buffer)
         }
     }

--- a/stdlib/public/Darwin/Foundation/DataProtocol.swift
+++ b/stdlib/public/Darwin/Foundation/DataProtocol.swift
@@ -125,7 +125,7 @@ extension DataProtocol {
                 break
             }
 
-            region.withUnsafeBytes { buffer in
+            region.withContiguousUnsafeBytes { buffer in
                 let offsetPtr = UnsafeMutableRawBufferPointer(rebasing: ptr[offset...])
                 let buf = UnsafeRawBufferPointer(start: buffer.baseAddress, count: Swift.min(buffer.count, amountToCopy))
                 offsetPtr.copyMemory(from: buf)
@@ -206,7 +206,7 @@ extension DataProtocol where Self : ContiguousBytes {
         precondition(ptr.baseAddress != nil)
 
         let concreteRange = range.relative(to: self)
-        withUnsafeBytes { fullBuffer in
+        withContiguousUnsafeBytes { fullBuffer in
             let adv = distance(from: startIndex, to: concreteRange.lowerBound)
             let delta = distance(from: concreteRange.lowerBound, to: concreteRange.upperBound)
             memcpy(ptr.baseAddress!, fullBuffer.baseAddress?.advanced(by: adv), delta)

--- a/stdlib/public/Darwin/Foundation/DispatchData+DataProtocol.swift
+++ b/stdlib/public/Darwin/Foundation/DispatchData+DataProtocol.swift
@@ -41,7 +41,7 @@ extension DispatchData : DataProtocol {
             return index + bytes.count
         }
 
-        public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        public func withContiguousUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
             return try body(UnsafeRawBufferPointer(bytes))
         }
     }


### PR DESCRIPTION
The recent refactor for `Data` added a new method of `withUnsafeBytes` that vends a `UnsafeRawBufferPointer` in its closure. However there were external projects that added this as a category to `Data` which unfortunately lead to un-reconcilable ambiguity. Marking this method as available in swift 5.0 it prevents the ambiguity at the cost of preventing the usage of the API that avoids undefined behavior in 4.2 mode.  