### PR TITLE
[5.0][Sema] Fix `resolveDependentMemberType` to properly handle nested typ…

### DIFF
--- a/validation-test/Sema/Inputs/rdar47334176_types.swift
+++ b/validation-test/Sema/Inputs/rdar47334176_types.swift
@@ -1,0 +1,10 @@
+public protocol P : class {
+  associatedtype V
+}
+
+public protocol R {
+  associatedtype V
+}
+
+public enum E<V> : R {}
+public class C<V> : R {}

--- a/validation-test/Sema/rdar47334176.swift
+++ b/validation-test/Sema/rdar47334176.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/rdar47334176_types.swiftmodule %S/Inputs/rdar47334176_types.swift
+// RUN: %target-swift-frontend -I %t -typecheck %s
+
+import rdar47334176_types
+
+// To test all possibilities let's declare one of the types
+// in the same module as function declaration which uses it.
+struct S<V> : R {}
+
+func foo<T : P, U>(_: T?, _: (T.V.V) -> Void) where T.V == E<U> {} // Ok
+func bar<T : P, U>(_: T?, _: (T.V.V) -> Void) where T.V == S<U> {} // Ok
+func baz<T : P, U>(_: T?, _: (T.V.V) -> Void) where T.V == C<U> {} // Ok


### PR DESCRIPTION
…es found in enum/struct/class

Currently if member has been found through same-type constraint
it would only be properly handled when it comes from a class type,
because that's the only time when base type gets replaced with
"concrete" type from equivalence class, but nested types could also
come from structs, enums and sometimes protocols (e.g. typealias)
which `resolveDependentMemberType` has to handle.

Resolves: rdar://problem/47334176
(cherry picked from commit 33cff97ab2d1334d70f6102804aa5b246bf8e3d8)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
