### PR TITLE
LLVMPasses: adjust for SVN r350503

### DIFF
--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -30,7 +30,7 @@ namespace swift {
                     const llvm::PreservedAnalyses &) { return false; }
 
     using AAResultBase::getModRefInfo;
-    llvm::ModRefInfo getModRefInfo(llvm::ImmutableCallSite CS,
+    llvm::ModRefInfo getModRefInfo(llvm::CallBase *Call,
                                    const llvm::MemoryLocation &Loc);
   };
 

--- a/lib/LLVMPasses/LLVMSwiftAA.cpp
+++ b/lib/LLVMPasses/LLVMSwiftAA.cpp
@@ -23,8 +23,8 @@ using namespace swift;
 //                           Alias Analysis Result
 //===----------------------------------------------------------------------===//
 
-static ModRefInfo getConservativeModRefForKind(const llvm::Instruction &I) {
-  switch (classifyInstruction(I)) {
+static ModRefInfo getConservativeModRefForKind(const llvm::CallBase &Call) {
+  switch (classifyInstruction(Call)) {
 #define KIND(Name, MemBehavior) case RT_ ## Name: return ModRefInfo:: MemBehavior;
 #include "LLVMSwift.def"
   }
@@ -32,17 +32,16 @@ static ModRefInfo getConservativeModRefForKind(const llvm::Instruction &I) {
   llvm_unreachable("Not a valid Instruction.");
 }
 
-ModRefInfo SwiftAAResult::getModRefInfo(llvm::ImmutableCallSite CS,
+ModRefInfo SwiftAAResult::getModRefInfo(llvm::CallBase *Call,
                                         const llvm::MemoryLocation &Loc) {
   // We know at compile time that certain entry points do not modify any
   // compiler-visible state ever. Quickly check if we have one of those
   // instructions and return if so.
-  if (ModRefInfo::NoModRef ==
-      getConservativeModRefForKind(*CS.getInstruction()))
+  if (ModRefInfo::NoModRef == getConservativeModRefForKind(*Call))
     return ModRefInfo::NoModRef;
 
   // Otherwise, delegate to the rest of the AA ModRefInfo machinery.
-  return AAResultBase::getModRefInfo(CS, Loc);
+  return AAResultBase::getModRefInfo(Call, Loc);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
ImmutableCallSite has been removed, and has been replaced with CallBase.  Adjust
the AA pass accordingly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
