### PR TITLE
[sil] Add a run of ome into the lowering pass pipeline.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -536,7 +536,8 @@ static void addSILDebugInfoGeneratorPipeline(SILPassPipelinePlan &P) {
 SILPassPipelinePlan
 SILPassPipelinePlan::getLoweringPassPipeline() {
   SILPassPipelinePlan P;
-  P.startPipeline("Address Lowering");
+  P.startPipeline("Lowering Pass Pipeline");
+  P.addOwnershipModelEliminator();
   P.addIRGenPrepare();
   P.addAddressLowering();
 


### PR DESCRIPTION
The reason why I am doing this is I am in the process of trying to have the
entire -Onone pipeline run with ownership. As part of this the question comes
up: when do we strip out ownership if at all? IRGen really doesn't have any need
to know about ossa, so it makes sense to strip it always at this point. This
conveniently also ensures that the SILModule before IRGen time (i.e. when we
serialize at -Onone) is always in ownership.
