### PR TITLE
[pmo] Update the memory use collector for ownership.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -78,8 +78,9 @@ static SILValue scalarizeLoad(LoadInst *LI,
   SmallVector<SILValue, 4> ElementTmps;
 
   for (unsigned i = 0, e = ElementAddrs.size(); i != e; ++i) {
-    auto *SubLI = B.createLoad(LI->getLoc(), ElementAddrs[i],
-                               LoadOwnershipQualifier::Unqualified);
+    auto *SubLI = B.createTrivialLoadOr(LI->getLoc(), ElementAddrs[i],
+                                        LI->getOwnershipQualifier(),
+                                        true /*supports unqualified*/);
     ElementTmps.push_back(SubLI);
   }
 
@@ -118,7 +119,7 @@ public:
 
 private:
   LLVM_NODISCARD bool collectUses(SILValue Pointer);
-  LLVM_NODISCARD bool collectContainerUses(AllocBoxInst *ABI);
+  LLVM_NODISCARD bool collectContainerUses(SILValue boxValue);
 };
 } // end anonymous namespace
 
@@ -130,8 +131,10 @@ bool ElementUseCollector::collectFrom() {
   return collectUses(TheMemory.getAddress());
 }
 
-bool ElementUseCollector::collectContainerUses(AllocBoxInst *abi) {
-  for (auto *ui : abi->getUses()) {
+bool ElementUseCollector::collectContainerUses(SILValue boxValue) {
+  assert(isa<AllocBoxInst>(boxValue) || isa<CopyValueInst>(boxValue));
+
+  for (auto *ui : boxValue->getUses()) {
     auto *user = ui->getUser();
 
     // dealloc_box deallocated a box containing uninitialized memory. This can
@@ -142,6 +145,14 @@ bool ElementUseCollector::collectContainerUses(AllocBoxInst *abi) {
     // Retaining the box doesn't effect the value inside the box.
     if (isa<StrongRetainInst>(user) || isa<RetainValueInst>(user))
       continue;
+
+    // Like retaining, copies do not effect the underlying value. We do need to
+    // recursively visit the copies users though.
+    if (auto *cvi = dyn_cast<CopyValueInst>(user)) {
+      if (!collectContainerUses(cvi))
+        return false;
+      continue;
+    }
 
     // Since we are trying to promote loads/stores, any releases of the box are
     // not considered uses of the underlying value due to:
@@ -162,7 +173,8 @@ bool ElementUseCollector::collectContainerUses(AllocBoxInst *abi) {
     // FIXME: Since we do not support promoting strong_release or release_value
     // today this will cause the underlying allocation to never be
     // eliminated. That should be implemented and fixed.
-    if (isa<StrongReleaseInst>(user) || isa<ReleaseValueInst>(user)) {
+    if (isa<StrongReleaseInst>(user) || isa<ReleaseValueInst>(user) ||
+        isa<DestroyValueInst>(user)) {
       Releases.push_back(user);
       continue;
     }
@@ -433,8 +445,9 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
         getScalarizedElements(SI->getOperand(0), ElementTmps, SI->getLoc(), B);
 
         for (unsigned i = 0, e = ElementAddrs.size(); i != e; ++i)
-          B.createStore(SI->getLoc(), ElementTmps[i], ElementAddrs[i],
-                        StoreOwnershipQualifier::Unqualified);
+          B.createTrivialStoreOr(SI->getLoc(), ElementTmps[i], ElementAddrs[i],
+                                 SI->getOwnershipQualifier(),
+                                 true /*supports unqualified*/);
         SI->eraseFromParent();
         continue;
       }


### PR DESCRIPTION
This is technically a NFC commit. The changes are:

1. When we scalarize loads/stores, we need to not just use unqualified
loads/stores. Instead we need to use the createTrivial{Load,Store}Or APIs. In
OSSA mode, this will propagate through the original ownership qualifier if the
sub-type is non-trivial, but if the sub-type is non-trivial will change the
qualifier to trivial. Today when the pass runs without ownership nothing is
changed since I am passing in the "supports unqualified" flag to the
createTrivial{Load,Store}Or API so that we just create an unqualified memop if
we are passed in an unqualified memop. Once we fully move pmo to ownership, this
flag will be removed and we will assert.

2. The container walker is taught about copy_value, destroy_value. Specifically,
we teach the walker how to recursively look through copy_values during the walk
and to treat a destroy_value of the box like a strong_release,
release_value. Since destroy_value, copy_value only exist in [ossa] today, this
is also NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
