### PR TITLE
[AutoDiff] Handle differentiation of `@autodiff` functions.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -1849,11 +1849,11 @@ emitAssociatedFunctionReference(
   if (auto *inst = original->getDefiningInstruction()) {
     if (auto *adfei = dyn_cast<AutoDiffFunctionExtractInst>(inst)) {
       if (adfei->getExtractee() == AutoDiffFunctionExtractee::Original) {
+        builder.createRetainValue(original.getLoc(), adfei->getFunctionOperand(),
+                                  builder.getDefaultAtomicity());
         SILValue assocFn = builder.createAutoDiffFunctionExtract(
             original.getLoc(), AutoDiffFunctionExtractee::VJP,
             /*differentiationOrder*/ 1, adfei->getFunctionOperand());
-        builder.createRetainValue(assocFn.getLoc(), assocFn,
-                                  builder.getDefaultAtomicity());
         auto autodiffFnType =
             adfei->getFunctionOperand()->getType().castTo<SILFunctionType>();
         if (autodiffFnType->getDifferentiationParameterIndices().test(

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -1826,11 +1826,12 @@ static WitnessMethodInst *findWitnessMethod(SILValue value) {
   return nullptr;
 }
 
-/// Emits a reference to the VJP of `original`, differentiated with respect to a
-/// superset of `desiredIndices`. Returns the `SILValue` for the VJP and the
-/// actual indices that the VJP is with respect to.
+/// Emits a reference to an associated function of `original`, differentiated
+/// with respect to a superset of `desiredIndices`. Returns the `SILValue` for
+/// the associated function and the actual indices that the associated function
+/// is with respect to.
 ///
-/// On failure, returns `None`.
+/// Returns `None` on failure.
 ///
 /// Creates new differentiation tasks, if necessary, using `invoker` as the
 /// invoker. Calls `taskCallback` for all newly-created tasks (but may also call
@@ -1843,17 +1844,18 @@ emitAssociatedFunctionReference(
     DifferentiationInvoker invoker,
     std::function<void(DifferentiationTask *)> taskCallback) {
 
-  // If `original` is itself an `AutoDiffFunctionExtractInst` whose VJP matches
-  // the desired differentiation parameter indices, simply extract its VJP,
-  // retain it, and return it.
+  // If `original` is itself an `AutoDiffFunctionExtractInst` whose kind matches
+  // the given kind and desired differentiation parameter indices, simply
+  // extract the associated function of its function operand, retain the
+  // associated function, and return it.
   if (auto *inst = original->getDefiningInstruction()) {
     if (auto *adfei = dyn_cast<AutoDiffFunctionExtractInst>(inst)) {
       if (adfei->getExtractee() == AutoDiffFunctionExtractee::Original) {
         builder.createRetainValue(original.getLoc(), adfei->getFunctionOperand(),
                                   builder.getDefaultAtomicity());
         SILValue assocFn = builder.createAutoDiffFunctionExtract(
-            original.getLoc(), AutoDiffFunctionExtractee::VJP,
-            /*differentiationOrder*/ 1, adfei->getFunctionOperand());
+            original.getLoc(), kind, /*differentiationOrder*/ 1,
+            adfei->getFunctionOperand());
         auto autodiffFnType =
             adfei->getFunctionOperand()->getType().castTo<SILFunctionType>();
         if (autodiffFnType->getDifferentiationParameterIndices().test(

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -24,4 +24,12 @@ CustomDerivativesTests.test("Make a differentiable function") {
   expectEqual(20, gradient(at: 10, in: diffableFoo))
 }
 
+CustomDerivativesTests.test("Differentiation of @autodiff function") {
+  let diffableFoo = differentiableFunction { x in
+    (value: foo(x), pullback: { v in v * x * 2 })
+  }
+  let diffableFooWrapper: @autodiff (Float) -> Float = { x in diffableFoo(x) }
+  expectEqual(20, gradient(at: 10, in: diffableFooWrapper))
+}
+
 runAllTests()

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -28,8 +28,7 @@ CustomDerivativesTests.test("Differentiation of @autodiff function") {
   let diffableFoo = differentiableFunction { x in
     (value: foo(x), pullback: { v in v * x * 2 })
   }
-  let diffableFooWrapper: @autodiff (Float) -> Float = { x in diffableFoo(x) }
-  expectEqual(20, gradient(at: 10, in: diffableFooWrapper))
+  expectEqual(20, gradient(at: 10, in: { x in diffableFoo(x) }))
 }
 
 runAllTests()


### PR DESCRIPTION
Given an `AutoDiffFunctionExtractInst` in PrimalGen, get its VJP by
simply extracting the VJP of its function operand.

Thanks for detailed guidance from @rxwei.