### PR TITLE
[AD] Fix accidental cotangent-of-cotangent in aggregate adjoint values

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -3749,8 +3749,8 @@ public:
             eltVals.push_back(av);
           else
             eltVals.push_back(AdjointValue::getZero(
-                getCotangentType(field->getType()->getCanonicalType(),
-                                 getModule())));
+                SILType::getPrimitiveObjectType(field->getType()
+                                                ->getCanonicalType())));
         }
         addAdjointValue(sei->getOperand(),
                         AdjointValue::getAggregate(cotangentVectorSILTy,


### PR DESCRIPTION
In one case, a type that already corresponds to the CotangentVector 
associated type of a primal type was wrapped in an extra 
getCotangentType, resulting in cotangent-of-cotangent (tangent) types in 
generated adjoint code.