### PR TITLE
Move API notes out of the arch-specific subdirectories in lib/swift/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -991,15 +991,6 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
                         ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
 endif()
 
-#
-# Set up global CMake variables for API notes.
-#
-set(SWIFT_API_NOTES_PATH "${SWIFT_SOURCE_DIR}/apinotes")
-include("${SWIFT_API_NOTES_PATH}/CMakeLists.txt")
-if(NOT DEFINED SWIFT_API_NOTES_INPUTS)
-  message(FATAL_ERROR "API notes are not available in ${SWIFT_API_NOTES_PATH}")
-endif()
-
 # Add all of the subdirectories, where we actually do work.
 
 ###############
@@ -1007,7 +998,7 @@ endif()
 ###############
 #
 # We have to include stdlib/ before tools/.
-# Do not move add_subdirectory(stdlib) after add_subdirectory(tools)!                                             
+# Do not move add_subdirectory(stdlib) after add_subdirectory(tools)!
 #
 # We must include stdlib/ before tools/ because stdlib/CMakeLists.txt
 # declares the swift-stdlib-* set of targets. These targets will then
@@ -1022,6 +1013,14 @@ endif()
 #
 # https://bugs.swift.org/browse/SR-5975
 add_subdirectory(stdlib)
+
+if(SWIFT_BUILD_SDK_OVERLAY)
+  list_intersect("${SWIFT_APPLE_PLATFORMS}" "${SWIFT_SDKS}"
+                 building_darwin_sdks)
+  if(building_darwin_sdks)
+    add_subdirectory(apinotes)
+  endif()
+endif()
 
 add_subdirectory(include)
 

