### PR TITLE
[AD] struct_extract result is varied only if field isn't `@noDerivative`

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1305,6 +1305,16 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
           if (isVaried(cai->getSrc(), i))
             recursivelySetVariedIfDifferentiable(cai->getDest(), i);
         }
+        else if (auto *sei = dyn_cast<StructExtractInst>(&inst)) {
+          if (isVaried(sei->getOperand(), i)) {
+            auto hasNoDeriv = sei->getField()->getAttrs()
+              .hasAttribute<NoDerivativeAttr>();
+            if (!hasNoDeriv) {
+              for (auto result: inst.getResults())
+                setVariedIfDifferentiable(result, i);
+            }
+          }
+        }
         // Handle everything else.
         else {
           for (auto &op : inst.getAllOperands())

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1308,7 +1308,7 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
         else if (auto *sei = dyn_cast<StructExtractInst>(&inst)) {
           if (isVaried(sei->getOperand(), i)) {
             auto hasNoDeriv = sei->getField()->getAttrs()
-              .hasAttribute<NoDerivativeAttr>();
+                .hasAttribute<NoDerivativeAttr>();
             if (!hasNoDeriv) {
               for (auto result: inst.getResults())
                 setVariedIfDifferentiable(result, i);


### PR DESCRIPTION
If a stored property of a struct with synthesized `Differentiable` 
conformance is of a type that conforms to `Differentiable`, but is 
marked `@noDerivative`, a struct_extract instruction that extracts 
that property shouldn't propagate variedness to its result.