### PR TITLE
[ConstraintSystem] Mark generic parameter bindings as potentially inc…

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2871,7 +2871,8 @@ private:
     /// A set of all constraints which contribute to pontential bindings.
     llvm::SmallPtrSet<Constraint *, 8> Sources;
 
-    PotentialBindings(TypeVariableType *typeVar) : TypeVar(typeVar) {}
+    PotentialBindings(TypeVariableType *typeVar)
+        : TypeVar(typeVar), PotentiallyIncomplete(isGenericParameter()) {}
 
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
@@ -2936,6 +2937,16 @@ private:
 
     /// Check if this binding is viable for inclusion in the set.
     bool isViable(PotentialBinding &binding) const;
+
+    bool isGenericParameter() const {
+      if (auto *locator = TypeVar->getImpl().getLocator()) {
+        auto path = locator->getPath();
+        return path.empty() ? false
+                            : path.back().getKind() ==
+                                  ConstraintLocator::GenericParameter;
+      }
+      return false;
+    }
 
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {

--- a/test/Constraints/sr9626.swift
+++ b/test/Constraints/sr9626.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+class BaseClass {}
+class SubClass: BaseClass {}
+struct Box<T> { init(_: T.Type) {} }
+
+
+func test1<T>(box: Box<T>) -> T.Type {
+  return T.self
+}
+
+func test2<T: BaseClass>(box: Box<T>) -> T.Type {
+  return T.self
+}
+
+// CHECK: [[F1:%.*]] = function_ref @$s6sr96263BoxVyACyxGxmcfC
+// CHECK-NEXT: apply [[F1]]<SubClass>({{.*}}, {{.*}})
+_ = test1(box: .init(SubClass.self))
+
+// CHECK: [[F2:%.*]] = function_ref @$s6sr96265test23boxxmAA3BoxVyxG_tAA9BaseClassCRbzlF
+// CHECK-NEXT: apply [[F2]]<SubClass>({{.*}})
+_ = test2(box: .init(SubClass.self))


### PR DESCRIPTION
…omplete by default

This helps to postpone attempting bindings related to generic
parameters with all else being equal.

Consider situation when function has class requirement on its
generic parameter. Without such requirement solver would infer
sub-class for `T`. But currently when requirement is present base
class is inferred instead, because when bindings for such generic
parameter are attempted early single available binding at that
point comes from the requirement.

```swift
class BaseClass {}
class SubClass: BaseClass {}

struct Box<T> { init(_: T.Type) {} }

func test<T: BaseClass>(box: Box<T>) -> T.Type {
  return T.self
}

test(box: .init(SubClass.self)) // `T` expected to be `SubClass`
```

Resolves: [SR-9626](https://bugs.swift.org/browse/SR-9626)
Resolves: rdar://problem/47324309

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
