### PR TITLE
[SR-9576][SourceKit] Fix syntax type when rethrows is present

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1041,6 +1041,8 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
     TokenNodes = TokenNodes.slice(I);
     return true;
   }
+  if (isa<RethrowsAttr>(D))
+    return true;
   return false;
 }
 

--- a/test/IDE/coloring_comments.swift
+++ b/test/IDE/coloring_comments.swift
@@ -194,7 +194,7 @@ func emptyDocBlockComment3() {}
 func malformedBlockComment(f : () throws -> ()) rethrows {}
 // CHECK: <doc-comment-block>/**/</doc-comment-block>
 
-// CHECK: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <attr-builtin>rethrows</attr-builtin> {}
+// CHECK: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <kw>rethrows</kw> {}
 
 //: playground doc comment line
 func playgroundCommentLine(f : () throws -> ()) rethrows {}

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -127,3 +127,5 @@ enum MyEnum {
 enum MySecondEnum {
   case One = 1
 }
+
+func someFunc(input :Int?, completion: () throws -> Void) rethrows {}

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2065,
+  key.length: 2136,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1286,6 +1286,44 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "someFunc(input:completion:)",
+      key.offset: 2066,
+      key.length: 69,
+      key.nameoffset: 2071,
+      key.namelength: 52,
+      key.bodyoffset: 2134,
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 2124,
+          key.length: 8,
+          key.attribute: source.decl.attribute.rethrows
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "input",
+          key.offset: 2080,
+          key.length: 11,
+          key.typename: "Int?",
+          key.nameoffset: 2080,
+          key.namelength: 5
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "completion",
+          key.offset: 2093,
+          key.length: 29,
+          key.typename: "() throws -> Void",
+          key.nameoffset: 2093,
+          key.namelength: 10
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2065,
+  key.length: 2136,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1286,6 +1286,44 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "someFunc(input:completion:)",
+      key.offset: 2066,
+      key.length: 69,
+      key.nameoffset: 2071,
+      key.namelength: 52,
+      key.bodyoffset: 2134,
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 2124,
+          key.length: 8,
+          key.attribute: source.decl.attribute.rethrows
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "input",
+          key.offset: 2080,
+          key.length: 11,
+          key.typename: "Int?",
+          key.nameoffset: 2080,
+          key.namelength: 5
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "completion",
+          key.offset: 2093,
+          key.length: 29,
+          key.typename: "() throws -> Void",
+          key.nameoffset: 2093,
+          key.namelength: 10
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2065,
+  key.length: 2136,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1286,6 +1286,44 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "someFunc(input:completion:)",
+      key.offset: 2066,
+      key.length: 69,
+      key.nameoffset: 2071,
+      key.namelength: 52,
+      key.bodyoffset: 2134,
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 2124,
+          key.length: 8,
+          key.attribute: source.decl.attribute.rethrows
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "input",
+          key.offset: 2080,
+          key.length: 11,
+          key.typename: "Int?",
+          key.nameoffset: 2080,
+          key.namelength: 5
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "completion",
+          key.offset: 2093,
+          key.length: 29,
+          key.typename: "() throws -> Void",
+          key.nameoffset: 2093,
+          key.namelength: 10
         }
       ]
     }

--- a/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
+++ b/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
@@ -54,3 +54,6 @@ func testArgumentLabels(in class: Int, _ case: (_ default: Int) -> Void) -> (in:
   let result: (in: Int, String) = (0, "test")
   return something ? result : (in: 2, "foo")
 }
+
+// https://bugs.swift.org/browse/SR-9576
+func someFunc(input :Int?, completion: () throws -> Void) rethrows {}

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 1049,
+  key.length: 1161,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -567,6 +567,61 @@
       key.kind: source.lang.swift.syntaxtype.string,
       key.offset: 1040,
       key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 1050,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment.url,
+      key.offset: 1053,
+      key.length: 37
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 1090,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1091,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1096,
+      key.length: 8
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1105,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 1112,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1118,
+      key.length: 10
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1133,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 1143,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1149,
+      key.length: 8
     }
   ]
 }


### PR DESCRIPTION
Before this patch, SourceKit would return `source.lang.swift.syntaxtype.identifier` for types in a function if `rethrows` is present - it should return `typeidentifier`. 

Another issue is that it'd return `source.lang.swift.syntaxtype.attribute.builtin` for `rethrows` - I think it should be `keyword`.

Resolves [SR-9576](https://bugs.swift.org/browse/SR-9576).

cc @nkcsgexi 
