### PR TITLE
[CMake] Include apinotes in StandaloneOverlay.cmake

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -61,6 +61,7 @@ precondition(TOOLCHAIN_DIR)
 # Some overlays include the runtime's headers,
 # and some of those headers are generated at build time.
 add_subdirectory("${SWIFT_SOURCE_DIR}/include" "swift/include")
+add_subdirectory("${SWIFT_SOURCE_DIR}/apinotes" "swift/apinotes")
 
 # Without this line, installing components is broken. This needs refactoring.
 swift_configure_components()


### PR DESCRIPTION
...because the Darwin overlay is responsible for installing them.

Context: Within Apple, overlays are sometimes built separately from the rest of the Swift project. This doesn't currently work with just the public repo (rdar://problem/47324189), but it could, and I broke it with my recent API notes cleanup. This should get things working again.

rdar://problem/47294352