### PR TITLE
migrator: handle function's return type changes from nonnull to nullable. rdar://47265255

### DIFF
--- a/test/Migrator/Inputs/CallExpr.json
+++ b/test/Migrator/Inputs/CallExpr.json
@@ -1,0 +1,24 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "WrapOptional",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6CitiesAAC1xABSi_tcfc",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "WrapOptional",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6CitiesAAC5noosaSaySDySSABGSgGyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "",
+    "ModuleName": "Cities"
+  }
+]

--- a/test/Migrator/call_expr_result.swift
+++ b/test/Migrator/call_expr_result.swift
@@ -1,0 +1,13 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -disable-migrator-fixits -primary-file %s  -I %t.mod -api-diff-data-file %S/Inputs/CallExpr.json -emit-migrated-file-path %t/call_expr_result.swift.result -o /dev/null
+// RUN: diff -u %S/call_expr_result.swift.expected %t/call_expr_result.swift.result
+
+import Cities
+
+func foo() {
+  let c1 = Cities(x: 3)
+  _ = Cities.init(x: 3)
+  _ = c1.noosa()
+}

--- a/test/Migrator/call_expr_result.swift.expected
+++ b/test/Migrator/call_expr_result.swift.expected
@@ -1,0 +1,13 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -disable-migrator-fixits -primary-file %s  -I %t.mod -api-diff-data-file %S/Inputs/CallExpr.json -emit-migrated-file-path %t/call_expr_result.swift.result -o /dev/null
+// RUN: diff -u %S/call_expr_result.swift.expected %t/call_expr_result.swift.result
+
+import Cities
+
+func foo() {
+  let c1 = Cities(x: 3)!
+  _ = Cities.init(x: 3)!
+  _ = c1.noosa()!
+}

--- a/test/Migrator/wrap_optional.swift.expected
+++ b/test/Migrator/wrap_optional.swift.expected
@@ -7,7 +7,7 @@
 import Cities
 
 class MyCities : Cities {
-  override init?(x: Int?) { super.init(x: x) }
+  override init?(x: Int?) { super.init(x: x)! }
   override init?(y: Int) { super.init(y: y) }
   override func newMooloolaba(newX x: Cities?, newY y: Cities) {}
   override func toowoomba(x: [Cities?], y: [Cities?]) {}


### PR DESCRIPTION
Adding exclamation brings an optional type back to its original nonnull
version.
 rdar://47265255 