### PR TITLE
Remove comment that is no longer true.

### DIFF
--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -520,7 +520,6 @@ ValueOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *BI) {
 //===----------------------------------------------------------------------===//
 
 ValueOwnershipKind SILValue::getOwnershipKind() const {
-  // Once we have multiple return values, this must be changed.
   ValueOwnershipKindClassifier Classifier;
   return Classifier.visit(const_cast<ValueBase *>(Value));
 }


### PR DESCRIPTION
This code was updated for multiple return values (the SILValue in that case is a
MultipleInstructionResult and we can just ask those for their ownership kind).