### PR TITLE
migrator/test: disable fixits while testing rename migration pass.

### DIFF
--- a/test/Migrator/rename.swift
+++ b/test/Migrator/rename.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/rename.swift.result -emit-remap-file-path %t/rename.swift.remap -o /dev/null
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/rename.swift.result -emit-remap-file-path %t/rename.swift.remap -o /dev/null -disable-migrator-fixits
 // RUN: diff -u %S/rename.swift.expected %t/rename.swift.result
 
 import Bar

--- a/test/Migrator/rename.swift.expected
+++ b/test/Migrator/rename.swift.expected
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/rename.swift.result -emit-remap-file-path %t/rename.swift.remap -o /dev/null
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/rename.swift.result -emit-remap-file-path %t/rename.swift.remap -o /dev/null -disable-migrator-fixits
 // RUN: diff -u %S/rename.swift.expected %t/rename.swift.result
 
 import Bar
@@ -16,7 +16,7 @@ func foo(_ b: BarForwardDeclaredClass) {
   b.barNewInstanceFunc1(newlabel1: 0, newlabel2: 1, newlabel3: 2, newlabel4: 3)
   barGlobalFuncNewName(newlabel: 2)
   _ = NewEnum.enumElement
-  _ = PropertyUserInterface.newMethodPlus()
+  _ = PropertyUserInterface.newMethodPlus()!
   let _: BarBase.Nested
   _ = AwesomeWrapper.newName(is: 0, at: 1, for: 2)
 }


### PR DESCRIPTION
The migration under testing is entirely driven by migration scripts. Having
fixits enabled may cause red herring.
