### PR TITLE
Only run predictable mem opts in the guaranteed pipeline.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -249,10 +249,6 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel,
   // Split up operations on stack-allocated aggregates (struct, tuple).
   P.addSROA();
 
-  // Re-run predictable memory optimizations, since previous optimization
-  // passes sometimes expose oppotunities here.
-  P.addPredictableMemoryOptimizations();
-
   // Promote stack allocations to values.
   P.addMem2Reg();
 


### PR DESCRIPTION
Just an experiment to see the performance impact of this. I am currently updating this pass for ownership and this will make it significantly easier to do.