### PR TITLE
test: remove target macro for Windows

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -338,10 +338,6 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
-if run_os == 'windows-msvc':
-  if run_cpu == 'x86_64':
-    config.swift_test_options += ' -Xcc -D_AMD64_'
-
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:
     config.swift_test_options += ' '


### PR DESCRIPTION
The target is now specified by the frontend so we do not need to specify
the target manually.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
