### PR TITLE
Adding TPU + eager support to CompilerRuntime.

### DIFF
--- a/stdlib/private/TensorFlowUnittest/TensorFlowUnittestRemote.swift
+++ b/stdlib/private/TensorFlowUnittest/TensorFlowUnittestRemote.swift
@@ -107,6 +107,6 @@ public func runAllTestsWithRemoteSession(taskCount: Int = 2) {
   _RuntimeConfig.tensorFlowRuntimeInitialized = true
 
   let testCluster = TestCluster(taskCount: taskCount)
-  _RuntimeConfig.session = .remote(grpcAddress: testCluster.serverDef)
+  _RuntimeConfig.session = .remote(serverDef: testCluster.serverDef)
   runAllTests()
 }


### PR DESCRIPTION
Eager mode takes a cluster config instead of a single server address. Construct this cluster config as a string based on the provided protocol://address string.

Example:
SWIFT_TENSORFLOW_SERVER_ADDRESS=grpc://127.0.0.1:1534 ./main