### PR TITLE
[Tests] Disable backward deployment tests requiring ASan

### DIFF
--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -4,6 +4,9 @@
 // REQUIRES: executable_test
 // REQUIRES: asan_runtime
 
+// rdar://problem/47367694 tracks re-enabling this test for backward deployment.
+// UNSUPPORTED: remote_run
+
 // Make sure we can handle swifterror. LLVM's address sanitizer pass needs to
 // ignore swifterror addresses.
 

--- a/validation-test/execution/arc_36509461.swift
+++ b/validation-test/execution/arc_36509461.swift
@@ -9,6 +9,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
+// rdar://problem/47367694 tracks re-enabling this test for backward deployment.
+// UNSUPPORTED: remote_run
+
 import Foundation
 
 struct FakeUUID {


### PR DESCRIPTION
Test requiring ASan are currently failing on internal bots that test
back deployment because of a test infrastructure problem with ASan bac
 deployment.

Mark those tests as unsupported for remote_run (which is currently only used
for those back-deployment tests) until we can address the underlying issue.