### PR TITLE
[AutoDiff] [API] Rewrite adjoints with VJPs.

### DIFF
--- a/stdlib/public/TensorFlow/CompositeMath.swift
+++ b/stdlib/public/TensorFlow/CompositeMath.swift
@@ -19,7 +19,7 @@
 /// Computes `sigmoid` of the specified tensor element-wise.
 /// Specifically, computes `1 / (1 + exp(-x))`.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointSigmoid(_:_:_:) where T : Differentiable)
+@differentiable(vjp: _vjpSigmoid(_:) where T : Differentiable)
 public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sigmoid(x)
 }
@@ -27,15 +27,15 @@ public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes `relu` of the specified tensor element-wise.
 /// Specifically, computes `max(0, x)`.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointRelu(_:_:_:) where T : Differentiable)
+@differentiable(vjp: _vjpRelu(_:) where T : Differentiable)
 public func relu<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return max(0, x)
 }
 
-/// Computes the softmax of the specified tensor element-wise.
+/// Computes the softmax of the specified tensor along the last axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: -1)`.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointSoftmax(_:_:_:) where T : Differentiable)
+@differentiable(vjp: _vjpSoftmax(_:) where T : Differentiable)
 public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.softmax(logits: x)
 }

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -10,32 +10,30 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file contains gradient definitions for Tensor ops.
+// This file contains vector-Jacobian product (VJP) definitions for Tensor ops.
 //
 // Terminology:
 // - originalValue (f): The function being differentiated, or the result of that
 //   function.
-// - Adjoint (f'): The function as the result of differentiation, computing
-//   the Jacobian-vector products or gradients with respect to all arguments,
-//   or the result of that function.
-// - Seed: The back-propagated adjoint, i.e. the adjoint of the caller of the
-//   function with respect to the result of the function.
+// - VJP (f'): The function as the result of differentiation, computing
+//   the vector-Jacobian products with respect to all arguments, or the result
+//   of that function.
 //
 // For more information, visit:
 // https://en.wikipedia.org/wiki/Automatic_differentiation
 //
-// Each function in this file is the adjoint of some corresponding function
-// defined in Ops.swift with respect to all of its parameters. The attribute
-// '@differentiable(adjoint: ...)' is used to define the adjoint for a
-// function. The automatic differentiation pass will pick up these adjoints
-// and chain them together for arbitrary differentiable programs.
+// Each function in this file is the VJP of some corresponding function
+// defined in Ops.swift with respect to all arguments. The attribute
+// '@differentiable(reverse, vjp: ...)' is used to define the VJP for a
+// function. The automatic differentiation pass will pick up these VJPs and
+// chain them together for arbitrary differentiable programs.
 //
 // NOTE:
-// - Currently, we do not want to expose adjoint functions to users. The name of
-//   each adjoint function should start with an underscore.
+// - Currently, we do not want to expose VJP functions to users. The name of
+//   each VJP function should start with an underscore.
 // TODO:
-// - Add gradients for more ops ('sum', 'mean', etc).
-// - Fix gradients for broadcasting ops (need to perform reduction).
+// - Add VJPs for more ops ('sum', 'mean', etc).
+// - Fix VJPs for broadcasting ops (need to perform reduction).
 //
 // FIXME:
 // - Handle scalar broadcasting.
