### PR TITLE
[5.0] SILCombine: fix a miscompile caused by dead-apply elimination

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -282,6 +282,9 @@ public:
     return LiveBlocks.count(BB) && BB != DefValue->getParent();
   }
 
+  /// Checks if there is a dealloc_ref inside the value's live range.
+  bool containsDeallocRef(const Frontier &Frontier);
+
   /// For debug dumping.
   void dump() const;
 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1980,6 +1980,89 @@ bb3:
   return %0 : $B
 }
 
+// CHECK-LABEL: sil @dont_delete_readonly_function_dealloc_ref_simple
+// CHECK:      apply
+// CHECK-NEXT: dealloc_ref
+// CHECK:      return
+sil @dont_delete_readonly_function_dealloc_ref_simple : $@convention(thin) () -> () {
+bb0:
+  %3 = alloc_ref [stack] $B
+  %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
+  %r = apply %f(%3) : $@convention(thin) (@owned B) -> @owned B
+  dealloc_ref [stack] %3 : $B
+  strong_release %r : $B
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @dont_delete_readonly_function_dealloc_ref_multibb
+// CHECK:      apply
+// CHECK:      dealloc_ref
+// CHECK-NEXT: strong_release
+// CHECK:      dealloc_ref
+// CHECK-NEXT: strong_release
+// CHECK:      return
+sil @dont_delete_readonly_function_dealloc_ref_multibb : $@convention(thin) () -> () {
+bb0:
+  %3 = alloc_ref [stack] $B
+  %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
+  %r = apply %f(%3) : $@convention(thin) (@owned B) -> @owned B
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_ref [stack] %3 : $B
+  strong_release %r : $B
+  br bb3
+
+bb2:
+  dealloc_ref [stack] %3 : $B
+  strong_release %r : $B
+  br bb3
+
+bb3:
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @delete_readonly_function_dealloc_ref_simple
+// CHECK-NOT:  apply
+// CHECK:      return
+sil @delete_readonly_function_dealloc_ref_simple : $@convention(thin) () -> () {
+bb0:
+  %3 = alloc_ref [stack] $B
+  %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
+  %r = apply %f(%3) : $@convention(thin) (@owned B) -> @owned B
+  strong_release %r : $B
+  dealloc_ref [stack] %3 : $B
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @delete_readonly_function_dealloc_ref_multibb
+// CHECK-NOT:  apply
+// CHECK:      return
+sil @delete_readonly_function_dealloc_ref_multibb : $@convention(thin) () -> () {
+bb0:
+  %3 = alloc_ref [stack] $B
+  %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
+  %r = apply %f(%3) : $@convention(thin) (@owned B) -> @owned B
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_release %r : $B
+  dealloc_ref [stack] %3 : $B
+  br bb3
+
+bb2:
+  strong_release %r : $B
+  dealloc_ref [stack] %3 : $B
+  br bb3
+
+bb3:
+  %10 = tuple ()
+  return %10 : $()
+}
+
 //CHECK-LABEL: sil @test_delete_readonly_try_apply
 //CHECK:      bb0(%0 : $ZZZ):
 //CHECK-NEXT:   [[IL:%[0-9]+]] = integer_literal $Builtin.Int1, 0

--- a/test/SILOptimizer/silcombine_runtime_crash.swift
+++ b/test/SILOptimizer/silcombine_runtime_crash.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// This is an end-to-end test for SR-9627.
+
+@inline(never)
+func save(value: Double?) {
+   var params: [[String : Any]] = [["a": 0]]
+   params = [[
+     "b": 0,
+     "c": value.map({ String.init($0) }) as Any
+   ]]
+}
+
+save(value: 0)
+
+// CHECK: ok
+print("ok")


### PR DESCRIPTION
SILCombine ended up moving a strong_release past a dealloc_ref.
fixes https://bugs.swift.org/browse/SR-9627
rdar://problem/47153896
