### PR TITLE
[benchmark] Janitor Duty: Thesaurus Heirloom

### DIFF
--- a/benchmark/multi-source/PrimsSplit/Prims_main.swift
+++ b/benchmark/multi-source/PrimsSplit/Prims_main.swift
@@ -15,11 +15,12 @@ import TestsUtils
 public let PrimsSplit = BenchmarkInfo(
   name: "PrimsSplit",
   runFunction: run_PrimsSplit,
-  tags: [.validation, .algorithm])
+  tags: [.validation, .algorithm],
+  legacyFactor: 5)
 
 @inline(never)
 public func run_PrimsSplit(_ N: Int) {
-  for _ in 1...5*N {
+  for _ in 1...N {
     let nodes : [Int] = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
       13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
       29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,

--- a/benchmark/single-source/ErrorHandling.swift
+++ b/benchmark/single-source/ErrorHandling.swift
@@ -15,7 +15,8 @@ import TestsUtils
 public let ErrorHandling = BenchmarkInfo(
   name: "ErrorHandling",
   runFunction: run_ErrorHandling,
-  tags: [.validation, .exceptions])
+  tags: [.validation, .exceptions],
+  legacyFactor: 10)
 
 enum PizzaError : Error {
   case Pepperoni, Olives, Anchovy
@@ -35,7 +36,7 @@ func doSomething() throws -> String {
 
 @inline(never)
 public func run_ErrorHandling(_ N: Int) {
-  for _ in 1...5000*N {
+  for _ in 1...500*N {
     do {
       _ = try doSomething()
     } catch _ {
@@ -43,4 +44,3 @@ public func run_ErrorHandling(_ N: Int) {
     }
   }
 }
-

--- a/benchmark/single-source/Hanoi.swift
+++ b/benchmark/single-source/Hanoi.swift
@@ -18,7 +18,8 @@ import TestsUtils
 public let Hanoi = BenchmarkInfo(
   name: "Hanoi",
   runFunction: run_Hanoi,
-  tags: [.validation, .algorithm])
+  tags: [.validation, .algorithm],
+  legacyFactor: 10)
 
 struct Move {
    var from: String
@@ -46,7 +47,7 @@ class TowersOfHanoi {
 
 @inline(never)
 public func run_Hanoi(_ N: Int) {
-  for _ in 1...100*N {
+  for _ in 1...10*N {
     let hanoi: TowersOfHanoi = TowersOfHanoi()
     hanoi.solve(10, start: "A", auxiliary: "B", end: "C")
   }

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -18,7 +18,8 @@ import TestsUtils
 public let HashTest = BenchmarkInfo(
   name: "HashTest",
   runFunction: run_HashTest,
-  tags: [.validation, .algorithm])
+  tags: [.validation, .algorithm],
+  legacyFactor: 10)
 
 class Hash {
   /// C'tor.
@@ -581,7 +582,7 @@ public func run_HashTest(_ N: Int) {
     "The quick brown fox jumps over the lazy dog." : "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"]
   let size = 50
 
-  for _ in 1...10*N {
+  for _ in 1...N {
     // Check for precomputed values.
     let MD = MD5()
     for (K, V) in TestMD5 {

--- a/benchmark/single-source/LazyFilter.swift
+++ b/benchmark/single-source/LazyFilter.swift
@@ -15,21 +15,29 @@
 import TestsUtils
 
 public let LazyFilter = [
-  BenchmarkInfo(name: "LazilyFilteredArrays2", runFunction: run_LazilyFilteredArrays, tags: [.validation, .api, .Array],
-      setUpFunction: { blackHole(filteredRange) }),
-  BenchmarkInfo(name: "LazilyFilteredRange", runFunction: run_LazilyFilteredRange, tags: [.validation, .api, .Array]),
+  BenchmarkInfo(name: "LazilyFilteredArrays2",
+    runFunction: run_LazilyFilteredArrays,
+    tags: [.validation, .api, .Array],
+    setUpFunction: { blackHole(filteredRange) },
+    legacyFactor: 100),
+  BenchmarkInfo(name: "LazilyFilteredRange",
+    runFunction: run_LazilyFilteredRange,
+    tags: [.validation, .api, .Array],
+    legacyFactor: 10),
   BenchmarkInfo(
     name: "LazilyFilteredArrayContains",
     runFunction: run_LazilyFilteredArrayContains,
     tags: [.validation, .api, .Array],
-    setUpFunction: setup_LazilyFilteredArrayContains,
-    tearDownFunction: teardown_LazilyFilteredArrayContains),
+    setUpFunction: {
+      multiplesOfThree = Array(1..<500).lazy.filter { $0 % 3 == 0 } },
+    tearDownFunction: { multiplesOfThree = nil },
+    legacyFactor: 100),
 ]
 
 @inline(never)
 public func run_LazilyFilteredRange(_ N: Int) {
   var res = 123
-  let c = (1..<1_000_000).lazy.filter { $0 % 7 == 0 }
+  let c = (1..<100_000).lazy.filter { $0 % 7 == 0 }
   for _ in 1...N {
     res += Array(c).count
     res -= Array(c).count
@@ -37,7 +45,7 @@ public func run_LazilyFilteredRange(_ N: Int) {
   CheckResults(res == 123)
 }
 
-let filteredRange = (1..<100_000).map({[$0]}).lazy.filter { $0.first! % 7 == 0 }
+let filteredRange = (1..<1_000).map({[$0]}).lazy.filter { $0.first! % 7 == 0 }
 
 @inline(never)
 public func run_LazilyFilteredArrays(_ N: Int) {
@@ -52,22 +60,14 @@ public func run_LazilyFilteredArrays(_ N: Int) {
 
 fileprivate var multiplesOfThree: LazyFilterCollection<Array<Int>>?
 
-fileprivate func setup_LazilyFilteredArrayContains() {
-  multiplesOfThree = Array(1..<5_000).lazy.filter { $0 % 3 == 0 }
-}
-
-fileprivate func teardown_LazilyFilteredArrayContains() {
-  multiplesOfThree = nil
-}
-
 @inline(never)
 fileprivate func run_LazilyFilteredArrayContains(_ N: Int) {
   let xs = multiplesOfThree!
   for _ in 1...N {
     var filteredCount = 0
-    for candidate in 1..<5_000 {
+    for candidate in 1..<500 {
       filteredCount += xs.contains(candidate) ? 1 : 0
     }
-    CheckResults(filteredCount == 1666)
+    CheckResults(filteredCount == 166)
   }
 }

--- a/benchmark/single-source/LinkedList.swift
+++ b/benchmark/single-source/LinkedList.swift
@@ -19,8 +19,13 @@ import TestsUtils
 public var LinkedList = BenchmarkInfo(
   name: "LinkedList",
   runFunction: run_LinkedList,
-  tags: [.runtime, .cpubench, .refcount]
-)
+  tags: [.runtime, .cpubench, .refcount],
+  setUpFunction: { for i in 0..<size { head = Node(n:head, d:i) } },
+  tearDownFunction: { head = Node(n:nil, d:0) },
+  legacyFactor: 40)
+
+let size = 100
+var head = Node(n:nil, d:0)
 
 final class Node {
   var next: Node?
@@ -34,16 +39,10 @@ final class Node {
 
 @inline(never)
 public func run_LinkedList(_ N: Int) {
-  let size = 100
-  var head = Node(n:nil, d:0)
-  for i in 0..<size {
-    head = Node(n:head, d:i)
-  }
-
   var sum = 0
   let ref_result = size*(size-1)/2
   var ptr = head
-  for _ in 1...5000*N {
+  for _ in 1...125*N {
     ptr = head
     sum = 0
     while let nxt = ptr.next {

--- a/benchmark/single-source/MapReduce.swift
+++ b/benchmark/single-source/MapReduce.swift
@@ -13,25 +13,41 @@
 import TestsUtils
 import Foundation
 
+let t: [BenchmarkCategory] = [.validation, .algorithm]
+let ts: [BenchmarkCategory] = [.validation, .algorithm, .String]
+
 public let MapReduce = [
-  BenchmarkInfo(name: "MapReduce", runFunction: run_MapReduce, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceAnyCollection", runFunction: run_MapReduceAnyCollection, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceAnyCollectionShort", runFunction: run_MapReduceAnyCollectionShort, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceClass2", runFunction: run_MapReduceClass, tags: [.validation, .algorithm],
+  BenchmarkInfo(name: "MapReduce", runFunction: run_MapReduce, tags: t),
+  BenchmarkInfo(name: "MapReduceAnyCollection",
+    runFunction: run_MapReduceAnyCollection, tags: t),
+  BenchmarkInfo(name: "MapReduceAnyCollectionShort",
+    runFunction: run_MapReduceAnyCollectionShort, tags: t, legacyFactor: 10),
+  BenchmarkInfo(name: "MapReduceClass2",
+    runFunction: run_MapReduceClass, tags: t,
     setUpFunction: { boxedNumbers(1000) }, tearDownFunction: releaseDecimals),
-  BenchmarkInfo(name: "MapReduceClassShort2", runFunction: run_MapReduceClassShort, tags: [.validation, .algorithm],
+  BenchmarkInfo(name: "MapReduceClassShort2",
+    runFunction: run_MapReduceClassShort, tags: t,
     setUpFunction: { boxedNumbers(10) }, tearDownFunction: releaseDecimals),
-  BenchmarkInfo(name: "MapReduceNSDecimalNumber", runFunction: run_MapReduceNSDecimalNumber, tags: [.validation, .algorithm],
+  BenchmarkInfo(name: "MapReduceNSDecimalNumber",
+    runFunction: run_MapReduceNSDecimalNumber, tags: t,
     setUpFunction: { decimals(1000) }, tearDownFunction: releaseDecimals),
-  BenchmarkInfo(name: "MapReduceNSDecimalNumberShort", runFunction: run_MapReduceNSDecimalNumberShort, tags: [.validation, .algorithm],
+  BenchmarkInfo(name: "MapReduceNSDecimalNumberShort",
+    runFunction: run_MapReduceNSDecimalNumberShort, tags: t,
     setUpFunction: { decimals(10) }, tearDownFunction: releaseDecimals),
-  BenchmarkInfo(name: "MapReduceLazyCollection", runFunction: run_MapReduceLazyCollection, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceLazyCollectionShort", runFunction: run_MapReduceLazyCollectionShort, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceLazySequence", runFunction: run_MapReduceLazySequence, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceSequence", runFunction: run_MapReduceSequence, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceShort", runFunction: run_MapReduceShort, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "MapReduceShortString", runFunction: run_MapReduceShortString, tags: [.validation, .algorithm, .String]),
-  BenchmarkInfo(name: "MapReduceString", runFunction: run_MapReduceString, tags: [.validation, .algorithm, .String]),
+  BenchmarkInfo(name: "MapReduceLazyCollection",
+    runFunction: run_MapReduceLazyCollection, tags: t),
+  BenchmarkInfo(name: "MapReduceLazyCollectionShort",
+    runFunction: run_MapReduceLazyCollectionShort, tags: t),
+  BenchmarkInfo(name: "MapReduceLazySequence",
+    runFunction: run_MapReduceLazySequence, tags: t),
+  BenchmarkInfo(name: "MapReduceSequence",
+    runFunction: run_MapReduceSequence, tags: t),
+  BenchmarkInfo(name: "MapReduceShort",
+    runFunction: run_MapReduceShort, tags: t, legacyFactor: 10),
+  BenchmarkInfo(name: "MapReduceShortString",
+    runFunction: run_MapReduceShortString, tags: ts),
+  BenchmarkInfo(name: "MapReduceString",
+    runFunction: run_MapReduceString, tags: ts),
 ]
 
 #if _runtime(_ObjC)
@@ -83,7 +99,7 @@ public func run_MapReduceAnyCollectionShort(_ N: Int) {
   let numbers = AnyCollection([Int](0..<10))
 
   var c = 0
-  for _ in 1...N*10000 {
+  for _ in 1...N*1_000 {
     let mapped = numbers.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
@@ -95,7 +111,7 @@ public func run_MapReduceShort(_ N: Int) {
   var numbers = [Int](0..<10)
 
   var c = 0
-  for _ in 1...N*10000 {
+  for _ in 1...N*1_000 {
     numbers = numbers.map { $0 &+ 5 }
     c += numbers.reduce(0, &+)
   }

--- a/benchmark/single-source/MonteCarloE.swift
+++ b/benchmark/single-source/MonteCarloE.swift
@@ -22,10 +22,11 @@ import TestsUtils
 public let MonteCarloE = BenchmarkInfo(
   name: "MonteCarloE",
   runFunction: run_MonteCarloE,
-  tags: [.validation, .algorithm])
+  tags: [.validation, .algorithm],
+  legacyFactor: 20)
 
 public func run_MonteCarloE(scale: Int) {
-  let N = 200000*scale
+  let N = 10_000*scale
   var intervals = [Bool](repeating: false, count: N)
   for _ in 1...N {
     let pos = Int(UInt(truncatingIfNeeded: Random())%UInt(N))
@@ -37,5 +38,5 @@ public func run_MonteCarloE(scale: Int) {
   CheckResults(numEmptyIntervals != N)
   let e_estimate = Double(N)/Double(numEmptyIntervals)
   let e = 2.71828
-  CheckResults(abs(e_estimate - e) < 0.1)
+  CheckResults(abs(e_estimate - e) < 0.2)
 }

--- a/benchmark/single-source/MonteCarloPi.swift
+++ b/benchmark/single-source/MonteCarloPi.swift
@@ -15,12 +15,13 @@ import TestsUtils
 public let MonteCarloPi = BenchmarkInfo(
   name: "MonteCarloPi",
   runFunction: run_MonteCarloPi,
-  tags: [.validation, .algorithm])
+  tags: [.validation, .algorithm],
+  legacyFactor: 125)
 
 public func run_MonteCarloPi(scale: Int) {
   var pointsInside = 0
   let r = 10000
-  let N = 500000*scale
+  let N = 4_000*scale
   for _ in 1...N {
     let x = Int(truncatingIfNeeded: Random())%r
     let y = Int(truncatingIfNeeded: Random())%r
@@ -30,5 +31,5 @@ public func run_MonteCarloPi(scale: Int) {
   }
   let pi_estimate: Double = Double(pointsInside)*4.0/Double(N)
   let pi = 3.1415
-  CheckResults(abs(pi_estimate - pi) < 0.1)
+  CheckResults(abs(pi_estimate - pi) < 0.2)
 }

--- a/benchmark/single-source/NSDictionaryCastToSwift.swift
+++ b/benchmark/single-source/NSDictionaryCastToSwift.swift
@@ -21,14 +21,15 @@ import TestsUtils
 public let NSDictionaryCastToSwift = BenchmarkInfo(
   name: "NSDictionaryCastToSwift",
   runFunction: run_NSDictionaryCastToSwift,
-  tags: [.validation, .api, .Dictionary, .bridging])
+  tags: [.validation, .api, .Dictionary, .bridging],
+  legacyFactor: 10)
 
 @inline(never)
 public func run_NSDictionaryCastToSwift(_ N: Int) {
 #if _runtime(_ObjC)
     let NSDict = NSDictionary()
     var swiftDict = [String: NSObject]()
-    for _ in 1...10000*N {
+    for _ in 1...1_000*N {
         swiftDict = NSDict as! [String: NSObject]
         if !swiftDict.isEmpty {
             break

--- a/benchmark/single-source/NibbleSort.swift
+++ b/benchmark/single-source/NibbleSort.swift
@@ -7,7 +7,8 @@ import TestsUtils
 public var NibbleSort = BenchmarkInfo(
   name: "NibbleSort",
   runFunction: run_NibbleSort,
-  tags: [.validation]
+  tags: [.validation],
+  legacyFactor: 10
 )
 
 @inline(never)
@@ -16,7 +17,7 @@ public func run_NibbleSort(_ N: Int) {
   let v: UInt64 = 0xbadbeef
   var c = NibbleCollection(v)
 
-  for _ in 1...10000*N {
+  for _ in 1...1_000*N {
     c.val = v
     c.sort()
 

--- a/benchmark/single-source/NopDeinit.swift
+++ b/benchmark/single-source/NopDeinit.swift
@@ -16,7 +16,8 @@ import TestsUtils
 public let NopDeinit = BenchmarkInfo(
   name: "NopDeinit",
   runFunction: run_NopDeinit,
-  tags: [.regression])
+  tags: [.regression],
+  legacyFactor: 100)
 
 class X<T : Comparable> {
   let deinitIters = 10000
@@ -32,7 +33,7 @@ class X<T : Comparable> {
 public func run_NopDeinit(_ N: Int) {
   for _ in 1...N {
     var arr :[X<Int>] = []
-    let size = 500
+    let size = 5
     for i in 1...size { arr.append(X(i)) }
     arr.removeAll()
     CheckResults(arr.count == 0)

--- a/benchmark/single-source/ObserverClosure.swift
+++ b/benchmark/single-source/ObserverClosure.swift
@@ -16,7 +16,8 @@ import TestsUtils
 public let ObserverClosure = BenchmarkInfo(
   name: "ObserverClosure",
   runFunction: run_ObserverClosure,
-  tags: [.validation])
+  tags: [.validation],
+  legacyFactor: 10)
 
 class Observer {
   @inline(never)
@@ -41,7 +42,7 @@ class Signal {
 public func run_ObserverClosure(_ iterations: Int) {
   let signal = Signal()
   let observer = Observer()
-  for _ in 0 ..< 10_000 * iterations {
+  for _ in 0 ..< 1_000 * iterations {
     signal.subscribe { i in observer.receive(i) }
   }
   signal.send(1)

--- a/benchmark/single-source/ObserverForwarderStruct.swift
+++ b/benchmark/single-source/ObserverForwarderStruct.swift
@@ -15,7 +15,8 @@ import TestsUtils
 public let ObserverForwarderStruct = BenchmarkInfo(
   name: "ObserverForwarderStruct",
   runFunction: run_ObserverForwarderStruct,
-  tags: [.validation])
+  tags: [.validation],
+  legacyFactor: 5)
 
 class Observer {
   @inline(never)
@@ -52,7 +53,7 @@ class Signal {
 public func run_ObserverForwarderStruct(_ iterations: Int) {
   let signal = Signal()
   let observer = Observer()
-  for _ in 0 ..< 10_000 * iterations {
+  for _ in 0 ..< 2_000 * iterations {
     signal.subscribe(Forwarder(object: observer))
   }
   signal.send(1)

--- a/benchmark/single-source/ObserverPartiallyAppliedMethod.swift
+++ b/benchmark/single-source/ObserverPartiallyAppliedMethod.swift
@@ -15,7 +15,8 @@ import TestsUtils
 public let ObserverPartiallyAppliedMethod = BenchmarkInfo(
   name: "ObserverPartiallyAppliedMethod",
   runFunction: run_ObserverPartiallyAppliedMethod,
-  tags: [.validation])
+  tags: [.validation],
+  legacyFactor: 20)
 
 class Observer {
   @inline(never)
@@ -40,7 +41,7 @@ class Signal {
 public func run_ObserverPartiallyAppliedMethod(_ iterations: Int) {
   let signal = Signal()
   let observer = Observer()
-  for _ in 0 ..< 10_000 * iterations {
+  for _ in 0 ..< 500 * iterations {
     signal.subscribe(observer.receive)
   }
   signal.send(1)

--- a/benchmark/single-source/ObserverUnappliedMethod.swift
+++ b/benchmark/single-source/ObserverUnappliedMethod.swift
@@ -15,7 +15,8 @@ import TestsUtils
 public let ObserverUnappliedMethod = BenchmarkInfo(
   name: "ObserverUnappliedMethod",
   runFunction: run_ObserverUnappliedMethod,
-  tags: [.validation])
+  tags: [.validation],
+  legacyFactor: 10)
 
 class Observer {
   @inline(never)
@@ -53,7 +54,7 @@ class Signal {
 public func run_ObserverUnappliedMethod(_ iterations: Int) {
   let signal = Signal()
   let observer = Observer()
-  for _ in 0 ..< 10_000 * iterations {
+  for _ in 0 ..< 1_000 * iterations {
     let forwarder = Forwarder(object: observer, method: Observer.receive)
     signal.subscribe(forwarder)
   }

--- a/benchmark/single-source/OpaqueConsumingUsers.swift
+++ b/benchmark/single-source/OpaqueConsumingUsers.swift
@@ -16,7 +16,8 @@ public let OpaqueConsumingUsers = BenchmarkInfo(
   name: "OpaqueConsumingUsers",
   runFunction: run_OpaqueConsumingUsers,
   tags: [.regression, .abstraction, .refcount],
-  setUpFunction: setup_OpaqueConsumingUsers)
+  setUpFunction: setup_OpaqueConsumingUsers,
+  legacyFactor: 20)
 
 // This test exercises the ability of the optimizer to propagate the +1 from a
 // consuming argument of a non-inlineable through multiple non-inlinable call
@@ -82,7 +83,7 @@ func callFrame4(_ data: Klass, _ user: ConsumingUser) {
 public func run_OpaqueConsumingUsers(_ N: Int) {
   let d = data.unsafelyUnwrapped
   let u = user.unsafelyUnwrapped
-  for _ in 0..<N*200000 {
+  for _ in 0..<N*10_000 {
     callFrame4(d, u)
   }
 }

--- a/benchmark/single-source/Phonebook.swift
+++ b/benchmark/single-source/Phonebook.swift
@@ -18,7 +18,8 @@ public let Phonebook = BenchmarkInfo(
   name: "Phonebook",
   runFunction: run_Phonebook,
   tags: [.validation, .api, .String],
-  setUpFunction: { blackHole(names) }
+  setUpFunction: { blackHole(names) },
+  legacyFactor: 7
 )
 
 let words = [
@@ -27,14 +28,6 @@ let words = [
   "Paul", "Mark", "George", "Steven", "Kenneth", "Andrew", "Edward", "Brian",
   "Joshua", "Kevin", "Ronald", "Timothy", "Jason", "Jeffrey", "Gary", "Ryan",
   "Nicholas", "Eric", "Stephen", "Jacob", "Larry", "Frank", "Jonathan", "Scott",
-  "Justin", "Raymond", "Brandon", "Gregory", "Samuel", "Patrick", "Benjamin",
-  "Jack", "Dennis", "Jerry", "Alexander", "Tyler", "Douglas", "Henry", "Peter",
-  "Walter", "Aaron", "Jose", "Adam", "Harold", "Zachary", "Nathan", "Carl",
-  "Kyle", "Arthur", "Gerald", "Lawrence", "Roger", "Albert", "Keith", "Jeremy",
-  "Terry", "Joe", "Sean", "Willie", "Jesse", "Ralph", "Billy", "Austin", "Bruce",
-  "Christian", "Roy", "Bryan", "Eugene", "Louis", "Harry", "Wayne", "Ethan",
-  "Jordan", "Russell", "Alan", "Philip", "Randy", "Juan", "Howard", "Vincent",
-  "Bobby", "Dylan", "Johnny", "Phillip", "Craig"
 ]
 let names: [Record] = {
   // The list of names in the phonebook.

--- a/benchmark/single-source/PointerArithmetics.swift
+++ b/benchmark/single-source/PointerArithmetics.swift
@@ -13,7 +13,10 @@
 import TestsUtils
 
 public let PointerArithmetics = [
-  BenchmarkInfo(name: "PointerArithmetics", runFunction: run_PointerArithmetics, tags: [.validation, .api]),
+  BenchmarkInfo(name: "PointerArithmetics",
+  runFunction: run_PointerArithmetics,
+  tags: [.validation, .api],
+  legacyFactor: 100),
 ]
 
 @inline(never)
@@ -23,7 +26,7 @@ public func run_PointerArithmetics(_ N: Int) {
   var c = 0
   withUnsafePointer(to: &numbers) {
     $0.withMemoryRebound(to: Int.self, capacity: 10) { ptr in
-      for _ in 1...N*10_000_000 {
+      for _ in 1...N*100_000 {
         c += (ptr + getInt(10) - getInt(5)).pointee
       }
     }

--- a/benchmark/single-source/PopFront.swift
+++ b/benchmark/single-source/PopFront.swift
@@ -13,19 +13,23 @@
 import TestsUtils
 
 public let PopFront = [
-  BenchmarkInfo(name: "PopFrontArray", runFunction: run_PopFrontArray, tags: [.validation, .api, .Array]),
-  BenchmarkInfo(name: "PopFrontUnsafePointer", runFunction: run_PopFrontUnsafePointer, tags: [.validation, .api]),
+  BenchmarkInfo(name: "PopFrontArray",
+    runFunction: run_PopFrontArray,
+    tags: [.validation, .api, .Array],
+    legacyFactor: 20),
+  BenchmarkInfo(name: "PopFrontUnsafePointer",
+    runFunction: run_PopFrontUnsafePointer,
+    tags: [.validation, .api],
+    legacyFactor: 100),
 ]
 
-let reps = 1
 let arrayCount = 1024
 
 @inline(never)
 public func run_PopFrontArray(_ N: Int) {
   let orig = Array(repeating: 1, count: arrayCount)
   var a = [Int]()
-  for _ in 1...20*N {
-    for _ in 1...reps {
+  for _ in 1...N {
       var result = 0
       a.append(contentsOf: orig)
       while a.count != 0 {
@@ -33,7 +37,6 @@ public func run_PopFrontArray(_ N: Int) {
         a.remove(at: 0)
       }
       CheckResults(result == arrayCount)
-    }
   }
 }
 
@@ -41,8 +44,7 @@ public func run_PopFrontArray(_ N: Int) {
 public func run_PopFrontUnsafePointer(_ N: Int) {
   var orig = Array(repeating: 1, count: arrayCount)
   let a = UnsafeMutablePointer<Int>.allocate(capacity: arrayCount)
-  for _ in 1...100*N {
-    for _ in 1...reps {
+  for _ in 1...N {
       for i in 0..<arrayCount {
         a[i] = orig[i]
       }
@@ -54,8 +56,6 @@ public func run_PopFrontUnsafePointer(_ N: Int) {
         count -= 1
       }
       CheckResults(result == arrayCount)
-    }
   }
   a.deallocate()
 }
-

--- a/benchmark/single-source/PopFrontGeneric.swift
+++ b/benchmark/single-source/PopFrontGeneric.swift
@@ -15,9 +15,9 @@ import TestsUtils
 public let PopFrontArrayGeneric = BenchmarkInfo(
   name: "PopFrontArrayGeneric",
   runFunction: run_PopFrontArrayGeneric,
-  tags: [.validation, .api, .Array])
+  tags: [.validation, .api, .Array],
+  legacyFactor: 20)
 
-let reps = 1
 let arrayCount = 1024
 
 // This test case exposes rdar://17440222 which caused rdar://17974483 (popFront
@@ -50,8 +50,7 @@ func myArrayReplace<
 public func run_PopFrontArrayGeneric(_ N: Int) {
   let orig = Array(repeating: 1, count: arrayCount)
   var a = [Int]()
-  for _ in 1...20*N {
-    for _ in 1...reps {
+  for _ in 1...N {
       var result = 0
       a.append(contentsOf: orig)
       while a.count != 0 {
@@ -59,6 +58,5 @@ public func run_PopFrontArrayGeneric(_ N: Int) {
         myArrayReplace(&a, 0..<1, EmptyCollection())
       }
       CheckResults(result == arrayCount)
-    }
   }
 }

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -25,7 +25,8 @@ import TestsUtils
 public let Prims = BenchmarkInfo(
   name: "Prims",
   runFunction: run_Prims,
-  tags: [.validation, .algorithm])
+  tags: [.validation, .algorithm],
+  legacyFactor: 5)
 
 class PriorityQueue {
   final var heap: Array<EdgeCost>
@@ -219,7 +220,7 @@ func Prims(_ graph : Array<GraphNode>, _ fun : (Int, Int) -> Double) -> Array<In
 
 @inline(never)
 public func run_Prims(_ N: Int) {
-  for _ in 1...5*N {
+  for _ in 1...N {
     let nodes : [Int] = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
       13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
       29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,

--- a/benchmark/single-source/Queue.swift
+++ b/benchmark/single-source/Queue.swift
@@ -17,15 +17,15 @@ public let QueueGeneric = BenchmarkInfo(
   runFunction: run_QueueGeneric,
   tags: [.validation, .api],
   setUpFunction: { buildWorkload() },
-  tearDownFunction: nil)
+  legacyFactor: 10)
 
 public let QueueConcrete = BenchmarkInfo(
   name: "QueueConcrete",
   runFunction: run_QueueConcrete,
   tags: [.validation, .api],
   setUpFunction: { buildWorkload() },
-  tearDownFunction: nil)
- 
+  legacyFactor: 10)
+
 // TODO: remove when there is a native equivalent in the std lib
 extension RangeReplaceableCollection where Self: BidirectionalCollection {
   public mutating func popLast() -> Element? {
@@ -40,14 +40,14 @@ where Storage: BidirectionalCollection {
 
   internal var _in: Storage
   internal var _out: Storage
-  
+
   public init() {
     _in = Storage()
     _out = Storage()
   }
 }
 
-extension Queue {  
+extension Queue {
   public mutating func enqueue(_ newElement: Element) {
     _in.append(newElement)
   }
@@ -72,7 +72,7 @@ where Elements.Element: Equatable {
   CheckResults(j == elements.count*2)
 }
 
-let n = 10_000
+let n = 1_000
 let workload = (0..<n).map { "\($0): A long enough string to defeat the SSO, or so I hope." }
 
 public func buildWorkload() {
@@ -90,14 +90,14 @@ func run_QueueGeneric(_ scale: Int) {
 public struct ConcreteQueue {
   internal var _in: [String]
   internal var _out: [String]
-  
+
   public init() {
     _in = Array()
     _out = Array()
   }
 }
 
-extension ConcreteQueue {  
+extension ConcreteQueue {
   public mutating func enqueue(_ newElement: String) {
     _in.append(newElement)
   }
@@ -128,4 +128,3 @@ func run_QueueConcrete(_ scale: Int) {
     testConcreteQueue(elements: workload)
   }
 }
-

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -19,14 +19,20 @@ import Foundation
 import TestsUtils
 
 public let RGBHistogram = [
-  BenchmarkInfo(name: "RGBHistogram", runFunction: run_RGBHistogram, tags: [.validation, .algorithm]),
-  BenchmarkInfo(name: "RGBHistogramOfObjects", runFunction: run_RGBHistogramOfObjects, tags: [.validation, .algorithm]),
+  BenchmarkInfo(name: "RGBHistogram",
+    runFunction: run_RGBHistogram,
+    tags: [.validation, .algorithm],
+    legacyFactor: 10),
+  BenchmarkInfo(name: "RGBHistogramOfObjects",
+    runFunction: run_RGBHistogramOfObjects,
+    tags: [.validation, .algorithm],
+    legacyFactor: 100),
 ]
 
 @inline(never)
 public func run_RGBHistogram(_ N: Int) {
     var histogram = [(key: rrggbb_t, value: Int)]()
-    for _ in 1...100*N {
+    for _ in 1...10*N {
         histogram = createSortedSparseRGBHistogram(samples)
         if !isCorrectHistogram(histogram) {
             break
@@ -164,7 +170,7 @@ func createSortedSparseRGBHistogramOfObjects<S : Sequence>(
 @inline(never)
 public func run_RGBHistogramOfObjects(_ N: Int) {
     var histogram = [(key: Box<rrggbb_t>, value: Box<Int>)]()
-    for _ in 1...100*N {
+    for _ in 1...N {
         histogram = createSortedSparseRGBHistogramOfObjects(samples)
         if !isCorrectHistogramOfObjects(histogram) {
             break
@@ -172,5 +178,3 @@ public func run_RGBHistogramOfObjects(_ N: Int) {
     }
     CheckResults(isCorrectHistogramOfObjects(histogram))
 }
-
-

--- a/benchmark/single-source/RandomShuffle.swift
+++ b/benchmark/single-source/RandomShuffle.swift
@@ -19,11 +19,9 @@ import TestsUtils
 
 public let RandomShuffle = [
   BenchmarkInfo(name: "RandomShuffleDef2", runFunction: run_RandomShuffleDef,
-    tags: [.api],
-    setUpFunction: { blackHole(numbersDef) }),
+    tags: [.api], setUpFunction: { blackHole(numbersDef) }, legacyFactor: 4),
   BenchmarkInfo(name: "RandomShuffleLCG2", runFunction: run_RandomShuffleLCG,
-    tags: [.api],
-    setUpFunction: { blackHole(numbersLCG) }),
+    tags: [.api], setUpFunction: { blackHole(numbersLCG) }, legacyFactor: 16),
 ]
 
 /// A linear congruential PRNG.
@@ -41,8 +39,8 @@ struct LCRNG: RandomNumberGenerator {
   }
 }
 
-var numbersDef: [Int] = Array(0...10_000)
-var numbersLCG: [Int] = Array(0...100_000)
+var numbersDef: [Int] = Array(0...2_500)
+var numbersLCG: [Int] = Array(0...6_250)
 
 @inline(never)
 public func run_RandomShuffleDef(_ N: Int) {

--- a/benchmark/single-source/RandomValues.swift
+++ b/benchmark/single-source/RandomValues.swift
@@ -19,21 +19,25 @@ import TestsUtils
 //
 
 public let RandomValues = [
-  BenchmarkInfo(name: "RandomIntegersDef", runFunction: run_RandomIntegersDef, tags: [.api]),
-  BenchmarkInfo(name: "RandomIntegersLCG", runFunction: run_RandomIntegersLCG, tags: [.api]),
-  BenchmarkInfo(name: "RandomDoubleDef", runFunction: run_RandomDoubleDef, tags: [.api]),
-  BenchmarkInfo(name: "RandomDoubleLCG", runFunction: run_RandomDoubleLCG, tags: [.api]),
+  BenchmarkInfo(name: "RandomIntegersDef", runFunction: run_RandomIntegersDef,
+    tags: [.api], legacyFactor: 100),
+  BenchmarkInfo(name: "RandomIntegersLCG", runFunction: run_RandomIntegersLCG,
+    tags: [.api]),
+  BenchmarkInfo(name: "RandomDoubleDef", runFunction: run_RandomDoubleDef,
+    tags: [.api], legacyFactor: 100),
+  BenchmarkInfo(name: "RandomDoubleLCG", runFunction: run_RandomDoubleLCG,
+    tags: [.api], legacyFactor: 2),
 ]
 
 /// A linear congruential PRNG.
 struct LCRNG: RandomNumberGenerator {
   private var state: UInt64
-  
+
   init(seed: Int) {
     state = UInt64(truncatingIfNeeded: seed)
     for _ in 0..<10 { _ = next() }
   }
-  
+
   mutating func next() -> UInt64 {
     state = 2862933555777941757 &* state &+ 3037000493
     return state
@@ -44,7 +48,7 @@ struct LCRNG: RandomNumberGenerator {
 public func run_RandomIntegersDef(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 1_000 {
       x &+= Int.random(in: 0...10_000)
     }
     blackHole(x)
@@ -67,7 +71,7 @@ public func run_RandomIntegersLCG(_ N: Int) {
 public func run_RandomDoubleDef(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0.0
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 1_000 {
       x += Double.random(in: -1000...1000)
     }
     blackHole(x)
@@ -79,7 +83,7 @@ public func run_RandomDoubleLCG(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0.0
     var generator = LCRNG(seed: 0)
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 50_000 {
       x += Double.random(in: -1000...1000, using: &generator)
     }
     blackHole(x)

--- a/benchmark/single-source/RangeReplaceableCollectionPlusDefault.swift
+++ b/benchmark/single-source/RangeReplaceableCollectionPlusDefault.swift
@@ -7,7 +7,8 @@ import TestsUtils
 public var RangeReplaceableCollectionPlusDefault = BenchmarkInfo(
   name: "RangeReplaceableCollectionPlusDefault",
   runFunction: run_RangeReplaceableCollectionPlusDefault,
-  tags: [.validation]
+  tags: [.validation],
+  legacyFactor: 4
 )
 
 @inline(never)
@@ -18,7 +19,7 @@ public func run_RangeReplaceableCollectionPlusDefault(_ N: Int) {
   var a = [Int]()
   var b = [Int]()
 
-  for _ in 1...1000*N {
+  for _ in 1...250*N {
     let a2: Array = mapSome(strings, toInt)
     let b2 = mapSome(strings, toInt)
     a = a2

--- a/benchmark/single-source/ReduceInto.swift
+++ b/benchmark/single-source/ReduceInto.swift
@@ -14,7 +14,7 @@ import TestsUtils
 import Foundation
 
 public let ReduceInto = [
-  BenchmarkInfo(name: "FilterEvenUsingReduce", runFunction: run_FilterEvenUsingReduce, tags: [.validation, .api]),
+  BenchmarkInfo(name: "FilterEvenUsingReduce", runFunction: run_FilterEvenUsingReduce, tags: [.validation, .api], legacyFactor: 10),
   BenchmarkInfo(name: "FilterEvenUsingReduceInto", runFunction: run_FilterEvenUsingReduceInto, tags: [.validation, .api]),
   BenchmarkInfo(name: "FrequenciesUsingReduce", runFunction: run_FrequenciesUsingReduce, tags: [.validation, .api]),
   BenchmarkInfo(name: "FrequenciesUsingReduceInto", runFunction: run_FrequenciesUsingReduceInto, tags: [.validation, .api]),
@@ -27,7 +27,7 @@ public let ReduceInto = [
 @inline(never)
 public func run_SumUsingReduce(_ N: Int) {
   let numbers = [Int](0..<1000)
-  
+
   var c = 0
   for _ in 1...N*1000 {
     c = c &+ numbers.reduce(0) { (acc: Int, num: Int) -> Int in
@@ -40,7 +40,7 @@ public func run_SumUsingReduce(_ N: Int) {
 @inline(never)
 public func run_SumUsingReduceInto(_ N: Int) {
   let numbers = [Int](0..<1000)
-  
+
   var c = 0
   for _ in 1...N*1000 {
     c = c &+ numbers.reduce(into: 0) { (acc: inout Int, num: Int) in
@@ -55,9 +55,9 @@ public func run_SumUsingReduceInto(_ N: Int) {
 @inline(never)
 public func run_FilterEvenUsingReduce(_ N: Int) {
   let numbers = [Int](0..<100)
-  
+
   var c = 0
-  for _ in 1...N*100 {
+  for _ in 1...N*10 {
     let a = numbers.reduce([]) { (acc: [Int], num: Int) -> [Int] in
       var a = acc
       if num % 2 == 0 {
@@ -73,7 +73,7 @@ public func run_FilterEvenUsingReduce(_ N: Int) {
 @inline(never)
 public func run_FilterEvenUsingReduceInto(_ N: Int) {
   let numbers = [Int](0..<100)
-  
+
   var c = 0
   for _ in 1...N*100 {
     let a = numbers.reduce(into: []) { (acc: inout [Int], num: Int) in
@@ -91,7 +91,7 @@ public func run_FilterEvenUsingReduceInto(_ N: Int) {
 @inline(never)
 public func run_FrequenciesUsingReduce(_ N: Int) {
   let s = "thequickbrownfoxjumpsoverthelazydogusingasmanycharacteraspossible123456789"
-  
+
   var c = 0
   for _ in 1...N*100 {
     let a = s.reduce([:]) {
@@ -108,7 +108,7 @@ public func run_FrequenciesUsingReduce(_ N: Int) {
 @inline(never)
 public func run_FrequenciesUsingReduceInto(_ N: Int) {
   let s = "thequickbrownfoxjumpsoverthelazydogusingasmanycharacteraspossible123456789"
-  
+
   var c = 0
   for _ in 1...N*100 {
     let a = s.reduce(into: [:]) {


### PR DESCRIPTION
This PR follows-up  #20861, #21413, #21516 and #21794. It's a next batch of benchmark clean-up to enable [robust performance measurements](https://forums.swift.org/t/towards-robust-performance-measurement/11490) by adjusting workloads to run in reasonable time (< 1000 μs), minimizing the accumulated error. To maintain long-term performance tracking, it applies [legacy factor](https://github.com/apple/swift/pull/20212) where necessary.

This one's without a unifying theme, just trodding down the alphabet, skipping over troublemakers.