### PR TITLE
[5.0 01-07-2019] KeyPaths: Don't relative-reference selector refs.

### DIFF
--- a/include/swift/ABI/KeyPath.h
+++ b/include/swift/ABI/KeyPath.h
@@ -190,17 +190,17 @@ public:
     VTableOffset,
   };
   
-  constexpr static uint32_t
-  getResolutionStrategy(ComputedPropertyIDKind idKind) {
-    return idKind == Pointer ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
-         : (assert("no resolution strategy implemented" && false), 0);
-  }
+  enum ComputedPropertyIDResolution {
+    Resolved,
+    IndirectPointer,
+    FunctionCall,
+  };
   
   constexpr static KeyPathComponentHeader
   forComputedProperty(ComputedPropertyKind kind,
                       ComputedPropertyIDKind idKind,
                       bool hasArguments,
-                      bool resolvedID) {
+                      ComputedPropertyIDResolution resolution) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ComputedTag
         << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -213,8 +213,10 @@ public:
       | (idKind == VTableOffset
            ? _SwiftKeyPathComponentHeader_ComputedIDByVTableOffsetFlag : 0)
       | (hasArguments ? _SwiftKeyPathComponentHeader_ComputedHasArgumentsFlag : 0)
-      | (resolvedID ? _SwiftKeyPathComponentHeader_ComputedIDResolved
-                    : getResolutionStrategy(idKind)));
+      | (resolution == Resolved ? _SwiftKeyPathComponentHeader_ComputedIDResolved
+       : resolution == IndirectPointer ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
+       : resolution == FunctionCall ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedFunctionCall
+       : (assert(false && "invalid resolution"), 0)));
   }
   
   constexpr static KeyPathComponentHeader

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -36,6 +36,7 @@
 #include "TypeInfo.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/TypeLowering.h"
