### PR TITLE
Fix findAccessedStorage to handle cyclic phis.

### DIFF
--- a/test/SILOptimizer/verifier.sil
+++ b/test/SILOptimizer/verifier.sil
@@ -6,6 +6,8 @@
 
 import Builtin
 
+sil_stage canonical
+
 // Don't fail in the verifier on a shared unreachable exit block of two loops.
 sil @dont_fail: $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
@@ -79,4 +81,29 @@ bb8:
 bb4:
   %10 = tuple ()
   return %10 : $()
+}
+
+// Verify that findAccessedStorage handles cyclic phis.
+// <rdar://47059671> swiftc crashes
+class AClass {
+  var aStoredProp: Builtin.Int32
+}
+
+sil @testPhiCycle : $@convention(thin) (@guaranteed AClass) -> () {
+bb0(%0 : $AClass):
+  %accessAddr = ref_element_addr %0 : $AClass, #AClass.aStoredProp
+  br bbloop(%accessAddr : $*Builtin.Int32)
+
+bbloop(%phiAddr : $*Builtin.Int32):
+  %access = begin_access [read] [dynamic] [no_nested_conflict] %phiAddr : $*Builtin.Int32
+  %val = load %access : $*Builtin.Int32
+  end_access %access : $*Builtin.Int32
+  cond_br undef, bbtail, bbreturn
+
+bbtail:
+  br bbloop(%phiAddr : $*Builtin.Int32)
+
+bbreturn:
+  %v = tuple ()
+  return %v : $()
 }


### PR DESCRIPTION
Fixes infinite recursion in findAccessedStorge. This routine was not
designed to be recursive, but recursion was recently added as a hack
for address-type phis. Naturally, phis can be cyclic, so this was not
a correct workaround.

This is only a problem with enforce-exclusivity=checked, with which
findAccessedStorge is invoked after arbitrary optimization passes that
introduce address-type phis. Ultimately, address phis will be
disallowed in SIL, but some optimizer passes must be fixed first.

Fixes <rdar://problem/47059671> swiftlang-1001.0.31.11 root: swiftc crashes

