### PR TITLE
[AutoDiff] [API] Add `Tensor`-specific `gradient` operators.

### DIFF
--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-simple-no-vjp-swift %swift-tensorflow-test-run-extra-options
-//
-// TODO(SR-9110): Make this pass in dynamic compilation mode.
-// %target-run-dynamic-compilation-swift
+// RUN: %target-run-dynamic-compilation-swift
 //
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
@@ -19,49 +17,49 @@ TensorADTests.testAllBackends("TestSimpleGrad") {
   func square(_ x: Tensor<Float>) -> Tensor<Float> {
     return x * x
   }
-  expectTrue(pullback(at: [0.1, 0.2, 0.3], in: square)(Tensor(1)) == [0.2, 0.4, 0.6])
-  expectTrue(pullback(at: [[10], [20]], in: square)(Tensor(1)) == [[20], [40]])
+  expectTrue(gradient(at: [0.1, 0.2, 0.3], in: square) == [0.2, 0.4, 0.6])
+  expectTrue(gradient(at: [[10], [20]], in: square) == [[20], [40]])
 }
 
 TensorADTests.testAllBackends("+") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a + b }
-  expectTrue(([1], [1]) == pullback(at: [0], [0], in: f)(Tensor(1)))
-  expectTrue(([1], [1]) == pullback(at: [1], [10], in: f)(Tensor(1)))
+  expectTrue(([1], [1]) == gradient(at: [0], [0], in: f))
+  expectTrue(([1], [1]) == gradient(at: [1], [10], in: f))
 }
 
 TensorADTests.testAllBackends("-") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a - b }
-  expectTrue(([1], [-1]) == pullback(at: [0], [0], in: f)(Tensor(1)))
-  expectTrue(([1], [-1]) == pullback(at: [1], [10], in: f)(Tensor(1)))
+  expectTrue(([1], [-1]) == gradient(at: [0], [0], in: f))
+  expectTrue(([1], [-1]) == gradient(at: [1], [10], in: f))
 }
 
 TensorADTests.testAllBackends("*") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a * b }
-  expectTrue(([0], [0]) == pullback(at: [0], [0], in: f)(Tensor(1)))
-  expectTrue(([10], [1]) == pullback(at: [1], [10], in: f)(Tensor(1)))
+  expectTrue(([0], [0]) == gradient(at: [0], [0], in: f))
+  expectTrue(([10], [1]) == gradient(at: [1], [10], in: f))
 }
 
 TensorADTests.testAllBackends("/") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a / b }
-  expectTrue(([0.1], [-0.01]) == pullback(at: [1], [10], in: f)(Tensor(1)))
+  expectTrue(([0.1], [-0.01]) == gradient(at: [1], [10], in: f))
 }
 
 TensorADTests.testAllBackends("matmul") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in matmul(a, b) }
-  expectTrue(([[0]], [[0]]) == pullback(at: [[0]], [[0]], in: f)(Tensor(1)))
-  expectTrue(([[10]], [[1]]) == pullback(at: [[1]], [[10]], in: f)(Tensor(1)))
+  expectTrue(([[0]], [[0]]) == gradient(at: [[0]], [[0]], in: f))
+  expectTrue(([[10]], [[1]]) == gradient(at: [[1]], [[10]], in: f))
 }
 
 TensorADTests.testAllBackends("•") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a • b }
-  expectTrue(([[0]], [[0]]) == pullback(at: [[0]], [[0]], in: f)(Tensor(1)))
-  expectTrue(([[10]], [[1]]) == pullback(at: [[1]], [[10]], in: f)(Tensor(1)))
+  expectTrue(([[0]], [[0]]) == gradient(at: [[0]], [[0]], in: f))
+  expectTrue(([[10]], [[1]]) == gradient(at: [[1]], [[10]], in: f))
 }
 
 TensorADTests.testAllBackends("negate") {
   let f = { (a: Tensor<Float>) in -a }
-  expectTrue([-1] == pullback(at: [0], in: f)(Tensor(1)))
-  expectTrue([-1] == pullback(at: [10], in: f)(Tensor(1)))
+  expectTrue([-1] == gradient(at: [0], in: f))
+  expectTrue([-1] == gradient(at: [10], in: f))
 }
 
 TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {


### PR DESCRIPTION
Add `Tensor`-specific `gradient` and `valueWithGradient` operators.
This is important for usability because many tensor functions return a semantically scalar `Tensor`.
Using `pullback(...)(Tensor(1))` everywhere is unergonomic.
Tensor gradient operators call pullbacks with `Tensor(1)`.

Change `Tensor` autodiff tests to use `gradient(...)` instead of `pullback(...)(Tensor(1))`.
Left one usage of `pullback(...)(Tensor(1))`.

Enable `RUN: %target-run-dynamic-compilation-swift` for
`test/TensorFlowRuntime/tensor_autodiff_runtime.swift`, since it no longer crashes.