### PR TITLE
[swift-ide-test] Make sure to enable '-fully-qualified-types' mode of printing if it is specified as option

### DIFF
--- a/test/IDE/print_ast_typechecked.swift
+++ b/test/IDE/print_ast_typechecked.swift
@@ -15,3 +15,6 @@ public class C {
 // CHECK1: {{^}}  var InternalVar1: Int, InternalVar2: Int{{$}}
 // CHECK1-NOT: private
 // CHECK1: {{^}}  var (InternalTuple1, InternalTuple2): (Int, Int){{$}}
+
+// RUN: %target-swift-ide-test -fully-qualified-types -print-ast-typechecked -access-filter-internal -source-filename %s | %FileCheck %s -check-prefix=FULLY_QUAL
+// FULLY_QUAL: public var PublicVar: Swift.Int

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3195,6 +3195,7 @@ int main(int argc, char *argv[]) {
     PrintOpts = PrintOptions::printDocInterface();
   } else {
     PrintOpts = PrintOptions::printEverything();
+    PrintOpts.FullyQualifiedTypes = options::FullyQualifiedTypes;
     PrintOpts.FullyQualifiedTypesIfAmbiguous =
       options::FullyQualifiedTypesIfAmbiguous;
     PrintOpts.SynthesizeSugarOnTypes = options::SynthesizeSugarOnTypes;


### PR DESCRIPTION
Previously it was only enabled for the 'print-types' action

rdar://47357583