### PR TITLE
[benchmark] BenchmarkDoctor: Lower runtime bound + Set.Empty fixes

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -442,7 +442,7 @@ class BenchmarkDoctor(object):
                     [[result.samples.min for result in i_series]
                      for i_series in
                      [select(measurements, num_iters=i) for i in [1, 2]]]]
-        setup = int(round(2.0 * (ti1 - ti2)))
+        setup = int(round(2.0 * (ti1 - ti2))) if ti2 > 20 else 0
         ratio = (setup / ti1) if ti1 > 0 else 0
         return (setup, ratio)
 

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -455,7 +455,8 @@ class BenchmarkDoctor(object):
                     [[result.samples.min for result in i_series]
                      for i_series in
                      [select(measurements, num_iters=i) for i in [1, 2]]]]
-        setup = int(round(2.0 * (ti1 - ti2))) if ti2 > 20 else 0
+        setup = (int(round(2.0 * (ti1 - ti2))) if ti2 > 20  # limit of accuracy
+                 else 0)
         ratio = (setup / ti1) if ti1 > 0 else 0
         return (setup, ratio)
 

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -435,6 +435,19 @@ class BenchmarkDoctor(object):
                 "Decrease the workload of '%s' by a factor of %d (%d), to be "
                 "less than %d μs.", name, factor(2), factor(10), threshold)
 
+        threshold = 20
+        if runtime < threshold:
+            log = (BenchmarkDoctor.log_runtime.error if runtime == 0 else
+                   BenchmarkDoctor.log_runtime.warning)
+            log("'%s' execution took %d μs.", name, runtime)
+
+            BenchmarkDoctor.log_runtime.info(
+                "Ensure the workload of '%s' has a properly measurable size"
+                " (runtime > %d μs) and is not eliminated by the compiler (use"
+                " `blackHole` function if necessary)." if runtime == 0 else
+                "Increase the workload of '%s' to be more than %d μs.",
+                name, threshold)
+
     @staticmethod
     def _setup_overhead(measurements):
         select = BenchmarkDoctor._select

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -728,11 +728,18 @@ class TestBenchmarkDoctor(unittest.TestCase):
                 'SO O i2a': _PTR(min=67), 'SO O i2b': _PTR(min=68)})
             doctor.analyze({'name': 'Zero', 'Zero O i1a': _PTR(min=0),
                             'Zero O i2a': _PTR(min=0)})
+            doctor.analyze({
+                'name': 'OOO',  # Out Of Order
+                # Impossible to detect overhead -- limits of precision:
+                # Even 1μs change in 20μs runtime is 5%.
+                'OOO O i1a': _PTR(min=21),
+                'OOO O i2a': _PTR(min=20)})
         output = out.getvalue()
 
         self.assertIn('runtime: ', output)
         self.assertNotIn('NoOverhead', output)
         self.assertNotIn('ZeroRuntime', output)
+        self.assertNotIn('OOO', output)
         self.assert_contains(
             ["'SO' has setup overhead of 4 μs (5.8%)."],
             self.logs['error'])

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -743,17 +743,17 @@ class TestBenchmarkDoctor(unittest.TestCase):
             doctor.analyze({'name': 'Zero', 'Zero O i1a': _PTR(min=0),
                             'Zero O i2a': _PTR(min=0)})
             doctor.analyze({
-                'name': 'OOO',  # Out Of Order
-                # Impossible to detect overhead -- limits of precision:
+                'name': 'LOA',  # Limit of Accuracy
+                # Impossible to detect overhead:
                 # Even 1μs change in 20μs runtime is 5%.
-                'OOO O i1a': _PTR(min=21),
-                'OOO O i2a': _PTR(min=20)})
+                'LOA O i1a': _PTR(min=21),
+                'LOA O i2a': _PTR(min=20)})
         output = out.getvalue()
 
         self.assertIn('runtime: ', output)
         self.assertNotIn('NoOverhead', output)
         self.assertNotIn('ZeroRuntime', output)
