### PR TITLE
[AutoDiff] Fix activity analysis for side-effecting instructions.

### DIFF
--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -9,4 +9,34 @@ func simpleStoreLoad(x: Float) -> Float {
 // expected-error @+1 {{function is not differentiable}}
 let _: @autodiff (Float) -> Float = simpleStoreLoad(x:)
 
+var global: Float = 10
+
+// Test differentiation of write to non-useful global variable.
+let _: @autodiff (Float) -> Float = { x in
+  global = x
+  return x * x
+}
+
+// Test differentiation of write to non-useful local variable.
+let _: @autodiff (Float) -> Float = { x in
+  var local = x // expected-warning {{initialization of variable 'local' was never used}}
+  return x + x
+}
+
+// Test differentiation of write to useful global variable.
+// expected-error @+1 {{function is not differentiable}}
+let _: @autodiff (Float) -> Float = { x in
+  global = x
+  // expected-note @+1 {{expression is not differentiable}}
+  return global + x
+}
+
+// Test differentiation of write to useful local variable.
+// expected-error @+1 {{function is not differentiable}}
+let _: @autodiff (Float) -> Float = { x in
+  var local = x // expected-warning {{variable 'local' was never mutated}}
+  // expected-note @+1 {{expression is not differentiable}}
+  return local + x
+}
+
 // TODO: Add file checks.


### PR DESCRIPTION
- Now, all address-operands of side-effecting instructions are marked as
  useful only if any result is useful.
  - This enables differentiation of non-useful mutation (so functions can
    mutate outside state).
  - Previously, all address-operands and results of side-effecting
    instructions were unconditionally marked as useful.

- If the source of an "modifying" side-effecting instruction
  (e.g. `store` or `copy_addr`) is varied, recursively mark results
  and their operands as varied.