### PR TITLE
build: make the windows build work on Linux again

### DIFF
--- a/utils/WindowsSDKVFSOverlay.yaml.in
+++ b/utils/WindowsSDKVFSOverlay.yaml.in
@@ -23,9 +23,27 @@ roots:
   - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um"
     type: directory
     contents:
+      - name: commctrl.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/CommCtrl.h"
+      - name: docobj.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/DocObj.h"
+      - name: exdisp.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ExDisp.h"
+      - name: isguids.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/IsGuids.h"
+      - name: knownfolders.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/KnownFolders.h"
       - name: oaidl.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/OAIdl.h"
+      - name: ocidl.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/OCIdl.h"
       - name: objidl.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ObjIdl.h"
@@ -47,6 +65,24 @@ roots:
       - name: psapi.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Psapi.h"
+      - name: shldisp.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlDisp.h"
+      - name: shlguid.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlGuid.h"
+      - name: shlobj.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlObj.h"
+      - name: shlobj_core.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlObj_core.h"
+      - name: shobjidl.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShObjIdl.h"
+      - name: shobjidl_core.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShObjIdl_core.h"
       - name: unknwn.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Unknwn.h"


### PR DESCRIPTION
Update the SDK overlay to have enough of the entries to make the WinSDK build
when building the SDK overlay on Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
