### PR TITLE
[5.0] Test that newer libobjcs let the Swift runtime set up a class's layout

### DIFF
--- a/validation-test/Runtime/Inputs/class-layout-from-objc/Classes.swift
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/Classes.swift
@@ -1,0 +1,65 @@
+import Resilient
+import Foundation
+import OneWordSuperclass
+
+public class StaticClass: OneWordSuperclass {
+  @objc var first: Int32 = 0
+  var middle = GrowsToInt64()
+  @objc var last: Int = 0
+
+  @objc public static var offsetOfFirst: Int {
+    // IRGen lays out Swift classes that subclass Objective-C classes as if the
+    // only superclass was NSObject, so the starting (offset % alignment) isn't
+    // always 0. This means that on 32-bit platforms we'll have a gap *before*
+    // 'first' when we need 8-byte alignment, rather than after as you'd see in
+    // a struct (or base class).
+    return max(MemoryLayout<Int>.size, MemoryLayout<GrowsToInt64>.alignment) +
+           MemoryLayout<Int>.size
+  }
+
+  @objc public static var totalSize: Int {
+    return (2 * MemoryLayout<Int>.size) +
+           (2 * MemoryLayout<GrowsToInt64>.size) + // alignment
+           MemoryLayout<Int>.size
+  }
+}
+
+/// This class has the same layout as `StaticClass`, but will be accessed using
+/// `NSClassFromString` instead of `+class`.
+public class DynamicClass: OneWordSuperclass {
+  @objc var first: Int32 = 0
+  var middle = GrowsToInt64()
+  @objc var last: Int = 0
+
+  @objc public static var offsetOfFirst: Int {
+    // See above.
+    return max(MemoryLayout<Int>.size, MemoryLayout<GrowsToInt64>.alignment) +
+           MemoryLayout<Int>.size
+  }
+
+  @objc public static var totalSize: Int {
+    return (2 * MemoryLayout<Int>.size) +
+           (2 * MemoryLayout<GrowsToInt64>.size) + // alignment
+           MemoryLayout<Int>.size
+  }
+}
+
+public class PureSwiftBaseClass {
+  var word: Int64 = 0
+}
+
+public class PureSwiftClass: PureSwiftBaseClass {
+  @objc var first: Int32 = 0
+  var middle = GrowsToInt64()
+  @objc var last: Int = 0
+
+  @objc public static var offsetOfFirst: Int {
+    return (2 * MemoryLayout<Int>.size) + MemoryLayout<Int64>.size
+  }
+
+  @objc public static var totalSize: Int {
+    return (2 * MemoryLayout<Int>.size) + MemoryLayout<Int64>.size +
+           (2 * MemoryLayout<GrowsToInt64>.size) + // alignment
+           MemoryLayout<Int>.size
+  }
+}

--- a/validation-test/Runtime/Inputs/class-layout-from-objc/OneWordSuperclass.h
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/OneWordSuperclass.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+@interface OneWordSuperclass : NSObject
+@end

--- a/validation-test/Runtime/Inputs/class-layout-from-objc/OneWordSuperclass.m
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/OneWordSuperclass.m
@@ -1,0 +1,6 @@
+#import "OneWordSuperclass.h"
+
+@implementation OneWordSuperclass {
+  intptr_t unused;
+}
+@end

--- a/validation-test/Runtime/Inputs/class-layout-from-objc/Resilient.swift
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/Resilient.swift
@@ -1,0 +1,11 @@
+public struct GrowsToInt64 {
+  #if SMALL
+  var value: Int32
+  #elseif BIG
+  var value: Int64
+  #else
+  #error("Must define SMALL or BIG")
+  #endif
+
+  public init() { self.value = 0 }
+}

--- a/validation-test/Runtime/Inputs/class-layout-from-objc/module.modulemap
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/module.modulemap
@@ -1,0 +1,4 @@
+module OneWordSuperclass {
+  header "OneWordSuperclass.h"
+  export *
+}

