### PR TITLE
[AST] If access control is disabled adjust declaration access to maxi…

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -869,7 +869,8 @@ public:
 
       if (D->hasAccess()) {
         PrettyStackTraceDecl debugStack("verifying access", D);
-        if (D->getFormalAccessScope().isPublic() &&
+        if (!D->getASTContext().isAccessControlDisabled() &&
+            D->getFormalAccessScope().isPublic() &&
             D->getFormalAccess() < AccessLevel::Public) {
           Out << "non-public decl has no formal access scope\n";
           D->dump(Out);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1274,9 +1274,6 @@ bool WitnessChecker::checkWitnessAccess(ValueDecl *requirement,
                                         ValueDecl *witness,
                                         bool *isSetter) {
   *isSetter = false;
-  if (TC.Context.isAccessControlDisabled())
-    return false;
-
   AccessScope actualScopeToCheck = getRequiredAccessScope();
 
   // Setting the 'forConformance' flag means that we admit witnesses in

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -497,9 +497,6 @@ protected:
   AccessScope getRequiredAccessScope();
 
   bool isUsableFromInlineRequired() {
-    if (TC.Context.isAccessControlDisabled())
-      return false;
-
     assert(RequiredAccessScopeAndUsableFromInline.hasValue() &&
            "must check access first using getRequiredAccessScope");
     return RequiredAccessScopeAndUsableFromInline.getValue().second;


### PR DESCRIPTION
…mum openness

This is a follow-up to https://github.com/apple/swift/pull/21783
which made `is{Setter}AccessibleFrom` respect `-disable-access-control`
flag. Now it's `getAdjustedFormalAccess` turn to do the same.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
