### PR TITLE
[API] [AD] Revamp `@differentiable` usages in stdlib.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2345,14 +2345,15 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
         // Conformance requirements are valid if:
         // - The first type is a generic type parameter type.
-        // - The second type is a protocol type.
+        // - The second type is a protocol type or protocol composition type.
         case RequirementKind::Conformance:
           if (diagnoseDifferentiableAttrIndirectGenericType(
                   attr->getLocation(), req.getFirstType(),
                   reqRepr->getSubjectRepr()))
             return false;
 
-          if (!req.getSecondType()->is<ProtocolType>()) {
+          if (!req.getSecondType()->is<ProtocolType>() &&
+              !req.getSecondType()->is<ProtocolCompositionType>()) {
             TC.diagnose(attr->getLocation(),
                      diag::differentiable_attr_non_protocol_type_constraint_req)
               .highlight(reqRepr->getSourceRange());

--- a/stdlib/public/TensorFlow/CompositeMath.swift
+++ b/stdlib/public/TensorFlow/CompositeMath.swift
@@ -19,7 +19,9 @@
 /// Computes `sigmoid` of the specified tensor element-wise.
 /// Specifically, computes `1 / (1 + exp(-x))`.
 @inlinable @inline(__always)
-public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func sigmoid<T>(_ x: Tensor<T>) -> Tensor<T>
+  where T : Differentiable & FloatingPoint
+{
   return 1 / (1 + exp(-x))
 }
 
@@ -27,14 +29,18 @@ public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Specifically, computes `max(0, x)`.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointRelu(_:_:_:))
-public func relu<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func relu<T>(_ x: Tensor<T>) -> Tensor<T>
+  where T : Differentiable & FloatingPoint
+{
   return max(0, x)
 }
 
 /// Computes the softmax of the specified tensor element-wise.
 /// Specifically, computes `exp(x) / exp(x).sum()`.
 @inlinable @inline(__always)
-public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func softmax<T>(_ x: Tensor<T>) -> Tensor<T>
+  where T : Differentiable & FloatingPoint
+{
   let expx = exp(x)
   let sum = expx.sum()
   return expx / sum
@@ -43,7 +49,7 @@ public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes the softmax of the specified tensor along the specified axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: axis)`.
 @inlinable @inline(__always)
-public func softmax<T : FloatingPoint>(
+public func softmax<T : Differentiable & FloatingPoint>(
   _ x: Tensor<T>, alongAxis axis: Int32
 ) -> Tensor<T> {
   let expx = exp(x)

--- a/stdlib/public/TensorFlow/CompositeMath.swift
+++ b/stdlib/public/TensorFlow/CompositeMath.swift
@@ -19,7 +19,7 @@
 /// Computes `sigmoid` of the specified tensor element-wise.
 /// Specifically, computes `1 / (1 + exp(-x))`.
 @inlinable @inline(__always)
-public func sigmoid<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return 1 / (1 + exp(-x))
 }
 
@@ -27,14 +27,14 @@ public func sigmoid<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Specifically, computes `max(0, x)`.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointRelu(_:_:_:))
-public func relu<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func relu<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return max(0, x)
 }
 
 /// Computes the softmax of the specified tensor element-wise.
 /// Specifically, computes `exp(x) / exp(x).sum()`.
 @inlinable @inline(__always)
-public func softmax<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   let expx = exp(x)
   let sum = expx.sum()
   return expx / sum
@@ -43,7 +43,7 @@ public func softmax<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes the softmax of the specified tensor along the specified axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: axis)`.
 @inlinable @inline(__always)
-public func softmax<T : BinaryFloatingPoint>(
+public func softmax<T : FloatingPoint>(
   _ x: Tensor<T>, alongAxis axis: Int32
 ) -> Tensor<T> {
   let expx = exp(x)

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -46,7 +46,7 @@
 // Elementwise binary
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : FloatingPoint {
+extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
   static func _adjointAdd(
     _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
@@ -81,7 +81,7 @@ extension Tensor where Scalar : FloatingPoint {
 }
 
 @inlinable
-func _adjointMinMax<T : FloatingPoint>(
+func _adjointMinMax<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
   let denom = 1 + Tensor<T>(x .== y)
@@ -91,7 +91,7 @@ func _adjointMinMax<T : FloatingPoint>(
 }
 
 @inlinable
-func _adjointPow<T : FloatingPoint>(
+func _adjointPow<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
   return ((seed * y * pow(x, y-1)).unbroadcast(like: x),
@@ -102,7 +102,7 @@ func _adjointPow<T : FloatingPoint>(
 // Elementwise unary
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : FloatingPoint {
+extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
   static func _adjointNegate(
     _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor
@@ -112,90 +112,90 @@ extension Tensor where Scalar : FloatingPoint {
 }
 
 @inlinable
-func _adjointLog<T : FloatingPoint>(
+func _adjointLog<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed / x
 }
 
 @inlinable
-func _adjointSin<T : FloatingPoint>(
+func _adjointSin<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * cos(x)
 }
 
 @inlinable
-func _adjointCos<T : FloatingPoint>(
+func _adjointCos<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return -seed * sin(x)
 }
 
 @inlinable
-func _adjointTan<T : FloatingPoint>(
+func _adjointTan<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * (1 + originalValue.squared())
 }
 
 @inlinable
-func _adjointSinh<T : FloatingPoint>(
+func _adjointSinh<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * cosh(x)
 }
 
 @inlinable
-func _adjointCosh<T : FloatingPoint>(
+func _adjointCosh<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * sinh(x)
 }
 
 @inlinable
-func _adjointTanh<T : FloatingPoint>(
+func _adjointTanh<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * (1 - originalValue.squared())
 }
 
 @inlinable
-func _adjointExp<T : FloatingPoint>(
+func _adjointExp<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return originalValue * seed
 }
 
 @inlinable
-func _adjointCeil<T : FloatingPoint>(
+func _adjointCeil<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return Tensor(0).broadcast(like: x)
 }
 
 @inlinable
-func _adjointFloor<T : FloatingPoint>(
+func _adjointFloor<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return Tensor(0).broadcast(like: x)
 }
 
 @inlinable
-func _adjointSqrt<T : FloatingPoint>(
+func _adjointSqrt<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed / (2 * originalValue)
 }
 
 @inlinable
-func _adjointRsqrt<T : FloatingPoint>(
+func _adjointRsqrt<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return -seed / 2 * pow(originalValue, 3)
 }
 
-func _adjointSquared<T : FloatingPoint>(
+func _adjointSquared<T : Differentiable & FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return 2 * x * seed
@@ -206,7 +206,7 @@ func _adjointSquared<T : FloatingPoint>(
 //===----------------------------------------------------------------------===//
 
 @inlinable
-func _adjointMatmul<Scalar : FloatingPoint>(
+func _adjointMatmul<Scalar : Differentiable & FloatingPoint>(
   _ seed: Tensor<Scalar>, _ originalValue: Tensor<Scalar>,
   _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
 ) -> (Tensor<Scalar>, Tensor<Scalar>) {
@@ -217,7 +217,7 @@ func _adjointMatmul<Scalar : FloatingPoint>(
 // TODO: We have to define a custom adjoint on • because AD can't yet
 // differentiate generic methods. After AD can differentiate generic methods,
 // remove the custom adjoint.
-extension Tensor where Scalar : FloatingPoint {
+extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
   static func _adjointMatmulOperator(seed: Tensor, originalValue: Tensor,
                                      lhs: Tensor, rhs: Tensor)
@@ -238,7 +238,7 @@ extension Tensor where Scalar : FloatingPoint {
 // Shape transformations
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : FloatingPoint {
+extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
   func _adjointReshaped(
     seed: Tensor, originalValue: Tensor, toShape newShape: Tensor<Int32>
@@ -298,7 +298,7 @@ extension Tensor where Scalar : BinaryFloatingPoint & Differentiable,
 // Convolution and pooling
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : FloatingPoint {
+extension Tensor where Scalar : Differentiable & FloatingPoint {
   /// TensorFlow builtin conv2d gradient helper for the input.
   @inlinable
   @differentiable(
@@ -442,7 +442,7 @@ extension Tensor where Scalar : FloatingPoint {
 //===----------------------------------------------------------------------===//
 
 @inlinable
-func _adjointRelu<T : FloatingPoint>(
+func _adjointRelu<T : Differentiable &  FloatingPoint>(
   _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return Tensor(x .> 0) * seed

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -79,7 +79,7 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   /// Adds two tensors and produces their sum.
   /// - Note: `+` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointAdd(_:_:_:_:))
+  @differentiable(adjoint: _adjointAdd(_:_:_:_:) where Scalar : FloatingPoint)
   public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.add(lhs, rhs)
   }
@@ -87,7 +87,9 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   /// Subtracts one tensor from another and produces their difference.
   /// - Note: `-` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointSubtract(_:_:_:_:))
+  @differentiable(
+    adjoint: _adjointSubtract(_:_:_:_:) where Scalar : FloatingPoint
+  )
   public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.sub(lhs, rhs)
   }
@@ -180,7 +182,9 @@ public extension Tensor where Scalar : Numeric {
   /// Multiplies two tensors and produces their product.
   /// - Note: `*` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointMultiply(_:_:_:_:))
+  @differentiable(
+    adjoint: _adjointMultiply(_:_:_:_:) where Scalar : FloatingPoint
+  )
   static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.mul(lhs, rhs)
   }
@@ -208,7 +212,9 @@ public extension Tensor where Scalar : Numeric {
   /// Returns the quotient of dividing the first tensor by the second.
   /// - Note: `/` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointDivide(_:_:_:_:))
+  @differentiable(
+    adjoint: _adjointDivide(_:_:_:_:) where Scalar : FloatingPoint
+  )
   static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.div(lhs, rhs)
   }
@@ -284,7 +290,7 @@ public extension Tensor where Scalar : Numeric {
 /// Performs matrix multiplication with another tensor and produces the
 /// result.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointMatmul(_:_:_:_:))
+@differentiable(adjoint: _adjointMatmul(_:_:_:_:) where Scalar : FloatingPoint)
 public func matmul<Scalar : Numeric>(
   _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
 ) -> Tensor<Scalar> {
@@ -304,7 +310,10 @@ public extension Tensor where Scalar : Numeric {
   /// Performs matrix multiplication between two tensors and produces the
   /// result.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointMatmulOperator(seed:originalValue:lhs:rhs:))
+  @differentiable(
+    adjoint: _adjointMatmulOperator(seed:originalValue:lhs:rhs:)
+    where Scalar : FloatingPoint
+  )
   static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
     return matmul(lhs, rhs)
   }
@@ -520,7 +529,7 @@ public extension Tensor where Scalar : Equatable {
 
 infix operator ≈ : ComparisonPrecedence
 
-public extension Tensor where Scalar : BinaryFloatingPoint & Equatable {
+public extension Tensor where Scalar : FloatingPoint & Equatable {
   /// Returns a `Tensor` of Boolean values indicating whether the elements of
   /// `self` are approximately equal to those of `other`.
   @inlinable @inline(__always)
@@ -571,7 +580,8 @@ public extension Tensor {
   /// Returns a transposed tensor, with dimensions permuted in the specified
   /// order.
   @inlinable @inline(__always)
-  @differentiable(wrt: (self), adjoint: _adjointTransposed(_:_:_:))
+  @differentiable(wrt: (self), adjoint: _adjointTransposed(_:_:_:)
+                  where Scalar : FloatingPoint)
   func transposed(
     withPermutations permutations: Tensor<Int32>
   ) -> Tensor {
@@ -687,7 +697,7 @@ public extension Tensor {
 public extension Tensor where Scalar : SignedNumeric {
   /// Computes the negation of the specified tensor element-wise.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointNegate(_:_:_:))
+  @differentiable(adjoint: _adjointNegate(_:_:_:) where Scalar : FloatingPoint)
   static prefix func - (rhs: Tensor) -> Tensor {
     return Raw.neg(rhs)
   }
@@ -702,84 +712,84 @@ public func abs<T : SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes the natural logarithm of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointLog(_:_:_:))
-public func log<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func log<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.log(x)
 }
 
 /// Computes `sin` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointSin(_:_:_:))
-public func sin<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func sin<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sin(x)
 }
 
 /// Computes `cos` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointCos(_:_:_:))
-public func cos<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func cos<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cos(x)
 }
 
 /// Computes `tan` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointTan(_:_:_:))
-public func tan<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func tan<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tan(x)
 }
 
 /// Computes `sinh` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointSinh(_:_:_:))
-public func sinh<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func sinh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sinh(x)
 }
 
 /// Computes `cosh` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointCosh(_:_:_:))
-public func cosh<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func cosh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cosh(x)
 }
 
 /// Computes `tanh` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointTanh(_:_:_:))
-public func tanh<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func tanh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tanh(x)
 }
 
 /// Computes the square root of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointSqrt(_:_:_:))
-public func sqrt<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func sqrt<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sqrt(x)
 }
 
 /// Computes the inverse square root of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointRsqrt(_:_:_:))
-public func rsqrt<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func rsqrt<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.rsqrt(x)
 }
 
 /// Computes `exp` of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointExp(_:_:_:))
-public func exp<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func exp<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.exp(x)
 }
 
 /// Computes the ceiling of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointCeil(_:_:_:))
-public func ceil<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func ceil<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.ceil(x)
 }
 
 /// Computes the floor of the specified tensor element-wise.
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointFloor(_:_:_:))
-public func floor<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func floor<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.floor(x)
 }
 
@@ -787,28 +797,28 @@ public func floor<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 @inlinable @inline(__always)
 @differentiable(adjoint: _adjointPow(_:_:_:_:))
 public func pow<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
-  where T : BinaryFloatingPoint {
+  where T : FloatingPoint {
   return Raw.pow(lhs, rhs)
 }
 
 /// Computes the power of the scalar to the tensor, broadcasting the scalar.
 @inlinable @inline(__always)
 public func pow<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
-  where T : BinaryFloatingPoint {
+  where T : FloatingPoint {
   return pow(Tensor(lhs), rhs)
 }
 
 /// Computes the power of the tensor to the scalar, broadcasting the scalar.
 @inlinable @inline(__always)
 public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
-  where T : BinaryFloatingPoint {
+  where T : FloatingPoint {
   return pow(lhs, Tensor(rhs))
 }
 
 /// Computes the element-wise maximum of two tensors.
 /// - Note: `max` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointMinMax(_:_:_:_:))
+@differentiable(adjoint: _adjointMinMax(_:_:_:_:) where T : FloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.maximum(lhs, rhs)
@@ -833,7 +843,7 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise minimum of two tensors.
 /// - Note: `min` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointMinMax(_:_:_:_:))
+@differentiable(adjoint: _adjointMinMax(_:_:_:_:) where T : FloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.minimum(lhs, rhs)
@@ -869,7 +879,7 @@ public extension Tensor where Scalar : Numeric {
 
 /// Computes the log-softmax of the specified tensor element-wise.
 @inlinable @inline(__always)
-public func logSoftmax<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+public func logSoftmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.logSoftmax(logits: x)
 }
 
@@ -1384,17 +1394,7 @@ public extension Tensor {
 // Normalization
 //===----------------------------------------------------------------------===//
 
-// The `Scalar : Differentiable` and `Scalar.CotangentVector == Scalar`
-// constraints make `batchNormalized` differentiable with respect to `offset`
-// and `scale`.
-// TODO: With improved support for constraints on the @differentiable attribute,
-// we could move the constraints to the @differentiable attribute so that
-// `batchNormalized` exists even for scalars not satisfying the constraints. If
-// we did that now, type checking for the adjoint would fail because it
-// doesn't see @differentiable attribute constraints.
-public extension Tensor where Scalar : BinaryFloatingPoint,
-                              Scalar : Differentiable,
-                              Scalar.CotangentVector == Scalar {
+public extension Tensor where Scalar : BinaryFloatingPoint {
   /// Computes the batch normalized tensor along the specified axis.
   ///
   /// Specifically, returns `(self - mu)/(var + epsilon) * gamma + beta` where
@@ -1407,11 +1407,11 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
   ///   - scale: The scalar scale, also known as gamma.
   ///   - epsilon: A small value added to the denominator for numerical
   ///     stability.
-  // NOTE: It is not possible to provide a floating point initial value for
-  // arguments (like `epsilon`) because `FloatingPoint` is not
-  // `ExpressibleByFloatLiteral`.
   @inlinable @inline(__always)
-  @differentiable(wrt: (self, .1, .2), adjoint: _adjointBatchNormalized)
+  @differentiable(
+    wrt: (self, .1, .2), adjoint: _adjointBatchNormalized
+    where Scalar : Differentiable, Scalar == Scalar.CotangentVector
+  )
   func batchNormalized(
     alongAxis axis: Int32,
     offset: Scalar = 0,
@@ -1452,7 +1452,7 @@ internal extension Padding {
   }
 }
 
-public extension Tensor where Scalar : BinaryFloatingPoint {
+public extension Tensor where Scalar : FloatingPoint {
   /// Computes a 2-D convolution using `self` as input, with the specified
   /// filter, strides, and padding.
   ///

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -79,7 +79,10 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   /// Adds two tensors and produces their sum.
   /// - Note: `+` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointAdd(_:_:_:_:) where Scalar : FloatingPoint)
+  @differentiable(
+    adjoint: _adjointAdd(_:_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.add(lhs, rhs)
   }
@@ -88,7 +91,8 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   /// - Note: `-` supports broadcasting.
   @inlinable @inline(__always)
   @differentiable(
-    adjoint: _adjointSubtract(_:_:_:_:) where Scalar : FloatingPoint
+    adjoint: _adjointSubtract(_:_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
   )
   public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.sub(lhs, rhs)
@@ -110,7 +114,9 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
 
 extension Tensor : ShapedVectorNumeric where Scalar : Numeric {}
 
-extension Tensor : Differentiable where Scalar : FloatingPoint {
+extension Tensor : Differentiable
+  where Scalar : Differentiable & FloatingPoint
+{
   public typealias TangentVector = Tensor
   public typealias CotangentVector = Tensor
   @inlinable @inline(__always)
@@ -183,7 +189,8 @@ public extension Tensor where Scalar : Numeric {
   /// - Note: `*` supports broadcasting.
   @inlinable @inline(__always)
   @differentiable(
-    adjoint: _adjointMultiply(_:_:_:_:) where Scalar : FloatingPoint
+    adjoint: _adjointMultiply(_:_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
   )
   static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.mul(lhs, rhs)
@@ -213,7 +220,8 @@ public extension Tensor where Scalar : Numeric {
   /// - Note: `/` supports broadcasting.
   @inlinable @inline(__always)
   @differentiable(
-    adjoint: _adjointDivide(_:_:_:_:) where Scalar : FloatingPoint
+    adjoint: _adjointDivide(_:_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
   )
   static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.div(lhs, rhs)
@@ -290,7 +298,10 @@ public extension Tensor where Scalar : Numeric {
 /// Performs matrix multiplication with another tensor and produces the
 /// result.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointMatmul(_:_:_:_:) where Scalar : FloatingPoint)
+@differentiable(
+  adjoint: _adjointMatmul(_:_:_:_:)
+  where Scalar : Differentiable & FloatingPoint
+)
 public func matmul<Scalar : Numeric>(
   _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
 ) -> Tensor<Scalar> {
@@ -312,7 +323,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     adjoint: _adjointMatmulOperator(seed:originalValue:lhs:rhs:)
-    where Scalar : FloatingPoint
+    where Scalar : Differentiable & FloatingPoint
   )
   static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
     return matmul(lhs, rhs)
@@ -580,8 +591,10 @@ public extension Tensor {
   /// Returns a transposed tensor, with dimensions permuted in the specified
   /// order.
   @inlinable @inline(__always)
-  @differentiable(wrt: (self), adjoint: _adjointTransposed(_:_:_:)
-                  where Scalar : FloatingPoint)
+  @differentiable(
+    wrt: (self), adjoint: _adjointTransposed(_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   func transposed(
     withPermutations permutations: Tensor<Int32>
   ) -> Tensor {
@@ -697,7 +710,10 @@ public extension Tensor {
 public extension Tensor where Scalar : SignedNumeric {
   /// Computes the negation of the specified tensor element-wise.
   @inlinable @inline(__always)
-  @differentiable(adjoint: _adjointNegate(_:_:_:) where Scalar : FloatingPoint)
+  @differentiable(
+    adjoint: _adjointNegate(_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   static prefix func - (rhs: Tensor) -> Tensor {
     return Raw.neg(rhs)
   }
@@ -711,91 +727,91 @@ public func abs<T : SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
 
 /// Computes the natural logarithm of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointLog(_:_:_:))
+@differentiable(adjoint: _adjointLog(_:_:_:) where T : Differentiable)
 public func log<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.log(x)
 }
 
 /// Computes `sin` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointSin(_:_:_:))
+@differentiable(adjoint: _adjointSin(_:_:_:) where T : Differentiable)
 public func sin<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sin(x)
 }
 
 /// Computes `cos` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointCos(_:_:_:))
+@differentiable(adjoint: _adjointCos(_:_:_:) where T : Differentiable)
 public func cos<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cos(x)
 }
 
 /// Computes `tan` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointTan(_:_:_:))
+@differentiable(adjoint: _adjointTan(_:_:_:) where T : Differentiable)
 public func tan<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tan(x)
 }
 
 /// Computes `sinh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointSinh(_:_:_:))
+@differentiable(adjoint: _adjointSinh(_:_:_:) where T : Differentiable)
 public func sinh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sinh(x)
 }
 
 /// Computes `cosh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointCosh(_:_:_:))
+@differentiable(adjoint: _adjointCosh(_:_:_:) where T : Differentiable)
 public func cosh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cosh(x)
 }
 
 /// Computes `tanh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointTanh(_:_:_:))
+@differentiable(adjoint: _adjointTanh(_:_:_:) where T : Differentiable)
 public func tanh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tanh(x)
 }
 
 /// Computes the square root of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointSqrt(_:_:_:))
+@differentiable(adjoint: _adjointSqrt(_:_:_:) where T : Differentiable)
 public func sqrt<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sqrt(x)
 }
 
 /// Computes the inverse square root of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointRsqrt(_:_:_:))
+@differentiable(adjoint: _adjointRsqrt(_:_:_:) where T : Differentiable)
 public func rsqrt<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.rsqrt(x)
 }
 
 /// Computes `exp` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointExp(_:_:_:))
+@differentiable(adjoint: _adjointExp(_:_:_:) where T : Differentiable)
 public func exp<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.exp(x)
 }
 
 /// Computes the ceiling of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointCeil(_:_:_:))
+@differentiable(adjoint: _adjointCeil(_:_:_:) where T : Differentiable)
 public func ceil<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.ceil(x)
 }
 
 /// Computes the floor of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointFloor(_:_:_:))
+@differentiable(adjoint: _adjointFloor(_:_:_:) where T : Differentiable)
 public func floor<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.floor(x)
 }
 
 /// Computes the power of the first tensor to the second tensor.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointPow(_:_:_:_:))
+@differentiable(adjoint: _adjointPow(_:_:_:_:) where T : Differentiable)
 public func pow<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : FloatingPoint {
   return Raw.pow(lhs, rhs)
@@ -818,7 +834,10 @@ public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise maximum of two tensors.
 /// - Note: `max` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointMinMax(_:_:_:_:) where T : FloatingPoint)
+@differentiable(
+  adjoint: _adjointMinMax(_:_:_:_:)
+  where T : Differentiable & FloatingPoint
+)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.maximum(lhs, rhs)
@@ -843,7 +862,10 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise minimum of two tensors.
 /// - Note: `min` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointMinMax(_:_:_:_:) where T : FloatingPoint)
+@differentiable(
+  adjoint: _adjointMinMax(_:_:_:_:)
+  where T : Differentiable & FloatingPoint
+)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.minimum(lhs, rhs)
@@ -1467,6 +1489,7 @@ public extension Tensor where Scalar : FloatingPoint {
   @differentiable(
     wrt: (self, .0),
     adjoint: _adjointConvolved2D(seed:originalValue:filter:strides:padding:)
+    where Scalar : Differentiable
   )
   func convolved2D(
     withFilter filter: Tensor,
@@ -1492,6 +1515,7 @@ public extension Tensor where Scalar : FloatingPoint {
   @differentiable(
     wrt: (self),
     adjoint: _adjointMaxPooled(seed:originalValue:kernelSize:strides:padding:)
+    where Scalar : Differentiable
   )
   func maxPooled(
     kernelSize: (Int32, Int32, Int32, Int32),
@@ -1517,6 +1541,7 @@ public extension Tensor where Scalar : FloatingPoint {
   @differentiable(
     wrt: (self),
     adjoint: _adjointAveragePooled(seed:originalValue:kernelSize:strides:padding:)
+    where Scalar : Differentiable
   )
   func averagePooled(
     kernelSize: (Int32, Int32, Int32, Int32),

--- a/stdlib/public/TensorFlow/Random.swift
+++ b/stdlib/public/TensorFlow/Random.swift
@@ -131,8 +131,9 @@ public final class UniformIntegerDistribution<T: FixedWidthInteger> {
 }
 
 @_fixed_layout
-public final class UniformFloatingPointDistribution<T: BinaryFloatingPoint>
-  where T.RawSignificand : FixedWidthInteger {
+public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>
+  where T.RawSignificand : FixedWidthInteger
+{
   public let lowerBound: T
   public let upperBound: T
 
@@ -147,8 +148,9 @@ public final class UniformFloatingPointDistribution<T: BinaryFloatingPoint>
 }
 
 @_fixed_layout
-public final class NormalDistribution<T: BinaryFloatingPoint>
-  where T.RawSignificand : FixedWidthInteger {
+public final class NormalDistribution<T : BinaryFloatingPoint>
+  where T.RawSignificand : FixedWidthInteger
+{
   public let mean: T
   public let standardDeviation: T
   private let uniformDist = UniformFloatingPointDistribution<T>()

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -796,7 +796,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: (self), adjoint: _adjointReshaped(seed:originalValue:toShape:)
-    where Scalar : FloatingPoint
+    where Scalar : Differentiable & FloatingPoint
   )
   func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
     return Raw.reshape(self, shape: newShape)
@@ -820,7 +820,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: (self), adjoint: _adjointExpandingShape(seed:originalValue:at:)
-    where Scalar : FloatingPoint
+    where Scalar : Differentiable & FloatingPoint
   )
   func expandingShape(at shapeIndex: Int32) -> Tensor {
     return Raw.expandDims(self, dim: Tensor<Int32>(shapeIndex))

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -795,8 +795,8 @@ public extension Tensor {
   /// - Precondition: The number of scalars matches the new shape.
   @inlinable @inline(__always)
   @differentiable(
-    wrt: (self),
-    adjoint: _adjointReshaped(seed:originalValue:toShape:)
+    wrt: (self), adjoint: _adjointReshaped(seed:originalValue:toShape:)
+    where Scalar : FloatingPoint
   )
   func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
     return Raw.reshape(self, shape: newShape)
@@ -819,8 +819,8 @@ public extension Tensor {
   /// specified shape index.
   @inlinable @inline(__always)
   @differentiable(
-    wrt: (self),
-    adjoint: _adjointExpandingShape(seed:originalValue:at:)
+    wrt: (self), adjoint: _adjointExpandingShape(seed:originalValue:at:)
+    where Scalar : FloatingPoint
   )
   func expandingShape(at shapeIndex: Int32) -> Tensor {
     return Raw.expandDims(self, dim: Tensor<Int32>(shapeIndex))

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -219,7 +219,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-11-01-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "c7c0a76f1d6b8ac2057434fbf638b77993c6b88e",
-                "tensorflow-swift-bindings": "09d795dfc15b85d44718a1ad57c7cf9e651eca2d"
+                "tensorflow-swift-bindings": "6389cbcf37552f161c4f1f6aeb9dfcd4ef04d254"
             }
         }
     }


### PR DESCRIPTION
- Use `FloatingPoint` rather than `BinaryFloatingPoint` to constrain
  differentiability.
  - Follows from:
    - https://github.com/apple/swift/pull/21673
    - https://github.com/tensorflow/swift-bindings/pull/11
- Use `@differentiable` where clauses to constrain differentiability
  of numeric operations.
  - The most common constraint is `where Scalar : FloatingPoint` because
    `Tensor` conditionally conforms to `Differentiable where Scalar : FloatingPoint`.
- `Tensor` now conditionally conforms to `Differentiable` where `Scalar : Differentiable & FloatingPoint`.
- Allow `@differentiable` where clause conformance requirements to protocol composition types.
- Make VJP applications use the correct substitution map.
  - If a custom `@differentiable` attribute defines a VJP and where clause
    requirements, VJP applications should use a substitution map involving
    those requirements.
  - Note: more related cases need to be handled, such as `@differentiable`
    attributes with where clause requirements but no VJP. These cases will
    be handled later.

Todos:
- Make more `Tensor` operations differentiable.
  - This includes reduction and broadcasting ops.
  - This is enabled by `@differentiable` where clause type-checking.
- Use VJP functions instead of adjoint functions.
  - I've started work on this.
  - I would prefer that this be done in a separate patch, after this patch
    adds the correct `@differentiable` where clauses.
- Add tests for newly `@differentiable` `Tensor` operations.