### PR TITLE
Also include -ltensorflow when compiling against TensorFlow

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -312,8 +312,10 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
 
     SmallString<128> swiftTensorFlowLibPath = SharedRuntimeLibPath;
     llvm::sys::path::append(swiftTensorFlowLibPath, "libswiftTensorFlow.so");
-    if (llvm::sys::fs::exists(swiftTensorFlowLibPath))
+    if (llvm::sys::fs::exists(swiftTensorFlowLibPath)) {
       Arguments.push_back("-lswiftTensorFlow");
+      Arguments.push_back("-ltensorflow");
+    }
   }
 
   // Explicitly pass the target to the linker


### PR DESCRIPTION
This way users do not need to include -ltensorflow when compiling against Tensorflow.

Multiple users have asked about how to handle linking problems that come from "import Tensorflow", this should resolve those errors.