@@ -208,54 +206,147 @@ public func gradient<T, U, V, R>(
 
 extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
-  static func _adjointAdd(
-    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
-  ) -> (Tensor, Tensor) {
-    let seed = seed.broadcast(like: originalValue)
-    return (seed.unbroadcast(like: x), seed.unbroadcast(like: y))
+  static func _vjpAdd(
+    lhs: Tensor, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    let value = lhs + rhs
+    return (value, { v in
+      let v = v.broadcast(like: value)
+      return (v.unbroadcast(like: lhs), v.unbroadcast(like: rhs))
+    })
   }
 
   @inlinable
-  static func _adjointSubtract(
-    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
-  ) -> (Tensor, Tensor) {
-    let seed = seed.broadcast(like: originalValue)
-    return (seed.unbroadcast(like: x), 0 - seed.unbroadcast(like: y))
+  static func _vjpSubtract(
+    lhs: Tensor, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    let value = lhs - rhs
+    return (value, { v in
+      let v = v.broadcast(like: value)
+      return (v.unbroadcast(like: lhs), -v.unbroadcast(like: rhs))
+    })
   }
 
   @inlinable
-  static func _adjointMultiply(
-    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
-  ) -> (Tensor, Tensor) {
-    return ((y * seed).unbroadcast(like: x),
-            (x * seed).unbroadcast(like: y))
+  static func _vjpMultiply(
+    lhs: Tensor, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    return (lhs * rhs, { v in
+
+      ((rhs * v).unbroadcast(like: lhs),
+       (lhs * v).unbroadcast(like: rhs))
+    })
   }
 
   @inlinable
-  static func _adjointDivide(
-    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
-  ) -> (Tensor, Tensor) {
-    return ((seed / y).unbroadcast(like: x),
-            ((0 - x) / y.squared() * seed).unbroadcast(like: y))
+  static func _vjpDivide(
+    lhs: Tensor, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    return (lhs * rhs, { v in
+      ((v / rhs).unbroadcast(like: lhs),
+       ((-lhs) / rhs.squared() * v).unbroadcast(like: rhs))
+    })
+  }
+}
+
+extension Tensor where Scalar : Differentiable & FloatingPoint,
+                       Scalar == Scalar.CotangentVector {
+  @inlinable
+  static func _vjpAdd(
+    lhs: Tensor, rhs: Scalar
+  ) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    return (lhs + rhs, { v in (v, v.sum().scalarized()) })
+  }
+
+   @inlinable
+  static func _vjpAdd(
+    lhs: Scalar, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    return (lhs + rhs, { v in (v.sum().scalarized(), v) })
+  }
+
+  @inlinable
+  static func _vjpSubtract(
+    lhs: Tensor, rhs: Scalar
+  ) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    return (lhs - rhs, { v in (v, 0 - v.sum().scalarized()) })
+  }
+
+  @inlinable
+  static func _vjpSubtract(
+    lhs: Scalar, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    return (lhs - rhs, { v in (v.sum().scalarized(), 0 - v) })
+  }
+
+  @inlinable
+  static func _vjpMultiply(
+    lhs: Tensor, rhs: Scalar
+  ) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    return (lhs * rhs, { v in (v * rhs, (v * lhs).sum().scalarized()) })
+  }
+
+  @inlinable
+  static func _vjpMultiply(
+    lhs: Scalar, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    return (lhs * rhs, { v in ((v * rhs).sum().scalarized(), v * lhs) })
+  }
+
+  @inlinable
+  static func _vjpDivide(
+    lhs: Tensor, rhs: Scalar
+  ) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    return (lhs / rhs, { v in
+      (v / rhs, (v * (0 - lhs) / Tensor(rhs).squared()).sum().scalarized())
+    })
+  }
+
+  @inlinable
+  static func _vjpDivide(
+    lhs: Scalar, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    return (lhs / rhs, { v in
+      ((v / rhs).sum().scalarized(), v * (0 - lhs) / rhs.squared())
+    })
   }
 }
 
 @inlinable
-func _adjointMinMax<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
+func _vjpMinMax<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, vector: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
   let denom = 1 + Tensor<T>(x .== y)
-  let dfdx = seed * Tensor<T>(x .== originalValue) / denom
-  let dfdy = seed * Tensor<T>(y .== originalValue) / denom
+  let dfdx = vector * Tensor<T>(x .== originalValue) / denom
+  let dfdy = vector * Tensor<T>(y .== originalValue) / denom
   return (dfdx.unbroadcast(like: x), dfdy.unbroadcast(like: y))
 }
 
 @inlinable
-func _adjointPow<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
-) -> (Tensor<T>, Tensor<T>) {
-  return ((seed * y * pow(x, y-1)).unbroadcast(like: x),
-          (seed * log(x) * originalValue).unbroadcast(like: y))
+func _vjpMax<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>, _ y: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+  let value = max(x, y)
+  return (value, { v in _vjpMinMax(x, y, originalValue: value, vector: v) })
+}
+
+@inlinable
+func _vjpMin<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>, _ y: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+  let value = min(x, y)
+  return (value, { v in _vjpMinMax(x, y, originalValue: value, vector: v) })
+}
+
+@inlinable
+func _vjpPow<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>, _ y: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+  let value = pow(x, y)
+  return (value, { v in
+    ((v * y * pow(x, y-1)).unbroadcast(like: x),
+     (v * log(x) * value).unbroadcast(like: y))
+  })
 }
 
 //===----------------------------------------------------------------------===//
@@ -264,109 +355,114 @@ func _adjointPow<T : Differentiable & FloatingPoint>(
 
 extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
-  static func _adjointNegate(
-    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor
-  ) -> Tensor {
-    return -seed.broadcast(like: originalValue)
+  static func _vjpNegate(_ x: Tensor) -> (Tensor, (Tensor) -> Tensor) {
+    return (-x, { v in -v.broadcast(like: x) })
   }
 }
 
 @inlinable
-func _adjointLog<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed / x
+func _vjpLog<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (x, { v in v / x })
 }
 
 @inlinable
-func _adjointSin<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed * cos(x)
+func _vjpSin<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (sin(x), { v in v * cos(x) })
 }
 
 @inlinable
-func _adjointCos<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return -seed * sin(x)
+func _vjpCos<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (cos(x), { v in -v * sin(x) })
 }
 
 @inlinable
-func _adjointTan<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed * (1 + originalValue.squared())
+func _vjpTan<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = tan(x)
+  return (value, { v in v * (1 + value.squared()) })
 }
 
 @inlinable
