### PR TITLE
[stdlib] [AutoDiff] Temporarily export API `_valueWithPullback(at:_:in:)` for methods.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -215,6 +215,16 @@ public func valueWithPullback<T, U, V, R>(
   return Builtin.autodiffApply_vjp_arity3(f, x, y, z)
 }
 
+// NOTE: This is not an official API.
+// TODO: Remove this once we flesh out differentiability for curried functions.
+@inlinable
+public func _valueWithPullback<T, U, R>(
+  at x: T, _ y: U, in f: @autodiff (T) -> (U) -> R
+) -> (value: R, pullback: (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector))
+  where T : Differentiable, U : Differentiable, R : Differentiable {
+  return Builtin.autodiffApply_vjp_method(f, x, y)
+}
+
 // Pullback
 
 @inlinable

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-simple-parse-stdlib-swift
+// RUN: %target-run-simple-swift
 
-import Swift
 import StdlibUnittest
 
 var ProtocolRequirementAutodiffTests = TestSuite("ProtocolRequirementAutodiff")
@@ -9,7 +8,8 @@ func _pullback<T, U, R>(
   at x: (T, U), in f: @autodiff (T) -> (U) -> R
 ) -> (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable, R : Differentiable {
-  return Builtin.autodiffApply_vjp_method(f, x.0, x.1).1
+  // Builtin.autodiffApply_vjp_method(f, x.0, x.1).1
+  return _valueWithPullback(at: x.0, x.1, in: f).1
 }
 
 protocol DiffReq : Differentiable {


### PR DESCRIPTION
Differentiating a method should be as simple as calling the method in the trailing closure of a differential operator. However, that is limited due to the fact that AD cannot differentiate generic functions yet. This PR exports differential operator `_valueWithPullback(at:_:in:)`, which wraps `Builtin.autodiffApply_vjp_method`. This makes it possible to define machine learning abstractions that take the derivative of differentiable protocol requirements.