### PR TITLE
Refactor delayed member parsing and fix a bug

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -614,8 +614,7 @@ public: // for static functions in Frontend.cpp
 
 private:
   void createREPLFile(const ImplicitImports &implicitImports);
-  std::unique_ptr<DelayedParsingCallbacks>
-  computeDelayedParsingCallback(bool isPrimary);
+  std::unique_ptr<DelayedParsingCallbacks> computeDelayedParsingCallback();
 
   void addMainFileToModule(const ImplicitImports &implicitImports);
 
@@ -626,15 +625,13 @@ private:
   void parseLibraryFile(unsigned BufferID,
                         const ImplicitImports &implicitImports,
                         PersistentParserState &PersistentState,
-                        DelayedParsingCallbacks *PrimaryDelayedCB,
-                        DelayedParsingCallbacks *SecondaryDelayedCB);
+                        DelayedParsingCallbacks *DelayedCB);
 
   /// Return true if had load error
   bool
   parsePartialModulesAndLibraryFiles(const ImplicitImports &implicitImports,
                                      PersistentParserState &PersistentState,
-                                     DelayedParsingCallbacks *PrimaryDelayedCB,
-                                     DelayedParsingCallbacks *SecondaryDelayedCB);
+                                     DelayedParsingCallbacks *DelayedCB);
 
   OptionSet<TypeCheckingFlags> computeTypeCheckingOptions();
 

--- a/include/swift/Parse/DelayedParsingCallbacks.h
+++ b/include/swift/Parse/DelayedParsingCallbacks.h
@@ -35,15 +35,6 @@ public:
                                               SourceRange BodyRange) = 0;
 };
 
-class AlwaysDelayedCallbacks : public DelayedParsingCallbacks {
-  bool shouldDelayFunctionBodyParsing(Parser &TheParser,
-                                      AbstractFunctionDecl *AFD,
-                                      const DeclAttributes &Attrs,
-                                      SourceRange BodyRange) override {
-    return true;
-  }
-};
-
 /// Implementation of callbacks that guide the parser in delayed
 /// parsing for code completion.
 class CodeCompleteDelayedCallbacks : public DelayedParsingCallbacks {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -207,8 +207,15 @@ public:
   /// Always empty if !SF.shouldBuildSyntaxTree().
   ParsedTrivia TrailingTrivia;
 
-  /// Whether we should disable delayed parsing.
-  bool DisableDelayedParsing;
+  /// Whether we should delay parsing nominal type and extension bodies,
+  /// and skip function bodies.
+  ///
+  /// This is false in primary files, since we want to type check all
+  /// declarations and function bodies.
+  ///
+  /// This is true for non-primary files, where declarations only need to be
+  /// lazily parsed and type checked.
+  bool DelayBodyParsing;
 
   /// The receiver to collect all consumed tokens.
   ConsumeTokenReceiver *TokReceiver;
@@ -357,16 +364,16 @@ public:
          SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool DisableDelayedParsing = false);
+         bool DelayBodyParsing = true);
   Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState = nullptr,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool DisableDelayedParsing = false);
+         bool DelayBodyParsing = true);
   Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
          SILParserTUStateBase *SIL = nullptr,
          PersistentParserState *PersistentState = nullptr,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool DisableDelayedParsing = false);
+         bool DelayBodyParsing = true);
   ~Parser();
 
   bool isInSILMode() const { return SIL != nullptr; }

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -798,6 +798,13 @@ public:
 
   void parseDeclListDelayed(IterableDeclContext *IDC);
 
+  bool canDelayMemberDeclParsing();
+
+  bool delayParsingDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
+                            SourceLoc PosBeforeLB,
+                            ParseDeclOptions Options,
+                            IterableDeclContext *IDC);
+
   ParserResult<TypeDecl> parseDeclTypeAlias(ParseDeclOptions Flags,
                                             DeclAttributes &Attributes);
 
