### PR TITLE
Replace deprecated Python unit test method usage

### DIFF
--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -101,7 +101,7 @@ class Test_parse_args(unittest.TestCase):
     def test_independent_samples(self):
         self.assertEqual(parse_args(['run']).independent_samples, 1)
         self.assertEqual(parse_args(['run', '-i', '3']).independent_samples,
-                          3)
+                         3)
         with captured_output() as (out, err):
             self.assertRaises(SystemExit,
                               parse_args, ['run', '-i', '-3'])
@@ -186,9 +186,9 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
             self.args, _subprocess=self.subprocess_mock)
         self.subprocess_mock.assert_called_all_expected()
         self.assertEqual(driver.tests,
-                          ['Benchmark1', 'Benchmark2'])
+                         ['Benchmark1', 'Benchmark2'])
         self.assertEqual(driver.all_tests,
-                          ['Benchmark1', 'Benchmark2'])
+                         ['Benchmark1', 'Benchmark2'])
         self.assertEquals(driver.test_number['Benchmark1'], "1")
         self.assertEquals(driver.test_number['Benchmark2'], "2")
 
@@ -209,7 +209,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         self.subprocess_mock.assert_called_all_expected()
         self.assertEqual(driver.tests, ['Benchmark1', 'Benchmark3'])
         self.assertEqual(driver.all_tests,
-                          ['Benchmark1', 'Benchmark2', 'Benchmark3'])
+                         ['Benchmark1', 'Benchmark2', 'Benchmark3'])
 
     def test_filters_benchmarks_by_pattern(self):
         self.args.filters = '-f .+3'.split()
@@ -219,7 +219,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         self.subprocess_mock.assert_called_all_expected()
         self.assertEqual(driver.tests, ['Benchmark3'])
         self.assertEqual(driver.all_tests,
-                          ['Benchmark1', 'Benchmark2', 'Benchmark3'])
+                         ['Benchmark1', 'Benchmark2', 'Benchmark3'])
 
     def test_log_file(self):
         """When swift-repo is set, log is tied to Git branch and revision."""
@@ -231,7 +231,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
             Stub(output_dir='/path', tests='/bin/', optimization='Suffix',
                  swift_repo=None,), tests=['ignored'])
         self.assertEqual(driver.log_file,
-                          '/path/Benchmark_Suffix-' + now + '.log')
+                         '/path/Benchmark_Suffix-' + now + '.log')
 
         r = '/repo/'
         subprocess_mock = SubprocessMock(responses=[
@@ -244,7 +244,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
             Stub(output_dir='/log/', tests='', optimization='S', swift_repo=r),
             tests=['ignored'], _subprocess=subprocess_mock)
         self.assertEqual(driver.log_file,
-                          '/log/branch/Benchmark_S-' + now + '-short_hash.log')
+                         '/log/branch/Benchmark_S-' + now + '-short_hash.log')
         subprocess_mock.assert_called_all_expected()
 
 
@@ -377,7 +377,7 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
         """Create log directory if it doesn't exist and write the log file."""
         def assert_log_written(out, log_file, content):
             self.assertEqual(out.getvalue(),
-                              'Logging results to: ' + log_file + '\n')
+                             'Logging results to: ' + log_file + '\n')
             with open(log_file, 'rU') as f:
                 text = f.read()
             self.assertEqual(text, "formatted output")
