### PR TITLE
Add a regression test for SR-9624

### DIFF
--- a/validation-test/execution/sr9624.swift
+++ b/validation-test/execution/sr9624.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+protocol P {
+  associatedtype T
+  func foo(t: inout T)
+}
+struct S: P {
+  func foo(t: inout () -> Void) {
+    t()
+    t = { print("new") }
+  }
+}
+
+func doTheFoo<SomeP: P>(_ p: SomeP, _ value: SomeP.T) -> SomeP.T {
+  var mutableValue = value
+  p.foo(t: &mutableValue)
+  return mutableValue
+}
+
+print("START")
+let newClosure = doTheFoo(S(), { print("old") })
+newClosure()
+print("DONE")
+
+// CHECK: START
+// CHECK-NEXT: old
+// CHECK-NEXT: new
+// CHECK-NEXT: DONE


### PR DESCRIPTION
It got fixed somewhere along the way in Swift 5.

https://bugs.swift.org/browse/SR-9624