### PR TITLE
[WIP] [Sema] Derive conformances to `KeyPathIterable` for classes.

### DIFF
--- a/lib/Sema/DerivedConformanceKeyPathIterable.cpp
+++ b/lib/Sema/DerivedConformanceKeyPathIterable.cpp
@@ -31,9 +31,8 @@
 using namespace swift;
 
 bool DerivedConformance::canDeriveKeyPathIterable(NominalTypeDecl *nominal) {
-  // Note: we could extend synthesis to support classes.
-  // Subclasses need to append `allKeyPaths` to `super.allKeyPaths`.
-  return isa<StructDecl>(nominal);
+  // Synthesis supports structs and classes.
+  return isa<StructDecl>(nominal) || isa<ClassDecl>(nominal);
 }
 
 // Compute `PartialKeyPathType<Nominal>`, bound to the given nominal

--- a/test/Sema/key_path_iterable.swift
+++ b/test/Sema/key_path_iterable.swift
@@ -74,6 +74,15 @@ struct A<T> {
   }
 }
 
+// Test classes.
+class BaseClass : KeyPathIterable {
+  var x: Int
+  var y: Float
+}
+class SubClass : BaseClass {
+  var z: Int
+}
+
 // Test generic optimizer.
 
 // `pow` is defined in Darwin on `Float` and `Double`, but there doesn't exist


### PR DESCRIPTION
The compiler now derives conformances `KeyPathIterable` for class types
based on the class's stored properties. Derivation of `allKeyPaths` works
just like it does for structs.

Conceptually, it makes sense for the implementation of `allKeyPaths` for subclasses
to prepend `super.allKeyPaths` if the superclass conforms to `KeyPathIterable`.

However, we found it impossible to express this in the type system because
`PartialKeyPath<BaseClass>` cannot be cast to `PartialKeyPath<SubClass>`.

Furthermore, subclasses inherit conformances from their superclass, so
`KeyPathIterable` synthesis will not be triggered for subclasses whose
superclass conforms to `KeyPathIterable`. This is a known phenomenon and
we don't attempt to derive conformance for such subclasses (`Codable`
synthesis has the same behavior).