@@ -942,7 +943,7 @@ emitKeyPathComponent(IRGenModule &IGM,
     auto id = component.getComputedPropertyId();
     KeyPathComponentHeader::ComputedPropertyIDKind idKind;
     llvm::Constant *idValue;
-    bool idResolved;
+    KeyPathComponentHeader::ComputedPropertyIDResolution idResolution;
     switch (id.getKind()) {
     case KeyPathPatternComponent::ComputedPropertyId::Function: {
       idKind = KeyPathComponentHeader::Pointer;
@@ -952,7 +953,9 @@ emitKeyPathComponent(IRGenModule &IGM,
       idValue = idRef.getValue();
       // If we got an indirect reference, we'll need to resolve it at
       // instantiation time.
-      idResolved = !idRef.isIndirect();
+      idResolution = idRef.isIndirect()
+        ? KeyPathComponentHeader::IndirectPointer
+        : KeyPathComponentHeader::Resolved;
       break;
     }
     case KeyPathPatternComponent::ComputedPropertyId::DeclRef: {
@@ -964,8 +967,35 @@ emitKeyPathComponent(IRGenModule &IGM,
       if (declRef.isForeign) {
         assert(IGM.ObjCInterop && "foreign keypath component w/o objc interop?!");
         idKind = KeyPathComponentHeader::Pointer;
-        idValue = IGM.getAddrOfObjCSelectorRef(declRef);
-        idResolved = false;
+        // FIXME: In non-JIT mode, ideally we would just refer to the selector
+        // reference variable here with an indirectpointer resolution,
+        // but ld64 section coalescing on the __objc_sel section can break
+        // relative references (and on some platforms, mach-o just doesn't
+        // support the necessary relocations).
+        // As a workaround, generate a stub function to resolve the selector.
+        //
+        // Note that we'd need to do this anyway in JIT mode because we would
+        // need to unique the selector at runtime anyway.
+        auto selectorName = IGM.getObjCSelectorName(declRef);
+        llvm::Type *fnParams[] = {IGM.Int8PtrTy};
+        auto fnTy = llvm::FunctionType::get(IGM.Int8PtrTy, fnParams, false);
+        SmallString<32> fnName;
+        fnName.append("keypath_get_selector_");
+        fnName.append(selectorName);
+        auto fn = cast<llvm::Function>(
+          IGM.Module.getOrInsertFunction(fnName, fnTy));
+        if (fn->empty()) {
+          fn->setLinkage(llvm::Function::PrivateLinkage);
+          IRGenFunction subIGF(IGM, fn);
+          if (IGM.DebugInfo)
+            IGM.DebugInfo->emitArtificialFunction(subIGF, fn);
+          
+          auto selectorValue = subIGF.emitObjCSelectorRefLoad(selectorName);
+          subIGF.Builder.CreateRet(selectorValue);
+        }
+        
+        idValue = fn;
+        idResolution = KeyPathComponentHeader::FunctionCall;
       } else {
         if (auto overridden = declRef.getOverriddenVTableEntry())
           declRef = overridden;
@@ -984,7 +1014,9 @@ emitKeyPathComponent(IRGenModule &IGM,
             LinkEntity::forMethodDescriptor(declRef));
 
           idValue = idRef.getValue();
-          idResolved = !idRef.isIndirect();
+          idResolution = idRef.isIndirect()
+            ? KeyPathComponentHeader::IndirectPointer
+            : KeyPathComponentHeader::Resolved;
           break;
         }
       
@@ -995,7 +1027,7 @@ emitKeyPathComponent(IRGenModule &IGM,
         auto index = protoInfo.getFunctionIndex(
                              cast<AbstractFunctionDecl>(declRef.getDecl()));
         idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());
-        idResolved = true;
+        idResolution = KeyPathComponentHeader::Resolved;
       }
       break;
     }
@@ -1008,7 +1040,7 @@ emitKeyPathComponent(IRGenModule &IGM,
         // Scan the stored properties of the struct to find the index. We should
         // only ever use a struct field as a uniquing key from inside the
         // struct's own module, so this is OK.
-        idResolved = true;
+        idResolution = KeyPathComponentHeader::Resolved;
         Optional<unsigned> structIdx;
         unsigned i = 0;
         for (auto storedProp : struc->getStoredProperties()) {
@@ -1029,7 +1061,7 @@ emitKeyPathComponent(IRGenModule &IGM,
         case FieldAccess::ConstantDirect:
         case FieldAccess::ConstantIndirect:
         case FieldAccess::NonConstantDirect:
-          idResolved = true;
+          idResolution = KeyPathComponentHeader::Resolved;
           idValue = llvm::ConstantInt::get(IGM.SizeTy,
                                        getClassFieldIndex(classDecl, property));
           break;
@@ -1042,7 +1074,7 @@ emitKeyPathComponent(IRGenModule &IGM,
     }
     
     auto header = KeyPathComponentHeader::forComputedProperty(componentKind,
-                                      idKind, !isInstantiableOnce, idResolved);
+                                     idKind, !isInstantiableOnce, idResolution);
     
     fields.addInt32(header.getData());
     switch (idKind) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -534,6 +534,11 @@ llvm::Constant *IRGenModule::getAddrOfObjCSelectorRef(SILDeclRef method) {
   return getAddrOfObjCSelectorRef(Selector(method).str());
 }
 
+std::string IRGenModule::getObjCSelectorName(SILDeclRef method) {
+  assert(method.isForeign);
+  return Selector(method).str();
+}
+
 static llvm::Value *emitSuperArgument(IRGenFunction &IGF,
                                       bool isInstanceMethod,
                                       llvm::Value *selfValue,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -832,6 +832,7 @@ public:
   llvm::Constant *getAddrOfGlobalUTF16String(StringRef utf8);
   llvm::Constant *getAddrOfObjCSelectorRef(StringRef selector);
   llvm::Constant *getAddrOfObjCSelectorRef(SILDeclRef method);
+  std::string getObjCSelectorName(SILDeclRef method);
   llvm::Constant *getAddrOfObjCMethodName(StringRef methodName);
   llvm::Constant *getAddrOfObjCProtocolRecord(ProtocolDecl *proto,
                                               ForDefinition_t forDefinition);

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -106,6 +106,8 @@ static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolved
   = 0x00000000U;
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
   = 0x00000002U;
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedFunctionCall
+  = 0x00000001U;
 
 extern const void *_Nonnull (swift_keyPathGenericWitnessTable[]);
 

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -18,9 +18,9 @@ sil_vtable C {}
 sil @x_get : $@convention(thin) (@in_guaranteed C) -> @out NSString
 
 // CHECK: [[KEYPATH_A:@keypath(\..*)?]] = private global
-// --             computed, get-only, indirect identifier
-// CHECK-SAME: <i32 0x0200_0002>,
-// CHECK-SAME: i8** @"\01L_selector(x)"
+// --             computed, get-only, function-instantiated identifier
+// CHECK-SAME: <i32 0x0200_0001>,
+// CHECK-SAME: i8* (i8*)* [[SELECTOR_FN:@[A-Za-z0-9_.]+]] to
 
 // CHECK: [[KEYPATH_B:@keypath(\..*)?]] = private global
 // --             class mutable stored property with indirect offset
@@ -45,6 +45,12 @@ entry(%0 : @trivial $@objc_metatype C.Type):
   unreachable
 }
 
+// CHECK: define private i8* [[SELECTOR_FN]]
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %1 = load {{.*}}selector(x)
+// CHECK-NEXT:   ret i8* %1
+
+// CHECK-LABEL: define swiftcc void @objc_stored_property()
 sil @objc_stored_property : $@convention(thin) () -> () {
 entry:
   // CHECK: call %swift.refcounted* @swift_getKeyPath({{.*}} [[KEYPATH_B]]


### PR DESCRIPTION
ld64 doesn't like this. Instead, generate a stub function to grab the instantiated selector. Fixes rdar://problem/47184763.