-func _adjointSinh<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed * cosh(x)
+func _vjpSinh<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (sinh(x), { v in v * cosh(x) })
 }
 
 @inlinable
-func _adjointCosh<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed * sinh(x)
+func _vjpCosh<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (cosh(x), { v in v * sinh(x) })
 }
 
 @inlinable
-func _adjointTanh<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed * (1 - originalValue.squared())
+func _vjpTanh<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = tanh(x)
+  return (value, { v in v * ( 1 - value.squared()) })
 }
 
 @inlinable
-func _adjointExp<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return originalValue * seed
+func _vjpExp<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = exp(x)
+  return (value, { v in value * v })
 }
 
 @inlinable
-func _adjointCeil<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return Tensor(0).broadcast(like: x)
+func _vjpCeil<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (ceil(x), { _ in Tensor(0).broadcast(like: x) })
 }
 
 @inlinable
-func _adjointFloor<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return Tensor(0).broadcast(like: x)
+func _vjpFloor<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (floor(x), { _ in Tensor(0).broadcast(like: x) })
 }
 
 @inlinable
-func _adjointSqrt<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return seed / (2 * originalValue)
+func _vjpSqrt<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = sqrt(x)
+  return (sqrt(x), { v in v / (2 * value) })
 }
 
 @inlinable
-func _adjointRsqrt<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return -seed / 2 * pow(originalValue, 3)
+func _vjpRsqrt<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = rsqrt(x)
+  return (value, { v in -v / 2 * value })
 }
 
 @inlinable
-func _adjointLogSoftmax<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  let seed = seed.broadcast(like: originalValue)
-  return seed - seed.sum(alongAxes: -1) * exp(originalValue)
+func _vjpLogSoftmax<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = logSoftmax(x)
+  return (value, { v in
+    v - v.sum(alongAxes: -1) * exp(value)
+  })
 }
 
 extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
-  func _adjointSquared(_ seed: Tensor, _ originalValue: Tensor) -> Tensor {
-    return 2 * self * seed
+  func _vjpSquared() -> (Tensor, (Tensor) -> Tensor) {
+    return (squared(), { 2 * self * $0 })
   }
 }
 
@@ -375,42 +471,45 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 //===----------------------------------------------------------------------===//
 
 @inlinable
-func _adjointMatmul<Scalar : Differentiable & FloatingPoint>(
-  _ seed: Tensor<Scalar>, _ originalValue: Tensor<Scalar>,
-  _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
-) -> (Tensor<Scalar>, Tensor<Scalar>) {
-  let bcSeed = seed.broadcast(like: originalValue)
-  return (matmul(bcSeed, right.transposed()), matmul(left.transposed(), bcSeed))
+func _vjpMatmul<Scalar : Differentiable & FloatingPoint>(
+  _ lhs: Tensor<Scalar>, _ rhs: Tensor<Scalar>
+) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+  let value = matmul(lhs, rhs)
+  return (value, { v in 
+    return (matmul(v, rhs.transposed()), matmul(lhs.transposed(), v))
+  })
 }
 
-// TODO: We have to define a custom adjoint on • because AD can't yet
+// TODO: We have to define a custom VJP on • because AD can't yet
 // differentiate generic methods. After AD can differentiate generic methods,
-// remove the custom adjoint.
+// remove the custom VJP.
 extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