@@ -1428,8 +1435,6 @@ public:
   parsePlatformVersionConstraintSpec();
   ParserResult<PlatformAgnosticVersionConstraintAvailabilitySpec>
   parsePlatformAgnosticVersionConstraintSpec();
-
-  bool canDelayMemberDeclParsing();
 };
 
 /// Describes a parsed declaration name.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -894,7 +894,7 @@ public:
                              llvm::function_ref<void(Decl*)> handler);
   bool parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
                      Diag<> ErrorDiag, ParseDeclOptions Options,
-                     llvm::function_ref<void(Decl*)> handler);
+                     IterableDeclContext *IDC);
   ParserResult<ExtensionDecl> parseDeclExtension(ParseDeclOptions Flags,
                                                  DeclAttributes &Attributes);
   ParserResult<EnumDecl> parseDeclEnum(ParseDeclOptions Flags,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -165,7 +165,9 @@ public:
 
   DelayedParsingCallbacks *DelayedParseCB = nullptr;
 
-  bool isDelayedParsingEnabled() const { return DelayedParseCB != nullptr; }
+  bool isDelayedParsingEnabled() const {
+    return DelayBodyParsing || DelayedParseCB != nullptr;
+  }
 
   void setDelayedParsingCallbacks(DelayedParsingCallbacks *DelayedParseCB) {
     this->DelayedParseCB = DelayedParseCB;

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -122,7 +122,7 @@ namespace swift {
                            SILParserState *SIL = nullptr,
                            PersistentParserState *PersistentState = nullptr,
                            DelayedParsingCallbacks *DelayedParseCB = nullptr,
-                           bool DisableDelayedParsing = false);
+                           bool DelayBodyParsing = true);
 
   /// Parse a single buffer into the given source file, until the full source
   /// contents are parsed.
@@ -131,7 +131,7 @@ namespace swift {
   bool parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
                              PersistentParserState *PersistentState = nullptr,
                              DelayedParsingCallbacks *DelayedParseCB = nullptr,
-                               bool DisableDelayedParsing = false);
+                               bool DelayBodyParsing = true);
 
   /// Finish the parsing by going over the nodes that were delayed
   /// during the first parsing pass.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3547,7 +3547,6 @@ void ClassDecl::addImplicitDestructor() {
   // Create an empty body for the destructor.
   DD->setBody(BraceStmt::create(ctx, getLoc(), { }, getLoc(), true));
   addMember(DD);