--- a/validation-test/Runtime/class-layout-from-objc.m
+++ b/validation-test/Runtime/class-layout-from-objc.m
@@ -1,0 +1,78 @@
+// Check that when Objective-C is first to touch a Swift class, it gives the
+// Swift runtime a chance to update instance size and ivar offset metadata.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -emit-module -o %t/libResilient.dylib %S/Inputs/class-layout-from-objc/Resilient.swift -Xlinker -install_name -Xlinker @executable_path/libResilient.dylib -Xfrontend -enable-resilience -DSMALL
+
+// RUN: %target-clang -c %S/Inputs/class-layout-from-objc/OneWordSuperclass.m -fmodules -fobjc-arc -o %t/OneWordSuperclass.o
+// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %t -I %S/Inputs/class-layout-from-objc/ %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t
+// RUN: %target-clang %s -I %S/Inputs/class-layout-from-objc/ -I %t -fmodules -fobjc-arc -o %t/main -lResilient -lClasses -L %t
+// RUN: %target-codesign %t/main %t/libResilient.dylib %t/libClasses.dylib
+// RUN: %target-run %t/main OLD %t/libResilient.dylib %t/libClasses.dylib
+
+// RUN: %target-build-swift -emit-library -emit-module -o %t/libResilient.dylib %S/Inputs/class-layout-from-objc/Resilient.swift -Xlinker -install_name -Xlinker @executable_path/libResilient.dylib -Xfrontend -enable-resilience -DBIG
+// RUN: %target-codesign %t/libResilient.dylib
+// RUN: %target-run %t/main NEW %t/libResilient.dylib %t/libClasses.dylib
+
+// Try again when the class itself is also resilient.
+// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %S/Inputs/class-layout-from-objc/ -I %t %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t
+// RUN: %target-codesign %t/libClasses.dylib
+// RUN: %target-run %t/main OLD %t/libResilient.dylib %t/libClasses.dylib
+
+// RUN: %target-build-swift -emit-library -emit-module -o %t/libResilient.dylib %S/Inputs/class-layout-from-objc/Resilient.swift -Xlinker -install_name -Xlinker @executable_path/libResilient.dylib -Xfrontend -enable-resilience -DSMALL
+// RUN: %target-codesign %t/libResilient.dylib
+// RUN: %target-run %t/main NEW %t/libResilient.dylib %t/libClasses.dylib
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+#import <objc/runtime.h>
+#import <assert.h>
+#import <dlfcn.h>
+#import <stdbool.h>
+#import <string.h>
+
+#import "Classes.h"
+
+void check(Class c) {
+  assert(c);
+
+  size_t expectedSize = [c totalSize];
+  size_t actualSize = class_getInstanceSize([c class]);
+  NSLog(@"%@: expected size %zd, actual size %zd", c, expectedSize, actualSize);
+  assert(expectedSize == actualSize);
+
+  size_t expectedOffsetOfFirst = [c offsetOfFirst];
+  size_t offsetOfFirst = ivar_getOffset(class_getInstanceVariable(c, "first"));
+  NSLog(@"expected offset of 'first' %zd, actual %zd",
+        expectedOffsetOfFirst, offsetOfFirst);
+  assert(offsetOfFirst == expectedOffsetOfFirst);
+
+  size_t offsetOfLast = ivar_getOffset(class_getInstanceVariable(c, "last"));
+  NSLog(@"offset of 'last' %zd", offsetOfLast);
+  assert(offsetOfLast == actualSize - sizeof(intptr_t));
+}
+
+int main(int argc, const char * const argv[]) {
+  assert(argc > 1);
+
+  if (!strcmp(argv[1], "OLD")) {
+    ;
+  } else if (!strcmp(argv[1], "NEW")) {
+    // Only test the new behavior on a new enough libobjc.
+    if (!dlsym(RTLD_NEXT, "_objc_realizeClassFromSwift")) {
+      fprintf(stderr, "skipping evolution tests; OS too old\n");
+      return EXIT_SUCCESS;
+    }
+  } else {
+    fprintf(stderr, "usage: %s (OLD|NEW)\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  @autoreleasepool {
+    NSLog(@"%zd", class_getInstanceSize([OneWordSuperclass class]));
+    check([StaticClass class]);
+    check(objc_getClass("Classes.DynamicClass"));
+    check(objc_getClass("Classes.PureSwiftClass"));
+  }
+}

--- a/validation-test/Runtime/class-layout-from-objc.m
+++ b/validation-test/Runtime/class-layout-from-objc.m
@@ -34,7 +34,7 @@
 
 #import "Classes.h"
 
-void check(Class c) {
+void checkClass(Class c) {
   assert(c);
 
   size_t expectedSize = [c totalSize];
@@ -71,8 +71,8 @@ int main(int argc, const char * const argv[]) {
 
   @autoreleasepool {
     NSLog(@"%zd", class_getInstanceSize([OneWordSuperclass class]));
-    check([StaticClass class]);
-    check(objc_getClass("Classes.DynamicClass"));
-    check(objc_getClass("Classes.PureSwiftClass"));
+    checkClass([StaticClass class]);
+    checkClass(objc_getClass("Classes.DynamicClass"));
+    checkClass(objc_getClass("Classes.PureSwiftClass"));
   }
 }


### PR DESCRIPTION
- **Explanation**: When a Swift class is referenced from Objective-C first, new versions of the Objective-C runtime will give the *Swift* runtime a chance to lay out that class properly. This is important for resilience, since up until now Objective-C isn't used to the size of a class changing based on anything other than a superclass's size changing.

    This commit is just a test; the actual implementation went in months ago, but didn't have a libobjc we could test against at the time.

- **Scope**: Most interesting behavior is only tested on unreleased Apple OSs, but it's still testing class layout on released OSs.

- **Issue**: rdar://problem/45718008

- **Risk**: None. Test change only.

- **Testing**: Tested on both old and new 64-bit macOS systems, old and new 64-bit iOS simulators, an old 32-bit iOS simulator, and a new 32-bit watchOS simulator.

- **Reviewed by**: @slavapestov, @mikeash 