### PR TITLE
Guard send/recv warnings behind a flag and remove from tests.

### DIFF
--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -341,7 +341,6 @@ public func testCriticalEdges() {
 public func SR8443(n: Int32) {
   var i: Int32 = 0
   while i < n {
-    // expected-warning @+1 {{implicitly copied to the host}}
     let images = Tensor<Float>(0.0)
     _hostOp(images)
     i += 1

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -7,20 +7,18 @@ import TensorFlow
 var someGlobal = Tensor<Int32>(1)
 
 public func iftest(z: Tensor<Int32>, y: Tensor<Int32>, c: Bool, d: Bool) -> Tensor<Int32> {
-  // expected-warning @-1 {{'z' implicitly copied to the accelerator}}
 
   var a = z
   if c {
     if d { fatalError() }
-    a = a + a // expected-note {{value used here}}
+    a = a + a
   } else {
     if d { fatalError() }
 
-    // expected-warning @+1 {{value implicitly copied to the accelerator}}
     a = someGlobal
   }
 
-  a = a * a  // expected-note {{value used here}}
+  a = a * a
   return a
 }
 
@@ -28,20 +26,17 @@ public func iftest(z: Tensor<Int32>, y: Tensor<Int32>, c: Bool, d: Bool) -> Tens
 // the return site, and this prevented the return block from being included in
 // the post dom set for the partitioning pass.
 public func postdom_crash1(w1: Tensor<Float>, inputBatch: Tensor<Float>) {
-  // expected-warning @-1 {{'w1' implicitly copied to the accelerator}}
-  // expected-warning @-2 {{'inputBatch' implicitly copied to the accelerator}}
   let iterationCount = 1000
   for _ in 0..<iterationCount {
-    _ = inputBatch • w1  // expected-note 2 {{value used here}}
+    _ = inputBatch • w1
   }
 }
 
 // This crashed the partitioning pass because the 1.0 scalar was hoisted out of
 // the loop.  The partitioning pass tried to sink it back in, but failed.
 public func sinking_crash(w1: Tensor<Float>) {
-  // expected-warning @-1 {{'w1' implicitly copied to the accelerator}}
   for _ in 0..<1000 {
-    let pred = w1+w1  // expected-note {{value used here}}
+    let pred = w1+w1
     let _ = 1.0 / Tensor<Float>(pred.scalarCountTensor)
   }
 }
@@ -59,11 +54,10 @@ public func endpointComputationCrash() {
 // This crashed lower graph because it produced an error about not being able
 // to lower a send and there wasn't enough error recovery to handle it well.
 public func lowerGraphCrash(x: Tensor<Int32>) {
-  // expected-warning @-1 {{'x' implicitly copied to the accelerator}}
 
-  _ = x*x  // expected-note {{value used here}}
+  _ = x*x
   for _ in 0..<1000 {
-    _ = x+someGlobal // expected-warning {{value implicitly copied to the accelerator}}
+    _ = x+someGlobal
   }
 }
 
@@ -186,8 +180,8 @@ func twoHandles() -> (TensorHandle<Int32>, ResourceHandle) {
 }
 
 public func testMultiResultUninlinable() {
-  let (x1, _) = twoHandles()  // expected-warning {{value implicitly copied to the accelerator}}
-  let _: TensorHandle<Float> = #tfop("Identity", x1)  // expected-note {{value used here}}
+  let (x1, _) = twoHandles()
+  let _: TensorHandle<Float> = #tfop("Identity", x1)
 }
 
 // Test support for copying multiple result outputs.
@@ -199,37 +193,27 @@ public func testMultiOutputsFnResults() -> (Tensor<Float>,  Tensor<Float>) {
   return (x.toHost(),y.toHost())
 }
 
-// expected-warning @+2{{implicitly copied to the accelerator}}
-// expected-warning @+1{{implicitly copied to the accelerator}}
 public func testMultiResultOp_tfop(x: Tensor<Float>, y: Tensor<Float>) {
   let (loss, backprop) : (TensorHandle<Float>, TensorHandle<Float>) =
     #tfop("SoftmaxCrossEntropyWithLogits", x, y)
-  // expected-note @-1{{value used here}}
-  // expected-note @-2{{value used here}}
   _hostOp(loss)
   _hostOp(backprop)
 }
 
-// expected-warning @+2{{implicitly copied to the accelerator}}
-// expected-warning @+1{{implicitly copied to the accelerator}}
 public func testMultiResultOp_rawop(x: Tensor<Float>, y: Tensor<Float>) {
-  // expected-note @+2{{value used here}}
-  // expected-note @+1{{value used here}}
   let results = TensorFlow.Raw.softmaxCrossEntropyWithLogits(features: x, labels: y)
   _hostOp(results.loss)
   _hostOp(results.backprop)
 }
 
 public func testMultiResultOp_send_recv() {
-  var x = Tensor<Float>([[1.0]])  // expected-warning {{implicitly copied to the host}}
+  var x = Tensor<Float>([[1.0]])
   // Accelerator -> Host
   _hostOp(x)
   x += [[2.0]]
-  // expected-warning @+1{{implicitly copied to the host}}
   let results = TensorFlow.Raw.softmaxCrossEntropyWithLogits(features: x, labels: x)
   // Accelerator -> Host
   _hostOp(results.loss)
-  // expected-note @+1{{value used here}}
   let adjustedLoss = results.loss.scalar! + 3.0
   // Host -> Accelerator
   let y = Tensor<Float>(adjustedLoss)
@@ -254,7 +238,7 @@ public func SR8191() {
   let t = Tensor<Float>(1.0)
   var i = 0
   repeat {
-    let y = t + t // expected-warning {{value implicitly copied to the host}}
+    let y = t + t
     _hostOp(y)
     i += 1
   } while i < 10
@@ -274,15 +258,11 @@ public func SR8191() {
 // "let _= a + b", and ends in that BB. So the tensor start point and tensor end
 // point should both be in that BB.
 public func SR8226(n: Float, m: Float, cond: Bool, cond2: Bool) {
-  // expected-warning @+1{{implicitly copied to the accelerator}}
   let a = Tensor<Float>([m, n])
 
   if cond {
-    // expected-warning @+1{{implicitly copied to the accelerator}}
     let b = Tensor<Float>([m, n])
     if cond2 {
-      // expected-note @+2{{value used here}}
-      // expected-note @+1{{value used here}}
       let _ = a + b
     }
   }
@@ -311,7 +291,6 @@ public func SR8222_cond_br_TensorHandle_Bool() {
   var i = Tensor<Int32>(0)
   repeat {
     let y = t + t
-    // expected-warning @-1{{implicitly copied to the host}}
     _hostOp(y)
     i += 1
   } while i != Tensor<Int32>(10)
@@ -385,14 +364,13 @@ extension AggregateStruct : TensorGroup {
 public func inlineDeabstracted_a() -> Tensor<Float> {
   return deabstractedCallee([1, 2, 3])
 }
-// expected-warning @+1 {{implicitly copied}}
+
 public func deabstractedCallee(_ t: Tensor<Float>) -> Tensor<Float> {
   // expected-error @+3 {{op named 'Dummy' is not registered in TensorFlow}}
   // expected-error @+2 {{op named 'Dummy' is not registered in TensorFlow}}
   // expected-error @+1 {{op named 'Dummy' is not registered in TensorFlow}}
   let aggregate: AggregateStruct = #tfop("Dummy") // packs results
 
-  // expected-note @+1 {{value used here}}
   return t ++ aggregate.a // concat uses an InputList
 }
 public func inlineDeabstracted_b() -> Tensor<Float> {

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -58,12 +58,11 @@ public func f(a: Tensor<Float>, idx: Tensor<Int32>) -> Tensor<Float> {
 }
 
 
-// expected-warning @+1 2 {{implicitly copied to the accelerator}}
 public func testInputListArguments(a: TensorHandle<Float>, b: Tensor<Float>) -> Tensor<Float> {
   // Pack takes an input list, not multiple inputs.  Here we're checking that
   // we can pass in an array of Tensor's and an array of TensorHandle's.
-  let x: TensorHandle<Float> = #tfop("Pack", [a, a, a])  // expected-note {{value used here}}
-  let y: TensorHandle<Float> = #tfop("Pack", [b, b, b])  // expected-note {{value used here}}
+  let x: TensorHandle<Float> = #tfop("Pack", [a, a, a])
+  let y: TensorHandle<Float> = #tfop("Pack", [b, b, b])
   return (Tensor(handle: x)+Tensor(handle: y)).toHost()
 }
 
@@ -74,11 +73,10 @@ CHECK: graph_op "Pack"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Fl
 CHECK-LABEL: ---- END OF INPUT FUNCTION
 */
 
-// expected-warning @+1 {{implicitly copied to the accelerator}}
 public func inputListMultipleUses(a: TensorHandle<Float>)
    -> (Tensor<Float>, [TensorHandle<Float>]) {
   let arr = [a, a, a]
-  let x: TensorHandle<Float> = #tfop("Pack", arr)  // expected-note {{value used here}}
+  let x: TensorHandle<Float> = #tfop("Pack", arr)
   return (Tensor(handle: x).toHost(), arr)
 }
 
@@ -268,9 +266,7 @@ public func testTensorFlowClosures(_ a: Float) -> Tensor<Int32>{
 // if they are only referred in code.  In this case, addOne should be
 // partitioned, but not getZero.
 //
-// expected-warning @+1 {{'x' implicitly copied to the accelerator}}
 private func addOne(_ x : Tensor<Float>) -> Tensor<Float> {
-  // expected-note @+1 {{value used here}}
   return x + Tensor<Float>(1.0)
 }
 private func getZero() -> Tensor<Float> { return Tensor<Float>(0.0) }

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-warn-send-recv -O -emit-sil -verify %s
 
 import TensorFlow
 

--- a/test/TensorFlow/diagnostics_scalar_transfers.swift
+++ b/test/TensorFlow/diagnostics_scalar_transfers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-warn-scalar-transfer=true -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-warn-send-recv -Xllvm -tf-warn-scalar-transfer=true -O -emit-sil -verify %s
 
 // Tests that we diagnose scalar transfers when tf-warn-scalar-transfer=true. There are parallel
 // tests in diagnostics.swift ensuring that we do not diagnost the transfers when

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -3,13 +3,12 @@
 import TensorFlow
 
 public func testTensor(a: Tensor<Float>, b: Tensor<Float>) {
-  // expected-warning @-1 {{'a' implicitly copied to the accelerator}}
   var x = a
-  x += x  // expected-note {{value used here}}
+  x += x
 
-  x -= x  // expected-warning {{value implicitly copied to the host, use .toHost() to make transfer explicit}}
+  x -= x
 
-  _hostOp(x) // expected-note {{value used here}}
+  _hostOp(x)
   var y = b.toAccelerator()
   y += y
   _hostOp(y)
@@ -122,8 +121,8 @@ public func testExitBranch2(i: Int) {
     return
   }
 
-  x += x    // expected-warning {{value implicitly copied to the host}}
-  _hostOp(x)  // expected-note {{value used here}}
+  x += x
+  _hostOp(x)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExitBranch2{{.*}}
@@ -284,8 +283,8 @@ public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>)
 // disprove away the optional check, so we'll need to send a bit back to the
 // host.
 public func scalar_manipulation(a : Float) -> Tensor<Float> {
-  let x = Tensor<Float>(a) + Tensor<Float>(1.0) // expected-warning {{value implicitly copied to the host}}
-  let y = x.scalar! + 2.0 // expected-note {{value used here}}
+  let x = Tensor<Float>(a) + Tensor<Float>(1.0)
+  let y = x.scalar! + 2.0
   let z = Tensor<Float>(y)
   return z+z
 }
@@ -307,8 +306,7 @@ public func scalar_manipulation(a : Float) -> Tensor<Float> {
 
 
 public func testCast(x: Tensor<Float>) -> Tensor<Int32> {
-  // expected-warning @-1 {{'x' implicitly copied to the accelerator}}
-  return Tensor<Int32>(x+x)  // expected-note {{value used here}}
+  return Tensor<Int32>(x+x)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testCast
@@ -318,12 +316,11 @@ public func testCast(x: Tensor<Float>) -> Tensor<Int32> {
 // CHECK:   [[CAST:%.*]] = graph_op "Cast"([[ADD]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Int32>
 // CHECK:   return [[CAST]] : $TensorHandle<Int32>
 
-// expected-warning @+1 2 {{implicitly copied to the accelerator}}
 public func testInputListArguments(a: TensorHandle<Float>, b: Tensor<Float>) -> Tensor<Float> {
   // Pack takes an input list, not multiple inputs.  Here we're checking that
   // we can pass in an array of Tensor's and an array of TensorHandle's.
-  let x: TensorHandle<Float> = #tfop("Pack", [a, a, a])  // expected-note {{value used here}}
-  let y: TensorHandle<Float> = #tfop("Pack", [b, b, b])  // expected-note {{value used here}}
+  let x: TensorHandle<Float> = #tfop("Pack", [a, a, a])
+  let y: TensorHandle<Float> = #tfop("Pack", [b, b, b])
   return (Tensor(handle: x)+Tensor(handle: y)).toHost()
 }
 
@@ -341,11 +338,11 @@ public func testInputListArguments(a: TensorHandle<Float>, b: Tensor<Float>) -> 
 // This should produce exactly one live out value in the call to
 // _swift_tfc_FinishTensorComputation.
 public func liveOutTest(
-  a: Tensor<Float>, // expected-warning {{'a' implicitly copied to the accelerator, use .toAccelerator() to make transfer explicit}}
-  b: Tensor<Float>, // expected-warning {{'b' implicitly copied to the accelerator, use .toAccelerator() to make transfer explicit}}
-  c: Tensor<Float> // expected-warning {{'c' implicitly copied to the accelerator, use .toAccelerator() to make transfer explicit}}
+  a: Tensor<Float>,
+  b: Tensor<Float>,
+  c: Tensor<Float>
 ) -> Tensor<Float> {
-  return a+b+c // expected-note 3 {{value used here}}
+  return a+b+c
 }
 
 /*
@@ -461,8 +458,8 @@ public struct NonInlineMethodExample {
   var b = Tensor<Float>(2.0)
 
   @inline(never)
-  public mutating func mutatingMethod() {  // expected-warning {{'self' implicitly copied}}
-    a += b   // expected-note {{value used here}}
+  public mutating func mutatingMethod() {
+    a += b
     b += a
   }
 }

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -22,7 +22,7 @@ public func testSendsInALoopGPU() {
   var count = 1
 
   while count < maxCount {
-    a += a    // expected-warning  {{implicitly copied to the host}}
+    a += a
     // One send.
     _hostOp(a.toHost())
     count += 1

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates %swift-tensorflow-extra-options -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil %s -verify | %FileCheck %filecheck-tensorflow-extra-options %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates %swift-tensorflow-extra-options -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -Xllvm -tf-warn-send-recv -O -emit-sil %s -verify | %FileCheck %filecheck-tensorflow-extra-options %s
 
 // In this file, send means accelerator->host, and recv means the opposite.
 

--- a/test/TensorFlow/sese_loop_canonicalization.swift
+++ b/test/TensorFlow/sese_loop_canonicalization.swift
@@ -5,12 +5,11 @@
 
 import TensorFlow
 
-// expected-warning @+1 {{value implicitly copied to the host}}
 public func testLoopMovementFromOutside(_ breakIndex: Int32) -> Tensor<Int32> {
   var i: Int32 = 1
   var sum = Tensor<Int32>(0)
   let maxCount: Int32 = 100
-  while i <= maxCount { // expected-note {{value used here}}
+  while i <= maxCount {
     sum += i
     if i == breakIndex {
       var k: Int32 = 0
@@ -18,9 +17,8 @@ public func testLoopMovementFromOutside(_ breakIndex: Int32) -> Tensor<Int32> {
         sum += i
         k += 1
       }
-      // expected-warning @+1 {{value implicitly copied to the host}}
       sum += 1
-      break // expected-note {{value used here}}
+      break
     }
     i += 1
   }
@@ -59,7 +57,6 @@ public func testLoopMovementFromOutside(_ breakIndex: Int32) -> Tensor<Int32> {
 
 // This example checks that the loop structure is preserved when we unroll
 // the body of a loop during canonicalization.
-//expected-warning @+1 {{value implicitly copied to the host}}
 public func testLoopWithNestedLoopsRequiringUnrolling(
   _ breakIndex:Int32, _ repetitions: Int32) -> Tensor<Int32> {
 	var result = Tensor<Int32>(0)
@@ -70,7 +67,6 @@ public func testLoopWithNestedLoopsRequiringUnrolling(
 		// once.  This corresponds to the loop at depth 2 in the dump of loop info
 		// before canonicalization.
 		repeat {
-			// expected-warning @+1 {{value implicitly copied to the host}}
 			if i > breakIndex {
 				// + 1 so that this is not a simple assignment. 
 				// (Simple assignments won't trigger cloning.)
@@ -79,7 +75,6 @@ public func testLoopWithNestedLoopsRequiringUnrolling(
 			}
 			// Crazy way to do `k = i` so that we have a loop when we unroll the body.
 			var k = Tensor<Int32>(0)
-			// expected-warning @+1 {{value implicitly copied to the host}}
 			while k < i {
 				k += 1
 			}
@@ -87,11 +82,9 @@ public func testLoopWithNestedLoopsRequiringUnrolling(
 			// + k so that this is not a simple assignment. 
 			// (Simple assignments won't trigger cloning.)
 			result = i + k
-			// expected-warning @+1 {{value implicitly copied to the host}}
 		} while i <= 100
 		result += 3
 	}
-	// expected-note @+1 {{value used here}}
 	return result
 }
 
@@ -152,7 +145,6 @@ public func testLoopWithNestedLoopsRequiringUnrolling(
 
 // This example checks that the loop structure is preserved when we unroll
 // the body of a loop during canonicalization.
-//expected-warning @+1 {{value implicitly copied to the host}}
 public func testLoopWithDoublyNestedLoopsRequiringUnrolling(
 	_ breakIndex:Int32, _ repetitions: Int32) -> Tensor<Int32> {
 	var result = Tensor<Int32>(0)
@@ -163,7 +155,6 @@ public func testLoopWithDoublyNestedLoopsRequiringUnrolling(
 		// once.  This corresponds to the loop at depth 2 in the dump of loop info
 		// before canonicalization.
 		repeat {
-			// expected-warning @+1 {{value implicitly copied to the host}}
 			if i > breakIndex {
 				// + 1 so that this is not a simple assignment. 
 				// (Simple assignments won't trigger cloning.)
@@ -173,10 +164,8 @@ public func testLoopWithDoublyNestedLoopsRequiringUnrolling(
 
 			// Crazy way to do k = i^2 so that we have a doubly loop when we unroll.
 			var k = Tensor<Int32>(0)
-			// expected-warning @+1 {{value implicitly copied to the host}}
 			while k < i {
 				var w = Tensor<Int32>(0)
-				// expected-warning @+1 {{value implicitly copied to the host}}
 				while w < i {
 					w += 1
 				}
@@ -186,11 +175,9 @@ public func testLoopWithDoublyNestedLoopsRequiringUnrolling(
 			// + k so that this is not a simple assignment. 
 			// (Simple assignments won't trigger cloning.)
 			result = i + k
-			// expected-warning @+1 {{value implicitly copied to the host}}
 		} while i <= 100
 		result += 3
 	}
-	// expected-note @+1 {{value used here}}
 	return result
 }
 

--- a/test/TensorFlow/tfop_packing.swift
+++ b/test/TensorFlow/tfop_packing.swift
@@ -121,10 +121,8 @@ public func unpackAggregate_generic() {
 // Checks that unpacking reuses extraction instructions instead of making new
 // ones for each element of the input list.
 // TODO(SR-8680): After fixing tuples, make x a tuple, so that we also test tuple extract reuse.
-// expected-warning @+1 {{copied to the accelerator}}
 public func unpackAggregate_reuse(x: Tensor<Float>) {
-  // expected-error @+2 {{op named 'SomeOp7' is not registered in TensorFlow}}
-  // expected-note @+1 {{value used here}}
+  // expected-error @+1 {{op named 'SomeOp7' is not registered in TensorFlow}}
   let _: Tensor<Float> = #tfop("SomeOp7", [x, x])
 }
 

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -20,8 +20,6 @@ public func testSharedRegion(_ count : Int32) -> Tensor<Int32> {
   do {
     if count > 0 {
       if count < 100 {
-        // expected-warning @+2 {{value implicitly copied to the host}}
-        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 1
       } else {
         result += 2
@@ -29,26 +27,18 @@ public func testSharedRegion(_ count : Int32) -> Tensor<Int32> {
       }
     } else {
       if count > -100 {
-        // expected-warning @+2 {{value implicitly copied to the host}}
-        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 3
       } else {
         result += 4
         throw TestError.NegativeOutOfBound
       }
-    } // expected-note {{value used here}}
-    // expected-note @+1 {{value used here}}
-  } catch { // expected-note {{value used here}}
-    // expected-warning @+2 {{value implicitly copied to the host}}
-    // expected-warning @+1 {{value implicitly copied to the host}}
+    }
+  } catch {
     result += 5
   }
   return result
 }
 
-// expected-note @+3 {{value used here}}
-// expected-note @+2 {{value used here}}
-// expected-note @+1 {{value used here}}
 SESERegionTests.testAllBackends("testSharedRegion") { 
   expectEqualWithScalarTensor(1, testSharedRegion(99))
   expectEqualWithScalarTensor(7, testSharedRegion(101))
@@ -81,8 +71,6 @@ public func testSharedRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
   do {
     if count > 0 {
       if count < 100 {
-        // expected-warning @+2 {{value implicitly copied to the host}}
-        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 1
       } else {
         result += 2
@@ -90,20 +78,15 @@ public func testSharedRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
       }
     } else {
       if count > -100 {
-        // expected-warning @+2 {{value implicitly copied to the host}}
-        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 3
       } else {
         result += 4
         throw TestError.NegativeOutOfBound
       }
-    } // expected-note {{value used here}}
-    // expected-note @+1 {{value used here}}
-  } catch { // expected-note {{value used here}}
+    }
+  } catch {
     var i: Int32 = 0
     while i < 2 {
-      // expected-warning @+2 {{value implicitly copied to the host}}
-      // expected-warning @+1 {{value implicitly copied to the host}}
       result += 5
       i += 1
     }
@@ -111,9 +94,6 @@ public func testSharedRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
   return result
 }
 
-// expected-note @+3 {{value used here}}
-// expected-note @+2 {{value used here}}
-// expected-note @+1 {{value used here}}
 SESERegionTests.testAllBackends("testSharedRegionWithLoop") { 
   expectEqualWithScalarTensor(1, testSharedRegionWithLoop(99))
 #if !CUDA


### PR DESCRIPTION
This PR removes "expected-warning/expected-note" related to send/receive warnings from all the tests except the ones specifically used to test the diagnostics.

Rationale: send/recv behavior seems to change whenever we move the deabstraction/partition passes to a different location in the pass pipeline. This is really slowing down the implementation of the changes required to get a solid eager mode with GPE on tensorflow convention functions. Given that we plan to completely revamp these diagnostics anyway, I prefer removing them from tests irrelevant for diagnostics. Adding counters will have the same issue.  