### PR TITLE
[AutoDiff] [API] Gardening for stdlib VJP definitions.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -22,11 +22,11 @@
 // For more information, visit:
 // https://en.wikipedia.org/wiki/Automatic_differentiation
 //
-// Each function in this file is the VJP of some corresponding function
-// defined in Ops.swift with respect to all arguments. The attribute
-// '@differentiable(reverse, vjp: ...)' is used to define the VJP for a
-// function. The automatic differentiation pass will identify these VJPs and
-// chain them together to produce arbitrary differentiable programs.
+// Every function in this file is the VJP of some corresponding function
+// defined in Ops.swift, with respect to all arguments. The attribute
+// '@differentiable(vjp: ...)' is used to register a function's VJP. The
+// automatic differentiation pass identifies these VJPs and chains them
+// together to produce arbitrary differentiable programs.
 //
 // NOTE:
 // - Currently, we do not want to expose VJP functions to users. The name of

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -24,14 +24,14 @@ TensorADTests.testAllBackends("TestSimpleGrad") {
 
 TensorADTests.testAllBackends("+") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a + b }
-  expectTrue(([1], [1]) == gradient(at: [0], [0], in: f))
-  expectTrue(([1], [1]) == gradient(at: [1], [10], in: f))
+  expectTrue((Tensor(1), Tensor(1)) == gradient(at: Tensor(0), Tensor(0), in: f))
+  expectTrue(([1], [1]) == pullback(at: [1], [10], in: f)([1]))
 }
 
 TensorADTests.testAllBackends("-") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a - b }
-  expectTrue(([1], [-1]) == gradient(at: [0], [0], in: f))
-  expectTrue(([1], [-1]) == gradient(at: [1], [10], in: f))
+  expectTrue((Tensor(1), Tensor(-1)) == gradient(at: Tensor(0), Tensor(0), in: f))
+  expectTrue(([1], [-1]) == pullback(at: [1], [10], in: f)([1]))
 }
 
 TensorADTests.testAllBackends("*") {


### PR DESCRIPTION
- Do not broadcast adjoint to original value in any VJP definition (where
  it is not necessary).
  - Instead, assume that adjoint has same shape as original result.
  - This formulation is mathematically correct. Users can manually specify
    non-scalar adjoints using `pullback`.
- Gardening.