### PR TITLE
Make eager mode (dynamic compilation) the default in the compiler. 

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -51,11 +51,11 @@ static llvm::cl::opt<bool> TFDumpIntermediatesToTmp(
 
 // The flag below is referenced in multiple translation units.
 namespace llvm {
-// This flag is used as a crutch to develop and test IRGen code that handles
-// graph_op insts.
-// TODO: Fold this flag into -Onone mode.
+// This (internal) flag is used to enable IRGen to generate code for op-by-op
+// dispatch and defaults to true.  When this flag is false, GPE is turned off
+// completely for non-tensorflow convention functions even in the -O mode.
 llvm::cl::opt<bool> TFDynamicCompilation(
-    "tf-dynamic-compilation", llvm::cl::init(false),
+    "tf-dynamic-compilation", llvm::cl::init(true),
     llvm::cl::desc(
         "When true, skip the partitioning and lowering pass, so that graph_op "
         "instructions flow to IRGen. This flag should not be turned on by end "

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module -Xllvm -tf-dynamic-compilation=false | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
 
 // This file contains various regression tests that crashed the compiler.
 

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil -verify %s | %FileCheck %s
 import TensorFlow
 
 // Creates a dataset, which produces one float scalar value in each get next

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
 import TensorFlow
 
 // FIXME: This should not build with -O.

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil -verify %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-warn-send-recv -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Xllvm -tf-warn-send-recv -O -emit-sil -verify %s
 
 import TensorFlow
 

--- a/test/TensorFlow/diagnostics_scalar_transfers.swift
+++ b/test/TensorFlow/diagnostics_scalar_transfers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-warn-send-recv -Xllvm -tf-warn-scalar-transfer=true -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-warn-send-recv -Xllvm -tf-warn-scalar-transfer=true -O -emit-sil -verify %s
 
 // Tests that we diagnose scalar transfers when tf-warn-scalar-transfer=true. There are parallel
 // tests in diagnostics.swift ensuring that we do not diagnost the transfers when

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 
 // This file contains tests that used to be in ./diagnostics.swift that produced
 // expected errors in the deabstraction pass, which prevented partitioning from

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-graph -O -emit-sil %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-graph -O -emit-sil %s -verify | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-module-level-graph=false %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-module-level-graph=false %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Onone -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Onone -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
 import TensorFlow
 
 public func testArrayValues() -> Tensor<Float> {

--- a/test/TensorFlow/playground_1.swift
+++ b/test/TensorFlow/playground_1.swift
@@ -5,9 +5,9 @@
 
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -debugger-support -dump-ast -playground %t/main.swift %S/PlaygroundsRuntime.swift
-// RUN: %target-swift-frontend -debugger-support -Xllvm -tf-dump-intermediates -O -emit-sil -playground %t/main.swift %S/PlaygroundsRuntime.swift
-// RUN: %target-swift-frontend -debugger-support -Xllvm -tf-dump-intermediates -O -emit-sil -playground %t/main.swift %S/PlaygroundsRuntime.swift -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -debugger-support -dump-ast -playground %t/main.swift %S/PlaygroundsRuntime.swift
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -debugger-support -Xllvm -tf-dump-intermediates -O -emit-sil -playground %t/main.swift %S/PlaygroundsRuntime.swift
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -debugger-support -Xllvm -tf-dump-intermediates -O -emit-sil -playground %t/main.swift %S/PlaygroundsRuntime.swift -verify | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/retain_release.swift
+++ b/test/TensorFlow/retain_release.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil %s -o -
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -o -
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates %swift-tensorflow-extra-options -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -Xllvm -tf-warn-send-recv -O -emit-sil %s -verify | %FileCheck %filecheck-tensorflow-extra-options %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates %swift-tensorflow-extra-options -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -Xllvm -tf-warn-send-recv -O -emit-sil %s -verify | %FileCheck %filecheck-tensorflow-extra-options %s
 
 // In this file, send means accelerator->host, and recv means the opposite.
 

--- a/test/TensorFlow/sese_loop_canonicalization.swift
+++ b/test/TensorFlow/sese_loop_canonicalization.swift
@@ -1,6 +1,6 @@
 // This test file has various test cases to check that unrollng the loop body
 // preserves the loop nesting.  Note that we use -Onone to preserve the
-// structuren of control flow for tests.
+// structure of control flow for tests.
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Onone -emit-sil %s -verify | %FileCheck %s
 
 import TensorFlow

--- a/test/TensorFlow/sese_loop_canonicalization.swift
+++ b/test/TensorFlow/sese_loop_canonicalization.swift
@@ -1,7 +1,7 @@
 // This test file has various test cases to check that unrollng the loop body
 // preserves the loop nesting.  Note that we use -Onone to preserve the
-// structure of control flow for tests.
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Onone -emit-sil %s -verify | %FileCheck %s
+// structuren of control flow for tests.
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Onone -emit-sil %s -verify | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
+++ b/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank0.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank3.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/tfop_packing.swift
+++ b/test/TensorFlow/tfop_packing.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/ExternalStructs.swift -enable-resilience -emit-module -emit-module-path %t/ExternalStructs.swiftmodule
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -enable-resilience -I %t -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -enable-resilience -I %t -verify %s | %FileCheck %s
 
 import TensorFlow
 import ExternalStructs

--- a/test/TensorFlow/top_level_code_1.swift
+++ b/test/TensorFlow/top_level_code_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
-// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in-graph:

--- a/test/TensorFlow/top_level_code_2.swift
+++ b/test/TensorFlow/top_level_code_2.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
-// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in-graph:

--- a/test/TensorFlow/with_device.swift
+++ b/test/TensorFlow/with_device.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-use-device-stack -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-use-device-stack -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -emit-sil -verify %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlowRuntime/accelerator_only.swift
+++ b/test/TensorFlowRuntime/accelerator_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-swift-frontend -emit-sil -O %s -verify | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/accelerator_only.swift
+++ b/test/TensorFlowRuntime/accelerator_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-swift-frontend -emit-sil -O %s -verify | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/codable.swift
+++ b/test/TensorFlowRuntime/codable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: objc_interop

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-use-device-stack-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-use-device-stack-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 
@@ -28,7 +28,7 @@ CollectiveTests.testAllBackends("SingletonGroup") {
 //
 // TODO: To enable this test in eager mode, need to put each collective op (or
 // the enclosing graph function) in a separate swift thread.
-#if !TF_DYNAMIC_COMPILATION
+#if TF_NODYNAMIC_COMPILATION
 CollectiveTests.testAllBackends("GroupWithSize2") {
   // Need 2 or more CPU devices for this test.
   let x = Tensor<Float>(1.0)
@@ -61,7 +61,7 @@ CollectiveTests.testAllBackends("GroupWithSize2") {
   _hostOp(t)
   expectEqualWithScalarTensor(2, t)
 }
-#endif // TF_DYNAMIC_COMPILATION
+#endif // !TF_NODYNAMIC_COMPILATION
 
 CollectiveTests.testAllBackends("GroupWithSize2_threads") {
   // Need 2 or more CPU devices for this test.

--- a/test/TensorFlowRuntime/conflicting_module.swift
+++ b/test/TensorFlowRuntime/conflicting_module.swift
@@ -4,9 +4,9 @@
 // crash at runtime when adding the functions to the eager context.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ConflictingModule1.swift -emit-module -emit-library -module-name ConflictingModule1 -o %t/libConflictingModule1.%target-dylib-extension -emit-module-path %t/ConflictingModule1.swiftmodule
-// RUN: %target-build-swift %S/Inputs/ConflictingModule2.swift -emit-module -emit-library -module-name ConflictingModule2 -o %t/libConflictingModule2.%target-dylib-extension -emit-module-path %t/ConflictingModule2.swiftmodule
-// RUN: %target-build-swift %s -I %t -L %t -lConflictingModule1 -lConflictingModule2 -Xlinker -rpath -Xlinker %t -o %t/a.out
+// RUN: %target-build-swift -Xllvm -tf-dynamic-compilation=false %S/Inputs/ConflictingModule1.swift -emit-module -emit-library -module-name ConflictingModule1 -o %t/libConflictingModule1.%target-dylib-extension -emit-module-path %t/ConflictingModule1.swiftmodule
+// RUN: %target-build-swift -Xllvm -tf-dynamic-compilation=false %S/Inputs/ConflictingModule2.swift -emit-module -emit-library -module-name ConflictingModule2 -o %t/libConflictingModule2.%target-dylib-extension -emit-module-path %t/ConflictingModule2.swiftmodule
+// RUN: %target-build-swift -Xllvm -tf-dynamic-compilation=false %s -I %t -L %t -lConflictingModule1 -lConflictingModule2 -Xlinker -rpath -Xlinker %t -o %t/a.out
 // RUN: %target-run %t/a.out %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/control_flow_objc.swift
+++ b/test/TensorFlowRuntime/control_flow_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: OS=macosx

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //
@@ -73,7 +73,7 @@ DatasetAPITests.testAllBackends("SingleValueBatched") {
 }
 
 // TODO(SR-9156): Make this test work in graph mode.
-#if TF_DYNAMIC_COMPILATION
+#if !TF_NODYNAMIC_COMPILATION
 DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
   let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let scalars2 = Tensor<Int32>(rangeFrom: 5, to: 10, stride: 1)
@@ -86,7 +86,7 @@ DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
     i += 1
   }
 }
-#endif // TF_DYNAMIC_COMPILATION
+#endif // !TF_NODYNAMIC_COMPILATION
 
 #endif //!CUDA
 

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/device_placement.swift
+++ b/test/TensorFlowRuntime/device_placement.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/device_placement.swift
+++ b/test/TensorFlowRuntime/device_placement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: tensorflow

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -238,6 +238,7 @@ DynamicAttributeTests.testAllBackends("NormalAttribute Float") {
   expectEqual(false, result2.scalar!)
 }
 
+#if !CUDA
 DynamicAttributeTests.testAllBackends("NormalAttribute String") {
   let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
                                     T$dtype: Float.tensorFlowDataType,
@@ -245,18 +246,22 @@ DynamicAttributeTests.testAllBackends("NormalAttribute String") {
                                     padding: loadVALIDString())
   expectEqual(convExpectedResult, result.array)
 }
+#endif //!CUDA
 
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Bool>") {
   // There aren't any ops that take bool list attributes!
 }
 
+#if !CUDA
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int32>") {
   let result = convImage.convolved2D(withFilter: convFilter,
                                      strides: loadStridesInt32(),
                                      padding: .valid)
   expectEqual(convExpectedResult, result.array)
 }
+#endif //!CUDA
 
+#if !CUDA
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int64>") {
   let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
                                     T$dtype: Float.tensorFlowDataType,
@@ -264,6 +269,7 @@ DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int64>") {
                                     padding: "VALID")
   expectEqual(convExpectedResult, result.array)
 }
+#endif //!CUDA
 
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Double>") {
   let input = Tensor<Double>([-1, 0.1, 4.3, 1.2])

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,5 +1,5 @@
 // TODO: Revert to %target-run-simple-swift once we fold dynamic compilation into -Onone.
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import CTensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,5 +1,5 @@
-// TODO: Revert to %target-run-eager-swift once we fold dynamic compilation into -Onone.
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// TODO: Revert to %target-run-gpe-swift once we fold dynamic compilation into -Onone.
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import CTensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,4 +1,4 @@
-// TODO: Revert to %target-run-simple-swift once we fold dynamic compilation into -Onone.
+// TODO: Revert to %target-run-eager-swift once we fold dynamic compilation into -Onone.
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 

--- a/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import TensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // XFAIL: *

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow

--- a/test/TensorFlowRuntime/random.swift
+++ b/test/TensorFlowRuntime/random.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/random.swift
+++ b/test/TensorFlowRuntime/random.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -1,6 +1,6 @@
 // This test has various test cases to check that SESE regions are computed correctly.
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil -O %s -verify | %FileCheck %s
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -1,5 +1,5 @@
 // This test has various test cases to check that SESE regions are computed correctly.
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -emit-sil -O %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil -O %s -verify | %FileCheck %s
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/string.swift
+++ b/test/TensorFlowRuntime/string.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/string.swift
+++ b/test/TensorFlowRuntime/string.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-eager-swift
 //
 // Note: GPE testing is disabled because GPE does not interact well with
 // VJP-based AD. See SR-9638.

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/with_device_1.swift
+++ b/test/TensorFlowRuntime/with_device_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-use-device-stack-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -635,7 +635,7 @@ def use_interpreter_for_simple_runs():
     # tests to the new code path (when the flag is true).
     config.target_run_simple_swift_use_device_stack = (
         "%s %%s -Xllvm -tf-use-device-stack" % (target_run_base))
-    config.target_run_swift_dynamic_compilation = (
+    config.target_run_swift_eager = (
         "%s %%s -Xllvm -tf-dynamic-compilation" % (target_run_base))
     config.target_run_swift_gpe = (
         "%s %%s -Xllvm -tf-dynamic-compilation=false" % (target_run_base))
@@ -1144,7 +1144,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
-    config.target_run_swift_dynamic_compilation = (
+    config.target_run_swift_eager = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -Xllvm -tf-dynamic-compilation -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
@@ -1300,7 +1300,7 @@ config.substitutions.append(('%target-run-simple-swift-swift3', config.target_ru
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-use-device-stack-swift', config.target_run_simple_swift_use_device_stack))
-config.substitutions.append(('%target-run-dynamic-compilation-swift', config.target_run_swift_dynamic_compilation))
+config.substitutions.append(('%target-run-eager-swift', config.target_run_swift_eager))
 config.substitutions.append(('%target-run-gpe-swift', config.target_run_swift_gpe))
 config.substitutions.append(('%target-run-simple-parse-stdlib-swift', config.target_run_simple_parse_stdlib_swift))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -637,6 +637,8 @@ def use_interpreter_for_simple_runs():
         "%s %%s -Xllvm -tf-use-device-stack" % (target_run_base))
     config.target_run_swift_dynamic_compilation = (
         "%s %%s -Xllvm -tf-dynamic-compilation" % (target_run_base))
+    config.target_run_swift_gpe = (
+        "%s %%s -Xllvm -tf-dynamic-compilation=false" % (target_run_base))
     config.target_run_simple_swiftgyb = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1138,13 +1140,19 @@ if not getattr(config, 'target_run_simple_swift', None):
     # SWIFT_ENABLE_TENSORFLOW
     config.target_run_simple_swift_use_device_stack = (
         '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -tf-use-device-stack -o %%t/a.out -module-name main %s && '
+        '%s %s %%s -Xllvm -tf-use-device-stack -Xllvm -tf-dynamic-compilation=false -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_swift_dynamic_compilation = (
         '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -tf-dynamic-compilation -DTF_DYNAMIC_COMPILATION -o %%t/a.out -module-name main %s && '
+        '%s %s %%s -Xllvm -tf-dynamic-compilation -o %%t/a.out -module-name main %s && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
+    config.target_run_swift_gpe = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -Xllvm -tf-dynamic-compilation=false -DTF_NODYNAMIC_COMPILATION -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
@@ -1293,6 +1301,7 @@ config.substitutions.append(('%target-run-simple-swift', config.target_run_simpl
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-use-device-stack-swift', config.target_run_simple_swift_use_device_stack))
 config.substitutions.append(('%target-run-dynamic-compilation-swift', config.target_run_swift_dynamic_compilation))
+config.substitutions.append(('%target-run-gpe-swift', config.target_run_swift_gpe))
 config.substitutions.append(('%target-run-simple-parse-stdlib-swift', config.target_run_simple_parse_stdlib_swift))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))


### PR DESCRIPTION
Make eager mode the default in the compiler. Note that this change disables GPE even in the "-O" mode. If you want to enable GPE, you will need to pass `-Xllvm -tf-dynamic-compilation=false` to the swift frontend.