### PR TITLE
[benchmark] Janitor Duty: Lexicon Legacy

### DIFF
--- a/benchmark/single-source/DeadArray.swift
+++ b/benchmark/single-source/DeadArray.swift
@@ -16,7 +16,9 @@ import TestsUtils
 public let DeadArray = BenchmarkInfo(
   name: "DeadArray",
   runFunction: run_DeadArray,
-  tags: [.regression, .unstable])
+  tags: [.regression, .unstable],
+  legacyFactor: 200
+)
 
 @inline(__always)
 func debug(_ m:String) {}
@@ -28,7 +30,7 @@ func bar() { Count += 1 }
 
 @inline(never)
 func runLoop(_ var1: Int, var2: Int) {
-  for _ in 0..<100_000 {
+  for _ in 0..<500 {
     debug("Var1: \(var1) Var2: \(var2)")
     bar()
   }
@@ -40,5 +42,5 @@ public func run_DeadArray(_ N: Int) {
     Count = 0
     runLoop(0, var2: 0)
   }
-  CheckResults(Count == 100_000)
+  CheckResults(Count == 500)
 }

--- a/benchmark/single-source/DictTest.swift
+++ b/benchmark/single-source/DictTest.swift
@@ -16,11 +16,13 @@ import TestsUtils
 public let Dictionary = [
   BenchmarkInfo(name: "Dictionary", runFunction: run_Dictionary,
     tags: [.validation, .api, .Dictionary],
-    setUpFunction: { blackHole(half) }),
+    setUpFunction: { blackHole(half) },
+    legacyFactor: 5),
   BenchmarkInfo(name: "DictionaryOfObjects",
     runFunction: run_DictionaryOfObjects,
     tags: [.validation, .api, .Dictionary],
-    setUpFunction: { blackHole(halfObjects) }),
+    setUpFunction: { blackHole(halfObjects) },
+    legacyFactor: 5),
 ]
 
 let text = [
@@ -132,9 +134,8 @@ let half: Dictionary<String, Bool> = {
 }()
 
 @inline(never)
-public func run_Dictionary(scale: Int) {
+public func run_Dictionary(N: Int) {
   var dict: Dictionary<String, Bool> = [:]
-  let N = 5*scale
 
   // Check performance of filling the dictionary:
   for _ in 1...N {
@@ -186,9 +187,8 @@ let halfObjects: Dictionary<Box<String>, Box<Bool>> = {
 }()
 
 @inline(never)
-public func run_DictionaryOfObjects(scale: Int) {
+public func run_DictionaryOfObjects(N: Int) {
   var dict: Dictionary<Box<String>, Box<Bool>> = [:]
-  let N = 5*scale
 
   // Check performance of filling the dictionary:
   for _ in 1...N {

--- a/benchmark/single-source/DictTest2.swift
+++ b/benchmark/single-source/DictTest2.swift
@@ -13,8 +13,14 @@
 import TestsUtils
 
 public let Dictionary2 = [
-  BenchmarkInfo(name: "Dictionary2", runFunction: run_Dictionary2, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "Dictionary2OfObjects", runFunction: run_Dictionary2OfObjects, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "Dictionary2",
+    runFunction: run_Dictionary2,
+    tags: [.validation, .api, .Dictionary],
+    legacyFactor: 5),
+  BenchmarkInfo(name: "Dictionary2OfObjects",
+    runFunction: run_Dictionary2OfObjects,
+    tags: [.validation, .api, .Dictionary],
+    legacyFactor: 5),
 ]
 
 @inline(never)
@@ -22,7 +28,7 @@ public func run_Dictionary2(_ N: Int) {
   let size = 500
   let ref_result = 199
   var res = 0
-  for _ in 1...5*N {
+  for _ in 1...N {
     var x: [String: Int] = [:]
     for i in 1...size {
       x[String(i, radix:16)] = i
@@ -64,7 +70,7 @@ public func run_Dictionary2OfObjects(_ N: Int) {
   let size = 500
   let ref_result = 199
   var res = 0
-  for _ in 1...5*N {
+  for _ in 1...N {
     var x: [Box<String>:Box<Int>] = [:]
     for i in 1...size {
       x[Box(String(i, radix:16))] = Box(i)

--- a/benchmark/single-source/DictionaryCompactMapValues.swift
+++ b/benchmark/single-source/DictionaryCompactMapValues.swift
@@ -2,8 +2,14 @@
 import TestsUtils
 
 public let DictionaryCompactMapValues = [
-  BenchmarkInfo(name: "DictionaryCompactMapValuesOfNilValue", runFunction: run_DictionaryCompactMapValuesOfNilValue, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "DictionaryCompactMapValuesOfCastValue", runFunction: run_DictionaryCompactMapValuesOfCastValue, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionaryCompactMapValuesOfNilValue",
+    runFunction: run_DictionaryCompactMapValuesOfNilValue,
+    tags: [.validation, .api, .Dictionary],
+    legacyFactor: 50),
+  BenchmarkInfo(name: "DictionaryCompactMapValuesOfCastValue",
+    runFunction: run_DictionaryCompactMapValuesOfCastValue,
+    tags: [.validation, .api, .Dictionary],
+    legacyFactor: 50),
 ]
 
 @inline(never)
@@ -27,7 +33,7 @@ public func run_DictionaryCompactMapValuesOfNilValue(_ N: Int) {
   }
 
   var newDict = [Int: Int]()
-  for _ in 1...1000*N {
+  for _ in 1...20*N {
     newDict = dict.compactMapValues({$0})
     if newDict != refDict {
       break
@@ -41,7 +47,7 @@ public func run_DictionaryCompactMapValuesOfNilValue(_ N: Int) {
 public func run_DictionaryCompactMapValuesOfCastValue(_ N: Int) {
   let size = 100
   var dict = [Int: String](minimumCapacity: size)
-  
+
   // Fill Dictionary
   for i in 1...size {
     if i % 2 == 0 {
@@ -50,7 +56,7 @@ public func run_DictionaryCompactMapValuesOfCastValue(_ N: Int) {
       dict[i] = "\(i)"
     }
   }
-  
+
   CheckResults(dict.count == size)
 
   var refDict = [Int: Int]()
@@ -59,13 +65,12 @@ public func run_DictionaryCompactMapValuesOfCastValue(_ N: Int) {
   }
 
   var newDict = [Int: Int]()
-  for _ in 1...1000*N {
+  for _ in 1...20*N {
     newDict = dict.compactMapValues(Int.init)
     if newDict != refDict {
       break
     }
   }
-  
+
   CheckResults(newDict == refDict)
 }
-

--- a/benchmark/single-source/DictionaryLiteral.swift
+++ b/benchmark/single-source/DictionaryLiteral.swift
@@ -17,7 +17,8 @@ import TestsUtils
 public let DictionaryLiteral = BenchmarkInfo(
   name: "DictionaryLiteral",
   runFunction: run_DictionaryLiteral,
-  tags: [.validation, .api, .Dictionary])
+  tags: [.validation, .api, .Dictionary],
+  legacyFactor: 10)
 
 @inline(never)
 func makeDictionary() -> [Int: Int] {
@@ -26,7 +27,7 @@ func makeDictionary() -> [Int: Int] {
 
 @inline(never)
 public func run_DictionaryLiteral(_ N: Int) {
-  for _ in 1...10000*N {
+  for _ in 1...1000*N {
     _ = makeDictionary()
   }
 }

--- a/benchmark/single-source/DictionaryRemove.swift
+++ b/benchmark/single-source/DictionaryRemove.swift
@@ -14,9 +14,13 @@
 // rdar://problem/19804127
 import TestsUtils
 
+let t: [BenchmarkCategory] = [.validation, .api, .Dictionary]
+
 public let DictionaryRemove = [
-  BenchmarkInfo(name: "DictionaryRemove", runFunction: run_DictionaryRemove, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "DictionaryRemoveOfObjects", runFunction: run_DictionaryRemoveOfObjects, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionaryRemove",
+    runFunction: run_DictionaryRemove, tags: t, legacyFactor: 10),
+  BenchmarkInfo(name: "DictionaryRemoveOfObjects",
+    runFunction: run_DictionaryRemoveOfObjects, tags: t, legacyFactor: 100),
 ]
 
 @inline(never)
@@ -31,7 +35,7 @@ public func run_DictionaryRemove(_ N: Int) {
     CheckResults(dict.count == size)
 
     var tmpDict = dict
-    for _ in 1...1000*N {
+    for _ in 1...100*N {
         tmpDict = dict
         // Empty dictionary
         for i in 1...size {
@@ -73,7 +77,7 @@ public func run_DictionaryRemoveOfObjects(_ N: Int) {
     CheckResults(dict.count == size)
 
     var tmpDict = dict
-    for _ in 1...1000*N {
+    for _ in 1...10*N {
         tmpDict = dict
         // Empty dictionary
         for i in 1...size {

--- a/benchmark/single-source/DictionarySubscriptDefault.swift
+++ b/benchmark/single-source/DictionarySubscriptDefault.swift
@@ -21,15 +21,12 @@ public let DictionarySubscriptDefault = [
                 tags: [.validation, .api, .Dictionary]),
   BenchmarkInfo(name: "DictionarySubscriptDefaultMutationOfObjects",
                 runFunction: run_DictionarySubscriptDefaultMutationOfObjects,
-                tags: [.validation, .api, .Dictionary]),
+                tags: [.validation, .api, .Dictionary], legacyFactor: 20),
   BenchmarkInfo(name: "DictionarySubscriptDefaultMutationArrayOfObjects",
                 runFunction:
                   run_DictionarySubscriptDefaultMutationArrayOfObjects,
-                tags: [.validation, .api, .Dictionary]),
+                tags: [.validation, .api, .Dictionary], legacyFactor: 20),
 ]
-
-let count = 10_000
-let result = count / 100
 
 @inline(never)
 public func run_DictionarySubscriptDefaultMutation(_ N: Int) {
@@ -37,12 +34,12 @@ public func run_DictionarySubscriptDefaultMutation(_ N: Int) {
 
     var dict = [Int: Int]()
 
-    for i in 0..<count {
+    for i in 0..<10_000 {
       dict[i % 100, default: 0] += 1
     }
 
     CheckResults(dict.count == 100)
-    CheckResults(dict[0]! == result)
+    CheckResults(dict[0]! == 100)
   }
 }
 
@@ -52,12 +49,12 @@ public func run_DictionarySubscriptDefaultMutationArray(_ N: Int) {
 
     var dict = [Int: [Int]]()
 
-    for i in 0..<count {
+    for i in 0..<10_000 {
       dict[i % 100, default: []].append(i)
     }
 
     CheckResults(dict.count == 100)
-    CheckResults(dict[0]!.count == result)
+    CheckResults(dict[0]!.count == 100)
   }
 }
 
@@ -99,26 +96,26 @@ public func run_DictionarySubscriptDefaultMutationOfObjects(_ N: Int) {
 
     var dict = [Box<Int>: Box<Int>]()
 
-    for i in 0..<count {
-      dict[Box(i % 100), default: Box(0)].mutateValue { $0 += 1 }
+    for i in 0..<500 {
+      dict[Box(i % 5), default: Box(0)].mutateValue { $0 += 1 }
     }
 
-    CheckResults(dict.count == 100)
-    CheckResults(dict[Box(0)]!.value == result)
+    CheckResults(dict.count == 5)
+    CheckResults(dict[Box(0)]!.value == 100)
   }
 }
 
 @inline(never)
 public func run_DictionarySubscriptDefaultMutationArrayOfObjects(_ N: Int) {
-  for _ in 1...N {
+    for _ in 1...N {
 
     var dict = [Box<Int>: [Box<Int>]]()
 
-    for i in 0..<count {
-      dict[Box(i % 100), default: []].append(Box(i))
+    for i in 0..<500 {
+      dict[Box(i % 5), default: []].append(Box(i))
     }
 
-    CheckResults(dict.count == 100)
-    CheckResults(dict[Box(0)]!.count == result)
+    CheckResults(dict.count == 5)
+    CheckResults(dict[Box(0)]!.count == 100)
   }
 }

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -14,11 +14,17 @@
 // rdar://problem/19804127
 import TestsUtils
 
+let t: [BenchmarkCategory] = [.validation, .api, .Dictionary]
+
 public let DictionarySwap = [
-  BenchmarkInfo(name: "DictionarySwap", runFunction: run_DictionarySwap, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "DictionarySwapOfObjects", runFunction: run_DictionarySwapOfObjects, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "DictionarySwapAt", runFunction: run_DictionarySwapAt, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "DictionarySwapAtOfObjects", runFunction: run_DictionarySwapAtOfObjects, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionarySwap",
+    runFunction: run_DictionarySwap, tags: t, legacyFactor: 4),
+  BenchmarkInfo(name: "DictionarySwapOfObjects",
+    runFunction: run_DictionarySwapOfObjects, tags: t, legacyFactor: 40),
+  BenchmarkInfo(name: "DictionarySwapAt",
+    runFunction: run_DictionarySwapAt, tags: t, legacyFactor: 4),
+  BenchmarkInfo(name: "DictionarySwapAtOfObjects",
+    runFunction: run_DictionarySwapAtOfObjects, tags: t, legacyFactor: 40),
 ]
 
 @inline(never)
@@ -33,7 +39,7 @@ public func run_DictionarySwap(_ N: Int) {
     CheckResults(dict.count == size)
 
     var swapped = false
-    for _ in 1...10000*N {
+    for _ in 1...2500*N {
         (dict[25], dict[75]) = (dict[75]!, dict[25]!)
         swapped = !swapped
         if !swappedCorrectly(swapped, dict[25]!, dict[75]!) {
@@ -56,7 +62,7 @@ public func run_DictionarySwapAt(_ N: Int) {
   CheckResults(dict.count == size)
 
   var swapped = false
-  for _ in 1...10000*N {
+  for _ in 1...2500*N {
     let i25 = dict.index(forKey: 25)!
     let i75 = dict.index(forKey: 75)!
 
@@ -104,7 +110,7 @@ public func run_DictionarySwapOfObjects(_ N: Int) {
     CheckResults(dict.count == size)
 
     var swapped = false
-    for _ in 1...10000*N {
+    for _ in 1...250*N {
         let b1 = Box(25)
         let b2 = Box(75)
         (dict[b1], dict[b2]) = (dict[b2]!, dict[b1]!)
@@ -129,7 +135,7 @@ public func run_DictionarySwapAtOfObjects(_ N: Int) {
   CheckResults(dict.count == size)
 
   var swapped = false
-  for _ in 1...10000*N {
+  for _ in 1...250*N {
     let b25 = Box(25)
     let b75 = Box(75)
     let i25 = dict.index(forKey: b25)!


### PR DESCRIPTION
This PR follows-up  #20861, #21413 and #21516. It's a next batch of benchmark clean-up to enable [robust performance measurements](https://forums.swift.org/t/towards-robust-performance-measurement/11490) by adjusting workloads to run in reasonable time (< 1000 μs), minimizing the accumulated error. To maintain long-term performance tracking, it applies [legacy factor](https://github.com/apple/swift/pull/20212) where necessary.

This one's about Dicts...