### PR TITLE
[SR-9630][SourceKit] Add request to get compiler version

### DIFF
--- a/test/SourceKit/Misc/compiler_version.swift
+++ b/test/SourceKit/Misc/compiler_version.swift
@@ -1,0 +1,5 @@
+// RUN: %sourcekitd-test -req=compiler-version | %FileCheck %s
+
+// CHECK: key.version_major: 5
+// CHECK: key.version_minor: 0
+// CHECK: key.version_patch: 0

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -28,6 +28,7 @@ The protocol is documented in the following format:
 | [Module interface generation](#module-interface-generation) | source.request.editor.open.interface |
 | [Indexing](#indexing) | source.request.indexsource  |
 | [Protocol Version](#protocol-version) | source.request.protocol_version |
+| [Compiler Version](#compiler-version) | source.request.compiler_version |
 
 
 # Requests
@@ -614,6 +615,45 @@ Welcome to SourceKit.  Type ':help' for assistance.
     key.request: source.request.protocol_version
 }
 ```
+
+## Compiler Version
+
+SourceKit can provide information about the version of the compiler version that is being used.
+
+### Request
+
+```
+{
+    <key.request>: (UID) <source.request.compiler_version>
+}
+```
+
+### Response
+
+```
+{
+    <key.version_major>: (int64) // The major version number in a version string
+    <key.version_minor>: (int64) // The minor version number in a version string
+    <key.version_patch>: (int64) // The patch version number in a version string
+}
+```
+
+### Testing
+
+```
+$ sourcekitd-test -req=compiler-version
+```
+
+or
+
+```
+$ sourcekitd-repl
+Welcome to SourceKit.  Type ':help' for assistance.
+(SourceKit) {
+    key.request: source.request.compiler_version
+}
+```
+
 
 ## Cursor Info
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -105,6 +105,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
     case OPT_req:
       Request = llvm::StringSwitch<SourceKitRequest>(InputArg->getValue())
         .Case("version", SourceKitRequest::ProtocolVersion)
+        .Case("compiler-version", SourceKitRequest::CompilerVersion)
         .Case("demangle", SourceKitRequest::DemangleNames)
         .Case("mangle", SourceKitRequest::MangleSimpleClasses)
         .Case("index", SourceKitRequest::Index)

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -22,6 +22,7 @@ namespace sourcekitd_test {
 enum class SourceKitRequest {
   None,
   ProtocolVersion,
+  CompilerVersion,
   DemangleNames,
   MangleSimpleClasses,
   Index,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -453,6 +453,10 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::ProtocolVersion:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestProtocolVersion);
     break;
+  
+  case SourceKitRequest::CompilerVersion:
+    sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestCompilerVersion);
+    break;
 
   case SourceKitRequest::DemangleNames:
     prepareDemangleRequest(Req, Opts);
@@ -999,6 +1003,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
       break;
 
     case SourceKitRequest::ProtocolVersion:
+    case SourceKitRequest::CompilerVersion:
     case SourceKitRequest::Close:
     case SourceKitRequest::Index:
     case SourceKitRequest::CodeComplete:

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -28,6 +28,7 @@
 
 #include "swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h"
 #include "swift/Basic/Mangler.h"
+#include "swift/Basic/Version.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
@@ -362,6 +363,19 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     auto dict = RB.getDictionary();
     dict.set(KeyVersionMajor, ProtocolMajorVersion);
     dict.set(KeyVersionMinor, static_cast<int64_t>(ProtocolMinorVersion));
+    return Rec(RB.createResponse());
+  }
+
+  if (ReqUID == RequestCompilerVersion) {
+    ResponseBuilder RB;
+    auto dict = RB.getDictionary();
+    auto thisVersion = swift::version::Version::getCurrentLanguageVersion();
+    dict.set(KeyVersionMajor, static_cast<int64_t>(thisVersion[0]));
+    dict.set(KeyVersionMinor, static_cast<int64_t>(thisVersion[1]));
+    if (thisVersion.size() > 2)
+      dict.set(KeyVersionPatch, static_cast<int64_t>(thisVersion[2]));
+    else
+      dict.set(KeyVersionPatch, static_cast<int64_t>(0));
     return Rec(RB.createResponse());
   }
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -19,6 +19,7 @@ class KIND(object):
 UID_KEYS = [
     KEY('VersionMajor', 'key.version_major'),
     KEY('VersionMinor', 'key.version_minor'),
+    KEY('VersionPatch', 'key.version_patch'),
     KEY('Results', 'key.results'),
     KEY('Request', 'key.request'),
     KEY('Notification', 'key.notification'),
@@ -165,6 +166,7 @@ UID_KEYS = [
 
 UID_REQUESTS = [
     REQUEST('ProtocolVersion', 'source.request.protocol_version'),
+    REQUEST('CompilerVersion', 'source.request.compiler_version'),
     REQUEST('CrashWithExit', 'source.request.crash_exit'),
     REQUEST('Demangle', 'source.request.demangle'),
     REQUEST('MangleSimpleClass', 'source.request.mangle_simple_class'),


### PR DESCRIPTION
Currently, [SwiftLint](https://github.com/realm/SwiftLint) tries to detect the compiler version by getting the structure from `editor.open` with a lot of `#if swift(>= X)`.

This was enough for our purposes, but since Swift 5.0, SourceKit returns structures inside conditional compilation blocks which never been compiled ([more details](https://github.com/realm/SwiftLint/issues/2542)).

I think this behavior change was caused by this PR: https://github.com/apple/swift/pull/20982.

One solution to this problem is to stop relying on the structure behavior and use a specific request. 

There's already a protocol request, but it has always returned 1.0.

This PR adds a new request to SourceKit to provide that information.

Using the version from `swiftc` would be a possibility, but for our purposes, it'd be better to not rely on parsing an user-facing value that can change (in theory, at least).

Resolves [SR-9630](https://bugs.swift.org/browse/SR-9630).

cc @nkcsgexi 
