### PR TITLE
Master next jan9 fixup

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -70,6 +70,7 @@
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Instrumentation.h"
+#include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/ObjCARC.h"
 
 #include <thread>
@@ -130,7 +131,7 @@ static void addAddressSanitizerPasses(const PassManagerBuilder &Builder,
 
 static void addThreadSanitizerPass(const PassManagerBuilder &Builder,
                                    legacy::PassManagerBase &PM) {
-  PM.add(createThreadSanitizerPass());
+  PM.add(createThreadSanitizerLegacyPassPass());
 }
 
 static void addSanitizerCoveragePass(const PassManagerBuilder &Builder,


### PR DESCRIPTION
This PR is just two simple changes to update Swift's master-next branch to build against the latest code in LLVM's upstream-with-swift branch.

The two changes are:
* Migrating from llvm::ImmutableCallSite to const llvm::CallBase*
* Switching to the legacy tsan pass because tsan was ported to the new pass manager