-  setHasDestructor();
 
   // Propagate access control and versioned-ness.
   DD->copyFormalAccessFrom(this, /*sourceIsParentContext*/true);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1437,6 +1437,11 @@ void MemberLookupTable::updateLookupTable(NominalTypeDecl *nominal) {
 }
 
 void NominalTypeDecl::addedMember(Decl *member) {
+  // Remember if we added a destructor.
+  if (auto *CD = dyn_cast<ClassDecl>(this))
+    if (isa<DestructorDecl>(member))
+      CD->setHasDestructor();
+
   // If we have a lookup table, add the new member to it.
   if (LookupTable.getPointer()) {
     LookupTable.getPointer()->addMember(member);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3050,8 +3050,6 @@ void Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
   } else if (auto *cd = dyn_cast<ClassDecl>(D)) {
     auto handler = [&] (Decl *D) {
       cd->addMember(D);
-      if (isa<DestructorDecl>(D))
-        cd->setHasDestructor();
     };
     parseDeclList(cd->getBraces().Start, RBLoc, Id,
                   ParseDeclOptions(DelayedState->Flags), handler);
@@ -6160,8 +6158,6 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
     } else {
       auto Handler = [&] (Decl *D) {
         CD->addMember(D);
-        if (isa<DestructorDecl>(D))
-          CD->setHasDestructor();
       };
       if (parseDeclList(LBLoc, RBLoc, diag::expected_rbrace_class,
                         Options, Handler))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5401,7 +5401,8 @@ void Parser::consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
 
   BodyRange.End = PreviousLoc;
 
-  if (DelayedParseCB->shouldDelayFunctionBodyParsing(*this, AFD, Attrs,
+  if (DelayedParseCB &&
+      DelayedParseCB->shouldDelayFunctionBodyParsing(*this, AFD, Attrs,
                                                      BodyRange)) {
     State->delayFunctionBodyParsing(AFD, BodyRange,
                                     BeginParserPosition.PreviousLoc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3496,7 +3496,7 @@ bool Parser::parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
 
 bool Parser::canDelayMemberDeclParsing() {
   // If explicitly disabled, respect the flag.
-  if (DisableDelayedParsing)
+  if (!DelayBodyParsing)
     return false;
   // There's no fundamental reasons that SIL cannnot be lasily parsed. We need
   // to keep SILParserTUStateBase persistent to make it happen.
@@ -3520,6 +3520,9 @@ bool Parser::canDelayMemberDeclParsing() {
   // so we cannot lazily parse members.
   if (isCodeCompletionFirstPass())
     return false;
+
+  // Skip until the matching right curly bracket; if we find a pound directive,
+  // we can't lazily parse.
   BacktrackingScope BackTrack(*this);
   bool HasPoundDirective;
   skipUntilMatchingRBrace(*this, HasPoundDirective, SyntaxContext);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5740,7 +5740,7 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
     RBLoc = LBLoc;
     Status.setIsParseError();
   } else {
-    Scope S(this, ScopeKind::ClassBody);
+    Scope S(this, ScopeKind::EnumBody);
     ParseDeclOptions Options(PD_HasContainerType | PD_AllowEnumElement | PD_InEnum);
     if (canDelayMemberDeclParsing()) {
       if (delayParsingDeclList(LBLoc, RBLoc, PosBeforeLB, Options, ED))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3498,27 +3498,9 @@ bool Parser::canDelayMemberDeclParsing() {
   // If explicitly disabled, respect the flag.
   if (!DelayBodyParsing)
     return false;
-  // There's no fundamental reasons that SIL cannnot be lasily parsed. We need
-  // to keep SILParserTUStateBase persistent to make it happen.
-  if (isInSILMode())
-    return false;
-  // Calculating interface hash requires tokens consumed in the original order.
-  if (SF.hasInterfaceHash())
-    return false;
-  if (SF.Kind == SourceFileKind::REPL)
-    return false;
-  // We always collect the entire syntax tree for IDE uses.
-  if (SF.shouldCollectToken())
-    return false;
-  if (SF.shouldBuildSyntaxTree())
-    return false;
-  // Recovering parser status later for #sourceLocaion is not-trivial and
+  // Recovering parser status later for #sourceLocation is not-trivial and
   // it may not worth it.
   if (InPoundLineEnvironment)
-    return false;
-  // The first code completion pass looks for code completion tokens extensively,
-  // so we cannot lazily parse members.
-  if (isCodeCompletionFirstPass())
     return false;
 
   // Skip until the matching right curly bracket; if we find a pound directive,

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -346,15 +346,15 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
 Parser::Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
                PersistentParserState *PersistentState,
                std::shared_ptr<SyntaxParseActions> SPActions,
-               bool DisableDelayedParsing)
+               bool DelayBodyParsing)
     : Parser(BufferID, SF, &SF.getASTContext().Diags, SIL, PersistentState,
-             std::move(SPActions), DisableDelayedParsing) {}
+             std::move(SPActions), DelayBodyParsing) {}
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
                SILParserTUStateBase *SIL,
                PersistentParserState *PersistentState,
                std::shared_ptr<SyntaxParseActions> SPActions,
-               bool DisableDelayedParsing)
+               bool DelayBodyParsing)
     : Parser(
           std::unique_ptr<Lexer>(new Lexer(
               SF.getASTContext().LangOpts, SF.getASTContext().SourceMgr,
@@ -369,7 +369,7 @@ Parser::Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
               SF.shouldBuildSyntaxTree()
                   ? TriviaRetentionMode::WithTrivia
                   : TriviaRetentionMode::WithoutTrivia)),
-          SF, SIL, PersistentState, std::move(SPActions), DisableDelayedParsing) {}
+          SF, SIL, PersistentState, std::move(SPActions), DelayBodyParsing) {}
 
 namespace {
 
@@ -490,7 +490,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
                SILParserTUStateBase *SIL,
                PersistentParserState *PersistentState,
                std::shared_ptr<SyntaxParseActions> SPActions,
-               bool DisableDelayedParsing)
+               bool DelayBodyParsing)
   : SourceMgr(SF.getASTContext().SourceMgr),
     Diags(SF.getASTContext().Diags),
     SF(SF),
@@ -498,7 +498,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     SIL(SIL),
     CurDeclContext(&SF),
     Context(SF.getASTContext()),
-    DisableDelayedParsing(DisableDelayedParsing),
+    DelayBodyParsing(DelayBodyParsing),
     TokReceiver(SF.shouldCollectToken() ?
                 new TokenRecorder(SF) :
                 new ConsumeTokenReceiver()),

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -139,7 +139,8 @@ private:
     SourceFile &SF = *AFD->getDeclContext()->getParentSourceFile();
     SourceManager &SourceMgr = SF.getASTContext().SourceMgr;
     unsigned BufferID = SourceMgr.findBufferContainingLoc(AFD->getLoc());
-    Parser TheParser(BufferID, SF, nullptr, &ParserState);
+    Parser TheParser(BufferID, SF, nullptr, &ParserState, nullptr,
+                     /*DelayBodyParsing=*/false);
     TheParser.SyntaxContext->disable();
     std::unique_ptr<CodeCompletionCallbacks> CodeCompletion;
     if (CodeCompletionFactory) {
@@ -165,7 +166,8 @@ static void parseDelayedDecl(
   SourceManager &SourceMgr = SF.getASTContext().SourceMgr;
   unsigned BufferID =
     SourceMgr.findBufferContainingLoc(ParserState.getDelayedDeclLoc());
-  Parser TheParser(BufferID, SF, nullptr, &ParserState);
+  Parser TheParser(BufferID, SF, nullptr, &ParserState, nullptr,
+                   /*DelayBodyParsing=*/false);
 
   // Disable libSyntax creation in the delayed parsing.
   TheParser.SyntaxContext->disable();
@@ -1105,7 +1107,8 @@ ParserUnit::ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned Buffer
 
   Impl.SF->SyntaxParsingCache = SyntaxCache;
   Impl.TheParser.reset(new Parser(BufferID, *Impl.SF, /*SIL=*/nullptr,
-                                  /*PersistentState=*/nullptr, Impl.SPActions));
+                                  /*PersistentState=*/nullptr, Impl.SPActions,
+                                  /*DelayBodyParsing=*/false));
 }
 
 ParserUnit::ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
@@ -1122,7 +1125,7 @@ ParserUnit::ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned Buffer
                       TriviaRetentionMode::WithoutTrivia,
                       Offset, EndOffset));
   Impl.TheParser.reset(new Parser(std::move(Lex), *Impl.SF, /*SIL=*/nullptr,
-    /*PersistentState=*/nullptr, Impl.SPActions));
+    /*PersistentState=*/nullptr, Impl.SPActions, /*DelayBodyParsing=*/false));
 }
 
 ParserUnit::~ParserUnit() {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -116,7 +116,7 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
                                 PersistentParserState *PersistentState,
                                 DelayedParsingCallbacks *DelayedParseCB,
                                 bool FullParse,
-                                bool DisableDelayedParsing) {
+                                bool DelayBodyParsing) {
   assert((!FullParse || (SF.canBeParsedInFull() && !SIL)) &&
          "cannot parse in full with the given parameters!");
 
@@ -129,7 +129,7 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
 
   SharedTimer timer("Parsing");
   Parser P(BufferID, SF, SIL ? SIL->Impl.get() : nullptr,
-           PersistentState, STreeCreator, DisableDelayedParsing);
+           PersistentState, STreeCreator, DelayBodyParsing);
   PrettyStackTraceParser StackTrace(P);
 
   llvm::SaveAndRestore<bool> S(P.IsParsingInterfaceTokens,
@@ -158,21 +158,21 @@ bool swift::parseIntoSourceFile(SourceFile &SF,
                                 SILParserState *SIL,
                                 PersistentParserState *PersistentState,
                                 DelayedParsingCallbacks *DelayedParseCB,
-                                bool DisableDelayedParsing) {
+                                bool DelayBodyParsing) {
   return parseIntoSourceFileImpl(SF, BufferID, Done, SIL,
                                  PersistentState, DelayedParseCB,
                                  /*FullParse=*/SF.shouldBuildSyntaxTree(),
-                                 DisableDelayedParsing);
+                                 DelayBodyParsing);
 }
 
 bool swift::parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
                                     PersistentParserState *PersistentState,
                                     DelayedParsingCallbacks *DelayedParseCB,
