### PR TITLE
[Sema] Look through OpenExistentialExpr in checkIgnoreExpr()

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1312,6 +1312,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       return checkIgnoredExpr(IIO->getSubExpr());
     if (auto *C = dyn_cast<CallExpr>(OEE->getSubExpr()))
       return checkIgnoredExpr(C);
+    if (auto *OE = dyn_cast<OpenExistentialExpr>(OEE->getSubExpr()))
+      return checkIgnoredExpr(OE);
   }
 
   if (auto *LE = dyn_cast<LiteralExpr>(valueE)) {

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -194,3 +194,20 @@ class SR7562_B : SR7562_A {}
 
 SR7562_A(input: 10) // okay
 SR7562_B(input: 10) // okay
+
+protocol FooProtocol {}
+
+extension FooProtocol {
+  @discardableResult
+  static func returnSomething() -> Bool? {
+    return true
+  }
+}
+
+class Foo {
+  var myOptionalFooProtocol: FooProtocol.Type?
+  
+  func doSomething() {
+    myOptionalFooProtocol?.returnSomething() // okay
+  }
+}


### PR DESCRIPTION
This PR fixes an issue where the `DiscardableResultAttr` would be ignored if the sub-expression of an `OptionalEvaluationExpr` was an `OpenExistentialExpr`.

Example:

```swift
protocol FooProtocol {}

extension FooProtocol {
  @discardableResult
  static func returnSomething() -> Bool? {
    return true
  }
}

class Foo {
  var myOptionalFooProtocol: FooProtocol.Type?

  func doSomething() {
    myOptionalFooProtocol?.returnSomething() // Expression of type 'Bool?' is unused
  }
}
```

Resolves [SR-9646](https://bugs.swift.org/browse/SR-9646).