### PR TITLE
[5.0][01-07-2019][sourcekitd][AST] Fix CursorInfo crash on methods with param with unresolved default values

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5109,6 +5109,14 @@ ParamDecl::getDefaultValueStringRepresentation(
       DefaultValueAndIsVariadic.getPointer()->StringRepresentation;
     if (!existing.empty())
       return existing;
+
+    if (!getDefaultValue()) {
+      // TypeChecker::checkDefaultArguments() nulls out the default value
+      // if it fails to type check it. This only seems to happen with an
+      // invalid/incomplete parameter list that contains a parameter with an
+      // unresolved default value.
+      return "<<empty>>";
+    }
     return extractInlinableText(getASTContext().SourceMgr, getDefaultValue(),
                                 scratch);
   }

--- a/test/SourceKit/CursorInfo/undefined-default-value.swift
+++ b/test/SourceKit/CursorInfo/undefined-default-value.swift
@@ -1,0 +1,9 @@
+enum LogLevel { case error }
+
+func logAsync(level: LogLevel = undefined, messageProducer producer
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:44 %s -- %s | %FileCheck %s
+
+// CHECK: source.lang.swift.decl.function.free (3:6-3:68)
+// CHECK: logAsync(level:messageProducer:)
+// CHECK: LogLevel</Type> = &lt;&lt;empty&gt;&gt


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/21749 (against 12-12-2018) for 01-07-2019

Resolves rdar://problem/46694149
See https://github.com/apple/swift/pull/21749 for info.
