### PR TITLE
[Sema] Restrict derived conformances.

### DIFF
--- a/test/AutoDiff/derived_conformances.swift
+++ b/test/AutoDiff/derived_conformances.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if os(macOS)
+import Darwin.C
+#else
+import Glibc
+#endif
+
+var DerivedConformanceTests = TestSuite("DerivedConformances")
+
+DerivedConformanceTests.test("MemberwiseInitializers") {
+  struct AllVarStoredPropertiesHaveInitialValue: Differentiable, AdditiveArithmetic {
+    var x = Float(100)
+    var y = Float(100)
+  }
+  // Verify that `.zero` actually initializes properties to zero.
+  expectEqual(AllVarStoredPropertiesHaveInitialValue(x: 0, y: 0),
+              AllVarStoredPropertiesHaveInitialValue.zero)
+  expectEqual(AllVarStoredPropertiesHaveInitialValue.zero.x, 0)
+  expectEqual(AllVarStoredPropertiesHaveInitialValue.zero.y, 0)
+
+  struct HasNoDerivativeConstant: Differentiable {
+    @noDerivative let constant1 = Float(1)
+    @noDerivative let constant2 = Double(1)
+    var x = Float(1)
+  }
+  expectEqual(HasNoDerivativeConstant.AllDifferentiableVariables(x: 0),
+              HasNoDerivativeConstant.AllDifferentiableVariables.zero)
+  expectEqual(HasNoDerivativeConstant.CotangentVector(x: 0),
+              HasNoDerivativeConstant.CotangentVector.zero)
+}
+
+runAllTests()

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -7,6 +7,31 @@ struct Empty : Differentiable {}
 // Previously, this crashed due to duplicate memberwise initializer synthesis.
 struct EmptyAdditiveArithmetic : AdditiveArithmetic, Differentiable {}
 
+// Test structs whose stored properties all have an initial value.
+struct AllLetStoredPropertiesHaveInitialValue : Differentiable { // expected-error {{does not conform to protocol 'Differentiable'}}
+  let x = Float(1)
+  let y = Float(1)
+}
+struct AllVarStoredPropertiesHaveInitialValue : Differentiable {
+  var x = Float(1)
+  var y = Float(1)
+}
+// Test struct with both an empty constructor and memberwise initializer.
+struct AllMixedStoredPropertiesHaveInitialValue : Differentiable { // expected-error {{does not conform to protocol 'Differentiable'}}
+  let x = Float(1)
+  var y = Float(1)
+  // Memberwise initializer should be `init(y:)` since `x` is immutable.
+  static func testMemberwiseInitializer() {
+    _ = AllMixedStoredPropertiesHaveInitialValue(y: 1)
+  }
+}
+struct HasCustomConstructor: Differentiable {
+  var x = Float(1)
+  var y = Float(1)
+  // Custom constructor should not affect synthesis.
+  init(x: Float, y: Float, z: Bool) {}
+}
+
 struct Simple : AdditiveArithmetic, Differentiable {
   var w: Float
   var b: Float
@@ -88,7 +113,7 @@ testVectorNumeric(AllMembersVectorNumeric.TangentVector.self)
 testVectorNumeric(AllMembersVectorNumeric.CotangentVector.self)
 
 // Test type with immutable, differentiable stored property.
-struct ImmutableStoredProperty : Differentiable {
+struct ImmutableStoredProperty : Differentiable { // expected-error {{does not conform to protocol 'Differentiable'}}
   var w: Float
   let fixedBias: Float = .pi
 }


### PR DESCRIPTION
Do not derive conformances to `AdditiveArithmetic` or `VectorNumeric` for
types with any `let` stored properties with an initial value.

Similarly for `Differentiable`, do not derive conformances for types with
any `let` stored properties not marked with `@noDerivative` with an initial value.

This restriction is important for expected behavior regarding memberwise
initializers. Without this restriction, `T.zero` may return an instance of `T`
where default-initialized `let` stored properties have a non-zero value.

This restriction may be lifted later with support for "true" memberwise
initializers that initialize all stored properties, including ones with initial
values.

Add tests, including first runtime derived conformances tests.

Addresses [SR-9684](https://bugs.swift.org/browse/SR-9684) via restriction. May be changed later.