### PR TITLE
Fix crash with redundant same-type constraints [5.0]

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6840,7 +6840,7 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
           // Put invalid locations after valid ones.
           if (locA.isInvalid() || locB.isInvalid()) {
             if (locA.isInvalid() != locB.isInvalid())
-              return locA.isInvalid() ? 1 : -1;
+              return locA.isValid() ? 1 : -1;
 
             return 0;
           }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6837,6 +6837,14 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
           auto locA = (*a)->constraint.source->getLoc();
           auto locB = (*b)->constraint.source->getLoc();
 
+          // Put invalid locations after valid ones.
+          if (locA.isInvalid() || locB.isInvalid()) {
+            if (locA.isInvalid() != locB.isInvalid())
+              return locA.isInvalid() ? 1 : -1;
+
+            return 0;
+          }
+
           auto bufferA = sourceMgr.findBufferContainingLoc(locA);
           auto bufferB = sourceMgr.findBufferContainingLoc(locB);
 

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -309,3 +309,14 @@ func testSameTypeCommutativity5<U, T: P1>(_ t: T, _ u: U)
 func testSameTypeCommutativity6<U, T: P1>(_ t: T, _ u: U)
   where U & P3 == T.Assoc { } // Equivalent to T.Assoc == U & P3
 // expected-error@-1 2 {{non-protocol, non-class type 'U' cannot be used within a protocol-constrained type}}
+
+// rdar;//problem/46848889
+struct Foo<A: P1, B: P1, C: P1> where A.Assoc == B.Assoc, A.Assoc == C.Assoc {}
+
+struct Bar<A: P1, B: P1> where A.Assoc == B.Assoc {
+  func f<C: P1>(with other: C) -> Foo<A, B, C> where A.Assoc == C.Assoc {
+    // expected-note@-1 {{previous same-type constraint 'B.Assoc' == 'C.Assoc' inferred from type here}}
+    // expected-warning@-2 {{redundant same-type constraint 'A.Assoc' == 'C.Assoc'}}
+    fatalError()
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0188-sr9496.swift
+++ b/validation-test/compiler_crashers_2_fixed/0188-sr9496.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+protocol P1 {
+    associatedtype A1
+}
+
+protocol P2 {
+    associatedtype A2
+}
+
+struct S1<G1: P1, G2: P1>: P1 where G1.A1 == G2.A1 {
+    typealias A1 = G1.A1
+}
+
+struct S2<G1: P1, G2: P2>: P2 where G1.A1 == G2.A2 {
+    typealias A2 = G2.A2
+}
+
+struct S3<G1: P1, G2: P2> where G1.A1 == G2.A2 {
+    func f<G: P1>(_: G) -> S3<S1<G, G1>, S2<G, G2>> {
+        fatalError()
+    }
+}


### PR DESCRIPTION
rdar://problem/46848889 / rdar://problem/46699008