### PR TITLE
[stdlib] Remove _HasContiguousBytes

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSStringAPI.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringAPI.swift
@@ -396,9 +396,7 @@ extension String {
   /// Unicode characters using a given `encoding`.
   public init?(data: __shared Data, encoding: Encoding) {
     if encoding == .utf8,
-       let str = data.withUnsafeBytes({
-         String._tryFromUTF8($0.bindMemory(to: UInt8.self))
-    }) {
+       let str = data.withUnsafeBytes(String._tryFromUTF8) {
       self = str
       return
     }

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -115,7 +115,7 @@ internal func _assertionFailure(
 ) -> Never {
   prefix.withUTF8Buffer {
     (prefix) -> Void in
-    message._withUnsafeBufferPointerToUTF8 {
+    message._withUTF8 {
       (messageUTF8) -> Void in
       file.withUTF8Buffer {
         (file) -> Void in
@@ -145,7 +145,7 @@ internal func _assertionFailure(
 ) -> Never {
   prefix.withUTF8Buffer {
     (prefix) -> Void in
-    message._withUnsafeBufferPointerToUTF8 {
+    message._withUTF8 {
       (messageUTF8) -> Void in
       _swift_stdlib_reportFatalError(
         prefix.baseAddress!, CInt(prefix.count),

--- a/stdlib/public/core/ContiguouslyStored.swift
+++ b/stdlib/public/core/ContiguouslyStored.swift
@@ -73,11 +73,7 @@ extension UnsafeMutableRawBufferPointer: _HasContiguousBytes {
     return try body(UnsafeRawBufferPointer(self))
   }
 }
-extension String: _HasContiguousBytes {
-  @inlinable
-  internal var _providesContiguousBytesNoCopy: Bool {
-    @inline(__always) get { return self._guts.isFastUTF8 }
-  }
+extension String {
 
   @inlinable @inline(__always)
   internal func _withUTF8<R>(
@@ -93,20 +89,9 @@ extension String: _HasContiguousBytes {
       try body($0)
     }
   }
-
-  @inlinable @inline(__always)
-  internal func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    return try self._withUTF8 { return try body(UnsafeRawBufferPointer($0)) }
-  }
 }
-extension Substring: _HasContiguousBytes {
-  @inlinable
-  internal var _providesContiguousBytesNoCopy: Bool {
-    @inline(__always) get { return self._wholeGuts.isFastUTF8 }
-  }
-
+extension Substring {
+  
   @inlinable @inline(__always)
   internal func _withUTF8<R>(
     _ body: (UnsafeBufferPointer<UInt8>) throws -> R
@@ -120,12 +105,5 @@ extension Substring: _HasContiguousBytes {
     return try ContiguousArray(self.utf8).withUnsafeBufferPointer {
       try body($0)
     }
-  }
-
-  @inlinable @inline(__always)
-  internal func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    return try self._withUTF8 { return try body(UnsafeRawBufferPointer($0)) }
   }
 }

--- a/stdlib/public/core/ContiguouslyStored.swift
+++ b/stdlib/public/core/ContiguouslyStored.swift
@@ -10,69 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@usableFromInline
-internal protocol _HasContiguousBytes {
-  func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R
-
-  var _providesContiguousBytesNoCopy: Bool { get }
-}
-extension _HasContiguousBytes {
-  @inlinable
-  var _providesContiguousBytesNoCopy: Bool {
-    @inline(__always) get { return true }
-  }
-}
-extension Array: _HasContiguousBytes {
-  @inlinable
-  var _providesContiguousBytesNoCopy: Bool {
-    @inline(__always) get {
-#if _runtime(_ObjC)
-      return _buffer._isNative
-#else
-      return true
-#endif
-    }
-  }
-}
-extension ContiguousArray: _HasContiguousBytes {}
-extension UnsafeBufferPointer: _HasContiguousBytes {
-  @inlinable @inline(__always)
-  func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    let ptr = UnsafeRawPointer(self.baseAddress._unsafelyUnwrappedUnchecked)
-    let len = self.count &* MemoryLayout<Element>.stride
-    return try body(UnsafeRawBufferPointer(start: ptr, count: len))
-  }
-}
-extension UnsafeMutableBufferPointer: _HasContiguousBytes {
-  @inlinable @inline(__always)
-  func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    let ptr = UnsafeRawPointer(self.baseAddress._unsafelyUnwrappedUnchecked)
-    let len = self.count &* MemoryLayout<Element>.stride
-    return try body(UnsafeRawBufferPointer(start: ptr, count: len))
-  }
-}
-extension UnsafeRawBufferPointer: _HasContiguousBytes {
-  @inlinable @inline(__always)
-  func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    return try body(self)
-  }
-}
-extension UnsafeMutableRawBufferPointer: _HasContiguousBytes {
-  @inlinable @inline(__always)
-  func withUnsafeBytes<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    return try body(UnsafeRawBufferPointer(self))
-  }
-}
 extension String {
 
   @inlinable @inline(__always)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -366,6 +366,10 @@ public protocol Sequence {
   func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R?  
+
+  func _withRawContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R?  
 }
 
 // Provides a default associated type witness for Iterator when the
@@ -1111,6 +1115,15 @@ extension Sequence {
   ) rethrows -> R? {
     return nil
   }  
+  
+  @inlinable
+  public func _withRawContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R?  {
+    return try withContiguousStorageIfAvailable { 
+      try body(UnsafeRawBufferPointer($0)) 
+    }
+  }
 }
 
 // FIXME(ABI)#182

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -241,7 +241,7 @@ extension _SmallString {
 
   // Direct from UTF-8
   @inlinable @inline(__always)
-  internal init?(_ input: UnsafeBufferPointer<UInt8>) {
+  internal init?(_ input: UnsafeRawBufferPointer) {
     let count = input.count
     guard count <= _SmallString.capacity else { return nil }
 
@@ -252,6 +252,11 @@ extension _SmallString {
     let trailing = count > 8 ? _bytesToUInt64(ptr + 8, count &- 8) : 0
 
     self.init(leading: leading, trailing: trailing, count: count)
+  }
+
+  @inlinable @inline(__always)
+  internal init?(_ input: UnsafeBufferPointer<UInt8>) {
+    self.init(UnsafeRawBufferPointer(input))
   }
 
   @usableFromInline // @testable
@@ -319,7 +324,7 @@ extension UInt64 {
 
 @inlinable @inline(__always)
 internal func _bytesToUInt64(
-  _ input: UnsafePointer<UInt8>,
+  _ input: UnsafeRawPointer,
   _ c: Int
 ) -> UInt64 {
   // FIXME: This should be unified with _loadPartialUnalignedUInt64LE.
@@ -328,7 +333,7 @@ internal func _bytesToUInt64(
   var r: UInt64 = 0
   var shift: Int = 0
   for idx in 0..<c {
-    r = r | (UInt64(input[idx]) &<< shift)
+    r = r | (UInt64(input.load(fromByteOffset: idx, as: UInt8.self)) &<< shift)
     shift = shift &+ 8
   }
   return r

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -405,12 +405,8 @@ extension String {
        sourceEncoding == UTF8.self,
        contigBytes._providesContiguousBytesNoCopy
     {
-      self = contigBytes.withUnsafeBytes { rawBufPtr in
-        let ptr = rawBufPtr.baseAddress._unsafelyUnwrappedUnchecked
-        return String._fromUTF8Repairing(
-          UnsafeBufferPointer(
-            start: ptr.assumingMemoryBound(to: UInt8.self),
-            count: rawBufPtr.count)).0
+      self = contigBytes.withUnsafeBytes { rawBufPtr -> String in
+        return String._fromUTF8Repairing(rawBufPtr).0
       }
       return
     }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -401,13 +401,11 @@ extension String {
   public init<C: Collection, Encoding: Unicode.Encoding>(
     decoding codeUnits: C, as sourceEncoding: Encoding.Type
   ) where C.Iterator.Element == Encoding.CodeUnit {
-    if let contigBytes = codeUnits as? _HasContiguousBytes,
-       sourceEncoding == UTF8.self,
-       contigBytes._providesContiguousBytesNoCopy
-    {
-      self = contigBytes.withUnsafeBytes { rawBufPtr -> String in
-        return String._fromUTF8Repairing(rawBufPtr).0
-      }
+    if sourceEncoding == UTF8.self,
+      let str = codeUnits._withRawContiguousStorageIfAvailable({
+        buf -> String in String._fromUTF8Repairing(buf).0
+      }) {
+      self = str
       return
     }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -320,4 +320,3 @@ func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
   }
   return result
 }
-

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -186,6 +186,12 @@ extension _StringGuts {
   internal mutating func appendInPlace(
     _ other: UnsafeBufferPointer<UInt8>, isASCII: Bool
   ) {
+    self.appendInPlace(UnsafeRawBufferPointer(other), isASCII: isASCII)
+  }
+
+  internal mutating func appendInPlace(
+    _ other: UnsafeRawBufferPointer, isASCII: Bool
+  ) {
     self._object.nativeStorage.appendInPlace(other, isASCII: isASCII)
 
     // We re-initialize from the modified storage to pick up new count, flags,
@@ -315,4 +321,3 @@ extension _StringGuts {
     self = _StringGuts(_object.nativeStorage)
   }
 }
-

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -393,7 +393,7 @@ extension __StringStorage {
 
   @_effects(releasenone)
   internal static func create(
-    initializingFrom bufPtr: UnsafeBufferPointer<UInt8>,
+    initializingFrom bufPtr: UnsafeRawBufferPointer,
     capacity: Int,
     isASCII: Bool
   ) -> __StringStorage {
@@ -403,9 +403,30 @@ extension __StringStorage {
     let storage = __StringStorage.create(
       capacity: capacity, countAndFlags: countAndFlags)
     let addr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
-    storage.mutableStart.initialize(from: addr, count: bufPtr.count)
+    UnsafeMutableRawPointer(storage.mutableStart)
+      .copyMemory(from: addr, byteCount: bufPtr.count)
     storage._invariantCheck()
     return storage
+  }
+
+  @_effects(releasenone)
+  internal static func create(
+    initializingFrom bufPtr: UnsafeRawBufferPointer, isASCII: Bool
+  ) -> __StringStorage {
+    return __StringStorage.create(
+      initializingFrom: bufPtr, capacity: bufPtr.count, isASCII: isASCII)
+  }
+
+  @_effects(releasenone)
+  internal static func create(
+    initializingFrom bufPtr: UnsafeBufferPointer<UInt8>,
+    capacity: Int,
+    isASCII: Bool
+  ) -> __StringStorage {
+    return __StringStorage.create(
+      initializingFrom: UnsafeRawBufferPointer(bufPtr), capacity: capacity,
+      isASCII: isASCII
+    )
   }
 
   @_effects(releasenone)
@@ -413,7 +434,7 @@ extension __StringStorage {
     initializingFrom bufPtr: UnsafeBufferPointer<UInt8>, isASCII: Bool
   ) -> __StringStorage {
     return __StringStorage.create(
-      initializingFrom: bufPtr, capacity: bufPtr.count, isASCII: isASCII)
+      initializingFrom: UnsafeRawBufferPointer(bufPtr), isASCII: isASCII)
   }
 }
 
@@ -538,12 +559,13 @@ extension __StringStorage {
 
   @_effects(releasenone)
   internal func appendInPlace(
-    _ other: UnsafeBufferPointer<UInt8>, isASCII: Bool
+    _ other: UnsafeRawBufferPointer, isASCII: Bool
   ) {
     _internalInvariant(self.capacity >= other.count)
     let srcAddr = other.baseAddress._unsafelyUnwrappedUnchecked
     let srcCount = other.count
-    self.mutableEnd.initialize(from: srcAddr, count: srcCount)
+    UnsafeMutableRawPointer(self.mutableEnd)
+      .copyMemory(from: srcAddr, byteCount: srcCount)
     _postAppendAdjust(appendedCount: srcCount, appendedIsASCII: isASCII)
   }
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -145,6 +145,17 @@ extension Unsafe${Mutable}RawBufferPointer: Sequence {
   public func makeIterator() -> Iterator {
     return Iterator(_position: _position, _end: _end)
   }
+
+  @inlinable @inline(__always)
+  public func _withRawContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R? {
+% if not mutable:
+      return try body(self)
+% else:
+      return try body(UnsafeRawBufferPointer(self))
+% end
+  }
 }
 
 extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -95,3 +95,4 @@ Struct String has removed conformance to _HasContiguousBytes
 Struct Substring has removed conformance to _HasContiguousBytes
 Var String._providesContiguousBytesNoCopy has been removed
 Var Substring._providesContiguousBytesNoCopy has been removed
+Func Sequence._withRawContiguousStorageIfAvailable(_:) has been added as a protocol requirement

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -85,3 +85,6 @@ Subscript String.UnicodeScalarView.subscript(_:) has been removed
 Subscript Substring.subscript(_:) has been removed
 
 Func Collection.makeIterator() has self access kind changing from NonMutating to __Consuming
+
+Func String._uncheckedFromUTF8(_:isASCII:) has parameter 0 type change from UnsafeBufferPointer<UInt8> to UnsafeRawBufferPointer
+Func _bytesToUInt64(_:_:) has parameter 0 type change from UnsafePointer<UInt8> to UnsafeRawPointer

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -86,5 +86,12 @@ Subscript Substring.subscript(_:) has been removed
 
 Func Collection.makeIterator() has self access kind changing from NonMutating to __Consuming
 
-Func String._uncheckedFromUTF8(_:isASCII:) has parameter 0 type change from UnsafeBufferPointer<UInt8> to UnsafeRawBufferPointer
+Func String._uncheckedFromUTF8(_:isASCII:) has been removed
 Func _bytesToUInt64(_:_:) has parameter 0 type change from UnsafePointer<UInt8> to UnsafeRawPointer
+Func String._uncheckedFromUTF8(_:asciiPreScanResult:) has been removed
+Func String.withUnsafeBytes(_:) has been removed
+Func Substring.withUnsafeBytes(_:) has been removed
+Struct String has removed conformance to _HasContiguousBytes
+Struct Substring has removed conformance to _HasContiguousBytes
+Var String._providesContiguousBytesNoCopy has been removed
+Var Substring._providesContiguousBytesNoCopy has been removed

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -96,3 +96,11 @@ Struct Substring has removed conformance to _HasContiguousBytes
 Var String._providesContiguousBytesNoCopy has been removed
 Var Substring._providesContiguousBytesNoCopy has been removed
 Func Sequence._withRawContiguousStorageIfAvailable(_:) has been added as a protocol requirement
+Func UnsafeBufferPointer.withUnsafeBytes(_:) has been removed
+Func UnsafeMutableBufferPointer.withUnsafeBytes(_:) has been removed
+Protocol _HasContiguousBytes has been removed
+Struct Array has removed conformance to _HasContiguousBytes
+Struct ContiguousArray has removed conformance to _HasContiguousBytes
+Struct UnsafeBufferPointer has removed conformance to _HasContiguousBytes
+Struct UnsafeMutableBufferPointer has removed conformance to _HasContiguousBytes
+Var Array._providesContiguousBytesNoCopy has been removed


### PR DESCRIPTION
`_HasContiguousBytes` is from the early UTF8 String work and is only used by a single fast-path on a single initialiser which effectively constrains the collection to contain `UInt8`s anyway. This means that `String` and `Substring`s conformances are redundant. Since it isn't adding anything significant, it would be nice to remove this protocol from ABI.

The only thing which [SE-237](https://github.com/apple/swift-evolution/blob/master/proposals/0237-contiguous-collection.md) doesn't include is `_providesContiguousBytesNoCopy`, which is only customised by bridged Arrays. If that's worth keeping, it's probably worth moving up to `Sequence` (and if time, probably worth making public as an extension to SE-237).

@milseman 