### PR TITLE
Sema: Fix crashes when a call of a closure value is missing a 'try' [5.0]

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PrettyStackTrace.h"
 
 using namespace swift;
 
@@ -1647,6 +1648,10 @@ void TypeChecker::checkFunctionErrorHandling(AbstractFunctionDecl *fn) {
   // In some cases, we won't have validated the signature
   // by the time we got here.
   if (!fn->hasInterfaceType()) return;
+
+#ifndef NDEBUG
+  PrettyStackTraceDecl debugStack("checking error handling for", fn);
+#endif
 
   CheckErrorCoverage checker(*this, Context::forFunction(fn));
 

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -903,7 +903,7 @@ private:
   Kind TheKind;
   bool DiagnoseErrorOnTry = false;
   DeclContext *RethrowsDC = nullptr;
-  InterpolatedStringLiteralExpr * InterpolatedString;
+  InterpolatedStringLiteralExpr *InterpolatedString = nullptr;
 
   explicit Context(Kind kind) : TheKind(kind) {}
 
@@ -1061,7 +1061,9 @@ public:
       insertLoc = loc;
       highlight = e->getSourceRange();
       
-      if (InterpolatedString && e->getCalledValue()->getBaseName() ==
+      if (InterpolatedString &&
+          e->getCalledValue() &&
+          e->getCalledValue()->getBaseName() ==
           TC.Context.Id_appendInterpolation) {
         message = diag::throwing_interpolation_without_try;
         insertLoc = InterpolatedString->getLoc();

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -258,3 +258,23 @@ struct IllegalContext {
     }
   }
 }
+
+// Crash in 'uncovered try' diagnostic when calling a function value - rdar://46973064
+struct FunctionHolder {
+  let fn: () throws -> ()
+  func receive() {
+    do {
+      _ = fn()
+      // expected-error@-1 {{call can throw but is not marked with 'try'}}
+      // expected-note@-2 {{did you mean to use 'try'?}}
+      // expected-note@-3 {{did you mean to handle error as optional value?}}
+      // expected-note@-4 {{did you mean to disable error propagation?}}
+      _ = "\(fn())"
+      // expected-error@-1 {{call can throw but is not marked with 'try'}}
+      // expected-note@-2 {{did you mean to use 'try'?}}
+      // expected-note@-3 {{did you mean to handle error as optional value?}}
+      // expected-note@-4 {{did you mean to disable error propagation?}}
+    } catch {}
+  }
+}
+


### PR DESCRIPTION
Fixes <rdar://problem/46973064>.