### PR TITLE
Additional Data benchmarks

### DIFF
--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -177,7 +177,7 @@ public let DataBenchmarks = [
   BenchmarkInfo(name: "Data.hash.Small",
     runFunction: { hash($0*10_000, data: small) }, tags: d),
   BenchmarkInfo(name: "Data.hash.Medium",
-    runFunction: { hash($0*10_000, data: medium) }, tags: d),
+    runFunction: { hash($0*1_000, data: medium) }, tags: d),
 ]
 
 let emptyString = ""

--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -120,9 +120,12 @@ public let DataBenchmarks = [
   BenchmarkInfo(name: "DataAppendSequence",
     runFunction: { append($0*100, sequenceLength: 809, to: medium) },
     tags: d, legacyFactor: 100),
+  BenchmarkInfo(name: "Data.append.Sequence.ExactCount", runFunction: {
+    append($0*100, sequence: repeatElement(UInt8(0xA0), count: 809),
+           to: medium) }, tags: d),
   BenchmarkInfo(name: "Data.append.Sequence.UnderestimatedCount", runFunction: {
     append($0*100, sequence: repeatElementSeq(809), to: medium) },
-    tags: d, legacyFactor: 100),
+    tags: d),
 
   BenchmarkInfo(name: "DataAppendDataSmallToSmall",
     runFunction: { append($0*500, data: small, to: small) }, tags: d,

--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -171,6 +171,13 @@ public let DataBenchmarks = [
   BenchmarkInfo(name: "StringToDataMedium",
     runFunction: { data($0*200, from: mediumString) }, tags: d,
     legacyFactor: 50),
+
+  BenchmarkInfo(name: "DataHashEmpty",
+    runFunction: { hash($0*10_000, data: Data()) }, tags: d),
+  BenchmarkInfo(name: "DataHashSmall",
+    runFunction: { hash($0*10_000, data: small) }, tags: d),
+  BenchmarkInfo(name: "DataHashMedium",
+    runFunction: { hash($0*10_000, data: medium) }, tags: d),
 ]
 
 let emptyString = ""
@@ -382,4 +389,14 @@ public func data(_ N: Int, from string: String) {
   for _ in 1...N {
     blackHole(Data(string.utf8))
   }
+}
+
+@inline(never)
+public func hash(_ N: Int, data: Data) {
+  var hasher = Hasher()
+  for _ in 0 ..< N {
+    hasher.combine(data)
+  }
+
+  let _ = hasher.finalize()
 }

--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -40,11 +40,11 @@ public let DataBenchmarks = [
       0, 1, 2, 3, 4, 5, 6,
     ])) } }, tags: d, legacyFactor: 20),
 
-  BenchmarkInfo(name: "DataCreateSequenceExactCount", runFunction: {
+  BenchmarkInfo(name: "Data.init.Sequence.ExactCount", runFunction: {
     for _ in 0..<$0*500 {
       blackHole(Data(repeatElement(UInt8(0xA0), count: 809)))
     } }, tags: d),
-  BenchmarkInfo(name: "DataCreateSequenceUnderestimatedCount", runFunction: {
+  BenchmarkInfo(name: "Data.init.Sequence.UnderestimatedCount", runFunction: {
     for _ in 0..<$0*500 { blackHole(Data(repeatElementSeq(809))) } }, tags: d),
 
   BenchmarkInfo(name: "DataSubscriptSmall",
@@ -117,10 +117,10 @@ public let DataBenchmarks = [
     replaceBuffer($0*10, data: medium, subrange:431..<809, with: large) },
     tags: d),
 
-  BenchmarkInfo(name: "DataAppendSequenceExactCount",
+  BenchmarkInfo(name: "DataAppendSequence",
     runFunction: { append($0*100, sequenceLength: 809, to: medium) },
     tags: d, legacyFactor: 100),
-  BenchmarkInfo(name: "DataAppendSequenceUnderestimatedCount", runFunction: {
+  BenchmarkInfo(name: "Data.append.Sequence.UnderestimatedCount", runFunction: {
     append($0*100, sequence: repeatElementSeq(809), to: medium) },
     tags: d, legacyFactor: 100),
 
@@ -172,11 +172,11 @@ public let DataBenchmarks = [
     runFunction: { data($0*200, from: mediumString) }, tags: d,
     legacyFactor: 50),
 
-  BenchmarkInfo(name: "DataHashEmpty",
+  BenchmarkInfo(name: "Data.hash.Empty",
     runFunction: { hash($0*10_000, data: Data()) }, tags: d),
-  BenchmarkInfo(name: "DataHashSmall",
+  BenchmarkInfo(name: "Data.hash.Small",
     runFunction: { hash($0*10_000, data: small) }, tags: d),
-  BenchmarkInfo(name: "DataHashMedium",
+  BenchmarkInfo(name: "Data.hash.Medium",
     runFunction: { hash($0*10_000, data: medium) }, tags: d),
 ]
 

--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -41,11 +41,11 @@ public let DataBenchmarks = [
     ])) } }, tags: d, legacyFactor: 20),
 
   BenchmarkInfo(name: "Data.init.Sequence.ExactCount", runFunction: {
-    for _ in 0..<$0*500 {
+    for _ in 0..<$0*100 {
       blackHole(Data(repeatElement(UInt8(0xA0), count: 809)))
     } }, tags: d),
   BenchmarkInfo(name: "Data.init.Sequence.UnderestimatedCount", runFunction: {
-    for _ in 0..<$0*500 { blackHole(Data(repeatElementSeq(809))) } }, tags: d),
+    for _ in 0..<$0*100 { blackHole(Data(repeatElementSeq(809))) } }, tags: d),
 
   BenchmarkInfo(name: "DataSubscriptSmall",
     runFunction: { let data = small


### PR DESCRIPTION
**What's in this pull request?**
Per @palimondo's suggestion, adds benchmarks covering worst-case `Data.init<S>(_:)`/`Data.append<S>(_:)` scenarios, as well as `Data` hashing.

Should go in for #21754 testing.