### PR TITLE
[AD] Support `@differentiable` where clauses with dependent member types.

### DIFF
--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -98,7 +98,7 @@ func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
 }
 
-// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
 func testWhereClause<T : Numeric>(x: T) -> T {
@@ -112,7 +112,7 @@ func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector
 
 protocol P {}
 extension P {
-  // CHECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
+  // CHECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable, Self : P)
   // CHECK-DAG: func testWhereClause() -> Self
   @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
   func testWhereClause() -> Self {
@@ -125,12 +125,11 @@ extension P where Self : Differentiable {
   }
 }
 
-/*
 // NOTE: The failing tests involve where clauses with member type constraints.
 // They pass type-checking but crash during serialization.
 
-// HECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
-// HECK-DAG: func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T : Numeric, T == T.CotangentVector)
+// CHECK-DAG: func testWhereClauseMemberTypeConstraint<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
 func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
   return x
@@ -141,18 +140,16 @@ func vjpTestWhereClauseMemberTypeConstraint<T>(x: T) -> (T, (T) -> T)
   return (x, { v in v })
 }
 
-protocol P {}
 extension P {
-  // HECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
-  // HECK-DAG: func testWhereClauseMemberTypeConstraint() -> Self {
+  // CHECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self : P, Self == Self.CotangentVector)
+  // CHECK-DAG: func testWhereClauseMemberTypeConstraint() -> Self
   @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
   func testWhereClauseMemberTypeConstraint() -> Self {
     return self
   }
 }
-extension P where Self : Differentiable {
+extension P where Self : Differentiable, Self == Self.CotangentVector {
   func vjpTestWhereClauseMemberTypeConstraint() -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
     return (self, { v in v })
   }
 }
-*/


### PR DESCRIPTION
Previously, where clauses with dependent type requirements crashed during
serialization. This was because where clause requirements were manually
computed. The solution is to use requirements computed by the type checker.

- Improve comments about where clause type-checking. There are two goals:
  - Compute the required generic signature for autodiff associated functions,
    which is formed based on the original function's generic signature and
    the attribute's where clause requirements.
  - Store resolved where clause requirements in the attribute for
    serialization.
- Add exercising tests.

This completes `@differentiable` attribute where clause type-checking.
I'll next work on adding where clauses to `@differentiable` usages in the stdlib.