### PR TITLE
[5.0] Restore initializing entry points for @objc convenience initializers

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2325,6 +2325,7 @@ mark_uninitialized
   mu_kind ::= 'derivedself'
   mu_kind ::= 'derivedselfonly'
   mu_kind ::= 'delegatingself'
+  mu_kind ::= 'delegatingselfallocated'
 
   %2 = mark_uninitialized [var] %1 : $*T
   // $T must be an address
@@ -2345,6 +2346,7 @@ the mark_uninitialized instruction refers to:
 - ``derivedself``: designates ``self`` in a derived (non-root) class
 - ``derivedselfonly``: designates ``self`` in a derived (non-root) class whose stored properties have already been initialized
 - ``delegatingself``: designates ``self`` on a struct, enum, or class in a delegating constructor (one that calls self.init)
+- ``delegatingselfallocated``: designates ``self`` on a class convenience initializer's initializing entry point
 
 The purpose of the ``mark_uninitialized`` instruction is to enable
 definitive initialization analysis for global variables (when marked as

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3654,6 +3654,10 @@ public:
     /// DelegatingSelf designates "self" on a struct, enum, or class
     /// in a delegating constructor (one that calls self.init).
     DelegatingSelf,
+
+    /// DelegatingSelfAllocated designates "self" in a delegating class
+    /// initializer where memory has already been allocated.
+    DelegatingSelfAllocated,
   };
 private:
   Kind ThisKind;
@@ -3682,6 +3686,9 @@ public:
   }
   bool isDelegatingSelf() const {
     return ThisKind == DelegatingSelf;
+  }
+  bool isDelegatingSelfAllocated() const {
+    return ThisKind == DelegatingSelfAllocated;
   }
 };
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -3355,10 +3355,12 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       Kind = MarkUninitializedInst::DerivedSelfOnly;
     else if (KindId.str() == "delegatingself")
       Kind = MarkUninitializedInst::DelegatingSelf;
+    else if (KindId.str() == "delegatingselfallocated")
+      Kind = MarkUninitializedInst::DelegatingSelfAllocated;
     else {
       P.diagnose(KindLoc, diag::expected_tok_in_sil_instr,
                  "var, rootself, crossmodulerootself, derivedself, "
-                 "derivedselfonly, or delegatingself");
+                 "derivedselfonly, delegatingself, or delegatingselfallocated");
       return true;
     }
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1297,6 +1297,9 @@ public:
       *this << "[derivedselfonly] ";
       break;
     case MarkUninitializedInst::DelegatingSelf: *this << "[delegatingself] ";break;
