### PR TITLE
Leave skeleton CU breadcrumbs fo imported Clang modules in the debug …

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -72,6 +72,7 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   const IRGenOptions &Opts;
   ClangImporter &CI;
   SourceManager &SM;
+  llvm::Module &M;
   llvm::DIBuilder DBuilder;
   IRGenModule &IGM;
   const PathRemapper &DebugPrefixMap;
@@ -559,36 +560,55 @@ private:
 
   llvm::DIModule *getOrCreateModule(const void *Key, llvm::DIScope *Parent,
                                     StringRef Name, StringRef IncludePath,
-                                    StringRef ConfigMacros = StringRef()) {
+                                    uint64_t Signature = ~1ULL,
+                                    StringRef ASTFile = StringRef()) {
     // Look in the cache first.
     auto Val = DIModuleCache.find(Key);
     if (Val != DIModuleCache.end())
       return cast<llvm::DIModule>(Val->second);
 
+    // For Clang modules / PCH, create a Skeleton CU pointing to the PCM/PCH.
+    bool CreateSkeletonCU = !ASTFile.empty();
+    bool IsRootModule = !Parent;
+    if (CreateSkeletonCU && IsRootModule) {
+      llvm::DIBuilder DIB(M);
+      DIB.createCompileUnit(IGM.ObjCInterop ? llvm::dwarf::DW_LANG_ObjC
+                                            : llvm::dwarf::DW_LANG_C99,
+                            DIB.createFile(Name, IncludePath),
+                            TheCU->getProducer(), true, StringRef(), 0, ASTFile,
+                            llvm::DICompileUnit::FullDebug, Signature);
+      DIB.finalize();
+    }
+
     StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
-    auto M = DBuilder.createModule(
-        Parent, Name, ConfigMacros, DebugPrefixMap.remapPath(IncludePath),
-        Sysroot);
+    auto M =
+        DBuilder.createModule(Parent, Name, ConfigMacros, IncludePath, Sysroot);
     DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
     return M;
   }
 
   llvm::DIModule *
   getOrCreateModule(clang::ExternalASTSource::ASTSourceDescriptor Desc) {
+    // PCH files don't have a signature field in the control block,
+    // but LLVM detects skeleton CUs by looking for a non-zero DWO id.
+    // We use the lower 64 bits for debug info.
+    uint64_t Signature =
+        Desc.getSignature()
+            ? (uint64_t)Desc.getSignature()[1] << 32 | Desc.getSignature()[0]
+            : ~1ULL;
+
     // Handle Clang modules.
     if (const clang::Module *ClangModule = Desc.getModuleOrNull()) {
       llvm::DIModule *Parent = nullptr;
       if (ClangModule->Parent)
         Parent = getOrCreateModule(*ClangModule->Parent);
-
-      return getOrCreateModule(ClangModule, Parent,
-                               Desc.getModuleName(), Desc.getPath(),
-                               ConfigMacros);
+      return getOrCreateModule(ClangModule, Parent, Desc.getModuleName(),
+                               Desc.getPath(), Signature, Desc.getASTFile());
     }
     // Handle PCH.
     return getOrCreateModule(Desc.getASTFile().bytes_begin(), nullptr,
-                             Desc.getModuleName(), Desc.getPath(),
-                             ConfigMacros);
+                             Desc.getModuleName(), Desc.getPath(), Signature,
+                             Desc.getASTFile());
   };
 
   llvm::DIModule *getOrCreateModule(ModuleDecl::ImportedModule IM) {
@@ -1480,7 +1500,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
                                        ClangImporter &CI, IRGenModule &IGM,
                                        llvm::Module &M,
                                        StringRef MainOutputFilenameForDebugInfo)
-    : Opts(Opts), CI(CI), SM(IGM.Context.SourceMgr), DBuilder(M),
+    : Opts(Opts), CI(CI), SM(IGM.Context.SourceMgr), M(M), DBuilder(M),
       IGM(IGM), DebugPrefixMap(Opts.DebugPrefixMap), MetadataTypeDecl(nullptr),
       InternalType(nullptr), LastDebugLoc({}), LastScope(nullptr) {
   assert(Opts.DebugInfoLevel > IRGenDebugInfoLevel::None &&

--- a/test/DebugInfo/ASTSection_ObjC.swift
+++ b/test/DebugInfo/ASTSection_ObjC.swift
@@ -1,3 +1,6 @@
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
 // RUN: %empty-directory(%t)
 
 // RUN: cp %S/Inputs/serialized-objc-header.h %t
@@ -9,9 +12,6 @@
 
 // RUN: %target-build-swift -emit-executable %S/ASTSection.swift -gline-tables-only -o %t/ASTSection -emit-module
 // RUN: %lldb-moduleimport-test -verbose %t/ASTSection | %FileCheck %s --allow-empty --check-prefix=LINETABLE-CHECK
-
-// REQUIRES: executable_test
-// REQUIRES: objc_interop
 
 // CHECK: - Target: {{.+}}-{{.+}}-{{.+}}
 // CHECK: Importing ASTSection... ok!

--- a/test/DebugInfo/BridgingHeaderPCH.swift
+++ b/test/DebugInfo/BridgingHeaderPCH.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend \
+// RUN:   -emit-pch %S/Inputs/InlineBridgingHeader.h -o %t.pch 
+// RUN: %target-swift-frontend \
+// RUN:   -import-objc-header %t.pch -emit-ir -g %s -o - | %FileCheck %s
+
+// CHECK: !DICompileUnit(language: DW_LANG_Swift
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},
+// CHECK-SAME:           splitDebugFilename: "{{.*}}.pch"
+// CHECK-SAME:           dwoId:
+
+Foo()

--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs \
+// RUN:   -Xcc -DFOO="foo" -Xcc -UBAR -o - | %FileCheck %s
+import ClangModule.SubModule
+import OtherClangModule.SubModule
+
+// Check for Clang module breadcrumbs.
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
+// CHECK-SAME:           ClangModule
+// CHECK-SAME:           dwoId:
+
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}}, {{.*}} producer: "{{.*}}Swift
+// CHECK-SAME:           OtherClangModule
+// CHECK-SAME:           dwoId:

--- a/test/DebugInfo/InlineBridgingHeader.swift
+++ b/test/DebugInfo/InlineBridgingHeader.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend \
 // RUN:   -import-objc-header %S/Inputs/InlineBridgingHeader.h \
 // RUN:   -emit-ir -g %s -o - | %FileCheck %s
-// REQUIRES: objc_interop
 
 // The Swift CU must come first.
 // CHECK: !llvm.dbg.cu = !{![[SWIFT_CU:[0-9]+]], ![[CLANG_CU:[0-9]+]]}
 // CHECK: ![[SWIFT_CU]] = distinct !DICompileUnit(language: DW_LANG_Swift
-// CHECK: ![[CLANG_CU]] = distinct !DICompileUnit(language: DW_LANG_ObjC
+// CHECK: ![[CLANG_CU]] = distinct !DICompileUnit(
+// CHECK-SAME:                          language: {{DW_LANG_ObjC|DW_LANG_C}}
 // CHECK: DISubprogram(name: "Foo"{{.*}} unit: ![[CLANG_CU]],
 
 Foo()


### PR DESCRIPTION
…info.

This allows the debugger to look up Clang-imported type definitions in
the correct module.
