### PR TITLE
Add a lit regex filter for the compatibility tests

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3152,7 +3152,7 @@ for host in "${ALL_HOSTS[@]}"; do
                                 "${lldb_build_dir}/lit" \
                                 ${LLVM_LIT_ARGS} \
                                 --xunit-xml-output=${results_dir}/results.xml \
-                                --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -G swift-history --swift-compiler \"${LLDB_TEST_SWIFT_COMPATIBILITY}\" -t -E \"${DOTEST_EXTRA}\""
+                                --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -G swift-history --swift-compiler \"${LLDB_TEST_SWIFT_COMPATIBILITY}\" -t -E \"${DOTEST_EXTRA}\"" --filter=compat
                     fi
                 else
                     with_pushd "${results_dir}" \


### PR DESCRIPTION
This speeds up the invocation since only a single test matches the
category and otherwise non-dotest.py tests would be run twice.