+    case MarkUninitializedInst::DelegatingSelfAllocated:
+      *this << "[delegatingselfallocated] ";
+      break;
     }
     
     *this << getIDAndType(MU->getOperand());

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1390,7 +1390,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
   bool isInitializingToAllocatingInitThunk = false;
   if (native.kind == SILDeclRef::Kind::Initializer) {
     if (auto ctor = dyn_cast<ConstructorDecl>(native.getDecl())) {
-      if (!ctor->isDesignatedInit()) {
+      if (!ctor->isDesignatedInit() && !ctor->isObjC()) {
         isInitializingToAllocatingInitThunk = true;
         native = SILDeclRef(ctor, SILDeclRef::Kind::Allocator);
       }

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -1810,7 +1810,8 @@ collectClassInitSelfLoadUses(MarkUninitializedInst *MUI,
 //===----------------------------------------------------------------------===//
 
 static bool shouldPerformClassInitSelf(const DIMemoryObjectInfo &MemoryInfo) {
-  assert(!MemoryInfo.isDelegatingInit());
+  if (MemoryInfo.MemoryInst->isDelegatingSelfAllocated())
+    return true;
 
   return MemoryInfo.isNonDelegatingInit() &&
          MemoryInfo.getType()->getClassOrBoundGenericClass() != nullptr &&
@@ -1824,18 +1825,18 @@ void swift::ownership::collectDIElementUsesFrom(
     const DIMemoryObjectInfo &MemoryInfo, DIElementUseInfo &UseInfo,
     bool isDIFinished, bool TreatAddressToPointerAsInout) {
 
+  if (shouldPerformClassInitSelf(MemoryInfo)) {
+    ClassInitElementUseCollector UseCollector(MemoryInfo, UseInfo);
+    UseCollector.collectClassInitSelfUses();
+    return;
+  }
+
   if (MemoryInfo.isDelegatingInit()) {
     // When we're analyzing a delegating constructor, we aren't field sensitive
     // at all. Just treat all members of self as uses of the single
     // non-field-sensitive value.
     assert(MemoryInfo.NumElements == 1 && "delegating inits only have 1 bit");
     collectDelegatingInitUses(MemoryInfo, UseInfo, MemoryInfo.MemoryInst);
-    return;
-  }
-
-  if (shouldPerformClassInitSelf(MemoryInfo)) {
-    ClassInitElementUseCollector UseCollector(MemoryInfo, UseInfo);
-    UseCollector.collectClassInitSelfUses();
     return;
   }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -119,9 +119,9 @@ public:
   /// True if the memory object is the 'self' argument of a class designated
   /// initializer.
   bool isClassInitSelf() const {
-    if (isDelegatingInit())
+    if (MemoryInst->isDelegatingSelf())
       return false;
-      
+
     if (!MemoryInst->isVar()) {
       if (auto decl = getType()->getAnyNominal()) {
         if (isa<ClassDecl>(decl)) {
@@ -153,14 +153,13 @@ public:
     return isClassInitSelf() && !MemoryInst->isRootSelf();
   }
 
-  /// isDelegatingInit - True if this is a delegating initializer, one that
-  /// calls 'self.init'.
+  /// True if this is a delegating initializer, one that calls 'self.init'.
   bool isDelegatingInit() const {
-    return MemoryInst->isDelegatingSelf();
+    return MemoryInst->isDelegatingSelf() ||
+           MemoryInst->isDelegatingSelfAllocated();
   }
 
-  /// isNonDelegatingInit - True if this is an initializer that initializes
-  /// stored properties.
+  /// True if this is an initializer that initializes stored properties.
   bool isNonDelegatingInit() const {
     switch (MemoryInst->getKind()) {
     case MarkUninitializedInst::Var:
@@ -171,6 +170,7 @@ public:
     case MarkUninitializedInst::DerivedSelfOnly:
       return true;
     case MarkUninitializedInst::DelegatingSelf:
+    case MarkUninitializedInst::DelegatingSelfAllocated:
       return false;
     }
     return false;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1952,13 +1952,12 @@ void LifetimeChecker::processUninitializedRelease(SILInstruction *Release,
     auto SILMetatypeTy = SILType::getPrimitiveObjectType(MetatypeTy);
     SILValue Metatype;
 
-    // A convenience initializer should never deal in partially allocated
-    // objects.
-    assert(!TheMemory.isDelegatingInit());
-
-    // In a designated initializer, we know the class of the thing
-    // we're cleaning up statically.
-    Metatype = B.createMetatype(Loc, SILMetatypeTy);
+    // In an inherited convenience initializer, we must use the dynamic
+    // type of the object since nothing is initialized yet.
+    if (TheMemory.isDelegatingInit())
+      Metatype = B.createValueMetatype(Loc, SILMetatypeTy, Pointer);
+    else
+      Metatype = B.createMetatype(Loc, SILMetatypeTy);
 
     // We've already destroyed any instance variables initialized by this
     // constructor, now destroy instance variables initialized by subclass

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -433,6 +433,36 @@ if #available(OSX 10.11, iOS 9.0, *) {
 
     KU.finishDecoding()
   }
+
+  FoundationTestSuite.test("NSKeyedUnarchiver/CycleWithConvenienceInit") {
+    @objc(HasACyclicReference)
+    class HasACyclicReference: NSObject, NSCoding {
+      var ref: AnyObject?
+      override init() {
+        super.init()
+        ref = self
+      }
+
+      required convenience init?(coder: NSCoder) {
+        let decodedRef = coder.decodeObject(forKey: "ref") as AnyObject?
+        self.init(ref: decodedRef)
+      }
+      @objc init(ref: AnyObject?) {
+        self.ref = ref
+        super.init()
+      }
+
+      func encode(with coder: NSCoder) {
+        coder.encode(ref, forKey: "ref")
+      }
+    }
+
+    let data = NSKeyedArchiver.archivedData(withRootObject: HasACyclicReference())
+    let decodedObj = NSKeyedUnarchiver.unarchiveObject(with: data) as! HasACyclicReference
+
+    expectEqual(ObjectIdentifier(decodedObj), ObjectIdentifier(decodedObj.ref!),
+                "cycle was not preserved (due to object replacement?)")
+  }
 }
 
 FoundationTestSuite.test("NotificationCenter/addObserver(_:selector:name:object:)") {

--- a/test/Interpreter/SDK/Inputs/convenience_init_peer_delegation.h
+++ b/test/Interpreter/SDK/Inputs/convenience_init_peer_delegation.h
@@ -1,0 +1,14 @@
+@import Foundation;
+
+extern NSInteger baseCounter;
+extern NSInteger subCounter;
+
+@interface Base : NSObject
+- (nonnull instancetype)init __attribute__((objc_designated_initializer));
+- (nonnull instancetype)initConveniently;
++ (nonnull instancetype)baseWithConvenientFactory:(_Bool)unused;
++ (nonnull Base *)baseWithNormalFactory:(_Bool)unused;
+@end
+
+@interface Sub : Base
+@end

--- a/test/Interpreter/SDK/Inputs/convenience_init_peer_delegation.m
+++ b/test/Interpreter/SDK/Inputs/convenience_init_peer_delegation.m
@@ -1,0 +1,40 @@
+#import "convenience_init_peer_delegation.h"
+#include <objc/runtime.h>
+#include <stdio.h>
+
+NSInteger baseCounter = 0;
+NSInteger subCounter = 0;
+
+@implementation Base
++ (nullable id)allocWithZone:(NSZone *)zone {
+  if (self == [Base class])
+    ++baseCounter;
+  else if (self == [Sub class])
+    ++subCounter;
+  return [super allocWithZone: zone];
+}
+
+- (nonnull instancetype)init {
+  fputs("init ", stdout);
+  puts(class_getName([self class]));
+  return self;
+}
+
+- (nonnull instancetype)initConveniently {
+  puts(__FUNCTION__);
+  return [self init];
+}
+
++ (nonnull instancetype)baseWithConvenientFactory:(_Bool)unused {
+  puts(__FUNCTION__);
+  return [[self alloc] init];
+}
+
++ (nonnull Base *)baseWithNormalFactory:(_Bool)unused {
+  puts(__FUNCTION__);
+  return [[Base alloc] init];
+}
+@end
+
+@implementation Sub
+@end

--- a/test/Interpreter/SDK/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/SDK/convenience_init_peer_delegation.swift
@@ -1,0 +1,127 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/convenience_init_peer_delegation.m -o %t/convenience_init_peer_delegation.objc.o -fmodules -fobjc-arc
+// RUN: %target-build-swift -c -o %t/convenience_init_peer_delegation.swift.o -import-objc-header %S/Inputs/convenience_init_peer_delegation.h %s
+// RUN: %target-swiftc_driver %t/convenience_init_peer_delegation.objc.o %t/convenience_init_peer_delegation.swift.o -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+extension Base {
+  convenience init(swiftToDesignated: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init()
+  }
+
+  convenience init(swiftToConvenience: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(conveniently: ())
+  }
+
+  convenience init(swiftToConvenienceFactory: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(convenientFactory: false)
+  }
+
+  convenience init(swiftToNormalFactory: ()) {
+    // FIXME: This shouldn't be allowed, since the factory won't actually use
+    // the dynamic Self type.
+    print("\(#function) \(type(of: self))")
+    self.init(normalFactory: false)
+  }
+
+  @objc convenience init(objcToDesignated: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init()
+  }
+  @objc convenience init(objcToConvenience: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(conveniently: ())
+  }
+  @objc convenience init(objcToConvenienceFactory: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(convenientFactory: false)
+  }
+  @objc convenience init(objcToNormalFactory: ()) {
+    // FIXME: This shouldn't be allowed, since the factory won't actually use
+    // the dynamic Self type.
+    print("\(#function) \(type(of: self))")
+    self.init(normalFactory: false)
+  }
+}
+
+/// Checks that `op` performs `base` allocations of Base and `sub` allocations
+/// of Sub.
+func check(base: Int = 0, sub: Int = 0,
+           file: StaticString = #file, line: UInt = #line,
+           op: () -> Void) {
+  baseCounter = 0
+  subCounter = 0
+  op()
+  precondition(baseCounter == base,
+               "expected \(base) Base instances, got \(baseCounter)",
+               file: file, line: line)
+  precondition(subCounter == sub,
+               "expected \(sub) Sub instances, got \(subCounter)",
+               file: file, line: line)
+}
+
+// CHECK: START
+print("START")
+
+// Check that this whole setup works.
+// CHECK-NEXT: init Base
+check(base: 1) { _ = Base() }
+// CHECK-NEXT: init Sub
+check(sub: 1) { _ = Sub() }
+
+// CHECK-NEXT: init(swiftToDesignated:) Sub
+// CHECK-NEXT: init Sub
+check(sub: 1) { _ = Sub(swiftToDesignated: ()) }
+// CHECK-NEXT: init(swiftToConvenience:) Sub
+// CHECK-NEXT: -[Base initConveniently]
+// CHECK-NEXT: init Sub
+check(sub: 1) { _ = Sub(swiftToConvenience: ()) }
+// CHECK-NEXT: init(swiftToConvenienceFactory:) Sub
+// CHECK-NEXT: +[Base baseWithConvenientFactory:]
+// CHECK-NEXT: init Sub
+check(sub: 1) { _ = Sub(swiftToConvenienceFactory: ()) }
+
+// FIXME: This shouldn't be allowed in the first place; see the definition 
+// above.
+// CHECK-NEXT: init(swiftToNormalFactory:) Base
+// CHECK-NEXT: +[Base baseWithNormalFactory:]
+// CHECK-NEXT: init Base
+check(base: 1) { _ = Base(swiftToNormalFactory: ()) }
+// CHECK-NEXT: init(swiftToNormalFactory:) Sub
+// CHECK-NEXT: +[Base baseWithNormalFactory:]
+// CHECK-NEXT: init Base
+check(base: 1) { _ = Sub(swiftToNormalFactory: ()) }
+
+// CHECK-NEXT: init(objcToDesignated:) Sub
+// CHECK-NEXT: init Sub
+check(sub: 1) { _ = Sub(objcToDesignated: ()) }
+// CHECK-NEXT: init(objcToConvenience:) Sub
+// CHECK-NEXT: -[Base initConveniently]
+// CHECK-NEXT: init Sub
+check(sub: 1) { _ = Sub(objcToConvenience: ()) }
+// CHECK-NEXT: init(objcToConvenienceFactory:) Sub
+// CHECK-NEXT: +[Base baseWithConvenientFactory:]
+// CHECK-NEXT: init Sub
+check(sub: 2) { _ = Sub(objcToConvenienceFactory: ()) }
+
+// FIXME: This shouldn't be allowed in the first place; see the definition 
+// above.
+// CHECK-NEXT: init(objcToNormalFactory:) Base
+// CHECK-NEXT: +[Base baseWithNormalFactory:]
+// CHECK-NEXT: init Base
+check(base: 2) { _ = Base(objcToNormalFactory: ()) }
+// CHECK-NEXT: init(objcToNormalFactory:) Sub
+// CHECK-NEXT: +[Base baseWithNormalFactory:]
+// CHECK-NEXT: init Base
+check(base: 1, sub: 1) { _ = Sub(objcToNormalFactory: ()) }
+
+// CHECK-NEXT: END
+print("END")
+

--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -100,12 +100,13 @@ allocObjectImpl.pointee = {
 
 /// Checks that `op` performs `base` allocations of Base and `sub` allocations
 /// of Sub.
+@inline(never)
 func check(base: Int = 0, sub: Int = 0,
            file: StaticString = #file, line: UInt = #line,
-           op: () -> Void) {
+           op: () -> AnyObject) {
   baseCounter = 0
   subCounter = 0
-  op()
+  _ = op()
   precondition(baseCounter == base,
                "expected \(base) Base instances, got \(baseCounter)",
                file: file, line: line)
@@ -114,48 +115,49 @@ func check(base: Int = 0, sub: Int = 0,
                file: file, line: line)
 }
 
+
 // CHECK: START
 print("START")
 
 // Check that this whole setup works.
 // CHECK-NEXT: init(swift:) Base
-check(base: 1) { _ = Base(swift: ()) }
+check(base: 1) { Base(swift: ()) }
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 1) { _ = Sub(swift: ()) }
+check(sub: 1) { Sub(swift: ()) }
 // CHECK-NEXT: init(objc:) Base
-check(base: 1) { _ = Base(objc: ()) }
+check(base: 1) { Base(objc: ()) }
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = Sub(objc: ()) }
+check(sub: 1) { Sub(objc: ()) }
 
 // CHECK-NEXT: init(swiftToSwift:) Sub
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 1) { _ = Sub(swiftToSwift: ()) }
+check(sub: 1) { Sub(swiftToSwift: ()) }
 // CHECK-NEXT: init(objcToSwift:) Sub
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 2) { _ = Sub(objcToSwift: ()) }
+check(sub: 2) { Sub(objcToSwift: ()) }
 // CHECK-NEXT: init(swiftToObjC:) Sub
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = Sub(swiftToObjC: ()) }
+check(sub: 1) { Sub(swiftToObjC: ()) }
 // CHECK-NEXT: init(objcToObjC:) Sub
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = Sub(objcToObjC: ()) }
+check(sub: 1) { Sub(objcToObjC: ()) }
 
 // CHECK-NEXT: init(swiftToSwiftConvenience:) Sub
 // CHECK-NEXT: init(swiftToSwift:) Sub
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 1) { _ = Sub(swiftToSwiftConvenience: ()) }
+check(sub: 1) { Sub(swiftToSwiftConvenience: ()) }
 // CHECK-NEXT: init(objcToSwiftConvenience:) Sub
 // CHECK-NEXT: init(swiftToSwift:) Sub
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 2) { _ = Sub(objcToSwiftConvenience: ()) }
+check(sub: 2) { Sub(objcToSwiftConvenience: ()) }
 // CHECK-NEXT: init(swiftToObjCConvenience:) Sub
 // CHECK-NEXT: init(objcToObjC:) Sub
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = Sub(swiftToObjCConvenience: ()) }
+check(sub: 1) { Sub(swiftToObjCConvenience: ()) }
 // CHECK-NEXT: init(objcToObjCConvenience:) Sub
 // CHECK-NEXT: init(objcToObjC:) Sub
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = Sub(objcToObjCConvenience: ()) }
+check(sub: 1) { Sub(objcToObjCConvenience: ()) }
 
 // Force ObjC dispatch without conforming Sub or Base to the protocol,
 // because it's possible that `required` perturbs things and we want to test
