### PR TITLE
[Sema] Fix derived conformances crasher.

### DIFF
--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -164,6 +164,10 @@ ConstructorDecl *createDesignatedInitOverride(TypeChecker &TC,
                                               ConstructorDecl *superclassCtor,
                                               DesignatedInitKind kind);
 
+// SWIFT_ENABLE_TENSORFLOW
+// Get memberwise initializer for a nominal type, if it exists.
+ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal);
+
 } // end namespace swift
 
 #endif

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -76,22 +76,6 @@ static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
   return lookup[0];
 }
 
-// Get memberwise initializer for a nominal type.
-static ConstructorDecl *getMemberwiseInitializer(NominalTypeDecl *nominal) {
-  ConstructorDecl *memberwiseInitDecl = nullptr;
-  for (auto member : nominal->getMembers()) {
-    // Find memberwise initializer.
-    if (!memberwiseInitDecl) {
-      auto initDecl = dyn_cast<ConstructorDecl>(member);
-      if (!initDecl || !initDecl->isMemberwiseInitializer())
-        continue;
-      assert(!memberwiseInitDecl && "Memberwise initializer already found");
-      memberwiseInitDecl = initDecl;
-    }
-  }
-  return memberwiseInitDecl;
-}
-
 // Return the `Scalar` associated type for a ValueDecl if it conforms to
 // `VectorNumeric` in the given context.
 // If the decl does not conform to `VectorNumeric`, return a null `Type`.

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -3,6 +3,10 @@
 
 struct Empty : Differentiable {}
 
+// Test interaction with `AdditiveArithmetic` derived conformances.
+// Previously, this crashed due to duplicate memberwise initializer synthesis.
+struct EmptyAdditiveArithmetic : AdditiveArithmetic, Differentiable {}
+
 struct Simple : AdditiveArithmetic, Differentiable {
   var w: Float
   var b: Float


### PR DESCRIPTION
Fix crasher regarding bad interaction between `AdditiveArithmetic` and
`Differentiable` derived conformances, where both code paths attempt to
synthesize memberwise initializers.

Move `getMemberwiseInitializer` to a shared location.