### PR TITLE
const evaluator: array values and initialization

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -104,6 +104,12 @@ private:
 
     /// This represents an index *into* a memory object.
     RK_DerivedAddress,
+
+    /// This represents an array value.
+    RK_Array,
+
+    /// This represents an address of a memory object containing an array.
+    RK_ArrayAddress,
   };
 
   union {
@@ -135,6 +141,12 @@ private:
     /// When this SymbolicValue is of "DerivedAddress" kind, this pointer stores
     /// information about the memory object and access path of the access.
     DerivedAddressValue *derivedAddress;
+
+    /// For RK_Array, this is the elements of the array.
+    ArraySymbolicValue *array;
+
+    /// For RK_ArrayAddress, this is the memory object referenced.
+    SymbolicValueMemoryObject *arrayAddress;
   } value;
 
   RepresentationKind representationKind : 8;
@@ -173,6 +185,9 @@ public:
 
     /// This value represents the address of, or into, a memory object.
     Address,
+
+    /// This represents an array value.
+    Array,
 
     /// These values are generally only seen internally to the system, external
     /// clients shouldn't have to deal with them.
@@ -270,6 +285,20 @@ public:
 
   /// Return just the memory object for an address value.
   SymbolicValueMemoryObject *getAddressValueMemoryObject() const;
+
+  /// Produce an array of elements.
+  static SymbolicValue getArray(ArrayRef<SymbolicValue> elements,
+                                CanType elementType,
+                                ASTContext &astContext);
+  static SymbolicValue
+  getArrayAddress(SymbolicValueMemoryObject *memoryObject) {
+    SymbolicValue result;
+    result.representationKind = RK_ArrayAddress;
+    result.value.directAddress = memoryObject;
+    return result;
+  }
+
+  ArrayRef<SymbolicValue> getArrayValue(CanType &elementType) const;
 
   //===--------------------------------------------------------------------===//
   // Helpers

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -82,6 +82,21 @@ public:
   /// that occur after after folding them.
   void computeConstantValues(ArrayRef<SILValue> values,
                              SmallVectorImpl<SymbolicValue> &results);
