### PR TITLE
[test] Run all the benchmarks once as a validation test

### DIFF
--- a/validation-test/benchmark/run-benchmarks.test-sh
+++ b/validation-test/benchmark/run-benchmarks.test-sh
@@ -1,0 +1,6 @@
+// RUN: %Benchmark_O --num-iters=1 --num-samples=1
+// REQUIRES: benchmark
+
+// Run all the benchmarks to make sure they don't crash, or uncover any stdlib
+// issues. This is most useful in +Asserts builds of the stdlib, which isn't a
+// useful configuration for actual benchmarking.


### PR DESCRIPTION
This is most useful in +Asserts builds of the stdlib, which isn't a useful configuration for actual benchmarking, but could still uncover issues in the implementation. (There actually is one right now found by SuperChars, [SR-9203](https://bugs.swift.org/browse/SR-9203), so I can't land this yet.)