### PR TITLE
Reduce flakyness in dynamic_attributes.swift test

### DIFF
--- a/stdlib/private/TensorFlowUnittest/TensorFlowUnittest.swift
+++ b/stdlib/private/TensorFlowUnittest/TensorFlowUnittest.swift
@@ -29,6 +29,15 @@ public func expectPointwiseNearlyEqual<T, C1, C2>(
   }
 }
 
+public func expectPointwiseNearlyEqual<T>(
+  _ lhs: ShapedArray<T>, _ rhs: ShapedArray<T>, byError error: T = 0.000001
+) where T : FloatingPoint & ExpressibleByFloatLiteral {
+  precondition(lhs.count == rhs.count, "Scalar count mismatch.")
+  for (l, r) in zip(lhs.scalars, rhs.scalars) {
+    expectNearlyEqual(l, r, byError: error)
+  }
+}
+
 // The following methods help keep the SIL code of our test cases simple.
 @inline(never)
 public func expectNearlyEqualWithScalarTensor<T : FloatingPoint & ExpressibleByFloatLiteral>(

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -238,7 +238,6 @@ DynamicAttributeTests.testAllBackends("NormalAttribute Float") {
   expectEqual(false, result2.scalar!)
 }
 
-#if !CUDA
 DynamicAttributeTests.testAllBackends("NormalAttribute String") {
   let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
                                     T$dtype: Float.tensorFlowDataType,
@@ -246,22 +245,18 @@ DynamicAttributeTests.testAllBackends("NormalAttribute String") {
                                     padding: loadVALIDString())
   expectPointwiseNearlyEqual(convExpectedResult, result.array)
 }
-#endif //!CUDA
 
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Bool>") {
   // There aren't any ops that take bool list attributes!
 }
 
-#if !CUDA
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int32>") {
   let result = convImage.convolved2D(withFilter: convFilter,
                                      strides: loadStridesInt32(),
                                      padding: .valid)
   expectPointwiseNearlyEqual(convExpectedResult, result.array)
 }
-#endif //!CUDA
 
-#if !CUDA
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int64>") {
   let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
                                     T$dtype: Float.tensorFlowDataType,
@@ -269,7 +264,6 @@ DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int64>") {
                                     padding: "VALID")
   expectPointwiseNearlyEqual(convExpectedResult, result.array)
 }
-#endif //!CUDA
 
 DynamicAttributeTests.testAllBackends("NormalAttribute Array<Double>") {
   let input = Tensor<Double>([-1, 0.1, 4.3, 1.2])

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -244,7 +244,7 @@ DynamicAttributeTests.testAllBackends("NormalAttribute String") {
                                     T$dtype: Float.tensorFlowDataType,
                                     strides: [1, 1, 1, 1] as [Int32],
                                     padding: loadVALIDString())
-  expectEqual(convExpectedResult, result.array)
+  expectPointwiseNearlyEqual(convExpectedResult, result.array)
 }
 #endif //!CUDA
 
@@ -257,7 +257,7 @@ DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int32>") {
   let result = convImage.convolved2D(withFilter: convFilter,
                                      strides: loadStridesInt32(),
                                      padding: .valid)
-  expectEqual(convExpectedResult, result.array)
+  expectPointwiseNearlyEqual(convExpectedResult, result.array)
 }
 #endif //!CUDA
 
@@ -267,7 +267,7 @@ DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int64>") {
                                     T$dtype: Float.tensorFlowDataType,
                                     strides: loadStridesInt64(),
                                     padding: "VALID")
-  expectEqual(convExpectedResult, result.array)
+  expectPointwiseNearlyEqual(convExpectedResult, result.array)
 }
 #endif //!CUDA
 


### PR DESCRIPTION
Use expectPointwiseNearlyEqual instead of expectEqual.  This required a creation of a version for ShapedArray. Otherwise, the typechecker crashed. (See https://bugs.swift.org/browse/SR-9640) 

Thanks @dan-zheng for the code snippet. 