### PR TITLE
[Syntax] Use absolute path to stdlib in round_trip_stdlib test

### DIFF
--- a/test/Syntax/round_trip_stdlib.swift
+++ b/test/Syntax/round_trip_stdlib.swift
@@ -1,2 +1,1 @@
-// RUN: %round-trip-syntax-test -d ../stdlib --swift-syntax-test %swift-syntax-test
-// REQUIRES: rdar30606232
+// RUN: %round-trip-syntax-test -d %swift_src_root/stdlib --swift-syntax-test %swift-syntax-test


### PR DESCRIPTION
This test was disabled for 2 years. Re-enable it, using the absolute
path to the stdlib instead of a relative path.

rdar://30606232