### PR TITLE
Update swift-tensorflow-bindings to include ops returning StringTensor.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -219,7 +219,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-11-01-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "c7c0a76f1d6b8ac2057434fbf638b77993c6b88e",
-                "tensorflow-swift-bindings": "6389cbcf37552f161c4f1f6aeb9dfcd4ef04d254"
+                "tensorflow-swift-bindings": "dc646305f9b13e226d16db4be2a8acb96961e5a8"
             }
         }
     }


### PR DESCRIPTION
I just submitted a change to tensorflow-swift-bindings to autogen code for StringTensor ops. Update to that CL.