### PR TITLE
GlobalOpt: fix a use after free

### DIFF
--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -701,7 +701,6 @@ replaceLoadsByKnownValue(BuiltinInst *CallToOnce, SILFunction *AddrF,
           SILBuilder B(CA);
           B.createStore(CA->getLoc(), NewAI, CA->getDest(),
                         StoreOwnershipQualifier::Unqualified);
-          CA->eraseFromParent();
         } else {
           // The result of the initializer is used as a value.
           replaceLoadSequence(Load, NewAI, B);


### PR DESCRIPTION
Detected by ASAN.
There is no need to remove the copy_address in the loop (which caused an iterator invalidation), because it's deleted with eraseUsesOfInstruction(Call)  anyway.

rdar://problem/47089910
