### PR TITLE
[Typechecker] allow @autoclosure closure to be a typealias

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2005,13 +2005,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       if (auto type = resolveTopLevelIdentTypeComponent(resolution, CITR,
                                                         typeAliasResolver)) {
         if (auto TAT = dyn_cast<TypeAliasType>(type.getPointer())) {
-          if (auto underlyingRepr = TAT->getDecl()
-                                       ->getUnderlyingTypeLoc()
-                                        .getTypeRepr()) {
-            if (!underlyingRepr->isInvalid()) {
-              repr = underlyingRepr;
-            }
-          }
+          repr = TAT->getDecl()->getUnderlyingTypeLoc().getTypeRepr();
         }
       }
     }

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -234,3 +234,14 @@ func rdar_30906031(in arr: [Int], fn: @autoclosure () -> Int) -> Bool {
     arr.lazy.filter { $0 >= escapableF() }.isEmpty
   }
 }
+
+// SR-2688
+class Foo {
+  typealias FooClosure = () -> String
+  func fooFunction(closure: @autoclosure FooClosure) {} // ok
+}
+
+class Bar {
+  typealias BarClosure = (String) -> String
+  func barFunction(closure: @autoclosure BarClosure) {} // expected-error {{argument type of @autoclosure parameter must be '()'}}
+}


### PR DESCRIPTION
This PR adds the ability for the @autoclosure closure to be a type alias.

Example:

```swift
class Foo {
  typealias FooClosure = () -> String
  func fooFunction(closure: @autoclosure FooClosure) {} // ok
}
```
Resolves [SR-2688](https://bugs.swift.org/browse/SR-2688).