### PR TITLE
Sema: Teach rethrows checking about OtherConstructorDeclRefExpr

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -155,6 +155,11 @@ public:
       }
     }
     
+    // Constructor delegation.
+    if (auto otherCtorDeclRef = dyn_cast<OtherConstructorDeclRefExpr>(fn)) {
+      return AbstractFunction(otherCtorDeclRef->getDecl());
+    }
+
     // Normal function references.
     if (auto declRef = dyn_cast<DeclRefExpr>(fn)) {
       ValueDecl *decl = declRef->getDecl();

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -584,3 +584,22 @@ func suchThat<A>(_ x: Box<A>) -> (@escaping (A) -> A) -> Box<A> {
 }
 
 Box(unbox: 1) |> suchThat <| { $0 + 1 } // expected-warning {{result of operator '<|' is unused}}
+
+// Constructor delegation -vs- rethrows
+class RethrowingConstructor {
+  init(_ block: () throws -> ()) rethrows {
+    try block()
+  }
+
+  convenience init(bar: Int) {
+    self.init {
+      print("Foo!")
+    }
+  }
+
+  convenience init(baz: Int) throws {
+    try self.init {
+      try throwingFunc()
+    }
+  }
+}


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-8788>.