### PR TITLE
Reserve AllDelayed vector to upper bound ( of llvm::DenseMap ).

### DIFF
--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -83,6 +83,7 @@ void PersistentParserState::delayDeclList(IterableDeclContext* D,
 
 void PersistentParserState::parseAllDelayedDeclLists() {
   std::vector<IterableDeclContext*> AllDelayed;
+  AllDelayed.reserve(DelayedDeclListStates.size());
   for (auto &P: DelayedDeclListStates) {
     AllDelayed.push_back(P.first);
   }


### PR DESCRIPTION
File: [swift/lib/Parse/PersistentParserState.cpp]

Observing this code snipped closely in function, [void PersistentParserState::parseAllDelayedDeclLists()]:

```
for (auto &P: DelayedDeclListStates) {
    AllDelayed.push_back(P.first);
}
```

We observe that 'AllDelayed' gets maximum of DelayedDeclListStates.size() elements pushed into it.
So it is better to reserve 'vector AllDelayed' to that max size, to save reallocation cost.

I believe we can use size() on [DelayedDeclListStates], which is of type: ```llvm::DenseMap<IterableDeclContext *, std::unique_ptr<DelayedDeclListState>>``` because of the ```DenseMapIterator``` implementation of size() in ```class DenseMapBase```.

Helpful Link: http://llvm.org/doxygen/DenseMap_8h_source.html#l00126

@swift-ci Please test
