### PR TITLE
Fix int literals which can clash with line numbers

### DIFF
--- a/test/SILOptimizer/pointer_conversion.swift
+++ b/test/SILOptimizer/pointer_conversion.swift
@@ -84,17 +84,17 @@ public func testMutableArrayToOptional() {
 
 // CHECK-LABEL: sil @$s18pointer_conversion21arrayLiteralPromotionyyF
 public func arrayLiteralPromotion() {
-  takesConstRawPointer([41,42,43,44])
+  takesConstRawPointer([-41,-42,-43,-44])
   
   // Stack allocate the array.
   // TODO: When stdlib checks are enabled, this becomes heap allocated... :-(
   // CHECK: alloc_ref {{.*}}[tail_elems $Int * {{.*}} : $Builtin.Word] $_ContiguousArrayStorage<Int>
   
   // Store the elements.
-  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 41
-  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 42
-  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 43
-  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 44
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, -41
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, -42
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, -43
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, -44
   
   // Call the function.
   // CHECK: [[PTR:%.+]] = mark_dependence


### PR DESCRIPTION
test/SILOptimizer/pointer_conversion.swift’s `arrayLiteralPromotion()` subtest uses integer literals for 41, 42, 43, and 44. If swift-evolve shuffles a particular `_internalInvariant()` call in stdlib/public/core/BridgeStorage.swift to lines 41-44, the compiler will generate code which reuses the `integer_literal` instruction for the line number later in the test, causing this test to fail. This happens about once per 45 runs of swift-evolve.

This change negates the integer literals so they will never match a line number.