### PR TITLE
[Sema] [AutoDiff] Infer `@noDerivative` in `Differentiable` derived conformances and emit warning.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2423,6 +2423,9 @@ ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
+WARNING(differentiable_implicit_noderivative_fixit,none,
+      "stored property has no derivative because it does not conform to "
+      "'Differentiable'; add '@noDerivative' to make it explicit", ())
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))
@@ -2739,12 +2742,12 @@ ERROR(tfparameter_attr_not_in_parameterized,none,
 
 // @noDerivative attribute
 ERROR(noderivative_only_on_stored_properties_in_differentiable_structs,none,
-      "@noDerivative is only allowed on stored properties in structure types "
+      "'@noDerivative' is only allowed on stored properties in structure types "
       "that declare a conformance to 'Differentiable'", ())
 
 // @_fieldwiseDifferentiable attribute
 ERROR(fieldwise_differentiable_only_on_differentiable_structs,none,
-      "@_fieldwiseDifferentiable is only allowed on structure types that "
+      "'@_fieldwiseDifferentiable' is only allowed on structure types that "
       "conform to 'Differentiable'", ())
 
 //------------------------------------------------------------------------------

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -58,16 +58,10 @@ getStoredPropertiesForDifferentiation(NominalTypeDecl *nominal,
       continue;
     if (!vd->hasInterfaceType())
       C.getLazyResolver()->resolveDeclSignature(vd);
-    // If a stored property's type does not conform to `Differentiable`, make
-    // the property implicitly `@noDerivative` and emit a warning later when we
-    // are deriving all associated types.
     if (!vd->hasInterfaceType() ||
-        !TypeChecker::conformsToProtocol(vd->getType(),
-                                         diffableProto, nominal,
-                                         ConformanceCheckFlags::Used)) {
-      vd->getAttrs().add(new (C) NoDerivativeAttr(/*implicit*/ true));
+        !TypeChecker::conformsToProtocol(vd->getType(), diffableProto, nominal,
+                                         ConformanceCheckFlags::Used))
       continue;
-    }
     result.push_back(vd);
   }
 }
@@ -240,6 +234,11 @@ static void deriveBodyDifferentiable_method(AbstractFunctionDecl *funcDecl,
     return;
   }
 
+  // Hash properties for differentiation into a set for fast lookup.
+  SmallVector<VarDecl *, 8> diffProps;
+  getStoredPropertiesForDifferentiation(nominal, diffProps);
+  SmallPtrSet<VarDecl *, 8> diffPropsSet(diffProps.begin(), diffProps.end());
+
   // Create call expression applying a member method to a parameter member.
   // Format: `<member>.method(<parameter>.<member>)`.
   // Example: `x.moved(along: direction.x)`.
@@ -253,12 +252,10 @@ static void deriveBodyDifferentiable_method(AbstractFunctionDecl *funcDecl,
       }
     }
     assert(selfMember && "Could not find corresponding self member");
-    // If member has `@noDerivative`, create direct reference to member.
-    if (retNominalMember->getAttrs().hasAttribute<NoDerivativeAttr>()) {
-      return new (C)
-          MemberRefExpr(selfDRE, SourceLoc(), selfMember, DeclNameLoc(),
-                        /*Implicit*/ true);
-    }
+    // If member is not for differentiation, create direct reference to member.
+    if (!diffPropsSet.count(selfMember))
+      return new (C) MemberRefExpr(selfDRE, SourceLoc(), selfMember,
+                                   DeclNameLoc(), /*Implicit*/ true);
     // Otherwise, construct member method call.
     auto module = nominal->getModuleContext();
     auto confRef = module->lookupConformance(selfMember->getType(), diffProto);
