### PR TITLE
Revert "Update use of the ThreadSanitizer pass to the Legacy pass"

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -70,7 +70,6 @@
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Instrumentation.h"
-#include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/ObjCARC.h"
 
 #include <thread>
@@ -131,7 +130,7 @@ static void addAddressSanitizerPasses(const PassManagerBuilder &Builder,
 
 static void addThreadSanitizerPass(const PassManagerBuilder &Builder,
                                    legacy::PassManagerBase &PM) {
-  PM.add(createThreadSanitizerLegacyPassPass());
+  PM.add(createThreadSanitizerPass());
 }
 
 static void addSanitizerCoveragePass(const PassManagerBuilder &Builder,


### PR DESCRIPTION
This reverts commit f4502b8463b186d4a231e8f88221187c78996bb9.

Porting tsan to the new PM was reverted in r350719, so this change needs
to be reverted as well.
