### PR TITLE
[test] Re-enable test whose issue has long since been fixed

### DIFF
--- a/test/SIL/Serialization/deserialize_foundation.sil
+++ b/test/SIL/Serialization/deserialize_foundation.sil
@@ -5,6 +5,3 @@
 // REQUIRES: objc_interop
 
 // CHECK-NOT: Unknown
-
-// FIXME: rdar://23805004 Non-fragile shared functions are incorrectly being referenced in fragile functions
-// REQUIRES: rdar23805004


### PR DESCRIPTION
Unfortunately deserialize_appkit.sil seems to have developed another issue in the mean time. Filed rdar://problem/47200045 for that.