@@ -164,21 +166,21 @@ let SubAsObjC = unsafeBitCast(Sub.self as AnyObject,
                               to: ForceObjCDispatch.Type.self)
 
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = SubAsObjC.init(objc: ()) }
+check(sub: 1) { SubAsObjC.init(objc: ()) }
 // CHECK-NEXT: init(objcToSwift:) Sub
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 2) { _ = SubAsObjC.init(objcToSwift: ()) }
+check(sub: 2) { SubAsObjC.init(objcToSwift: ()) }
 // CHECK-NEXT: init(objcToObjC:) Sub
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = SubAsObjC.init(objcToObjC: ()) }
+check(sub: 1) { SubAsObjC.init(objcToObjC: ()) }
 // CHECK-NEXT: init(objcToSwiftConvenience:) Sub
 // CHECK-NEXT: init(swiftToSwift:) Sub
 // CHECK-NEXT: init(swift:) Sub
-check(sub: 2) { _ = SubAsObjC.init(objcToSwiftConvenience: ()) }
+check(sub: 2) { SubAsObjC.init(objcToSwiftConvenience: ()) }
 // CHECK-NEXT: init(objcToObjCConvenience:) Sub
 // CHECK-NEXT: init(objcToObjC:) Sub
 // CHECK-NEXT: init(objc:) Sub
