### PR TITLE
[5.0] Reduce compile time for large strongly connected call graphs.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
@@ -15,6 +15,10 @@
 // used by AccessEnforcementOpts to locally fold access scopes and remove
 // dynamic checks based on whole module analysis.
 //
+// This analysis may return conservative results by setting
+// FunctionAccessedStorage.unidentifiedAccess. This does not imply that all
+// accesses within the function have Unidentified AccessedStorage.
+//
 // Note: This interprocedural analysis can be easily augmented to simultaneously
 // compute FunctionSideEffects, without using a separate analysis, by adding
 // FunctionSideEffects as a member of FunctionAccessedStorage. However, passes
@@ -125,7 +129,10 @@ namespace swift {
 /// additional StorageAccessInfo bits are recorded as results of this analysis.
 ///
 /// Any unidentified accesses are summarized as a single unidentifiedAccess
-/// property.
+/// property. This property may also be used to conservatively summarize
+/// results, either because the call graph is unknown or the access sets are too
+/// large. It does not imply that all accesses have Unidentified
+/// AccessedStorage, which is never allowed for class or global access.
 class FunctionAccessedStorage {
   using AccessedStorageSet = llvm::SmallDenseSet<StorageAccessInfo, 8>;
 
@@ -163,6 +170,9 @@ public:
     storageAccessSet.clear();
     unidentifiedAccess = None;
   }
+
+  /// Return true if these effects are fully conservative.
+  bool hasWorstEffects() { return unidentifiedAccess == SILAccessKind::Modify; }
 
   /// Sets the most conservative effects, if we don't know anything about the
   /// function.

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -15,11 +15,11 @@
 ///
 /// This maps each access of identified storage onto a disjoint access
 /// location. Local accesses (Box and Stack) already have unique AccessedStorage
-/// and should be removed by an earlier function pass. This pass handles Class
-/// and Global access by partitioning their non-unique AccessedStorage objects
-/// into unique DisjointAccessLocations. These disjoint access locations may be
-/// accessed across multiple functions, so a module pass is required to identify
-/// and optimize them.
+/// and should be removed by an earlier function pass if possible. This pass
+/// handles Class and Global access by partitioning their non-unique
+/// AccessedStorage objects into unique DisjointAccessLocations. These disjoint
+/// access locations may be accessed across multiple functions, so a module pass
+/// is required to identify and optimize them.
 ///
 /// Class accesses are partitioned by their fully qualified property
 /// name. Global accesses are partitioned by the global variable name. Argument
@@ -48,7 +48,9 @@
 ///
 /// Note: This optimization must be aware of all possible access to a Class or
 /// Global address. This includes unpaired access instructions and keypath
-/// instructions. Ignoring any access pattern would weaken enforcement.
+/// instructions. Ignoring any access pattern would weaken enforcement. For
+/// example, AccessedStorageAnalysis cannot be used here because that analysis
+/// may conservatively summarize some functions.
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "access-enforcement-wmo"


### PR DESCRIPTION
Improves SwiftSyntax release build speed by 4x.

Limit the size of the sets tracked by inter procedural
AccessedStorageAnalysis. There is a lot of leeway in this limit since
"normal" code doesn't come close to hitting it and SwiftSyntax compile
time isn't noticeably affected until 10x this limit.

This change also avoids reanalyzing function bodies once results have
bottomed out and avoids copying sets in the common case.

Fixes <rdar://problem/46905624> Release build time regression, a lot of time spent on AccessEnforcementOpts::run().

This is just a band aid. The fundamental problem is really:
<rdar://problem/47195282> Recomputing BottomUpIPAnalysis takes most of
the SwiftSyntax compile time.

SwiftSyntax compile time is still at least an order of magnitude
longer than it should be.

(cherry picked from commit 5b424694c59844cd4f86a783b549dffeff719fa8)
