### PR TITLE
Basic: set the correct storage class for the alignment

### DIFF
--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -349,7 +349,10 @@ ImmutablePointerSet<T> ImmutablePointerSetFactory<T>::EmptyPtrSet =
     ImmutablePointerSet<T>(nullptr, {});
 
 template <typename T>
-constexpr unsigned ImmutablePointerSetFactory<T>::AllocAlignment =
+#if !defined(_MSC_VER) || defined(__clang__)
+constexpr
+#endif
+const unsigned ImmutablePointerSetFactory<T>::AllocAlignment =
     (alignof(PtrSet) > alignof(PtrTy)) ? alignof(PtrSet) : alignof(PtrTy);
 
 } // end swift namespace


### PR DESCRIPTION
`cl` objects to the initialization of the templated type differing in storage
class due to the indication of `constexpr`.  `constexpr` does not give the value
itself a `const` storage class.  However, because the value is not initialized
inline, it does not like the `constexpr` attribute.  Apply the `constexpr` only
on clang, and correct the storage to `const`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
