### PR TITLE
[AutoDiff] Add more `Tensor` op adjoint definitions.

### DIFF
--- a/stdlib/public/TensorFlow/CompositeMath.swift
+++ b/stdlib/public/TensorFlow/CompositeMath.swift
@@ -19,31 +19,25 @@
 /// Computes `sigmoid` of the specified tensor element-wise.
 /// Specifically, computes `1 / (1 + exp(-x))`.
 @inlinable @inline(__always)
-public func sigmoid<T>(_ x: Tensor<T>) -> Tensor<T>
-  where T : Differentiable & FloatingPoint
-{
-  return 1 / (1 + exp(-x))
+@differentiable(adjoint: _adjointSigmoid(_:_:_:) where T : Differentiable)
+public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+  return Raw.sigmoid(x)
 }
 
 /// Computes `relu` of the specified tensor element-wise.
 /// Specifically, computes `max(0, x)`.
 @inlinable @inline(__always)
-@differentiable(adjoint: _adjointRelu(_:_:_:))
-public func relu<T>(_ x: Tensor<T>) -> Tensor<T>
-  where T : Differentiable & FloatingPoint
-{
+@differentiable(adjoint: _adjointRelu(_:_:_:) where T : Differentiable)
+public func relu<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return max(0, x)
 }
 
 /// Computes the softmax of the specified tensor element-wise.
-/// Specifically, computes `exp(x) / exp(x).sum()`.
+/// Specifically, computes `exp(x) / exp(x).sum(alongAxes: -1)`.
 @inlinable @inline(__always)
-public func softmax<T>(_ x: Tensor<T>) -> Tensor<T>
-  where T : Differentiable & FloatingPoint
-{
-  let expx = exp(x)
-  let sum = expx.sum()
-  return expx / sum
+@differentiable(adjoint: _adjointSoftmax(_:_:_:) where T : Differentiable)
+public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+  return Raw.softmax(logits: x)
 }
 
 /// Computes the softmax of the specified tensor along the specified axis.

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -398,7 +398,6 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   func _adjointTransposed(
     _ seed: Tensor, _ originalValue: Tensor, _ permutations: Tensor<Int32>
   ) -> Tensor {
-    let seed = seed.broadcast(like: originalValue)
     return seed.transposed(withPermutations: permutations)
   }
 
@@ -406,13 +405,11 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   func _adjointTransposed(
     _ seed: Tensor, _ originalValue: Tensor, _ permutations: [Int32]
   ) -> Tensor {
-    let seed = seed.broadcast(like: originalValue)
     return seed.transposed(withPermutations: permutations)
   }
 
   @inlinable
   func _adjointTransposed(_ seed: Tensor, _ originalValue: Tensor) -> Tensor {
-    let seed = seed.broadcast(like: originalValue)
     return seed.transposed()
   }
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -604,6 +604,10 @@ public extension Tensor {
   /// Returns a transposed tensor, with dimensions permuted in the specified
   /// order.
   @inlinable @inline(__always)
+  @differentiable(
+    wrt: (self), adjoint: _adjointTransposed(_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   func transposed(withPermutations permutations: [Int32]) -> Tensor {
     return transposed(withPermutations: Tensor<Int32>(permutations))
   }
@@ -611,12 +615,20 @@ public extension Tensor {
   /// Returns a transposed tensor, with dimensions permuted in the specified
   /// order.
   @inlinable @inline(__always)
+  @differentiable(
+    wrt: (self), adjoint: _adjointTransposed(_:_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   func transposed(withPermutations permutations: Int32...) -> Tensor {
     return transposed(withPermutations: permutations)
   }
 
   /// Returns a transposed tensor, with dimensions permuted in reverse order.
   @inlinable @inline(__always)
+  @differentiable(
+    wrt: (self), adjoint: _adjointTransposed(_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   func transposed() -> Tensor {
     let defaultPermutations = rankTensor - 1 - Tensor<Int32>(
       rangeFrom: 0, to: rank, stride: 1
@@ -897,17 +909,18 @@ public func min<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the square of the tensor.
 public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
+  @differentiable(
+    wrt: (self), adjoint: _adjointSquared(_:_:)
+    where Scalar : Differentiable & FloatingPoint
+  )
   func squared() -> Tensor {
     return Raw.square(self)
   }
 }
 
-//===----------------------------------------------------------------------===//
-// Non-elementwise math functions
-//===----------------------------------------------------------------------===//
-
 /// Computes the log-softmax of the specified tensor element-wise.
 @inlinable @inline(__always)
+@differentiable(adjoint: _adjointLogSoftmax(_:_:_:) where T : Differentiable)
 public func logSoftmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.logSoftmax(logits: x)
 }


### PR DESCRIPTION
Add adjoint definitions for:
- `Tensor.squared`
- `Tensor.transposed` (all variants)
- `sigmoid`
- `softmax`
- `logSoftmax`

Redundant adjoint definitions for op variants (e.g. all the variants of
`transposed`) can be removed once AD supports generics.