### PR TITLE
[IRGen] Do not emit ObjC property ivar field when getters and setters are non-trivial.

### DIFF
--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -100,7 +100,7 @@ import Foundation
 
 // CHECK: @_PROPERTIES__TtC11objc_bridge3Bas = private constant { i32, i32, [5 x { i8*, i8* }] } {
 
-// CHECK: [[OBJC_BLOCK_PROPERTY:@.*]] = private unnamed_addr constant [11 x i8] c"T@?,N,C,Vx\00"
+// CHECK: [[OBJC_BLOCK_PROPERTY:@.*]] = private unnamed_addr constant [8 x i8] c"T@?,N,C\00"
 // CHECK: @_PROPERTIES__TtC11objc_bridge21OptionalBlockProperty = private constant {{.*}} [[OBJC_BLOCK_PROPERTY]]
 
 func getDescription(_ o: NSObject) -> String {

--- a/test/IRGen/objc_property_attrs.swift
+++ b/test/IRGen/objc_property_attrs.swift
@@ -50,11 +50,11 @@ class Foo: NSManagedObject {
 
   // -- Bridged value types
 
-  // nonatomic, copy, ivar k
-  // CHECK: private unnamed_addr constant {{.*}} c"T@\22NSString\22,N,C,Vk\00"
+  // nonatomic, copy
+  // CHECK: private unnamed_addr constant {{.*}} c"T@\22NSString\22,N,C\00"
   @objc var k: String = ""
-  // nonatomic, readonly, ivar l
-  // CHECK: private unnamed_addr constant {{.*}} c"T@\22NSString\22,N,R,Vl\00"
+  // nonatomic, readonly
+  // CHECK: private unnamed_addr constant {{.*}} c"T@\22NSString\22,N,R\00"
   @objc let l: String? = nil
 
   // -- Protocol types:


### PR DESCRIPTION
This patch prevents writing ivar field for ObjC property whose type is not trivially representable in ObjC within its DeclContext, as spotted by Jordan Rose when reviewing [SR-9541](https://bugs.swift.org/browse/SR-9541).

For example, in the case of the property `@objc var foo: String`, it is accessed as an `NSString` on the ObjC side. Without this patch, this property is backed with an ivar, to which direct accesses would fail.

Resolves [SR-9557](https://bugs.swift.org/browse/SR-9557).

~~Something I am not confident is how to handle the `StaticBridged` properties (e.g., [this one](https://github.com/dingobye/swift/blob/sr9557/test/IRGen/objc_bridge.swift#L202)). Being conservative, this patch still emits ivar names in this case.~~