@@ -309,7 +306,7 @@ static void deriveBodyDifferentiable_method(AbstractFunctionDecl *funcDecl,
   // Create array of member method call expressions.
   llvm::SmallVector<Expr *, 2> memberMethodCallExprs;
   llvm::SmallVector<Identifier, 2> memberNames;
-  for (auto member : retNominal->getStoredProperties()) {
+  for (auto *member : retNominal->getStoredProperties()) {
     // Initialized `let` properties don't get an argument in memberwise
     // initializers.
     if (member->isLet() && member->getParentInitializer())
@@ -784,12 +781,19 @@ static void addAssociatedTypeAliasDecl(Identifier name,
 // a fixit so that the user will make it explicit.
 static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
                                                  NominalTypeDecl *nominal) {
-  for (auto *vd : nominal->getStoredProperties())
-    if (auto *attr = vd->getAttrs().getAttribute<NoDerivativeAttr>())
-      if (attr->isImplicit())
-        TC.diagnose(vd, diag::differentiable_implicit_noderivative_fixit)
-            .fixItInsert(vd->getAttributeInsertionLoc(/*forModifier*/ false),
-                         "@noDerivative ");
+  auto *diffableProto =
+      TC.Context.getProtocol(KnownProtocolKind::Differentiable);
+  for (auto *vd : nominal->getStoredProperties()) {
+    if (vd->getAttrs().hasAttribute<NoDerivativeAttr>() ||
+        TC.conformsToProtocol(vd->getType(), diffableProto, nominal,
+                              ConformanceCheckFlags::Used))
+      continue;
+    nominal->getAttrs().add(
+        new (TC.Context) NoDerivativeAttr(/*Implicit*/ true));
+    TC.diagnose(vd, diag::differentiable_implicit_noderivative_fixit)
+        .fixItInsert(vd->getAttributeInsertionLoc(/*forModifier*/ false),
+                     "@noDerivative ");
+  }
 }
 
 // Get or synthesize all associated struct types: 'TangentVector',

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -784,14 +784,12 @@ static void addAssociatedTypeAliasDecl(Identifier name,
 // a fixit so that the user will make it explicit.
 static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
                                                  NominalTypeDecl *nominal) {
-  for (auto *vd : nominal->getStoredProperties()) {
-    if (auto *attr = vd->getAttrs().getAttribute<NoDerivativeAttr>()) {
-      if (attr->isImplicit()) {
+  for (auto *vd : nominal->getStoredProperties())
+    if (auto *attr = vd->getAttrs().getAttribute<NoDerivativeAttr>())
+      if (attr->isImplicit())
         TC.diagnose(vd, diag::differentiable_implicit_noderivative_fixit)
-            .fixItInsert(vd->getStartLoc(), "@noDerivative ");
-      }
-    }
-  }
+            .fixItInsert(vd->getAttributeInsertionLoc(/*forModifier*/ false),
+                         "@noDerivative ");
 }
 
 // Get or synthesize all associated struct types: 'TangentVector',

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2769,7 +2769,7 @@ void AttributeChecker::visitFieldwiseDifferentiableAttr(
 
 void AttributeChecker::visitNoDerivativeAttr(NoDerivativeAttr *attr) {
   auto *vd = dyn_cast<VarDecl>(D);
-  if (!vd) {
+  if (!vd || vd->isStatic()) {
     diagnoseAndRemoveAttr(attr,
         diag::noderivative_only_on_stored_properties_in_differentiable_structs);
     return;

--- a/test/AutoDiff/noderivative-attr.swift
+++ b/test/AutoDiff/noderivative-attr.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
-// expected-error @+1 {{@noDerivative is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
+// expected-error @+1 {{'@noDerivative' is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
 @noDerivative var flag: Bool
 
 struct Foo {
-  // expected-error @+1 {{@noDerivative is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
+  // expected-error @+1 {{'@noDerivative' is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
   @noDerivative var flag: Bool
 }
 

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -243,5 +243,5 @@ struct ImplicitNoDerivative : Differentiable {
 
 struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
   var x: DifferentiableSubset
-  var b: Bool // expected-warning {{stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
+  var b: Bool // expected-warning {{stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -226,3 +226,22 @@ struct VectorSpaceCustomStruct : AdditiveArithmetic, Differentiable { // expecte
     typealias CotangentVector = VectorSpaceCustomStruct.CotangentVector
   }
 }
+
+struct StaticNoDerivative : Differentiable {
+  @noDerivative static var s: Bool = true // expected-error {{'@noDerivative' is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
+}
+
+struct StaticMembersShouldNotAffectAnything : AdditiveArithmetic, Differentiable {
+  static var x: Bool = true
+  static var y: Bool = false
+}
+
+struct ImplicitNoDerivative : Differentiable {
+  var a: Float
+  var b: Bool // expected-warning {{stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
+}
+
+struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
+  var x: DifferentiableSubset
+  var b: Bool // expected-warning {{stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
+}


### PR DESCRIPTION
* In `Differentiable` derived conformances, if a stored property is neither marked `@noDerivative` or conforming to `Differentiable`, the compiler would confusingly refuse to derive anything and fall back to the default "does not conform to protocol" errors. To better this user experience without losing predictability, we make the compiler imply `@noDerivative` (not having a corresponding field in `AllDifferentiableVariables`, `TangentVector` or `CotangentVector`) and emit a warning and a fixit so that the user will add a `@noDerivative` attribute.

    ```console
      var b: Bool
          ^
  @noDerivative
    testsynthesis.swift:3:7: warning: stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit
    ```

* Add diagnostics for `@noDerivative` on stored type properties.

* Add tests with stored type properties and verify that their existence will not affect `Differentiable` derived conformances.