### PR TITLE
const evaluator: string values and init operations

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -95,6 +95,10 @@ private:
     /// This value is represented with an inline integer representation.
     RK_IntegerInline,
 
+    /// This value is represented with a bump-pointer allocated char array
+    /// representing a UTF-8 encoded string.
+    RK_String,
+
     /// This value is a struct or tuple of constants.  This is tracked by the
     /// "aggregate" member of the value union.
     RK_Aggregate,
@@ -124,6 +128,10 @@ private:
     /// This holds the bits of an integer for an inline representation.
     uint64_t integerInline;
 
+    /// When this SymbolicValue is of "String" kind, this pointer stores
+    /// information about the StringRef value it holds.
+    const char *string;
+
     /// When this SymbolicValue is of "Aggregate" kind, this pointer stores
     /// information about the array elements and count.
     const SymbolicValue *aggregate;
@@ -147,6 +155,9 @@ private:
     /// representation, which makes the number of entries in the list derivable.
     unsigned integerBitwidth;
 
+    /// This is the number of bytes for an RK_String representation.
+    unsigned stringNumBytes;
+
     /// This is the number of elements for an RK_Aggregate representation.
     unsigned aggregateNumElements;
   } auxInfo;
@@ -167,6 +178,10 @@ public:
 
     /// This is an integer constant.
     Integer,
+
+    /// String values may have SIL type of Builtin.RawPointer or Builtin.Word
+    /// type.
+    String,
 
     /// This can be an array, struct, tuple, etc.
     Aggregate,
@@ -241,6 +256,13 @@ public:
 
   APInt getIntegerValue() const;
   unsigned getIntegerValueBitWidth() const;
+
+  /// Returns a SymbolicValue representing a UTF-8 encoded string.
+  static SymbolicValue getString(StringRef string,
+                                 ASTContext &astContext);
+
+  /// Returns the UTF-8 encoded string underlying a SymbolicValue.
+  StringRef getStringValue() const;
 
   /// This returns an aggregate value with the specified elements in it.  This
   /// copies the elements into the specified ASTContext.

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -367,6 +367,7 @@ public struct String {
   ///     let empty = ""
   ///     let alsoEmpty = String()
   @inlinable @inline(__always)
+  @_semantics("string.init_empty")
   public init() { self.init(_StringGuts()) }
 }
 

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -455,3 +455,45 @@ func testStructPassedAsProtocols() {
   #assert(callProtoSimpleMethod(s) == 0) // expected-error {{#assert condition not constant}}
     // expected-note@-1 {{could not fold operation}}
 }
+
+//===----------------------------------------------------------------------===//
+// Strings
+//
+// TODO: The constant evaluator does not implement string accesses/comparisons
+// so theses tests cannot test that the implemented string operations produce
+// correct values in the arrays. These tests only test that the implemented
+// string operations do not crash or produce unknown values. As soon as we have
+// string accesses/comparisons, modify these tests to check the values in the
+// strings.
+//===----------------------------------------------------------------------===//
+
+struct ContainsString {
+  let x: Int
+  let str: String
+}
+
+func stringInitEmptyTopLevel() {
+  let c = ContainsString(x: 1, str: "")
+  #assert(c.x == 1)
+}
+
+func stringInitNonEmptyTopLevel() {
+  let c = ContainsString(x: 1, str: "hello world")
+  #assert(c.x == 1)
+}
+
+func stringInitEmptyFlowSensitive() -> ContainsString {
+  return ContainsString(x: 1, str: "")
+}
+
+func invokeStringInitEmptyFlowSensitive() {
+  #assert(stringInitEmptyFlowSensitive().x == 1)
+}
+
+func stringInitNonEmptyFlowSensitive() -> ContainsString {
+  return ContainsString(x: 1, str: "hello world")
+}
+
+func invokeStringInitNonEmptyFlowSensitive() {
+  #assert(stringInitNonEmptyFlowSensitive().x == 1)
+}


### PR DESCRIPTION
Adds string values, string initialization operations (using a "WellKnownFunction" mechanism), and some tests that invoke string initialization but do not check the contents of the strings.

This very basic string handling is all that we have in the tensorflow branch const evaluator right now.