### PR TITLE
[5.0][stdlib][Foundation] Avoid coexistence conflicts with JSONEncoder/Decoder and _stdlib_AtomicInt.

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -53,9 +53,9 @@ extension Dictionary : _JSONStringDictionaryDecodableMarker where Key == String,
 /// `JSONEncoder` facilitates the encoding of `Encodable` values into JSON.
 // NOTE: older overlays had Foundation.JSONEncoder as the ObjC name.
 // The two must coexist, so it was renamed. The old name must not be
-// used in the new runtime. _TtC10Foundation12_JSONEncoder is the
-// mangled name for Foundation._JSONEncoder.
-@_objcRuntimeName(_TtC10Foundation12_JSONEncoder)
+// used in the new runtime. _TtC10Foundation13__JSONEncoder is the
+// mangled name for Foundation.__JSONEncoder.
+@_objcRuntimeName(_TtC10Foundation13__JSONEncoder)
 open class JSONEncoder {
     // MARK: Options
 
@@ -1017,9 +1017,9 @@ fileprivate class __JSONReferencingEncoder : __JSONEncoder {
 /// `JSONDecoder` facilitates the decoding of JSON into semantic `Decodable` types.
 // NOTE: older overlays had Foundation.JSONDecoder as the ObjC name.
 // The two must coexist, so it was renamed. The old name must not be
-// used in the new runtime. _TtC10Foundation12_JSONDecoder is the
-// mangled name for Foundation._JSONDecoder.
-@_objcRuntimeName(_TtC10Foundation12_JSONDecoder)
+// used in the new runtime. _TtC10Foundation13__JSONDecoder is the
+// mangled name for Foundation.__JSONDecoder.
+@_objcRuntimeName(_TtC10Foundation13__JSONDecoder)
 open class JSONDecoder {
     // MARK: Options
 
@@ -1190,7 +1190,7 @@ open class JSONDecoder {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: error))
         }
 
-        let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
+        let decoder = __JSONDecoder(referencing: topLevel, options: self.options)
         guard let value = try decoder.unbox(topLevel, as: type) else {
             throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
         }
@@ -1199,9 +1199,12 @@ open class JSONDecoder {
     }
 }
 
-// MARK: - _JSONDecoder
+// MARK: - __JSONDecoder
 
-fileprivate class _JSONDecoder : Decoder {
+// NOTE: older overlays called this class _JSONDecoder. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+fileprivate class __JSONDecoder : Decoder {
     // MARK: Properties
 
     /// The decoder's storage.
@@ -1307,7 +1310,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
-    private let decoder: _JSONDecoder
+    private let decoder: __JSONDecoder
 
     /// A reference to the container we're reading from.
     private let container: [String : Any]
@@ -1318,7 +1321,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    fileprivate init(referencing decoder: _JSONDecoder, wrapping container: [String : Any]) {
+    fileprivate init(referencing decoder: __JSONDecoder, wrapping container: [String : Any]) {
         self.decoder = decoder
         switch decoder.options.keyDecodingStrategy {
         case .useDefaultKeys:
@@ -1637,7 +1640,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
         defer { self.decoder.codingPath.removeLast() }
 
         let value: Any = self.container[key.stringValue] ?? NSNull()
-        return _JSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+        return __JSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
     }
 
     public func superDecoder() throws -> Decoder {
@@ -1653,7 +1656,7 @@ fileprivate struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
-    private let decoder: _JSONDecoder
+    private let decoder: __JSONDecoder
 
     /// A reference to the container we're reading from.
     private let container: [Any]
@@ -1667,7 +1670,7 @@ fileprivate struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    fileprivate init(referencing decoder: _JSONDecoder, wrapping container: [Any]) {
+    fileprivate init(referencing decoder: __JSONDecoder, wrapping container: [Any]) {
         self.decoder = decoder
         self.container = container
         self.codingPath = decoder.codingPath
@@ -2000,11 +2003,11 @@ fileprivate struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
 
         let value = self.container[self.currentIndex]
         self.currentIndex += 1
-        return _JSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+        return __JSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
     }
 }
 
-extension _JSONDecoder : SingleValueDecodingContainer {
+extension __JSONDecoder : SingleValueDecodingContainer {
     // MARK: SingleValueDecodingContainer Methods
 
     private func expectNonNull<T>(_ type: T.Type) throws {
@@ -2095,7 +2098,7 @@ extension _JSONDecoder : SingleValueDecodingContainer {
 
 // MARK: - Concrete Value Representations
 
-extension _JSONDecoder {
+extension __JSONDecoder {
     /// Returns the given value unboxed from a container.
     fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -10,7 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOTE: older runtimes had Swift._stdlib_AtomicInt as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtCs18__stdlib_AtomicInt is the mangled
+// name for Swift.__stdlib_AtomicInt
 @available(swift, deprecated: 4.2, obsoleted: 5.0)
+@_objcRuntimeName(_TtCs18__stdlib_AtomicInt)
 public final class _stdlib_AtomicInt {
   internal var _value: Int
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/21958 to swift-5.0-branch.

JSONEcoder/Decoder get another underscore in their ObjC name, as the one with a single underscore conflicts with older Swifts that had _JSONEcoder/Decoder as internal rather than fileprivate.

_JSONEncoder/Decoder get another underscore in their Swift name to avoid conflicting with the ObjC name from the ones in older overlays.

rdar://problem/47331573