### PR TITLE
build: install the libdispatch dependencies into the right location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,12 +977,24 @@ if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
   add_dependencies(dispatch libdispatch-install)
   add_dependencies(BlocksRuntime libdispatch-install)
 
+  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
+    set(SOURCEKIT_RUNTIME_DIR bin)
+  else()
+    set(SOURCEKIT_RUNTIME_DIR lib)
+  endif()
   swift_install_in_component(sourcekit-inproc
                              FILES
                                $<TARGET_FILE:dispatch>
                                $<TARGET_FILE:BlocksRuntime>
-                             DESTINATION
-                               lib${LLVM_LIBDIR_SUFFIX})
+                             DESTINATION ${SOURCEKIT_RUNTIME_DIR})
+  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
+    swift_install_in_component(sourcekit-inproc
+                               FILES
+                                 $<TARGET_LINKER_FILE:dispatch>
+                                 $<TARGET_LINKER_FILE:BlocksRuntime>
+                               DESTINATION lib)
+  endif()
+
 
   # FIXME(compnerd) this should be taken care of by the
   # INTERFACE_INCLUDE_DIRECTORIES above


### PR DESCRIPTION
On Windows targets, the runtime components are installed into bin, the link time
components are installed into lib.  In order to accomodate this, we need to
install via the TARGETS type rather than FILES.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
