### PR TITLE
make Range and ClosedRange conditionally Codable

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -456,3 +456,22 @@ extension ClosedRange {
 // shorthand. TODO: Add documentation
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger
+
+extension ClosedRange : Codable where Bound : Codable {
+    private enum CodingKeys : String, CodingKey {
+        case lowerBound = "lowerBound", upperBound = "upperBound"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
+        let upperBound = try container.decode(Bound.self, forKey: .upperBound)
+        self = lowerBound...upperBound
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(lowerBound, forKey: .lowerBound)
+        try container.encode(upperBound, forKey: .upperBound)
+    }
+}

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -898,3 +898,22 @@ public typealias CountableRange<Bound: Strideable> = Range<Bound>
 // shorthand. TODO: Add documentation
 public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
   where Bound.Stride : SignedInteger
+
+extension Range : Codable where Bound : Codable {
+    private enum CodingKeys : String, CodingKey {
+        case lowerBound = "lowerBound", upperBound = "upperBound"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
+        let upperBound = try container.decode(Bound.self, forKey: .upperBound)
+        self = lowerBound..<upperBound
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(lowerBound, forKey: .lowerBound)
+        try container.encode(upperBound, forKey: .upperBound)
+    }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request makes Range and ClosedRange conform to Codable, conditioned on Bound conforming to Bound.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
No bug.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
