### PR TITLE
[benchmark] Rework SuperChars

### DIFF
--- a/benchmark/single-source/SuperChars.swift
+++ b/benchmark/single-source/SuperChars.swift
@@ -14,24 +14,18 @@
 import TestsUtils
 
 public let SuperChars = BenchmarkInfo(
-  name: "SuperChars",
+  name: "SuperChars2",
   runFunction: run_SuperChars,
   tags: [.validation, .api, .String],
   setUpFunction: { blackHole(alphabetInput) })
 
 // Permute some characters.
 let alphabetInput: [Character] = [
-  "A", "B", "C", "D", "E", "F", "G",
-   "«", // throw in some unicode to make it slower
-  "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
-  "á", "お",
-  "S", "T", "U",
-  "🇯🇵",
-  "V", "W", "X", "Y", "Z", "/", "f", "Z", "z", "6", "7", "C", "j", "f", "9",
-  "🇯🇵🇺🇸", "🇯🇵🇺🇸🇨🇳", "🇯🇵🇺🇸🇨🇳🇩🇪",
-  "g", "g", "I", "J", "K", "c", "x", "i", ".",
-  "🇯🇵🇺🇸🇨🇳🇩🇪", "🇯🇵🇺🇸", "🇯🇵🇺🇸🇨🇳",
-  "2", "a", "t", "i", "o", "e", "q", "n", "X", "Y", "Z", "?", "m", "Z", ","
+  "A", "B", "C", "D", "E", "F", "«",
+  "H", "I", "J", "K", "L", "M", "N",
+  "á", "お", "S", "T", "U", "🇯🇵",
+  "🧟‍♀️", "👩‍👦‍👦", "g", "g", "I",
+  "🕴🏿", "2", "a", "t", "n", "?",
   ]
 
 @inline(never)
@@ -43,7 +37,7 @@ public func run_SuperChars(_ N: Int) {
     for firstChar in alphabet {
       for middleChar in alphabet {
         for lastChar in alphabet {
-          _ = ((firstChar == middleChar) != (middleChar < lastChar))
+          blackHole((firstChar == middleChar) != (middleChar < lastChar))
         }
       }
     }

--- a/benchmark/single-source/SuperChars.swift
+++ b/benchmark/single-source/SuperChars.swift
@@ -22,10 +22,8 @@ public let SuperChars = BenchmarkInfo(
 // Permute some characters.
 let alphabetInput: [Character] = [
   "A", "B", "C", "D", "E", "F", "«",
-  "H", "I", "J", "K", "L", "M", "N",
   "á", "お", "S", "T", "U", "🇯🇵",
-  "🧟‍♀️", "👩‍👦‍👦", "g", "g", "I",
-  "🕴🏿", "2", "a", "t", "n", "?",
+  "🧟‍♀️", "👩‍👦‍👦", "🕴🏿", "2", "?",
   ]
 
 @inline(never)


### PR DESCRIPTION
Rework SuperChars into something that:

* Doesn't crash in asserts configurations (i.e. has valid Characters)
* Actually runs (i.e. use blackHole on comparison result)
* Runs in around 1ms (it's cubic complexity in payload size)

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