+
+  /// Try to decode the specified apply of the _allocateUninitializedArray
+  /// function in the standard library.  This attempts to figure out how the
+  /// resulting elements will be initialized.  This fills in the result with
+  /// a lists of operands used to pass element addresses for initialization,
+  /// and returns false on success.
+  ///
+  /// If arrayInsts is non-null and if decoding succeeds, this function adds
+  /// all of the instructions relevant to the definition of this array into
+  /// the set.  If decoding fails, then the contents of this set is undefined.
+  ///
+  static bool
+  decodeAllocUninitializedArray(ApplyInst *apply, uint64_t numElements,
+                                SmallVectorImpl<Operand*> &elementsAtInit,
+                                SmallPtrSet<SILInstruction*, 8> *arrayInsts);
 };
 
 } // end namespace swift

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -803,6 +803,7 @@ extension Array: RangeReplaceableCollection {
   ///     // Prints "true"
   @inlinable
   @_semantics("array.init")
+  @_semantics("array.init_empty")
   public init() {
     _buffer = _Buffer()
   }

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -27,6 +27,7 @@ public struct _DependenceToken {
 /// - Precondition: `storage` is `_ContiguousArrayStorage`.
 @inlinable // FIXME(inline-always)
 @inline(__always)
+@_semantics("array.allocate_uninitialized")
 public // COMPILER_INTRINSIC
 func _allocateUninitializedArray<Element>(_  builtinCount: Builtin.Word)
     -> (Array<Element>, Builtin.RawPointer) {

--- a/test/SILOptimizer/pound_assert.sil
+++ b/test/SILOptimizer/pound_assert.sil
@@ -263,3 +263,70 @@ bb0(%arg : $Int64):
   %ret = tuple ()
   return %ret : $()
 }
+
+// Helper function to force const-evaluation of an array.
+sil @forceArrayConstEval : $@convention(thin) (Array<Int64>) -> (Int64) {
+bb0(%arr : $Array<Int64>):
+  %builtinInt = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%builtinInt : $Builtin.Int64)
+  return %int : $Int64
+}
+
+// TODO: The constant evaluator does not implement any array access operations,
+// so theses tests cannot test that the implemented array operations produce
+// correct values in the arrays. These tests only test that the implemented
+// array operations do not crash or produce unknown values. As soon as we have
+// array access operations, modify these tests to check the values in the
+// arrays.
+
+// Tests the "apply", "store", and "copy_addr" cases in
+// "decodeAllocUninitializedArray".
+sil @testDecodeAllocUninitializedArray : $@convention(thin) () -> () {
+bb0:
+  // Allocate the uninitialized array.
+  %0 = metatype $@thin Int64.Type
+  %1 = metatype $@thin Array<Int64>.Type
+  %arraySize = integer_literal $Builtin.Word, 3
+  // function_ref _allocateUninitializedArray<A>(_:)
+  %3 = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %4 = apply %3<Int64>(%arraySize) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %array = tuple_extract %4 : $(Array<Int64>, Builtin.RawPointer), 0
+  %arrayPtr = tuple_extract %4 : $(Array<Int64>, Builtin.RawPointer), 1
+  %arrayAddr = pointer_to_address %arrayPtr : $Builtin.RawPointer to [strict] $*Int64
+
+  // Use "apply" to initialize the first element of the array to 1.
+  %setInt64To1 = function_ref @setInt64To1: $@convention(thin) () -> (@out Int64)
+  %setInt64To1Result = apply %setInt64To1(%arrayAddr) : $@convention(thin) () -> (@out Int64)
+
+  // Use "store" to initialize the second element of the array to 2.
+  %secondElementIndex = integer_literal $Builtin.Word, 1
+  %secondElementAddr = index_addr %arrayAddr : $*Int64, %secondElementIndex : $Builtin.Word
+  %builtin_2 = integer_literal $Builtin.Int64, 2
+  %int64_2 = struct $Int64 (%builtin_2 : $Builtin.Int64)
+  store %int64_2 to %secondElementAddr : $*Int64
+
+  // Use "copy_addr" to initialize the third element of the array to 3.
+  %stackAddr = alloc_stack $Int64
+  %builtin_3 = integer_literal $Builtin.Int64, 3
+  %int64_3 = struct $Int64 (%builtin_3 : $Builtin.Int64)
+  store %int64_3 to %stackAddr : $*Int64
+  %thirdElementIndex = integer_literal $Builtin.Word, 2
+  %thirdElementAddr = index_addr %arrayAddr : $*Int64, %thirdElementIndex : $Builtin.Word
+  copy_addr %stackAddr to %thirdElementAddr : $*Int64
+  dealloc_stack %stackAddr : $*Int64
+
+  // Use the helper function to force const evaluation of the array.
+  %forceArrayConstEval = function_ref @forceArrayConstEval : $@convention(thin) (Array<Int64>) -> (Int64)
+  %forceArrayConstEvalResult = apply %forceArrayConstEval(%array) : $@convention(thin) (Array<Int64>) -> (Int64)
+  %expectedResult = integer_literal $Builtin.Int64, 42
+  %extracted = struct_extract %forceArrayConstEvalResult : $Int64, #Int64._value
+  %cmpResult = builtin "cmp_eq_Int64"(%extracted : $Builtin.Int64, %expectedResult : $Builtin.Int64) : $Builtin.Int1
+  %message = string_literal utf8 ""
+  %assertResult = builtin "poundAssert"(%cmpResult : $Builtin.Int1, %message : $Builtin.RawPointer) : $()
+
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// _allocateUninitializedArray<A>(_:)
+sil [serialized] [_semantics "array.allocate_uninitialized"] [always_inline] @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -455,3 +455,59 @@ func testStructPassedAsProtocols() {
   #assert(callProtoSimpleMethod(s) == 0) // expected-error {{#assert condition not constant}}
     // expected-note@-1 {{could not fold operation}}
 }
+
+//===----------------------------------------------------------------------===//
+// Arrays
+//
+// TODO: The constant evaluator does not implement any array access operations,
+// so theses tests cannot test that the implemented array operations produce
+// correct values in the arrays. These tests only test that the implemented
+// array operations do not crash or produce unknown values. As soon as we have
+// array access operations, modify these tests to check the values in the
+// arrays.
+//===----------------------------------------------------------------------===//
+
+struct ContainsArray {
+  let x: Int
+  let arr: [Int]
+}
+
+func arrayInitEmptyTopLevel() {
+  let c = ContainsArray(x: 1, arr: [])
+  #assert(c.x == 1)
+}
+
+func arrayInitNonEmptyTopLevel() {
+  let c = ContainsArray(x: 1, arr: [2, 3, 4])
+  #assert(c.x == 1)
+}
+
+func arrayInitNonConstantElementTopLevel(x: Int) {
+  // expected-note @+1 {{could not fold operation}}
+  let c = ContainsArray(x: 1, arr: [x])
+  // expected-error @+1 {{#assert condition not constant}}
+  #assert(c.x == 1)
+}
+
+// TODO: More work necessary for flow-sensitive array initialization to work.
+// expected-note @+1 {{could not fold operation}}
+func arrayInitEmptyFlowSensitive() -> ContainsArray {
+  return ContainsArray(x: 1, arr: [])
+}
+
+func invokeArrayInitEmptyFlowSensitive() {
+  // expected-error @+2 {{#assert condition not constant}}
+  // expected-note @+1 {{when called from here}}
+  #assert(arrayInitEmptyFlowSensitive().x == 1)
+}
+
+func arrayInitNonEmptyFlowSensitive() -> ContainsArray {
+  // expected-note @+1 {{could not fold operation}}
+  return ContainsArray(x: 1, arr: [2, 3, 4])
+}
+
+func invokeArrayInitFlowSensitive() {
+  // expected-error @+2 {{#assert condition not constant}}
+  // expected-note @+1 {{when called from here}}
+  #assert(arrayInitNonEmptyFlowSensitive().x == 1)
+}


### PR DESCRIPTION
Adds array values, initialization operations, and some tests that initialize arrays but that do not check the contents of the initialized arrays.