### PR TITLE
[Sema] Propagate `@_fixed_layout` during `Differentiable` derived con…

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3235,6 +3235,10 @@ public:
   /// Get the memberwise initializer of the nominal type, if it exists.
   ConstructorDecl *getMemberwiseInitializer();
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Add `@_fixed_layout` attribute to the nominal type, if possible.
+  void addFixedLayoutAttr();
+
 private:
   /// Predicate used to filter StoredPropertyRange.
   struct ToStoredProperty {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3048,6 +3048,25 @@ ConstructorDecl *NominalTypeDecl::getMemberwiseInitializer() {
   return memberwiseInitDecl;
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+void NominalTypeDecl::addFixedLayoutAttr() {
+  auto &C = getASTContext();
+  // If nominal already has `@_fixed_layout`, return.
+  if (getAttrs().hasAttribute<FixedLayoutAttr>())
+    return;
+  auto access = getEffectiveAccess();
+  // If nominal does not have at least internal access, return.
+  if (access < AccessLevel::Internal)
+    return;
+  // If nominal is internal, it should have the `@usableFromInline` attribute.
+  if (access == AccessLevel::Internal &&
+      !getAttrs().hasAttribute<UsableFromInlineAttr>()) {
+    getAttrs().add(new (C) UsableFromInlineAttr(/*Implicit*/ true));
+  }
+  // Add `@_fixed_layout` to the nominal.
+  getAttrs().add(new (C) FixedLayoutAttr(/*Implicit*/ true));
+}
+
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,
                                  Identifier name, SourceLoc nameLoc,
                                  MutableArrayRef<TypeLoc> inherited,

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -907,8 +907,9 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
 
   // Since associated types will be derived, we make this struct a fieldwise
   // differentiable type.
-  nominal->getAttrs().add(
-      new (C) FieldwiseDifferentiableAttr(/*implicit*/ true));
+  if (!nominal->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>())
+    nominal->getAttrs().add(
+        new (C) FieldwiseDifferentiableAttr(/*implicit*/ true));
 
   // Get all stored properties for differentation.
   SmallVector<VarDecl *, 16> diffProperties;

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -725,6 +725,11 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     }
   }
 
+  // If nominal type has `@_fixed_layout` attribute, mark associated struct as
+  // `@_fixed_layout` as well.
+  if (nominal->getAttrs().hasAttribute<FixedLayoutAttr>())
+    structDecl->addFixedLayoutAttr();
+
   // The implicit memberwise constructor must be explicitly created so that it
   // can called in `AdditiveArithmetic` and `Differentiable` methods. Normally,
   // the memberwise constructor is synthesized during SILGen, which is too late.


### PR DESCRIPTION
…formances.

During `Differentiable` derived conformances, propagate `@_fixed_layout`
to synthesized associated structs if the nominal struct is marked with
`@_fixed_layout`. This is important for resilience.

Refactor `addFixedLayoutAttr` and move to a common location.

---

Tests omitted because it's difficult to test (`@_fixed_layout` doesn't show up on `-print-ast` or `-emit-silgen`). However, this resilience behavior will be exercised by the TensorFlow high-level APIs that are coming soon.