### PR TITLE
Minor typo fix `understimatedCap` -> `underestimatedCap`

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -590,10 +590,10 @@ extension Sequence where Element: StringProtocol {
   internal func _joined(separator: String) -> String {
     // A likely-under-estimate, but lets us skip some of the growth curve
     // for large Sequences.
-    let understimatedCap =
+    let underestimatedCap =
       (1 &+ separator._guts.count) &* self.underestimatedCount
     var result = ""
-    result.reserveCapacity(understimatedCap)
+    result.reserveCapacity(underestimatedCap)
     if separator.isEmpty {
       for x in self {
         result.append(x._ephemeralString)


### PR DESCRIPTION
A tiny typo I noticed when going through the source code. Wasn't sure if its too nit-picky for a PR, but thought I'll push it anyways :) 