### PR TITLE
Disable ExistentialSpecializer pass on devirt_protocol_method_invocations test  since it does not test ExistentialSpecializer functionalities.

### DIFF
--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -module-name devirt_protocol_method_invocations -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name devirt_protocol_method_invocations -O -Xllvm -sil-disable-pass=ExistentialSpecializer -emit-sil %s | %FileCheck %s
 
 protocol PPP {
     func f()


### PR DESCRIPTION
Disable ExistentialSpecializer on devirt_protocol_method_invocations test since it does not test ExistentialSpecializer functionalities.