### PR TITLE
[5.0][12-12-2018][sourcekitd][AST] Fix CursorInfo crash on methods with param with unresolved default values

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5109,6 +5109,14 @@ ParamDecl::getDefaultValueStringRepresentation(
       DefaultValueAndIsVariadic.getPointer()->StringRepresentation;
     if (!existing.empty())
       return existing;
+
+    if (!getDefaultValue()) {
+      // TypeChecker::checkDefaultArguments() nulls out the default value
+      // if it fails to type check it. This only seems to happen with an
+      // invalid/incomplete parameter list that contains a parameter with an
+      // unresolved default value.
+      return "<<empty>>";
+    }
     return extractInlinableText(getASTContext().SourceMgr, getDefaultValue(),
                                 scratch);
   }

--- a/test/SourceKit/CursorInfo/undefined-default-value.swift
+++ b/test/SourceKit/CursorInfo/undefined-default-value.swift
@@ -1,0 +1,9 @@
+enum LogLevel { case error }
+
+func logAsync(level: LogLevel = undefined, messageProducer producer
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:44 %s -- %s | %FileCheck %s
+
+// CHECK: source.lang.swift.decl.function.free (3:6-3:68)
+// CHECK: logAsync(level:messageProducer:)
+// CHECK: LogLevel</Type> = &lt;&lt;empty&gt;&gt


### PR DESCRIPTION
- **Explanation**: When printing the annotated decl information of a method with an imcomplete parameter list containing a param with an unresolved identifier for its default value (e.g. while editing it), we would would assume the param's default value is present since the default value kind was "Normal". That assumption doesn't hold for some cases though, so we were crashing. This adds an explicit check that the default value is present.
- **Scope of issue**: crashes SourceKit when performing jump-to-definition, quick help, or invoking the action menu on a method with an incomplete parameter list with a param whose default value is undefined, or invoking interface generation on a file containing such a method.
- **Risk**: Low, adds a simple check that the default value is present, rather than assuming based on the default value kind.
- **Origination**: Recent changes for the textual interface work
- **Reviewed by**: @nkcsgexi and @harlanhaskins  on master: https://github.com/apple/swift/pull/21515)
- **Testing**: Added regression test
- **Radar / SR**: rdar://problem/46694149, https://bugs.swift.org/browse/SR-9546

master PR: https://github.com/apple/swift/pull/21515
swift-5.0-branch PR: https://github.com/apple/swift/pull/21528