### PR TITLE
[AST] `Decl::is*AccessibleFrom` methods should respect access control…

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -936,6 +936,12 @@ public:
     return LangOpts.isSwiftVersionAtLeast(major, minor);
   }
 
+  /// Check whether it's important to respect access control restrictions
+  /// in current context.
+  bool isAccessControlDisabled() const {
+    return !LangOpts.EnableAccessControl;
+  }
+
 private:
   friend Decl;
   Optional<RawComment> getRawComment(const Decl *D);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2750,12 +2750,6 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC,
                                        treatUsableFromInlineAsPublic);
 }
 
-/// Check whether it's important to respect access control restrictions
-/// in current context.
-static bool isAccessControlDisabled(const ASTContext &ctx) {
-  return !ctx.LangOpts.EnableAccessControl;
-}
-
 /// Checks if \p VD may be used from \p useDC, taking \@testable imports into
 /// account.
 ///
@@ -2766,7 +2760,7 @@ static bool isAccessControlDisabled(const ASTContext &ctx) {
 static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
                                          const ValueDecl *VD,
                                          AccessLevel access) {
-  if (isAccessControlDisabled(VD->getASTContext()))
+  if (VD->getASTContext().isAccessControlDisabled())
     return true;
 
   AccessScope accessScope =
@@ -2788,7 +2782,7 @@ static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
 /// See ValueDecl::isAccessibleFrom for a description of \p forConformance.
 static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
                         AccessLevel access, bool forConformance) {
-  if (isAccessControlDisabled(VD->getASTContext()))
+  if (VD->getASTContext().isAccessControlDisabled())
     return true;
 
   auto *sourceDC = VD->getDeclContext();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2781,10 +2781,12 @@ static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
 ///
 /// See ValueDecl::isAccessibleFrom for a description of \p forConformance.
 static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
-                        AccessLevel access, bool forConformance) {
+                        bool forConformance,
+                        llvm::function_ref<AccessLevel()> getAccessLevel) {
   if (VD->getASTContext().isAccessControlDisabled())
     return true;
 
+  auto access = getAccessLevel();
   auto *sourceDC = VD->getDeclContext();
 
   if (!forConformance) {
@@ -2846,8 +2848,8 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
 
 bool ValueDecl::isAccessibleFrom(const DeclContext *useDC,
                                  bool forConformance) const {
-  auto access = getFormalAccess();
-  bool result = checkAccess(useDC, this, access, forConformance);
+  bool result = checkAccess(useDC, this, forConformance,
+                            [&]() { return getFormalAccess(); });
 
   // For everything outside of protocols and operators, we should get the same
   // result using either implementation of checkAccess, because useDC must
@@ -2856,9 +2858,9 @@ bool ValueDecl::isAccessibleFrom(const DeclContext *useDC,
   // because we're finding internal operators within private types. Fortunately
   // we have a requirement that a member operator take the enclosing type as an
   // argument, so it won't ever match.
-  assert(getDeclContext()->getSelfProtocolDecl() ||
-         isOperator() ||
-         result == checkAccessUsingAccessScopes(useDC, this, access));
+  assert(getDeclContext()->getSelfProtocolDecl() || isOperator() ||
+         result ==
+             checkAccessUsingAccessScopes(useDC, this, getFormalAccess()));
 
   return result;
 }
@@ -2876,8 +2878,8 @@ bool AbstractStorageDecl::isSetterAccessibleFrom(const DeclContext *DC,
   if (isa<ParamDecl>(this))
     return true;
 
-  auto access = getSetterFormalAccess();
-  return checkAccess(DC, this, access, forConformance);
+  return checkAccess(DC, this, forConformance,
+                     [&]() { return getSetterFormalAccess(); });
 }
 
 void ValueDecl::copyFormalAccessFrom(const ValueDecl *source,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2750,6 +2750,12 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC,
                                        treatUsableFromInlineAsPublic);
 }
 
+/// Check whether it's important to respect access control restrictions
+/// in current context.
+static bool isAccessControlDisabled(const ASTContext &ctx) {
+  return !ctx.LangOpts.EnableAccessControl;
+}
+
 /// Checks if \p VD may be used from \p useDC, taking \@testable imports into
 /// account.
 ///
@@ -2760,6 +2766,9 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC,
 static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
                                          const ValueDecl *VD,
                                          AccessLevel access) {
+  if (isAccessControlDisabled(VD->getASTContext()))
+    return true;
+
   AccessScope accessScope =
       getAccessScopeForFormalAccess(VD, access, useDC,
                                     /*treatUsableFromInlineAsPublic*/false);
@@ -2779,6 +2788,9 @@ static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
 /// See ValueDecl::isAccessibleFrom for a description of \p forConformance.
 static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
                         AccessLevel access, bool forConformance) {
+  if (isAccessControlDisabled(VD->getASTContext()))
+    return true;
+
   auto *sourceDC = VD->getDeclContext();
 
   if (!forConformance) {

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -258,8 +258,8 @@ void namelookup::lookupInModule(ModuleDecl *startModule,
                                 ArrayRef<ModuleDecl::ImportedModule> extraImports) {
   assert(moduleScopeContext && moduleScopeContext->isModuleScopeContext());
   ModuleLookupCache cache;
-  bool respectAccessControl = startModule->getASTContext().LangOpts
-                                .EnableAccessControl;
+  bool respectAccessControl =
+      !startModule->getASTContext().isAccessControlDisabled();
   ::lookupInModule<CanTypeSet>(startModule, topAccessPath, decls,
                                resolutionKind, /*canReturnEarly=*/true,
                                typeResolver, cache, moduleScopeContext,
@@ -282,7 +282,7 @@ void namelookup::lookupVisibleDeclsInModule(
     ArrayRef<ModuleDecl::ImportedModule> extraImports) {
   assert(moduleScopeContext && moduleScopeContext->isModuleScopeContext());
   ModuleLookupCache cache;
-  bool respectAccessControl = M->getASTContext().LangOpts.EnableAccessControl;
+  bool respectAccessControl = !M->getASTContext().isAccessControlDisabled();
   ::lookupInModule<NamedCanTypeSet>(M, accessPath, decls,
                                     resolutionKind, /*canReturnEarly=*/false,
                                     typeResolver, cache, moduleScopeContext,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -65,12 +65,11 @@ void DebuggerClient::anchor() {}
 
 void AccessFilteringDeclConsumer::foundDecl(ValueDecl *D,
                                             DeclVisibilityKind reason) {
-  if (D->getASTContext().LangOpts.EnableAccessControl) {
-    if (D->isInvalid())
-      return;
-    if (!D->isAccessibleFrom(DC))
-      return;
-  }
+  if (D->isInvalid())
+    return;
+  if (!D->isAccessibleFrom(DC))
+    return;
+
   ChainedConsumer.foundDecl(D, reason);
 }
 
@@ -1843,7 +1842,7 @@ static void configureLookup(const DeclContext *dc,
                             ReferencedNameTracker *&tracker,
                             bool &isLookupCascading) {
   auto &ctx = dc->getASTContext();
-  if (!ctx.LangOpts.EnableAccessControl)
+  if (ctx.isAccessControlDisabled())
     options |= NL_IgnoreAccessControl;
 
   // Find the dependency tracker we'll need for this lookup.

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1122,7 +1122,7 @@ private:
 
     ASTContext &ctx = M.getASTContext();
     bool isSettable = VD->isSettable(nullptr);
-    if (isSettable && ctx.LangOpts.EnableAccessControl)
+    if (isSettable && !ctx.isAccessControlDisabled())
       isSettable = (VD->getSetterFormalAccess() >= minRequiredAccess);
     if (!isSettable)
       os << ", readonly";

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6791,9 +6791,8 @@ static Type adjustSelfTypeForMember(Type baseTy, ValueDecl *member,
   // If the base of the access is mutable, then we may be invoking a getter or
   // setter that requires the base to be mutable.
   auto *SD = cast<AbstractStorageDecl>(member);
-  bool isSettableFromHere = SD->isSettable(UseDC)
-    && (!UseDC->getASTContext().LangOpts.EnableAccessControl
-        || SD->isSetterAccessibleFrom(UseDC));
+  bool isSettableFromHere =
+      SD->isSettable(UseDC) && SD->isSetterAccessibleFrom(UseDC);
 
   // If neither the property's getter nor its setter are mutating, the base
   // can be an rvalue.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -732,8 +732,7 @@ static bool doesStorageProduceLValue(TypeChecker &TC,
   if (!storage->isSettable(useDC, base))
     return false;
   
-  if (TC.Context.LangOpts.EnableAccessControl &&
-      !storage->isSetterAccessibleFrom(useDC))
+  if (!storage->isSetterAccessibleFrom(useDC))
     return false;
 
   // If there is no base, or if the base isn't being used, it is settable.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -129,8 +129,7 @@ static bool isDeclVisibleInLookupMode(ValueDecl *Member, LookupState LS,
 
   // Check access when relevant.
   if (!Member->getDeclContext()->isLocalContext() &&
-      !isa<GenericTypeParamDecl>(Member) && !isa<ParamDecl>(Member) &&
-      FromContext->getASTContext().LangOpts.EnableAccessControl) {
+      !isa<GenericTypeParamDecl>(Member) && !isa<ParamDecl>(Member)) {
     if (!Member->isAccessibleFrom(FromContext))
       return false;
   }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -160,7 +160,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     Type type, TypeRepr *typeRepr, AccessScope contextAccessScope,
     const DeclContext *useDC, bool mayBeInferred,
     llvm::function_ref<CheckTypeAccessCallback> diagnose) {
-  if (!TC.getLangOpts().EnableAccessControl)
+  if (TC.Context.isAccessControlDisabled())
     return;
   if (!type)
     return;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2775,7 +2775,7 @@ public:
         }
       }
 
-      if (TC.getLangOpts().EnableAccessControl) {
+      if (!TC.Context.isAccessControlDisabled()) {
         // Require the superclass to be open if this is outside its
         // defining module.  But don't emit another diagnostic if we
         // already complained about the class being inherently

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -761,7 +761,7 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
 
 static void checkOverrideAccessControl(ValueDecl *baseDecl, ValueDecl *decl,
                                        ASTContext &ctx) {
-  if (!ctx.LangOpts.EnableAccessControl)
+  if (ctx.isAccessControlDisabled())
     return;
 
   auto &diags = ctx.Diags;
@@ -1479,7 +1479,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     // read-only.  Observing properties look at change, read-only properties
     // have nothing to observe!
     bool baseIsSettable = baseASD->isSettable(baseASD->getDeclContext());
-    if (baseIsSettable && ctx.LangOpts.EnableAccessControl) {
+    if (baseIsSettable) {
       baseIsSettable =
          baseASD->isSetterAccessibleFrom(overrideASD->getDeclContext());
     }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -90,7 +90,7 @@ namespace {
                         bool isMemberLookup)
       : Result(result), DC(dc), Options(options),
         IsMemberLookup(isMemberLookup) {
-      if (!dc->getASTContext().LangOpts.EnableAccessControl)
+      if (dc->getASTContext().isAccessControlDisabled())
         Options |= NameLookupFlags::IgnoreAccessControl;
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1274,7 +1274,7 @@ bool WitnessChecker::checkWitnessAccess(ValueDecl *requirement,
                                         ValueDecl *witness,
                                         bool *isSetter) {
   *isSetter = false;
-  if (!TC.getLangOpts().EnableAccessControl)
+  if (TC.Context.isAccessControlDisabled())
     return false;
 
   AccessScope actualScopeToCheck = getRequiredAccessScope();

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -497,7 +497,7 @@ protected:
   AccessScope getRequiredAccessScope();
 
   bool isUsableFromInlineRequired() {
-    if (!TC.getLangOpts().EnableAccessControl)
+    if (TC.Context.isAccessControlDisabled())
       return false;
 
     assert(RequiredAccessScopeAndUsableFromInline.hasValue() &&

--- a/validation-test/Sema/Inputs/rdar30933988_enum.swift
+++ b/validation-test/Sema/Inputs/rdar30933988_enum.swift
@@ -1,0 +1,4 @@
+enum E<T> {
+  case foo
+  case bar(T)
+}

--- a/validation-test/Sema/rdar30933988.swift
+++ b/validation-test/Sema/rdar30933988.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/rdar30933988_enum.swiftmodule %S/Inputs/rdar30933988_enum.swift
+// RUN:  %target-typecheck-verify-swift -I %t  -disable-access-control
+
+import rdar30933988_enum
+
+let _: E = .foo
+// expected-error@-1 {{generic parameter 'T' could not be inferred}}
+let _: E<Int> = .foo // Ok
+let _: E = .bar(42)  // Ok
+let _: E<String> = .bar(42)
+// expected-error@-1 {{member 'bar' in 'E<String>' produces result of type 'E<T>', but context expects 'E<String>'}}
+let _: E<Int> = .bar(42) // Ok


### PR DESCRIPTION
… flag

Otherwise integrated REPL and other tools like LLDB would produce
incorrect results or crash.

Resolves: rdar://problem/30933988

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
