### PR TITLE
[Typechecker] Allow @objc functions to return dynamic self

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -523,6 +523,7 @@ bool swift::isRepresentableInObjC(
     if (!ResultType->hasError() &&
         !ResultType->isVoid() &&
         !ResultType->isUninhabited() &&
+        !ResultType->hasDynamicSelfType() &&
         !ResultType->isRepresentableIn(ForeignLanguage::ObjectiveC,
                                        const_cast<FuncDecl *>(FD))) {
       if (Diagnose) {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -273,8 +273,7 @@ func classAnyObject(_ obj: NSObject) {
 class Wobbler : NSWobbling {
   @objc func wobble() { }
 
-  func returnMyself() -> Self { return self } // expected-error{{non-'@objc' method 'returnMyself()' does not satisfy requirement of '@objc' protocol 'NSWobbling'}}{{none}}
-  // expected-error@-1{{method cannot be an implementation of an @objc requirement because its result type cannot be represented in Objective-C}}
+  func returnMyself() -> Self { return self }
 }
 
 extension Wobbler : NSMaybeInitWobble { // expected-error{{type 'Wobbler' does not conform to protocol 'NSMaybeInitWobble'}}

--- a/test/PrintAsObjC/dynamicself.swift
+++ b/test/PrintAsObjC/dynamicself.swift
@@ -1,30 +1,37 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name dynamicself -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/dynamicself.swiftmodule -typecheck -emit-objc-header-path %t/dynamicself.h -disable-objc-attr-requires-foundation-module
-// RUN: %FileCheck %s < %t/dynamicself.h
-// RUN: %check-in-clang %t/dynamicself.h
-
 // REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
+// FIXME: END -enable-source-import hackaround
+
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/dynamicself.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/dynamicself.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/dynamicself.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/dynamicself.h
 
 import Foundation
 
 // CHECK-LABEL: @protocol FooProtocol
-// CHECK-NEXT:    - (nonnull instancetype)fooFunc SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT:    - (nullable instancetype)optionalFooFunc SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT:  @end
-
 @objc protocol FooProtocol {
+  // CHECK: - (nonnull instancetype)fooFunc SWIFT_WARN_UNUSED_RESULT;
   func fooFunc() -> Self
+  // CHECK: - (nullable instancetype)optionalFooFunc SWIFT_WARN_UNUSED_RESULT;
   func optionalFooFunc() -> Self?
 }
+// CHECK: @end
 
 // CHECK-LABEL: @interface BarClass : NSObject <FooProtocol>
-// CHECK-NEXT:    - (nonnull instancetype)fooFunc SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT:    - (nullable instancetype)optionalFooFunc SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT:    - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT:  @end
-
 @objc @objcMembers class BarClass: NSObject, FooProtocol {
+  // CHECK: - (nonnull instancetype)fooFunc SWIFT_WARN_UNUSED_RESULT;
   func fooFunc() -> Self { return self }
+  // CHECK: - (nullable instancetype)optionalFooFunc SWIFT_WARN_UNUSED_RESULT;
   func optionalFooFunc() -> Self? { return self }
+  // CHECK: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 }
+// CHECK: @end

--- a/test/PrintAsObjC/dynamicself.swift
+++ b/test/PrintAsObjC/dynamicself.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name dynamicself -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/dynamicself.swiftmodule -typecheck -emit-objc-header-path %t/dynamicself.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/dynamicself.h
+// RUN: %check-in-clang %t/dynamicself.h
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// CHECK-LABEL: @protocol FooProtocol
+// CHECK-NEXT:    - (nonnull instancetype)fooFunc SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT:    - (nullable instancetype)optionalFooFunc SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT:  @end
+
+@objc protocol FooProtocol {
+  func fooFunc() -> Self
+  func optionalFooFunc() -> Self?
+}
+
+// CHECK-LABEL: @interface BarClass : NSObject <FooProtocol>
+// CHECK-NEXT:    - (nonnull instancetype)fooFunc SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT:    - (nullable instancetype)optionalFooFunc SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT:    - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT:  @end
+
+@objc @objcMembers class BarClass: NSObject, FooProtocol {
+  func fooFunc() -> Self { return self }
+  func optionalFooFunc() -> Self? { return self }
+}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -323,7 +323,6 @@ class ConcreteContext3 {
   func dynamicSelf1() -> Self { return self }
 
   @objc func dynamicSelf1_() -> Self { return self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   @objc func genericParams<T: NSObject>() -> [T] { return [] }
   // expected-error@-1{{method cannot be marked @objc because it has generic parameters}}


### PR DESCRIPTION
This PR lifts a restriction on @objc functions which disallowed dynamic self as return type.

```swift
@objc protocol Foo {
    static func makeFoo() -> Self // ok
}
```
Resolves [SR-7601](https://bugs.swift.org/browse/SR-7601).
