### PR TITLE
Fix test case regressions on s390x arch

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1113,7 +1113,7 @@ protected:
       case MetadataKind::Tuple: {
         auto numElementsAddress = address +
           TargetTupleTypeMetadata<Runtime>::getOffsetToNumElements();
-        uint32_t numElements;
+        StoredSize numElements;
         if (!Reader->readInteger(RemoteAddress(numElementsAddress),
                                  &numElements))
           return nullptr;


### PR DESCRIPTION
Code refactoring in `Remote/MetadataReader.h` resulted in RemoteAST test case failures on s390x architecture.  Specifically, `RemoteAST/structural_types.swift`

Problems happens in `MetadataRef readMetadata(StoredPointer address)` method when a Tuple metadata is read.  On s390x architecture, numElements, is returned correctly when its type is restored back to StoredSize.