-check(sub: 1) { _ = SubAsObjC.init(objcToObjCConvenience: ()) }
+check(sub: 1) { SubAsObjC.init(objcToObjCConvenience: ()) }
 
 // CHECK-NEXT: END
 print("END")

--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -1,0 +1,184 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift %s -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// RUN: sed -e 's/required//g' < %s > %t/without_required.swift
+// RUN: %target-build-swift %t/without_required.swift -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/without_required
+// RUN: %target-codesign %t/without_required
+// RUN: %target-run %t/without_required | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Darwin
+
+class Base {
+  init(swift: ()) {
+    print("\(#function) \(type(of: self))")
+  }
+  @objc(initAsObjC) required init(objc: ()) {
+    print("\(#function) \(type(of: self))")
+  }
+
+  convenience init(swiftToSwift: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(swift: ())
+  }
+  @objc convenience required init(objcToSwift: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(swift: ())
+  }
+  convenience init(swiftToObjC: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(objc: ())
+  }
+  @objc convenience required init(objcToObjC: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(objc: ())
+  }
+
+  convenience init(swiftToSwiftConvenience: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(swiftToSwift: ())
+  }
+  @objc convenience required init(objcToSwiftConvenience: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(swiftToSwift: ())
+  }
+  convenience init(swiftToObjCConvenience: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(objcToObjC: ())
+  }
+  @objc convenience required init(objcToObjCConvenience: ()) {
+    print("\(#function) \(type(of: self))")
+    self.init(objcToObjC: ())
+  }
+}
+
+class Sub: Base {}
+
+@objc protocol ForceObjCDispatch {
+  @objc(initAsObjC) init(objc: ())
+  init(objcToSwift: ())
+  init(objcToObjC: ())
+  init(objcToSwiftConvenience: ())
+  init(objcToObjCConvenience: ())
+}
+
+// Replace swift_allocObject so that we can keep track of what gets allocated.
+var baseCounter = 0
+var subCounter = 0
+
+typealias AllocObjectType =
+    @convention(c) (UnsafeRawPointer, Int, Int) -> UnsafeMutableRawPointer
+let allocObjectImpl =
+  dlsym(UnsafeMutableRawPointer(bitPattern: -1), "_swift_allocObject")
+    .assumingMemoryBound(to: AllocObjectType.self)
+
+/// Like `ObjectIdentifier.init(Any.Type)`, but with a pointer as the
+/// destination type.
+func asUnsafeRawPointer(_ someClass: AnyObject.Type) -> UnsafeRawPointer {
+  let opaque = Unmanaged.passUnretained(someClass as AnyObject).toOpaque()
+  return UnsafeRawPointer(opaque)
+}
+
+let originalAllocObject = allocObjectImpl.pointee
+allocObjectImpl.pointee = {
+  switch $0 {
+  case asUnsafeRawPointer(Base.self):
+    baseCounter += 1
+  case asUnsafeRawPointer(Sub.self):
+    subCounter += 1
+  default:
+    break
+  }
+
+  return originalAllocObject($0, $1, $2)
+}
+
+/// Checks that `op` performs `base` allocations of Base and `sub` allocations
+/// of Sub.
+func check(base: Int = 0, sub: Int = 0,
+           file: StaticString = #file, line: UInt = #line,
+           op: () -> Void) {
+  baseCounter = 0
+  subCounter = 0
+  op()
+  precondition(baseCounter == base,
+               "expected \(base) Base instances, got \(baseCounter)",
+               file: file, line: line)
+  precondition(subCounter == sub,
+               "expected \(sub) Sub instances, got \(subCounter)",
+               file: file, line: line)
+}
+
+// CHECK: START
+print("START")
+
+// Check that this whole setup works.
+// CHECK-NEXT: init(swift:) Base
+check(base: 1) { _ = Base(swift: ()) }
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 1) { _ = Sub(swift: ()) }
+// CHECK-NEXT: init(objc:) Base
+check(base: 1) { _ = Base(objc: ()) }
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = Sub(objc: ()) }
+
+// CHECK-NEXT: init(swiftToSwift:) Sub
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 1) { _ = Sub(swiftToSwift: ()) }
+// CHECK-NEXT: init(objcToSwift:) Sub
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 2) { _ = Sub(objcToSwift: ()) }
+// CHECK-NEXT: init(swiftToObjC:) Sub
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = Sub(swiftToObjC: ()) }
+// CHECK-NEXT: init(objcToObjC:) Sub
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = Sub(objcToObjC: ()) }
+
+// CHECK-NEXT: init(swiftToSwiftConvenience:) Sub
+// CHECK-NEXT: init(swiftToSwift:) Sub
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 1) { _ = Sub(swiftToSwiftConvenience: ()) }
+// CHECK-NEXT: init(objcToSwiftConvenience:) Sub
+// CHECK-NEXT: init(swiftToSwift:) Sub
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 2) { _ = Sub(objcToSwiftConvenience: ()) }
+// CHECK-NEXT: init(swiftToObjCConvenience:) Sub
+// CHECK-NEXT: init(objcToObjC:) Sub
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = Sub(swiftToObjCConvenience: ()) }
+// CHECK-NEXT: init(objcToObjCConvenience:) Sub
+// CHECK-NEXT: init(objcToObjC:) Sub
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = Sub(objcToObjCConvenience: ()) }
+
+// Force ObjC dispatch without conforming Sub or Base to the protocol,
+// because it's possible that `required` perturbs things and we want to test
+// both ways.
+let SubAsObjC = unsafeBitCast(Sub.self as AnyObject,
+                              to: ForceObjCDispatch.Type.self)
+
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = SubAsObjC.init(objc: ()) }
+// CHECK-NEXT: init(objcToSwift:) Sub
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 2) { _ = SubAsObjC.init(objcToSwift: ()) }
+// CHECK-NEXT: init(objcToObjC:) Sub
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = SubAsObjC.init(objcToObjC: ()) }
+// CHECK-NEXT: init(objcToSwiftConvenience:) Sub
+// CHECK-NEXT: init(swiftToSwift:) Sub
+// CHECK-NEXT: init(swift:) Sub
+check(sub: 2) { _ = SubAsObjC.init(objcToSwiftConvenience: ()) }
+// CHECK-NEXT: init(objcToObjCConvenience:) Sub
+// CHECK-NEXT: init(objcToObjC:) Sub
+// CHECK-NEXT: init(objc:) Sub
+check(sub: 1) { _ = SubAsObjC.init(objcToObjCConvenience: ()) }
+
+// CHECK-NEXT: END
+print("END")

