### PR TITLE
[AutoDiff] Tweak `Differentiable` associated struct synthesis.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -951,8 +951,8 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
   }
 
   // Otherwise, check if all stored properties have all `Differentiable`
-  // protocol associated types equal to `Self`:
-  // `Self == TangentVector == CotangentVector == AllDifferentiableVariables`.
+  // protocol associated types equal to each other:
+  // `TangentVector == CotangentVector == AllDifferentiableVariables`.
   bool allMembersAssocTypesEqualsSelf =
       llvm::all_of(diffProperties, [&](VarDecl *member) {
         auto tangentType =
@@ -961,9 +961,8 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
             getAssociatedType(member, nominal, C.Id_CotangentVector);
         auto allDiffableVarsType =
             getAssociatedType(member, nominal, C.Id_AllDifferentiableVariables);
-        return member->getType()->isEqual(tangentType) &&
-               member->getType()->isEqual(cotangentType) &&
-               member->getType()->isEqual(allDiffableVarsType);
+        return tangentType->isEqual(cotangentType) &&
+            tangentType->isEqual(allDiffableVarsType);
       });
 
   // If the following conditions hold:

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -87,6 +87,10 @@ _ = pullback(at: Nested(simple: simple, mixed: mixed, generic: genericSame)) { m
   model.simple + model.simple
 }
 
+// Verify that a `Differentiable` type upholds `AllDifferentiableVariables == CotangentVector`.
+func checkAllDifferentiableVariablesEqualsCotangentVector<T>(_: T.Type)
+  where T : Differentiable, T.AllDifferentiableVariables == T.CotangentVector {}
+
 // Test type that does not conform to `AdditiveArithmetic` but whose members do.
 // Thus, `Self` cannot be used as `TangentVector` or `CotangentVector`.
 // Vector space structs types must be synthesized.
@@ -96,6 +100,7 @@ struct AllMembersAdditiveArithmetic : Differentiable {
   var w: Float
   var b: Float
 }
+checkAllDifferentiableVariablesEqualsCotangentVector(AllMembersAdditiveArithmetic.self)
 
 // Test type `AllMembersVectorNumeric` whose members conforms to `VectorNumeric`,
 // in which case we should make `TangentVector` and `CotangentVector` conform to
@@ -126,6 +131,7 @@ struct DifferentiableSubset : Differentiable {
   @noDerivative var flag: Bool
   @noDerivative let technicallyDifferentiable: Float = .pi
 }
+checkAllDifferentiableVariablesEqualsCotangentVector(DifferentiableSubset.self)
 let tangentSubset = DifferentiableSubset.TangentVector(w: 1, b: 1)
 let cotangentSubset = DifferentiableSubset.CotangentVector(w: 1, b: 1)
 let allDiffVarsSubset = DifferentiableSubset.AllDifferentiableVariables(w: 1, b: 1)
@@ -140,6 +146,7 @@ struct NestedDifferentiableSubset : Differentiable {
   var mixed: Mixed
   @noDerivative var technicallyDifferentiable: Float
 }
+checkAllDifferentiableVariablesEqualsCotangentVector(NestedDifferentiableSubset.self)
 
 // Test type that uses synthesized vector space types but provides custom
 // method.


### PR DESCRIPTION
Relax condition for synthesizing `AllDifferentiableVariables` struct and
letting `TangentVector` and `CotangentVector` alias it.

Previously, the condition was "all stored properties have
`Self = TangentVector = CotangentVector = AllDifferentiableVariables`".
This is overly restrictive and doesn't support the case where properties
have all associated types equal to one another but `Self != AllDifferentiables`.

This occurs when the stored property type:
- Has any `@noDerivative` properties.
- Doesn't itself conform to `AdditiveArithmetic`.

The precise correct condition is "all stored properties have
`TangentVector = CotangentVector = AllDifferentiableVariables`".

---

Unblocks model development because keypath-based optimizers are
parameterized on a `Model` type where `Model.AllDifferentiableVariables == Model.CotangentVector`.