### PR TITLE
build: make libxml2 handling explicit and use in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,12 +883,11 @@ find_package(PythonInterp REQUIRED)
 # Find optional dependencies.
 #
 
-# Find libxml.
-# FIXME: unify with CLANG_HAVE_LIBXML, which is set in LLVM anyway.
-find_package(LibXml2)
-option(SWIFT_HAVE_LIBXML
-    "Whether to build with libxml"
-    ${LIBXML2_FOUND})
+if(LLVM_ENABLE_LIBXML2)
+  find_package(Libxml2 REQUIRED)
+else()
+  find_package(LibXml2)
+endif()
 
 # You need libedit linked in order to check if you have el_wgets.
 cmake_push_check_state()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -172,6 +172,12 @@ foreach(SDK ${SWIFT_SDKS})
     set(validation_test_bin_dir
         "${CMAKE_CURRENT_BINARY_DIR}/../validation-test${VARIANT_SUFFIX}")
 
+    if(LibXml2_FOUND)
+      set(SWIFT_HAVE_LIBXML2 TRUE)
+    else()
+      set(SWIFT_HAVE_LIBXML2 FALSE)
+    endif()
+
     swift_configure_lit_site_cfg(
         "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
         "${test_bin_dir}/lit.site.cfg"

--- a/test/IDE/comment_to_xml.swift
+++ b/test/IDE/comment_to_xml.swift
@@ -6,4 +6,5 @@
 // RUN: %FileCheck %s -check-prefix=WRONG < %t.txt
 
 // REQUIRES: no_asan
+// REQUIRES: libxml2
 // WRONG-NOT: CommentXMLInvalid

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -91,6 +91,9 @@ if "@SWIFT_BUILD_SYNTAXPARSERLIB@" == "TRUE":
 if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
     config.available_features.add('sourcekit')
 
+if "@SWIFT_HAVE_LIBXML2@" == "TRUE":
+    config.available_features.add('libxml2')
+
 if "@SWIFT_ENABLE_LLD_LINKER@" == "TRUE":
     config.android_linker_name = "lld"
 else:

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -11,10 +11,10 @@ target_link_libraries(swift-ide-test
                         swiftIDE)
 
 # If libxml2 is available, make it available for swift-ide-test.
-if(SWIFT_HAVE_LIBXML)
+if(LibXml2_FOUND)
   include_directories(SYSTEM ${LIBXML2_INCLUDE_DIR})
   target_link_libraries(swift-ide-test PRIVATE ${LIBXML2_LIBRARIES})
-  add_definitions(-DSWIFT_HAVE_LIBXML="1")
+  target_compile_definitions(swift-ide-test PRIVATE SWIFT_HAVE_LIBXML=1)
 endif()
 
 # Create a symlink for swift-api-dump.py in the bin directory


### PR DESCRIPTION
Address the TODO in the build and unify the libxml2 handling with
LLVM/clang.  Use the information now and propagate this into the lit
configuration so that tests can be made aware of libxml2 status.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