--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -1,24 +1,33 @@
-set(SWIFT_API_NOTES_INPUTS
-  Accelerate
-  Dispatch
-  ScriptingBridge
-  os
+set(sources
+  Accelerate.apinotes
+  Dispatch.apinotes
+  ScriptingBridge.apinotes
+  os.apinotes
 )
 
-if(NOT DEFINED SWIFT_API_NOTES_PATH)
-  message(FATAL_ERROR "Define SWIFT_API_NOTES_PATH before including this file")
-endif()
+set(output_dir "${SWIFTLIB_DIR}/apinotes")
 
-foreach(module ${SWIFT_API_NOTES_INPUTS})
-  if(NOT EXISTS "${SWIFT_API_NOTES_PATH}/${module}.apinotes")
-    message(SEND_ERROR "Missing apinotes for ${module}")
-  endif()
+set(inputs)
+set(outputs)
+foreach(input ${sources})
+  list(APPEND inputs "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
+  list(APPEND outputs "${output_dir}/${input}")
 endforeach()
 
-file(GLOB SWIFT_API_NOTES_INPUT_FILES "${SWIFT_API_NOTES_PATH}/*.apinotes")
-foreach(file ${SWIFT_API_NOTES_INPUT_FILES})
-  get_filename_component(name "${file}" NAME_WE)
-  if(NOT "${name}" IN_LIST SWIFT_API_NOTES_INPUTS)
-    message(SEND_ERROR "Found apinotes for ${name}; please add to CMakeLists.txt")
-  endif()
-endforeach()
+add_custom_command(
+    OUTPUT "${output_dir}"
+    COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${output_dir}")
+add_custom_command(
+    OUTPUT ${outputs}
+    DEPENDS ${inputs} "${output_dir}"
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "copy_if_different" ${inputs} "${output_dir}/")
+
+add_custom_target("copy_apinotes"
+    DEPENDS "${outputs}" "${output_dir}"
+    COMMENT "Copying API notes to ${output_dir}"
+    SOURCES "${sources}")
+
+swift_install_in_component(sdk-overlay
+    FILES ${sources}
+    DESTINATION "lib/swift/apinotes")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -606,7 +606,6 @@ endfunction()
 #     [C_COMPILE_FLAGS flag1...]
 #     [SWIFT_COMPILE_FLAGS flag1...]
 #     [LINK_FLAGS flag1...]
-#     [API_NOTES_NON_OVERLAY]
 #     [FILE_DEPENDS target1 ...]
 #     [DONT_EMBED_BITCODE]
 #     [IS_STDLIB]
@@ -661,9 +660,6 @@ endfunction()
 # LINK_FLAGS
 #   Extra linker flags.
 #
-# API_NOTES_NON_OVERLAY
-#   Generate API notes for non-overlayed modules with this target.
-#
 # FILE_DEPENDS
 #   Additional files this library depends on.
 #
@@ -686,7 +682,6 @@ endfunction()
 #   Sources to add into this library
 function(_add_swift_library_single target name)
   set(SWIFTLIB_SINGLE_options
-        API_NOTES_NON_OVERLAY
         DONT_EMBED_BITCODE
         FORCE_BUILD_OPTIMIZED
         IS_SDK_OVERLAY
@@ -805,22 +800,6 @@ function(_add_swift_library_single target name)
       SWIFTLIB_SINGLE_SOURCES
       "${SWIFTLIB_SINGLE_ARCHITECTURE}")
 
-  # Figure out whether and which API notes to create.
-  set(SWIFTLIB_SINGLE_API_NOTES)
-  if(SWIFTLIB_SINGLE_API_NOTES_NON_OVERLAY)
-    # Adopt all of the non-overlay API notes.
-    foreach(framework_name ${SWIFT_API_NOTES_INPUTS})
-      if (${framework_name} STREQUAL "WatchKit" AND
-          ${SWIFTLIB_SINGLE_SDK} STREQUAL "OSX")
-        # HACK: don't build WatchKit API notes for OS X.
-      else()
-        # Always build the "non-overlay" apinotes to keep them in sync
-        # rdar://40496966
-        list(APPEND SWIFTLIB_SINGLE_API_NOTES "${framework_name}")
-      endif()
-    endforeach()
-  endif()
-
   # Remove the "swift" prefix from the name to determine the module name.
   if(SWIFTLIB_IS_STDLIB_CORE)
     set(module_name "Swift")
@@ -870,7 +849,6 @@ function(_add_swift_library_single target name)
         ${SWIFTLIB_SINGLE_INTERFACE_LINK_LIBRARIES}
       SDK ${SWIFTLIB_SINGLE_SDK}
       ARCHITECTURE ${SWIFTLIB_SINGLE_ARCHITECTURE}
-      API_NOTES ${SWIFTLIB_SINGLE_API_NOTES}
       MODULE_NAME ${module_name}
       COMPILE_FLAGS ${SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS}
       ${SWIFTLIB_SINGLE_IS_STDLIB_keyword}
@@ -1471,7 +1449,6 @@ endfunction()
 #     [SWIFT_COMPILE_FLAGS flag1...]
 #     [LINK_FLAGS flag1...]
 #     [DONT_EMBED_BITCODE]
-#     [API_NOTES_NON_OVERLAY]
 #     [INSTALL]
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
@@ -1550,9 +1527,6 @@ endfunction()
 # LINK_FLAGS
 #   Extra linker flags.
 #
-# API_NOTES_NON_OVERLAY
-#   Generate API notes for non-overlayed modules with this target.
-#
 # DONT_EMBED_BITCODE
 #   Don't embed LLVM bitcode in this target, even if it is enabled globally.
 #
@@ -1589,7 +1563,6 @@ endfunction()
 #   Sources to add into this library.
 function(add_swift_target_library name)
   set(SWIFTLIB_options
-        API_NOTES_NON_OVERLAY
         DONT_EMBED_BITCODE
         FORCE_BUILD_OPTIMIZED
         HAS_SWIFT_CONTENT
@@ -1921,7 +1894,6 @@ function(add_swift_target_library name)
         INCORPORATE_OBJECT_LIBRARIES ${SWIFTLIB_INCORPORATE_OBJECT_LIBRARIES}
         INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY ${SWIFTLIB_INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY}
         ${SWIFTLIB_DONT_EMBED_BITCODE_keyword}
-        ${SWIFTLIB_API_NOTES_NON_OVERLAY_keyword}
         ${SWIFTLIB_IS_STDLIB_keyword}
         ${SWIFTLIB_IS_STDLIB_CORE_keyword}
         ${SWIFTLIB_IS_SDK_OVERLAY_keyword}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -612,10 +612,12 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
   // Enable API notes alongside headers/in frameworks.
   invocationArgStrs.push_back("-fapinotes-modules");
-  invocationArgStrs.push_back("-iapinotes-modules");
-  invocationArgStrs.push_back(searchPathOpts.RuntimeLibraryImportPath);
   invocationArgStrs.push_back("-fapinotes-swift-version=" +
-      languageVersion.asAPINotesVersionString());
+                              languageVersion.asAPINotesVersionString());
+  invocationArgStrs.push_back("-iapinotes-modules");
+  invocationArgStrs.push_back((llvm::Twine(searchPathOpts.RuntimeResourcePath) +
+                               llvm::sys::path::get_separator() +
+                               "apinotes").str());
 }
 
 static void

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -14,7 +14,10 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_
     SWIFT_COMPILE_FLAGS -Xfrontend -disable-objc-attr-requires-foundation-module "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
     TARGET_SDKS ALL_APPLE_PLATFORMS
-    API_NOTES_NON_OVERLAY)
+
+    # This is overly conservative, but we have so few API notes files that
+    # haven't migrated to the Swift repo that it's probably fine in practice.
+    DEPENDS copy_apinotes)
 
 add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Glibc.swift.gyb

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -64,7 +64,8 @@ foreach(input ${sources})
       COMMAND
         "${CMAKE_COMMAND}" "-E" "copy_if_different"
         "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-        "${output_dir}/${input}")
+        "${output_dir}/${input}"
+      COMMENT "Copying ${input} to ${output_dir}")
   list(APPEND outputs "${output_dir}/${input}")
 endforeach()
 # Put the output dir itself last so that it isn't considered the primary output.


### PR DESCRIPTION
They're all the same anyway, and no longer even need to be compiled, just copied in as text.

And drastically simplify how we "generate" them. Instead of attaching their build jobs to the appropriate overlays, if present, "just" have one job to copy them all and attach it to the Darwin overlay. That's what we do for the overlay shim headers, and it's good enough. (Eventually we want to get out of the business of shipping them altogether.)

This does have the same flaw as the shim headers: if you *just* change API notes, the corresponding overlay does not get rebuilt. You have to touch that too. But in practice that'll happen most of the time anyway.

Part of rdar://problem/43545560