### PR TITLE
[5.0 12-12-2018] [IRGen/Runtime] Anonymous context descriptors can (should be) generic.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -510,6 +510,7 @@ namespace {
     
     void layout() {
       super::layout();
+      asImpl().addGenericSignature();
     }
   
     ConstantReference getParent() {
@@ -522,7 +523,7 @@ namespace {
     }
     
     GenericSignature *getGenericSignature() {
-      return nullptr;
+      return DC->getGenericSignatureOfContext();
     }
     
     bool isUniqueDescriptor() {

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -46,6 +46,9 @@ swift::_buildDemanglingForContext(const ContextDescriptor *context,
     [&](const ContextDescriptor *context) -> NodePointer {
       if (demangledGenerics.empty())
         return nullptr;
+
+      if (context->getKind() == ContextDescriptorKind::Anonymous)
+        return nullptr;
       
       auto generics = context->getGenericContext();
       if (!generics)

--- a/test/IRGen/anonymous_context_descriptors.sil
+++ b/test/IRGen/anonymous_context_descriptors.sil
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+protocol P { }
+
+class Blah<T: P> {
+  private struct Inner<U: P> { }
+}
+
+// Anonymous descriptor
+// CHECK: @"$s29anonymous_context_descriptors4BlahC5Inner33{{.*}}MXX" =
+
+// Flags: anonymous (2) + generic (0x80) + unique (0x40)
+// CHECK-SAME: i32 194
+
+// Parent
+// CHECK-SAME: $s29anonymous_context_descriptors4BlahCMn
+
+// # generic header
+// CHECK-SAME: i16 2, i16 2
+// CHECK-SAME: i16 4, i16 0

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -43,6 +43,10 @@ private protocol P2 {
   associatedtype A
 }
 
+private func getP2_A<T: P2>(_: T.Type) -> Any.Type {
+  return T.A.self
+}
+
 struct Bar: P2 {
   typealias A = Int
 }
@@ -54,5 +58,20 @@ private class C2<T: P2>: C1<T.A> { }
 AssociatedTypeDemangleTests.test("private protocols") {
   expectEqual("C2<Bar>", String(describing: C2<Bar>.self))
 }
+
+// rdar://problem/46853806
+class C3<T: P>: P2 {
+  fileprivate struct Inner<U: P> { }
+  fileprivate typealias A = Inner<T>
+}
+
+extension Int: P {
+  typealias A = Int
+}
+
+AssociatedTypeDemangleTests.test("generic anonymous contexts") {
+  expectEqual("Inner<Int>", String(describing: getP2_A(C3<Int>.self)))
+}
+
 
 runAllTests()


### PR DESCRIPTION
**Explanation**: Anonymous context descriptors were being treated as non-generic by
IRGen, which lead to problems for (file)private types within generic
types. Emit generic parameters and requirements for anonymous contexts
as well, and deal with this in the runtime.
**Scope**: Regression from 4.2. Affects private generic types within private generic types.
**Issue**: rdar://problem/46853806
**Risk**: Low; small change to type metadata emission
**Testing**: Swift CI, two projects that triggered this particular bug
**Reviewed by**: @jckarter  