### PR TITLE
[AutoDiff] Add a differentiation checkpointing API.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -145,6 +145,36 @@ public func differentiableFunction<T, U, R>(
   return original
 }
 
+/// Make a function be recomputed in its pullback, known as "checkpointing" in
+/// traditional automatic differentiation.
+@inlinable
+public func withRecomputationInPullbacks<T, U>(
+  _ body: @escaping @autodiff (T) -> U
+) -> @autodiff (T) -> U where T : Differentiable, U : Differentiable {
+  return differentiableFunction { x in
+    (value: body(x), pullback: { v in pullback(at: x, in: body)(v) })
+  }
+}
+
+// FIXME: The method variant produces a zero cotangent. Need to investigate.
+//
+// public extension Differentiable {
+//   @inlinable
+//   @differentiable(wrt: self, vjp: _vjp_withRecomputationInPullbacks)
+//   func withRecomputationInPullbacks<Result : Differentiable>(
+//     _ body: @escaping @autodiff (Self) -> Result
+//   ) -> Result {
+//     return body(self)
+//   }
+// 
+//   @usableFromInline
+//   internal func _vjp_withRecomputationInPullbacks<Result : Differentiable>(
+//     _ body: @escaping @autodiff (Self) -> Result
+//   ) -> (Result, (Result.CotangentVector) -> CotangentVector) {
+//     return valueWithPullback(in: Swift.withRecomputationInPullbacks(body))
+//   }
+// }
+
 //===----------------------------------------------------------------------===//
 // Method-style differential operators
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -45,4 +45,30 @@ CustomDerivativesTests.test("differentiableFunction-binary") {
   expectEqual((20, 10), gradient(at: 5, 10, in: { diffableBinary($0, $1) * 2 }))
 }
 
+CustomDerivativesTests.test("Checkpointing") {
+  var count = 0
+  func f(_ x: Float) -> Float {
+    count += 1
+    return x * x * x
+  }
+  // Test the top-level function variant of the checkpointing API.
+  expectEqual(324, gradient(at: 3) { (x: Float) -> Float in
+    expectEqual(0, count)
+    let y = withRecomputationInPullbacks(f)(x)
+    expectEqual(1, count)
+    return y * 3 * x
+  })
+  expectEqual(2, count)
+  // Reset and test the method variant.
+  // FIXME: The method variant produces a zero cotangent. Need to investigate.
+  // count = 0
+  // expectEqual(324, gradient(at: 3) { (x: Float) -> Float in
+  //   expectEqual(0, count)
+  //   let y = x.withRecomputationInPullbacks(f)
+  //   expectEqual(1, count)
+  //   return y * 3 * x
+  // })
+  // expectEqual(2, count)
+}
+
 runAllTests()


### PR DESCRIPTION
Add an API that make a function be recomputed in its pullback when needed. This is most useful for reducing memory usage in gradient computation (i.e. reverse-mode differentiation). Our AD semantics allow this to be defined as a library function with zero compiler changes.

```swift
gradient { x in
    withRecomputationInPullbacks(f)(x) + g(x)
}
```

This patch also adds a commented-out method variant. It does not work yet because it requires support for indirect parameters and results.

```swift
// Does not work yet.
gradient { x in
    g(x) + withRecomputationInDerivatives(x) { x in
        h(f(x))
    }
}
```