### PR TITLE
Windows: add FOF_NO_UI into the overlay

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -33,3 +33,7 @@ public let TRUE: BOOL = 1
 // handleapi.h
 public let INVALID_HANDLE_VALUE: HANDLE = HANDLE(bitPattern: -1)!
 
+// shellapi.h
+public let FOF_NO_UI: DWORD =
+    DWORD(FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR)
+


### PR DESCRIPTION
This constant is needed for SHFileOperation which is needed for
Foundation.  Unfortunately, it is a complex macro which will not be
imported by the ClangImporter.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
