### PR TITLE
SwiftRemoteMirror: add a host build for the tools

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2136,6 +2136,10 @@ function(_add_swift_executable_single name)
         "${SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES}"
         "-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}"
         SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES_TARGETS)
+    _list_add_string_suffix(
+        "${SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES}"
+        "-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTEXE_SINGLE_ARCHITECTURE}"
+        SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES)
   else()
     _list_add_string_suffix(
         "${SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES}"

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -1,15 +1,36 @@
 # libswiftRemoteMirror.dylib should not have runtime dependencies; it's
 # always built as a shared library.
-if(SWIFT_BUILD_DYNAMIC_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
+if(SWIFT_BUILD_DYNAMIC_STDLIB)
   add_swift_target_library(swiftRemoteMirror
-                    SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
-                    SwiftRemoteMirror.cpp
-                    LINK_LIBRARIES
-                      swiftReflection
-                    C_COMPILE_FLAGS
-                      ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
-                    LINK_FLAGS
-                      ${SWIFT_RUNTIME_LINK_FLAGS}
-                    INSTALL_IN_COMPONENT
-                      swift-remote-mirror)
+                           SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
+                           SwiftRemoteMirror.cpp
+                           LINK_LIBRARIES
+                             swiftReflection
+                           C_COMPILE_FLAGS
+                             ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
+                           LINK_FLAGS
+                             ${SWIFT_RUNTIME_LINK_FLAGS}
+                           INSTALL_IN_COMPONENT
+                             swift-remote-mirror)
 endif()
+
+# Build a specific version for the host with the host toolchain.  This is going
+# to be used by tools (e.g. lldb)
+if(SWIFT_INCLUDE_TOOLS)
+  if(NOT SWIFT_BUILD_DYNAMIC_STDLIB)
+    add_custom_target(swiftRemoteMirror-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
+  endif()
+
+  if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+    set(CMAKE_C_COMPILER ${HOST_CMAKE_C_COMPILER})
+    set(CMAKE_CXX_COMPILER ${HOST_CMAKE_CXX_COMPILER})
+  endif()
+
+  add_swift_host_library(swiftRemoteMirror STATIC
+    SwiftRemoteMirror.cpp)
+  target_compile_options(swiftRemoteMirror PRIVATE
+    ${SWIFT_RUNTIME_CXX_FLAGS})
+  set_property(TARGET swiftRemoteMirror APPEND_STRING PROPERTY LINK_FLAGS
+    ${SWIFT_RUNTIME_LINK_FLAGS})
+endif()
+

--- a/stdlib/tools/swift-reflection-test/CMakeLists.txt
+++ b/stdlib/tools/swift-reflection-test/CMakeLists.txt
@@ -2,5 +2,6 @@ add_swift_target_executable(swift-reflection-test BUILD_WITH_STDLIB
   swift-reflection-test.c
   overrides.c
   LINK_FAT_LIBRARIES
-    swiftRemoteMirror)
+    swiftRemoteMirror
+    swiftReflection)
 


### PR DESCRIPTION
This adds an explicit version of the SwiftRemoteMirror library for use
in the tools that comprise the toolchain.  This is a separate build from
the target specific builds of the library even though we may be building
the runtime for the (same) host.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
