### PR TITLE
Fix a crash by removing the RestateFilteringConsumer

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -432,7 +432,7 @@ Type TypeBase::addCurriedSelfType(const DeclContext *dc) {
                              genericFn->getExtInfo());
   }
 
-  auto selfTy = dc->getDeclaredInterfaceType();
+  auto selfTy = dc->getSelfInterfaceType();
   auto selfParam = AnyFunctionType::Param(selfTy);
   if (sig)
     return GenericFunctionType::get(sig, {selfParam}, type);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -853,7 +853,6 @@ Type TypeBase::getMetatypeInstanceType() {
   if (auto metaTy = getAs<AnyMetatypeType>())
     return metaTy->getInstanceType();
 
-  // For mutable value type methods, we need to dig through inout types.
   return this;
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4178,13 +4178,12 @@ public:
     }
   }
 
-  void addDesignatedInitializers(Type CurrTy) {
+  void addDesignatedInitializers(NominalTypeDecl *NTD) {
     if (hasFuncIntroducer || hasVarIntroducer || hasTypealiasIntroducer ||
         hasOverridabilityModifier)
       return;
 
-    assert(CurrTy);
-    const auto *CD = dyn_cast_or_null<ClassDecl>(CurrTy->getAnyNominal());
+    const auto *CD = dyn_cast<ClassDecl>(NTD);
     if (!CD)
       return;
     if (!CD->hasSuperclass())
@@ -4201,13 +4200,11 @@ public:
     }
   }
 
