### PR TITLE
Cherry-Picking of Improve the behavior of the custom @objc name in the available attribute when generates ObjC headers to Swift 5.0

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -137,7 +137,7 @@ namespace {
 using DelayedMemberSet = llvm::SmallSetVector<const ValueDecl *, 32>;
 
 class ObjCPrinter : private DeclVisitor<ObjCPrinter>,
-                    private TypeVisitor<ObjCPrinter, void, 
+                    private TypeVisitor<ObjCPrinter, void,
                                         Optional<OptionalTypeKind>>
 {
   friend ASTVisitor;
@@ -528,7 +528,7 @@ private:
     return sel.getNumArgs() == 0 &&
            sel.getSelectorPieces().front().str() == "init";
   }
-                                          
+  
   void printAbstractFunctionAsMethod(AbstractFunctionDecl *AFD,
                                      bool isClassMethod,
                                      bool isNSUIntegerSubscript = false) {
@@ -553,7 +553,7 @@ private:
     auto resultTy = getForeignResultType(AFD, methodTy, errorConvention);
 
     // Constructors and methods returning DynamicSelf return
-    // instancetype.    
+    // instancetype.
     if (isa<ConstructorDecl>(AFD) ||
         (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->hasDynamicSelf())) {
       if (errorConvention && errorConvention->stripsResultOptionality()) {
@@ -776,9 +776,8 @@ private:
   };
 
   /// Returns \c true if anything was printed.
-  bool printAvailability(
-      const Decl *D,
-      PrintLeadingSpace printLeadingSpace = PrintLeadingSpace::Yes) {
+  bool printAvailability(const Decl *D, PrintLeadingSpace printLeadingSpace =
+                                            PrintLeadingSpace::Yes) {
     bool hasPrintedAnything = false;
     auto maybePrintLeadingSpace = [&] {
       if (printLeadingSpace == PrintLeadingSpace::Yes || hasPrintedAnything)
@@ -788,7 +787,8 @@ private:
 
     for (auto AvAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
       if (AvAttr->Platform == PlatformKind::none) {
-        if (AvAttr->PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
+        if (AvAttr->PlatformAgnostic ==
+            PlatformAgnosticAvailabilityKind::Unavailable) {
           // Availability for *
           if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
             // rename
@@ -833,11 +833,10 @@ private:
       }
 
       // Availability for a specific platform
-      if (!AvAttr->Introduced.hasValue()
-          && !AvAttr->Deprecated.hasValue()
-          && !AvAttr->Obsoleted.hasValue()
-          && !AvAttr->isUnconditionallyDeprecated()
-          && !AvAttr->isUnconditionallyUnavailable()) {
+      if (!AvAttr->Introduced.hasValue() && !AvAttr->Deprecated.hasValue() &&
+          !AvAttr->Obsoleted.hasValue() &&
+          !AvAttr->isUnconditionallyDeprecated() &&
+          !AvAttr->isUnconditionallyUnavailable()) {
         continue;
       }
 
@@ -912,43 +911,75 @@ private:
     }
     return hasPrintedAnything;
   }
-    
-  void printRenameForDecl(const AvailableAttr *AvAttr, const ValueDecl *D,
-                          bool includeQuotes) {
-    assert(!AvAttr->Rename.empty());
-    
-    auto renamedParsedDeclName = parseDeclName(AvAttr->Rename);
-    auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());
-    
+
+  const ValueDecl *getRenameDecl(const ValueDecl *D,
+                                 const ParsedDeclName renamedParsedDeclName) {
     auto declContext = D->getDeclContext();
-    const ValueDecl *renamedDecl = nullptr;
-    
+    ASTContext &astContext = D->getASTContext();
+    auto renamedDeclName = renamedParsedDeclName.formDeclName(astContext);
+
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
+      if (!renamedParsedDeclName.ContextName.empty()) {
+        return nullptr;
+      }
       UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),
-                               declContext->getModuleScopeContext(),
-                               nullptr,
+                               declContext->getModuleScopeContext(), nullptr,
                                SourceLoc(),
                                UnqualifiedLookup::Flags::TypeLookup);
-      renamedDecl = lookup.getSingleTypeResult();
+      return lookup.getSingleTypeResult();
+    }
+
+    TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
+
+    const ValueDecl *renamedDecl = nullptr;
+    SmallVector<ValueDecl *, 4> lookupResults;
+    declContext->lookupQualified(typeDecl->getDeclaredInterfaceType(),
+                                 renamedDeclName, NL_QualifiedDefault, nullptr,
+                                 lookupResults);
+
+    if (lookupResults.size() == 1) {
+      auto candidate = lookupResults[0];
+      if (!shouldInclude(candidate))
+        return nullptr;
+      if (candidate->getKind() != D->getKind() ||
+          (candidate->isInstanceMember() !=
+           cast<ValueDecl>(D)->isInstanceMember()))
+        return nullptr;
+
+      renamedDecl = candidate;
     } else {
-      SmallVector<ValueDecl *, 4> lookupResults;
-      declContext->lookupQualified(
-        declContext->getSelfNominalTypeDecl(),
-        renamedDeclName, NL_QualifiedDefault, lookupResults);
       for (auto candidate : lookupResults) {
         if (!shouldInclude(candidate))
           continue;
-        
+
         if (candidate->getKind() != D->getKind() ||
             (candidate->isInstanceMember() !=
              cast<ValueDecl>(D)->isInstanceMember()))
           continue;
-        
-        if (isa<FuncDecl>(candidate) &&
-            (cast<FuncDecl>(candidate)->getParameters()->size() !=
-             cast<FuncDecl>(D)->getParameters()->size()))
-          continue;
-        
+
+        if (isa<AbstractFunctionDecl>(candidate)) {
+          auto cParams = cast<AbstractFunctionDecl>(candidate)->getParameters();
+          auto dParams = cast<AbstractFunctionDecl>(D)->getParameters();
+
+          if (cParams->size() != dParams->size())
+            continue;
+
+          bool hasSameParameterTypes = true;
+          for (auto index : indices(*cParams)) {
+            auto cParamsType = cParams->get(index)->getType();
+            auto dParamsType = dParams->get(index)->getType();
+            if (!cParamsType->matchesParameter(dParamsType,
+                                               TypeMatchOptions())) {
+              hasSameParameterTypes = false;
+              break;
+            }
+          }
+
+          if (!hasSameParameterTypes) {
+            continue;
+          }
+        }
+
         if (renamedDecl) {
           // If we found a duplicated candidate then we would silently fail.
           renamedDecl = nullptr;
@@ -957,11 +988,20 @@ private:
         renamedDecl = candidate;
       }
     }
-    
+    return renamedDecl;
+  }
+
+  void printRenameForDecl(const AvailableAttr *AvAttr, const ValueDecl *D,
+                          bool includeQuotes) {
+    assert(!AvAttr->Rename.empty());
+
+    const ValueDecl *renamedDecl =
+        getRenameDecl(D, parseDeclName(AvAttr->Rename));
+
     if (renamedDecl) {
       SmallString<128> scratch;
-      auto renamedObjCRuntimeName = renamedDecl->getObjCRuntimeName()
-        ->getString(scratch);
+      auto renamedObjCRuntimeName =
+          renamedDecl->getObjCRuntimeName()->getString(scratch);
       printEncodedString(renamedObjCRuntimeName, includeQuotes);
     } else {
       printEncodedString(AvAttr->Rename, includeQuotes);
@@ -1476,9 +1516,9 @@ private:
       MAP(UnsafeMutableRawPointer, "void *", true);
 
       Identifier ID_ObjectiveC = ctx.Id_ObjectiveC;
-      specialNames[{ID_ObjectiveC, ctx.getIdentifier("ObjCBool")}] 
+      specialNames[{ID_ObjectiveC, ctx.getIdentifier("ObjCBool")}]
         = { "BOOL", false};
-      specialNames[{ID_ObjectiveC, ctx.getIdentifier("Selector")}] 
+      specialNames[{ID_ObjectiveC, ctx.getIdentifier("Selector")}]
         = { "SEL", true };
       specialNames[{ID_ObjectiveC,
                     ctx.getIdentifier(
@@ -1605,7 +1645,7 @@ private:
     os << clangDecl->getKindName() << " ";
   }
 
-  void visitStructType(StructType *ST, 
+  void visitStructType(StructType *ST,
                        Optional<OptionalTypeKind> optionalKind) {
     const StructDecl *SD = ST->getStructOrBoundGenericStruct();
 
@@ -1829,7 +1869,7 @@ private:
     visitExistentialType(PT, optionalKind, /*isMetatype=*/false);
   }
 
-  void visitProtocolCompositionType(ProtocolCompositionType *PCT, 
+  void visitProtocolCompositionType(ProtocolCompositionType *PCT,
                                     Optional<OptionalTypeKind> optionalKind) {
     visitExistentialType(PCT, optionalKind, /*isMetatype=*/false);
   }
@@ -1840,7 +1880,7 @@ private:
     visitExistentialType(instanceTy, optionalKind, /*isMetatype=*/true);
   }
 
-  void visitMetatypeType(MetatypeType *MT, 
+  void visitMetatypeType(MetatypeType *MT,
                          Optional<OptionalTypeKind> optionalKind) {
     Type instanceTy = MT->getInstanceType();
     if (auto classTy = instanceTy->getAs<ClassType>()) {
@@ -1875,7 +1915,7 @@ private:
     os << cast<clang::ObjCTypeParamDecl>(decl->getClangDecl())->getName();
     printNullability(optionalKind);
   }
-                      
+    
   void printFunctionType(FunctionType *FT, char pointerSigil,
                          Optional<OptionalTypeKind> optionalKind) {
     visitPart(FT->getResult(), OTK_None);
@@ -1884,7 +1924,7 @@ private:
     openFunctionTypes.push_back(FT);
   }
 
-  void visitFunctionType(FunctionType *FT, 
+  void visitFunctionType(FunctionType *FT,
                          Optional<OptionalTypeKind> optionalKind) {
     switch (FT->getRepresentation()) {
     case AnyFunctionType::Representation::Thin:
@@ -1928,18 +1968,18 @@ private:
     visitPart(PT->getSinglyDesugaredType(), optionalKind);
   }
 
-  void visitSyntaxSugarType(SyntaxSugarType *SST, 
+  void visitSyntaxSugarType(SyntaxSugarType *SST,
                             Optional<OptionalTypeKind> optionalKind) {
     visitPart(SST->getSinglyDesugaredType(), optionalKind);
   }
 
-  void visitDynamicSelfType(DynamicSelfType *DST, 
+  void visitDynamicSelfType(DynamicSelfType *DST,
                             Optional<OptionalTypeKind> optionalKind) {
     printNullability(optionalKind, NullabilityPrintKind::ContextSensitive);
     os << "instancetype";
   }
 
-  void visitReferenceStorageType(ReferenceStorageType *RST, 
+  void visitReferenceStorageType(ReferenceStorageType *RST,
                                  Optional<OptionalTypeKind> optionalKind) {
     visitPart(RST->getReferentType(), optionalKind);
   }
@@ -1977,7 +2017,7 @@ private:
   /// finishFunctionType()). If only a part of a type is being printed, use
   /// visitPart().
 public:
-  void print(Type ty, Optional<OptionalTypeKind> optionalKind, 
+  void print(Type ty, Optional<OptionalTypeKind> optionalKind,
              Identifier name = Identifier(),
              IsFunctionParam_t isFuncParam = IsNotFunctionParam) {
     PrettyStackTraceType trace(M.getASTContext(), "printing", ty);
@@ -2829,9 +2869,9 @@ public:
       // FIXME: This will end up taking linear time.
       auto lhsMembers = cast<ExtensionDecl>(*lhs)->getMembers();
       auto rhsMembers = cast<ExtensionDecl>(*rhs)->getMembers();
-      unsigned numLHSMembers = std::distance(lhsMembers.begin(), 
+      unsigned numLHSMembers = std::distance(lhsMembers.begin(),
                                              lhsMembers.end());
-      unsigned numRHSMembers = std::distance(rhsMembers.begin(), 
+      unsigned numRHSMembers = std::distance(rhsMembers.begin(),
                                              rhsMembers.end());
       if (numLHSMembers != numRHSMembers)
         return numLHSMembers < numRHSMembers ? Descending : Ascending;

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -46,22 +46,22 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
 // CHECK-SAME: ;
-// CHECK-NEXT: - (void)overloadingMethodWithFirst:(NSInteger)first second:(NSInteger)second;
-// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadingMethodWithFirst:second:");
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
-// CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)overloadMethodWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethod' has been renamed to 'overloadMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadMethodWithFirst:second:'");
 
 // CHECK-NEXT: - (void)firstOverloadingMethodWithDiffernceNameWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: - (void)secondOverloadingMethodWithDiffernceNameWithFirst:(double)first second:(double)second;
 // CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "overloadMethodWithDifferenceObjCName(first:second:)");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "firstOverloadingMethodWithDiffernceNameWithFirst:second:");
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'firstOverloadingMethodWithDiffernceNameWithFirst:second:'");
 // CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'firstOverloadingMethodWithDiffernceNameWithFirst:second:'");
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'firstOverloadingMethodWithDiffernceNameWithFirst:second:'");
 
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value
@@ -101,17 +101,17 @@
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToSimpleProperty
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToSimpleProperty' has been renamed to 'simpleProperty'");
 
-// CHECK-NEXT: - (NSInteger)methodReturningInt
+// CHECK-NEXT: - (NSInteger)methodReturningInt SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (NSInteger)methodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT;
 
-// CHECK-NEXT: - (NSInteger)deprecatedMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-NEXT: - (NSInteger)deprecatedMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:");
-// CHECK-NEXT: - (NSInteger)deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
-// CHECK-NEXT: - (NSInteger)unavailableMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
-// CHECK-NEXT: - (NSInteger)unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)deprecatedOnMacOSMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToMethodWithoutCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)unavailableMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToMethodWithoutCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)unavailableOnMacOSMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToMethodWithoutCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
 
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value
@@ -124,7 +124,17 @@
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'__makeUnavailableOnMacOSAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
 
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)x OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "initWithFirst:second:");
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedOnMacOSFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'init' has been renamed to 'initWithFirst:second:'");
+// CHECK-NEXT: - (nonnull instancetype)initWithUnavailableFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'init' has been renamed to 'initWithFirst:second:'");
+// CHECK-NEXT: - (nonnull instancetype)initWithUnavailableOnMacOSFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'init' has been renamed to 'initWithFirst:second:'");
+
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger simpleProperty;
 // CHECK-NEXT: @property (nonatomic) NSInteger alwaysUnavailableProperty SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableProperty' has been renamed to 'baz': whatever");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger alwaysDeprecatedProperty SWIFT_DEPRECATED_MSG("use something else", "quux");
@@ -163,49 +173,71 @@
 // CHECK-LABEL: @interface AvailabilitySub
 // CHECK-NEXT: - (nonnull instancetype)init SWIFT_UNAVAILABLE;
 // CHECK-NEXT: + (nonnull instancetype)new SWIFT_DEPRECATED_MSG("-init is unavailable");
-// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)x SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedZ:(NSInteger)deprecatedZ OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_MSG("init(deprecatedZ:) was deprecated. Use the new one instead", "initWithNewZ:")
 // CHECK-NEXT: - (nonnull instancetype)initWithNewZ:(NSInteger)z OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: @end
+// CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedOnMacOSFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
+// CHECK: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
-// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)");
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead");
+
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithClassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)': use method in another class instead");
+
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
-// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)");
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
-// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second;
+// CHECK-NEXT: - (void)deprecatedMethodReplacingInReplacementClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
+// CHECK-SAME: "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:")
+// CHECK-NEXT: - (void)deprecatedmethodReplacingInReplacementClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
+// CHECK-SAME: "replacingMethodInReplacementClassWithClassObjectParametersWithFirst:second:")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
 // CHECK-NEXT: - (void)replacingMethodInReplacementProtocolWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
+
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
-// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead");
+
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithClassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithClassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
-// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -291,7 +323,7 @@
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
   
-    @objc(overloadingMethodWithFirst:second:) func overloadMethod(first: Int, second: Int) {}
+    @objc func overloadMethod(first: Int, second: Int) {}
     func overloadMethod(first: Double, second: Double) {}
 
     @available(*, deprecated, renamed: "overloadMethod(first:second:)")
@@ -374,18 +406,18 @@
     @objc public func unavailableOnMacOSMethodRenamedToSimpleProperty() {}
 
     @objc(methodReturningInt) public func simpleMethodReturningInt() -> Int { return -1 }
-  
+
     @objc public func methodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
     @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func deprecatedMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func deprecatedMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
     @available(macOS, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func deprecatedOnMacOSMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
     @available(*, unavailable, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func unavailableMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func unavailableMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
     @available(macOS, unavailable, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func unavailableOnMacOSMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
 
     @objc(unavailableAvailabilityWithValue:)
@@ -412,8 +444,23 @@
 
     @objc init() {}
     @available(macOS 10.10, *)
-    @objc init(x _: Int) {}
-
+    @objc init(x: Int) {}
+    
+    @objc init(first: Int, second: Int) {}
+    init(first: Double, second: Double) {}
+    
+    @available(*, deprecated, renamed: "init(first:second:)")
+    @objc init(deprecatedFirst first: Int, second: Int) {}
+    
+    @available(macOS, deprecated, renamed: "init(first:second:)")
+    @objc init(deprecatedOnMacOSFirst first: Int, second: Int) {}
+    
+    @available(*, unavailable, renamed: "init(first:second:)")
+    @objc init(unavailableFirst first: Int, second: Int) {}
+    
+    @available(macOS, unavailable, renamed: "init(first:second:)")
+    @objc init(unavailableOnMacOSFirst first: Int, second: Int) {}
+    
     @objc var simpleProperty: Int {
         get {
             return 100
@@ -517,7 +564,6 @@
 extension Availability {
     @objc func extensionAvailability(_: WholeClassAvailability) {}
     
-    
     @available(macOS, deprecated: 10.10)
     @objc var propertyDeprecatedInsideExtension: Int {
         get {
@@ -529,7 +575,7 @@ extension Availability {
 @objc class AvailabilitySub: Availability {
     private override init() { super.init() }
     @available(macOS 10.10, *)
-    private override init(x _: Int) { super.init() }
+    private override init(x: Int) { super.init() }
     @available(*, deprecated, message: "init(deprecatedZ:) was deprecated. Use the new one instead", renamed: "init(z:)")
     @objc init(deprecatedZ: Int) { super.init() }
     @objc(initWithNewZ:) init(z: Int) { super.init() }
@@ -546,45 +592,73 @@ extension Availability {
     func wholeProtoAvailability(_: WholeClassAvailability)
 }
 
-
 @objc(SWTReplacementAvailable) class ReplacementAvailable {
-    @objc(replacingMethodInReplacementClassWithFirst:second:) func methodReplacingInReplacementClass(first: Int, second: Int) -> Void {}
+    @objc(replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:)
+    func methodReplacingInReplacementClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    
+    @objc(replacingMethodInReplacementClassWithClassObjectParametersWithFirst:second:)
+    func methodReplacingInReplacementClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodReplacingInReplacementClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedmethodReplacingInReplacementClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailable")
 @objc class DeprecatedAvailability {
-    @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
-    @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
+    @available(*, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    @available(macOS, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+  
+    @available(*, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(macOS, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailable")
 @objc class UnavailableAvailability {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-  @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void {}
-  @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-  @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void {}
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+  
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @objc(SWTReplacementAvailableProtocol) protocol ReplacementAvailableProtocol {
-  @objc(replacingMethodInReplacementProtocolWithFirst:second:) func methodReplacingInReplacementProtocol(first: Int, second: Int) -> Void
+    @objc(replacingMethodInReplacementProtocolWithFirst:second:)
+    func methodReplacingInReplacementProtocol(first: Int, second: Int) -> Void
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailableProtocol")
 @objc protocol DeprecatedAvailabilityProtocol {
-  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
-  @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void
-  @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
-  @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void
+    @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void
+    @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailableProtocol")
 @objc protocol UnavailableAvailabilityProtocol {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
-  @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void
-  @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
-  @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void
 }
 
 


### PR DESCRIPTION
This PR is a cherry-picking of #19645 to the Swift 5.0 branch. Since this is a small improvement PR which has low risk in my opinion. This PR is also a part of [SR-8231](https://bugs.swift.org/browse/SR-8231)

This PR is an improvement of the #18081. It adds a few improvements for the custom @objc name in the available attribute when generates ObjC headers.

Here's a list of the improvements

- The compiler will follow the base type when the rename attribute references to the declaration in other Type
- The compiler will try to look at the type of the method parameter when the rename attribute references to an overloading method