@@ -446,15 +446,15 @@ class TestLoggingReportFormatter(unittest.TestCase):
                 'levelname': level_name, 'msg': 'Hi!'})
         f = LoggingReportFormatter(use_color=True)
         self.assertEqual(f.format(record(logging.DEBUG, 'DEBUG')),
-                          '\x1b[1;39mcategory: Hi!\x1b[1;0m')
+                         '\x1b[1;39mcategory: Hi!\x1b[1;0m')
         self.assertEqual(f.format(record(logging.INFO, 'INFO')),
-                          '\x1b[1;32mcategory: Hi!\x1b[1;0m')
+                         '\x1b[1;32mcategory: Hi!\x1b[1;0m')
         self.assertEqual(f.format(record(logging.WARNING, 'WARNING')),
-                          '\x1b[1;33mcategory: Hi!\x1b[1;0m')
+                         '\x1b[1;33mcategory: Hi!\x1b[1;0m')
         self.assertEqual(f.format(record(logging.ERROR, 'ERROR')),
-                          '\x1b[1;31mcategory: Hi!\x1b[1;0m')
+                         '\x1b[1;31mcategory: Hi!\x1b[1;0m')
         self.assertEqual(f.format(record(logging.CRITICAL, 'CRITICAL')),
-                          '\x1b[1;35mcategory: Hi!\x1b[1;0m')
+                         '\x1b[1;35mcategory: Hi!\x1b[1;0m')
 
     def test_no_prefix_for_base_logging(self):
         lr = logging.makeLogRecord({

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -57,13 +57,13 @@ class Test_parse_args(unittest.TestCase):
 
     def test_run_benchmarks_by_name_or_ordinal(self):
         benchmarks = ['AngryPhonebook', '42']
-        self.assertEquals(
+        self.assertEqual(
             parse_args(['run'] + benchmarks).benchmarks, benchmarks)
 
     def test_run_benchmarks_matching_pattern(self):
         regexes = ['Prefix', '.*Suffix.*']
         filters = ['-f', regexes[0], '-f', regexes[1]]
-        self.assertEquals(parse_args(['run'] + filters).filters, regexes)
+        self.assertEqual(parse_args(['run'] + filters).filters, regexes)
 
     def test_run_benchmarks_and_filters_are_exclusive(self):
         with captured_output() as (_, err):
@@ -76,17 +76,17 @@ class Test_parse_args(unittest.TestCase):
 
     def test_tests_location(self):
         here = os.path.dirname(os.path.abspath(__file__))
-        self.assertEquals(parse_args(['run']).tests, here)
+        self.assertEqual(parse_args(['run']).tests, here)
         tests = '/benchmarks/are/here'
-        self.assertEquals(parse_args(['run', '-t', tests]).tests, tests)
+        self.assertEqual(parse_args(['run', '-t', tests]).tests, tests)
 
     def test_optimization_argument(self):
-        self.assertEquals(parse_args(['run']).optimization, 'O')
-        self.assertEquals(
+        self.assertEqual(parse_args(['run']).optimization, 'O')
+        self.assertEqual(
             parse_args(['run', '-o', 'O']).optimization, 'O')
-        self.assertEquals(
+        self.assertEqual(
             parse_args(['run', '-o', 'Onone']).optimization, 'Onone')
-        self.assertEquals(
+        self.assertEqual(
             parse_args(['run', '-o', 'Osize']).optimization, 'Osize')
 
         with captured_output() as (_, err):
@@ -99,8 +99,8 @@ class Test_parse_args(unittest.TestCase):
             err.getvalue())
 
     def test_independent_samples(self):
-        self.assertEquals(parse_args(['run']).independent_samples, 1)
-        self.assertEquals(parse_args(['run', '-i', '3']).independent_samples,
+        self.assertEqual(parse_args(['run']).independent_samples, 1)
+        self.assertEqual(parse_args(['run', '-i', '3']).independent_samples,
                           3)
         with captured_output() as (out, err):
             self.assertRaises(SystemExit,
@@ -112,7 +112,7 @@ class Test_parse_args(unittest.TestCase):
 
     def test_output_dir(self):
         self.assertIsNone(parse_args(['run']).output_dir)
-        self.assertEquals(
+        self.assertEqual(
             parse_args(['run', '--output-dir', '/log']).output_dir, '/log')
 
     def test_check_supports_vebose_output(self):
@@ -169,12 +169,12 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         self.subprocess_mock = SubprocessMock()
 
     def test_test_harness(self):
-        self.assertEquals(
+        self.assertEqual(
             BenchmarkDriver(self.args, tests=['ignored']).test_harness,
             '/benchmarks/Benchmark_O')
         self.args.tests = '/path'
         self.args.optimization = 'Suffix'
-        self.assertEquals(
+        self.assertEqual(
             BenchmarkDriver(self.args, tests=['ignored']).test_harness,
             '/path/Benchmark_Suffix')
 
@@ -185,9 +185,9 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         driver = BenchmarkDriver(
             self.args, _subprocess=self.subprocess_mock)
         self.subprocess_mock.assert_called_all_expected()
-        self.assertEquals(driver.tests,
+        self.assertEqual(driver.tests,
                           ['Benchmark1', 'Benchmark2'])
-        self.assertEquals(driver.all_tests,
+        self.assertEqual(driver.all_tests,
                           ['Benchmark1', 'Benchmark2'])
         self.assertEquals(driver.test_number['Benchmark1'], "1")
         self.assertEquals(driver.test_number['Benchmark2'], "2")
@@ -207,8 +207,8 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         driver = BenchmarkDriver(
             self.args, _subprocess=self.subprocess_mock)
         self.subprocess_mock.assert_called_all_expected()
-        self.assertEquals(driver.tests, ['Benchmark1', 'Benchmark3'])
-        self.assertEquals(driver.all_tests,
+        self.assertEqual(driver.tests, ['Benchmark1', 'Benchmark3'])
+        self.assertEqual(driver.all_tests,
                           ['Benchmark1', 'Benchmark2', 'Benchmark3'])
 
     def test_filters_benchmarks_by_pattern(self):
@@ -217,8 +217,8 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         driver = BenchmarkDriver(
             self.args, _subprocess=self.subprocess_mock)
         self.subprocess_mock.assert_called_all_expected()
-        self.assertEquals(driver.tests, ['Benchmark3'])
-        self.assertEquals(driver.all_tests,
+        self.assertEqual(driver.tests, ['Benchmark3'])
+        self.assertEqual(driver.all_tests,
                           ['Benchmark1', 'Benchmark2', 'Benchmark3'])
 
     def test_log_file(self):
@@ -230,7 +230,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         driver = BenchmarkDriver(
             Stub(output_dir='/path', tests='/bin/', optimization='Suffix',
                  swift_repo=None,), tests=['ignored'])
-        self.assertEquals(driver.log_file,
+        self.assertEqual(driver.log_file,
                           '/path/Benchmark_Suffix-' + now + '.log')
 
         r = '/repo/'
@@ -243,7 +243,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         driver = BenchmarkDriver(
             Stub(output_dir='/log/', tests='', optimization='S', swift_repo=r),
             tests=['ignored'], _subprocess=subprocess_mock)
-        self.assertEquals(driver.log_file,
+        self.assertEqual(driver.log_file,
                           '/log/branch/Benchmark_S-' + now + '-short_hash.log')
         subprocess_mock.assert_called_all_expected()
 
@@ -332,14 +332,14 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
         """Extract up to 20 measurements from an independent run."""
         self.driver.args.independent_samples = 3
         r = self.driver.run_independent_samples('b1')
-        self.assertEquals(self.subprocess_mock.calls.count(
+        self.assertEqual(self.subprocess_mock.calls.count(
             ('/benchmarks/Benchmark_O', 'b1', '--num-iters=1', '--memory',
              '--quantile=20', '--delta')), 3)
-        self.assertEquals(r.num_samples, 3)  # results are merged
+        self.assertEqual(r.num_samples, 3)  # results are merged
 
     def test_run_and_log(self):
         def mock_run(test):
-            self.assertEquals(test, 'b1')
+            self.assertEqual(test, 'b1')
             return PerformanceTestResult(
                 '3,b1,5,101,1,1,1,1,888'.split(','),
                 quantiles=True, delta=True, memory=True)
@@ -352,8 +352,8 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
         header = '#,TEST,SAMPLES,MIN(μs),Q1(μs),MEDIAN(μs),Q3(μs),MAX(μs),' +\
             'MAX_RSS(B)\n'
         csv_log = '3,b1,5,101,102,103,104,105,888\n'
-        self.assertEquals(log, None)
-        self.assertEquals(
+        self.assertEqual(log, None)
+        self.assertEqual(
             out.getvalue(),
             header +
             csv_log +
@@ -363,8 +363,8 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
         with captured_output() as (out, _):
             log = driver.run_and_log(csv_console=False)
 
-        self.assertEquals(log, header + csv_log)
-        self.assertEquals(
+        self.assertEqual(log, header + csv_log)
+        self.assertEqual(
             out.getvalue(),
             '  # TEST                      SAMPLES MIN(μs) Q1(μs)' +
             ' MEDIAN(μs) Q3(μs) MAX(μs) MAX_RSS(B)\n' +
@@ -376,11 +376,11 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
     def test_log_results(self):
         """Create log directory if it doesn't exist and write the log file."""
         def assert_log_written(out, log_file, content):
-            self.assertEquals(out.getvalue(),
+            self.assertEqual(out.getvalue(),
                               'Logging results to: ' + log_file + '\n')
             with open(log_file, 'rU') as f:
                 text = f.read()
-            self.assertEquals(text, "formatted output")
+            self.assertEqual(text, "formatted output")
 
         try:
             import tempfile  # setUp
@@ -408,7 +408,7 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
     def test_deterministing_hashing(self):
         cmd = ['printenv', 'SWIFT_DETERMINISTIC_HASHING']
         driver = BenchmarkDriver(['no args'], tests=['ignored'])
-        self.assertEquals(driver._invoke(cmd).strip(), '1')
+        self.assertEqual(driver._invoke(cmd).strip(), '1')
 
 
 class BenchmarkDriverMock(Mock):
@@ -437,7 +437,7 @@ class TestLoggingReportFormatter(unittest.TestCase):
             'name': 'Base.category', 'level': logging.DEBUG,
             'levelname': 'DEBUG', 'msg': 'Hi!'})
         f = LoggingReportFormatter()
-        self.assertEquals(f.format(lr), 'DEBUG category: Hi!')
+        self.assertEqual(f.format(lr), 'DEBUG category: Hi!')
 
     def test_colored_log_format(self):
         def record(level, level_name):
@@ -445,15 +445,15 @@ class TestLoggingReportFormatter(unittest.TestCase):
                 'name': 'Base.category', 'levelno': level,
                 'levelname': level_name, 'msg': 'Hi!'})
         f = LoggingReportFormatter(use_color=True)
-        self.assertEquals(f.format(record(logging.DEBUG, 'DEBUG')),
+        self.assertEqual(f.format(record(logging.DEBUG, 'DEBUG')),
                           '\x1b[1;39mcategory: Hi!\x1b[1;0m')
-        self.assertEquals(f.format(record(logging.INFO, 'INFO')),
+        self.assertEqual(f.format(record(logging.INFO, 'INFO')),
                           '\x1b[1;32mcategory: Hi!\x1b[1;0m')
-        self.assertEquals(f.format(record(logging.WARNING, 'WARNING')),
+        self.assertEqual(f.format(record(logging.WARNING, 'WARNING')),
                           '\x1b[1;33mcategory: Hi!\x1b[1;0m')
-        self.assertEquals(f.format(record(logging.ERROR, 'ERROR')),
+        self.assertEqual(f.format(record(logging.ERROR, 'ERROR')),
                           '\x1b[1;31mcategory: Hi!\x1b[1;0m')
-        self.assertEquals(f.format(record(logging.CRITICAL, 'CRITICAL')),
+        self.assertEqual(f.format(record(logging.CRITICAL, 'CRITICAL')),
                           '\x1b[1;35mcategory: Hi!\x1b[1;0m')
 
     def test_no_prefix_for_base_logging(self):
@@ -461,7 +461,7 @@ class TestLoggingReportFormatter(unittest.TestCase):
             'name': 'Base', 'level': logging.INFO,
             'levelname': 'INFO', 'msg': 'Hi!'})
         f = LoggingReportFormatter()
-        self.assertEquals(f.format(lr), 'INFO Hi!')
+        self.assertEqual(f.format(lr), 'INFO Hi!')
 
 
 class TestMarkdownReportHandler(unittest.TestCase):
@@ -481,7 +481,7 @@ class TestMarkdownReportHandler(unittest.TestCase):
             'levelno': level, 'msg': msg})
 
     def test_init_writes_table_header(self):
-        self.assertEquals(self.handler.level, logging.INFO)
+        self.assertEqual(self.handler.level, logging.INFO)
         self.assert_contains(['Benchmark Check Report\n', '---|---'])
 
     def test_close_writes_final_newlines(self):
@@ -552,7 +552,7 @@ class TestBenchmarkDoctor(unittest.TestCase):
         with captured_output() as (out, _):
             BenchmarkDoctor(self.args, driver)
         self.assert_contains(['Checking tests: B1, B2'], self.logs['debug'])
-        self.assertEquals(out.getvalue(), '')
+        self.assertEqual(out.getvalue(), '')
 
     def test_supports_verbose_output(self):
         driver = BenchmarkDriverMock(tests=['B1', 'B2'])
@@ -607,7 +607,7 @@ class TestBenchmarkDoctor(unittest.TestCase):
              'B1 O i1a', 'B1 O i1b', 'B1 O i1c', 'B1 O i1d', 'B1 O i1e',
              'B1 O i2a', 'B1 O i2b', 'B1 O i2c', 'B1 O i2d', 'B1 O i2e'],
             measurements.keys())
-        self.assertEquals(measurements['name'], 'B1')
+        self.assertEqual(measurements['name'], 'B1')
         self.assert_contains(
             ['Calibrating num-samples for B1:',
              'Runtime 300 μs yields 4096 adjusted samples per second.',

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -35,15 +35,15 @@ from test_utils import captured_output
 class TestSample(unittest.TestCase):
     def test_has_named_fields(self):
         s = Sample(1, 2, 3)
-        self.assertEquals(s.i, 1)
-        self.assertEquals(s.num_iters, 2)
-        self.assertEquals(s.runtime, 3)
+        self.assertEqual(s.i, 1)
+        self.assertEqual(s.num_iters, 2)
+        self.assertEqual(s.runtime, 3)
 
     def test_is_iterable(self):
         s = Sample(1, 2, 3)
-        self.assertEquals(s[0], 1)
-        self.assertEquals(s[1], 2)
-        self.assertEquals(s[2], 3)
+        self.assertEqual(s[0], 1)
+        self.assertEqual(s[1], 2)
+        self.assertEqual(s[2], 3)
 
 
 class TestPerformanceTestSamples(unittest.TestCase):
@@ -52,34 +52,34 @@ class TestPerformanceTestSamples(unittest.TestCase):
         self.samples.add(Sample(7, 42, 1000))
 
     def test_has_name(self):
-        self.assertEquals(self.samples.name, 'B1')
+        self.assertEqual(self.samples.name, 'B1')
 
     def test_stores_samples(self):
-        self.assertEquals(self.samples.count, 1)
+        self.assertEqual(self.samples.count, 1)
         s = self.samples.samples[0]
         self.assertTrue(isinstance(s, Sample))
-        self.assertEquals(s.i, 7)
-        self.assertEquals(s.num_iters, 42)
-        self.assertEquals(s.runtime, 1000)
+        self.assertEqual(s.i, 7)
+        self.assertEqual(s.num_iters, 42)
+        self.assertEqual(s.runtime, 1000)
 
     def test_quantile(self):
-        self.assertEquals(self.samples.quantile(1), 1000)
-        self.assertEquals(self.samples.quantile(0), 1000)
+        self.assertEqual(self.samples.quantile(1), 1000)
+        self.assertEqual(self.samples.quantile(0), 1000)
         self.samples.add(Sample(2, 1, 1100))
-        self.assertEquals(self.samples.quantile(0), 1000)
-        self.assertEquals(self.samples.quantile(1), 1100)
+        self.assertEqual(self.samples.quantile(0), 1000)
+        self.assertEqual(self.samples.quantile(1), 1100)
         self.samples.add(Sample(3, 1, 1050))
-        self.assertEquals(self.samples.quantile(0), 1000)
-        self.assertEquals(self.samples.quantile(.5), 1050)
-        self.assertEquals(self.samples.quantile(1), 1100)
+        self.assertEqual(self.samples.quantile(0), 1000)
+        self.assertEqual(self.samples.quantile(.5), 1050)
+        self.assertEqual(self.samples.quantile(1), 1100)
 
     def assertEqualFiveNumberSummary(self, ss, expected_fns):
         e_min, e_q1, e_median, e_q3, e_max = expected_fns
-        self.assertEquals(ss.min, e_min)
-        self.assertEquals(ss.q1, e_q1)
-        self.assertEquals(ss.median, e_median)
-        self.assertEquals(ss.q3, e_q3)
-        self.assertEquals(ss.max, e_max)
+        self.assertEqual(ss.min, e_min)
+        self.assertEqual(ss.q1, e_q1)
+        self.assertEqual(ss.median, e_median)
+        self.assertEqual(ss.q3, e_q3)
+        self.assertEqual(ss.max, e_max)
 
     def test_computes_five_number_summary(self):
         self.assertEqualFiveNumberSummary(
@@ -98,38 +98,38 @@ class TestPerformanceTestSamples(unittest.TestCase):
             self.samples, (1000, 1025, 1050, 1075, 1100))
 
     def test_computes_inter_quartile_range(self):
-        self.assertEquals(self.samples.iqr, 0)
+        self.assertEqual(self.samples.iqr, 0)
         self.samples.add(Sample(2, 1, 1025))
         self.samples.add(Sample(3, 1, 1050))
         self.samples.add(Sample(4, 1, 1075))
         self.samples.add(Sample(5, 1, 1100))
-        self.assertEquals(self.samples.iqr, 50)
+        self.assertEqual(self.samples.iqr, 50)
 
-    def assertEqualStats(self, stats, expected_stats):
+    def assertEqualtats(self, stats, expected_stats):
         for actual, expected in zip(stats, expected_stats):
             self.assertAlmostEquals(actual, expected, places=2)
 
     def test_computes_mean_sd_cv(self):
         ss = self.samples
-        self.assertEqualStats(
+        self.assertEqualtats(
             (ss.mean, ss.sd, ss.cv), (1000.0, 0.0, 0.0))
         self.samples.add(Sample(2, 1, 1100))
-        self.assertEqualStats(
+        self.assertEqualtats(
             (ss.mean, ss.sd, ss.cv), (1050.0, 70.71, 6.7 / 100))
 
     def test_computes_range_spread(self):
         ss = self.samples
-        self.assertEqualStats(
+        self.assertEqualtats(
             (ss.range, ss.spread), (0, 0))
         self.samples.add(Sample(2, 1, 1100))
-        self.assertEqualStats(
+        self.assertEqualtats(
             (ss.range, ss.spread), (100, 10.0 / 100))
 
     def test_init_with_samples(self):
         self.samples = PerformanceTestSamples(
             'B2', [Sample(0, 1, 1000), Sample(1, 1, 1100)])
-        self.assertEquals(self.samples.count, 2)
-        self.assertEqualStats(
+        self.assertEqual(self.samples.count, 2)
+        self.assertEqualtats(
             (self.samples.mean, self.samples.sd,
              self.samples.range, self.samples.spread),
             (1050.0, 70.71, 100, 9.52 / 100))
@@ -138,7 +138,7 @@ class TestPerformanceTestSamples(unittest.TestCase):
         # guard against dividing by 0
         self.samples = PerformanceTestSamples('Zero')
         self.samples.add(Sample(0, 1, 0))
-        self.assertEqualStats(
+        self.assertEqualtats(
             (self.samples.mean, self.samples.sd, self.samples.cv,
              self.samples.range, self.samples.spread),
             (0, 0, 0.0, 0, 0.0))
@@ -149,17 +149,17 @@ class TestPerformanceTestSamples(unittest.TestCase):
               '5 1 1000, 6 1 1025, 7 1 1050, 8 1 1075, 9 1 1100, '
               '10 1 1050, 11 1 949, 12 1 1151'.split(',')]
         self.samples = PerformanceTestSamples('Outliers', ss)
-        self.assertEquals(self.samples.count, 13)
-        self.assertEqualStats(
+        self.assertEqual(self.samples.count, 13)
+        self.assertEqualtats(
             (self.samples.mean, self.samples.sd), (1050, 52.36))
 
         self.samples.exclude_outliers()
 
-        self.assertEquals(self.samples.count, 11)
-        self.assertEquals(self.samples.outliers, ss[11:])
+        self.assertEqual(self.samples.count, 11)
+        self.assertEqual(self.samples.outliers, ss[11:])
         self.assertEqualFiveNumberSummary(
             self.samples, (1000, 1025, 1050, 1075, 1100))
-        self.assertEqualStats(
+        self.assertEqualtats(
             (self.samples.mean, self.samples.sd), (1050, 35.36))
 
     def test_excludes_outliers_zero_IQR(self):
@@ -168,12 +168,12 @@ class TestPerformanceTestSamples(unittest.TestCase):
         self.samples.add(Sample(1, 2, 18))
         self.samples.add(Sample(2, 2, 18))
         self.samples.add(Sample(3, 2, 18))
-        self.assertEquals(self.samples.iqr, 0)
+        self.assertEqual(self.samples.iqr, 0)
 
         self.samples.exclude_outliers()
 
-        self.assertEquals(self.samples.count, 3)
-        self.assertEqualStats(
+        self.assertEqual(self.samples.count, 3)
+        self.assertEqualtats(
             (self.samples.min, self.samples.max), (18, 18))
 
     def test_excludes_outliers_top_only(self):
@@ -181,61 +181,61 @@ class TestPerformanceTestSamples(unittest.TestCase):
               '0 1 1, 1 1 2, 2 1 2, 3 1 2, 4 1 3'.split(',')]
         self.samples = PerformanceTestSamples('Top', ss)
         self.assertEqualFiveNumberSummary(self.samples, (1, 2, 2, 2, 3))
-        self.assertEquals(self.samples.iqr, 0)
+        self.assertEqual(self.samples.iqr, 0)
 
         self.samples.exclude_outliers(top_only=True)
 
-        self.assertEquals(self.samples.count, 4)
-        self.assertEqualStats((self.samples.min, self.samples.max), (1, 2))
+        self.assertEqual(self.samples.count, 4)
+        self.assertEqualtats((self.samples.min, self.samples.max), (1, 2))
 
 
 class TestPerformanceTestResult(unittest.TestCase):
     def test_init(self):
         log_line = '1,AngryPhonebook,20,10664,12933,11035,576,10884'
         r = PerformanceTestResult(log_line.split(','))
-        self.assertEquals(r.test_num, '1')
-        self.assertEquals(r.name, 'AngryPhonebook')
-        self.assertEquals(
+        self.assertEqual(r.test_num, '1')
+        self.assertEqual(r.name, 'AngryPhonebook')
+        self.assertEqual(
             (r.num_samples, r.min, r.max, r.mean, r.sd, r.median),
             (20, 10664, 12933, 11035, 576, 10884))
-        self.assertEquals(r.samples, None)
+        self.assertEqual(r.samples, None)
 
         log_line = '1,AngryPhonebook,1,12045,12045,12045,0,12045,10510336'
         r = PerformanceTestResult(log_line.split(','))
-        self.assertEquals(r.max_rss, 10510336)
+        self.assertEqual(r.max_rss, 10510336)
 
     def test_init_quantiles(self):
         # #,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs)
         log = '1,Ackermann,3,54383,54512,54601'
         r = PerformanceTestResult(log.split(','), quantiles=True)
-        self.assertEquals(r.test_num, '1')
-        self.assertEquals(r.name, 'Ackermann')
-        self.assertEquals((r.num_samples, r.min, r.median, r.max),
+        self.assertEqual(r.test_num, '1')
+        self.assertEqual(r.name, 'Ackermann')
+        self.assertEqual((r.num_samples, r.min, r.median, r.max),
                           (3, 54383, 54512, 54601))
         self.assertAlmostEquals(r.mean, 54498.67, places=2)
         self.assertAlmostEquals(r.sd, 109.61, places=2)
-        self.assertEquals(r.samples.count, 3)
-        self.assertEquals(r.samples.num_samples, 3)
-        self.assertEquals([s.runtime for s in r.samples.all_samples],
+        self.assertEqual(r.samples.count, 3)
+        self.assertEqual(r.samples.num_samples, 3)
+        self.assertEqual([s.runtime for s in r.samples.all_samples],
                           [54383, 54512, 54601])
 
         # #,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs),MAX_RSS(B)
         log = '1,Ackermann,3,54529,54760,55807,266240'
         r = PerformanceTestResult(log.split(','), quantiles=True, memory=True)
-        self.assertEquals((r.samples.count, r.max_rss), (3, 266240))
+        self.assertEqual((r.samples.count, r.max_rss), (3, 266240))
         # #,TEST,SAMPLES,MIN(μs),Q1(μs),Q2(μs),Q3(μs),MAX(μs)
         log = '1,Ackermann,5,54570,54593,54644,57212,58304'
         r = PerformanceTestResult(log.split(','), quantiles=True, memory=False)
-        self.assertEquals((r.num_samples, r.min, r.median, r.max),
+        self.assertEqual((r.num_samples, r.min, r.median, r.max),
                           (5, 54570, 54644, 58304))
-        self.assertEquals((r.samples.q1, r.samples.q3), (54593, 57212))
-        self.assertEquals(r.samples.count, 5)
+        self.assertEqual((r.samples.q1, r.samples.q3), (54593, 57212))
+        self.assertEqual(r.samples.count, 5)
         # #,TEST,SAMPLES,MIN(μs),Q1(μs),Q2(μs),Q3(μs),MAX(μs),MAX_RSS(B)
         log = '1,Ackermann,5,54686,54731,54774,55030,63466,270336'
         r = PerformanceTestResult(log.split(','), quantiles=True, memory=True)
-        self.assertEquals(r.samples.num_samples, 5)
-        self.assertEquals(r.samples.count, 4)  # outlier was excluded
-        self.assertEquals(r.max_rss, 270336)
+        self.assertEqual(r.samples.num_samples, 5)
+        self.assertEqual(r.samples.count, 4)  # outlier was excluded
+        self.assertEqual(r.max_rss, 270336)
 
     def test_init_delta_quantiles(self):
         # #,TEST,SAMPLES,MIN(μs),𝚫MEDIAN,𝚫MAX
@@ -243,10 +243,10 @@ class TestPerformanceTestResult(unittest.TestCase):
         # the difference is 0, which is ommited -- only separator remains
         log = '202,DropWhileArray,2,265,,22'
         r = PerformanceTestResult(log.split(','), quantiles=True, delta=True)
-        self.assertEquals((r.num_samples, r.min, r.median, r.max),
+        self.assertEqual((r.num_samples, r.min, r.median, r.max),
                           (2, 265, 265, 287))
-        self.assertEquals(r.samples.count, 2)
-        self.assertEquals(r.samples.num_samples, 2)
+        self.assertEqual(r.samples.count, 2)
+        self.assertEqual(r.samples.num_samples, 2)
 
     def test_init_oversampled_quantiles(self):
         """When num_samples is < quantile + 1, some of the measurements are
@@ -265,8 +265,8 @@ class TestPerformanceTestResult(unittest.TestCase):
             num_samples = deq.count('1')
             r = PerformanceTestResult(['0', 'B', str(num_samples)] + deq,
                                       quantiles=True, delta=True)
-            self.assertEquals(r.samples.num_samples, num_samples)
-            self.assertEquals([s.runtime for s in r.samples.all_samples],
+            self.assertEqual(r.samples.num_samples, num_samples)
+            self.assertEqual([s.runtime for s in r.samples.all_samples],
                               range(1, num_samples + 1))
 
         delta_encoded_quantiles = """
@@ -311,7 +311,7 @@ class TestPerformanceTestResult(unittest.TestCase):
     def test_repr(self):
         log_line = '1,AngryPhonebook,20,10664,12933,11035,576,10884'
         r = PerformanceTestResult(log_line.split(','))
-        self.assertEquals(
+        self.assertEqual(
             str(r),
             '<PerformanceTestResult name:\'AngryPhonebook\' samples:20 '
             'min:10664 max:12933 mean:11035 sd:576 median:10884>'
@@ -333,16 +333,16 @@ class TestPerformanceTestResult(unittest.TestCase):
                     r.sd, r.median, r.max_rss, r.setup)
 
         r = results[0]
-        self.assertEquals(as_tuple(r),
+        self.assertEqual(as_tuple(r),
                           (1, 12045, 12045, 12045, 0, 12045, None, None))
         r.merge(results[1])
-        self.assertEquals(as_tuple(r),  # drops SD and median, +max_rss
+        self.assertEqual(as_tuple(r),  # drops SD and median, +max_rss
                           (2, 12045, 12325, 12185, None, None, 10510336, None))
         r.merge(results[2])
-        self.assertEquals(as_tuple(r),  # picks smaller of the MAX_RSS, +setup
+        self.assertEqual(as_tuple(r),  # picks smaller of the MAX_RSS, +setup
                           (3, 11616, 12325, 11995.33, None, None, 10502144, 9))
         r.merge(results[3])
-        self.assertEquals(as_tuple(r),  # picks smaller of the setup values
+        self.assertEqual(as_tuple(r),  # picks smaller of the setup values
                           (4, 11616, 12325, 12064, None, None, 10498048, 7))
 
 
@@ -359,14 +359,14 @@ class TestResultComparison(unittest.TestCase):
 
     def test_init(self):
         rc = ResultComparison(self.r1, self.r2)
-        self.assertEquals(rc.name, 'AngryPhonebook')
+        self.assertEqual(rc.name, 'AngryPhonebook')
         self.assertAlmostEquals(rc.ratio, 12325.0 / 11616.0)
         self.assertAlmostEquals(rc.delta, (((11616.0 / 12325.0) - 1) * 100),
                                 places=3)
         # handle test results that sometimes change to zero, when compiler
         # optimizes out the body of the incorrectly written test
         rc = ResultComparison(self.r0, self.r0)
-        self.assertEquals(rc.name, 'GlobalClass')
+        self.assertEqual(rc.name, 'GlobalClass')
         self.assertAlmostEquals(rc.ratio, 1)
         self.assertAlmostEquals(rc.delta, 0, places=3)
         rc = ResultComparison(self.r0, self.r01)
@@ -452,14 +452,14 @@ Total performance tests executed: 1
         parser = LogParser()
         results = parser.parse_results(log.splitlines())
         self.assertTrue(isinstance(results[0], PerformanceTestResult))
-        self.assertEquals(results[0].name, 'BitCount')
+        self.assertEqual(results[0].name, 'BitCount')
 
     def test_parse_results_tab_delimited(self):
         log = '34\tBitCount\t20\t3\t4\t4\t0\t4'
         parser = LogParser()
         results = parser.parse_results(log.splitlines())
         self.assertTrue(isinstance(results[0], PerformanceTestResult))
-        self.assertEquals(results[0].name, 'BitCount')
+        self.assertEqual(results[0].name, 'BitCount')
 
     def test_parse_results_formatted_text(self):
         """Parse format that Benchmark_Driver prints to console"""
@@ -473,32 +473,32 @@ Total performance tests executed: 1
         results = parser.parse_results(log.splitlines()[1:])  # without 1st \n
         self.assertTrue(isinstance(results[0], PerformanceTestResult))
         r = results[0]
-        self.assertEquals(r.name, 'Array2D')
-        self.assertEquals(r.max_rss, 20915200)
+        self.assertEqual(r.name, 'Array2D')
+        self.assertEqual(r.max_rss, 20915200)
 
     def test_parse_quantiles(self):
         """Gathers samples from reported quantiles. Handles optional memory."""
         r = LogParser.results_from_string(
             """#,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs)
 1,Ackermann,3,54383,54512,54601""")['Ackermann']
-        self.assertEquals([s.runtime for s in r.samples.all_samples],
+        self.assertEqual([s.runtime for s in r.samples.all_samples],
                           [54383, 54512, 54601])
         r = LogParser.results_from_string(
             """#,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs),MAX_RSS(B)
 1,Ackermann,3,54529,54760,55807,266240""")['Ackermann']
-        self.assertEquals([s.runtime for s in r.samples.all_samples],
+        self.assertEqual([s.runtime for s in r.samples.all_samples],
                           [54529, 54760, 55807])
-        self.assertEquals(r.max_rss, 266240)
+        self.assertEqual(r.max_rss, 266240)
 
     def test_parse_delta_quantiles(self):
         r = LogParser.results_from_string(  # 2-quantile aka. median
             '#,TEST,SAMPLES,MIN(μs),𝚫MEDIAN,𝚫MAX\n0,B,1,101,,')['B']
-        self.assertEquals(
+        self.assertEqual(
             (r.num_samples, r.min, r.median, r.max, r.samples.count),
             (1, 101, 101, 101, 1))
         r = LogParser.results_from_string(
             '#,TEST,SAMPLES,MIN(μs),𝚫MEDIAN,𝚫MAX\n0,B,2,101,,1')['B']
-        self.assertEquals(
+        self.assertEqual(
             (r.num_samples, r.min, r.median, r.max, r.samples.count),
             (2, 101, 101, 102, 2))
         r = LogParser.results_from_string(  # 20-quantiles aka. ventiles
@@ -506,7 +506,7 @@ Total performance tests executed: 1
             '𝚫V9,𝚫VA,𝚫VB,𝚫VC,𝚫VD,𝚫VE,𝚫VF,𝚫VG,𝚫VH,𝚫VI,𝚫VJ,𝚫MAX\n' +
             '202,DropWhileArray,200,214,,,,,,,,,,,,1,,,,,,2,16,464'
         )['DropWhileArray']
-        self.assertEquals(
+        self.assertEqual(
             (r.num_samples, r.min, r.max, r.samples.count),
             # last 3 ventiles were outliers and were excluded from the sample
             (200, 214, 215, 18))
@@ -538,28 +538,28 @@ Totals,2"""
         results = parser.parse_results(verbose_log.split('\n'))
 
         r = results[0]
-        self.assertEquals(
+        self.assertEqual(
             (r.name, r.min, r.max, int(r.mean), int(r.sd), r.median),
             ('AngryPhonebook', 11467, 13898, 12392, 1315, 11812)
         )
-        self.assertEquals(r.num_samples, r.samples.num_samples)
-        self.assertEquals(results[0].samples.all_samples,
+        self.assertEqual(r.num_samples, r.samples.num_samples)
+        self.assertEqual(results[0].samples.all_samples,
                           [(0, 78, 11812), (1, 90, 13898), (2, 90, 11467)])
-        self.assertEquals(r.yields, None)
+        self.assertEqual(r.yields, None)
 
         r = results[1]
-        self.assertEquals(
+        self.assertEqual(
             (r.name, r.min, r.max, int(r.mean), int(r.sd), r.median),
             ('Array2D', 369900, 381039, 373994, 6127, 371043)
         )
-        self.assertEquals(r.setup, 14444)
-        self.assertEquals(r.num_samples, r.samples.num_samples)
-        self.assertEquals(results[1].samples.all_samples,
+        self.assertEqual(r.setup, 14444)
+        self.assertEqual(r.num_samples, r.samples.num_samples)
+        self.assertEqual(results[1].samples.all_samples,
                           [(0, 1, 369900), (1, 1, 381039), (2, 1, 371043)])
         yielded = r.yields[0]
-        self.assertEquals(yielded.before_sample, 1)
-        self.assertEquals(yielded.after, 369918)
-        self.assertEquals(r.yields, [(1, 369918), (2, 381039)])
+        self.assertEqual(yielded.before_sample, 1)
+        self.assertEqual(yielded.after, 369918)
+        self.assertEqual(r.yields, [(1, 369918), (2, 381039)])
 
     def test_parse_environment_verbose(self):
         """Parse stats about environment in verbose mode."""
@@ -572,21 +572,21 @@ Totals,2"""
         results = parser.parse_results(verbose_log.split('\n'))
 
         r = results[0]
-        self.assertEquals(r.max_rss, 32768)
-        self.assertEquals(r.mem_pages, 8)
-        self.assertEquals(r.voluntary_cs, 1)
-        self.assertEquals(r.involuntary_cs, 1109)
+        self.assertEqual(r.max_rss, 32768)
+        self.assertEqual(r.mem_pages, 8)
+        self.assertEqual(r.voluntary_cs, 1)
+        self.assertEqual(r.involuntary_cs, 1109)
 
     def test_results_from_merge(self):
         """Parsing concatenated log merges same PerformanceTestResults"""
         concatenated_logs = """4,ArrayAppend,20,23641,29000,24990,0,24990
 4,ArrayAppend,1,20000,20000,20000,0,20000"""
         results = LogParser.results_from_string(concatenated_logs)
-        self.assertEquals(results.keys(), ['ArrayAppend'])
+        self.assertEqual(results.keys(), ['ArrayAppend'])
         result = results['ArrayAppend']
         self.assertTrue(isinstance(result, PerformanceTestResult))
-        self.assertEquals(result.min, 20000)
-        self.assertEquals(result.max, 29000)
+        self.assertEqual(result.min, 20000)
+        self.assertEqual(result.max, 29000)
 
     def test_results_from_merge_verbose(self):
         """Parsing verbose log  merges all PerformanceTestSamples.
@@ -604,18 +604,18 @@ Totals,2"""
     Sample 3,364245
 3,Array2D,4,363094,376131,368159,5931,369169"""
         results = LogParser.results_from_string(concatenated_logs)
-        self.assertEquals(results.keys(), ['Array2D'])
+        self.assertEqual(results.keys(), ['Array2D'])
         result = results['Array2D']
         self.assertTrue(isinstance(result, PerformanceTestResult))
-        self.assertEquals(result.min, 350815)
-        self.assertEquals(result.max, 376131)
-        self.assertEquals(result.median, 358817)
+        self.assertEqual(result.min, 350815)
+        self.assertEqual(result.max, 376131)
+        self.assertEqual(result.median, 358817)
         self.assertAlmostEquals(result.sd, 8443.37, places=2)
         self.assertAlmostEquals(result.mean, 361463.25, places=2)
-        self.assertEquals(result.num_samples, 8)
+        self.assertEqual(result.num_samples, 8)
         samples = result.samples
         self.assertTrue(isinstance(samples, PerformanceTestSamples))
-        self.assertEquals(samples.count, 8)
+        self.assertEqual(samples.count, 8)
 
     def test_excludes_outliers_from_samples(self):
         verbose_log = """Running DropFirstAnySeqCntRangeLazy for 10 samples.
@@ -643,9 +643,9 @@ Totals,2"""
 """
         parser = LogParser()
         result = parser.parse_results(verbose_log.split('\n'))[0]
-        self.assertEquals(result.num_samples, 10)
-        self.assertEquals(result.samples.count, 8)
-        self.assertEquals(len(result.samples.outliers), 2)
+        self.assertEqual(result.num_samples, 10)
+        self.assertEqual(result.samples.count, 8)
+        self.assertEqual(len(result.samples.outliers), 2)
 
 
 class TestTestComparator(OldAndNewLog):
@@ -654,27 +654,27 @@ class TestTestComparator(OldAndNewLog):
             return [t.name for t in tests]
 
         tc = TestComparator(self.old_results, self.new_results, 0.05)
-        self.assertEquals(names(tc.unchanged), ['AngryPhonebook', 'Array2D'])
-        self.assertEquals(names(tc.increased), ['ByteSwap', 'ArrayAppend'])
-        self.assertEquals(names(tc.decreased), ['BitCount'])
-        self.assertEquals(names(tc.added), ['TwoSum'])
-        self.assertEquals(names(tc.removed), ['AnyHashableWithAClass'])
+        self.assertEqual(names(tc.unchanged), ['AngryPhonebook', 'Array2D'])
+        self.assertEqual(names(tc.increased), ['ByteSwap', 'ArrayAppend'])
+        self.assertEqual(names(tc.decreased), ['BitCount'])
+        self.assertEqual(names(tc.added), ['TwoSum'])
+        self.assertEqual(names(tc.removed), ['AnyHashableWithAClass'])
         # other way around
         tc = TestComparator(self.new_results, self.old_results, 0.05)
-        self.assertEquals(names(tc.unchanged), ['AngryPhonebook', 'Array2D'])
-        self.assertEquals(names(tc.increased), ['BitCount'])
-        self.assertEquals(names(tc.decreased), ['ByteSwap', 'ArrayAppend'])
-        self.assertEquals(names(tc.added), ['AnyHashableWithAClass'])
-        self.assertEquals(names(tc.removed), ['TwoSum'])
+        self.assertEqual(names(tc.unchanged), ['AngryPhonebook', 'Array2D'])
+        self.assertEqual(names(tc.increased), ['BitCount'])
+        self.assertEqual(names(tc.decreased), ['ByteSwap', 'ArrayAppend'])
+        self.assertEqual(names(tc.added), ['AnyHashableWithAClass'])
+        self.assertEqual(names(tc.removed), ['TwoSum'])
         # delta_threshold determines the sorting into change groups;
         # report only change above 100% (ByteSwap's runtime went to 0):
         tc = TestComparator(self.old_results, self.new_results, 1)
-        self.assertEquals(
+        self.assertEqual(
             names(tc.unchanged),
             ['AngryPhonebook', 'Array2D', 'ArrayAppend', 'BitCount']
         )
-        self.assertEquals(names(tc.increased), ['ByteSwap'])
-        self.assertEquals(tc.decreased, [])
+        self.assertEqual(names(tc.increased), ['ByteSwap'])
+        self.assertEqual(tc.decreased, [])
 
 
 class TestReportFormatter(OldAndNewLog):
@@ -696,12 +696,12 @@ class TestReportFormatter(OldAndNewLog):
         self.assert_report_contains(texts, self.html)
 
     def test_values(self):
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.values(PerformanceTestResult(
                 '1,AngryPhonebook,20,10664,12933,11035,576,10884'.split(','))),
             ('AngryPhonebook', '10664', '12933', '11035', '—')
         )
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.values(PerformanceTestResult(
                 '1,AngryPhonebook,1,12045,12045,12045,0,12045,10510336'
                 .split(','))),
@@ -712,16 +712,16 @@ class TestReportFormatter(OldAndNewLog):
             '1,AngryPhonebook,1,12325,12325,12325,0,12325,10510336'.split(','))
         r2 = PerformanceTestResult(
             '1,AngryPhonebook,1,11616,11616,11616,0,11616,10502144'.split(','))
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.values(ResultComparison(r1, r2)),
             ('AngryPhonebook', '12325', '11616', '-5.8%', '1.06x')
         )
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.values(ResultComparison(r2, r1)),
             ('AngryPhonebook', '11616', '12325', '+6.1%', '0.94x')
         )
         r2.max = r1.min + 1
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.values(ResultComparison(r1, r2))[4],
             '1.06x (?)'  # is_dubious
         )
@@ -742,12 +742,12 @@ class TestReportFormatter(OldAndNewLog):
         PerformanceTestResults.
         """
         performance_test_result = self.tc.added[0]
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.header_for(performance_test_result),
             ('TEST', 'MIN', 'MAX', 'MEAN', 'MAX_RSS')
         )
         comparison_result = self.tc.increased[0]
-        self.assertEquals(
+        self.assertEqual(
             ReportFormatter.header_for(comparison_result),
             ('TEST', 'OLD', 'NEW', 'DELTA', 'RATIO')
         )
@@ -859,17 +859,17 @@ class Test_parse_args(unittest.TestCase):
         self.assertIn('usage: compare_perf_tests.py', err.getvalue())
 
         args = parse_args(self.required)
-        self.assertEquals(args.old_file, 'old.log')
-        self.assertEquals(args.new_file, 'new.log')
+        self.assertEqual(args.old_file, 'old.log')
+        self.assertEqual(args.new_file, 'new.log')
 
     def test_format_argument(self):
-        self.assertEquals(parse_args(self.required).format, 'markdown')
-        self.assertEquals(
+        self.assertEqual(parse_args(self.required).format, 'markdown')
+        self.assertEqual(
             parse_args(self.required + ['--format', 'markdown']).format,
             'markdown')
-        self.assertEquals(
+        self.assertEqual(
             parse_args(self.required + ['--format', 'git']).format, 'git')
-        self.assertEquals(
+        self.assertEqual(
             parse_args(self.required + ['--format', 'html']).format, 'html')
 
         with captured_output() as (_, err):
@@ -882,14 +882,14 @@ class Test_parse_args(unittest.TestCase):
     def test_delta_threshold_argument(self):
         # default value
         args = parse_args(self.required)
-        self.assertEquals(args.delta_threshold, 0.05)
+        self.assertEqual(args.delta_threshold, 0.05)
         # float parsing
         args = parse_args(self.required + ['--delta-threshold', '0.1'])
-        self.assertEquals(args.delta_threshold, 0.1)
+        self.assertEqual(args.delta_threshold, 0.1)
         args = parse_args(self.required + ['--delta-threshold', '1'])
-        self.assertEquals(args.delta_threshold, 1.0)
+        self.assertEqual(args.delta_threshold, 1.0)
         args = parse_args(self.required + ['--delta-threshold', '.2'])
-        self.assertEquals(args.delta_threshold, 0.2)
+        self.assertEqual(args.delta_threshold, 0.2)
 
         with captured_output() as (_, err):
             self.assertRaises(SystemExit, parse_args,
@@ -899,8 +899,8 @@ class Test_parse_args(unittest.TestCase):
                       err.getvalue())
 
     def test_output_argument(self):
-        self.assertEquals(parse_args(self.required).output, None)
-        self.assertEquals(parse_args(self.required +
+        self.assertEqual(parse_args(self.required).output, None)
+        self.assertEqual(parse_args(self.required +
                                      ['--output', 'report.log']).output,
                           'report.log')
 
@@ -962,7 +962,7 @@ class Test_compare_perf_tests_main(OldAndNewLog, FileSystemIntegration):
         """Writes Markdown formatted report to stdout and `--output` file."""
         report_out, report_file = (
             self.execute_main_with_format('markdown', test_output=True))
-        self.assertEquals(report_out, report_file)
+        self.assertEqual(report_out, report_file)
         self.assert_report_contains(self.markdown, report_file)
 
     def test_git(self):
@@ -974,7 +974,7 @@ class Test_compare_perf_tests_main(OldAndNewLog, FileSystemIntegration):
         """Writes Git formatted report to stdout and `--output` file."""
         report_out, report_file = (
             self.execute_main_with_format('git', test_output=True))
-        self.assertEquals(report_out, report_file)
+        self.assertEqual(report_out, report_file)
         self.assert_report_contains(self.git, report_file)
 
     def test_html(self):
@@ -986,7 +986,7 @@ class Test_compare_perf_tests_main(OldAndNewLog, FileSystemIntegration):
         """Writes HTML formatted report to stdout and `--output` file."""
         report_out, report_file = (
             self.execute_main_with_format('html', test_output=True))
-        self.assertEquals(report_out, report_file)
+        self.assertEqual(report_out, report_file)
         self.assert_report_contains(self.html, report_file)
 
 

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -211,13 +211,13 @@ class TestPerformanceTestResult(unittest.TestCase):
         self.assertEqual(r.test_num, '1')
         self.assertEqual(r.name, 'Ackermann')
         self.assertEqual((r.num_samples, r.min, r.median, r.max),
-                          (3, 54383, 54512, 54601))
+                         (3, 54383, 54512, 54601))
         self.assertAlmostEquals(r.mean, 54498.67, places=2)
         self.assertAlmostEquals(r.sd, 109.61, places=2)
         self.assertEqual(r.samples.count, 3)
         self.assertEqual(r.samples.num_samples, 3)
         self.assertEqual([s.runtime for s in r.samples.all_samples],
-                          [54383, 54512, 54601])
+                         [54383, 54512, 54601])
 
         # #,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs),MAX_RSS(B)
         log = '1,Ackermann,3,54529,54760,55807,266240'
@@ -227,7 +227,7 @@ class TestPerformanceTestResult(unittest.TestCase):
         log = '1,Ackermann,5,54570,54593,54644,57212,58304'
         r = PerformanceTestResult(log.split(','), quantiles=True, memory=False)
         self.assertEqual((r.num_samples, r.min, r.median, r.max),
-                          (5, 54570, 54644, 58304))
+                         (5, 54570, 54644, 58304))
         self.assertEqual((r.samples.q1, r.samples.q3), (54593, 57212))
         self.assertEqual(r.samples.count, 5)
         # #,TEST,SAMPLES,MIN(μs),Q1(μs),Q2(μs),Q3(μs),MAX(μs),MAX_RSS(B)
@@ -244,7 +244,7 @@ class TestPerformanceTestResult(unittest.TestCase):
         log = '202,DropWhileArray,2,265,,22'
         r = PerformanceTestResult(log.split(','), quantiles=True, delta=True)
         self.assertEqual((r.num_samples, r.min, r.median, r.max),
-                          (2, 265, 265, 287))
+                         (2, 265, 265, 287))
         self.assertEqual(r.samples.count, 2)
         self.assertEqual(r.samples.num_samples, 2)
 
@@ -267,7 +267,7 @@ class TestPerformanceTestResult(unittest.TestCase):
                                       quantiles=True, delta=True)
             self.assertEqual(r.samples.num_samples, num_samples)
             self.assertEqual([s.runtime for s in r.samples.all_samples],
-                              range(1, num_samples + 1))
+                             range(1, num_samples + 1))
 
         delta_encoded_quantiles = """
 1,,
@@ -334,16 +334,16 @@ class TestPerformanceTestResult(unittest.TestCase):
 
         r = results[0]
         self.assertEqual(as_tuple(r),
-                          (1, 12045, 12045, 12045, 0, 12045, None, None))
+                         (1, 12045, 12045, 12045, 0, 12045, None, None))
         r.merge(results[1])
         self.assertEqual(as_tuple(r),  # drops SD and median, +max_rss
-                          (2, 12045, 12325, 12185, None, None, 10510336, None))
+                         (2, 12045, 12325, 12185, None, None, 10510336, None))
         r.merge(results[2])
         self.assertEqual(as_tuple(r),  # picks smaller of the MAX_RSS, +setup
-                          (3, 11616, 12325, 11995.33, None, None, 10502144, 9))
+                         (3, 11616, 12325, 11995.33, None, None, 10502144, 9))
         r.merge(results[3])
         self.assertEqual(as_tuple(r),  # picks smaller of the setup values
-                          (4, 11616, 12325, 12064, None, None, 10498048, 7))
+                         (4, 11616, 12325, 12064, None, None, 10498048, 7))
 
 
 class TestResultComparison(unittest.TestCase):
@@ -482,12 +482,12 @@ Total performance tests executed: 1
             """#,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs)
 1,Ackermann,3,54383,54512,54601""")['Ackermann']
         self.assertEqual([s.runtime for s in r.samples.all_samples],
-                          [54383, 54512, 54601])
+                         [54383, 54512, 54601])
         r = LogParser.results_from_string(
             """#,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs),MAX_RSS(B)
 1,Ackermann,3,54529,54760,55807,266240""")['Ackermann']
         self.assertEqual([s.runtime for s in r.samples.all_samples],
-                          [54529, 54760, 55807])
+                         [54529, 54760, 55807])
         self.assertEqual(r.max_rss, 266240)
 
     def test_parse_delta_quantiles(self):
@@ -544,7 +544,7 @@ Totals,2"""
         )
         self.assertEqual(r.num_samples, r.samples.num_samples)
         self.assertEqual(results[0].samples.all_samples,
-                          [(0, 78, 11812), (1, 90, 13898), (2, 90, 11467)])
+                         [(0, 78, 11812), (1, 90, 13898), (2, 90, 11467)])
         self.assertEqual(r.yields, None)
 
         r = results[1]
@@ -555,7 +555,7 @@ Totals,2"""
         self.assertEqual(r.setup, 14444)
         self.assertEqual(r.num_samples, r.samples.num_samples)
         self.assertEqual(results[1].samples.all_samples,
-                          [(0, 1, 369900), (1, 1, 381039), (2, 1, 371043)])
+                         [(0, 1, 369900), (1, 1, 381039), (2, 1, 371043)])
         yielded = r.yields[0]
         self.assertEqual(yielded.before_sample, 1)
         self.assertEqual(yielded.after, 369918)
@@ -901,8 +901,8 @@ class Test_parse_args(unittest.TestCase):
     def test_output_argument(self):
         self.assertEqual(parse_args(self.required).output, None)
         self.assertEqual(parse_args(self.required +
-                                     ['--output', 'report.log']).output,
-                          'report.log')
+                                    ['--output', 'report.log']).output,
+                         'report.log')
 
     def test_changes_only_argument(self):
         self.assertFalse(parse_args(self.required).changes_only)

--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -120,11 +120,11 @@ class FuncBugReducerTestCase(unittest.TestCase):
         output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
-        self.assertEquals(sum(output_matches), 1)
+        self.assertEqual(sum(output_matches), 1)
         # Make sure our final output command does not have -emit-sib in
         # the output. We want users to get sil output when they type in
         # the relevant command.
-        self.assertEquals([], [o for o in output if '-emit-sib' in o])
+        self.assertEqual([], [o for o in output if '-emit-sib' in o])
 
 
 if __name__ == '__main__':

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -108,11 +108,11 @@ class OptBugReducerTestCase(unittest.TestCase):
         output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
-        self.assertEquals(sum(output_matches), 1)
+        self.assertEqual(sum(output_matches), 1)
         # Make sure our final output command does not have -emit-sib in
         # the output. We want users to get sil output when they type in
         # the relevant command.
-        self.assertEquals([], [o for o in output if '-emit-sib' in o])
+        self.assertEqual([], [o for o in output if '-emit-sib' in o])
 
     def test_suffix_in_need_of_prefix(self):
         name = 'testsuffixinneedofprefix'
@@ -137,11 +137,11 @@ class OptBugReducerTestCase(unittest.TestCase):
         output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
-        self.assertEquals(sum(output_matches), 1)
+        self.assertEqual(sum(output_matches), 1)
         # Make sure our final output command does not have -emit-sib in the
         # output. We want users to get sil output when they type in the
         # relevant command.
-        self.assertEquals([], [o for o in output if '-emit-sib' in o])
+        self.assertEqual([], [o for o in output if '-emit-sib' in o])
 
     def test_reduce_function(self):
         name = 'testreducefunction'
@@ -170,11 +170,11 @@ class OptBugReducerTestCase(unittest.TestCase):
         output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
-        self.assertEquals(sum(output_matches), 1)
+        self.assertEqual(sum(output_matches), 1)
         # Make sure our final output command does not have -emit-sib in the
         # output. We want users to get sil output when they type in the
         # relevant command.
-        self.assertEquals([], [o for o in output if '-emit-sib' in o])
+        self.assertEqual([], [o for o in output if '-emit-sib' in o])
 
 
 if __name__ == '__main__':

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -561,14 +561,14 @@ class TestDriverArgumentParser(unittest.TestCase):
         with self.assertNotRaises(ParserError):
             namespace = self.parse_default_args(['--debug'])
 
-            self.assertEquals(namespace.cmark_build_variant, 'Debug')
-            self.assertEquals(namespace.foundation_build_variant, 'Debug')
-            self.assertEquals(namespace.libdispatch_build_variant, 'Debug')
-            self.assertEquals(namespace.libicu_build_variant, 'Debug')
-            self.assertEquals(namespace.lldb_build_variant, 'Debug')
-            self.assertEquals(namespace.llvm_build_variant, 'Debug')
-            self.assertEquals(namespace.swift_build_variant, 'Debug')
-            self.assertEquals(namespace.swift_stdlib_build_variant, 'Debug')
+            self.assertEqual(namespace.cmark_build_variant, 'Debug')
+            self.assertEqual(namespace.foundation_build_variant, 'Debug')
+            self.assertEqual(namespace.libdispatch_build_variant, 'Debug')
+            self.assertEqual(namespace.libicu_build_variant, 'Debug')
+            self.assertEqual(namespace.lldb_build_variant, 'Debug')
+            self.assertEqual(namespace.llvm_build_variant, 'Debug')
+            self.assertEqual(namespace.swift_build_variant, 'Debug')
+            self.assertEqual(namespace.swift_stdlib_build_variant, 'Debug')
 
     def test_implied_defaults_skip_build(self):
         with self.assertNotRaises(ParserError):


### PR DESCRIPTION
Python 2.7's `unittest` module deprecated the `assertEquals()` method, preferring the name `assertEqual()`. Replace all outdated uses with the recommended usage.