### PR TITLE
[Sema] [AutoDiff] Derive `@_fieldwiseProductSpace` when tangent/cotangent is Self

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -374,6 +374,7 @@ ERROR(autodiff_unsupported_type,none,
       "differentiating '%0' is not supported yet", (Type))
 ERROR(autodiff_function_not_differentiable,none,
       "function is not differentiable", ())
+// TODO: Change this to a note.
 ERROR(autodiff_property_not_differentiable,none,
       "property is not differentiable", ())
 NOTE(autodiff_function_generic_functions_unsupported,none,

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -582,11 +582,15 @@ deriveDifferentiable_VectorSpace(DerivedConformance &derived,
     auto *aliasDecl = new (C) TypeAliasDecl(
         SourceLoc(), SourceLoc(), getVectorSpaceIdentifier(kind, C),
         SourceLoc(), {}, nominal);
+    aliasDecl->setUnderlyingType(selfType);
     aliasDecl->setImplicit();
     aliasDecl->getAttrs().add(
         new (C) FieldwiseProductSpaceAttr(/*implicit*/ true));
-    aliasDecl->setUnderlyingType(selfType);
     nominal->addMember(aliasDecl);
+    aliasDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
+    aliasDecl->setValidationToChecked();
+    TC.validateDecl(aliasDecl);
+    C.addSynthesizedDecl(aliasDecl);
     return selfType;
   }
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -585,7 +585,7 @@ deriveDifferentiable_VectorSpace(DerivedConformance &derived,
     aliasDecl->setImplicit();
     aliasDecl->getAttrs().add(
         new (C) FieldwiseProductSpaceAttr(/*implicit*/ true));
-    aliasDecl->setUnderlyingType(selfType->mapTypeOutOfContext());
+    aliasDecl->setUnderlyingType(selfType);
     nominal->addMember(aliasDecl);
     return selfType;
   }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -577,7 +577,17 @@ deriveDifferentiable_VectorSpace(DerivedConformance &derived,
                             parentDC, ConformanceCheckFlags::Used);
   // Return `Self` if conditions are met.
   if (allMembersVectorSpaceEqualsSelf && nominalConformsToAddArith) {
-    return parentDC->mapTypeIntoContext(nominal->getDeclaredInterfaceType());
+    auto selfType =
+        parentDC->mapTypeIntoContext(nominal->getDeclaredInterfaceType());
+    auto *aliasDecl = new (C) TypeAliasDecl(
+        SourceLoc(), SourceLoc(), getVectorSpaceIdentifier(kind, C),
+        SourceLoc(), {}, nominal);
+    aliasDecl->setImplicit();
+    aliasDecl->getAttrs().add(
+        new (C) FieldwiseProductSpaceAttr(/*implicit*/ true));
+    aliasDecl->setUnderlyingType(selfType->mapTypeOutOfContext());
+    nominal->addMember(aliasDecl);
+    return selfType;
   }
 
   // Get or synthesize both `TangentVector` and `CotangentVector` structs at

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -1,12 +1,27 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s --check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s --check-prefix=CHECK-SILGEN
+// RUN: %target-swift-frontend -emit-sil -verify %s
 
 public struct Foo : Differentiable {
   public var a: Float
 }
 
-// CHECK-LABEL: public struct Foo : Differentiable {
-// CHECK:   @sil_stored @differentiable()
-// CHECK:   public var a: Float { get set }
+// CHECK-AST-LABEL: public struct Foo : Differentiable {
+// CHECK-AST:   @sil_stored @differentiable()
+// CHECK-AST:   public var a: Float { get set }
 
-// CHECK-LABEL: // Foo.a.getter
-// CHECK: sil [transparent] [serialized] [differentiable source 0 wrt 0] @$s33derived_differentiable_properties3FooV1aSfvg : $@convention(method) (Foo) -> Float
+// CHECK-SILGEN-LABEL: // Foo.a.getter
+// CHECK-SILGEN: sil [transparent] [serialized] [differentiable source 0 wrt 0] @$s33derived_differentiable_properties3FooV1aSfvg : $@convention(method) (Foo) -> Float
+
+struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
+  var a: Float
+}
+let _: @autodiff (AdditiveTangentIsSelf) -> Float = { x in
+  x.a + x.a
+}
+
+// CHECK-AST-LABEL: struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
+// CHECK-AST-NOT:     @differentiable
+// CHECK-AST:         @_fieldwiseProductSpace typealias TangentVector = AdditiveTangentIsSelf
+// CHECK-AST:         @_fieldwiseProductSpace typealias CotangentVector = AdditiveTangentIsSelf
+


### PR DESCRIPTION
In `Differentiable` derived conformances, fix a bug where `@_fieldwiseProductSpace` is not added to derived typealiases when `TangentVector` and/or `CotangentVector` are inferred as `Self`. Without this change, field access `x.a` could not be differentiated.

```swift
struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
  var a: Float
}
let _: @autodiff (AdditiveTangentIsSelf) -> Float = { x in
  x.a + x.a
}
```