### PR TITLE
swift-remote-test: correct the location of the ABI marker

### DIFF
--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -42,8 +42,8 @@ static ASTContext *Context = nullptr;
 
 // FIXME: swiftcall
 /// func printType(forMetadata: Any.Type)
-LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
-extern "C" void printMetadataType(const Metadata *typeMetadata) {
+LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
+printMetadataType(const Metadata *typeMetadata) {
   assert(Context && "context was not set");
 
   std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
@@ -64,8 +64,8 @@ extern "C" void printMetadataType(const Metadata *typeMetadata) {
 
 // FIXME: swiftcall
 /// func printDynamicType(_: AnyObject)
-LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
-extern "C" void printHeapMetadataType(void *object) {
+LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
+printHeapMetadataType(void *object) {
   assert(Context && "context was not set");
 
   std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
@@ -127,8 +127,8 @@ static void printMemberOffset(const Metadata *typeMetadata,
 
 // FIXME: swiftcall
 /// func printTypeMemberOffset(forType: Any.Type, memberName: StaticString)
-LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
-extern "C" void printTypeMemberOffset(const Metadata *typeMetadata,
+LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
+printTypeMemberOffset(const Metadata *typeMetadata,
                                       const char *memberName) {
   printMemberOffset(typeMetadata, memberName, /*pass metadata*/ false);
 }
@@ -136,15 +136,15 @@ extern "C" void printTypeMemberOffset(const Metadata *typeMetadata,
 // FIXME: swiftcall
 /// func printTypeMetadataMemberOffset(forType: Any.Type,
 ///                                    memberName: StaticString)
-LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
-extern "C" void printTypeMetadataMemberOffset(const Metadata *typeMetadata,
-                                              const char *memberName) {
+LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
+printTypeMetadataMemberOffset(const Metadata *typeMetadata,
+                              const char *memberName) {
   printMemberOffset(typeMetadata, memberName, /*pass metadata*/ true);
 }
 
 // FIXME: swiftcall
 /// func printDynamicTypeAndAddressForExistential<T>(_: T)
-LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI extern "C" void
+LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
 printDynamicTypeAndAddressForExistential(void *object,
                                          const Metadata *typeMetadata) {
   assert(Context && "context was not set");


### PR DESCRIPTION
The incorrect location of the ABI marker would result in the symbol not being
exposed when building with `cl` as it expects `__declspec(dllexport)` to be
after the return type.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
