### PR TITLE
[stdlib][SR-2239][5.0] Implement AAPCS64 variable argument list support.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -322,8 +322,21 @@ getSwiftStdlibType(const clang::TypedefNameDecl *D,
     break;
 
   case MappedCTypeKind::VaList:
-    if (ClangTypeSize != ClangCtx.getTypeSize(ClangCtx.VoidPtrTy))
-      return std::make_pair(Type(), "");
+    switch (ClangCtx.getTargetInfo().getBuiltinVaListKind()) {
+      case clang::TargetInfo::CharPtrBuiltinVaList:
+      case clang::TargetInfo::VoidPtrBuiltinVaList:
+      case clang::TargetInfo::PowerABIBuiltinVaList:
+      case clang::TargetInfo::AAPCSABIBuiltinVaList:
+        assert(ClangCtx.getTypeSize(ClangCtx.VoidPtrTy) == ClangTypeSize &&
+               "expected va_list type to be sizeof(void *)");
+        break;
+      case clang::TargetInfo::AArch64ABIBuiltinVaList:
+        break;
+      case clang::TargetInfo::PNaClABIBuiltinVaList:
+      case clang::TargetInfo::SystemZBuiltinVaList:
+      case clang::TargetInfo::X86_64ABIBuiltinVaList:
+        return std::make_pair(Type(), "");
+    }
     break;
 
   case MappedCTypeKind::ObjCBool:

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -219,6 +219,39 @@ extension UInt {
 }
 
 /// A wrapper around a C `va_list` pointer.
+#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
+@_fixed_layout
+public struct CVaListPointer {
+  @usableFromInline // unsafe-performance
+  internal var _value: (__stack: UnsafeMutablePointer<Int>?,
+                        __gr_top: UnsafeMutablePointer<Int>?,
+                        __vr_top: UnsafeMutablePointer<Int>?,
+                        __gr_off: Int32,
+                        __vr_off: Int32)
+
+  @inlinable // unsafe-performance
+  public // @testable
+  init(__stack: UnsafeMutablePointer<Int>?,
+       __gr_top: UnsafeMutablePointer<Int>?,
+       __vr_top: UnsafeMutablePointer<Int>?,
+       __gr_off: Int32,
+       __vr_off: Int32) {
+    _value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
+  }
+}
+
+extension CVaListPointer : CustomDebugStringConvertible {
+  public var debugDescription: String {
+    return "(\(_value.__stack.debugDescription), " +
+           "\(_value.__gr_top.debugDescription), " +
+           "\(_value.__vr_top.debugDescription), " +
+           "\(_value.__gr_off), " +
+           "\(_value.__vr_off))"
+  }
+}
+
+#else
+
 @_fixed_layout
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance
@@ -237,6 +270,8 @@ extension CVaListPointer : CustomDebugStringConvertible {
     return _value.debugDescription
   }
 }
+
+#endif
 
 @inlinable
 internal func _memcpy(

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -90,6 +90,23 @@ internal let _registerSaveWords = _countGPRegisters + _countFPRegisters * _fpReg
 internal let _countGPRegisters = 16
 @usableFromInline
 internal let _registerSaveWords = _countGPRegisters
+
+#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
+// ARM Procedure Call Standard for aarch64. (IHI0055B)
+// The va_list type may refer to any parameter in a parameter list may be in one
+// of three memory locations depending on its type and position in the argument
+// list :
+// 1. GP register save area x0 - x7
+// 2. 128-bit FP/SIMD register save area q0 - q7
+// 3. Stack argument area
+@usableFromInline
+internal let _countGPRegisters = 8
+@usableFromInline
+internal let _countFPRegisters = 8
+@usableFromInline
+internal let _fpRegisterWords = 16 /  MemoryLayout<Int>.size
+@usableFromInline
+internal let _registerSaveWords = _countGPRegisters + (_countFPRegisters * _fpRegisterWords)
 #endif
 
 #if arch(s390x)
@@ -391,7 +408,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
-  
+
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
   @inlinable // FIXME(sil-serialize-all)
@@ -402,7 +419,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
 }
 #endif
 
