### PR TITLE
[Sema] Report unused newValue when getter is accessed in custom setter

### DIFF
--- a/test/Sema/diag_self_assign.swift
+++ b/test/Sema/diag_self_assign.swift
@@ -50,7 +50,7 @@ class SA3 {
       return foo // expected-warning {{attempting to access 'foo' within its own getter}} expected-note{{access 'self' explicitly to silence this warning}} {{14-14=self.}}
     }
     set {
-      foo = foo // expected-error {{assigning a property to itself}} expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}}
+      foo = foo // expected-error {{assigning a property to itself}} expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}} expected-warning{{setter argument 'newValue' was never used, but the property was accessed}} expected-note{{did you mean to use 'newValue' instead of accessing the property's current value?}}
       self.foo = self.foo // expected-error {{assigning a property to itself}}
       foo = self.foo // expected-error {{assigning a property to itself}} expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}}
       self.foo = foo // expected-error {{assigning a property to itself}}

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -303,14 +303,6 @@ func sr964() {
       }
     }
   }
-  extension MemberGetterClass {
-    var suspiciousSetterExt: String {
-      get { return "" }
-      set {
-        print(suspiciousSetterExt) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{15-34=newValue}}
-      }
-    }
-  }
   var namedSuspiciousSetter: String {
     get { return "" }
     set(parameter) {
@@ -326,6 +318,15 @@ func sr964() {
     set {
       print(multiTriggerSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{13-31=newValue}}
       print(multiTriggerSetter)
+    }
+  }
+}
+struct MemberGetterExtension {}
+extension MemberGetterExtension {
+  var suspiciousSetter: String {
+    get { return "" }
+    set {
+      print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{13-29=newValue}}
     }
   }
 }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -287,11 +287,27 @@ func sr964() {
       print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{13-29=newValue}}
     }
   }
-  struct MemberGetter {
+  struct MemberGetterStruct {
     var suspiciousSetter: String {
       get { return "" }
       set {
         print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{15-31=newValue}}
+      }
+    }
+  }
+  class MemberGetterClass {
+    var suspiciousSetter: String {
+      get { return "" }
+      set {
+        print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{15-31=newValue}}
+      }
+    }
+  }
+  extension MemberGetterClass {
+    var suspiciousSetterExt: String {
+      get { return "" }
+      set {
+        print(suspiciousSetterExt) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{15-34=newValue}}
       }
     }
   }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -287,6 +287,14 @@ func sr964() {
       print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{13-29=newValue}}
     }
   }
+  struct MemberGetter {
+    var suspiciousSetter: String {
+      get { return "" }
+      set {
+        print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{15-31=newValue}}
+      }
+    }
+  }
   var namedSuspiciousSetter: String {
     get { return "" }
     set(parameter) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a missed scenario in an [earlier fix](https://github.com/apple/swift/pull/11465) for [SR-964](https://bugs.swift.org/browse/SR-964) which warns if a getter is accessed when the `newValue` parameter of a setter is not used. The previous fix, disappointingly misses the case of variables inside of classes or structs and only works on global variables. I experienced a bit of unit-test tunnel vision, and didn't test the scenario I was hoping to fix 😬.
 
Really ™️ Resolves [SR-964](https://bugs.swift.org/browse/SR-964).


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
