### PR TITLE
test: define expansion macro always

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1275,6 +1275,8 @@ config.substitutions.append(('%target-clang', config.target_clang))
 config.substitutions.append(('%target-ld', config.target_ld))
 if hasattr(config, 'target_cc_options'):
     config.substitutions.append(('%target-cc-options', config.target_cc_options))
+else:
+    config.substitutions.append(('%target-cc-options', ''))
 
 config.substitutions.append(
     (r'%hardlink-or-copy\(from: *(.*), *to: *(.*)\)',


### PR DESCRIPTION
If `%target-cc-options` was used but the substitution was not defined,
we would end up substituting it as `%t`arget-cc-options which is rather
confusing.  Always define the macro, even if it is expanded to the empty
string.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
