### PR TITLE
[Parse] Character literals version II

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -148,6 +148,10 @@ ERROR(lex_invalid_escape_delimiter,none,
       "too many '#' characters in delimited escape", ())
 ERROR(lex_invalid_closing_delimiter,none,
       "too many '#' characters in closing delimiter", ())
+ERROR(character_literal_not_cluster,none,
+      "character literal is not a single extended grapheme cluster", ())
+ERROR(character_literal_interpolating,none,
+      "character literal can not contain interpolations", ())
 
 ERROR(lex_invalid_unicode_scalar,none,
       "invalid unicode scalar", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2817,6 +2817,16 @@ ERROR(builtin_string_literal_broken_proto,none,
 ERROR(string_literal_broken_proto,none,
       "protocol 'ExpressibleByStringLiteral' is broken", ())
 
+ERROR(character_literal_overflow,none,
+      "character literal '%1' overflows when stored into %0", (Type, unsigned))
+ERROR(character_literal_quotes,none,
+      "integers can only be expressed by single quoted character literals", ())
+ERROR(character_literal_not_cluster,none,
+      "character literal is not a single extended grapheme cluster", ())
+WARNING(character_literal_migration,none,
+      "double quotes deprecated in favour of single quotes to express %0",
+      (Type))
+
 // Array literals
 ERROR(should_use_dictionary_literal,none,
       "dictionary of type %0 cannot be %select{used|initialized}1 "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2817,6 +2817,11 @@ ERROR(builtin_string_literal_broken_proto,none,
 ERROR(string_literal_broken_proto,none,
       "protocol 'ExpressibleByStringLiteral' is broken", ())
 
+ERROR(character_literal_nolatin1,none,
+      "character literal '%1' is obsolete latin1 encoding and can't express %0",
+      (Type, unsigned))
+ERROR(character_literal_overflow,none,
+      "character literal '%1' overflows when stored into %0", (Type, unsigned))
 ERROR(character_literal_not_ascii,none,
       "character literal can only contain ASCII when expressing %0", (Type))
 ERROR(character_literal_quotes,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2817,11 +2817,6 @@ ERROR(builtin_string_literal_broken_proto,none,
 ERROR(string_literal_broken_proto,none,
       "protocol 'ExpressibleByStringLiteral' is broken", ())
 
-ERROR(character_literal_nolatin1,none,
-      "character literal '%1' is obsolete latin1 encoding and can't express %0",
-      (Type, unsigned))
-ERROR(character_literal_overflow,none,
-      "character literal '%1' overflows when stored into %0", (Type, unsigned))
 ERROR(character_literal_not_ascii,none,
       "character literal can only contain ASCII when expressing %0", (Type))
 ERROR(character_literal_quotes,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2817,12 +2817,10 @@ ERROR(builtin_string_literal_broken_proto,none,
 ERROR(string_literal_broken_proto,none,
       "protocol 'ExpressibleByStringLiteral' is broken", ())
 
-ERROR(character_literal_overflow,none,
-      "character literal '%1' overflows when stored into %0", (Type, unsigned))
+ERROR(character_literal_not_ascii,none,
+      "character literal can only contain ASCII when expressing %0", (Type))
 ERROR(character_literal_quotes,none,
       "integers can only be expressed by single quoted character literals", ())
-ERROR(character_literal_not_cluster,none,
-      "character literal is not a single extended grapheme cluster", ())
 WARNING(character_literal_migration,none,
       "double quotes deprecated in favour of single quotes to express %0",
       (Type))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -903,6 +903,12 @@ public:
     OneUnicodeScalar
   };
 
+  static bool isCharacterLiteralExpr(Expr *expr) {
+    if (auto stringLiteral = dyn_cast_or_null<StringLiteralExpr>(expr))
+      return stringLiteral->Bits.StringLiteralExpr.IsCharacterLiteral;
+    return false;
+  }
+
   StringLiteralExpr(StringRef Val, SourceRange Range,
                     bool Implicit = false, bool IsCharacterLiteral = false);
 
@@ -925,10 +931,6 @@ public:
 
   bool isSingleExtendedGraphemeCluster() const {
     return Bits.StringLiteralExpr.IsSingleExtendedGraphemeCluster;
-  }
-
-  bool isCharacterLiteral() const {
-    return Bits.StringLiteralExpr.IsCharacterLiteral;
   }
 
   /// Retrieve the builtin initializer that will be used to construct the string

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -905,7 +905,7 @@ public:
 
   static bool isCharacterLiteralExpr(Expr *expr) {
     if (auto stringLiteral = dyn_cast_or_null<StringLiteralExpr>(expr))
-      return stringLiteral->Bits.StringLiteralExpr.IsCharacterLiteral;
+      return stringLiteral->isCharacterLiteral();
     return false;
   }
 
@@ -931,6 +931,10 @@ public:
 
   bool isSingleExtendedGraphemeCluster() const {
     return Bits.StringLiteralExpr.IsSingleExtendedGraphemeCluster;
+  }
+
+  bool isCharacterLiteral() const {
+    return Bits.StringLiteralExpr.IsCharacterLiteral;
   }
 
   /// Retrieve the builtin initializer that will be used to construct the string

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -161,10 +161,11 @@ protected:
     IsNegative : 1
   );
 
-  SWIFT_INLINE_BITFIELD(StringLiteralExpr, LiteralExpr, 3+1+1,
+  SWIFT_INLINE_BITFIELD(StringLiteralExpr, LiteralExpr, 3+1+1+1,
     Encoding : 3,
     IsSingleUnicodeScalar : 1,
-    IsSingleExtendedGraphemeCluster : 1
+    IsSingleExtendedGraphemeCluster : 1,
+    IsCharacterLiteral : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(InterpolatedStringLiteralExpr, LiteralExpr, 32+20,
@@ -902,7 +903,8 @@ public:
     OneUnicodeScalar
   };
 
-  StringLiteralExpr(StringRef Val, SourceRange Range, bool Implicit = false);
+  StringLiteralExpr(StringRef Val, SourceRange Range,
+                    bool Implicit = false, bool IsCharacterLiteral = false);
 
   StringRef getValue() const { return Val; }
   SourceRange getSourceRange() const { return Range; }
@@ -923,6 +925,10 @@ public:
 
   bool isSingleExtendedGraphemeCluster() const {
     return Bits.StringLiteralExpr.IsSingleExtendedGraphemeCluster;
+  }
+
+  bool isCharacterLiteral() const {
+    return Bits.StringLiteralExpr.IsCharacterLiteral;
   }
 
   /// Retrieve the builtin initializer that will be used to construct the string

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -80,6 +80,7 @@ PROTOCOL_(ObjectiveCBridgeable)
 PROTOCOL_(DestructorSafeContainer)
 
 PROTOCOL(StringInterpolationProtocol)
+PROTOCOL(EnableExpressingIntegerByUnicodeScalar)
 
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -80,7 +80,6 @@ PROTOCOL_(ObjectiveCBridgeable)
 PROTOCOL_(DestructorSafeContainer)
 
 PROTOCOL(StringInterpolationProtocol)
-PROTOCOL(EnableExpressingIntegerByUnicodeScalar)
 
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -515,7 +515,7 @@ private:
   void formToken(tok Kind, const char *TokStart);
   void formEscapedIdentifierToken(const char *TokStart);
   void formStringLiteralToken(const char *TokStart, bool IsMultilineString,
-                              unsigned CustomDelimiterLen);
+                        unsigned CustomDelimiterLen, bool IsCharacterLiteral);
 
   /// Advance to the end of the line.
   /// If EatNewLine is true, CurPtr will be at end of newline character.

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -45,10 +45,13 @@ class Token {
   /// Modifiers for string literals
   unsigned MultilineString : 1;
 
+  /// Single quoted grapheme literal
+  unsigned CharacterLiteral : 1;
+
   /// Length of custom delimiter of "raw" string literals
   unsigned CustomDelimiterLen : 8;
 
-  // Padding bits == 32 - 11;
+  // Padding bits == 32 - 12;
 
   /// The length of the comment that precedes the token.
   unsigned CommentLength;
@@ -65,8 +68,8 @@ class Token {
 public:
   Token(tok Kind, StringRef Text, unsigned CommentLength = 0)
           : Kind(Kind), AtStartOfLine(false), EscapedIdentifier(false),
-            MultilineString(false), CustomDelimiterLen(0),
-            CommentLength(CommentLength), Text(Text) {}
+            MultilineString(false), CharacterLiteral(false),
+            CustomDelimiterLen(0), CommentLength(CommentLength), Text(Text) {}
 
   Token() : Token(tok::NUM_TOKENS, {}, 0) {}
 
@@ -225,15 +228,21 @@ public:
   bool isMultilineString() const {
     return MultilineString;
   }
+  /// True if the token is 'character' literal.
+  bool isCharacterLiteral() const {
+    return CharacterLiteral;
+  }
   /// Count of extending escaping '#'.
   unsigned getCustomDelimiterLen() const {
     return CustomDelimiterLen;
   }
   /// Set characteristics of string literal token.
-  void setStringLiteral(bool IsMultilineString, unsigned CustomDelimiterLen) {
+  void setStringLiteral(bool IsMultilineString, unsigned CustomDelimiterLen,
+                        bool IsCharacterLiteral = false) {
     assert(Kind == tok::string_literal);
     this->MultilineString = IsMultilineString;
     this->CustomDelimiterLen = CustomDelimiterLen;
+    this->CharacterLiteral = IsCharacterLiteral;
   }
   
   /// getLoc - Return a source location identifier for the specified

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -965,7 +965,7 @@ llvm::APFloat FloatLiteralExpr::getValue() const {
 }
 
 StringLiteralExpr::StringLiteralExpr(StringRef Val, SourceRange Range,
-                                     bool Implicit)
+                                     bool Implicit, bool IsCharacterLiteral)
     : LiteralExpr(ExprKind::StringLiteral, Implicit), Val(Val),
       Range(Range) {
   Bits.StringLiteralExpr.Encoding = static_cast<unsigned>(UTF8);
@@ -973,6 +973,7 @@ StringLiteralExpr::StringLiteralExpr(StringRef Val, SourceRange Range,
       unicode::isSingleUnicodeScalar(Val);
   Bits.StringLiteralExpr.IsSingleExtendedGraphemeCluster =
       unicode::isSingleExtendedGraphemeCluster(Val);
+  Bits.StringLiteralExpr.IsCharacterLiteral = IsCharacterLiteral;
 }
 
 static ArrayRef<Identifier> getArgumentLabelsFromArgument(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4013,7 +4013,6 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::ExpressibleByStringLiteral:
   case KnownProtocolKind::ExpressibleByNilLiteral:
   case KnownProtocolKind::ExpressibleByUnicodeScalarLiteral:
-  case KnownProtocolKind::EnableExpressingIntegerByUnicodeScalar:
   case KnownProtocolKind::ExpressibleByColorLiteral:
   case KnownProtocolKind::ExpressibleByImageLiteral:
   case KnownProtocolKind::ExpressibleByFileReferenceLiteral:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4013,6 +4013,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::ExpressibleByStringLiteral:
   case KnownProtocolKind::ExpressibleByNilLiteral:
   case KnownProtocolKind::ExpressibleByUnicodeScalarLiteral:
+  case KnownProtocolKind::EnableExpressingIntegerByUnicodeScalar:
   case KnownProtocolKind::ExpressibleByColorLiteral:
   case KnownProtocolKind::ExpressibleByImageLiteral:
   case KnownProtocolKind::ExpressibleByFileReferenceLiteral:

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -327,11 +327,13 @@ static void validateMultilineIndents(const Token &Str, DiagnosticEngine *Diags);
 
 void Lexer::formStringLiteralToken(const char *TokStart,
                                    bool IsMultilineString,
-                                   unsigned CustomDelimiterLen) {
+                                   unsigned CustomDelimiterLen,
+                                   bool IsCharacterLiteral) {
   formToken(tok::string_literal, TokStart);
   if (NextToken.is(tok::eof))
     return;
-  NextToken.setStringLiteral(IsMultilineString, CustomDelimiterLen);
+  NextToken.setStringLiteral(IsMultilineString, CustomDelimiterLen,
+                             IsCharacterLiteral);
 
   if (IsMultilineString && Diags)
     validateMultilineIndents(NextToken, Diags);
@@ -1787,51 +1789,6 @@ static void validateMultilineIndents(const Token &Str,
                                   commonIndentation);
 }
 
-/// Emit diagnostics for single-quote string and suggest replacement
-/// with double-quoted equivalent.
-static void diagnoseSingleQuoteStringLiteral(const char *TokStart,
-                                             const char *TokEnd,
-                                             DiagnosticEngine *D) {
-  assert(*TokStart == '\'' && TokEnd[-1] == '\'');
-  if (!D)
-    return;
-
-  SmallString<32> replacement;
-  replacement.push_back('"');
-  const char *Ptr = TokStart + 1;
-  const char *OutputPtr = Ptr;
-
-  while (*Ptr++ != '\'' && Ptr < TokEnd) {
-    if (Ptr[-1] == '\\') {
-      if (*Ptr == '\'') {
-        replacement.append(OutputPtr, Ptr - 1);
-        OutputPtr = Ptr + 1;
-        // Un-escape single quotes.
-        replacement.push_back('\'');
-      } else if (*Ptr == '(') {
-        // Preserve the contents of interpolation.
-        Ptr = skipToEndOfInterpolatedExpression(Ptr + 1, replacement.end(),
-                                                /*IsMultiline=*/false);
-        assert(*Ptr == ')');
-      }
-      // Skip over escaped characters.
-      ++Ptr;
-    } else if (Ptr[-1] == '"') {
-      replacement.append(OutputPtr, Ptr - 1);
-      OutputPtr = Ptr;
-      // Escape double quotes.
-      replacement.append("\\\"");
-    }
-  }
-  assert(Ptr == TokEnd && Ptr[-1] == '\'');
-  replacement.append(OutputPtr, Ptr - 1);
-  replacement.push_back('"');
-
-  D->diagnose(Lexer::getSourceLoc(TokStart), diag::lex_single_quote_string)
-      .fixItReplaceChars(Lexer::getSourceLoc(TokStart),
-                         Lexer::getSourceLoc(TokEnd), replacement);
-}
-
 /// lexStringLiteral:
 ///   string_literal ::= ["]([^"\\\n\r]|character_escape)*["]
 ///   string_literal ::= ["]["]["].*["]["]["] - approximately
@@ -1892,17 +1849,11 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
     wasErroneous |= CharValue == ~1U;
   }
 
-  if (QuoteChar == '\'') {
-    assert(!IsMultilineString && CustomDelimiterLen == 0 &&
-           "Single quoted string cannot have custom delimitor, nor multiline");
-    diagnoseSingleQuoteStringLiteral(TokStart, CurPtr, Diags);
-  }
-
   if (wasErroneous)
     return formToken(tok::unknown, TokStart);
 
   return formStringLiteralToken(TokStart, IsMultilineString,
-                                CustomDelimiterLen);
+                                CustomDelimiterLen, QuoteChar == '\'');
 }
 
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2014,14 +2014,17 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     consumeToken();
     auto expr = createStringLiteralExprFromSegment(Context, L, Segments.front(),
                                                    Loc, isCharacterLiteral);
-    if (isCharacterLiteral && !expr->isSingleExtendedGraphemeCluster())
+    if (isCharacterLiteral && !expr->isSingleExtendedGraphemeCluster()) {
       diagnose(EntireTok, diag::character_literal_not_cluster);
+      return makeParserResult(new (Context) ErrorExpr(Loc));
+    }
     return makeParserResult(expr);
   }
 
   if (isCharacterLiteral) {
+    consumeToken();
     diagnose(EntireTok, diag::character_literal_interpolating);
-    return nullptr;
+    return makeParserResult(new (Context) ErrorExpr(Loc));
   }
 
   // We are now sure this is a string interpolation expression.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1779,7 +1779,8 @@ static StringLiteralExpr *
 createStringLiteralExprFromSegment(ASTContext &Ctx,
                                    const Lexer *L,
                                    Lexer::StringSegment &Segment,
-                                   SourceLoc TokenLoc) {
+                                   SourceLoc TokenLoc,
+                                   bool IsCharacterLiteral = false) {
   assert(Segment.Kind == Lexer::StringSegment::Literal);
   // FIXME: Consider lazily encoding the string when needed.
   llvm::SmallString<256> Buf;
@@ -1789,7 +1790,8 @@ createStringLiteralExprFromSegment(ASTContext &Ctx,
            "Returned string is not from buffer?");
     EncodedStr = Ctx.AllocateCopy(EncodedStr);
   }
-  return new (Ctx) StringLiteralExpr(EncodedStr, TokenLoc);
+  return new (Ctx) StringLiteralExpr(EncodedStr, TokenLoc,
+                                     false, IsCharacterLiteral);
 }
 
 ParserStatus Parser::
@@ -2010,7 +2012,8 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
       Segments.front().Kind == Lexer::StringSegment::Literal) {
     consumeToken();
     return makeParserResult(
-        createStringLiteralExprFromSegment(Context, L, Segments.front(), Loc));
+        createStringLiteralExprFromSegment(Context, L, Segments.front(), Loc,
+                                           EntireTok.isCharacterLiteral()));
   }
 
   // We are now sure this is a string interpolation expression.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2026,6 +2026,8 @@ namespace {
 
       bool isStringLiteral = true;
       bool isGraphemeClusterLiteral = false;
+      bool isCharacter = StringLiteralExpr::isCharacterLiteralExpr(expr);
+      bool notCharacter = stringLiteral && !isCharacter;
       ProtocolDecl *protocol = tc.getProtocol(
           expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
 
@@ -2051,7 +2053,7 @@ namespace {
 
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
-      if (auto defaultType = tc.getDefaultType(protocol, dc)) {
+      if (auto defaultType = tc.getDefaultType(protocol, dc, isCharacter)) {
         if (defaultType->isEqual(type))
           type = defaultType;
       }
@@ -2062,10 +2064,8 @@ namespace {
       DeclName builtinLiteralFuncName;
       Diag<> brokenProtocolDiag;
       Diag<> brokenBuiltinProtocolDiag;
-      bool notCharacter = stringLiteral && !stringLiteral->isCharacterLiteral();
 
-      if (stringLiteral && stringLiteral->isCharacterLiteral() &&
-          !stringLiteral->isSingleExtendedGraphemeCluster())
+      if (isCharacter && !stringLiteral->isSingleExtendedGraphemeCluster())
         tc.diagnose(expr->getLoc(), diag::character_literal_not_cluster);
 
       auto migrateQuotes = [&]() {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -30,7 +30,6 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/StringExtras.h"
-#include "swift/Basic/Unicode.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
@@ -2079,7 +2078,6 @@ namespace {
           else if (body == "\\\"")
             body = "\"";
 
-// To be enabled to encourage "" -> '' when the tests are ready.
 //          tc.diagnose(expr->getLoc(), diag::character_literal_migration, type)
 //            .fixItReplaceChars(range.Start, range.End, "'" + body + "'");
         }
@@ -2157,32 +2155,10 @@ namespace {
             if (notCharacter)
               tc.diagnose(expr->getLoc(), diag::character_literal_quotes);
 
-            if (isCharacter && intTy->isFixedWidth()) {
-              StringRef Encoded = stringLiteral->getValue();
-              unsigned scalar = unicode::extractFirstUnicodeScalar(Encoded);
-
-              // Declare protocol EnableExpressingIntegerByUnicodeScalar to
-              // opt in to ability to express 21 bit unicode scalar values
-              // with a character literal - otherwise it it is ASCII only.
-              SmallVector<ValueDecl *, 1> results;
-              dc->getParentModule()->lookupValue({ },
-                  tc.Context.getIdentifier(getProtocolName(
-                    KnownProtocolKind::EnableExpressingIntegerByUnicodeScalar)),
-                  NLKind::UnqualifiedLookup, results);
-
-              if (results.size() != 0) {
-                unsigned numBits = intTy->getFixedWidth();
-                if(numBits < 32 && scalar >= (1 << numBits))
-                  tc.diagnose(expr->getLoc(), diag::character_literal_overflow,
-                              type, scalar);
-                else if (numBits == 8 && scalar > 0x7f)
-                  tc.diagnose(expr->getLoc(), diag::character_literal_nolatin1,
-                              type, scalar);
-              }
-              else if (scalar > 0x7f)
-                tc.diagnose(expr->getLoc(), diag::character_literal_not_ascii,
-                            type);
-            }
+            bool notASCII = stringLiteral->getValue()[0] & 0x80;
+            if (intTy && isCharacter && notASCII)
+              tc.diagnose(expr->getLoc(), diag::character_literal_not_ascii,
+                          type);
           }
         }
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2078,8 +2078,8 @@ namespace {
           else if (body == "\\\"")
             body = "\"";
 
-          tc.diagnose(expr->getLoc(), diag::character_literal_migration, type)
-            .fixItReplaceChars(range.Start, range.End, "'" + body + "'");
+//          tc.diagnose(expr->getLoc(), diag::character_literal_migration, type)
+//            .fixItReplaceChars(range.Start, range.End, "'" + body + "'");
         }
       };
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -511,7 +511,9 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
       // If there is a default literal type for this protocol, it's a
       // potential binding.
-      auto defaultType = tc.getDefaultType(constraint->getProtocol(), DC);
+      Expr *anchor = constraint->getLocator()->anchor;
+      auto defaultType = tc.getDefaultType(constraint->getProtocol(), DC,
+                           StringLiteralExpr::isCharacterLiteralExpr(anchor));
       if (!defaultType)
         continue;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4768,11 +4768,11 @@ static Optional<std::string> buildDefaultInitializerString(TypeChecker &tc,
     }
     CHECK_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "[]")
     CHECK_LITERAL_PROTOCOL(ExpressibleByDictionaryLiteral, "[:]")
-    CHECK_LITERAL_PROTOCOL(ExpressibleByUnicodeScalarLiteral, "\"\"")
     CHECK_LITERAL_PROTOCOL(ExpressibleByExtendedGraphemeClusterLiteral, "\"\"")
     CHECK_LITERAL_PROTOCOL(ExpressibleByFloatLiteral, "0.0")
     CHECK_LITERAL_PROTOCOL(ExpressibleByIntegerLiteral, "0")
     CHECK_LITERAL_PROTOCOL(ExpressibleByStringLiteral, "\"\"")
+    CHECK_LITERAL_PROTOCOL(ExpressibleByUnicodeScalarLiteral, "\"\"")
 #undef CHECK_LITERAL_PROTOCOL
 
     // For optional types, use 'nil'.

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -672,8 +672,7 @@ getKnownProtocolKindIfAny(const ProtocolDecl *protocol) {
 }
 
 Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc,
-                                 bool isCharacterLiteral);
-) {
+                                 bool isCharacterLiteral) {
   // This is a tempoprary workaround until ExpressibleByUnicodeScalarLiteral
   // and ExpressibleByExtendedGraphemeClusterLiteral are removed as literal
   // protocols for Strings to give character literals Character default type.
@@ -681,7 +680,7 @@ Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc,
   // return these protocols only for character literals which will complete
   // making String and Character literals distinct in time for Swift 6.
   if (isCharacterLiteral) {
-    TypeChecker &tc = getTypeChecker();
+    TypeChecker &tc = createForContext(dc->getASTContext());
     return lookupDefaultLiteralType(tc, tc.getStdlibModule(dc), "Character");
   }
   if (auto knownProtocolKindIfAny = getKnownProtocolKindIfAny(protocol)) {

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -674,6 +674,12 @@ getKnownProtocolKindIfAny(const ProtocolDecl *protocol) {
 Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc,
                                  bool isCharacterLiteral);
 ) {
+  // This is a tempoprary workaround until ExpressibleByUnicodeScalarLiteral
+  // and ExpressibleByExtendedGraphemeClusterLiteral are removed as literal
+  // protocols for Strings to give character literals Character default type.
+  // Remove this at the same time as changing TypeChecker.cpp, line 171 to
+  // return these protocols only for character literals which will complete
+  // making String and Character literals distinct in time for Swift 6.
   if (isCharacterLiteral) {
     TypeChecker &tc = getTypeChecker();
     return lookupDefaultLiteralType(tc, tc.getStdlibModule(dc), "Character");

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -671,7 +671,13 @@ getKnownProtocolKindIfAny(const ProtocolDecl *protocol) {
   return None;
 }
 
-Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {
+Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc,
+                                 bool isCharacterLiteral);
+) {
+  if (isCharacterLiteral) {
+    TypeChecker &tc = getTypeChecker();
+    return lookupDefaultLiteralType(tc, tc.getStdlibModule(dc), "Character");
+  }
   if (auto knownProtocolKindIfAny = getKnownProtocolKindIfAny(protocol)) {
     Type t = evaluateOrDefault(
         Context.evaluator,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -114,6 +114,8 @@ ProtocolDecl *TypeChecker::getLiteralProtocol(Expr *expr) {
                        KnownProtocolKind::ExpressibleByBooleanLiteral);
 
   if (const auto *SLE = dyn_cast<StringLiteralExpr>(expr)) {
+// Switch off double quoted strings expressing Character and Unicode.Scalar here
+//    if (SLE->isCharacterLiteral()) {
     if (SLE->isSingleUnicodeScalar())
       return getProtocol(
           expr->getLoc(),
@@ -123,7 +125,7 @@ ProtocolDecl *TypeChecker::getLiteralProtocol(Expr *expr) {
       return getProtocol(
           expr->getLoc(),
           KnownProtocolKind::ExpressibleByExtendedGraphemeClusterLiteral);
-
+//    }
     return getProtocol(expr->getLoc(),
                        KnownProtocolKind::ExpressibleByStringLiteral);
   }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -114,18 +114,18 @@ ProtocolDecl *TypeChecker::getLiteralProtocol(Expr *expr) {
                        KnownProtocolKind::ExpressibleByBooleanLiteral);
 
   if (const auto *SLE = dyn_cast<StringLiteralExpr>(expr)) {
-// Switch off double quoted strings expressing Character and Unicode.Scalar here
-//    if (SLE->isCharacterLiteral()) {
-    if (SLE->isSingleUnicodeScalar())
-      return getProtocol(
-          expr->getLoc(),
-          KnownProtocolKind::ExpressibleByUnicodeScalarLiteral);
+    if (!Context.LangOpts.isSwiftVersionAtLeast(6) ||
+        SLE->isCharacterLiteral()) {
+      if (SLE->isSingleUnicodeScalar())
+        return getProtocol(
+            expr->getLoc(),
+            KnownProtocolKind::ExpressibleByUnicodeScalarLiteral);
 
-    if (SLE->isSingleExtendedGraphemeCluster())
-      return getProtocol(
-          expr->getLoc(),
-          KnownProtocolKind::ExpressibleByExtendedGraphemeClusterLiteral);
-//    }
+      if (SLE->isSingleExtendedGraphemeCluster())
+        return getProtocol(
+            expr->getLoc(),
+            KnownProtocolKind::ExpressibleByExtendedGraphemeClusterLiteral);
+    }
     return getProtocol(expr->getLoc(),
                        KnownProtocolKind::ExpressibleByStringLiteral);
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1583,7 +1583,8 @@ public:
   ///
   /// \returns the default type, or null if there is no default type for
   /// this protocol.
-  Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
+  Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc,
+                      bool isCharacterLiteral = false);
 
   /// Convert the given expression to the given type.
   ///

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1663,6 +1663,19 @@ extension ${Self} : _HasCustomAnyHashableRepresentation {
   }
 }
 
+extension ${Self} :
+    _ExpressibleByBuiltinUnicodeScalarLiteral,
+    ExpressibleByUnicodeScalarLiteral {
+  @_transparent
+  public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
+    self = ${Self}(truncatingIfNeeded: UInt32(value))
+  }
+  @_transparent
+  public init(unicodeScalarLiteral value: ${Self}) {
+    self = value
+  }
+}
+
 // FIXME(integers): this section here is to help the typechecker,
 // as it seems to have problems with a pattern where the nonmutating operation
 // is defined on a protocol in terms of a mutating one that is itself defined

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1663,14 +1663,17 @@ extension ${Self} : _HasCustomAnyHashableRepresentation {
   }
 }
 
+/// Conformances for character literals
+/// Users will need to opt-in for now.
 extension ${Self} :
-    _ExpressibleByBuiltinUnicodeScalarLiteral,
-    ExpressibleByUnicodeScalarLiteral {
+    _ExpressibleByBuiltinUnicodeScalarLiteral/*,
+    ExpressibleByUnicodeScalarLiteral*/ {
   @_transparent
   public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
     self = ${Self}(truncatingIfNeeded: UInt32(value))
   }
   @_transparent
+  @available(swift 5.1)
   public init(unicodeScalarLiteral value: ${Self}) {
     self = value
   }

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1663,22 +1663,6 @@ extension ${Self} : _HasCustomAnyHashableRepresentation {
   }
 }
 
-/// Conformances for character literals
-/// Users will need to opt-in for now.
-extension ${Self} :
-    _ExpressibleByBuiltinUnicodeScalarLiteral/*,
-    ExpressibleByUnicodeScalarLiteral*/ {
-  @_transparent
-  public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
-    self = ${Self}(truncatingIfNeeded: UInt32(value))
-  }
-  @_transparent
-  @available(swift 5.1)
-  public init(unicodeScalarLiteral value: ${Self}) {
-    self = value
-  }
-}
-
 // FIXME(integers): this section here is to help the typechecker,
 // as it seems to have problems with a pattern where the nonmutating operation
 // is defined on a protocol in terms of a mutating one that is itself defined
@@ -1848,6 +1832,17 @@ internal struct _IntegerAnyHashableBox<
     guard let value = _value as? T else { return false }
     result.initialize(to: value)
     return true
+  }
+}
+
+/// Intended for character literals. Per-integer type
+/// conformances to ExpressibleByUnicodeScalarLiteral
+/// will have to wait until they can be gated to 5.1.
+extension FixedWidthInteger {
+  @_transparent
+  @available(swift 5.1)
+  public init(unicodeScalarLiteral value: Unicode.Scalar) {
+    self.init(truncatingIfNeeded: value.value)
   }
 }
 

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -101,7 +101,9 @@ public typealias UnicodeScalarType = String
 /// The default type for an otherwise-unconstrained Unicode extended
 /// grapheme cluster literal.
 public typealias ExtendedGraphemeClusterType = String
-/// The default type for an otherwise-unconstrained string literal.
+/// The default type for an otherwise-unconstrained 'character' literal.
+public typealias CharacterLiteralType = Character
+/// The default type for an otherwise-unconstrained "string" literal.
 public typealias StringLiteralType = String
 
 //===----------------------------------------------------------------------===//

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -182,8 +182,8 @@ func recArea(_ h: Int, w : Int) {
 
 // <rdar://problem/17224804> QoI: Error In Ternary Condition is Wrong
 func r17224804(_ monthNumber : Int) {
-  // expected-error @+2 {{binary operator '+' cannot be applied to operands of type 'String' and 'Int'}}
-  // expected-note @+1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String)}}
+  // expected-error @+2 {{integers can only be expressed by single quoted character literals}}
+  // expected-error @+1 {{result values in '? :' expression have mismatching types 'Int' and 'String'}}
   let monthString = (monthNumber <= 9) ? ("0" + monthNumber) : String(monthNumber)
 }
 
@@ -985,8 +985,8 @@ func SR_6272_b() {
 }
 
 func SR_6272_c() {
-  // expected-error@+2 {{binary operator '*' cannot be applied to operands of type 'Int' and 'String'}} {{none}}
-  // expected-note@+1 {{expected an argument list of type '(Int, Int)'}}
+  // expected-warning@+2 {{result of operator '*' is unused}}
+  // expected-error@+1 {{integers can only be expressed by single quoted character literals}}
   Int(3) * "0"
 
   struct S {}

--- a/test/IDE/complete_value_literals.swift
+++ b/test/IDE/complete_value_literals.swift
@@ -152,7 +152,7 @@ func testDouble0() {
 func testString0() {
   let x: Int = #^STRING_0^#
 }
-// STRING_0: Literal[String]/None: "{#(abc)#}"[#String#];
+// STRING_0: Literal[Nil]/None:                  nil;
 
 func testString1() {
   let x: MyString1 = #^STRING_1^#

--- a/test/Interpreter/constructor.swift
+++ b/test/Interpreter/constructor.swift
@@ -37,11 +37,11 @@ BChar()
 // CHECK: e
 BChar(1)
 // CHECK: f
-BChar("2")
+BChar("2" as UnicodeScalar)
 // CHECK: g
 BChar(1, "2")
 // CHECK: h
-BChar("1", "2")
+BChar("1" as UnicodeScalar, "2" as UnicodeScalar)
 
 // <rdar://problem/12965934> Destructors for classes with constrained type parameters
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -7,15 +7,15 @@ protocol FooProtocol {}
 //===--- Tests.
 
 func garbage() -> () {
-  var a : Int
+  var a : Int // expected-warning{{variable 'a' was never mutated; consider changing to 'let' constant}}
   ] this line is invalid, but we will stop at the keyword below... // expected-error{{expected expression}}
-  return a + "a" // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String)}}
+  return a + "a" // expected-error{{integers can only be expressed by single quoted character literals}} expected-error{{unexpected non-void return value in void function}}
 }
 
 func moreGarbage() -> () {
   ) this line is invalid, but we will stop at the declaration... // expected-error{{expected expression}}
   func a() -> Int { return 4 }
-  return a() + "a" // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String)}}
+  return a() + "a" // expected-error{{integers can only be expressed by single quoted character literals}} expected-error{{unexpected non-void return value in void function}}
 }
 
 

--- a/test/SourceKit/CodeComplete/complete_literals.swift
+++ b/test/SourceKit/CodeComplete/complete_literals.swift
@@ -60,6 +60,7 @@ if #^EXPR3^# { }
 foo(#^EXPR4^#)
 // LITERAL_INT-NOT: source.lang.swift.literal
 // LITERAL_INT: key.kind: source.lang.swift.literal.integer
+// LITERAL_INT: key.kind: source.lang.swift.literal.string
 // LITERAL_INT-NOT: source.lang.swift.literal
 
 // RUN: %complete-test -tok=EXPR5 %s -raw | %FileCheck %s -check-prefix=LITERAL_TUPLE

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1353,6 +1353,31 @@
         },
         {
           "kind": "Conformance",
+          "name": "_ExpressibleByBuiltinUnicodeScalarLiteral",
+          "printedName": "_ExpressibleByBuiltinUnicodeScalarLiteral"
+        },
+        {
+          "kind": "Conformance",
+          "name": "ExpressibleByUnicodeScalarLiteral",
+          "printedName": "ExpressibleByUnicodeScalarLiteral",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "UnicodeScalarLiteralType",
+              "printedName": "UnicodeScalarLiteralType",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Int",
+                  "usr": "s:Si"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Conformance",
           "name": "CustomReflectable",
           "printedName": "CustomReflectable"
         },

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1246,6 +1246,26 @@
         },
         {
           "kind": "Conformance",
+          "name": "ExpressibleByUnicodeScalarLiteral",
+          "printedName": "ExpressibleByUnicodeScalarLiteral",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "UnicodeScalarLiteralType",
+              "printedName": "UnicodeScalarLiteralType",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Int",
+                  "usr": "s:Si"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Conformance",
           "name": "CustomReflectable",
           "printedName": "CustomReflectable"
         },

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -125,7 +125,6 @@ struct BadCase3 : PA { // expected-error {{type 'BadCase3' does not conform to p
 extension UInt32: ExpressibleByStringLiteral {}
 // expected-error@-1 {{type 'UInt32' does not conform to protocol 'ExpressibleByStringLiteral'}}
 // expected-error@-2 {{type 'UInt32' does not conform to protocol 'ExpressibleByExtendedGraphemeClusterLiteral'}}
-// expected-error@-3 {{type 'UInt32' does not conform to protocol 'ExpressibleByUnicodeScalarLiteral'}}
 
 // After successfully type-checking this (due to the presumption of
 // the type actually conforming), do not crash when failing to find

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -499,25 +499,24 @@ func stringliterals(_ d: [String: Int]) {
 }
 
 func testSingleQuoteStringLiterals() {
-  _ = 'abc' // expected-error{{single-quoted string literal found, use '"'}}{{7-12="abc"}}
-  _ = 'abc' + "def" // expected-error{{single-quoted string literal found, use '"'}}{{7-12="abc"}}
+  _ = 'abc' // expected-error{{character literal is not a single extended grapheme cluster}}
+  _ = 'abc' + "def" // expected-error{{character literal is not a single extended grapheme cluster}}
 
-  _ = 'ab\nc' // expected-error{{single-quoted string literal found, use '"'}}{{7-14="ab\\nc"}}
+  _ = 'ab\nc' // expected-error{{character literal is not a single extended grapheme cluster}}
 
-  _ = "abc\('def')" // expected-error{{single-quoted string literal found, use '"'}}{{13-18="def"}}
-  _ = 'ab\("c")' // expected-error{{single-quoted string literal found, use '"'}}{{7-17="ab\\("c")"}}
-  _ = 'a\('b')c' // expected-error{{single-quoted string literal found, use '"'}}{{7-17="a\\('b')c"}}
-                 // expected-error@-1{{single-quoted string literal found, use '"'}}{{11-14="b"}}
+  _ = "abc\('def')" // expected-error{{character literal is not a single extended grapheme cluster}}
+  _ = 'ab\("c")' // expected-error{{character literal can not contain interpolations}}
+  _ = 'a\('b')c' // expected-error{{character literal can not contain interpolations}}
+
+  _ = 'ab\'c' // expected-error{{character literal is not a single extended grapheme cluster}}
+
+  _ = 'ab"c' // expected-error{{character literal is not a single extended grapheme cluster}}
+  _ = 'ab\"c' // expected-error{{character literal is not a single extended grapheme cluster}}
+  _ = 'ab\\"c' // expected-error{{character literal is not a single extended grapheme cluster}}
 
   _ = "abc' // expected-error{{unterminated string literal}}
   _ = 'abc" // expected-error{{unterminated string literal}}
   _ = "a'c"
-
-  _ = 'ab\'c' // expected-error{{single-quoted string literal found, use '"'}}{{7-14="ab'c"}}
-
-  _ = 'ab"c' // expected-error{{single-quoted string literal found, use '"'}}{{7-13="ab\\"c"}}
-  _ = 'ab\"c' // expected-error{{single-quoted string literal found, use '"'}}{{7-14="ab\\"c"}}
-  _ = 'ab\\"c' // expected-error{{single-quoted string literal found, use '"'}}{{7-15="ab\\\\\\"c"}}
 }
 
 // <rdar://problem/17128913>

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -62,7 +62,7 @@ tests.test("${Self}/success") {
   let isSigned = ${str(type.is_signed).lower()}
 
   //===--- Important cases ------------------------------------------------===//
-  expectEqual(0, ${Self}("0"))      // zero
+  expectEqual(0, ${Self}("0" as String))      // zero
   expectEqual(17, ${Self}("17"))    // non-zero with no radix
 
   // Leading zeroes, with and without a radix
@@ -86,7 +86,7 @@ tests.test("${Self}/success") {
   // Out-of-range values
   expectEqual(nil, ${Self}("${maxValue + 1}"))
   expectEqual(nil, ${Self}("${minValue - 1}"))
-  expectEqual(nil, ${Self}("\u{1D7FF}"))  // MATHEMATICAL MONOSPACE DIGIT NINE
+  expectEqual(nil, ${Self}("\u{1D7FF}" as String))  // MATHEMATICAL MONOSPACE DIGIT NINE
 
   // Cases that should fail to parse
   expectEqual(nil, ${Self}("--0")) // Zero w/ repeated plus


### PR DESCRIPTION
Hi Apple,

This is the essentially complete implementation for introducing character literals to swift as pitched at length in the [swift forum thread](https://forums.swift.org/t/prepitch-character-integer-literals/10442/292).

Could someone run this through the compatibility suite for me please to see if there is something I missed.

Resolves [SR-9032](https://bugs.swift.org/browse/SR-9032).