### PR TITLE
[Diagnostics] Diagnose subscript operator misuse via fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -64,6 +64,9 @@ ERROR(ambiguous_reference_to_decl,none,
 ERROR(ambiguous_subscript,none,
       "ambiguous subscript with base type %0 and index type %1",
       (Type, Type))
+NOTE(ambiguous_subscript_candidate_requires_operator,none,
+     "candidate requires use of the subscript operator", ())
+
 ERROR(could_not_find_value_subscript,none,
       "value of type %0 has no subscripts",
       (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -64,9 +64,6 @@ ERROR(ambiguous_reference_to_decl,none,
 ERROR(ambiguous_subscript,none,
       "ambiguous subscript with base type %0 and index type %1",
       (Type, Type))
-NOTE(ambiguous_subscript_candidate_requires_operator,none,
-     "candidate requires use of the subscript operator", ())
-
 ERROR(could_not_find_value_subscript,none,
       "value of type %0 has no subscripts",
       (Type))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1327,8 +1327,7 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
 
 bool SubscriptMisuseFailure::diagnoseAsNote() {
   if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
-    emitDiagnostic(overload->choice.getDecl(),
-                   diag::ambiguous_subscript_candidate_requires_operator);
+    emitDiagnostic(overload->choice.getDecl(), diag::found_candidate);
     return true;
   }
   return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -78,6 +78,10 @@ FailureDiagnostic::emitDiagnostic(ArgTypes &&... Args) const {
   return cs.TC.diagnose(std::forward<ArgTypes>(Args)...);
 }
 
+Expr *FailureDiagnostic::findParentExpr(Expr *subExpr) const {
+  return E ? E->getParentMap()[subExpr] : nullptr;
+}
+
 Type RequirementFailure::getOwnerType() const {
   return getType(getAnchor())->getInOutObjectType()->getMetatypeInstanceType();
 }
@@ -1274,4 +1278,58 @@ bool MissingCallFailure::diagnoseAsError() {
   emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function_value)
       .fixItInsertAfter(insertLoc, "()");
   return true;
+}
+
+bool SubscriptMisuseFailure::diagnoseAsError() {
+  auto &sourceMgr = getASTContext().SourceMgr;
+
+  auto *memberExpr = cast<UnresolvedDotExpr>(getRawAnchor());
+  auto *baseExpr = getAnchor();
+
+  auto memberRange = baseExpr->getSourceRange();
+  (void)simplifyLocator(getConstraintSystem(), getLocator(), memberRange);
+
+  auto nameLoc = DeclNameLoc(memberRange.Start);
+
+  auto diag = emitDiagnostic(baseExpr->getLoc(),
+                             diag::could_not_find_subscript_member_did_you_mean,
+                             getType(baseExpr));
+
+  diag.highlight(memberRange).highlight(nameLoc.getSourceRange());
+
+  auto *parentExpr = findParentExpr(memberExpr);
+  assert(parentExpr && "Couldn't find a parent expression for a member call?!");
+
+  auto *argExpr = cast<ApplyExpr>(parentExpr)->getArg();
+
+  auto toCharSourceRange = Lexer::getCharSourceRangeFromSourceRange;
+  auto lastArgSymbol = toCharSourceRange(sourceMgr, argExpr->getEndLoc());
+
+  diag.fixItReplace(SourceRange(argExpr->getStartLoc()),
+                    getTokenText(tok::l_square));
+  diag.fixItRemove(nameLoc.getSourceRange());
+  diag.fixItRemove(SourceRange(memberExpr->getDotLoc()));
+
+  if (sourceMgr.extractText(lastArgSymbol) == getTokenText(tok::r_paren))
+    diag.fixItReplace(SourceRange(argExpr->getEndLoc()),
+                      getTokenText(tok::r_square));
+  else
+    diag.fixItInsertAfter(argExpr->getEndLoc(), getTokenText(tok::r_square));
+
+  diag.flush();
+  if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
+    emitDiagnostic(overload->choice.getDecl(), diag::kind_declared_here,
+                   DescriptiveDeclKind::Subscript);
+  }
+
+  return true;
+}
+
+bool SubscriptMisuseFailure::diagnoseAsNote() {
+  if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
+    emitDiagnostic(overload->choice.getDecl(),
+                   diag::ambiguous_subscript_candidate_requires_operator);
+    return true;
+  }
+  return false;
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -235,3 +235,12 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
 }
+
+bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+UseSubscriptOperator *UseSubscriptOperator::create(ConstraintSystem &cs,
+                                                   ConstraintLocator *locator) {
+  return new (cs.getAllocator()) UseSubscriptOperator(cs, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -237,7 +237,8 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
 }
 
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {
-  return false;
+  auto failure = SubscriptMisuseFailure(root, getConstraintSystem(), getLocator());
+  return failure.diagnose(asNote);
 }
 
 UseSubscriptOperator *UseSubscriptOperator::create(ConstraintSystem &cs,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -96,6 +96,9 @@ enum class FixKind : uint8_t {
 
   /// Add explicit `()` at the end of function or member to call it.
   InsertCall,
+
+  /// Instead of spelling out `subscript` directly, use subscript operator.
+  UseSubscriptOperator,
 };
 
 class ConstraintFix {
@@ -445,6 +448,21 @@ public:
 
   static InsertExplicitCall *create(ConstraintSystem &cs,
                                     ConstraintLocator *locator);
+};
+
+class UseSubscriptOperator final : public ConstraintFix {
+public:
+  UseSubscriptOperator(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::UseSubscriptOperator, locator) {}
+
+  std::string getName() const override {
+    return "replace '.subscript(...)' with subscript operator";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static UseSubscriptOperator *create(ConstraintSystem &cs,
+                                      ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2205,8 +2205,16 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   {
     DiagnosticTransaction transaction(TC.Diags);
 
-    TC.diagnose(commonAnchor->getLoc(), diag::ambiguous_reference_to_decl,
-                decl->getDescriptiveKind(), decl->getFullName());
+    const auto *fix = viableSolutions.front().second;
+    if (fix->getKind() == FixKind::UseSubscriptOperator) {
+      auto *UDE = cast<UnresolvedDotExpr>(commonAnchor);
+      TC.diagnose(commonAnchor->getLoc(),
+                  diag::could_not_find_subscript_member_did_you_mean,
+                  getType(UDE->getBase()));
+    } else {
+      TC.diagnose(commonAnchor->getLoc(), diag::ambiguous_reference_to_decl,
+                  decl->getDescriptiveKind(), decl->getFullName());
+    }
 
     for (const auto &viable : viableSolutions) {
       // Create scope so each applied solution is rolled back.

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -265,8 +265,12 @@ func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 }
 
 struct SubscriptTest1 {
-  subscript(keyword:String) -> Bool { return true }  // expected-note 2 {{found this candidate}}
-  subscript(keyword:String) -> String? {return nil }  // expected-note 2 {{found this candidate}}
+  subscript(keyword:String) -> Bool { return true }
+  // expected-note@-1 2 {{found this candidate}}
+  // expected-note@-2 2 {{candidate requires use of the subscript operator}}
+  subscript(keyword:String) -> String? {return nil }
+  // expected-note@-1 2 {{found this candidate}}
+  // expected-note@-2 2 {{candidate requires use of the subscript operator}}
 
   subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
   subscript(arg: Protocol) -> Bool { return true } // expected-note 2 {{declared here}}
@@ -285,7 +289,7 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   _ = s1.subscript((true, (5, baz: SubSubClass())), "hello")
   // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{60-61=]}}
   _ = s1.subscript((fo: true, (5, baz: SubClass())), "hello")
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{cannot convert value of type '(fo: Bool, (Int, baz: SubClass))' to expected argument type '(foo: Bool, bar: (Int, baz: SubClass))'}}
   _ = s1.subscript(SubSubClass())
   // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}
   _ = s1.subscript(ClassConformingToProtocol())
@@ -293,13 +297,15 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   _ = s1.subscript(ClassConformingToRefinedProtocol())
   // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
   _ = s1.subscript(true)
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(Bool)'}}
+  // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
   _ = s1.subscript(SuperClass())
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(SuperClass)'}}
+  // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
   _ = s1.subscript("hello")
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+  // expected-error@-1 {{ambiguous reference to subscript 'subscript(_:)'}}
   _ = s1.subscript("hello"
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-27=]}}
+  // expected-error@-1 {{ambiguous reference to subscript 'subscript(_:)'}}
   // expected-note@-2 {{to match this opening '('}}
 
   let _ = s1["hello"]

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -266,11 +266,9 @@ func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }
-  // expected-note@-1 2 {{found this candidate}}
-  // expected-note@-2 2 {{candidate requires use of the subscript operator}}
+  // expected-note@-1 4 {{found this candidate}}
   subscript(keyword:String) -> String? {return nil }
-  // expected-note@-1 2 {{found this candidate}}
-  // expected-note@-2 2 {{candidate requires use of the subscript operator}}
+  // expected-note@-1 4 {{found this candidate}}
 
   subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
   subscript(arg: Protocol) -> Bool { return true } // expected-note 2 {{declared here}}
@@ -303,9 +301,9 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(SuperClass)'}}
   // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
   _ = s1.subscript("hello")
-  // expected-error@-1 {{ambiguous reference to subscript 'subscript(_:)'}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
   _ = s1.subscript("hello"
-  // expected-error@-1 {{ambiguous reference to subscript 'subscript(_:)'}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
   // expected-note@-2 {{to match this opening '('}}
 
   let _ = s1["hello"]


### PR DESCRIPTION
Fix to use subscript operator instead of spelled out name helps
to produce a solution, that makes it much easier to diagnose
problems precisely and provide proper fix-its, it also helps to
diagnose ambiguous cases, and stacks up nicely with other errors.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
