### PR TITLE
IRGen: prevent WeakExternal on COFF

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -42,6 +42,7 @@ bool useDllStorage(const llvm::Triple &triple);
 class UniversalLinkageInfo {
 public:
   bool IsELFObject;
+  bool IsCOFFObject;
   bool UseDLLStorage;
 
   /// True iff are multiple llvm modules.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1466,8 +1466,9 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
     if (isDefinition)
       return RESULT(AvailableExternally, Default, Default);
 
-    auto linkage = isWeakImported ? llvm::GlobalValue::ExternalWeakLinkage
-                                  : llvm::GlobalValue::ExternalLinkage;
+    auto linkage = llvm::GlobalValue::ExternalLinkage;
+    if (!info.IsCOFFObject && isWeakImported)
+      linkage = llvm::GlobalValue::ExternalWeakLinkage;
     return {linkage, llvm::GlobalValue::DefaultVisibility, ImportedStorage};
   }
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -73,6 +73,7 @@ UniversalLinkageInfo::UniversalLinkageInfo(const llvm::Triple &triple,
                                            bool hasMultipleIGMs,
                                            bool isWholeModule)
     : IsELFObject(triple.isOSBinFormatELF()),
+      IsCOFFObject(triple.isOSBinFormatCOFF()),
       UseDLLStorage(useDllStorage(triple)), HasMultipleIGMs(hasMultipleIGMs),
       IsWholeModule(isWholeModule) {}
 


### PR DESCRIPTION
We cannot use ExternalWeakLinkage on PE/COFF as the semantics for that
do not exist.  It is theoretically possible to emulate this by manually
creating a default value for the symbol that evaluates to 0, but that
requires adding a set of linker directives and variable definitions.
Disable the weak linkage rather than generate an invalid module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
