### PR TITLE
[AST] [AutoDiff] Allow an `implicit` flag in `@differentiable` attribute constructor

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -386,7 +386,8 @@ SIMPLE_DECL_ATTR(_nonoverride, NonOverride,
 
 // SWIFT_ENABLE_TENSORFLOW
 DECL_ATTR(differentiable, Differentiable,
-          OnAccessor | OnFunc | OnVar | LongAttribute, 80)
+  OnAccessor | OnFunc | OnVar | LongAttribute | AllowMultipleAttributes,
+  80)
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
                  OnAccessor | OnFunc | OnConstructor | OnSubscript,
                  /* Not serialized */ 81)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1357,8 +1357,8 @@ private:
   /// where clause exists.
   MutableArrayRef<Requirement> Requirements;
 
-  explicit DifferentiableAttr(ASTContext &context, SourceLoc atLoc,
-                              SourceRange baseRange,
+  explicit DifferentiableAttr(ASTContext &context, bool implicit,
+                              SourceLoc atLoc, SourceRange baseRange,
                               ArrayRef<AutoDiffParameter> parameters,
                               Optional<DeclNameWithLoc> primal,
                               Optional<DeclNameWithLoc> adjoint,
@@ -1366,8 +1366,8 @@ private:
                               Optional<DeclNameWithLoc> vjp,
                               TrailingWhereClause *clause);
 
-  explicit DifferentiableAttr(ASTContext &context, SourceLoc atLoc,
-                              SourceRange baseRange,
+  explicit DifferentiableAttr(ASTContext &context, bool implicit,
+                              SourceLoc atLoc, SourceRange baseRange,
                               ArrayRef<AutoDiffParameter> parameters,
                               Optional<DeclNameWithLoc> primal,
                               Optional<DeclNameWithLoc> adjoint,
@@ -1376,8 +1376,8 @@ private:
                               ArrayRef<Requirement> requirements);
 
 public:
-  static DifferentiableAttr *create(ASTContext &context, SourceLoc atLoc,
-                                    SourceRange baseRange,
+  static DifferentiableAttr *create(ASTContext &context, bool implicit,
+                                    SourceLoc atLoc, SourceRange baseRange,
                                     ArrayRef<AutoDiffParameter> parameters,
                                     Optional<DeclNameWithLoc> primal,
                                     Optional<DeclNameWithLoc> adjoint,
@@ -1385,8 +1385,8 @@ public:
                                     Optional<DeclNameWithLoc> vjp,
                                     TrailingWhereClause *clause);
 
-  static DifferentiableAttr *create(ASTContext &context, SourceLoc atLoc,
-                                    SourceRange baseRange,
+  static DifferentiableAttr *create(ASTContext &context, bool implicit,
+                                    SourceLoc atLoc, SourceRange baseRange,
                                     ArrayRef<AutoDiffParameter> parameters,
                                     Optional<DeclNameWithLoc> primal,
                                     Optional<DeclNameWithLoc> adjoint,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1575,6 +1575,7 @@ namespace decls_block {
   // SWIFT_ENABLE_TENSORFLOW
   using DifferentiableDeclAttrLayout = BCRecordLayout<
     Differentiable_DECL_ATTR,
+    BCFixed<1>, // Implicit flag.
     IdentifierIDField, // Primal name.
     DeclIDField, // Primal function declaration.
     IdentifierIDField, // Adjoint name.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1044,15 +1044,15 @@ SpecializeAttr *SpecializeAttr::create(ASTContext &Ctx, SourceLoc atLoc,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-DifferentiableAttr::DifferentiableAttr(ASTContext &context, SourceLoc atLoc,
-                                       SourceRange baseRange,
+DifferentiableAttr::DifferentiableAttr(ASTContext &context, bool implicit,
+                                       SourceLoc atLoc, SourceRange baseRange,
                                        ArrayRef<AutoDiffParameter> parameters,
                                        Optional<DeclNameWithLoc> primal,
                                        Optional<DeclNameWithLoc> adjoint,
                                        Optional<DeclNameWithLoc> jvp,
                                        Optional<DeclNameWithLoc> vjp,
                                        TrailingWhereClause *clause)
-  : DeclAttribute(DAK_Differentiable, atLoc, baseRange, /*Implicit*/false),
+  : DeclAttribute(DAK_Differentiable, atLoc, baseRange, implicit),
     NumParameters(parameters.size()),
     Primal(std::move(primal)), Adjoint(std::move(adjoint)),
     JVP(std::move(jvp)), VJP(std::move(vjp)), WhereClause(clause) {
@@ -1060,15 +1060,15 @@ DifferentiableAttr::DifferentiableAttr(ASTContext &context, SourceLoc atLoc,
             getTrailingObjects<AutoDiffParameter>());
 }
 
-DifferentiableAttr::DifferentiableAttr(ASTContext &context, SourceLoc atLoc,
-                                       SourceRange baseRange,
+DifferentiableAttr::DifferentiableAttr(ASTContext &context, bool implicit,
+                                       SourceLoc atLoc, SourceRange baseRange,
                                        ArrayRef<AutoDiffParameter> parameters,
                                        Optional<DeclNameWithLoc> primal,
                                        Optional<DeclNameWithLoc> adjoint,
                                        Optional<DeclNameWithLoc> jvp,
                                        Optional<DeclNameWithLoc> vjp,
                                        ArrayRef<Requirement> requirements)
-  : DeclAttribute(DAK_Differentiable, atLoc, baseRange, /*Implicit*/false),
+  : DeclAttribute(DAK_Differentiable, atLoc, baseRange, implicit),
     NumParameters(parameters.size()),
     Primal(std::move(primal)), Adjoint(std::move(adjoint)),
     JVP(std::move(jvp)), VJP(std::move(vjp)) {
@@ -1078,8 +1078,8 @@ DifferentiableAttr::DifferentiableAttr(ASTContext &context, SourceLoc atLoc,
 }
 
 DifferentiableAttr *
-DifferentiableAttr::create(ASTContext &context, SourceLoc atLoc,
-                           SourceRange baseRange,
+DifferentiableAttr::create(ASTContext &context, bool implicit,
+                           SourceLoc atLoc, SourceRange baseRange,
                            ArrayRef<AutoDiffParameter> parameters,
                            Optional<DeclNameWithLoc> primal,
                            Optional<DeclNameWithLoc> adjoint,
@@ -1088,14 +1088,15 @@ DifferentiableAttr::create(ASTContext &context, SourceLoc atLoc,
                            TrailingWhereClause *clause) {
   unsigned size = totalSizeToAlloc<AutoDiffParameter>(parameters.size());
   void *mem = context.Allocate(size, alignof(DifferentiableAttr));
-  return new (mem) DifferentiableAttr(context, atLoc, baseRange, parameters,
-                                      std::move(primal), std::move(adjoint),
-                                      std::move(jvp), std::move(vjp), clause);
+  return new (mem) DifferentiableAttr(context, implicit, atLoc, baseRange,
+                                      parameters, std::move(primal),
+                                      std::move(adjoint), std::move(jvp),
+                                      std::move(vjp), clause);
 }
 
 DifferentiableAttr *
-DifferentiableAttr::create(ASTContext &context, SourceLoc atLoc,
-                           SourceRange baseRange,
+DifferentiableAttr::create(ASTContext &context, bool implicit,
+                           SourceLoc atLoc, SourceRange baseRange,
                            ArrayRef<AutoDiffParameter> parameters,
                            Optional<DeclNameWithLoc> primal,
                            Optional<DeclNameWithLoc> adjoint,
@@ -1104,10 +1105,10 @@ DifferentiableAttr::create(ASTContext &context, SourceLoc atLoc,
                            ArrayRef<Requirement> requirements) {
   unsigned size = totalSizeToAlloc<AutoDiffParameter>(parameters.size());
   void *mem = context.Allocate(size, alignof(DifferentiableAttr));
-  return new (mem) DifferentiableAttr(context, atLoc, baseRange, parameters,
-                                      std::move(primal), std::move(adjoint),
-                                      std::move(jvp), std::move(vjp),
-                                      requirements);
+  return new (mem) DifferentiableAttr(context, implicit, atLoc, baseRange,
+                                      parameters, std::move(primal),
+                                      std::move(adjoint), std::move(jvp),
+                                      std::move(vjp), requirements);
 }
 
 void DifferentiableAttr::setRequirements(ASTContext &context,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -858,7 +858,8 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   }
 
   return ParserResult<DifferentiableAttr>(
-    DifferentiableAttr::create(Context, atLoc, SourceRange(loc, rParenLoc),
+    DifferentiableAttr::create(Context, /*implicit*/ false, atLoc,
+                               SourceRange(loc, rParenLoc),
                                params, primalSpec, adjointSpec, jvpSpec,
                                vjpSpec, whereClause));
 }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -520,8 +520,8 @@ getOrSynthesizeVectorSpaceStruct(DerivedConformance &derived,
     if (member->getEffectiveAccess() > AccessLevel::Internal &&
         !member->getAttrs().hasAttribute<DifferentiableAttr>()) {
       auto *diffableAttr = DifferentiableAttr::create(
-          C, SourceLoc(), SourceLoc(), ArrayRef<AutoDiffParameter>(), None,
-          None, None, None, nullptr);
+          C, /*implicit*/ true, SourceLoc(), SourceLoc(), {}, None, None, None,
+          None, nullptr);
       member->getAttrs().add(diffableAttr);
       auto *getterType =
           member->getGetter()->getInterfaceType()->castTo<AnyFunctionType>();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2543,6 +2543,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
 
       // SWIFT_ENABLE_TENSORFLOW
       case decls_block::Differentiable_DECL_ATTR: {
+        bool isImplicit;
         uint64_t primalNameId;
         DeclID primalDeclId;
         uint64_t adjointNameId;
@@ -2555,8 +2556,9 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
         SmallVector<Requirement, 4> requirements;
 
         serialization::decls_block::DifferentiableDeclAttrLayout::readRecord(
-            scratch, primalNameId, primalDeclId, adjointNameId, adjointDeclId,
-            jvpNameId, jvpDeclId, vjpNameId, vjpDeclId, paramValues);
+            scratch, isImplicit, primalNameId, primalDeclId, adjointNameId,
+            adjointDeclId, jvpNameId, jvpDeclId, vjpNameId, vjpDeclId,
+            paramValues);
 
         using FuncSpecifier = DifferentiableAttr::DeclNameWithLoc;
         Optional<FuncSpecifier> primal;
@@ -2596,8 +2598,9 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
         readGenericRequirements(requirements, DeclTypeCursor);
 
         auto diffAttr =
-          DifferentiableAttr::create(ctx, loc, SourceRange(), parameters,
-                                     primal, adjoint, jvp, vjp, requirements);
+          DifferentiableAttr::create(ctx, isImplicit, loc, SourceRange(),
+                                     parameters, primal, adjoint, jvp, vjp,
+                                     requirements);
         diffAttr->setPrimalFunction(primalDecl);
         diffAttr->setAdjointFunction(adjointDecl);
         diffAttr->setJVPFunction(jvpDecl);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2384,8 +2384,8 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
     }
 
     DifferentiableDeclAttrLayout::emitRecord(
-      Out, ScratchRecord, abbrCode, primalName, primalRef, adjointName,
-      adjointRef, jvpName, jvpRef, vjpName, vjpRef, parameters);
+      Out, ScratchRecord, abbrCode, attr->isImplicit(), primalName, primalRef,
+      adjointName, adjointRef, jvpName, jvpRef, vjpName, vjpRef, parameters);
     // TODO: Serialize CheckedParameterIndices.
     writeGenericRequirements(attr->getRequirements(), DeclTypeAbbrCodes);
     return;

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -2,7 +2,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
+// RUN: llvm-bcanalyzer %t/differentiable_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
+
+// BCANALYZER-NOT: UnknownCode
 
 struct CheckpointsFoo {}
 func pfoo(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) {


### PR DESCRIPTION
Since `@differentiable` is sometimes being created implicitly (through derived conformances), the `implicit` flag should be made customizable instead of being set to `false`.