### PR TITLE
Compute the linkage for jvp using the same logic as vjp.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3889,10 +3889,10 @@ void DifferentiationTask::createJVP() {
       jvpGenericSig);
 
   SILOptFunctionBuilder fb(context.getTransform());
-  jvp = fb.createFunction(original->getLinkage(), jvpName, jvpType,
-                          jvpGenericEnv, original->getLocation(),
-                          original->isBare(), IsNotTransparent,
-                          original->isSerialized());
+  auto linkage = getAutoDiffFunctionLinkage(original->getLinkage());
+  jvp = fb.createFunction(linkage, jvpName, jvpType, jvpGenericEnv,
+                          original->getLocation(), original->isBare(),
+                          IsNotTransparent, original->isSerialized());
   jvp->setUnqualifiedOwnership();
   jvp->setDebugScope(new (module) SILDebugScope(original->getLocation(), jvp));
   attr->setJVPName(jvp->getName());


### PR DESCRIPTION
This is necessary to ensure that the jvp function is serialized when swift::serialize is called. The serialization functionality is needed to support cross-cell differentiation in co-lab/jupyter. (See [SR-8613](https://bugs.swift.org/browse/SR-8613))

