### PR TITLE
[test] Remove a fixme for requiring optimized stdlib in 32-bit string literal test

### DIFF
--- a/test/SILOptimizer/concat_string_literals.32.swift
+++ b/test/SILOptimizer/concat_string_literals.32.swift
@@ -1,11 +1,9 @@
 // RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck %s
 // RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // We have a separate test for 64-bit architectures.
 // REQUIRES: PTRSIZE=32
-
-// rdar://problem/46096829 - stdlib-DebugAssert builds fail this test
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'
 // CHECK-LABEL: test_ascii_scalar_scalar2


### PR DESCRIPTION
The requirement is valid; debug builds are not expected to pass due to invariant checks etc.

It also matches the 64-bit variant of the same test.

rdar://problem/46096829