### PR TITLE
Shims: make the `__swift_ssize_t` handling more portable

### DIFF
--- a/stdlib/public/SwiftShims/SwiftStddef.h
+++ b/stdlib/public/SwiftShims/SwiftStddef.h
@@ -29,11 +29,18 @@ typedef __SIZE_TYPE__ __swift_size_t;
 #endif
 
 // This selects the signed equivalent of the unsigned type chosen for size_t.
+#if __STDC_VERSION__-0 >= 201112l
 typedef __typeof__(_Generic((__swift_size_t)0,                                 \
                             unsigned long long int : (long long int)0,         \
                             unsigned long int : (long int)0,                   \
                             unsigned int : (int)0,                             \
                             unsigned short : (short)0,                         \
                             unsigned char : (signed char)0)) __swift_ssize_t;
+#elif defined(__cplusplus)
+#include <type_traits>
+using __swift_ssize_t = std::make_signed<__swift_size_t>::type;
+#else
+#error "do not have __swift_ssize_t defined"
+#endif
 
 #endif // SWIFT_STDLIB_SHIMS_SWIFT_STDDEF_H


### PR DESCRIPTION
Unfortunately, `cl` does not support C11.  Guard the `_Generic` approach and in
C++ mode use `std::make_signed`.  Thanks to Jordan Rose for the reminder about
the type_traits helper!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