-  void addAssociatedTypes(Type CurrTy) {
+  void addAssociatedTypes(NominalTypeDecl *NTD) {
     if (!hasTypealiasIntroducer &&
         (hasFuncIntroducer || hasVarIntroducer || hasInitializerModifier ||
          hasOverride || hasOverridabilityModifier))
       return;
-
-    NominalTypeDecl *NTD = CurrTy->getAnyNominal();
 
     for (auto Conformance : NTD->getAllConformances()) {
       auto Proto = Conformance->getProtocol();
@@ -4234,13 +4231,14 @@ public:
     if (isa<ProtocolDecl>(CurrDeclContext))
       return;
 
-    Type CurrTy = CurrDeclContext->getDeclaredTypeInContext();
+    Type CurrTy = CurrDeclContext->getSelfTypeInContext();
+    auto *NTD = CurrDeclContext->getSelfNominalTypeDecl();
     if (CurrTy && !CurrTy->is<ErrorType>()) {
       lookupVisibleMemberDecls(*this, CurrTy, CurrDeclContext,
                                TypeResolver,
                                /*includeInstanceMembers=*/false);
-      addDesignatedInitializers(CurrTy);
-      addAssociatedTypes(CurrTy);
+      addDesignatedInitializers(NTD);
+      addAssociatedTypes(NTD);
     }
   }
 };

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3179,19 +3179,10 @@ public:
     Kind = LookupKind::ValueExpr;
     NeedLeadingDot = !HaveDot;
 
-    // This is horrible
     ExprType = ExprType->getRValueType();
+    assert(!ExprType->hasTypeParameter());
+
     this->ExprType = ExprType;
-    if (ExprType->hasTypeParameter()) {
-      DeclContext *DC = nullptr;
-      if (VD)
-        DC = VD->getInnermostDeclContext();
-      else if (auto NTD = ExprType->getInOutObjectType()
-                   ->getMetatypeInstanceType()->getAnyNominal())
-        DC = NTD;
-      if (DC)
-        ExprType = DC->mapTypeIntoContext(ExprType);
-    }
 
     // Handle special cases
     bool isIUO = VD && VD->getAttrs()

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3184,6 +3184,21 @@ public:
 
     this->ExprType = ExprType;
 
+    // Open existential types, so that lookupVisibleMemberDecls() can properly
+    // substitute them.
+    bool WasOptional = false;
+    if (auto OptionalType = ExprType->getOptionalObjectType()) {
+      ExprType = OptionalType;
+      WasOptional = true;
+    }
+
+    if (!ExprType->getMetatypeInstanceType()->isAnyObject())
+      if (ExprType->isAnyExistentialType())
+        ExprType = OpenedArchetypeType::getAny(ExprType);
+
+    if (WasOptional)
+      ExprType = OptionalType::get(ExprType);
+
     // Handle special cases
     bool isIUO = VD && VD->getAttrs()
         .hasAttribute<ImplicitlyUnwrappedOptionalAttr>();

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -837,7 +837,8 @@ public:
     // don't substitute either.
     bool shouldSubst = (!BaseTy->isAnyObject() &&
                         !BaseTy->hasTypeVariable() &&
-                        BaseTy->getNominalOrBoundGenericNominal() &&
+                        (BaseTy->getNominalOrBoundGenericNominal() ||
+                         BaseTy->is<ArchetypeType>()) &&
                         VD->getDeclContext()->isTypeContext());
     ModuleDecl *M = DC->getParentModule();
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -763,17 +763,6 @@ template <> struct DenseMapInfo<FoundDeclTy> {
 
 namespace {
 
-/// Hack to guess at whether substituting into the type of a declaration will
-/// be okay.
-/// FIXME: This is awful. We should either have Type::subst() work for
-/// GenericFunctionType, or we should kill it outright.
-static bool shouldSubstIntoDeclType(Type type) {
-  auto genericFnType = type->getAs<GenericFunctionType>();
-  if (!genericFnType) return true;
-
-  return false;
-}
-
 class OverrideFilteringConsumer : public VisibleDeclConsumer {
 public:
   std::set<ValueDecl *> AllFoundDecls;
@@ -865,8 +854,7 @@ public:
 
     auto FoundSignature = VD->getOverloadSignature();
     auto FoundSignatureType = VD->getOverloadSignatureType();
-    if (FoundSignatureType && shouldSubst &&
-        shouldSubstIntoDeclType(FoundSignatureType)) {
+    if (FoundSignatureType && shouldSubst) {
       auto subs = BaseTy->getMemberSubstitutionMap(M, VD);
       if (auto CT = FoundSignatureType.subst(subs))
         FoundSignatureType = CT->getCanonicalType();
@@ -883,8 +871,7 @@ public:
 
       auto OtherSignature = OtherVD->getOverloadSignature();
       auto OtherSignatureType = OtherVD->getOverloadSignatureType();
-      if (OtherSignatureType && shouldSubst &&
-          shouldSubstIntoDeclType(OtherSignatureType)) {
+      if (OtherSignatureType && shouldSubst) {
         auto subs = BaseTy->getMemberSubstitutionMap(M, OtherVD);
         if (auto CT = OtherSignatureType.subst(subs))
           OtherSignatureType = CT->getCanonicalType();

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -785,7 +785,9 @@ public:
 
     // If this kind of declaration doesn't participate in overriding, there's
     // no filtering to do here.
-    if (!isa<AbstractFunctionDecl>(VD) && !isa<AbstractStorageDecl>(VD)) {
+    if (!isa<AbstractFunctionDecl>(VD) &&
+        !isa<AbstractStorageDecl>(VD) &&
+        !isa<AssociatedTypeDecl>(VD)) {
       DeclsToReport.insert(FoundDeclTy(VD, Reason));
       return;
     }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -771,16 +771,12 @@ public:
   Type BaseTy;
   const DeclContext *DC;
   LazyResolver *TypeResolver;
-  bool IsTypeLookup = false;
 
   OverrideFilteringConsumer(Type BaseTy, const DeclContext *DC,
                             LazyResolver *resolver)
-      : BaseTy(BaseTy), DC(DC), TypeResolver(resolver) {
+      : BaseTy(BaseTy->getMetatypeInstanceType()),
+        DC(DC), TypeResolver(resolver) {
     assert(!BaseTy->hasLValueType());
-    if (auto *MetaTy = BaseTy->getAs<AnyMetatypeType>()) {
-      BaseTy = MetaTy->getInstanceType();
-      IsTypeLookup = true;
-    }
     assert(DC && BaseTy);
   }
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -466,92 +466,6 @@ lookupVisibleMemberDeclsImpl(Type BaseTy, VisibleDeclConsumer &Consumer,
                              GenericSignatureBuilder *GSB,
                              VisitedSet &Visited);
 
-// Filters out restated declarations from a protocol hierarchy
-// or equivalent requirements from protocol composition types.
-class RestateFilteringConsumer : public VisibleDeclConsumer {
-  LazyResolver *resolver;
-
-  using FoundDecl = std::pair<ValueDecl*, DeclVisibilityKind>;
-  using NameAndType = std::pair<DeclName, CanType>;
-
-  llvm::DenseMap<DeclName, FoundDecl> foundVars;
-  llvm::DenseMap<NameAndType, FoundDecl> foundFuncs;
-  llvm::MapVector<ValueDecl*, DeclVisibilityKind> declsToReport;
-
-  template <typename K>
-  void addDecl(llvm::DenseMap<K, FoundDecl> &Map, K Key, FoundDecl FD) {
-    // Add the declaration if we haven't found an equivalent yet, otherwise
-    // replace the equivalent if the found decl has a higher access level.
-    auto existingDecl = Map.find(Key);
-
-    if ((existingDecl == Map.end()) ||
-        (Map[Key].first->getFormalAccess() < FD.first->getFormalAccess())) {
-      if (existingDecl != Map.end())
-        declsToReport.erase({existingDecl->getSecond().first});
-      Map[Key] = FD;
-      declsToReport.insert(FD);
-    }
-  }
-
-  CanType stripSelfRequirementsIfNeeded(ValueDecl *VD,
-                                        GenericFunctionType *GFT) const {
-    // Preserve the generic signature if this is a subscript, which are uncurried,
-    // or if we have generic params other than Self. Otherwise, use
-    // the resultType of the curried function type.
-    // When we keep the generic signature, we remove the requirements
-    // from Self to make sure they don't prevent us from recognizing restatements.
-    auto params = GFT->getGenericParams();
-    if (params.size() == 1 && !isa<SubscriptDecl>(VD)) {
-      return GFT->getResult()->getCanonicalType();
-    }
-    auto Self = VD->getDeclContext()->getSelfInterfaceType();
-    SmallVector<Requirement, 4> newReqs;
-    for (auto req: GFT->getRequirements()) {
-      if (!Self->isEqual(req.getFirstType()))
-        newReqs.push_back(req);
-    }
-    auto newSig = GenericSignature::get(params, newReqs, false);
-
-    return GenericFunctionType::get(newSig, GFT->getParams(),
-                                    GFT->getResult(), GFT->getExtInfo())
-      ->getCanonicalType();
-  }
-
-public:
-  RestateFilteringConsumer(Type baseTy, const DeclContext *DC,
-                           LazyResolver *resolver)
-  : resolver(resolver) {
-    assert(DC && baseTy && !baseTy->hasLValueType());
-  }
-
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
-    assert(VD);
-    // If this isn't a protocol context, don't look further into the decl.
-    if (!isa<ProtocolDecl>(VD->getDeclContext())) {
-      declsToReport.insert({VD, Reason});
-      return;
-    }
-    if (resolver)
-      resolver->resolveDeclSignature(VD);
-
-    if (!VD->hasInterfaceType()) {
-      declsToReport.insert({VD, Reason});
-      return;
-    }
-    if (auto GFT = VD->getInterfaceType()->getAs<GenericFunctionType>()) {
-      auto type = stripSelfRequirementsIfNeeded(VD, GFT);
-      addDecl(foundFuncs, {VD->getFullName(), type}, {VD, Reason});
-      return;
-    }
-    addDecl(foundVars, VD->getFullName(), {VD, Reason});
-  }
-
-  void feedResultsToConsumer(VisibleDeclConsumer &Consumer) const {
-    for (const auto entry: declsToReport)
-      Consumer.foundDecl(entry.first, entry.second);
-  }
-};
-
 static void
   lookupVisibleProtocolMemberDecls(Type BaseTy, ProtocolType *PT,
                                    VisibleDeclConsumer &Consumer,
@@ -911,13 +825,11 @@ static void lookupVisibleMemberDecls(
     LookupState LS, DeclVisibilityKind Reason, LazyResolver *TypeResolver,
     GenericSignatureBuilder *GSB) {
   OverrideFilteringConsumer overrideConsumer(BaseTy, CurrDC, TypeResolver);
-  RestateFilteringConsumer restateConsumer(BaseTy, CurrDC, TypeResolver);
   VisitedSet Visited;
-  lookupVisibleMemberDeclsImpl(BaseTy, restateConsumer, CurrDC, LS, Reason,
+  lookupVisibleMemberDeclsImpl(BaseTy, overrideConsumer, CurrDC, LS, Reason,
                                TypeResolver, GSB, Visited);
 
   // Report the declarations we found to the real consumer.
-  restateConsumer.feedResultsToConsumer(overrideConsumer);
   for (const auto &DeclAndReason : overrideConsumer.DeclsToReport)
     Consumer.foundDecl(DeclAndReason.D, DeclAndReason.Reason);
 }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -637,12 +637,11 @@ static void lookupVisibleMemberDeclsImpl(
     for (auto Proto : Archetype->getConformsTo())
       lookupVisibleProtocolMemberDecls(
           BaseTy, Proto->getDeclaredType(), Consumer, CurrDC, LS,
-          getReasonForSuper(Reason), TypeResolver, GSB, Visited);
+          Reason, TypeResolver, GSB, Visited);
 
     if (auto superclass = Archetype->getSuperclass())
       lookupVisibleMemberDeclsImpl(superclass, Consumer, CurrDC, LS,
-                                   getReasonForSuper(Reason), TypeResolver,
-                                   GSB, Visited);
+                                   Reason, TypeResolver, GSB, Visited);
     return;
   }
 

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -148,7 +148,7 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/CurrNominal:   append({#(newElement): Equatable#})[#Void#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/CurrNominal:   insert({#(newElement): Equatable#}, {#at: Int#})[#Void#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst()[#ArraySlice<Equatable>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropLast()[#ArraySlice<Equatable>#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropLast()[#[Equatable]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         enumerated()[#EnumeratedSequence<[Equatable]>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         min({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}

--- a/test/IDE/complete_members_optional.swift
+++ b/test/IDE/complete_members_optional.swift
@@ -29,8 +29,8 @@ func optionalMembers1(_ a: HasOptionalMembers1) {
   a.#^OPTIONAL_MEMBERS_1^#
 }
 // OPTIONAL_MEMBERS_1: Begin completions, 3 items
-// OPTIONAL_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   optionalInstanceFunc?()[#Int#]{{; name=.+$}}
-// OPTIONAL_MEMBERS_1-DAG: Decl[InstanceVar]/CurrNominal:      optionalInstanceProperty[#Int?#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal: optionalInstanceFunc?()[#Int#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_1-DAG: Decl[InstanceVar]/CurrNominal: optionalInstanceProperty[#Int?#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_1-DAG: Keyword[self]/CurrNominal: self[#HasOptionalMembers1#]; name=self
 // OPTIONAL_MEMBERS_1: End completions
 
@@ -38,8 +38,8 @@ func optionalMembers2<T : HasOptionalMembers1>(_ a: T) {
   T.#^OPTIONAL_MEMBERS_2^#
 }
 // OPTIONAL_MEMBERS_2: Begin completions, 4 items
-// OPTIONAL_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         optionalInstanceFunc?({#self: HasOptionalMembers1#})[#() -> Int#]{{; name=.+$}}
-// OPTIONAL_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           optionalClassFunc?()[#Int#]{{; name=.+$}}
-// OPTIONAL_MEMBERS_2-DAG: Decl[StaticVar]/Super:              optionalClassProperty[#Int?#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal: optionalInstanceFunc?({#self: HasOptionalMembers1#})[#() -> Int#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_2-DAG: Decl[StaticMethod]/CurrNominal: optionalClassFunc?()[#Int#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_2-DAG: Decl[StaticVar]/CurrNominal: optionalClassProperty[#Int?#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_2-DAG: Keyword[self]/CurrNominal: self[#T.Type#]; name=self
 // OPTIONAL_MEMBERS_2: End completions

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -279,8 +279,8 @@ func testInfix15<T: P where T.T == S2>() {
   T#^INFIX_15^#
 }
 // INFIX_15: Begin completions, 3 items
-// INFIX_15-NEXT: Decl[AssociatedType]/Super:         .T; name=T
-// INFIX_15-NEXT: Decl[InstanceMethod]/Super:         .foo({#self: P#})[#() -> S2#]; name=foo(P)
+// INFIX_15-NEXT: Decl[AssociatedType]/CurrNominal:   .T; name=T
+// INFIX_15-NEXT: Decl[InstanceMethod]/CurrNominal:   .foo({#self: P#})[#() -> S2#]; name=foo(P)
 // INFIX_15-NEXT: Keyword[self]/CurrNominal:          .self[#T.Type#]; name=self
 // INFIX_15: End completions
 

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -456,7 +456,7 @@ typealias FooTypealias = Int
 //===---
 
 // TYPE_IN_PROTOCOL: Begin completions
-// TYPE_IN_PROTOCOL-DAG: Decl[GenericTypeParam]/Super: Self[#Self#]{{; name=.+$}}
+// TYPE_IN_PROTOCOL-DAG: Decl[GenericTypeParam]/CurrNominal: Self[#Self#]{{; name=.+$}}
 // TYPE_IN_PROTOCOL: End completions
 
 protocol TestSelf1 {
@@ -1013,7 +1013,7 @@ func testTypeIdentifierGeneric1<
     >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_1^#
 
 // TYPE_IDENTIFIER_GENERIC_1: Begin completions
-// TYPE_IDENTIFIER_GENERIC_1-NEXT: Decl[AssociatedType]/Super: FooTypeAlias1{{; name=.+$}}
+// TYPE_IDENTIFIER_GENERIC_1-NEXT: Decl[AssociatedType]/CurrNominal: FooTypeAlias1{{; name=.+$}}
 // TYPE_IDENTIFIER_GENERIC_1-NEXT: Keyword/None:          Type[#GenericFoo.Type#]
 // TYPE_IDENTIFIER_GENERIC_1-NEXT: End completions
 
@@ -1022,8 +1022,8 @@ func testTypeIdentifierGeneric2<
     >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_2^#
 
 // TYPE_IDENTIFIER_GENERIC_2: Begin completions
-// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/Super: BarTypeAlias1{{; name=.+$}}
-// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/Super: FooTypeAlias1{{; name=.+$}}
+// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/CurrNominal: BarTypeAlias1{{; name=.+$}}
+// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/CurrNominal: FooTypeAlias1{{; name=.+$}}
 // TYPE_IDENTIFIER_GENERIC_2-NEXT: Keyword/None:          Type[#GenericFoo.Type#]
 // TYPE_IDENTIFIER_GENERIC_2-NEXT: End completions
 

--- a/test/IDE/complete_type_subscript.swift
+++ b/test/IDE/complete_type_subscript.swift
@@ -100,7 +100,7 @@ extension G6 {
   subscript(b x: T.#^GEN_EXT_PARAM_6^#) -> Int { return 0 }
   subscript(b x: Int) -> T.#^GEN_EXT_RETURN_6^# { return 0 }
 }
-// GEN_PARAM_6-DAG: Decl[AssociatedType]/Super:         Assoc;
+// GEN_PARAM_6-DAG: Decl[AssociatedType]/CurrNominal:   Assoc;
 // GEN_PARAM_6-DAG: Keyword/None:                       Type[#T.Type#];
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_PARAM_1 | %FileCheck %s -check-prefix=GENPROTO_1
@@ -116,5 +116,5 @@ extension GP1 {
   subscript(b x: I.#^GENPROTO_EXT_PARAM_1^#) -> Int { return 1 }
   subscript(b x: Int) -> I.#^GENPROTO_EXT_RETURN_1^# { return 1 }
 }
-// GENPROTO_1-DAG: Decl[AssociatedType]/Super:         Assoc;
+// GENPROTO_1-DAG: Decl[AssociatedType]/CurrNominal:   Assoc;
 // GENPROTO_1-DAG: Keyword/None:                       Type[#Self.I.Type#];

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -122,9 +122,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ4 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ5 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ6 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_TYPE1 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_TYPE
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_TYPE2 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_TYPE
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_TYPE3 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_TYPE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_TYPE1 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_TYPE1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_TYPE2 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_TYPE2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_TYPE3 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_TYPE3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_NODOT1 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_NODOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_NODOT2 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_NODOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NODUP_RESTATED_REQ_NODOT3 | %FileCheck %s -check-prefix=CHECK_NODUP_RESTATED_REQ_NODOT
@@ -1006,10 +1006,10 @@ func testResolveFuncParam3<Foo : FooProtocol>(_ foo: Foo) {
   foo.#^RESOLVE_FUNC_PARAM_3^#
 // RESOLVE_FUNC_PARAM_3: Begin completions
 // RESOLVE_FUNC_PARAM_3-NEXT: Keyword[self]/CurrNominal: self[#Foo#]; name=self
-// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar1[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceVar]/CurrNominal: fooInstanceVar1[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceVar]/CurrNominal: fooInstanceVar2[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_3-NEXT: End completions
 }
 
@@ -1017,13 +1017,13 @@ func testResolveFuncParam4<FooBar : FooProtocol & BarProtocol>(_ fooBar: FooBar)
   fooBar.#^RESOLVE_FUNC_PARAM_4^#
 // RESOLVE_FUNC_PARAM_4: Begin completions
 // RESOLVE_FUNC_PARAM_4-NEXT: Keyword[self]/CurrNominal: self[#FooBar#]; name=self
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/Super:    barInstanceVar[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/Super: barInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/Super: barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar1[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/CurrNominal:    barInstanceVar[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/CurrNominal: barInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/CurrNominal: barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/CurrNominal: fooInstanceVar1[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/CurrNominal: fooInstanceVar2[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_4-NEXT: End completions
 }
 
@@ -1031,15 +1031,15 @@ func testResolveFuncParam5<FooExBarEx : FooExProtocol & BarExProtocol>(_ a: FooE
   a.#^RESOLVE_FUNC_PARAM_5^#
 // RESOLVE_FUNC_PARAM_5: Begin completions
 // RESOLVE_FUNC_PARAM_5-NEXT: Keyword[self]/CurrNominal: self[#FooExBarEx#]; name=self
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super:    barInstanceVar[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super: barInstanceVar[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: barInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: barExInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar1[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/CurrNominal: barExInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super: fooInstanceVar1[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super: fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/CurrNominal: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: End completions
 }
 
@@ -1047,13 +1047,13 @@ func testResolveFuncParam6<Foo : FooProtocol where Foo : FooClass>(_ foo: Foo) {
   foo.#^RESOLVE_FUNC_PARAM_6^#
 // RESOLVE_FUNC_PARAM_6: Begin completions
 // RESOLVE_FUNC_PARAM_6-NEXT: Keyword[self]/CurrNominal: self[#Foo#]; name=self
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar1[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/Super:    fooClassInstanceVar[#Int#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooClassInstanceFunc0()[#Void#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooClassInstanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/CurrNominal: fooInstanceVar1[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/CurrNominal: fooInstanceVar2[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/CurrNominal: fooClassInstanceVar[#Int#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/CurrNominal: fooClassInstanceFunc0()[#Void#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/CurrNominal: fooClassInstanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-NEXT: End completions
 }
 
@@ -1068,10 +1068,10 @@ class TestResolveConstructorParam2 {
     foo.#^RESOLVE_CONSTRUCTOR_PARAM_2^#
 // RESOLVE_CONSTRUCTOR_PARAM_2: Begin completions
 // RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Keyword[self]/CurrNominal: self[#Foo#]; name=self
-// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar1[#Int#]{{; name=.+$}}
-// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
-// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceVar]/CurrNominal:  fooInstanceVar1[#Int#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceVar]/CurrNominal:  fooInstanceVar2[#Int#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: End completions
   }
 }
@@ -1081,10 +1081,10 @@ class TestResolveConstructorParam3<Foo : FooProtocol> {
     foo.#^RESOLVE_CONSTRUCTOR_PARAM_3^#
 // RESOLVE_CONSTRUCTOR_PARAM_3: Begin completions
 // RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Keyword[self]/CurrNominal: self[#Foo#]; name=self
-// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar1[#Int#]{{; name=.+$}}
-// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
-// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
-// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceVar]/CurrNominal:  fooInstanceVar1[#Int#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceVar]/CurrNominal:  fooInstanceVar2[#Int#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: End completions
   }
 }
@@ -1516,29 +1516,29 @@ func testGenericConforming1<T: P1>(x: T) {
   x.#^PROTOCOL_EXT_GENERICP1^#
 }
 // PROTOCOL_EXT_GENERICP1: Begin completions
-// PROTOCOL_EXT_GENERICP1-DAG: Decl[InstanceMethod]/Super:   reqP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP1-DAG: Decl[InstanceMethod]/Super:   extP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP1-DAG: Decl[InstanceMethod]/CurrNominal: reqP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP1-DAG: Decl[InstanceMethod]/CurrNominal: extP1()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_GENERICP1: End completions
 
 func testGenericConforming2<T: P2>(x: T) {
   x.#^PROTOCOL_EXT_GENERICP2^#
 }
 // PROTOCOL_EXT_GENERICP2: Begin completions
-// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/Super:   reqP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/Super:   reqP2()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/Super:   extP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/Super:   extP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/Super: reqP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/CurrNominal:  reqP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/Super: extP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP2-DAG: Decl[InstanceMethod]/CurrNominal: extP2()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_GENERICP2: End completions
 
 func testGenericConforming3<T: P3>(x: T) {
   x.#^PROTOCOL_EXT_GENERICP3^#
 }
 // PROTOCOL_EXT_GENERICP3: Begin completions
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super:   reqP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super:   reqP2()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super:   extP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super:   extP2()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super:   extP3()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: reqP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: reqP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: extP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: extP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/CurrNominal: extP3()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_GENERICP3: End completions
 
 protocol NoDupReq1 {
@@ -1647,14 +1647,26 @@ func checkOverrideInclusion2(_ arg: Override3) {
 // CHECK_NODUP_RESTATED_REQ_NODOT-NOT: Decl[InstanceVar]/{{Super|CurrNominal}}:    .doo[#Int#]; name=doo
 // CHECK_NODUP_RESTATED_REQ_NODOT: End completions
 
-// CHECK_NODUP_RESTATED_REQ_TYPE: Begin completions
-// CHECK_NODUP_RESTATED_REQ_TYPE-DAG: Decl[InstanceMethod]/Super: foo({#self: [[ARG:.+]]#})[#() -> Void#]; name=foo([[ARG]])
-// CHECK_NODUP_RESTATED_REQ_TYPE-DAG: Decl[InstanceMethod]/Super: roo({#self: [[ARG]]#})[#(arg1: Int) -> Void#]; name=roo([[ARG]])
-// CHECK_NODUP_RESTATED_REQ_TYPE-DAG: Decl[AssociatedType]/Super: E; name=E
-// CHECK_NODUP_RESTATED_REQ_TYPE-DAG: Decl[InstanceMethod]/Super: roo({#self: [[ARG]]#})[#(arg2: Int) -> Void#]; name=roo([[ARG]])
-// CHECK_NODUP_RESTATED_REQ_TYPE-NOT: Decl[InstanceMethod]/Super: foo({#self: [[ARG:.+]]#})[#() -> Void#]; name=foo([[ARG]])
-// CHECK_NODUP_RESTATED_REQ_TYPE-NOT: Decl[AssociatedType]/Super: E; name=E
-// CHECK_NODUP_RESTATED_REQ_TYPE: End completions
+// CHECK_NODUP_RESTATED_REQ_TYPE1: Begin completions, 5 items
+// CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/Super: foo({#self: NoDupReq6#})[#() -> Void#]; name=foo(NoDupReq6)
+// CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/Super: roo({#self: NoDupReq6#})[#(arg1: Int) -> Void#]; name=roo(NoDupReq6
+// CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[AssociatedType]/Super: E; name=E
+// CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/CurrNominal: roo({#self: NoDupReq6#})[#(arg2: Int) -> Void#]; name=roo(NoDupReq6)
+// CHECK_NODUP_RESTATED_REQ_TYPE1: End completions
+
+// CHECK_NODUP_RESTATED_REQ_TYPE2: Begin completions, 5 items
+// CHECK_NODUP_RESTATED_REQ_TYPE2: Decl[InstanceMethod]/CurrNominal: foo({#self: NoDupReq1 & NoDupReq2 & NoDupReq3#})[#() -> Void#]; name=foo(NoDupReq1 & NoDupReq2 & NoDupReq3)
+// CHECK_NODUP_RESTATED_REQ_TYPE2: Decl[InstanceMethod]/CurrNominal: roo({#self: NoDupReq1 & NoDupReq2 & NoDupReq3#})[#(arg1: Int) -> Void#]; name=roo(NoDupReq1 & NoDupReq2 & NoDupReq3)
+// CHECK_NODUP_RESTATED_REQ_TYPE2: Decl[AssociatedType]/CurrNominal: E; name=E
+// CHECK_NODUP_RESTATED_REQ_TYPE2: Decl[InstanceMethod]/CurrNominal: roo({#self: NoDupReq1 & NoDupReq2 & NoDupReq3#})[#(arg2: Int) -> Void#]; name=roo(NoDupReq1 & NoDupReq2 & NoDupReq3)
+// CHECK_NODUP_RESTATED_REQ_TYPE2: End completions
+
+// CHECK_NODUP_RESTATED_REQ_TYPE3: Begin completions, 5 items
+// CHECK_NODUP_RESTATED_REQ_TYPE3: Decl[InstanceMethod]/CurrNominal: foo({#self: NoDupReq1 & NoDupReq2 & NoDupReq3#})[#() -> Void#]; name=foo(NoDupReq1 & NoDupReq2 & NoDupReq3)
+// CHECK_NODUP_RESTATED_REQ_TYPE3: Decl[InstanceMethod]/CurrNominal: roo({#self: NoDupReq1 & NoDupReq2 & NoDupReq3#})[#(arg1: Int) -> Void#]; name=roo(NoDupReq1 & NoDupReq2 & NoDupReq3)
+// CHECK_NODUP_RESTATED_REQ_TYPE3: Decl[AssociatedType]/CurrNominal: E; name=E
+// CHECK_NODUP_RESTATED_REQ_TYPE3: Decl[InstanceMethod]/CurrNominal: roo({#self: NoDupReq1 & NoDupReq2 & NoDupReq3#})[#(arg2: Int) -> Void#]; name=roo(NoDupReq1 & NoDupReq2 & NoDupReq3)
+// CHECK_NODUP_RESTATED_REQ_TYPE3: End completions
 
 // CHECK_PROT_OVERRIDES: Decl[InstanceMethod]/{{Super|CurrNominal}}: foo({#(arg): NoDupReq1#})[#Void#]; name=foo(arg: NoDupReq1)
 // CHECK_PROT_OVERRIDES: Decl[InstanceMethod]/{{Super|CurrNominal}}: foo({#(arg): NoDupReq2#})[#Void#]; name=foo(arg: NoDupReq2)
@@ -1715,8 +1727,8 @@ extension Concrete1 {
 }
 // PROTOCOL_EXT_P4_P1: Begin completions
 // PROTOCOL_EXT_P4_P1-NOT: extP4OnlyMe()
-// PROTOCOL_EXT_P4_P1-DAG: Decl[InstanceMethod]/Super:         extP4WhenP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_P4_P1-DAG: Decl[InstanceVar]/Super:         x[#Int#]{{; name=.+$}}
+// PROTOCOL_EXT_P4_P1-DAG: Decl[InstanceMethod]/{{Super|CurrNominal}}: extP4WhenP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_P4_P1-DAG: Decl[InstanceVar]/{{Super|CurrNominal}}: x[#Int#]{{; name=.+$}}
 // PROTOCOL_EXT_P4_P1-NOT: extP4OnlyMe()
 // PROTOCOL_EXT_P4_P1: End completions
 
@@ -1746,13 +1758,13 @@ extension Concrete2 {
 // PROTOCOL_EXT_P4_ONLYME: Begin completions
 // PROTOCOL_EXT_P4_ONLYME-NOT: extP4WhenP1()
 // PROTOCOL_EXT_P4_ONLYME-NOT: x[#Int#]
-// PROTOCOL_EXT_P4_ONLYME-DAG: Decl[InstanceMethod]/Super:    extP4OnlyMe()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_P4_ONLYME-DAG: Decl[InstanceMethod]/{{Super|CurrNominal}}: extP4OnlyMe()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_P4_ONLYME-NOT: extP4WhenP1()
 // PROTOCOL_EXT_P4_ONLYME-NOT: x[#Int#]
 // PROTOCOL_EXT_P4_ONLYME: End completions
 
 // PROTOCOL_EXT_P4_ONLYME_SUB: Begin completions
-// PROTOCOL_EXT_P4_ONLYME_SUB: Decl[Subscript]/Super:              [{#Int#}][#Int#]{{; name=.+$}}
+// PROTOCOL_EXT_P4_ONLYME_SUB: Decl[Subscript]/{{Super|CurrNominal}}: [{#Int#}][#Int#]{{; name=.+$}}
 // PROTOCOL_EXT_P4_ONLYME_SUB: End completions
 
 func testTypealias1() {
@@ -1770,7 +1782,7 @@ func testProtExtInit1() {
 }
 
 // PROTOCOL_EXT_INIT_1: Begin completions
-// PROTOCOL_EXT_INIT_1: Decl[Constructor]/Super:            ['(']{#x: Int#}[')'][#Concrete1#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_1: Decl[Constructor]/{{Super|CurrNominal}}: ['(']{#x: Int#}[')'][#Concrete1#]{{; name=.+$}}
 // PROTOCOL_EXT_INIT_1: End completions
 
 func testProtExtInit2<S: P4 where S.T : P1>() {
@@ -1779,9 +1791,9 @@ func testProtExtInit2<S: P4 where S.T : P1>() {
   S#^PROTOCOL_EXT_INIT_4^#
 }
 
-// PROTOCOL_EXT_INIT_2: Decl[Constructor]/Super: ['(']{#x: Int#}[')'][#P4#]{{; name=.+$}}
-// PROTOCOL_EXT_INIT_3: Decl[Constructor]/Super: init({#x: Int#})[#P4#]{{; name=.+$}}
-// PROTOCOL_EXT_INIT_4: Decl[Constructor]/Super: ({#x: Int#})[#P4#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_2: Decl[Constructor]/CurrNominal: ['(']{#x: Int#}[')'][#P4#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_3: Decl[Constructor]/CurrNominal: init({#x: Int#})[#P4#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_4: Decl[Constructor]/CurrNominal: ({#x: Int#})[#P4#]{{; name=.+$}}
 
 extension P4 where Self.T == OnlyMe {
   final func test1() {
@@ -1793,7 +1805,7 @@ extension P4 where Self.T == OnlyMe {
 }
 // PROTOCOL_EXT_P4_DOT: Begin completions
 // PROTOCOL_EXT_P4_DOT-NOT: extP4WhenP1()
-// PROTOCOL_EXT_P4_DOT-DAG: Decl[InstanceMethod]/Super:         extP4OnlyMe()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_P4_DOT-DAG: Decl[InstanceMethod]/{{Super|CurrNominal}}: extP4OnlyMe()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_P4_DOT-NOT: extP4WhenP1()
 // PROTOCOL_EXT_P4_DOT: End completions
 
@@ -1871,10 +1883,10 @@ func testDeDuped2(_ x: dedupP) {
 func testDeDuped3<T : dedupP where T.T == Int>(_ x: T) {
   x#^PROTOCOL_EXT_DEDUP_3^#
 // PROTOCOL_EXT_DEDUP_3: Begin completions, 5 items
-// PROTOCOL_EXT_DEDUP_3: Decl[InstanceMethod]/Super:   .foo()[#Int#]; name=foo()
-// PROTOCOL_EXT_DEDUP_3: Decl[InstanceVar]/Super:      .bar[#Int#]; name=bar
-// PROTOCOL_EXT_DEDUP_3: Decl[Subscript]/Super:        [{#Self.T#}][#Self.T#]; name=[Self.T]
-// PROTOCOL_EXT_DEDUP_3: Keyword[self]/CurrNominal:    .self[#T#]; name=self
+// PROTOCOL_EXT_DEDUP_3: Decl[InstanceMethod]/CurrNominal:   .foo()[#Int#]; name=foo()
+// PROTOCOL_EXT_DEDUP_3: Decl[InstanceVar]/CurrNominal:      .bar[#Int#]; name=bar
+// PROTOCOL_EXT_DEDUP_3: Decl[Subscript]/CurrNominal:        [{#Self.T#}][#Self.T#]; name=[Self.T]
+// PROTOCOL_EXT_DEDUP_3: Keyword[self]/CurrNominal:          .self[#T#]; name=self
 // PROTOCOL_EXT_DEDUP_3: End completions
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1851,12 +1851,11 @@ func testDeDuped(_ x: dedupS) {
   x#^PROTOCOL_EXT_DEDUP_1^#
 // FIXME: Should produce 3 items (?)
 
-// PROTOCOL_EXT_DEDUP_1: Begin completions, 6 items
+// PROTOCOL_EXT_DEDUP_1: Begin completions, 5 items
 // PROTOCOL_EXT_DEDUP_1: Decl[InstanceMethod]/CurrNominal:   .foo()[#Int#]; name=foo()
 // PROTOCOL_EXT_DEDUP_1: Decl[InstanceVar]/CurrNominal:      .bar[#Int#]; name=bar
 // PROTOCOL_EXT_DEDUP_1: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]
 // PROTOCOL_EXT_DEDUP_1: Decl[InstanceVar]/Super:            .bar[#Int#]; name=bar
-// PROTOCOL_EXT_DEDUP_1: Decl[Subscript]/Super:              [{#Self.T#}][#Self.T#]; name=[Self.T]
 // PROTOCOL_EXT_DEDUP_1: Keyword[self]/CurrNominal:          .self[#dedupS#]; name=self
 // PROTOCOL_EXT_DEDUP_1: End completions
 }

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1850,10 +1850,13 @@ struct dedupS : dedupP {
 func testDeDuped(_ x: dedupS) {
   x#^PROTOCOL_EXT_DEDUP_1^#
 // FIXME: Should produce 3 items (?)
-// PROTOCOL_EXT_DEDUP_1: Begin completions, 7 items
+
+// PROTOCOL_EXT_DEDUP_1: Begin completions, 6 items
 // PROTOCOL_EXT_DEDUP_1: Decl[InstanceMethod]/CurrNominal:   .foo()[#Int#]; name=foo()
 // PROTOCOL_EXT_DEDUP_1: Decl[InstanceVar]/CurrNominal:      .bar[#Int#]; name=bar
 // PROTOCOL_EXT_DEDUP_1: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]
+// PROTOCOL_EXT_DEDUP_1: Decl[InstanceVar]/Super:            .bar[#Int#]; name=bar
+// PROTOCOL_EXT_DEDUP_1: Decl[Subscript]/Super:              [{#Self.T#}][#Self.T#]; name=[Self.T]
 // PROTOCOL_EXT_DEDUP_1: Keyword[self]/CurrNominal:          .self[#dedupS#]; name=self
 // PROTOCOL_EXT_DEDUP_1: End completions
 }

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -76,8 +76,7 @@ func ab<T: A & B>(_ arg: T) where T.#^FUNC_ASSOC_NODUP_1^#
 func ab<T: D>(_ arg: T) where T.#^FUNC_ASSOC_NODUP_2^#
 
 // GEN_T_ASSOC_E: Begin completions, 2 items
-// GEN_T_ASSOC_E-NEXT: Decl[AssociatedType]/Super: E; name=E
-// GEN_T_ASSOC_E-NOT:  Decl[AssociatedType]/Super: E; name=E
+// GEN_T_ASSOC_E-NEXT: Decl[AssociatedType]/{{Super|CurrNominal}}: E; name=E
 // GEN_T_ASSOC_E-NEXT: Keyword/None:               Type[#T.Type#];
 // GEN_T_ASSOC_E: End completions
 
@@ -94,7 +93,7 @@ func f2<T>(_: T) where T.#^FUNC_2^# {}
 // GEN_T_DOT: End completions
 func f2b<T: Assoc>(_: T) where T.#^FUNC_2_ASSOC^# {}
 // GEN_T_ASSOC_DOT: Begin completions
-// GEN_T_ASSOC_DOT-DAG: Decl[AssociatedType]/Super:         Q;
+// GEN_T_ASSOC_DOT-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}: Q;
 // GEN_T_ASSOC_DOT-DAG: Keyword/None:                       Type[#T.Type#];
 // GEN_T_ASSOC_DOT-NOT: Keyword/CurrNominal:                self[#T#];
 // GEN_T_ASSOC_DOT: End completions
@@ -127,9 +126,9 @@ protocol P2 {
 }
 
 // P2: Begin completions
-// P2-DAG: Decl[GenericTypeParam]/Super: Self[#Self#];
-// P2-DAG: Decl[AssociatedType]/Super:   T;
-// P2-DAG: Decl[AssociatedType]/Super:   U;
+// P2-DAG: Decl[GenericTypeParam]/{{Super|CurrNominal}}: Self[#Self#];
+// P2-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}:   T;
+// P2-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}:   U;
 // P2: End completions
 
 // U_DOT: Begin completions

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -113,10 +113,12 @@ struct Generic<T> {
 }
 
 protocol P { // expected-note {{'P' previously declared here}}
+  // expected-note@-1 {{did you mean 'P'?}}
   typealias a = Generic
 }
 
 protocol P {} // expected-error {{invalid redeclaration of 'P'}}
+// expected-note@-1 {{did you mean 'P'?}}
 
 func hasTypo() {
   _ = P.a.a // expected-error {{type 'P.a' (aka 'Generic') has no member 'a'}}
@@ -170,7 +172,7 @@ class CircularValidationWithTypo {
 // Crash with invalid extension that has not been bound -- https://bugs.swift.org/browse/SR-8984
 protocol PP {}
 
-func boo() { // expected-note {{did you mean 'boo'?}}
+func boo() {
   extension PP { // expected-error {{declaration is only valid at file scope}}
     func g() {
       booo() // expected-error {{use of unresolved identifier 'booo'}}
@@ -196,4 +198,23 @@ func test_underscored_match() {
 func testFwdRef() {
   let _ = forward_refX + 1 // expected-error {{use of unresolved identifier 'forward_refX'}}
   let forward_ref1 = 4
+}
+
+// Crash with protocol members.
+protocol P1 {
+  associatedtype A1
+  associatedtype A2
+}
+
+protocol P2 {
+  associatedtype A1
+  associatedtype A2
+
+  func method<T: P1>(_: T) where T.A1 == A1, T.A2 == A2
+}
+
+extension P2 {
+  func f() { // expected-note {{did you mean 'f'?}}
+    _ = a // expected-error {{use of unresolved identifier 'a'}}
+  }
 }

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
@@ -6,7 +6,7 @@
       key.sourcetext: "optionalMethod?()",
       key.description: "optionalMethod?()",
       key.typename: "Int",
-      key.context: source.codecompletion.context.superclass,
+      key.context: source.codecompletion.context.thisclass,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "c:@M@complete_optionalmethod@objc(pl)Proto(im)optionalMethod",
       key.modulename: "complete_optionalmethod"


### PR DESCRIPTION
The implementation of RestateFilteringConsumer was building a new GenericSignature "from scratch" by calling `GenericSignature::get()`. This violates GenericSignatureBuilder invariants and could cause crashes.

Instead, note that OverrideFilteringConsumer can already do most of what RestateFilteringConsumer did. Clean up and refactor things until RestateFilteringConsumer is removed altogether.

Fixes rdar://problem/46853611.