### PR TITLE
Allow differentiation to look across modules for definitions in repl mode

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -68,6 +68,12 @@ template <typename T> static inline void debugDump(T &v) {
                           << v << "\n==== END DEBUG DUMP ====\n");
 }
 
+static bool isInLLDBREPL(SILModule &module) {
+  llvm::StringRef module_name = module.getSwiftModule()->getNameStr();
+  // TODO(SR-9704): Use a more prinicpled way to do this check.
+  return module_name.startswith("__lldb_expr_");
+}
+
 /// Creates arguments in the entry block based on the function type.
 static void createEntryArguments(SILFunction *f) {
   auto *entry = f->getEntryBlock();
@@ -1651,11 +1657,9 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
         context.lookUpMinimalDifferentiationTask(originalFn, desiredIndices);
     if (!task) {
       if (originalFn->isExternalDeclaration()) {
-        llvm::StringRef module_name =
-            original->getModule()->getSwiftModule()->getNameStr();
-        // For lldb repl, we should attempt to load the function
-        // as this may be defined in a different cell.
-        if (module_name.startswith("__lldb_expr_")) {
+        // For lldb repl, we should attempt to load the function as
+        // this may be defined in a different cell.
+        if (isInLLDBREPL(*original->getModule())) {
           original->getModule()->loadFunction(originalFn);
         }
         // If we still don't have the definition, generate an error message.


### PR DESCRIPTION
This is needed to enable cross-cell differentiation support in colab/jupyter notebooks.

This uses name of the module to determine if we are lldb repl mode as a temporary hack. This should be fixed with a more principled to determine whether we are in repl  mode or not. 