### PR TITLE
Fix LLDB build when not building the standard library.

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -1,15 +1,29 @@
 # libswiftRemoteMirror.dylib should not have runtime dependencies; it's
 # always built as a shared library.
 if(SWIFT_BUILD_DYNAMIC_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
-  add_swift_target_library(swiftRemoteMirror
-                    SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
-                    SwiftRemoteMirror.cpp
-                    LINK_LIBRARIES
-                      swiftReflection
-                    C_COMPILE_FLAGS
-                      ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
-                    LINK_FLAGS
-                      ${SWIFT_RUNTIME_LINK_FLAGS}
-                    INSTALL_IN_COMPONENT
-                      swift-remote-mirror)
+  if (SWIFT_BUILD_STDLIB)
+    add_swift_target_library(swiftRemoteMirror
+                      SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
+                      SwiftRemoteMirror.cpp
+                      LINK_LIBRARIES
+                        swiftReflection
+                      C_COMPILE_FLAGS
+                        ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
+                      LINK_FLAGS
+                        ${SWIFT_RUNTIME_LINK_FLAGS}
+                      INSTALL_IN_COMPONENT
+                        swift-remote-mirror)
+  else()
+    add_swift_host_library(swiftRemoteMirror
+                      STATIC
+                      SwiftRemoteMirror.cpp
+                      LINK_LIBRARIES
+                        swiftReflection
+                      C_COMPILE_FLAGS
+                        ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
+                      LINK_FLAGS
+                        ${SWIFT_RUNTIME_LINK_FLAGS}
+                      INSTALL_IN_COMPONENT
+                        swift-remote-mirror)
+  endif()
 endif()


### PR DESCRIPTION
When building the tools (SWIFT_INCLUDE_TOOLS), but not the standard library,
the reflection target needs to generate a host library for the tools to link
to. This was working by chance before, but the recent-ish build system
changes broke that configuration.
