### PR TITLE
[sil-optimizer] At -Onone serialize when running the Onone optimizati…

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1248,11 +1248,7 @@ static bool performCompileStepsPostSILGen(
     return serializeSIB(SM.get(), PSPs, Instance.getASTContext(), MSF);
 
   {
-    const bool haveModulePath = PSPs.haveModuleOrModuleDocOutputPaths();
-    if (haveModulePath && !SM->isSerialized())
-      SM->serialize();
-
-    if (haveModulePath) {
+    if (PSPs.haveModuleOrModuleDocOutputPaths()) {
       if (Action == FrontendOptions::ActionType::MergeModules ||
           Action == FrontendOptions::ActionType::EmitModuleOnly) {
         // What if MSF is a module?

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -635,6 +635,9 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
   // Has only an effect if the -gsil option is specified.
   P.addSILDebugInfoGenerator();
 
+  // Finally serialize the SIL if we are asked to.
+  P.addSerializeSILPass();
+
   return P;
 }
 

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -51,7 +51,14 @@ public:
     // to avoid linker errors, the object file of the current module should
     // contain all the symbols which were alive at the time of serialization.
     LLVM_DEBUG(llvm::dbgs() << "Serializing SILModule in SerializeSILPass\n");
-    getModule()->serialize();
+    M.serialize();
+
+    // If we are not optimizing, do not strip the [serialized] flag. We *could*
+    // do this since after serializing [serialized] is irrelevent. But this
+    // would incur an unnecessary compile time cost since if we are not
+    // optimizing we are not going to perform any sort of DFE.
+    if (!getOptions().shouldOptimize())
+      return;
     removeSerializedFlagFromAllFunctions(M);
   }
 };

--- a/test/sil-func-extractor/basic.swift
+++ b/test/sil-func-extractor/basic.swift
@@ -1,16 +1,18 @@
 // Passing demangled name
 
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func="basic.foo" | %FileCheck %s -check-prefix=EXTRACT-FOO
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func="basic.X.test" | %FileCheck %s -check-prefix=EXTRACT-TEST
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func="basic.Vehicle.init" | %FileCheck %s -check-prefix=EXTRACT-INIT
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func="basic.Vehicle.now" | %FileCheck %s -check-prefix=EXTRACT-NOW
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/demangle-ext-foo.sib; %target-sil-func-extractor -module-name basic -func="basic.foo" %t/demangle-ext-foo.sib | %FileCheck %s -check-prefix=EXTRACT-FOO
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/demangle-ext-test.sib; %target-sil-func-extractor -module-name basic -func="basic.X.test" %t/demangle-ext-test.sib | %FileCheck %s -check-prefix=EXTRACT-TEST
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/demangle-ext-init.sib; %target-sil-func-extractor -module-name basic -func="basic.Vehicle.init" %t/demangle-ext-init.sib | %FileCheck %s -check-prefix=EXTRACT-INIT
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/demangle-ext-now.sib; %target-sil-func-extractor -module-name basic -func="basic.Vehicle.now" %t/demangle-ext-now.sib | %FileCheck %s -check-prefix=EXTRACT-NOW
 
 // Passing mangled name
 
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func='$s5basic3fooSiyF' | %FileCheck %s -check-prefix=EXTRACT-FOO
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func='$s5basic1XV4testyyF' | %FileCheck %s -check-prefix=EXTRACT-TEST
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func='$s5basic7VehicleC1nACSi_tcfc' | %FileCheck %s -check-prefix=EXTRACT-INIT
-// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o - | %target-sil-func-extractor -module-name basic -func='$s5basic7VehicleC3nowSiyF' | %FileCheck %s -check-prefix=EXTRACT-NOW
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/mangle-ext-foo.sib; %target-sil-func-extractor -module-name basic -func='$s5basic3fooSiyF' %t/mangle-ext-foo.sib | %FileCheck %s -check-prefix=EXTRACT-FOO
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/mangle-ext-test.sib; %target-sil-func-extractor -module-name basic -func='$s5basic1XV4testyyF' %t/mangle-ext-test.sib | %FileCheck %s -check-prefix=EXTRACT-TEST
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/mangle-ext-init.sib; %target-sil-func-extractor -module-name basic -func='$s5basic7VehicleC1nACSi_tcfc' %t/mangle-ext-init.sib | %FileCheck %s -check-prefix=EXTRACT-INIT
+// RUN: %target-swift-frontend %s -g -module-name basic -emit-sib -o %t/mangle-ext-now.sib; %target-sil-func-extractor -module-name basic -func='$s5basic7VehicleC3nowSiyF' %t/mangle-ext-now.sib | %FileCheck %s -check-prefix=EXTRACT-NOW
 
 
 // EXTRACT-FOO-NOT: sil hidden @$s5basic1XV4testyyF : $@convention(method) (X) -> () {


### PR DESCRIPTION
…on pipeline instead of after running SIL passes.

NOTE: This is not in the mandatory passes (which run before this). This will
enable me to strip out ownership after we serialize without touching frontend
code. It also makes Onone and O use the same code paths for serialization
instead of one happening in the driver (Onone today) and the other in a SIL pass
(-O, -Osize).

The reason that I updated the sil-func-extractor test is that I found a bug in
how we emit sib files, namely if you try to emit a sib file to stdout, the
llvm-bcanalyzer flags it as malformed. If I output the .sib into a file rather
than trying to use stdout, everything works.
