### PR TITLE
[TF] [stdlib] Improve primitive derivatives and remove some stdlib cruft.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -206,8 +206,9 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   static func _vjpAdd(
     lhs: Tensor, rhs: Tensor
   ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-    return (lhs + rhs, { [rhsShape = rhs.shapeTensor] v in
-      return (v.unbroadcast(like: lhs), v.unbroadcast(toShape: rhsShape))
+    return (lhs + rhs, {
+      [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
+      return (v.unbroadcast(toShape: lhsShape), v.unbroadcast(toShape: rhsShape))
     })
   }
 
@@ -215,9 +216,10 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   static func _vjpSubtract(
     lhs: Tensor, rhs: Tensor
   ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-    let value = lhs - rhs
-    return (value, { v in
-      return (v.unbroadcast(like: lhs), -v.unbroadcast(like: rhs))
+    return (lhs - rhs, {
+      [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
+      return (v.unbroadcast(toShape: lhsShape),
+              -v.unbroadcast(toShape: rhsShape))
     })
   }
 
@@ -225,9 +227,10 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   static func _vjpMultiply(
     lhs: Tensor, rhs: Tensor
   ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-    return (lhs * rhs, { v in
-      ((rhs * v).unbroadcast(like: lhs),
-       (lhs * v).unbroadcast(like: rhs))
+    return (lhs * rhs, {
+      [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
+      ((rhs * v).unbroadcast(toShape: lhsShape),
+       (lhs * v).unbroadcast(toShape: rhsShape))
     })
   }
 
@@ -235,9 +238,10 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   static func _vjpDivide(
     lhs: Tensor, rhs: Tensor
   ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-    return (lhs * rhs, { v in
-      ((v / rhs).unbroadcast(like: lhs),
-       ((-lhs) / rhs.squared() * v).unbroadcast(like: rhs))
+    return (lhs * rhs, {
+      [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
+      ((v / rhs).unbroadcast(toShape: lhsShape),
+       ((-lhs) / rhs.squared() * v).unbroadcast(toShape: rhsShape))
     })
   }
 }

--- a/stdlib/public/TensorFlow/Random.swift
+++ b/stdlib/public/TensorFlow/Random.swift
@@ -132,8 +132,7 @@ public final class UniformIntegerDistribution<T: FixedWidthInteger> {
 
 @_fixed_layout
 public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>
-  where T.RawSignificand : FixedWidthInteger
-{
+  where T.RawSignificand : FixedWidthInteger {
   public let lowerBound: T
   public let upperBound: T
 
@@ -149,8 +148,7 @@ public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>
 
 @_fixed_layout
 public final class NormalDistribution<T : BinaryFloatingPoint>
-  where T.RawSignificand : FixedWidthInteger
-{
+  where T.RawSignificand : FixedWidthInteger {
   public let mean: T
   public let standardDeviation: T
   private let uniformDist = UniformFloatingPointDistribution<T>()


### PR DESCRIPTION
* Improve some derivatives so that they won't capture large tensors.

* Remove some unnecessary `@inline(__always)` in tensor ops. They were required by efficient GPE but are now just burdens on compilation time in optimized builds.

* Remove the `_TFHoistable` and `@autoclosure` hacks in `padded(forSizes:with:)` (you don't wanna know why this was necessary).
