### PR TITLE
Pseudo-cherry-pick https://github.com/apple/swift/commit/96691208e9b8…

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -302,12 +302,9 @@ extension String {
 // The @_swift_native_objc_runtime_base attribute
 // This allows us to subclass an Objective-C class and use the fast Swift
 // memory allocator.
-@_fixed_layout // FIXME(sil-serialize-all)
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSStringBase)
-public class __SwiftNativeNSString {
-  @usableFromInline // FIXME(sil-serialize-all)
-  @objc
-  internal init() {}
+class __SwiftNativeNSString {
+  @objc internal init() {}
   deinit {}
 }
 

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -76,9 +76,8 @@ extension _AbstractStringStorage {
       fallthrough
     case (_cocoaUTF8Encoding, _):
       guard maxLength >= count + 1 else { return 0 }
-      let buffer =
-        UnsafeMutableBufferPointer(start: outputPtr, count: maxLength)
-      buffer.initialize(from: UnsafeBufferPointer(start: start, count: count))
+      let buffer = UnsafeMutableBufferPointer(start: outputPtr, count: maxLength)
+      _ = buffer.initialize(from: UnsafeBufferPointer(start: start, count: count))
       buffer[count] = 0
       return 1
     default:

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -1,1 +1,1 @@
-
+Class __SwiftNativeNSString has been removed


### PR DESCRIPTION
Virtually all of the substantive changes made it over already, but a few were missed. This is ABI impacting, so we should take it for 5.0.

cc @airspeedswift 