### PR TITLE
[Parser] Expose a flag to allow users explicitly disable delayed parsing. NFC

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -206,6 +206,9 @@ public:
   /// Always empty if !SF.shouldBuildSyntaxTree().
   syntax::Trivia TrailingTrivia;
 
+  /// Whether we should disable delayed parsing.
+  bool DisableDelayedParsing;
+
   /// The receiver to collect all consumed tokens.
   ConsumeTokenReceiver *TokReceiver;
 
@@ -352,14 +355,17 @@ public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
          SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
+         std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
+         bool DisableDelayedParsing = false);
   Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState = nullptr,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
+         std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
+         bool DisableDelayedParsing = false);
   Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
          SILParserTUStateBase *SIL = nullptr,
          PersistentParserState *PersistentState = nullptr,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
+         std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
+         bool DisableDelayedParsing = false);
   ~Parser();
 
   bool isInSILMode() const { return SIL != nullptr; }

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -121,7 +121,8 @@ namespace swift {
   bool parseIntoSourceFile(SourceFile &SF, unsigned BufferID, bool *Done,
                            SILParserState *SIL = nullptr,
                            PersistentParserState *PersistentState = nullptr,
-                           DelayedParsingCallbacks *DelayedParseCB = nullptr);
+                           DelayedParsingCallbacks *DelayedParseCB = nullptr,
+                           bool DisableDelayedParsing = false);
 
   /// Parse a single buffer into the given source file, until the full source
   /// contents are parsed.
@@ -129,7 +130,8 @@ namespace swift {
   /// \return true if the parser found code with side effects.
   bool parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
                              PersistentParserState *PersistentState = nullptr,
-                             DelayedParsingCallbacks *DelayedParseCB = nullptr);
+                             DelayedParsingCallbacks *DelayedParseCB = nullptr,
+                               bool DisableDelayedParsing = false);
 
   /// Finish the parsing by going over the nodes that were delayed
   /// during the first parsing pass.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3495,6 +3495,9 @@ bool Parser::parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
 }
 
 bool Parser::canDelayMemberDeclParsing() {
+  // If explicitly disabled, respect the flag.
+  if (DisableDelayedParsing)
+    return false;
   // There's no fundamental reasons that SIL cannnot be lasily parsed. We need
   // to keep SILParserTUStateBase persistent to make it happen.
   if (isInSILMode())

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -335,14 +335,16 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
                PersistentParserState *PersistentState,
-               std::shared_ptr<SyntaxParseActions> SPActions)
+               std::shared_ptr<SyntaxParseActions> SPActions,
+               bool DisableDelayedParsing)
     : Parser(BufferID, SF, &SF.getASTContext().Diags, SIL, PersistentState,
-             std::move(SPActions)) {}
+             std::move(SPActions), DisableDelayedParsing) {}
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
                SILParserTUStateBase *SIL,
                PersistentParserState *PersistentState,
-               std::shared_ptr<SyntaxParseActions> SPActions)
+               std::shared_ptr<SyntaxParseActions> SPActions,
+               bool DisableDelayedParsing)
     : Parser(
           std::unique_ptr<Lexer>(new Lexer(
               SF.getASTContext().LangOpts, SF.getASTContext().SourceMgr,
@@ -357,7 +359,7 @@ Parser::Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
               SF.shouldBuildSyntaxTree()
                   ? TriviaRetentionMode::WithTrivia
                   : TriviaRetentionMode::WithoutTrivia)),
-          SF, SIL, PersistentState, std::move(SPActions)) {}
+          SF, SIL, PersistentState, std::move(SPActions), DisableDelayedParsing) {}
 
 namespace {
 
@@ -477,7 +479,8 @@ public:
 Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
                SILParserTUStateBase *SIL,
                PersistentParserState *PersistentState,
-               std::shared_ptr<SyntaxParseActions> SPActions)
+               std::shared_ptr<SyntaxParseActions> SPActions,
+               bool DisableDelayedParsing)
   : SourceMgr(SF.getASTContext().SourceMgr),
     Diags(SF.getASTContext().Diags),
     SF(SF),
@@ -485,6 +488,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     SIL(SIL),
     CurDeclContext(&SF),
     Context(SF.getASTContext()),
+    DisableDelayedParsing(DisableDelayedParsing),
     TokReceiver(SF.shouldCollectToken() ?
                 new TokenRecorder(SF) :
                 new ConsumeTokenReceiver()),

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -115,7 +115,8 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
                                 SILParserState *SIL,
                                 PersistentParserState *PersistentState,
                                 DelayedParsingCallbacks *DelayedParseCB,
-                                bool FullParse) {
+                                bool FullParse,
+                                bool DisableDelayedParsing) {
   assert((!FullParse || (SF.canBeParsedInFull() && !SIL)) &&
          "cannot parse in full with the given parameters!");
 
@@ -127,7 +128,7 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
 
   SharedTimer timer("Parsing");
   Parser P(BufferID, SF, SIL ? SIL->Impl.get() : nullptr,
-           PersistentState, STreeCreator);
+           PersistentState, STreeCreator, DisableDelayedParsing);
   PrettyStackTraceParser StackTrace(P);
 
   llvm::SaveAndRestore<bool> S(P.IsParsingInterfaceTokens,
@@ -155,19 +156,22 @@ bool swift::parseIntoSourceFile(SourceFile &SF,
                                 bool *Done,
                                 SILParserState *SIL,
                                 PersistentParserState *PersistentState,
-                                DelayedParsingCallbacks *DelayedParseCB) {
+                                DelayedParsingCallbacks *DelayedParseCB,
+                                bool DisableDelayedParsing) {
   return parseIntoSourceFileImpl(SF, BufferID, Done, SIL,
                                  PersistentState, DelayedParseCB,
-                                 /*FullParse=*/SF.shouldBuildSyntaxTree());
+                                 /*FullParse=*/SF.shouldBuildSyntaxTree(),
+                                 DisableDelayedParsing);
 }
 
 bool swift::parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
                                     PersistentParserState *PersistentState,
-                                    DelayedParsingCallbacks *DelayedParseCB) {
+                                    DelayedParsingCallbacks *DelayedParseCB,
+                                    bool DisableDelayedParsing) {
   bool Done = false;
   return parseIntoSourceFileImpl(SF, BufferID, &Done, /*SIL=*/nullptr,
                                  PersistentState, DelayedParseCB,
-                                 /*FullParse=*/true);
+                                 /*FullParse=*/true, DisableDelayedParsing);
 }
 
 


### PR DESCRIPTION
Discussed with @dcci, this patch is necessary to fix an lldb test failure. rdar://38396444