-  static func _adjointMatmulOperator(seed: Tensor, originalValue: Tensor,
-                                     lhs: Tensor, rhs: Tensor)
-      -> (Tensor, Tensor) {
-    return _adjointMatmul(seed, originalValue, lhs, rhs)
+  static func _vjpMatmulOperator(
+    lhs: Tensor, rhs: Tensor
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    return _vjpMatmul(lhs, rhs)
   }
 
   @inlinable
-  func _adjointTransposed(
-    _ seed: Tensor, _ originalValue: Tensor, _ permutations: Tensor<Int32>
-  ) -> Tensor {
-    return seed.transposed(withPermutations: permutations)
+  func _vjpTransposed(
+    withPermutations permutations: Tensor<Int32>
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    let value = transposed()
+    return (value, { $0.transposed(withPermutations: permutations) })
   }
 
   @inlinable
-  func _adjointTransposed(
-    _ seed: Tensor, _ originalValue: Tensor, _ permutations: [Int32]
-  ) -> Tensor {
-    return seed.transposed(withPermutations: permutations)
+  func _vjpTransposed(
+    withPermutations permutations: [Int32]
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    let value = transposed()
+    return (value, { $0.transposed(withPermutations: permutations) })
   }
 
   @inlinable
-  func _adjointTransposed(_ seed: Tensor, _ originalValue: Tensor) -> Tensor {
-    return seed.transposed()
+  func _vjpTransposed() -> (Tensor, (Tensor) -> Tensor) {
+    return (transposed(), { $0.transposed() })
   }
 }
 
@@ -420,19 +519,23 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 
 extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
-  func _adjointReshaped(
-    seed: Tensor, originalValue: Tensor, toShape newShape: Tensor<Int32>
-  ) -> Tensor {
-    let seed = seed.broadcast(like: originalValue)
-    return seed.reshaped(toShape: shapeTensor)
+  func _vjpReshaped(
+    toShape newShape: Tensor<Int32>
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    let value = reshaped(toShape: newShape)
+    return (value, { v in
+      return v.reshaped(toShape: newShape)
+    })
   }
 
   @inlinable
-  func _adjointExpandingShape(
-    seed: Tensor, originalValue: Tensor, at shapeIndex: Int32
-  ) -> Tensor {
-    let seed = seed.broadcast(like: originalValue)
-    return seed.squeezingShape(at: shapeIndex)
+  func _vjpExpandingShape(
+    at shapeIndex: Int32
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    let value = expandingShape(at: shapeIndex)
+    return (value, { v in
+      return v.squeezingShape(at: shapeIndex)
+    })
   }
 }
 
@@ -442,27 +545,29 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 
 extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
-  func _adjointMean(_ seed: Tensor, _ originalValue: Tensor) -> Tensor {
-      return seed.broadcast(like: self) / Tensor(scalarCountTensor)
+  func _vjpMean() -> (Tensor, (Tensor) -> Tensor) {
+    return (mean(), {
+      $0.broadcast(like: self) / Tensor(self.scalarCountTensor)
+    })
   }
 
   @inlinable
-  func _adjointSum(_ seed: Tensor, _ originalValue: Tensor) -> Tensor {
-      return seed.broadcast(like: self)
+  func _vjpSum() -> (Tensor, (Tensor) -> Tensor) {
+    return (sum(), { $0.broadcast(like: self) })
   }
 
   @inlinable
-  func _adjointMean(
-    _ seed: Tensor, _ originalValue: Tensor, squeezingAxes axes: [Int32]
-  ) -> Tensor {
-      return seed.broadcast(like: self) / Tensor(scalarCountTensor)
+  func _vjpMean(squeezingAxes axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
+    let value = mean(squeezingAxes: axes)
+    return (value, {
+      $0.broadcast(like: self) / Tensor(self.scalarCountTensor)
+    })
   }
 
   @inlinable
-  func _adjointSum(
-    _ seed: Tensor, _ originalValue: Tensor, squeezingAxes axes: [Int32]
-  ) -> Tensor {
-      return seed.broadcast(like: self)
+  func _vjpSum(squeezingAxes axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
+    let value = sum(squeezingAxes: axes)
+    return (value, { $0.broadcast(like: self) })
   }
 }
 
@@ -474,33 +579,35 @@ extension Tensor where Scalar : BinaryFloatingPoint & Differentiable,
                        Scalar == Scalar.CotangentVector {
   // TODO: Verify that these calculations are correct.
   @inlinable
-  func _adjointBatchNormalized(
-    seed: Tensor,
-    originalValue: Tensor,
+  func _vjpBatchNormalized(
     alongAxis axis: Int32,
     offset: Scalar,
     scale: Scalar,
     epsilon: Scalar
-  ) -> (Tensor, Scalar, Scalar) {
-    let mean = self.mean(alongAxes: axis)
-    let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
-    let variance = squaredDiff.mean(alongAxes: axis)
+  ) -> (Tensor, (Tensor) -> (Tensor, Scalar, Scalar)) {
+    let value = batchNormalized(alongAxis: axis, offset: offset, scale: scale,
+                                epsilon: epsilon)
+    return (value, { v in
+      let mean = self.mean(alongAxes: axis)
+      let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
+      let variance = squaredDiff.mean(alongAxes: axis)
 
-    let diff = self - mean
-    let inv = rsqrt(variance + epsilon)
-    let norm = diff * inv
+      let diff = self - mean
+      let inv = rsqrt(variance + epsilon)
+      let norm = diff * inv
 
-    let dNorm = seed * scale
-    let dVariance = -(dNorm * diff).sum(alongAxes: axis) / 2 * pow(inv, -3)
-    let dMean = (-dNorm * inv).sum(alongAxes: axis) +
-      dVariance * (-diff * 2).mean(alongAxes: axis)
-    let dOffset = seed.sum(alongAxes: axis)
-    let dScale = (norm * seed).sum(alongAxes: axis)
-    let dim = Tensor(Tensor<Int32>(shapeTensor[axis]))
-    let tmp = (dNorm * inv) + (dVariance * 2 * dMean / dim)
-    let dSelf = tmp + (dMean / dim)
-    return (dSelf, _TFGetScalarOrDie(dOffset.handle),  
-            _TFGetScalarOrDie(dScale.handle))
+      let dNorm = v * scale
+      let dVariance = -(dNorm * diff).sum(alongAxes: axis) / 2 * pow(inv, -3)
+      let dMean = (-dNorm * inv).sum(alongAxes: axis) +
+        dVariance * (-diff * 2).mean(alongAxes: axis)
+      let dOffset = v.sum(alongAxes: axis)
+      let dScale = (norm * v).sum(alongAxes: axis)
+      let dim = Tensor(Tensor<Int32>(self.shapeTensor[axis]))
+      let tmp = (dNorm * inv) + (dVariance * 2 * dMean / dim)
+      let dSelf = tmp + (dMean / dim)
+      return (dSelf, _TFGetScalarOrDie(dOffset.handle),  
+              _TFGetScalarOrDie(dScale.handle))
+    })
   }
 }
 
@@ -513,7 +620,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
   @differentiable(
     wrt: (.1, .2),
-    adjoint: _adjointTFConv2DBackpropInput(_:_:_:_:_:_:_:)
+    vjp: _vjpTFConv2DBackpropInput(_:_:_:_:_:)
   )
   func _TFConv2DBackpropInput(
     shape: Tensor<Int32>,
@@ -534,7 +641,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   @inlinable
   @differentiable(
     wrt: (.0, .2),
-    adjoint: _adjointTFConv2DBackpropFilter(_:_:_:_:_:_:_:)
+    vjp: _vjpTFConv2DBackpropFilter(_:_:_:_:_:)
   )
   func _TFConv2DBackpropFilter(
     input: Tensor,
@@ -552,98 +659,110 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   }
 
   @inlinable
-  func _adjointTFConv2DBackpropInput(
-    _ seed: Tensor,
-    _ originalValue: Tensor,
+  func _vjpTFConv2DBackpropInput(
     _ shape: Tensor<Int32>,
     _ filter: Tensor,
     _ backpropOutput: Tensor,
     _ strides: (Int32, Int32, Int32, Int32),
     _ padding: Padding
-  ) -> (Tensor, Tensor) {
-    return (
-      _TFConv2DBackpropFilter(input: seed, filterSizes: shape,
-                              backpropOutput: backpropOutput, strides: strides,
-                              padding: padding),
-      seed.convolved2D(withFilter: filter, strides: strides, padding: padding)
-    )
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    let value = _TFConv2DBackpropInput(shape: shape, filter: filter,
+                                       backpropOutput: backpropOutput,
+                                       strides: strides, padding: padding)
+    return (value, { v in
+      return (
+        self._TFConv2DBackpropFilter(input: v, filterSizes: shape,
+                                     backpropOutput: backpropOutput,
+                                     strides: strides, padding: padding),
+        v.convolved2D(withFilter: filter, strides: strides, padding: padding)
+      )
+    })
   }
 
   @inlinable
-  func _adjointTFConv2DBackpropFilter(
-    _ seed: Tensor,
-    _ originalValue: Tensor,
+  func _vjpTFConv2DBackpropFilter(
     _ input: Tensor,
     _ filterSizes: Tensor<Int32>,
     _ backpropOutput: Tensor,
     _ strides: (Int32, Int32, Int32, Int32),
     _ padding: Padding
-  ) -> (Tensor, Tensor) {
-    return (
-      _TFConv2DBackpropInput(shape: filterSizes, filter: seed,
-                             backpropOutput: backpropOutput, strides: strides,
-                             padding: padding),
-      input.convolved2D(withFilter: seed, strides: strides, padding: padding)
-    )
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    let value = _TFConv2DBackpropFilter(input: input, filterSizes: filterSizes,
+                                        backpropOutput: backpropOutput,
+                                        strides: strides, padding: padding)
+    return (value, { v in
+      return (
+        self._TFConv2DBackpropInput(shape: filterSizes, filter: v,
+                                    backpropOutput: backpropOutput,
+                                    strides: strides, padding: padding),
+        input.convolved2D(withFilter: v, strides: strides, padding: padding)
+      )
+    })
   }
 
   @inlinable
-  func _adjointConvolved2D(
-    seed: Tensor,
-    originalValue: Tensor,
+  func _vjpConvolved2D(
     filter: Tensor,
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
-  ) -> (Tensor, Tensor) {
-    return (
-      _TFConv2DBackpropInput(
-        shape: shapeTensor, filter: filter, backpropOutput: seed,
-        strides: strides, padding: padding
-      ),
-      _TFConv2DBackpropFilter(
-        input: self, filterSizes: filter.shapeTensor, backpropOutput: seed,
-        strides: strides, padding: padding
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    let value = convolved2D(withFilter: filter, strides: strides,
+                            padding: padding)
+    return (value, { v in
+      return (
+        self._TFConv2DBackpropInput(
+          shape: self.shapeTensor, filter: filter, backpropOutput: v,
+          strides: strides, padding: padding
+        ),
+        self._TFConv2DBackpropFilter(
+          input: self, filterSizes: filter.shapeTensor, backpropOutput: v,
+          strides: strides, padding: padding
+        )
       )
-    )
+    })
   }
 
   @inlinable
-  func _adjointMaxPooled(
-    seed: Tensor,
-    originalValue: Tensor,
+  func _vjpMaxPooled(
     kernelSize: (Int32, Int32, Int32, Int32),
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
-  ) -> Tensor {
+  ) -> (Tensor, (Tensor) -> Tensor) {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
-    return Raw.maxPoolGradV2(
-      origInput: self,
-      origOutput: originalValue,
-      grad: seed,
-      ksize: Tensor<Int32>(kernelSize),
-      strides: Tensor<Int32>(strides),
-      padding: padding.raw
-    )
+    let value = maxPooled(kernelSize: kernelSize, strides: strides,
+                          padding: padding)
+    return (value, { v in
+      return Raw.maxPoolGradV2(
+        origInput: self,
+        origOutput: value,
+        grad: v,
+        ksize: Tensor<Int32>(kernelSize),
+        strides: Tensor<Int32>(strides),
+        padding: padding.raw
+      )
+    })
   }
 
   @inlinable
-  func _adjointAveragePooled(
-    seed: Tensor,
-    originalValue: Tensor,
+  func _vjpAveragePooled(
     kernelSize: (Int32, Int32, Int32, Int32),
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
-  ) -> Tensor {
+  ) -> (Tensor, (Tensor) -> Tensor) {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
-    return Raw.avgPoolGrad(
-      origInputShape: shapeTensor,
-      grad: seed,
-      ksize: [kernelSize.0, kernelSize.1, kernelSize.2, kernelSize.3],
-      strides: [strides.0, strides.1, strides.2, strides.3],
-      padding: padding.raw
-    )
+    let value = averagePooled(kernelSize: kernelSize, strides: strides,
+                              padding: padding)
+    return (value, { v in
+      return Raw.avgPoolGrad(
+        origInputShape: self.shapeTensor,
+        grad: v,
+        ksize: [kernelSize.0, kernelSize.1, kernelSize.2, kernelSize.3],
+        strides: [strides.0, strides.1, strides.2, strides.3],
+        padding: padding.raw
+      )
+    })
   }
 }
 
@@ -652,23 +771,27 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 //===----------------------------------------------------------------------===//
 
 @inlinable
-func _adjointSigmoid<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return Raw.sigmoidGrad(originalValue, dy: seed)
+func _vjpSigmoid<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = sigmoid(x)
+  return (value, { v in Raw.sigmoidGrad(value, dy: v) })
 }
 
 @inlinable
-func _adjointSoftmax<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  let sumChannels = (seed * originalValue).sum(alongAxes: -1)
-  return (seed - sumChannels) * originalValue
+func _vjpSoftmax<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let value = softmax(x)
+  return (value, { v in
+    let sumChannels = (v * value).sum(alongAxes: -1)
+    return (v - sumChannels) * value
+  })
 }
 
 @inlinable
-func _adjointRelu<T : Differentiable & FloatingPoint>(
-  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
-) -> Tensor<T> {
-  return Tensor(x .> 0) * seed
+func _vjpRelu<T : Differentiable & FloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  return (relu(x), { v in Tensor(x .> 0) * v })
 }

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -795,7 +795,7 @@ public extension Tensor {
   /// - Precondition: The number of scalars matches the new shape.
   @inlinable @inline(__always)
   @differentiable(
-    wrt: (self), adjoint: _adjointReshaped(seed:originalValue:toShape:)
+    wrt: (self), vjp: _vjpReshaped(toShape:)
     where Scalar : Differentiable & FloatingPoint
   )
   func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
@@ -819,7 +819,7 @@ public extension Tensor {
   /// specified shape index.
   @inlinable @inline(__always)
   @differentiable(
-    wrt: (self), adjoint: _adjointExpandingShape(seed:originalValue:at:)
+    wrt: (self), vjp: _vjpExpandingShape(at:)
     where Scalar : Differentiable & FloatingPoint
   )
   func expandingShape(at shapeIndex: Int32) -> Tensor {

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1822,7 +1822,7 @@ extension FloatingPoint {
   /// - Returns: The square root of the value.
   @_transparent
   // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: (self), adjoint: _adjointSquareRoot
+  @differentiable(wrt: (self), vjp: _vjpSquareRoot
                   where Self : Differentiable, Self == Self.CotangentVector)
   public func squareRoot( ) -> Self {
     var lhs = self
@@ -1845,7 +1845,7 @@ extension FloatingPoint {
   /// - Returns: The product of `lhs` and `rhs`, added to this value.
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: (self, .0, .1), adjoint: _adjointAddingProduct
+  @differentiable(wrt: (self, .0, .1), vjp: _vjpAddingProduct
                   where Self : Differentiable, Self == Self.CotangentVector)
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
@@ -2025,22 +2025,21 @@ extension FloatingPoint {
 /// SWIFT_ENABLE_TENSORFLOW
 extension FloatingPoint where Self : Differentiable,
                               Self == Self.CotangentVector {
-  /// The adjoint of `addingProduct`. Returns the gradient of `addingProduct`
-  /// with respect to `self`, `lhs` and `rhs`.
+  /// The vector-Jacobian product function of `addingProduct`. Returns the
+  /// original result and pullback of `addingProduct` with respect to `self`,
+  /// `lhs` and `rhs`.
   @inlinable
-  func _adjointAddingProduct(
-    _ adjoint: Self,
-    _ originalValue: Self,
+  func _vjpAddingProduct(
     _ lhs: Self, _ rhs: Self
-  ) -> (Self, Self, Self) {
-    return (1, rhs, lhs)
+  ) -> (Self, (Self) -> (Self, Self, Self)) {
+    return (addingProduct(lhs, rhs), { _ in (1, rhs, lhs) })
   }
 
-  /// The adjoint of `squareRoot`. Returns the gradient of `squareRoot` with
-  /// respect to `self`.
+  /// The vector-Jacobian product function of `squareRoot`. Returns the original
+  /// result and pullback of `squareRoot` with respect to `self`.
   @inlinable // FIXME(sil-serialize-all)
-  func _adjointSquareRoot(_ adjoint: Self, _ originalValue: Self) -> Self {
-    return 2 * self * adjoint
+  func _vjpSquareRoot(_ x: Self) -> (Self, (Self) -> Self) {
+    return (x.squareRoot(), { v in 2 * self * v })
   }
 }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1583,21 +1583,18 @@ extension ${Self} {
 extension ${Self} {
   @_transparent
   // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(adjoint: _adjointNegate)
+  @differentiable(vjp: _vjpNegate(x:))
   public static prefix func - (x: ${Self}) -> ${Self} {
     return ${Self}(Builtin.fneg_FPIEEE${bits}(x._value))
   }
 }
 
-// SWIFT_ENABLE_TENSORFLOW
 extension ${Self} {
   @usableFromInline
   @_transparent
   // SWIFT_ENABLE_TENSORFLOW
-  static func _adjointNegate(
-    seed: ${Self}, originalValue: ${Self}, x: ${Self}
-  ) -> ${Self} {
-    return -seed
+  static func _vjpNegate(x: ${Self}) -> (${Self}, (${Self}) -> ${Self}) {
+    return (-x, { v in -v })
   }
 }
 
@@ -1719,7 +1716,7 @@ extension ${Self} {
 extension ${Self} {
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(adjoint: _adjointAdd)
+  @differentiable(vjp: _vjpAdd(lhs:rhs:))
   public static func + (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs += rhs
@@ -1728,7 +1725,7 @@ extension ${Self} {
 
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(adjoint: _adjointSubtract)
+  @differentiable(vjp: _vjpSubtract(lhs:rhs:))
   public static func - (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs -= rhs
@@ -1737,7 +1734,7 @@ extension ${Self} {
 
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(adjoint: _adjointMultiply)
+  @differentiable(vjp: _vjpMultiply(lhs:rhs:))
   public static func * (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs *= rhs
@@ -1746,7 +1743,7 @@ extension ${Self} {
 
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(adjoint: _adjointDivide)
+  @differentiable(vjp: _vjpDivide(lhs:rhs:))
   public static func / (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs /= rhs
@@ -1755,42 +1752,38 @@ extension ${Self} {
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// Adjoints of standard binary operators.
+/// Vector-Jacobian products of standard binary operators.
 extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
-  static func _adjointAdd(
-    _ adjoint: ${Self}, _ originalValue: ${Self},
-    _ lhs: ${Self}, _ rhs: ${Self}
-  ) -> (${Self}, ${Self}) {
-    return (adjoint, adjoint)
+  static func _vjpAdd(
+    lhs: ${Self}, rhs: ${Self}
+  ) -> (${Self}, (${Self}) -> (${Self}, ${Self})) {
+    return (lhs + rhs, { v in (v, v) })
   }
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
-  static func _adjointSubtract(
-    _ adjoint: ${Self}, _ originalValue: ${Self},
-    _ lhs: ${Self}, _ rhs: ${Self}
-  ) -> (${Self}, ${Self}) {
-    return (adjoint, -adjoint)
+  static func _vjpSubtract(
+    lhs: ${Self}, rhs: ${Self}
+  ) -> (${Self}, (${Self}) -> (${Self}, ${Self})) {
+    return (lhs - rhs, { v in (v, -v) })
   }
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
-  static func _adjointMultiply(
-    _ adjoint: ${Self}, _ originalValue: ${Self},
-    _ lhs: ${Self}, _ rhs: ${Self}
-  ) -> (${Self}, ${Self}) {
-    return (rhs * adjoint, lhs * adjoint)
+  static func _vjpMultiply(
+    lhs: ${Self}, rhs: ${Self}
+  ) -> (${Self}, (${Self}) -> (${Self}, ${Self})) {
+    return (lhs * rhs, { v in (rhs * v, lhs * v) })
   }
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
-  static func _adjointDivide(
-    _ adjoint: ${Self}, _ originalValue: ${Self},
-    _ lhs: ${Self}, _ rhs: ${Self}
-  ) -> (${Self}, ${Self}) {
-    return (adjoint / rhs, -lhs / (rhs * rhs) * adjoint)
+  static func _vjpDivide(
+    lhs: ${Self}, rhs: ${Self}
+  ) -> (${Self}, (${Self}) -> (${Self}, ${Self})) {
+    return (lhs / rhs, { v in (v / rhs, -lhs / (rhs * rhs) * v) })
   }
 }
 

--- a/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
+++ b/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
@@ -3,7 +3,7 @@
 _ = gradient(at: Float(1)) { x in x + x * x }
 
 // CHECK-LABEL: // static Float.* infix(_:_:)
-// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 primitive jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @AD__$sSf1moiyS2f_SftFZ__vjp_src_0_wrt_0_1] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 primitive jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 
 // CHECK-LABEL: // static Float.+ infix(_:_:)
-// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 primitive jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @AD__$sSf1poiyS2f_SftFZ__vjp_src_0_wrt_0_1] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 primitive jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float

--- a/test/AutoDiff/superset_adjoint_loaded.swift
+++ b/test/AutoDiff/superset_adjoint_loaded.swift
@@ -6,7 +6,7 @@
 // There was a bug where the AD pass would not see the custom [differentiable]
 // attribute on `Float.*` wrt both parameters until after the AD pass generated
 // its own adjoint for `Float.*` wrt the second parameter. This test verifies
-// that the AD pass uses the custom adjoint defined on `Float.*`.
+// that the AD pass uses the custom VJP defined on `Float.*`.
 
 func mul3(_ x: Float) -> Float {
   return 3 * x
@@ -15,4 +15,4 @@ func mul3(_ x: Float) -> Float {
 let _ = gradient(at: 0, in: mul3)
 
 // CHECK-LABEL: sil{{.*}} @AD__{{.*}}mul3{{.*}}__primal{{.*}}
-// CHECK: function_ref AD__$sSf1moiyS2f_SftFZ__vjp_src_0_wrt_0_1
+// CHECK: function_ref @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZSf_SftSfcfU_

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -47,14 +47,16 @@ TensorADTests.testAllBackends("/") {
 
 TensorADTests.testAllBackends("matmul") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in matmul(a, b) }
-  expectTrue(([[0]], [[0]]) == gradient(at: [[0]], [[0]], in: f))
-  expectTrue(([[10]], [[1]]) == gradient(at: [[1]], [[10]], in: f))
+  let v = Tensor<Float>(ones: [1, 1])
+  expectTrue(([[0]], [[0]]) == pullback(at: [[0]], [[0]], in: f)(v))
+  expectTrue(([[10]], [[1]]) == pullback(at: [[1]], [[10]], in: f)(v))
 }
 
 TensorADTests.testAllBackends("•") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a • b }
-  expectTrue(([[0]], [[0]]) == gradient(at: [[0]], [[0]], in: f))
-  expectTrue(([[10]], [[1]]) == gradient(at: [[1]], [[10]], in: f))
+  let v = Tensor<Float>(ones: [1, 1])
+  expectTrue(([[0]], [[0]]) == pullback(at: [[0]], [[0]], in: f)(v))
+  expectTrue(([[10]], [[1]]) == pullback(at: [[1]], [[10]], in: f)(v))
 }
 
 TensorADTests.testAllBackends("negate") {
@@ -104,7 +106,6 @@ TensorADTests.testAllBackends("transposed") {
 
 TensorADTests.testAllBackends("relu") {
   let f = { (a: Tensor<Float>) in relu(a) }
-  print(gradient(at: [5, -5, 0], in: f))
   expectTrue([1, 0, 0] == gradient(at: [5, -5, 0], in: f))
 }
 
@@ -112,6 +113,11 @@ TensorADTests.testAllBackends("softmax") {
   let pb = pullback(at: Tensor(ones: [2, 2])) { (a: Tensor<Float>) in softmax(a) }
   expectTrue([[0, 0], [0, 0]] == pb([[1, 1], [1, 1]]))
   expectTrue([[-0.25, 0.25], [0.75, -0.75]] == pb([[1, 2], [4, 1]]))
+}
+
+TensorADTests.testAllBackends("log_softmax") {
+  let pb = pullback(at: Tensor(ones: [3, 3])) { (a: Tensor<Float>) in logSoftmax(a) }
+  expectTrue(Tensor(shape: [3, 3], repeating: 5.9604645e-08) == pb(Tensor(ones: [3, 3])))
 }
 
 TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {


### PR DESCRIPTION
Rewrite all `@differentiable(adjoint: ...)` usages with `@differentiable(vjp: ...)`
in the stdlib, including `core` and `TensorFlow`.

Add `logSoftmax` differentiation runtime test.