### PR TITLE
ParseSIL: prevent `_weakLinked` on COFF targets

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1337,6 +1337,8 @@ WARNING(attr_renamed_warning, none,
         "'@%0' has been renamed to '@%1'", (StringRef, StringRef))
 ERROR(attr_name_close_match, none,
       "no attribute named '@%0'; did you mean '@%1'?", (StringRef, StringRef))
+ERROR(attr_unsupported_on_target, none,
+      "attribute '%0' is unsupported on target '%1'", (StringRef, StringRef))
 
 // availability
 ERROR(attr_availability_platform,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -906,7 +906,15 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       !isInSILMode()) {
     diagnose(Loc, diag::only_allowed_in_sil, AttrName);
     DiscardAttribute = true;
-  }  
+  }
+
+  if (Context.LangOpts.Target.isOSBinFormatCOFF()) {
+    if (DK == DAK_WeakLinked) {
+      diagnose(Loc, diag::attr_unsupported_on_target, AttrName,
+               Context.LangOpts.Target.str());
+      DiscardAttribute = true;
+    }
+  }
 
   // Filled in during parsing.  If there is a duplicate
   // diagnostic this can be used for better error presentation.

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1009,7 +1009,12 @@ static bool parseDeclSILOptional(bool *isTransparent,
     else if (isGlobalInit && SP.P.Tok.getText() == "global_init")
       *isGlobalInit = true;
     else if (isWeakLinked && SP.P.Tok.getText() == "_weakLinked")
-      *isWeakLinked = true;
+      if (M.getASTContext().LangOpts.Target.isOSBinFormatCOFF())
+        SP.P.diagnose(SP.P.Tok, diag::attr_unsupported_on_target,
+                      SP.P.Tok.getText(),
+                      M.getASTContext().LangOpts.Target.str());
+      else
+        *isWeakLinked = true;
     else if (inlineStrategy && SP.P.Tok.getText() == "noinline")
       *inlineStrategy = NoInline;
     else if (optimizationMode && SP.P.Tok.getText() == "Onone")

--- a/test/IRGen/weakLinked.sil
+++ b/test/IRGen/weakLinked.sil
@@ -1,0 +1,10 @@
+// RUN: %swift -target x86_64-unknown-windows-msvc -emit-ir -verify %s
+
+sil_stage canonical
+
+// expected-error@+1{{attribute '_weakLinked' is unsupported on target 'x86_64-unknown-windows-msvc'}}
+sil [_weakLinked] @f : $@convention(thin) () -> () {
+  %unit = tuple()
+  return %unit : $()
+}
+

--- a/test/Parse/weakLinked.swift
+++ b/test/Parse/weakLinked.swift
@@ -1,0 +1,5 @@
+// RUN: %swift -target x86_64-unknown-windows-msvc -parse-stdlib -typecheck -verify %s
+
+// expected-error@+1{{attribute '_weakLinked' is unsupported on target 'x86_64-unknown-windows-msvc'}}
+@_weakLinked func f() { }
+


### PR DESCRIPTION
PE/COFF does not provide weak linking semantics.  Ensure that we
diagnose use of `_weakLinked` on those targets rather than consuming it
and attempting to generate IR for that.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