-#if arch(x86_64) || arch(s390x)
+#if arch(x86_64) || arch(s390x) || (arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows)))
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
@@ -412,6 +429,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
 @_fixed_layout
 @usableFromInline // c-abi
 final internal class __VaListBuilder {
+  #if arch(x86_64) || arch(s390x)
   @_fixed_layout // c-abi
   @usableFromInline
   internal struct Header {
@@ -428,15 +446,19 @@ final internal class __VaListBuilder {
     @usableFromInline // c-abi
     internal var reg_save_area: UnsafeMutablePointer<Int>?
   }
+  #endif
 
   @usableFromInline // c-abi
   internal var gpRegistersUsed = 0
   @usableFromInline // c-abi
   internal var fpRegistersUsed = 0
 
+  #if arch(x86_64) || arch(s390x)
   @usableFromInline // c-abi
   final  // Property must be final since it is used by Builtin.addressof.
   internal var header = Header()
+  #endif
+
   @usableFromInline // c-abi
   internal var storage: ContiguousArray<Int>
 
@@ -453,12 +475,16 @@ final internal class __VaListBuilder {
   internal func append(_ arg: CVarArg) {
     var encoded = arg._cVarArgEncoding
 
-#if arch(x86_64)
+#if arch(x86_64) || arch(arm64)
     let isDouble = arg is _CVarArgPassedAsDouble
 
     if isDouble && fpRegistersUsed < _countFPRegisters {
-      var startIndex = _countGPRegisters
-           + (fpRegistersUsed * _fpRegisterWords)
+      #if arch(arm64)
+        var startIndex = fpRegistersUsed * _fpRegisterWords
+      #else
+        var startIndex = _countGPRegisters
+             + (fpRegistersUsed * _fpRegisterWords)
+      #endif
       for w in encoded {
         storage[startIndex] = w
         startIndex += 1
@@ -468,7 +494,12 @@ final internal class __VaListBuilder {
     else if encoded.count == 1
       && !isDouble
       && gpRegistersUsed < _countGPRegisters {
-      storage[gpRegistersUsed] = encoded[0]
+      #if arch(arm64)
+        let startIndex = ( _fpRegisterWords * _countFPRegisters) + gpRegistersUsed
+      #else
+        let startIndex = gpRegistersUsed
+      #endif
+      storage[startIndex] = encoded[0]
       gpRegistersUsed += 1
     }
     else {
@@ -493,12 +524,23 @@ final internal class __VaListBuilder {
 
   @inlinable // c-abi
   internal func va_list() -> CVaListPointer {
-    header.reg_save_area = storage._baseAddress
-    header.overflow_arg_area
-      = storage._baseAddress + _registerSaveWords
-    return CVaListPointer(
-             _fromUnsafeMutablePointer: UnsafeMutableRawPointer(
-               Builtin.addressof(&self.header)))
+    #if arch(x86_64) || arch(s390x)
+      header.reg_save_area = storage._baseAddress
+      header.overflow_arg_area
+        = storage._baseAddress + _registerSaveWords
+      return CVaListPointer(
+               _fromUnsafeMutablePointer: UnsafeMutableRawPointer(
+                 Builtin.addressof(&self.header)))
+    #elseif arch(arm64)
+      let vr_top = storage._baseAddress + (_fpRegisterWords * _countFPRegisters)
+      let gr_top = vr_top + _countGPRegisters
+
+      return CVaListPointer(__stack: gr_top,
+                            __gr_top: gr_top,
+                            __vr_top: vr_top,
+                            __gr_off: -64,
+                            __vr_off: -128)
+    #endif
   }
 }
 


### PR DESCRIPTION
Use the already existing support for x86_64 and s390 to implement AAPCS64 __VaListBuilder. The parts where each implementation differ are the x86_64 header, and the order of the general and vector registers.

This change brings in one commit the changes introduced in #20862 and in #21237.

Resolves [SR-2239](https://bugs.swift.org/browse/SR-2239).

/cc @bob-wilson 