### PR TITLE
[Sema] Fix derived property setter logic.

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -483,6 +483,10 @@ DerivedConformance::declareDerivedPropertySetter(TypeChecker &tc,
   if (isFinal && parentDC->getSelfClassDecl() &&
       !setterDecl->isFinal())
     setterDecl->getAttrs().add(new (C) FinalAttr(/*Implicit*/ true));
+
+  // Compute the interface type of the setter.
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    setterDecl->setGenericEnvironment(env);
   setterDecl->computeType();
   setterDecl->copyFormalAccessFrom(property);
   setterDecl->setValidationToChecked();

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -163,6 +163,11 @@ func testKeyPathIterable(x: TestKeyPathIterable) {
   _ = x.allDifferentiableVariables.allKeyPaths
 }
 
+// Test type with generic environment.
+struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differentiable {
+  var x: Float
+}
+
 /*
 // Test type with generic members that conform to `Differentiable`.
 // Since it's not the case that


### PR DESCRIPTION
Derived property setters should inherit their parent's generic environment.
This logic already existed in `declareDerivedPropertyGetter` but wasn't copied
to `declareDerivedPropertySetter` for some reason.

Add test using a derived `Differentiable.allDifferentiableVariables` setter in
a generic nominal type.