--- a/test/SILGen/Inputs/convenience_init_peer_delegation_import.h
+++ b/test/SILGen/Inputs/convenience_init_peer_delegation_import.h
@@ -1,0 +1,11 @@
+@interface Base
+@end
+@interface ImportedClass : Base
+- (nonnull instancetype)init __attribute__((objc_designated_initializer));
+- (nonnull instancetype)initConveniently;
++ (nonnull instancetype)importedClassWithConvenientFactory:(_Bool)unused;
++ (nonnull ImportedClass *)importedClassWithNormalFactory:(_Bool)unused;
+@end
+
+@interface Sub : ImportedClass
+@end

--- a/test/SILGen/convenience_init_peer_delegation.swift
+++ b/test/SILGen/convenience_init_peer_delegation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
 
 class X {
   init() {
@@ -75,6 +75,77 @@ func invocations(xt: X.Type) {
   _ = xt.init(requiredConvenience: ())
   // CHECK: class_method {{%.*}}, #X.init!allocator.1
   _ = xt.init(requiredDoubleConvenience: ())
+}
+
+class ObjCBase {
+  init(swift: ()) {}
+  @objc(initAsObjC) init(objc: ()) {}
+
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfC
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfC'
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfc
+  // CHECK: class_method {{%.+}} : $@thick ObjCBase.Type, #ObjCBase.init!allocator.1
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfcTo
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfcTo'
+  @objc convenience init(objcToSwift: ()) {
+    self.init(swift: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC07swiftToE1CACyt_tcfC
+  // CHECK: class_method %0 : $@thick ObjCBase.Type, #ObjCBase.init!allocator.1
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC07swiftToE1CACyt_tcfC'
+  convenience init(swiftToObjC: ()) {
+    self.init(objc: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfC
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfC'
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfc
+  // CHECK: objc_method {{%.+}} : $ObjCBase, #ObjCBase.init!initializer.1.foreign
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfcTo
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC06objcToE1CACyt_tcfcTo'
+  @objc convenience init(objcToObjC: ()) {
+    self.init(objc: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfC
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfC'
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfc
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC07swiftToE1CACyt_tcfC :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfcTo
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC22objcToSwiftConvenienceACyt_tcfcTo'
+  @objc convenience init(objcToSwiftConvenience: ()) {
+    self.init(swiftToObjC: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC07swiftToE12CConvenienceACyt_tcfC
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC11objcToSwiftACyt_tcfC
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC07swiftToE12CConvenienceACyt_tcfC'
+  convenience init(swiftToObjCConvenience: ()) {
+    self.init(objcToSwift: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfC
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfC'
+  // CHECK-LABEL: sil hidden @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfc
+  // CHECK: objc_method {{%.+}} : $ObjCBase, #ObjCBase.init!initializer.1.foreign
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfcTo
+  // CHECK: function_ref @$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfc :
+  // CHECK: end sil function '$s32convenience_init_peer_delegation8ObjCBaseC06objcToE12CConvenienceACyt_tcfcTo'
+  @objc convenience init(objcToObjCConvenience: ()) {
+    self.init(objcToObjC: ())
+  }
 }
 
 // CHECK-LABEL: sil_vtable X

--- a/test/SILGen/convenience_init_peer_delegation_import.swift
+++ b/test/SILGen/convenience_init_peer_delegation_import.swift
@@ -1,0 +1,98 @@
+// RUN: %target-swift-emit-silgen -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/convenience_init_peer_delegation_import.h %s | %FileCheck %s
+
+extension ImportedClass {
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17swiftToDesignatedAByt_tcfC
+  // CHECK: objc_method {{%.+}} : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE17swiftToDesignatedAByt_tcfC'
+  convenience init(swiftToDesignated: ()) {
+    self.init()
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE18swiftToConvenienceAByt_tcfC
+  // CHECK: objc_method {{%.+}} : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE18swiftToConvenienceAByt_tcfC'
+  convenience init(swiftToConvenience: ()) {
+    self.init(conveniently: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE25swiftToConvenienceFactoryAByt_tcfC
+  // CHECK: objc_method {{%.+}} : $@objc_metatype ImportedClass.Type, #ImportedClass.init!allocator.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE25swiftToConvenienceFactoryAByt_tcfC'
+  convenience init(swiftToConvenienceFactory: ()) {
+    self.init(convenientFactory: false)
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE20swiftToNormalFactoryAByt_tcfC
+  // CHECK: objc_method {{%.+}} : $@objc_metatype ImportedClass.Type, #ImportedClass.init!allocator.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE20swiftToNormalFactoryAByt_tcfC'
+  convenience init(swiftToNormalFactory: ()) {
+    // FIXME: This shouldn't be allowed, since the factory won't actually use
+    // the dynamic Self type.
+    self.init(normalFactory: false)
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfC
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfcTD :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfC'
+  // CHECK-LABEL: sil shared [transparent] [serializable] [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfcTD
+  // CHECK: objc_method %0 : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfcTD'
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfc
+  // CHECK: objc_method {{%.+}} : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfcTo
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE16objcToDesignatedAByt_tcfc :
+  @objc convenience init(objcToDesignated: ()) {
+    self.init()
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfC
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfcTD :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfC'
+  // CHECK-LABEL: sil shared [transparent] [serializable] [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfcTD
+  // CHECK: objc_method %0 : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfcTD'
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfc
+  // CHECK: objc_method {{%.+}} : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfcTo
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfc :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE17objcToConvenienceAByt_tcfcTo'
+  @objc convenience init(objcToConvenience: ()) {
+    self.init(conveniently: ())
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfC
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfcTD :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfC'
+  // CHECK-LABEL: sil shared [transparent] [serializable] [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfcTD
+  // CHECK: objc_method %0 : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfcTD'
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfc
+  // CHECK: objc_method {{%.+}} : $@objc_metatype ImportedClass.Type, #ImportedClass.init!allocator.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfcTo
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfc :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE24objcToConvenienceFactoryAByt_tcfcTo'
+  @objc convenience init(objcToConvenienceFactory: ()) {
+    self.init(convenientFactory: false)
+  }
+
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfC
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfcTD :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfC'
+  // CHECK-LABEL: sil shared [transparent] [serializable] [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfcTD
+  // CHECK: objc_method %0 : $ImportedClass, #ImportedClass.init!initializer.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfcTD'
+  // CHECK-LABEL: sil hidden @$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfc
+  // CHECK: objc_method {{%.+}} : $@objc_metatype ImportedClass.Type, #ImportedClass.init!allocator.1.foreign
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfc'
+  // CHECK-LABEL: sil hidden [thunk] @$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfcTo
+  // CHECK: function_ref @$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfc :
+  // CHECK: end sil function '$sSo13ImportedClassC39convenience_init_peer_delegation_importE19objcToNormalFactoryAByt_tcfcTo'
+  @objc convenience init(objcToNormalFactory: ()) {
+    // FIXME: This shouldn't be allowed, since the factory won't actually use
+    // the dynamic Self type.
+    self.init(normalFactory: false)
+  }
+}

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -1,4 +1,8 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -disable-objc-attr-requires-foundation-module -enable-objc-interop %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
 
 // FIXME: This needs more tests
 
@@ -28,6 +32,10 @@ class FakeNSObject {
 
 class Cat : FakeNSObject {
   let x: LifetimeTracked
+
+  // CHECK-LABEL: sil hidden @$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_SbtcfC
+  // CHECK: function_ref @$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_Sbtcfc :
+  // CHECK: end sil function '$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_SbtcfC'
 
   // CHECK-LABEL: sil hidden @$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_Sbtcfc : $@convention(method) (Int, Bool, @owned Cat) -> @owned Optional<Cat>
   // CHECK: bb0(%0 : $Int, %1 : $Bool, %2 : $Cat):
@@ -70,11 +78,86 @@ class Cat : FakeNSObject {
   // CHECK: bb5([[RESULT:%.*]] : $Optional<Cat>):
     // CHECK-NEXT: return [[RESULT]] : $Optional<Cat>
 
-  init?(n: Int, after: Bool) {
+  // CHECK-LABEL: sil hidden [thunk] @$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_SbtcfcTo
+  // CHECK: function_ref @$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_Sbtcfc :
+  // CHECK: end sil function '$s40definite_init_failable_initializers_objc3CatC1n5afterACSgSi_SbtcfcTo'
+
+  @objc init?(n: Int, after: Bool) {
     self.x = LifetimeTracked(0)
     if after {
       return nil
     }
     super.init()
+  }
+
+  // CHECK-LABEL: sil hidden @$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_SbtcfC
+  // CHECK: function_ref @$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_Sbtcfc :
+  // CHECK: end sil function '$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_SbtcfC'
+
+  // CHECK-LABEL: sil hidden @$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_Sbtcfc : $@convention(method) (Bool, Bool, @owned Cat) -> @owned Optional<Cat>
+  // CHECK: bb0(%0 : $Bool, %1 : $Bool, %2 : $Cat):
+    // CHECK-NEXT: [[HAS_RUN_INIT_BOX:%.+]] = alloc_stack $Builtin.Int1
+    // CHECK-NEXT: [[SELF_BOX:%.+]] = alloc_stack $Cat
+    // CHECK:      store %2 to [[SELF_BOX]] : $*Cat
+    // CHECK-NEXT: [[COND:%.+]] = struct_extract %0 : $Bool, #Bool._value
+    // CHECK-NEXT: cond_br [[COND]], bb1, bb2
+
+  // CHECK: bb1:
+    // CHECK-NEXT: br bb6
+
+  // CHECK: bb2:
+    // CHECK-NEXT: br bb3
+
+  // CHECK: bb3:
+    // CHECK: [[SELF_INIT:%.+]] = objc_method %2 : $Cat, #Cat.init!initializer.1.foreign : (Cat.Type) -> (Int, Bool) -> Cat?
+    // CHECK: [[NEW_OPT_SELF:%.+]] = apply [[SELF_INIT]]({{%.+}}, {{%.+}}, %2) : $@convention(objc_method) (Int, ObjCBool, @owned Cat) -> @owned Optional<Cat>
+    // CHECK: [[COND:%.+]] = select_enum [[NEW_OPT_SELF]] : $Optional<Cat>
+    // CHECK-NEXT: cond_br [[COND]], bb5, bb4
+
+  // CHECK: bb4:
+    // CHECK-NEXT: release_value [[NEW_OPT_SELF]]
+    // CHECK-NEXT: br bb6
+
+  // CHECK: bb5:
+    // CHECK-NEXT: [[NEW_SELF:%.+]] = unchecked_enum_data [[NEW_OPT_SELF]] : $Optional<Cat>, #Optional.some!enumelt.1
+    // CHECK-NEXT: store [[NEW_SELF]] to [[SELF_BOX]] : $*Cat
+    // TODO: Once we re-enable arbitrary take promotion, this retain and the associated destroy_addr will go away.
+    // CHECK-NEXT: strong_retain [[NEW_SELF]]
+    // CHECK-NEXT: [[RESULT:%.+]] = enum $Optional<Cat>, #Optional.some!enumelt.1, [[NEW_SELF]] : $Cat
+    // CHECK-NEXT: destroy_addr [[SELF_BOX]]
+    // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
+    // CHECK-NEXT: br bb10([[RESULT]] : $Optional<Cat>)
+
+  // CHECK: bb6:
+    // CHECK-NEXT: [[COND:%.+]] = load [[HAS_RUN_INIT_BOX]] : $*Builtin.Int1
+    // CHECK-NEXT: cond_br [[COND]], bb7, bb8
+
+  // CHECK: bb7:
+    // CHECK-NEXT: br bb9
+
+  // CHECK: bb8:
+    // CHECK-NEXT: [[MOST_DERIVED_TYPE:%.+]] = value_metatype $@thick Cat.Type, %2 : $Cat
+    // CHECK-NEXT: dealloc_partial_ref %2 : $Cat, [[MOST_DERIVED_TYPE]] : $@thick Cat.Type
+    // CHECK-NEXT: br bb9
+
+  // CHECK: bb9:
+    // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
+    // CHECK-NEXT: [[NIL_RESULT:%.+]] = enum $Optional<Cat>, #Optional.none!enumelt
+    // CHECK-NEXT: br bb10([[NIL_RESULT]] : $Optional<Cat>)
+
+  // CHECK: bb10([[RESULT:%.+]] : $Optional<Cat>):
+    // CHECK-NEXT: dealloc_stack [[HAS_RUN_INIT_BOX]] : $*Builtin.Int1
+    // CHECK-NEXT: return [[RESULT]] : $Optional<Cat>
+
+  // CHECK: end sil function '$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_Sbtcfc'
+
+  // CHECK-LABEL: sil hidden [thunk] @$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_SbtcfcTo
+  // CHECK: function_ref @$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_Sbtcfc :
+  // CHECK: end sil function '$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_SbtcfcTo'
+  @objc convenience init?(fail: Bool, after: Bool) {
+    if fail {
+      return nil
+    }
+    self.init(n: 0, after: after)
   }
 }

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -77,6 +77,75 @@ bb0(%0 : @trivial $*MyStruct2, %1 : @trivial $@thin MyStruct2.Type):
   return %13 : $()
 }
 
+// CHECK-LABEL: sil @test_delegating_box_release
+// CHECK: bb0([[ARG:%.*]] : @owned $RootClassWithNontrivialStoredProperties):
+// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+// CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELFBOX]]
+// CHECK-NEXT: store [[ARG]] to [init] [[PB]]
+// CHECK-NEXT: [[SELF:%[0-9]+]] = load [take] [[PB]]
+// CHECK-NEXT: [[METATYPE:%[0-9]+]] = value_metatype $@thick RootClassWithNontrivialStoredProperties.Type, [[SELF]] : $RootClassWithNontrivialStoredProperties
+// CHECK-NEXT: dealloc_partial_ref [[SELF]] : $RootClassWithNontrivialStoredProperties, [[METATYPE]] : $@thick RootClassWithNontrivialStoredProperties.Type
+// CHECK-NEXT: dealloc_box [[SELFBOX]]
+sil @test_delegating_box_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>, 0
+  %4 = mark_uninitialized [delegatingselfallocated] %2a : $*RootClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*RootClassWithNontrivialStoredProperties
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+
+  %13 = tuple ()
+  return %13 : $()
+}
+
+
+// CHECK-LABEL: sil @test_delegating_rvalue_release
+// CHECK: bb0([[ARG:%.*]] : @owned $RootClassWithNontrivialStoredProperties):
+// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+// CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELFBOX]]
+// CHECK-NEXT: store [[ARG]] to [init] [[PB]]
+// CHECK-NEXT: [[SELF:%[0-9]+]] = load [take] [[PB]]
+// CHECK-NEXT: [[METATYPE:%[0-9]+]] = value_metatype $@thick RootClassWithNontrivialStoredProperties.Type, [[SELF]] : $RootClassWithNontrivialStoredProperties
+// CHECK-NEXT: dealloc_partial_ref [[SELF]] : $RootClassWithNontrivialStoredProperties, [[METATYPE]] : $@thick RootClassWithNontrivialStoredProperties.Type
+// CHECK-NEXT: [[SELF2:%[0-9]+]] = load [take] [[PB]]
+// CHECK-NEXT: [[METATYPE2:%[0-9]+]] = value_metatype $@thick RootClassWithNontrivialStoredProperties.Type, [[SELF2]] : $RootClassWithNontrivialStoredProperties
+// CHECK-NEXT: dealloc_partial_ref [[SELF2]] : $RootClassWithNontrivialStoredProperties, [[METATYPE2]] : $@thick RootClassWithNontrivialStoredProperties.Type
+// CHECK-NEXT: dealloc_box [[SELFBOX]]
+sil @test_delegating_rvalue_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>, 0
+  %4 = mark_uninitialized [delegatingselfallocated] %2a : $*RootClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*RootClassWithNontrivialStoredProperties
+  %6 = load [take] %4 : $*RootClassWithNontrivialStoredProperties
+  destroy_value %6 : $RootClassWithNontrivialStoredProperties
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+
+  %13 = tuple ()
+  return %13 : $()
+}
+
+// CHECK-LABEL: sil @test_delegating_derived_release
+// CHECK: bb0([[ARG:%.*]] : @owned $DerivedClassWithNontrivialStoredProperties):
+// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_stack $DerivedClassWithNontrivialStoredProperties
+// CHECK-NEXT: store [[ARG]] to [init] [[SELFBOX]]
+// CHECK-NEXT: [[SELF:%[0-9]+]] = load [take] [[SELFBOX]]
+// CHECK-NEXT: [[METATYPE:%[0-9]+]] = value_metatype $@thick DerivedClassWithNontrivialStoredProperties.Type, [[SELF]] : $DerivedClassWithNontrivialStoredProperties
+// CHECK-NEXT: dealloc_partial_ref [[SELF]] : $DerivedClassWithNontrivialStoredProperties, [[METATYPE]] : $@thick DerivedClassWithNontrivialStoredProperties.Type
+// CHECK-NEXT: dealloc_stack [[SELFBOX]]
+sil @test_delegating_derived_release : $@convention(method) (@owned DerivedClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
+  %2 = alloc_stack $DerivedClassWithNontrivialStoredProperties
+  %4 = mark_uninitialized [delegatingselfallocated] %2 : $*DerivedClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*DerivedClassWithNontrivialStoredProperties
+
+  destroy_addr %4 : $*DerivedClassWithNontrivialStoredProperties
+  dealloc_stack %2 : $*DerivedClassWithNontrivialStoredProperties
+
+  %13 = tuple ()
+  return %13 : $()
+}
+
 // <rdar://problem/20608881> DI miscompiles this testcase into a memory leak
 struct MyStruct3 {
   @_hasStorage var c: C
@@ -135,3 +204,74 @@ bb2:
 class MyClass3 {
 }
 sil @selfinit_myclass3 : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+
+// CHECK-LABEL: sil hidden @test_conditional_destroy_class_delegating_init
+sil hidden @test_conditional_destroy_class_delegating_init : $@convention(thin) (Builtin.Int1, @owned MyClass3) -> () {
+bb0(%0 : @trivial $Builtin.Int1, %1 : @owned $MyClass3):
+// CHECK:  [[CONTROL:%[0-9]+]] = alloc_stack $Builtin.Int2
+// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_stack $MyClass3
+
+  %2 = alloc_stack $MyClass3
+  %3 = mark_uninitialized [delegatingselfallocated] %2 : $*MyClass3
+  store %1 to [init] %3 : $*MyClass3
+
+// CHECK:  cond_br %0, [[SUCCESS:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+  cond_br %0, bb1, bb2
+
+// CHECK: [[SUCCESS]]:
+bb1:
+  %4 = load [take] %3 : $*MyClass3
+  %5 = function_ref @selfinit_myclass3 : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+  %6 = apply %5(%4) : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+  store %6 to [init] %3 : $*MyClass3
+
+// CHECK:       [[SET:%[0-9]+]] = integer_literal $Builtin.Int2, -2
+// CHECK-NEXT:  [[OLD:%.*]] = load [trivial] [[CONTROL]]
+// CHECK-NEXT:  [[UPDATE:%.*]] = builtin "or_Int2"([[OLD]] : $Builtin.Int2, [[SET]] : $Builtin.Int2)
+// CHECK-NEXT:  store [[UPDATE]] to [trivial] [[CONTROL]] : $*Builtin.Int2
+
+// CHECK:       [[SET:%[0-9]+]] = integer_literal $Builtin.Int2, 1
+// CHECK-NEXT:  [[OLD:%.*]] = load [trivial] [[CONTROL]]
+// CHECK-NEXT:  [[UPDATE:%.*]] = builtin "or_Int2"([[OLD]] : $Builtin.Int2, [[SET]] : $Builtin.Int2)
+// CHECK-NEXT:  store [[UPDATE]] to [trivial] [[CONTROL]] : $*Builtin.Int2
+
+// CHECK: [[NEW_SELF:%[0-9]+]] = apply {{.*}}({{.*}})  : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+// CHECK-NEXT:  store [[NEW_SELF]] to [init] [[SELF_BOX]] : $*MyClass3
+
+// CHECK-NEXT:  br [[CHECK:bb[0-9]+]]
+  br bb2
+
+// CHECK: [[CHECK]]:
+bb2:
+
+// CHECK-NEXT:  [[BIT:%.*]] = load [trivial] [[CONTROL]]
+// CHECK-NEXT:  [[COND:%.*]] = builtin "trunc_Int2_Int1"([[BIT]] : $Builtin.Int2) : $Builtin.Int1
+// CHECK-NEXT:  cond_br [[COND]], [[PARTIAL:bb[0-9]+]], [[UNINITIALIZED:bb[0-9]+]]
+
+// CHECK: [[PARTIAL]]:
+// CHECK-NEXT:  [[BIT:%.*]] = load [trivial] [[CONTROL]]
+// CHECK-NEXT:  [[ONE:%.*]] = integer_literal $Builtin.Int2, 1
+// CHECK-NEXT:  [[SHIFTED:%.*]] = builtin "lshr_Int2"([[BIT]] : $Builtin.Int2, [[ONE]] : $Builtin.Int2) : $Builtin.Int2
+// CHECK-NEXT:  [[COND:%.*]] = builtin "trunc_Int2_Int1"([[SHIFTED]] : $Builtin.Int2) : $Builtin.Int1
+// CHECK-NEXT:  cond_br [[COND]], [[INITIALIZED:bb[0-9]+]], [[CONSUMED:bb[0-9]+]]
+
+// CHECK: [[INITIALIZED]]:
+// CHECK-NEXT:  destroy_addr [[SELF_BOX]] : $*MyClass3
+// CHECK-NEXT:  br [[EXIT:bb[0-9]+]]
+
+// CHECK: [[CONSUMED]]:
+// CHECK-NEXT:  br [[EXIT]]
+
+// CHECK: [[UNINITIALIZED]]:
+// CHECK-NEXT:  [[OLD_SELF:%[0-9]+]] = load [take] [[SELF_BOX]] : $*MyClass3
+// CHECK-NEXT:  [[METATYPE:%[0-9]+]] = value_metatype $@thick MyClass3.Type, [[OLD_SELF]] : $MyClass3
+// CHECK-NEXT:  dealloc_partial_ref [[OLD_SELF]] : $MyClass3, [[METATYPE]] : $@thick MyClass3.Type
+// CHECK-NEXT:  br [[EXIT:bb[0-9]+]]
+
+// CHECK: [[EXIT]]:
+
+  destroy_addr %3 : $*MyClass3
+  dealloc_stack %2 : $*MyClass3
+  %7 = tuple ()
+  return %7 : $()
+}


### PR DESCRIPTION
- **Explanation**: Early in the Swift 5 release, @jckarter simplified Swift's implementation of convenience initializers to always go through the "allocating" entry point—in practice, delaying the responsibility of allocating `self` until necessary, which in practice means "until calling a designated initializer, or an initializer implemented in Objective-C". This had a number of benefits for the rest of the compiler, the primary one being a significant simplification in how vtables are built (which also manifests as a minor code size win). However, it also broke the decoding of object graphs with circular references through NSCoding, including Interface Builder files, because the unarchiver object can't know that its initial allocation (through Objective-C's `+allocWithZone:`) is going to be replaced. (That is, it breaks it when the implementation of `init(coder:)` in Swift is a convenience initializer.)

    To restore this capability, allow initializer delegating (`self.init`) to go through initializing (non-allocating) entry points when the delegated-to initializer is exposed to Objective-C. This doesn't change any safety guarantees or normally-observed behavior, and still allows the correct dynamic dispatch of the delegated-to initializer, but it does mean that as long as all initializers are `@objc`, the initial allocation won't be thrown away.

    This still isn't 100% the same as the behavior in Swift 4.2 and earlier, so it'll be worth release-noting.

- **Scope**: Affects convenience initializers that call `@objc` initializers, as well as the definitive initialization checking for `@objc` convenience initializers.

- **Issue**: rdar://problem/46823518

- **Risk**: Medium. Most of the patch is undoing changes that Joe made, but he made them a while ago, and so we've been living on the new way.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @jckarter  