### PR TITLE
[ome] Make sure to skip functions that do not have ownership.

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -297,6 +297,10 @@ struct OwnershipModelEliminator : SILModuleTransform {
       if (F.wasDeserializedCanonical())
         continue;
 
+      // If F does not have ownership, skip it. We have no further work to do.
+      if (!F.hasOwnership())
+        continue;
+
       // Set F to have unqualified ownership.
       F.setOwnershipEliminated();
 


### PR DESCRIPTION
This is not an actual bug since given where OME is in the pipeline today it will
only process ossa functions. But philosophically this is the right thing to do.
