### PR TITLE
 [TF] Bring batchNormalized in line with standard batchnorm formula

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -575,10 +575,10 @@ extension Tensor where Scalar : BinaryFloatingPoint & Differentiable,
   @inlinable
   func _vjpBatchNormalized(
     alongAxis axis: Int32,
-    offset: Scalar,
-    scale: Scalar,
+    offset: Tensor,
+    scale: Tensor,
     epsilon: Scalar
-  ) -> (Tensor, (Tensor) -> (Tensor, Scalar, Scalar)) {
+  ) -> (Tensor, (Tensor) -> (Tensor, Tensor, Tensor)) {
     let value = batchNormalized(alongAxis: axis, offset: offset, scale: scale,
                                 epsilon: epsilon)
     return (value, { v in
@@ -599,8 +599,7 @@ extension Tensor where Scalar : BinaryFloatingPoint & Differentiable,
       let dim = Tensor(Tensor<Int32>(self.shapeTensor[axis]))
       let tmp = (dNorm * inv) + (dVariance * 2 * dMean / dim)
       let dSelf = tmp + (dMean / dim)
-      return (dSelf, _TFGetScalarOrDie(dOffset.handle),  
-              _TFGetScalarOrDie(dScale.handle))
+      return (dSelf, dOffset, dScale)
     })
   }
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1610,8 +1610,8 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
   ///
   /// - Parameters:
   ///   - axis: The batch dimension.
-  ///   - offset: The scalar offset, also known as beta.
-  ///   - scale: The scalar scale, also known as gamma.
+  ///   - offset: The offset, also known as beta.
+  ///   - scale: The scale, also known as gamma.
   ///   - epsilon: A small value added to the denominator for numerical
   ///     stability.
   @inlinable @inline(__always)
@@ -1621,8 +1621,8 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
   )
   func batchNormalized(
     alongAxis axis: Int32,
-    offset: Scalar = 0,
-    scale: Scalar = 1,
+    offset: Tensor = Tensor(0),
+    scale: Tensor = Tensor(1),
     epsilon: Scalar = 0.001
   ) -> Tensor {
     let mean = self.mean(alongAxes: axis)


### PR DESCRIPTION
Most batchnorm implementations, including those in Keras and TF, use
vector scale and offsets treated elementwise, not scalars.