### PR TITLE
Revert "IRGen: Ensure that default witness thunks are emitted in the same thread as the protocol descriptor"

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -984,7 +984,7 @@ static bool hasCodeCoverageInstrumentation(SILFunction &f, SILModule &m) {
   return f.getProfiler() && m.getOptions().EmitProfileCoverageMapping;
 }
 
-void IRGenerator::emitGlobalTopLevel() {
+void IRGenerator::emitGlobalTopLevel(bool emitForParallelEmission) {
   // Generate order numbers for the functions in the SIL module that
   // correspond to definitions in the LLVM module.
   unsigned nextOrderNumber = 0;
@@ -992,6 +992,13 @@ void IRGenerator::emitGlobalTopLevel() {
     // Don't bother adding external declarations to the function order.
     if (!silFn.isDefinition()) continue;
     FunctionOrder.insert(std::make_pair(&silFn, nextOrderNumber++));
+  }
+
+  // Ensure that relative symbols are collocated in the same LLVM module.
+  for (SILWitnessTable &wt : PrimaryIGM->getSILModule().getWitnessTableList()) {
+    CurrentIGMPtr IGM = getGenModule(wt.getDeclContext());
+    if (emitForParallelEmission)
+      IGM->ensureRelativeSymbolCollocation(wt);
   }
 
   for (SILGlobalVariable &v : PrimaryIGM->getSILModule().getSILGlobals()) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4046,9 +4046,6 @@ void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
   if (isResilient(protocol, ResilienceExpansion::Minimal))
     defaultWitnesses = getSILModule().lookUpDefaultWitnessTable(protocol);
 
-  if (defaultWitnesses)
-    IRGen.ensureRelativeSymbolCollocation(*defaultWitnesses);
-
   {
     ProtocolDescriptorBuilder builder(*this, protocol, defaultWitnesses);
     builder.emit();

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -38,10 +38,8 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILDeclRef.h"
-#include "swift/SIL/SILDefaultWitnessTable.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILValue.h"
-#include "swift/SIL/SILWitnessTable.h"
 #include "swift/SIL/SILWitnessVisitor.h"
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/SmallString.h"
@@ -2081,10 +2079,7 @@ void IRGenModule::emitProtocolConformance(
   setTrueConstGlobal(var);
 }
 
-void IRGenerator::ensureRelativeSymbolCollocation(SILWitnessTable &wt) {
-  if (!CurrentIGM)
-    return;
-
+void IRGenModule::ensureRelativeSymbolCollocation(SILWitnessTable &wt) {
   // Only resilient conformances use relative pointers for witness methods.
   if (wt.isDeclaration() || isAvailableExternally(wt.getLinkage()) ||
       !isResilientConformance(wt.getConformance()))
@@ -2095,20 +2090,7 @@ void IRGenerator::ensureRelativeSymbolCollocation(SILWitnessTable &wt) {
       continue;
     auto *witness = entry.getMethodWitness().Witness;
     if (witness)
-      forceLocalEmitOfLazyFunction(witness);
-  }
-}
-
-void IRGenerator::ensureRelativeSymbolCollocation(SILDefaultWitnessTable &wt) {
-  if (!CurrentIGM)
-    return;
-
-  for (auto &entry : wt.getEntries()) {
-    if (entry.getKind() != SILWitnessTable::Method)
-      continue;
-    auto *witness = entry.getMethodWitness().Witness;
-    if (witness)
-      forceLocalEmitOfLazyFunction(witness);
+      IRGen.forceLocalEmitOfLazyFunction(witness);
   }
 }
 
@@ -2251,10 +2233,6 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   // Also, it is not a big benefit for LLVM to emit such witness tables.
   if (isAvailableExternally(wt->getLinkage()))
     return;
-
-  // Ensure that relatively-referenced symbols for witness thunks are collocated
-  // in the same LLVM module.
-  IRGen.ensureRelativeSymbolCollocation(*wt);
 
   auto conf = wt->getConformance();
   PrettyStackTraceConformance _st(Context, "emitting witness table for", conf);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -964,11 +964,11 @@ static void performParallelIRGeneration(
   }
 
   // Emit the module contents.
-  irgen.emitGlobalTopLevel();
+  irgen.emitGlobalTopLevel(true /*emitForParallelEmission*/);
 
   for (auto *File : M->getFiles()) {
     if (auto *SF = dyn_cast<SourceFile>(File)) {
-      CurrentIGMPtr IGM = irgen.getGenModule(SF);
+      IRGenModule *IGM = irgen.getGenModule(SF);
       IGM->emitSourceFile(*SF);
     } else {
       File->collectLinkLibraries([&](LinkLibrary LinkLib) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -93,7 +93,6 @@ namespace swift {
   class ProtocolCompositionType;
   class RootProtocolConformance;
   struct SILDeclRef;
-  class SILDefaultWitnessTable;
   class SILGlobalVariable;
   class SILModule;
   class SILProperty;
@@ -312,7 +311,11 @@ public:
   
   /// Emit functions, variables and tables which are needed anyway, e.g. because
   /// they are externally visible.
-  void emitGlobalTopLevel();
+  /// If \p emitForParallelEmission is true ensures that symbols that are
+  /// expressed as relative pointers are collocated in the same output module
+  /// with their base symbol. For example, witness methods need to be collocated
+  /// with the witness table in the same LLVM module.
+  void emitGlobalTopLevel(bool emitForParallelEmission = false);
 
   /// Emit references to each of the protocol descriptors defined in this
   /// IR module.
@@ -351,10 +354,6 @@ public:
   void forceLocalEmitOfLazyFunction(SILFunction *f) {
     DefaultIGMForFunction[f] = CurrentIGM;
   }
-
-  void ensureRelativeSymbolCollocation(SILWitnessTable &wt);
-
-  void ensureRelativeSymbolCollocation(SILDefaultWitnessTable &wt);
 
   void noteUseOfTypeMetadata(NominalTypeDecl *type) {
     noteUseOfTypeGlobals(type, true, RequireMetadata);
@@ -1386,6 +1385,8 @@ public:
   void addSwiftErrorAttributes(llvm::AttributeList &attrs, unsigned argIndex);
 
   void emitSharedContextDescriptor(DeclContext *dc);
+
+  void ensureRelativeSymbolCollocation(SILWitnessTable &wt);
 
   llvm::GlobalVariable *
   getGlobalForDynamicallyReplaceableThunk(LinkEntity &entity, llvm::Type *type,

--- a/test/IRGen/Inputs/multithread_resilience_other.swift
+++ b/test/IRGen/Inputs/multithread_resilience_other.swift
@@ -1,3 +1,0 @@
-extension Defaultable {
-  public func defaulted() {}
-}

--- a/test/IRGen/multithread_resilience.swift
+++ b/test/IRGen/multithread_resilience.swift
@@ -1,9 +1,0 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c %S/Inputs/multithread_resilience_other.swift %s -num-threads 2 -o %t/1.o -o %t/2.o -module-name multithread_resilience
-// RUN: %target-swift-frontend -c %S/Inputs/multithread_resilience_other.swift %s -num-threads 2 -o %t/1.o -o %t/2.o -module-name multithread_resilience -enable-testing
-// RUN: %target-swift-frontend -c %S/Inputs/multithread_resilience_other.swift %s -num-threads 2 -o %t/1.o -o %t/2.o -module-name multithread_resilience -enable-resilience
-// RUN: %target-swift-frontend -c %S/Inputs/multithread_resilience_other.swift %s -num-threads 2 -o %t/1.o -o %t/2.o -module-name multithread_resilience -enable-testing -enable-resilience
-
-public protocol Defaultable {
-  func defaulted()
-}


### PR DESCRIPTION
This broke the source compat suite.

Reverts apple/swift#21850