### PR TITLE
AST: Fix failure to diagnose with redundant same-type constraints

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6838,7 +6838,7 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
           // Put invalid locations after valid ones.
           if (locA.isInvalid() || locB.isInvalid()) {
             if (locA.isInvalid() != locB.isInvalid())
-              return locA.isInvalid() ? 1 : -1;
+              return locA.isValid() ? 1 : -1;
 
             return 0;
           }

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -309,3 +309,14 @@ func testSameTypeCommutativity5<U, T: P1>(_ t: T, _ u: U)
 func testSameTypeCommutativity6<U, T: P1>(_ t: T, _ u: U)
   where U & P3 == T.Assoc { } // Equivalent to T.Assoc == U & P3
 // expected-error@-1 2 {{non-protocol, non-class type 'U' cannot be used within a protocol-constrained type}}
+
+// rdar;//problem/46848889
+struct Foo<A: P1, B: P1, C: P1> where A.Assoc == B.Assoc, A.Assoc == C.Assoc {}
+
+struct Bar<A: P1, B: P1> where A.Assoc == B.Assoc {
+  func f<C: P1>(with other: C) -> Foo<A, B, C> where A.Assoc == C.Assoc {
+    // expected-note@-1 {{previous same-type constraint 'B.Assoc' == 'C.Assoc' inferred from type here}}
+    // expected-warning@-2 {{redundant same-type constraint 'A.Assoc' == 'C.Assoc'}}
+    fatalError()
+  }
+}


### PR DESCRIPTION
This test case used to crash because the source-location-based order
here did not handle invalid source locations, but Doug fixed it already
in #21656. However, fixing it to sort invalid locations after valid
locations meant that the diagnostic code would pick the invalid location
to emit the diagnostic on, so no diagnostic was emitted.

This is not a big deal since the diagnostics in question are warnings,
but we do want to emit these redundant constraint warnings to avoid
confusing users if possible so let's fix it to do the right thing.

More completely fixes rdar://problem/46848889 (but it was already not
crashing after Doug's fix).