### PR TITLE
Fix typo in assert message

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -404,7 +404,7 @@ public:
     assert((!StartLoc || StartLoc->isValid()) &&
            "Expected start location to be valid");
     assert((!EndLoc || EndLoc->isValid()) &&
-           "Expected start location to be valid");
+           "Expected end location to be valid");
   }
 
   SourceMappingRegion(SourceMappingRegion &&Region) = default;


### PR DESCRIPTION
Fix typo in assert message ("start" -> "end").