### PR TITLE
[gyb] Fix Windows path normalization

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -395,6 +395,8 @@ class ParseContext(object):
 
     def __init__(self, filename, template=None):
         self.filename = os.path.abspath(filename)
+        if sys.platform == 'win32':
+            self.filename = self.filename.replace('\\', '/')
         if template is None:
             with open(filename) as f:
                 self.template = f.read()
@@ -573,8 +575,6 @@ class ExecutionContext(object):
                 # We can only insert the line directive at a line break
                 if len(self.result_text) == 0 \
                    or self.result_text[-1].endswith('\n'):
-                    if sys.platform == 'win32':
-                        file = file.replace('\\', '/')
                     substitutions = {'file': file, 'line': line + 1}
                     format_str = self.line_directive + '\n'
                     self.result_text.append(format_str % substitutions)
@@ -779,7 +779,7 @@ def expand(filename, line_directive=_default_line_directive, **local_bindings):
     ...                    'line: %(line)d)',
     ...     x=2
     ... ).replace(
-    ...   '"%s"' % f.name, '"dummy.file"')
+    ...   '"%s"' % f.name.replace('\\', '/'), '"dummy.file"')
     >>> print(result, end='')
     //#sourceLocation(file: "dummy.file", line: 1)
     ---
@@ -1067,7 +1067,7 @@ def execute_template(
     Keyword arguments become local variable bindings in the execution context
 
     >>> root_directory = os.path.abspath('/')
-    >>> file_name = root_directory + 'dummy.file'
+    >>> file_name = (root_directory + 'dummy.file').replace('\\', '/')
     >>> ast = parse_template(file_name, text=
     ... '''Nothing
     ... % if x:
@@ -1239,7 +1239,7 @@ def main():
 
              Example: `#sourceLocation(file: "%%(file)s", line: %%(line)d)`
 
-             The default works automatically with the `line-directive` tool, 
+             The default works automatically with the `line-directive` tool,
              which see for more information.
              ''')
 


### PR DESCRIPTION
A number of gyb tests (`gyb --test`) were failing on Windows. It appears it was introduced by commit d57b41e which altered the behaviour of line directives to print paths with forward-slashes even on Windows.

This commit changes two areas of `gyb.py`:

1. Doctests use normalized paths where applicable.
2. Path normalization is done early in `ParseContext` initialization instead of when formatting line directives in `ExecutionContext.append_text`.

Resolves [SR-9644](https://bugs.swift.org/browse/SR-9644).