### PR TITLE
[pmo] When exploding a copy_addr that assigns into memory, treat the …

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -930,6 +930,12 @@ void AvailableValueDataflowContext::explodeCopyAddr(CopyAddrInst *CAI) {
       // something else), track it as an access.
       if (StoreUse.isValid()) {
         StoreUse.Inst = NewInst;
+        // If our store use by the copy_addr is an assign, then we know that
+        // before we store the new value, we loaded the old value implying that
+        // our store is technically initializing memory when it occurs. So
+        // change the kind to Initialization.
+        if (StoreUse.Kind == Assign)
+          StoreUse.Kind = Initialization;
         NonLoadUses[NewInst] = Uses.size();
         Uses.push_back(StoreUse);
       }


### PR DESCRIPTION
…resulting store as an init, not an assign.

This models the semantics we are trying to have here more closely without
changing current output. Specifically, an assign in this case is supposed to
mean that the underlying value is overwritten and destroyed (via a ref count
decrement). This is obviously true with the non-init copy_addr form, i.e.:

  %0 = alloc_stack $Builtin.NativeObject
  %1 = alloc_stack $Builtin.NativeObject
  ...
  copy_addr [take] %0 to %1 : $*Builtin.NativeObject
  ...

Notice how the instruction is actively going to destroy whatever is in %1. Lets
consider the same SIL after exploding the copy_addr.

  %0 = alloc_stack $Builtin.NativeObject
  %1 = alloc_stack $Builtin.NativeObject
  ...
  %2 = load %0 : $*Builtin.NativeObject
  %3 = load %1 : $*Builtin.NativeObject      (1)
  store %2 to %1 : $*Builtin.NativeObject
  destroy_value %3 : $Builtin.NativeObject   (2)
  ...

In this case, the store is actually acting like an initialization since the
destructive part of the assign is performed by (1), (2). So considering the
store to be an assign is incorrect since a store that is an assign /should/
destroy the underlying value itself.

In terms of the actual effect on the result of the pass today, Initialization
and Assign stores are treated the same when it comes to getting available values
from stores and (for stores) destroying allocations. So this should be an NFC
change, but gets us closer to the model where assigns are only used for things
that store into memory and destroy the underlying model directly.