### PR TITLE
ClangImporter: setup macros for WinSDK import

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -541,6 +541,25 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       });
     }
 
+    if (triple.isOSWindows()) {
+      switch (triple.getArch()) {
+      default: llvm_unreachable("unsupported Windows architecture");
+      case llvm::Triple::arm:
+      case llvm::Triple::thumb:
+        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_ARM_"});
+        break;
+      case llvm::Triple::aarch64:
+        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_ARM64_"});
+        break;
+      case llvm::Triple::x86:
+        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_X86_"});
+        break;
+      case llvm::Triple::x86_64:
+        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_AMD64_"});
+        break;
+      }
+    }
+
     // The module map used for Glibc depends on the target we're compiling for,
     // and is not included in the resource directory with the other implicit
     // module maps. It's at {freebsd|linux}/{arch}/glibc.modulemap.

--- a/test/ClangImporter/windows-sdk-macros.swift
+++ b/test/ClangImporter/windows-sdk-macros.swift
@@ -1,0 +1,14 @@
+// REQUIRES: CODEGENERATOR=AArch64
+// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: CODEGENERATOR=X86
+
+// RUN: %swift -target i686-unknown-windows-msvc -typecheck %s -parse-stdlib -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-X86
+// RUN: %swift -target x86_64-unknown-windows-msvc -typecheck %s -parse-stdlib -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-X64
+// RUN: %swift -target thumbv7-unknown-windows-msvc -typecheck %s -parse-stdlib -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-ARM
+// RUN: %swift -target aarch64-unknown-windows-msvc -typecheck %s -parse-stdlib -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-ARM64
+
+// CHECK-X86: -D_X86_
+// CHECK-X64: -D_AMD64_
+// CHECK-ARM: -D_ARM_
+// CHECK-ARM64: -D_ARM64_
+


### PR DESCRIPTION
Windows SDK requires that the platform target is identified.
Unfortunately, `cl` does not specify the value, so we cannot actually
specify the value in the clang frontend.  Specify this in the swift
frontend as this obscures the clang invocation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
