### PR TITLE
[5.0][ClangImporter] Fix issue with source order comparisons of clang source locations when using a bridging PCH

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1144,6 +1144,14 @@ ClangImporter::Implementation::getNextIncludeLoc() {
   if (!DummyIncludeBuffer.isValid()) {
     clang::SourceLocation includeLoc =
         srcMgr.getLocForStartOfFile(srcMgr.getMainFileID());
+    // Picking the beginning of the main FileID as include location is also what
+    // the clang PCH mechanism is doing (see
+    // clang::ASTReader::getImportLocation()). Choose the next source location
+    // here to avoid having the exact same import location as the clang PCH.
+    // Otherwise, if we are using a PCH for bridging header, we'll have
+    // problems with source order comparisons of clang source locations not
+    // being deterministic.
+    includeLoc = includeLoc.getLocWithOffset(1);
     DummyIncludeBuffer = srcMgr.createFileID(
         llvm::make_unique<ZeroFilledMemoryBuffer>(
           256*1024, StringRef(moduleImportBufferName)),

--- a/test/IDE/clang-importing/Inputs/bridge.h
+++ b/test/IDE/clang-importing/Inputs/bridge.h
@@ -1,1 +1,4 @@
+@import Foundation;
 @import somemod1;
+
+void func_in_bridge(void);

--- a/test/IDE/clang-importing/complete_with_clang_comments.swift
+++ b/test/IDE/clang-importing/complete_with_clang_comments.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP -code-completion-comments=true \
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=TOP -code-completion-comments=true \
 // RUN:    -import-objc-header %S/Inputs/bridge.h -I %S/Inputs/somemod1 -I %S/Inputs/somemod2 | %FileCheck %s -check-prefix=CHECK-TOP
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=TOP -code-completion-comments=true \
+// RUN:    -import-objc-header %S/Inputs/bridge.h -pch-output-dir %t.pch -I %S/Inputs/somemod1 -I %S/Inputs/somemod2 | %FileCheck %s -check-prefix=CHECK-TOP
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Clang importer was picking the beginning of the main FileID as include location of its modules, which is the same location that the clang PCH mechanism is using as import location.
Make sure to use a different location otherwise we'll have problems with source order comparisons of clang source locations not being deterministic.

rdar://29137319

master: https://github.com/apple/swift/pull/21952