### PR TITLE
[Diagnostics] Diagnose missing members via fixes

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -245,3 +245,14 @@ UseSubscriptOperator *UseSubscriptOperator::create(ConstraintSystem &cs,
                                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) UseSubscriptOperator(cs, locator);
 }
+
+bool DefineMemberBasedOnUse::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+DefineMemberBasedOnUse *
+DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
+                               DeclName member, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      DefineMemberBasedOnUse(cs, baseType, member, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -247,7 +247,9 @@ UseSubscriptOperator *UseSubscriptOperator::create(ConstraintSystem &cs,
 }
 
 bool DefineMemberBasedOnUse::diagnose(Expr *root, bool asNote) const {
-  return false;
+  auto failure = MissingMemberFailure(root, getConstraintSystem(), BaseType,
+                                      Name, getLocator());
+  return failure.diagnose(asNote);
 }
 
 DefineMemberBasedOnUse *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -99,6 +99,11 @@ enum class FixKind : uint8_t {
 
   /// Instead of spelling out `subscript` directly, use subscript operator.
   UseSubscriptOperator,
+
+  /// Requested name is not associated with a give base type,
+  /// fix this issue by pretending that member exists and matches
+  /// given arguments/result types exactly.
+  DefineMemberBasedOnUse,
 };
 
 class ConstraintFix {
@@ -463,6 +468,30 @@ public:
 
   static UseSubscriptOperator *create(ConstraintSystem &cs,
                                       ConstraintLocator *locator);
+};
+
+class DefineMemberBasedOnUse final : public ConstraintFix {
+  Type BaseType;
+  DeclName Name;
+
+public:
+  DefineMemberBasedOnUse(ConstraintSystem &cs, Type baseType, DeclName member,
+                         ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::DefineMemberBasedOnUse, locator),
+        BaseType(baseType), Name(member) {}
+
+  std::string getName() const override {
+    llvm::SmallVector<char, 16> scratch;
+    auto memberName = Name.getString(scratch);
+    return "define missing member named '" + memberName.str() +
+           "' based on its use";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
+                                        DeclName member,
+                                        ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3668,6 +3668,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     DeclContext *useDC, FunctionRefKind functionRefKind,
     ArrayRef<OverloadChoice> outerAlternatives, TypeMatchOptions flags,
     ConstraintLocatorBuilder locatorB) {
+  // We'd need to record original base type because it might be a type
+  // variable representing another missing member.
+  auto origBaseTy = baseTy;
   // Resolve the base type, if we can. If we can't resolve the base type,
   // then we can't solve this constraint.
   baseTy = simplifyType(baseTy, flags);
@@ -3715,6 +3718,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
   // If the lookup found no hits at all (either viable or unviable), diagnose it
   // as such and try to recover in various ways.
   if (shouldAttemptFixes()) {
+    // Let's record missing member in constraint system, this helps to prevent
+    // stacking up fixes for the same member, because e.g. if its base was of
+    // optional type, we'd re-introduce member constraint with optional stripped
+    // off to see if the problem is related to base not being explicitly unwrapped.
+    if (!MissingMembers.insert(locator))
+      return SolutionKind::Error;
+
     if (baseObjTy->getOptionalObjectType()) {
       // If the base type was an optional, look through it.
 
@@ -3760,15 +3770,22 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       return SolutionKind::Solved;
     }
 
+    auto solveWithNewBaseOrName = [&](Type baseType,
+                                      DeclName memberName) -> SolutionKind {
+      // Let's re-enable fixes for this member, because
+      // the base or member name has been changed.
+      MissingMembers.remove(locator);
+      return simplifyMemberConstraint(kind, baseType, memberName, memberTy,
+                                      useDC, functionRefKind, outerAlternatives,
+                                      flags, locatorB);
+    };
+
     if (auto *funcType = baseTy->getAs<FunctionType>()) {
       // We can't really suggest anything useful unless
       // function takes no arguments, otherwise it
       // would make sense to report this a missing member.
       if (funcType->getNumParams() == 0) {
-        auto result = simplifyMemberConstraint(
-            kind, funcType->getResult(), member, memberTy, useDC,
-            functionRefKind, outerAlternatives, flags, locatorB);
-
+        auto result = solveWithNewBaseOrName(funcType->getResult(), member);
         // If there is indeed a member with given name in result type
         // let's return, otherwise let's fall-through and report
         // this problem as a missing member.
@@ -3781,16 +3798,59 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
     // Instead of using subscript operator spelled out `subscript` directly.
     if (member.getBaseName() == getTokenText(tok::kw_subscript)) {
-      auto result = simplifyMemberConstraint(
-          kind, baseTy, DeclBaseName::createSubscript(), memberTy, useDC,
-          functionRefKind, {}, flags, locatorB);
-
+      auto result =
+          solveWithNewBaseOrName(baseTy, DeclBaseName::createSubscript());
       // Looks like it was indeed meant to be a subscript operator.
       if (result == SolutionKind::Solved)
         return recordFix(UseSubscriptOperator::create(*this, locator))
                    ? SolutionKind::Error
                    : SolutionKind::Solved;
     }
+
+    // FIXME(diagnostics): This is more of a hack than anything.
+    // Let's not try to suggest that there is no member related to an
+    // obscure underscored type, the real problem would be somewhere
+    // else. This helps to diagnose pattern matching cases.
+    {
+      if (auto *metatype = baseTy->getAs<MetatypeType>()) {
+        auto instanceTy = metatype->getInstanceType();
+        if (auto *NTD = instanceTy->getAnyNominal()) {
+          if (NTD->getName() == getASTContext().Id_OptionalNilComparisonType)
+            return SolutionKind::Error;
+        }
+      }
+    }
+
+    // FIXME(diagnostics): Errors related to `AnyObject` could be diagnosed
+    // better in the future, relevant failure information has to be extracted
+    // from `performMemberLookup` result, in order to figure out if it was a
+    // simple labeling or # of arguments mismatch, or member with requested name
+    // really doesn't exist.
+    if (baseTy->isAnyObject())
+      return SolutionKind::Error;
+
+    result = performMemberLookup(kind, member, baseTy, functionRefKind, locator,
+                                 /*includeInaccessibleMembers*/ true);
+
+    // FIXME(diagnostics): If there were no viable results, but there are
+    // unviable ones, we'd have to introduce fix for each specific problem.
+    if (!result.UnviableCandidates.empty())
+      return SolutionKind::Error;
+
+    // Since member with given base and name doesn't exist, let's try to
+    // fake its presence based on use, that makes it possible to diagnose
+    // problems related to member lookup more precisely.
+    auto *fix =
+        DefineMemberBasedOnUse::create(*this, origBaseTy, member, locator);
+    if (recordFix(fix))
+      return SolutionKind::Error;
+
+    // Allow member type to default to `Any` to make it possible to form
+    // solutions when contextual type of the result cannot be deduced e.g.
+    // `let _ = x.foo`.
+    addConstraint(ConstraintKind::Defaultable, memberTy,
+                  getASTContext().TheAnyType, locator);
+    return SolutionKind::Solved;
   }
   return SolutionKind::Error;
 }
@@ -4507,6 +4567,25 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   // By construction, the left hand side is a type that looks like the
   // following: $T1 -> $T2.
   assert(type1->is<FunctionType>());
+
+  // Let's check if this member couldn't be found and is fixed
+  // to exist based on its usage.
+  if (auto *memberTy = type2->getAs<TypeVariableType>()) {
+    auto *locator = memberTy->getImpl().getLocator();
+    if (MissingMembers.count(locator)) {
+      auto *funcTy = type1->castTo<FunctionType>();
+      // Bind type variable associated with member to a type of argument
+      // application, which makes it seem like member exists with the
+      // types of the parameters matching argument types exactly.
+      addConstraint(ConstraintKind::Bind, memberTy, funcTy, locator);
+      // There might be no contextual type for result of the application,
+      // in cases like `let _ = x.foo()`, so let's default result to `Any`
+      // to make expressions like that type-check.
+      addConstraint(ConstraintKind::Defaultable, funcTy->getResult(),
+                    getASTContext().TheAnyType, locator);
+      return SolutionKind::Solved;
+    }
+  }
 
   // Drill down to the concrete type on the right hand side.
   type2 = getFixedTypeRecursive(type2, flags, /*wantRValue=*/true);
@@ -5461,6 +5540,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AddConformance:
   case FixKind::AutoClosureForwarding:
   case FixKind::RemoveUnwrap:
+  case FixKind::DefineMemberBasedOnUse:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -945,6 +945,7 @@ public:
   friend class SplitterStep;
   friend class ComponentStep;
   friend class TypeVariableStep;
+  friend class MissingMemberFailure;
 
   class SolverScope;
 
@@ -1783,6 +1784,8 @@ public:
 
     return !solverState || solverState->recordFixes;
   }
+
+  ArrayRef<ConstraintFix *> getFixes() const { return Fixes; }
 
   bool shouldSuppressDiagnostics() const {
     return Options.contains(ConstraintSystemFlags::SuppressDiagnostics);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -593,6 +593,9 @@ public:
   /// The list of fixes that need to be applied to the initial expression
   /// to make the solution work.
   llvm::SmallVector<ConstraintFix *, 4> Fixes;
+  /// The list of member references which couldn't be resolved,
+  /// and had to be assumed based on their use.
+  llvm::SmallVector<ConstraintLocator *, 4> MissingMembers;
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.
@@ -1038,6 +1041,8 @@ private:
 
   /// The set of fixes applied to make the solution work.
   llvm::SmallVector<ConstraintFix *, 4> Fixes;
+  /// The set of type variables representing types of missing members.
+  llvm::SmallSetVector<ConstraintLocator *, 4> MissingMembers;
 
   /// The set of remembered disjunction choices used to reach
   /// the current constraint system.
@@ -1485,6 +1490,8 @@ public:
     unsigned numDefaultedConstraints;
 
     unsigned numCheckedConformances;
+
+    unsigned numMissingMembers;
 
     /// The previous score.
     Score PreviousScore;

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -161,7 +161,7 @@ func testRenamedTrueEnum() {
   // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumValue'
   _ = TrueEnumValue
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'TrueEnumValue'
+  // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'TrueEnumValue'
   _ = TrueEnum.TrueEnumValue
 
   // CHECK-DIAGS: [[@LINE+1]]:16: error: 'Value' has been renamed to 'value'
@@ -172,14 +172,14 @@ func testRenamedTrueEnum() {
   // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumRenamed'
   _ = TrueEnumRenamed
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'TrueEnumRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'TrueEnumRenamed'
   _ = TrueEnum.TrueEnumRenamed
 
   // CHECK-DIAGS-5: [[@LINE+1]]:16: error: 'Renamed' has been renamed to 'renamedSwiftUnversioned'
   _ = TrueEnum.Renamed
   // CHECK-DIAGS-4: [[@LINE-1]]:16: error: 'Renamed' has been renamed to 'renamedSwift4'
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'renamed'
+  // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'renamed'
   _ = TrueEnum.renamed
 
   // CHECK-DIAGS-5-NOT: :[[@LINE+1]]:16:
@@ -193,14 +193,14 @@ func testRenamedTrueEnum() {
   // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumAliasRenamed'
   _ = TrueEnumAliasRenamed
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'TrueEnumAliasRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'TrueEnumAliasRenamed'
   _ = TrueEnum.TrueEnumAliasRenamed
 
   // CHECK-DIAGS-5: [[@LINE+1]]:16: error: 'AliasRenamed' has been renamed to 'aliasRenamedSwiftUnversioned'
   _ = TrueEnum.AliasRenamed
   // CHECK-DIAGS-4: [[@LINE-1]]:16: error: 'AliasRenamed' has been renamed to 'aliasRenamedSwift4'
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'aliasRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'aliasRenamed'
   _ = TrueEnum.aliasRenamed
 
   // CHECK-DIAGS-5-NOT: :[[@LINE+1]]:16:
@@ -216,7 +216,7 @@ func testRenamedOptionyEnum() {
   // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'OptionyEnumValue'
   _ = OptionyEnumValue
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'OptionyEnum' has no member 'OptionyEnumValue'
+  // CHECK-DIAGS: [[@LINE+1]]:19: error: type 'OptionyEnum' has no member 'OptionyEnumValue'
   _ = OptionyEnum.OptionyEnumValue
 
   // CHECK-DIAGS: [[@LINE+1]]:19: error: 'Value' has been renamed to 'value'
@@ -227,14 +227,14 @@ func testRenamedOptionyEnum() {
   // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'OptionyEnumRenamed'
   _ = OptionyEnumRenamed
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'OptionyEnum' has no member 'OptionyEnumRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:19: error: type 'OptionyEnum' has no member 'OptionyEnumRenamed'
   _ = OptionyEnum.OptionyEnumRenamed
 
   // CHECK-DIAGS-5: [[@LINE+1]]:19: error: 'Renamed' has been renamed to 'renamedSwiftUnversioned'
   _ = OptionyEnum.Renamed
   // CHECK-DIAGS-4: [[@LINE-1]]:19: error: 'Renamed' has been renamed to 'renamedSwift4'
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'OptionyEnum' has no member 'renamed'
+  // CHECK-DIAGS: [[@LINE+1]]:19: error: type 'OptionyEnum' has no member 'renamed'
   _ = OptionyEnum.renamed
 
   // CHECK-DIAGS-5-NOT: :[[@LINE+1]]:19:

--- a/test/Compatibility/protocol_composition.swift
+++ b/test/Compatibility/protocol_composition.swift
@@ -38,6 +38,7 @@ func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class t
   let _: (P1 & P2).Type = x! // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
   let _: Int = x!.p1() // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
   let _: Int? = x?.p2 // expected-error {{cannot use optional chaining on non-optional value of type 'P1'}}
+                      // expected-error@-1 {{value of type 'P1' has no member 'p2'}}
 }
 
 func bar() -> ((P1 & P2)?).Type {

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -57,4 +57,4 @@ func f23798944() {
   }
 }
 
-.sr_3506 = 0 // expected-error {{reference to member 'sr_3506' cannot be resolved without a contextual type}}
+.sr_3506 = 0 // expected-error {{type 'Int' has no member 'sr_3506'}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -556,6 +556,7 @@ r32432145 { _,_ in
 // rdar://problem/30106822 - Swift ignores type error in closure and presents a bogus error about the caller
 [1, 2].first { $0.foo = 3 }
 // expected-error@-1 {{value of type 'Int' has no member 'foo'}}
+// expected-error@-2 {{cannot convert value of type '()' to closure result type 'Bool'}}
 
 // rdar://problem/32433193, SR-5030 - Higher-order function diagnostic mentions the wrong contextual type conversion problem
 protocol A_SR_5030 {

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -107,3 +107,20 @@ struct Foo_32551313 {
     return E_32551313.Left("", Foo_32551313()) // expected-error {{extra argument in call}}
   }
 }
+
+func rdar34583132() {
+  enum E {
+    case timeOut
+  }
+
+  struct S {
+    func foo(_ x: Int) -> E { return .timeOut }
+  }
+
+  func bar(_ s: S) {
+    guard s.foo(1 + 2) == .timeout else {
+    // expected-error@-1 {{enum type 'E' has no case 'timeout'; did you mean 'timeOut'}}
+      fatalError()
+    }
+  }
+}

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -72,7 +72,7 @@ struct Delegate {
 }
 
 extension Array {
-  subscript(safe safe: Int) -> Element? { // expected-note {{found this candidate}}
+  subscript(safe safe: Int) -> Element? {
     get { }
     set { }
   }
@@ -84,6 +84,4 @@ struct ShellTask {
 
 let delegate = Delegate(shellTasks: [])
 _ = delegate.shellTasks[safe: 0]?.commandLine.compactMap({ $0.asString.hasPrefix("") ? $0 : nil }).count ?? 0
-// expected-error@-1 {{ambiguous reference to member 'subscript'}}
-
-// FIXME: Horrible diagnostic, but at least we no longer crash
+// expected-error@-1 {{value of type 'String' has no member 'asString'}}

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -122,8 +122,7 @@ case iPadHair.HairForceOne: // expected-error{{generic enum type 'iPadHair' is a
   ()
 case Watch.Edition: // TODO: should warn that cast can't succeed with currently known conformances
   ()
-// TODO: Bad error message
-case .HairForceOne: // expected-error{{cannot convert}}
+case .HairForceOne: // expected-error{{type 'HairType' has no member 'HairForceOne'}}
   ()
 default:
   break

--- a/test/Parse/ConditionalCompilation/switch_case.swift
+++ b/test/Parse/ConditionalCompilation/switch_case.swift
@@ -180,7 +180,7 @@ func foo(x: E, intVal: Int) {
   switch x {
     print() // expected-error {{all statements inside a switch must be covered by a 'case' or 'default'}}
 #if ENABLE_C
-    case .NOT_EXIST: // expected-error {{pattern cannot match values of type 'E'}}
+    case .NOT_EXIST: // expected-error {{type 'E' has no member 'NOT_EXIST'}}
       break
     case .C:
       break

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -107,7 +107,7 @@ enum Voluntary<T> : Equatable {
     }
 
     switch foo {
-    case .Naught: // expected-error{{pattern cannot match values of type 'Foo'}}
+    case .Naught: // expected-error{{type 'Foo' has no member 'Naught'}}
       ()
     case .A, .B, .C:
       ()
@@ -152,7 +152,7 @@ case .Twain,
 var notAnEnum = 0
 
 switch notAnEnum {
-case .Foo: // expected-error{{pattern cannot match values of type 'Int'}}
+case .Foo: // expected-error{{type 'Int' has no member 'Foo'}}
   ()
 }
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -307,7 +307,7 @@ Gronk: // expected-error {{switch must be exhaustive}} expected-note{{do you wan
 
 func enumElementSyntaxOnTuple() {
   switch (1, 1) {
-  case .Bar: // expected-error {{pattern cannot match values of type '(Int, Int)'}}
+  case .Bar: // expected-error {{value of tuple type '(Int, Int)' has no member 'Bar'}}
     break
   default:
     break

--- a/test/decl/nested/reserved_name.swift
+++ b/test/decl/nested/reserved_name.swift
@@ -14,5 +14,5 @@ struct S2 {
   }
 }
 
-let s1: S1.Type = .A // expected-error{{type of expression is ambiguous without more context}}
+let s1: S1.Type = .A // expected-error {{type 'S1.Type' has no member 'A'}}
 let s2: S2.`Type` = .A // no-error


### PR DESCRIPTION
Try to fix constraint system in a way where member
reference is going to be defined in terms of its use,
which makes it seem like parameters match arguments
exactly. Such helps to produce solutions and diagnose
failures related to missing members precisely.

These changes would be further extended to diagnose use
of unavailable members and other structural member failures.

Resolves: rdar://problem/34583132
Resolves: rdar://problem/36989788
Resolved: rdar://problem/39586166
Resolves: rdar://problem/40537782
Resolves: rdar://problem/46211109

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
