### PR TITLE
[AutoDiff] Support differentiating global constant closures.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -373,6 +373,10 @@ NOTE(autodiff_function_generic_functions_unsupported,none,
 NOTE(autodiff_external_nondifferentiable_function,none,
      "cannot differentiate an external function that has not been marked "
      "'@differentiable'", ())
+NOTE(autodiff_global_let_closure_not_differentiable,none,
+     "global constant closure is not differentiable", ())
+NOTE(autodiff_cannot_differentiate_global_var_closures,none,
+     "cannot differentiate global mutable closures", ())
 NOTE(autodiff_protocol_member_not_differentiable,none,
      "member is not differentiable because the corresponding protocol "
      "requirement is not '@differentiable'", ())

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -73,4 +73,11 @@ SimpleMathTests.test("CaptureGlobal") {
   expectEqual(30, gradient(at: 0, in: foo))
 }
 
+let foo: (Float) -> Float = { x in
+  return x * x
+}
+SimpleMathTests.test("GlobalLetFunction") {
+  expectEqual(2, gradient(at: 1, in: foo))
+}
+
 runAllTests()

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -76,8 +76,20 @@ SimpleMathTests.test("CaptureGlobal") {
 let foo: (Float) -> Float = { x in
   return x * x
 }
-SimpleMathTests.test("GlobalLetFunction") {
+SimpleMathTests.test("GlobalLet") {
   expectEqual(2, gradient(at: 1, in: foo))
+}
+
+var foo_diffable: @autodiff (Float) -> (Float) 
+  = differentiableFunction { x in (x * x, { v in 2 * x * v }) }
+SimpleMathTests.test("GlobalDiffableFunc") {
+  expectEqual(2, gradient(at: 1, in: foo_diffable))
+  expectEqual(2, gradient(at: 1, in: { x in foo_diffable(x) }))
+  expectEqual(1, gradient(at: 1, in: { (x: Float) -> Float in
+    foo_diffable = { x in x + 1 }; 
+    return foo_diffable(x)
+  }))
+  expectEqual(1, gradient(at: 1, in: foo_diffable))
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -143,4 +143,9 @@ TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {
   expectEqual(Tensor(1.0), pb(Tensor(1)))
 }
 
+let cube: (Tensor<Float>) -> Tensor<Float> = { $0 * $0 * $0 }
+TensorADTests.testAllBackends("DifferentiateGlobal") {
+  expectEqual(Tensor(48), gradient(at: Tensor(4), in: cube))
+}
+
 runAllTests()


### PR DESCRIPTION
* When there is a reference to a global `let` closure, we find its initializer in `@main`, trace back to the original `function_ref`, and differentiate that.

* NFC: Refactor `findReferenceToVisibleFunction` and `findWitnessMethod` to a single template.

Resolves [SR-9695](https://bugs.swift.org/browse/SR-9695).