### PR TITLE
Fix dynamic_replacement test on devices

### DIFF
--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -133,7 +133,7 @@ DynamicallyReplaceable.test("DynamicallyReplaceable") {
 #elseif os(Windows)
         _ = LoadLibraryA(target_library_name("Module2"))
 #else
-	_ = dlopen(target_library_name("Module2"), RTLD_NOW)
+	_ = dlopen(executablePath+target_library_name("Module2"), RTLD_NOW)
 #endif
 	checkExpectedResults(forOriginalLibrary: false)
 }


### PR DESCRIPTION
We need the absolute path to the dylib