-                                    bool DisableDelayedParsing) {
+                                    bool DelayBodyParsing) {
   bool Done = false;
   return parseIntoSourceFileImpl(SF, BufferID, &Done, /*SIL=*/nullptr,
                                  PersistentState, DelayedParseCB,
-                                 /*FullParse=*/true, DisableDelayedParsing);
+                                 /*FullParse=*/true, DelayBodyParsing);
 }
 
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -127,6 +127,18 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
         SF.SyntaxParsingCache, SF.getASTContext().getSyntaxArena());
   }
 
+  // Not supported right now.
+  if (SF.Kind == SourceFileKind::REPL)
+    DelayBodyParsing = false;
+  if (SF.hasInterfaceHash())
+    DelayBodyParsing = false;
+  if (SF.shouldCollectToken())
+    DelayBodyParsing = false;
+  if (SF.shouldBuildSyntaxTree())
+    DelayBodyParsing = false;
+  if (SIL)
+    DelayBodyParsing = false;
+
   SharedTimer timer("Parsing");
   Parser P(BufferID, SF, SIL ? SIL->Impl.get() : nullptr,
            PersistentState, STreeCreator, DelayBodyParsing);

--- a/validation-test/compiler_scale/function_bodies.gyb
+++ b/validation-test/compiler_scale/function_bodies.gyb
@@ -3,3 +3,35 @@
 // REQUIRES: asserts
 
 func method${N}() {}
+
+class C${N} {
+    func method${N}() {}
+}
+
+extension C${N} {
+    func otherMethod${N}() {}
+}
+
+struct S${N} {
+    func method${N}() {}
+}
+
+extension S${N} {
+    func otherMethod${N}() {}
+}
+
+enum E${N} {
+    func method${N}() {}
+}
+
+extension E${N} {
+    func otherMethod${N}() {}
+}
+
+protocol P${N} {
+    func method${N}()
+}
+
+extension P${N} {
+    func otherMethod${N}() {}
+}


### PR DESCRIPTION
There was a bad interaction between the old delayed function body parsing, and the new delayed member parsing that was added post-4.2.

When delayed member parsing parses a nominal type or extension body, it would create a new parser instance without delayed parsing callbacks. Since right now, nominal type bodies are parsed a lot more often than needed due to global operator lookup, this actually manifested as a regression because we were once again parsing function bodies in non-primary files.

Clean this up so that the delayed parsing callbacks are only used for code completion, with a new flag controlling skipping of function bodies, which is what we want in non-code completion, non-primary file frontend jobs.

Add a `scale_test` to ensure that delayed function body parsing is kicking in for methods defined inside types, not just top-level functions like the old test was testing.