### PR TITLE
[5.0] Mark another thorough String test as requiring an optimized stdlib

### DIFF
--- a/validation-test/stdlib/StringNormalization.swift
+++ b/validation-test/stdlib/StringNormalization.swift
@@ -21,6 +21,7 @@
 // RUN: %target-run %t/a.out %S/Inputs/NormalizationTest.txt
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: optimized_stdlib
 
 import Swift
 import StdlibUnittest


### PR DESCRIPTION
- **Explanation**: This particular test is taking a pretty long time on simulators, only sometimes making it under the timeout limit. It's a pretty thorough test of string normalization, which means that an unoptimized stdlib is going to take a *long* time to complete it.

- **Scope**: Disables this one test in "unoptimized stdlib" configurations.

- **Issue**: rdar://problem/46736948

- **Risk**: None. Runs a test less often, with the disabled configuration being something we don't ship.

- **Testing**: Passed CI testing on master.

- **Reviewed by**: @milseman  