### PR TITLE
IRGen: apply IR linkage to trivial property descriptors

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1269,14 +1269,18 @@ void IRGenModule::emitSILProperty(SILProperty *prop) {
       var->setConstant(true);
       var->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
       var->setAlignment(4);
-      
+
       TheTrivialPropertyDescriptor = var;
     } else {
       auto entity = LinkEntity::forPropertyDescriptor(prop->getDecl());
       auto linkInfo = LinkInfo::get(*this, entity, ForDefinition);
-      llvm::GlobalAlias::create(linkInfo.getLinkage(),
-                                linkInfo.getName(),
-                                TheTrivialPropertyDescriptor);
+      auto *GA = llvm::GlobalAlias::create(linkInfo.getLinkage(),
+                                           linkInfo.getName(),
+                                           TheTrivialPropertyDescriptor);
+      ApplyIRLinkage({linkInfo.getLinkage(),
+                      linkInfo.getVisibility(),
+                      llvm::GlobalValue::DLLExportStorageClass})
+          .to(GA);
     }
     return;
   }

--- a/test/IRGen/trivial-property-descriptors.swift
+++ b/test/IRGen/trivial-property-descriptors.swift
@@ -1,0 +1,10 @@
+// RUN: %swift -target x86_64-unknown-windows-msvc -parse-stdlib -module-name Swift -enable-resilience -S -emit-ir -o - %s | %FileCheck %s
+
+public struct S {}
+extension S {
+  public var i: () { return () }
+  public var j: () { return () }
+}
+
+// CHECK: @"$ss1SV1jytvpMV" = dllexport alias { i32 }, { i32 }* @"$ss1SV1iytvpMV"
+


### PR DESCRIPTION
This ensures that the trivial property descriptors is externally
accessible on targets like Windows which does not export symbols by
default.  Thanks to Joe Groff for the pointer about the global aliases
for trivial property descriptors!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