-        self.assertNotIn('OOO', output)
+        self.assertNotIn('LOA', output)
         self.assert_contains(
             ["'SO' has setup overhead of 4 μs (5.8%)."],
             self.logs['error'])

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -63,6 +63,11 @@ public let SetTests = [
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
+    name: "Set.isSubset.Int0.Empty",
+    runFunction: { n in run_SetIsSubsetInt(setAB, setE, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setE]) }),
+  BenchmarkInfo(
     name: "SetIsSubsetInt0",
     runFunction: { n in run_SetIsSubsetInt(setAB, setCD, false, 5000 * n) },
     tags: [.validation, .api, .Set],
@@ -99,10 +104,20 @@ public let SetTests = [
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
+    name: "Set.isDisjoint.Int0.Empty",
+    runFunction: { n in run_SetIsDisjointInt(setAB, setE, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setE]) }),
+  BenchmarkInfo(
     name: "Set.isDisjoint.Empty.Box0",
     runFunction: { n in run_SetIsDisjointBox(setOE, setOAB, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Box0.Empty",
+    runFunction: { n in run_SetIsDisjointBox(setOAB, setOE, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOE]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Int0",
     runFunction: { n in run_SetIsDisjointInt(setAB, setCD, true, 50 * n) },
@@ -233,10 +248,20 @@ public let SetTests = [
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
+    name: "Set.subtracting.Int0.Empty",
+    runFunction: { n in run_SetSubtractingInt(setAB, setE, countAB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setE]) }),
+  BenchmarkInfo(
     name: "Set.subtracting.Empty.Box0",
     runFunction: { n in run_SetSubtractingBox(setOE, setOAB, 0, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Box0.Empty",
+    runFunction: { n in run_SetSubtractingBox(setOAB, setOE, countAB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOE]) }),
   BenchmarkInfo(
     name: "SetSubtractingInt0",
     runFunction: { n in run_SetSubtractingInt(setAB, setCD, countAB, 10 * n) },

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -58,7 +58,7 @@ let setQ: Set<Int> = {
 public let SetTests = [
   // Mnemonic: number after name is percentage of common elements in input sets.
   BenchmarkInfo(
-    name: "Set.Empty.IsSubsetInt0",
+    name: "Set.isSubset.Empty.Int0",
     runFunction: { n in run_SetIsSubsetInt(setE, setAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
@@ -94,46 +94,46 @@ public let SetTests = [
     setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
-    name: "Set.Empty.IsDisjointInt0",
+    name: "Set.isDisjoint.Empty.Int0",
     runFunction: { n in run_SetIsDisjointInt(setE, setAB, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
-    name: "Set.Empty.IsDisjointBox0",
+    name: "Set.isDisjoint.Empty.Box0",
     runFunction: { n in run_SetIsDisjointBox(setOE, setOAB, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
   BenchmarkInfo(
-    name: "SetIsDisjointInt0",
+    name: "Set.isDisjoint.Int0",
     runFunction: { n in run_SetIsDisjointInt(setAB, setCD, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setCD]) }),
   BenchmarkInfo(
-    name: "SetIsDisjointBox0",
+    name: "Set.isDisjoint.Box0",
     runFunction: { n in run_SetIsDisjointBox(setOAB, setOCD, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
-    name: "SetIsDisjointInt25",
+    name: "Set.isDisjoint.Int25",
     runFunction: { n in run_SetIsDisjointInt(setB, setAB, false, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setB, setAB]) }),
   BenchmarkInfo(
-    name: "SetIsDisjointBox25",
+    name: "Set.isDisjoint.Box25",
     runFunction: { n in run_SetIsDisjointBox(setOB, setOAB, false, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOB, setOAB]) }),
   BenchmarkInfo(
-    name: "SetIsDisjointInt50",
+    name: "Set.isDisjoint.Int50",
     runFunction: { n in run_SetIsDisjointInt(setY, setXY, false, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setY, setXY]) }),
   BenchmarkInfo(
-    name: "SetIsDisjointInt100",
+    name: "Set.isDisjoint.Int100",
     runFunction: { n in run_SetIsDisjointInt(setP, setQ, false, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
-  
+
   BenchmarkInfo(
     name: "SetSymmetricDifferenceInt0",
     runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 10 * n) },
@@ -228,12 +228,12 @@ public let SetTests = [
     setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
-    name: "Set.Empty.SubtractingInt0",
+    name: "Set.subtracting.Empty.Int0",
     runFunction: { n in run_SetSubtractingInt(setE, setAB, 0, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
-    name: "Set.Empty.SubtractingBox0",
+    name: "Set.subtracting.Empty.Box0",
     runFunction: { n in run_SetSubtractingBox(setOE, setOAB, 0, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -58,12 +58,12 @@ let setQ: Set<Int> = {
 public let SetTests = [
   // Mnemonic: number after name is percentage of common elements in input sets.
   BenchmarkInfo(
-    name: "Set.isSubset.Empty.Int0",
+    name: "Set.isSubset.Empty.Int",
     runFunction: { n in run_SetIsSubsetInt(setE, setAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
-    name: "Set.isSubset.Int0.Empty",
+    name: "Set.isSubset.Int.Empty",
     runFunction: { n in run_SetIsSubsetInt(setAB, setE, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setE]) }),
@@ -99,22 +99,22 @@ public let SetTests = [
     setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
-    name: "Set.isDisjoint.Empty.Int0",
+    name: "Set.isDisjoint.Empty.Int",
     runFunction: { n in run_SetIsDisjointInt(setE, setAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
-    name: "Set.isDisjoint.Int0.Empty",
+    name: "Set.isDisjoint.Int.Empty",
     runFunction: { n in run_SetIsDisjointInt(setAB, setE, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setE]) }),
   BenchmarkInfo(
-    name: "Set.isDisjoint.Empty.Box0",
+    name: "Set.isDisjoint.Empty.Box",
     runFunction: { n in run_SetIsDisjointBox(setOE, setOAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
   BenchmarkInfo(
-    name: "Set.isDisjoint.Box0.Empty",
+    name: "Set.isDisjoint.Box.Empty",
     runFunction: { n in run_SetIsDisjointBox(setOAB, setOE, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOE]) }),
@@ -243,22 +243,22 @@ public let SetTests = [
     setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
-    name: "Set.subtracting.Empty.Int0",
+    name: "Set.subtracting.Empty.Int",
     runFunction: { n in run_SetSubtractingInt(setE, setAB, 0, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
-    name: "Set.subtracting.Int0.Empty",
+    name: "Set.subtracting.Int.Empty",
     runFunction: { n in run_SetSubtractingInt(setAB, setE, countAB, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setE]) }),
   BenchmarkInfo(
-    name: "Set.subtracting.Empty.Box0",
+    name: "Set.subtracting.Empty.Box",
     runFunction: { n in run_SetSubtractingBox(setOE, setOAB, 0, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
   BenchmarkInfo(
-    name: "Set.subtracting.Box0.Empty",
+    name: "Set.subtracting.Box.Empty",
     runFunction: { n in run_SetSubtractingBox(setOAB, setOE, countAB, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOE]) }),

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -100,22 +100,22 @@ public let SetTests = [
 
   BenchmarkInfo(
     name: "Set.isDisjoint.Empty.Int0",
-    runFunction: { n in run_SetIsDisjointInt(setE, setAB, true, 50 * n) },
+    runFunction: { n in run_SetIsDisjointInt(setE, setAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Int0.Empty",
-    runFunction: { n in run_SetIsDisjointInt(setAB, setE, true, 50 * n) },
+    runFunction: { n in run_SetIsDisjointInt(setAB, setE, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setE]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Empty.Box0",
-    runFunction: { n in run_SetIsDisjointBox(setOE, setOAB, true, 50 * n) },
+    runFunction: { n in run_SetIsDisjointBox(setOE, setOAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Box0.Empty",
-    runFunction: { n in run_SetIsDisjointBox(setOAB, setOE, true, 50 * n) },
+    runFunction: { n in run_SetIsDisjointBox(setOAB, setOE, true, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOE]) }),
   BenchmarkInfo(
@@ -130,22 +130,22 @@ public let SetTests = [
     setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Int25",
-    runFunction: { n in run_SetIsDisjointInt(setB, setAB, false, 50 * n) },
+    runFunction: { n in run_SetIsDisjointInt(setB, setAB, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setB, setAB]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Box25",
-    runFunction: { n in run_SetIsDisjointBox(setOB, setOAB, false, 50 * n) },
+    runFunction: { n in run_SetIsDisjointBox(setOB, setOAB, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOB, setOAB]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Int50",
-    runFunction: { n in run_SetIsDisjointInt(setY, setXY, false, 50 * n) },
+    runFunction: { n in run_SetIsDisjointInt(setY, setXY, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setY, setXY]) }),
   BenchmarkInfo(
     name: "Set.isDisjoint.Int100",
-    runFunction: { n in run_SetIsDisjointInt(setP, setQ, false, 50 * n) },
+    runFunction: { n in run_SetIsDisjointInt(setP, setQ, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
 
@@ -244,22 +244,22 @@ public let SetTests = [
 
   BenchmarkInfo(
     name: "Set.subtracting.Empty.Int0",
-    runFunction: { n in run_SetSubtractingInt(setE, setAB, 0, 10 * n) },
+    runFunction: { n in run_SetSubtractingInt(setE, setAB, 0, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, setAB]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Int0.Empty",
-    runFunction: { n in run_SetSubtractingInt(setAB, setE, countAB, 10 * n) },
+    runFunction: { n in run_SetSubtractingInt(setAB, setE, countAB, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setE]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Empty.Box0",
-    runFunction: { n in run_SetSubtractingBox(setOE, setOAB, 0, 10 * n) },
+    runFunction: { n in run_SetSubtractingBox(setOE, setOAB, 0, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, setOAB]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Box0.Empty",
-    runFunction: { n in run_SetSubtractingBox(setOAB, setOE, countAB, 10 * n) },
+    runFunction: { n in run_SetSubtractingBox(setOAB, setOE, countAB, 1000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOE]) }),
   BenchmarkInfo(


### PR DESCRIPTION
The new Set.Empty tests introduced in #20631 have too small workloads with runtimes near or at 0 μs. This needs to be fixed by adjusting the loop multipliers. In order to prevent this kind of error when writing new benchmarks, this PR extends `BenchmarkDoctor` with a check for lower runtime bound.
