### PR TITLE
[pmo] Eliminate PMOUseKind::PartialStore.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -254,14 +254,11 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
 
       // Coming out of SILGen, we assume that raw stores are initializations,
       // unless they have trivial type (which we classify as InitOrAssign).
-      PMOUseKind Kind;
-      if (InStructSubElement)
-        Kind = PMOUseKind::PartialStore;
-      else if (PointeeType.isTrivial(User->getModule()))
-        Kind = PMOUseKind::InitOrAssign;
-      else
-        Kind = PMOUseKind::Initialization;
-
+      auto Kind = ([&]() -> PMOUseKind {
+        if (PointeeType.isTrivial(User->getModule()))
+          return PMOUseKind::InitOrAssign;
+        return PMOUseKind::Initialization;
+      })();
       Uses.emplace_back(User, Kind);
       continue;
     }
@@ -270,9 +267,7 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
   if (auto *SI = dyn_cast<Store##Name##Inst>(User)) {                          \
     if (UI->getOperandNumber() == 1) {                                         \
       PMOUseKind Kind;                                                         \
-      if (InStructSubElement)                                                  \
-        Kind = PMOUseKind::PartialStore;                                       \
-      else if (SI->isInitializationOfDest())                                   \
+      if (SI->isInitializationOfDest())                                        \
         Kind = PMOUseKind::Initialization;                                     \
       else                                                                     \
         Kind = PMOUseKind::Assign;                                             \
@@ -294,16 +289,15 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
       // the destination, then this is an unknown assignment.  Note that we'll
       // revisit this instruction and add it to Uses twice if it is both a load
       // and store to the same aggregate.
-      PMOUseKind Kind;
-      if (UI->getOperandNumber() == 0)
-        Kind = PMOUseKind::Load;
-      else if (InStructSubElement)
-        Kind = PMOUseKind::PartialStore;
-      else if (CAI->isInitializationOfDest())
-        Kind = PMOUseKind::Initialization;
-      else
-        Kind = PMOUseKind::Assign;
-
+      //
+      // Inline constructor.
+      auto Kind = ([&]() -> PMOUseKind {
+        if (UI->getOperandNumber() == CopyAddrInst::Src)
+          return PMOUseKind::Load;
+        if (CAI->isInitializationOfDest())
+          return PMOUseKind::Initialization;
+        return PMOUseKind::Assign;
+      })();
       Uses.emplace_back(User, Kind);
       continue;
     }

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -116,9 +116,6 @@ enum PMOUseKind {
   /// value.
   Assign,
 
-  /// The instruction is a store to a member of a larger struct value.
-  PartialStore,
-
   /// An indirect 'inout' parameter of an Apply instruction.
   InOutUse,
 

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -911,7 +911,7 @@ void AvailableValueDataflowContext::explodeCopyAddr(CopyAddrInst *CAI) {
   assert((LoadUse.isValid() || StoreUse.isValid()) &&
          "we should have a load or a store, possibly both");
   assert(StoreUse.isInvalid() || StoreUse.Kind == Assign ||
-         StoreUse.Kind == PartialStore || StoreUse.Kind == Initialization);
+         StoreUse.Kind == Initialization);
 
   // Now that we've emitted a bunch of instructions, including a load and store
   // but also including other stuff, update the internal state of
@@ -1286,7 +1286,6 @@ bool AllocOptimize::tryToRemoveDeadAllocation() {
 
     switch (u.Kind) {
     case PMOUseKind::Assign:
-    case PMOUseKind::PartialStore:
     case PMOUseKind::InitOrAssign:
       break;    // These don't prevent removal.
     case PMOUseKind::Initialization:


### PR DESCRIPTION
PartialStore is a PMOUseKind that is a vestigal remnant of Definite Init in the
PMO source. This can be seen by noting that in Definite Init, PartialStore is
how Definite Init diagnoses partially initialized values and errors. In contrast
in PMO the semantics of PartialStore are:

1. It can only be produced if we have a raw store use or a copy_addr.
2. We allow for the use to provide an available value just like if it was an
assign or an init.
3. We ignore it for the purposes of removing store only allocations since by
itself without ownership, stores (and stores from exploded copy_addr) do not
effect ownership in any way.

Rather than keeping this around, in this commit I review it since it doesn't
provide any additional value or [init] or [assign]. Functionally there should be
no change.
