### PR TITLE
Mark another thorough String test as requiring an optimized stdlib

### DIFF
--- a/validation-test/stdlib/StringNormalization.swift
+++ b/validation-test/stdlib/StringNormalization.swift
@@ -22,6 +22,7 @@
 // RUN: %target-run %t/a.out %S/Inputs/NormalizationTest.txt
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: optimized_stdlib
 
 import Swift
 import StdlibUnittest


### PR DESCRIPTION
This one's taking a pretty long time on simulators, only sometimes making it under the timeout limit.