### PR TITLE
Support mapping path prefixes for index stores

### DIFF
--- a/include/swift/Index/IndexRecord.h
+++ b/include/swift/Index/IndexRecord.h
@@ -21,6 +21,7 @@ namespace swift {
 class DependencyTracker;
 class ModuleDecl;
 class SourceFile;
+class PathRemapper;
 
 namespace index {
 
@@ -44,7 +45,8 @@ namespace index {
 bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
                     StringRef indexStorePath, bool indexSystemModules,
                     bool isDebugCompilation, StringRef targetTriple,
-                    const DependencyTracker &dependencyTracker);
+                    const DependencyTracker &dependencyTracker,
+                    const PathRemapper &debugPrefixMap);
 
 /// Index the given module and store the results to \p indexStorePath.
 ///

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1364,7 +1364,8 @@ static bool emitIndexDataIfNeeded(SourceFile *PrimarySourceFile,
     if (index::indexAndRecord(PrimarySourceFile, PSPs.OutputFilename,
                               opts.IndexStorePath, opts.IndexSystemModules,
                               isDebugCompilation, Invocation.getTargetTriple(),
-                              *Instance.getDependencyTracker())) {
+                              *Instance.getDependencyTracker(),
+                              Invocation.getIRGenOptions().DebugPrefixMap)) {
       return true;
     }
   } else {


### PR DESCRIPTION
This change builds on #17665, which added `-debug-prefix-map` to rewrite source paths embedded in the debug info of outputs. This change uses same flag to also remap source paths embedded in the index store.

The goal of this is just like the purpose of `-debug-prefix-map`, to produce artifacts (index store) that contain paths that refer to a known source path, not the build system's chosen build location. The end goal is to have indexes provided from a build cache.

I haven't discussed this with anyone on the Swift team, there are a few things to discuss:

1. First, are there reasons this can't or shouldn't be done
2. Which paths in the index should be mapped, currently only source file paths are remapped
3. Are there any cases where there debug info and index store need separate prefix maps?
4. Is it ok to expand `-debug-prefix-map`  to include more than debug info? I think "debug" could be taken to mean outputs used for "development"

TODO

- [ ] Add tests
- [ ] Add equivalent support to clang
