### PR TITLE
Add support for building a toolchain against GPU enabled tensorflow.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1866,6 +1866,14 @@ enable-tensorflow
 mixin-preset=buildbot_linux,no_test
 enable-tensorflow
 
+[preset: tensorflow_linux,gpu]
+mixin-preset=tensorflow_linux
+enable-tensorflow-gpu
+
+[preset: tensorflow_linux,gpu,no_test]
+mixin-preset=tensorflow_linux,no_test
+enable-tensorflow-gpu
+
 #===------------------------------------------------------------------------===#
 # Swift for TensorFlow Preset
 # Tools: DebInfo and Assertions


### PR DESCRIPTION
These presets are just like their non-gpu counterparts, but also have: --enable-tensorflow-gpu added.
