### PR TITLE
[DoNotMerge] [stdlib] Drop `Scalar` from `VectorNumeric`.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -23,20 +23,37 @@
 /// A type that represents an unranked vector space. Values of this type are
 /// elements in this vector space and have either no shape or a static shape.
 public protocol VectorNumeric : AdditiveArithmetic {
-  /// The type of scalars in the vector space.
-  associatedtype Scalar : AdditiveArithmetic
-
-  static func * (lhs: Scalar, rhs: Self) -> Self
-  static func *= (lhs: inout Self, rhs: Scalar)
+  static func * <Scalar : BinaryInteger>(lhs: Scalar, rhs: Self) -> Self
+  static func * <Scalar : BinaryFloatingPoint>(lhs: Scalar, rhs: Self) -> Self
+  static func *= <Scalar : BinaryInteger>(lhs: inout Self, rhs: Scalar)
+  static func *= <Scalar : BinaryFloatingPoint>(lhs: inout Self, rhs: Scalar)
 }
 
 public extension VectorNumeric {
-  static func * (lhs: Self, rhs: Scalar) -> Self {
+  static func * <Scalar : BinaryInteger>(lhs: Self, rhs: Scalar) -> Self {
     return rhs * lhs
   }
 
-  static func *= (lhs: inout Self, rhs: Scalar) {
+  static func *= <Scalar : BinaryInteger>(lhs: inout Self, rhs: Scalar) {
     lhs = rhs * lhs
+  }
+
+  static func * <Scalar : BinaryFloatingPoint>(lhs: Self, rhs: Scalar) -> Self {
+    return rhs * lhs
+  }
+
+  static func *= <Scalar : BinaryFloatingPoint>(lhs: inout Self, rhs: Scalar) {
+    lhs = rhs * lhs
+  }
+}
+
+public extension VectorNumeric where Self : BinaryFloatingPoint {
+  static func * <Scalar : BinaryInteger>(lhs: Scalar, rhs: Self) -> Self {
+    return Self(lhs) * rhs
+  }
+
+  static func * <Scalar : BinaryFloatingPoint>(lhs: Scalar, rhs: Self) -> Self {
+    return Self(lhs) * rhs
   }
 }
 


### PR DESCRIPTION
We've found that the `Scalar` associated type is complicating the generic signature of ML APIs (see optimizers implemented [here](https://github.com/rxwei/MachineLearning/blob/73475171d209dba9b9ced5ba808cac9fa3f8d6a6/Sources/MachineLearning/Optimizer.swift#L26). This is an experimental patch/proposal that drops `Scalar` from `VectorNumeric` and makes scalar multiplication take a generic `Scalar`.

Mostly wondering what @stephentyrone thinks about this.