### PR TITLE
Fix value of `platform_module_dir` in `lit.cfg`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1325,7 +1325,7 @@ if hasattr(config, 'target_swift_autolink_extract'):
 config.substitutions.append(('%target-swift-modulewrap',
                              config.target_swift_modulewrap))
 
-platform_module_dir = make_path(test_resource_dir, '%target-sdk-name', run_cpu)
+platform_module_dir = make_path(test_resource_dir, config.target_sdk_name, run_cpu)
 lit_config.note('Using platform module dir: ' + platform_module_dir)
 if test_sdk_overlay_dir is not None:
     platform_sdk_overlay_dir = make_path(test_sdk_overlay_dir, run_cpu)


### PR DESCRIPTION
In `lit.cfg`, the `platform_module_dir` variable's value is constructed based on the `%target-sdk-name` substitution. However, substitutions are not applied at this point in `lit.cfg`'s logic, so the resulting value was always the actual string `%target-sdk-name`. Instead, use the actual value of `target_sdk_name`, making `platform_module_dir` correctly reflect the target SDK.