### PR TITLE
fixed small String comparison for big_endian

### DIFF
--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -33,10 +33,10 @@ internal func _stringCompareWithSmolCheck(
 
     if lhsRaw.0 != rhsRaw.0 {
       return _lexicographicalCompare(
-        lhsRaw.0.byteSwapped, rhsRaw.0.byteSwapped, expecting: expecting)
+        lhsRaw.0.bigEndian, rhsRaw.0.bigEndian, expecting: expecting)
     }
     return _lexicographicalCompare(
-      lhsRaw.1.byteSwapped, rhsRaw.1.byteSwapped, expecting: expecting)
+      lhsRaw.1.bigEndian, rhsRaw.1.bigEndian, expecting: expecting)
   }
 
   return _stringCompareInternal(lhs, rhs, expecting: expecting)


### PR DESCRIPTION
<!-- What's in this pull request? -->
When debugging the the test case `stdlib/Algorithm.swift`, it is found that there is an issue on small string comparison on big_endian platform. A small string is represented by two UInt64s in `.littleEndian`,  for example,  `"ab"`  memory layout on little_endian platform is:
```
0x7fffffffcd80: 0x61 0x62 0x00 0x00 0x00 0x00 0x00 0x00   
0x7fffffffcd88: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0xe2
```
When it is used as an UInt64 to compare, the order of each character is reverse of the actual string order.  so it does need to `byteSwapped`  on little_endian before comparison.   
However on big_endian platform it is shown as:
```
0x3ffffffd0a0: 0x00 0x00 0x00 0x00 0x00 0x00 0x62 0x61
0x3ffffffd0a8: 0xe2 0x00 0x00 0x00 0x00 0x00 0x00 0x00
```
The order is the same as the actual string order when it is taken as UInt64, so  it does not need `byteSwapped`

To work on both platforms,  updating  from `byteSwapped` to `bigEndian`
