### PR TITLE
[sil] Add SILBuilder helpers for updating passes to handle both ossa …

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -673,11 +673,11 @@ static void explodeTuple(SILGenFunction &SGF, SILLocation loc,
   bool isPlusOne = managedTuple.hasCleanup();
 
   if (managedTuple.getType().isAddress()) {
-    SGF.B.emitShallowDestructureAddressOperation(loc, managedTuple.forward(SGF),
-                                                 elements);
+    SGF.B.emitDestructureAddressOperation(loc, managedTuple.forward(SGF),
+                                          elements);
   } else {
-    SGF.B.emitShallowDestructureValueOperation(loc, managedTuple.forward(SGF),
-                                               elements);
+    SGF.B.emitDestructureValueOperation(loc, managedTuple.forward(SGF),
+                                        elements);
   }
 
   for (auto element : elements) {


### PR DESCRIPTION
…and non-ossa code.

Specifically we add two groups of APIs: ones for borrows and ones for
destructure.

The borrow helper (emitBeginBorrowOperation) makes it easier to update passes
by:

* If ownership is disabled, the passed in intruction is just returned.
* Otherwise if the value is already guaranteed, return an empty SILValue(). This
  is useful since when writing a recursive function it enables one to tell if
  one needs to insert an end_borrow or not.
* Otherwise, we return (begin_borrow x).

The destructure helpers are a family of functions built around
emitDestructureValueOperation. These in ossa produce destructures and pass the
results off to the caller in some manner that hides the internal destructure
instruction. In non-ossa, the appropriate projections are created and passed off
to the caller.
