### PR TITLE
[cmake] Make install of stdlib target libraries OPTIONAL

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1974,6 +1974,12 @@ function(add_swift_target_library name)
             WORLD_READ)
       endif()
 
+      set(optional_arg)
+      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+        # Allow installation of stdlib without building all variants on Darwin.
+        set(optional_arg "OPTIONAL")
+      endif()
+
       if(sdk STREQUAL WINDOWS AND CMAKE_SYSTEM_NAME STREQUAL Windows)
         swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
           TARGETS ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}
@@ -1986,7 +1992,7 @@ function(add_swift_target_library name)
             FILES "${UNIVERSAL_LIBRARY_NAME}"
             DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}"
             PERMISSIONS ${file_permissions}
-            OPTIONAL)
+            "${optional_arg}")
       endif()
       if(sdk STREQUAL WINDOWS)
         foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
@@ -2034,7 +2040,7 @@ function(add_swift_target_library name)
               OWNER_READ OWNER_WRITE
               GROUP_READ
               WORLD_READ
-            OPTIONAL)
+            "${optional_arg}")
       endif()
 
       # Add Swift standard library targets as dependencies to the top-level

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1985,7 +1985,8 @@ function(add_swift_target_library name)
         swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
             FILES "${UNIVERSAL_LIBRARY_NAME}"
             DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}"
-            PERMISSIONS ${file_permissions})
+            PERMISSIONS ${file_permissions}
+            OPTIONAL)
       endif()
       if(sdk STREQUAL WINDOWS)
         foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
@@ -2032,7 +2033,8 @@ function(add_swift_target_library name)
             PERMISSIONS
               OWNER_READ OWNER_WRITE
               GROUP_READ
-              WORLD_READ)
+              WORLD_READ
+            OPTIONAL)
       endif()
 
       # Add Swift standard library targets as dependencies to the top-level

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -349,7 +349,8 @@ function(_compile_swift_files
 
   swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
     FILES ${module_outputs}
-    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
+    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}"
+    OPTIONAL)
 
   set(line_directive_tool "${SWIFT_SOURCE_DIR}/utils/line-directive")
   set(swift_compiler_tool "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -347,10 +347,16 @@ function(_compile_swift_files
     list(APPEND module_outputs "${interface_file}")
   endif()
 
+  set(optional_arg)
+  if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+    # Allow installation of stdlib without building all variants on Darwin.
+    set(optional_arg "OPTIONAL")
+  endif()
+
   swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
     FILES ${module_outputs}
     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}"
-    OPTIONAL)
+    "${optional_arg}")
 
   set(line_directive_tool "${SWIFT_SOURCE_DIR}/utils/line-directive")
   set(swift_compiler_tool "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")


### PR DESCRIPTION
This fixes using `--install-swift` on macOS when not building all of the
variant stdlibs (e.g. iphonesimulator, etc.).

When we build swift on macOS, by default we build only the macOS stdlib.
The other stdlib variants are still configured and there are targets to
build them if you e.g. run `ninja swift-stdlib-iphonesimulator-x86_64`
manually.  However, we do not separate the _install_ actions.  This
meant that you couldn't install without building all the configured
stdlib variants.