### PR TITLE
[Diag] Improve diagnostics for optional unwrapping

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -591,9 +591,10 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
 
   auto *tryExpr = dyn_cast<OptionalTryExpr>(unwrapped);
   if (!tryExpr) {
-    auto resolvedBaseTy = BaseType ? resolveType(BaseType) : BaseType;
+    auto resolvedBaseTy =
+        resolveType(BaseType)->reconstituteSugar(/*recursive=*/true);
     auto resolvedUnwrappedTy =
-        UnwrappedType ? resolveType(UnwrappedType) : UnwrappedType;
+        resolveType(UnwrappedType)->reconstituteSugar(/*recursive=*/true);
     return diagnoseUnwrap(getConstraintSystem(), unwrapped, resolvedBaseTy,
                           resolvedUnwrappedTy);
   }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -480,10 +480,14 @@ public:
 /// Diagnose failures related to use of the unwrapped optional types,
 /// which require some type of force-unwrap e.g. "!" or "try!".
 class MissingOptionalUnwrapFailure final : public FailureDiagnostic {
+  Type BaseType;
+  Type UnwrappedType;
+
 public:
-  MissingOptionalUnwrapFailure(Expr *expr, ConstraintSystem &cs,
-                               ConstraintLocator *locator)
-      : FailureDiagnostic(expr, cs, locator) {}
+  MissingOptionalUnwrapFailure(Expr *expr, ConstraintSystem &cs, Type baseType,
+                               Type unwrappedType, ConstraintLocator *locator)
+      : FailureDiagnostic(expr, cs, locator), BaseType(baseType),
+        UnwrappedType(unwrappedType) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -65,14 +65,16 @@ ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type toType,
 }
 
 bool ForceOptional::diagnose(Expr *root, bool asNote) const {
-  MissingOptionalUnwrapFailure failure(root, getConstraintSystem(),
-                                       getLocator());
+  MissingOptionalUnwrapFailure failure(root, getConstraintSystem(), BaseType,
+                                       UnwrappedType, getLocator());
   return failure.diagnose(asNote);
 }
 
-ForceOptional *ForceOptional::create(ConstraintSystem &cs,
+ForceOptional *ForceOptional::create(ConstraintSystem &cs, Type baseType,
+                                     Type unwrappedType,
                                      ConstraintLocator *locator) {
-  return new (cs.getAllocator()) ForceOptional(cs, locator);
+  return new (cs.getAllocator())
+      ForceOptional(cs, baseType, unwrappedType, locator);
 }
 
 bool UnwrapOptionalBase::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -73,8 +73,9 @@ bool ForceOptional::diagnose(Expr *root, bool asNote) const {
 ForceOptional *ForceOptional::create(ConstraintSystem &cs, Type baseType,
                                      Type unwrappedType,
                                      ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      ForceOptional(cs, baseType, unwrappedType, locator);
+  return new (cs.getAllocator()) ForceOptional(
+      cs, baseType, unwrappedType,
+      cs.getConstraintLocator(simplifyLocatorToAnchor(cs, locator)));
 }
 
 bool UnwrapOptionalBase::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -166,16 +166,21 @@ public:
 
 /// Introduce a '!' to force an optional unwrap.
 class ForceOptional final : public ConstraintFix {
-  ForceOptional(ConstraintSystem &cs, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::ForceOptional, locator) {}
+  Type BaseType;
+  Type UnwrappedType;
+
+  ForceOptional(ConstraintSystem &cs, Type baseType, Type unwrappedType,
+                ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::ForceOptional, locator), BaseType(baseType),
+        UnwrappedType(unwrappedType) {}
 
 public:
   std::string getName() const override { return "force optional"; }
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static ForceOptional *create(ConstraintSystem &cs,
-                               ConstraintLocator *locator);
+  static ForceOptional *create(ConstraintSystem &cs, Type baseType,
+                               Type unwrappedType, ConstraintLocator *locator);
 };
 
 /// Unwrap an optional base when we have a member access.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2390,11 +2390,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           forceUnwrapPossible = false;
         }
       }
-      
 
       if (forceUnwrapPossible) {
-        conversionsOrFixes.push_back(
-            ForceOptional::create(*this, getConstraintLocator(locator)));
+        conversionsOrFixes.push_back(ForceOptional::create(
+            *this, objectType1, objectType1->getOptionalObjectType(),
+            getConstraintLocator(locator)));
       }
     }
 
@@ -2743,7 +2743,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         locator.withPathElement(LocatorPathElt::getGenericArgument(0)),
         subflags);
     if (result == SolutionKind::Solved) {
-      auto *fix = ForceOptional::create(*this, getConstraintLocator(locator));
+      auto *fix = ForceOptional::create(*this, type, optionalObjectType,
+                                        getConstraintLocator(locator));
       if (recordFix(fix)) {
         return SolutionKind::Error;
       }
@@ -2996,6 +2997,7 @@ ConstraintSystem::simplifyFunctionComponentConstraint(
                                         TypeMatchOptions flags,
                                         ConstraintLocatorBuilder locator) {
   auto simplified = simplifyType(first);
+  auto simplifiedCopy = simplified;
 
   unsigned unwrapCount = 0;
   if (shouldAttemptFixes()) {
@@ -3038,7 +3040,9 @@ ConstraintSystem::simplifyFunctionComponentConstraint(
   }
 
   if (unwrapCount > 0) {
-    auto *fix = ForceOptional::create(*this, getConstraintLocator(locator));
+    auto *fix = ForceOptional::create(*this, simplifiedCopy,
+                                      simplifiedCopy->getOptionalObjectType(),
+                                      getConstraintLocator(locator));
     while (unwrapCount-- > 0) {
       if (recordFix(fix))
         return SolutionKind::Error;
@@ -4662,7 +4666,9 @@ ConstraintSystem::simplifyApplicableFnConstraint(
       return SolutionKind::Error;
 
     // Record any fixes we attempted to get to the correct solution.
-    auto *fix = ForceOptional::create(*this, getConstraintLocator(locator));
+    auto *fix = ForceOptional::create(*this, origType2,
+                                      origType2->getOptionalObjectType(),
+                                      getConstraintLocator(locator));
     while (unwrapCount-- > 0) {
       if (recordFix(fix))
         return SolutionKind::Error;
@@ -4685,7 +4691,9 @@ ConstraintSystem::simplifyApplicableFnConstraint(
 
     // Record any fixes we attempted to get to the correct solution.
     if (simplified == SolutionKind::Solved) {
-      auto *fix = ForceOptional::create(*this, getConstraintLocator(locator));
+      auto *fix = ForceOptional::create(*this, origType2,
+                                        origType2->getOptionalObjectType(),
+                                        getConstraintLocator(locator));
       while (unwrapCount-- > 0) {
         if (recordFix(fix))
           return SolutionKind::Error;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2394,7 +2394,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (forceUnwrapPossible) {
         conversionsOrFixes.push_back(ForceOptional::create(
             *this, objectType1, objectType1->getOptionalObjectType(),
-            getConstraintLocator(locator.getAnchor())));
+            getConstraintLocator(locator)));
       }
     }
 
@@ -2744,7 +2744,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         subflags);
     if (result == SolutionKind::Solved) {
       auto *fix = ForceOptional::create(*this, type, optionalObjectType,
-                                        getConstraintLocator(locator.getAnchor()));
+                                        getConstraintLocator(locator));
       if (recordFix(fix)) {
         return SolutionKind::Error;
       }
@@ -3042,7 +3042,7 @@ ConstraintSystem::simplifyFunctionComponentConstraint(
   if (unwrapCount > 0) {
     auto *fix = ForceOptional::create(*this, simplifiedCopy,
                                       simplifiedCopy->getOptionalObjectType(),
-                                      getConstraintLocator(locator.getAnchor()));
+                                      getConstraintLocator(locator));
     while (unwrapCount-- > 0) {
       if (recordFix(fix))
         return SolutionKind::Error;
@@ -4668,7 +4668,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     // Record any fixes we attempted to get to the correct solution.
     auto *fix = ForceOptional::create(*this, origType2,
                                       origType2->getOptionalObjectType(),
-                                      getConstraintLocator(locator.getAnchor()));
+                                      getConstraintLocator(locator));
     while (unwrapCount-- > 0) {
       if (recordFix(fix))
         return SolutionKind::Error;
@@ -4693,7 +4693,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (simplified == SolutionKind::Solved) {
       auto *fix = ForceOptional::create(*this, origType2,
                                         origType2->getOptionalObjectType(),
-                                        getConstraintLocator(locator.getAnchor()));
+                                        getConstraintLocator(locator));
       while (unwrapCount-- > 0) {
         if (recordFix(fix))
           return SolutionKind::Error;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2394,7 +2394,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (forceUnwrapPossible) {
         conversionsOrFixes.push_back(ForceOptional::create(
             *this, objectType1, objectType1->getOptionalObjectType(),
-            getConstraintLocator(locator)));
+            getConstraintLocator(locator.getAnchor())));
       }
     }
 
@@ -2744,7 +2744,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         subflags);
     if (result == SolutionKind::Solved) {
       auto *fix = ForceOptional::create(*this, type, optionalObjectType,
-                                        getConstraintLocator(locator));
+                                        getConstraintLocator(locator.getAnchor()));
       if (recordFix(fix)) {
         return SolutionKind::Error;
       }
@@ -3042,7 +3042,7 @@ ConstraintSystem::simplifyFunctionComponentConstraint(
   if (unwrapCount > 0) {
     auto *fix = ForceOptional::create(*this, simplifiedCopy,
                                       simplifiedCopy->getOptionalObjectType(),
-                                      getConstraintLocator(locator));
+                                      getConstraintLocator(locator.getAnchor()));
     while (unwrapCount-- > 0) {
       if (recordFix(fix))
         return SolutionKind::Error;
@@ -4668,7 +4668,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     // Record any fixes we attempted to get to the correct solution.
     auto *fix = ForceOptional::create(*this, origType2,
                                       origType2->getOptionalObjectType(),
-                                      getConstraintLocator(locator));
+                                      getConstraintLocator(locator.getAnchor()));
     while (unwrapCount-- > 0) {
       if (recordFix(fix))
         return SolutionKind::Error;
@@ -4693,7 +4693,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (simplified == SolutionKind::Solved) {
       auto *fix = ForceOptional::create(*this, origType2,
                                         origType2->getOptionalObjectType(),
-                                        getConstraintLocator(locator));
+                                        getConstraintLocator(locator.getAnchor()));
       while (unwrapCount-- > 0) {
         if (recordFix(fix))
           return SolutionKind::Error;
@@ -5409,12 +5409,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix) {
     // This situation might happen when the same fix kind is applicable to
     // different overload choices.
     auto *loc = fix->getLocator();
-    auto *anchor = loc->getAnchor();
     auto existingFix = llvm::find_if(Fixes, [&](const ConstraintFix *e) {
-      if (e->getKind() == FixKind::ForceOptional &&
-          e->getLocator()->getAnchor() == anchor) {
-        return true;
-      }
       // If we already have a fix like this recorded, let's not do it again,
       return e->getKind() == fix->getKind() && e->getLocator() == loc;
     });

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5409,7 +5409,12 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix) {
     // This situation might happen when the same fix kind is applicable to
     // different overload choices.
     auto *loc = fix->getLocator();
+    auto *anchor = loc->getAnchor();
     auto existingFix = llvm::find_if(Fixes, [&](const ConstraintFix *e) {
+      if (e->getKind() == FixKind::ForceOptional &&
+          e->getLocator()->getAnchor() == anchor) {
+        return true;
+      }
       // If we already have a fix like this recorded, let's not do it again,
       return e->getKind() == fix->getKind() && e->getLocator() == loc;
     });

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -17,7 +17,7 @@ func test_cfunc2(_ i: Int) {
 
 func test_cfunc3_a() {
   let b = cfunc3( { (a : Double, b : Double) -> Double in a + b } )
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'Optional<double_bin_op_block>' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
@@ -26,7 +26,7 @@ func test_cfunc3_a() {
 
 func test_cfunc3_b() {
   let b = cfunc3( { a, b in a + b } )
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'Optional<double_bin_op_block>' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
@@ -35,7 +35,7 @@ func test_cfunc3_b() {
 
 func test_cfunc3_c() {
   let b = cfunc3({ $0 + $1 })
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'Optional<double_bin_op_block>' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -17,7 +17,7 @@ func test_cfunc2(_ i: Int) {
 
 func test_cfunc3_a() {
   let b = cfunc3( { (a : Double, b : Double) -> Double in a + b } )
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'Optional<double_bin_op_block>' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
@@ -26,7 +26,7 @@ func test_cfunc3_a() {
 
 func test_cfunc3_b() {
   let b = cfunc3( { a, b in a + b } )
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'Optional<double_bin_op_block>' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
@@ -35,7 +35,7 @@ func test_cfunc3_b() {
 
 func test_cfunc3_c() {
   let b = cfunc3({ $0 + $1 })
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'Optional<double_bin_op_block>' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -290,7 +290,7 @@ extension Wobbler2 : NSMaybeInitWobble { // expected-error{{type 'Wobbler2' does
 
 func optionalMemberAccess(_ w: NSWobbling) {
   w.wobble()
-  w.wibble() // expected-error{{value of optional type '(() -> Void)?' must be unwrapped}}
+  w.wibble() // expected-error{{value of optional type 'Optional<() -> Void>' must be unwrapped to a value of type '() -> Void'}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   let x = w[5]!!

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -290,7 +290,7 @@ extension Wobbler2 : NSMaybeInitWobble { // expected-error{{type 'Wobbler2' does
 
 func optionalMemberAccess(_ w: NSWobbling) {
   w.wobble()
-  w.wibble() // expected-error{{value of optional type 'Optional<() -> Void>' must be unwrapped to a value of type '() -> Void'}}
+  w.wibble() // expected-error{{value of optional type '(() -> Void)?' must be unwrapped to a value of type '() -> Void'}}
   // expected-note@-1{{coalesce}}
   // expected-note@-2{{force-unwrap}}
   let x = w[5]!!

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -295,9 +295,9 @@ func simplified1069() {
     func genericallyNonOptional<T: AnyObject>(_ a: T, _ b: T, _ c: T) { }
 
     func f(_ a: C?, _ b: C?, _ c: C) {
-      genericallyNonOptional(a, b, c) // expected-error 2{{value of optional type 'C?' must be unwrapped to a value of type 'C'}}
-      // expected-note @-1 2{{coalesce}}
-      // expected-note @-2 2{{force-unwrap}}
+      genericallyNonOptional(a, b, c) // expected-error {{value of optional type 'C?' must be unwrapped to a value of type 'C'}}
+      // expected-note @-1 {{coalesce}}
+      // expected-note @-2 {{force-unwrap}}
     }
   }
 }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -295,9 +295,9 @@ func simplified1069() {
     func genericallyNonOptional<T: AnyObject>(_ a: T, _ b: T, _ c: T) { }
 
     func f(_ a: C?, _ b: C?, _ c: C) {
-      genericallyNonOptional(a, b, c) // expected-error {{value of optional type 'C?' must be unwrapped to a value of type 'C'}}
-      // expected-note @-1 {{coalesce}}
-      // expected-note @-2 {{force-unwrap}}
+      genericallyNonOptional(a, b, c) // expected-error 2{{value of optional type 'C?' must be unwrapped to a value of type 'C'}}
+      // expected-note @-1 2{{coalesce}}
+      // expected-note @-2 2{{force-unwrap}}
     }
   }
 }

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -160,7 +160,9 @@ struct S1116 {
 }
 
 let a1116: [S1116] = []
-var s1116 = Set(1...10).subtracting(a1116.map({ $0.s })) // expected-error {{cannot convert value of type '[Int?]' to expected argument type 'Set<Int>'}}
+var s1116 = Set(1...10).subtracting(a1116.map({ $0.s })) // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
+                                                        // expected-note@-1{{force-unwrap}}
+                                                       // expected-note@-2{{coalesce}}
 
 
 func moreComplexUnwrapFixes() {
@@ -202,22 +204,16 @@ func moreComplexUnwrapFixes() {
   // expected-note@-4{{force-unwrap using '!'}}{{17-17=!}}
 
   takeNon(os?.value) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-  // expected-note@-1{{force-unwrap using '!'}}{{13-14=!}}
+  // expected-note@-1{{force-unwrap using '!'}}{{21-21=!}}
   // expected-note@-2{{coalesce}}
   takeNon(os?.optValue) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-  // expected-note@-1{{force-unwrap using '!'}}{{11-11=(}}{{23-23=)!}}
+  // expected-note@-1{{force-unwrap using '!'}}{{24-24=!}}
   // expected-note@-2{{coalesce}}
 
   func sample(a: Int?, b: Int!) {
     let aa = a
-    // expected-note@-1{{short-circuit using 'guard'}}{{5-5=guard }} {{15-15= else \{ return \}}}
-    // expected-note@-2{{force-unwrap}}
-    // expected-note@-3{{coalesce}}
 
-    let bb = b // expected-note{{value inferred to be type 'Int?' when initialized with an implicitly unwrapped value}}
-    // expected-note@-1{{short-circuit using 'guard'}}{{5-5=guard }} {{15-15= else \{ return \}}}
-    // expected-note@-2{{force-unwrap}}
-    // expected-note@-3{{coalesce}}
+    let bb = b
 
     let cc = a
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -93,7 +93,7 @@ func extraCall() {
   var i = 7
   i = i() // expected-error{{cannot call value of non-function type 'Int'}}{{8-10=}}
 
-  maybeFn()(5) // expected-error{{value of optional type '((Int) -> Int)?' must be unwrapped to a value of type '(Int) -> Int'}}
+  maybeFn()(5) // expected-error{{value of optional type 'Optional<((Int) -> Int)>' must be unwrapped to a value of type '(Int) -> Int'}}
   // expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}}
   // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
 }

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -243,3 +243,47 @@ func moreComplexUnwrapFixes() {
 
   }
 }
+
+struct FooStruct {
+  func a() -> Int?? { return 10 }
+
+  var b: Int?? {
+    return 15
+  }
+
+  func c() -> Int??? { return 20 }
+
+  var d: Int??? {
+    return 25
+  }
+
+  let e: BarStruct? = BarStruct()
+}
+
+struct BarStruct {
+  func a() -> Int? { return 30 }
+  var b: Int?? {
+    return 35
+  }
+}
+
+let thing: FooStruct? = FooStruct()
+
+let _: Int? = thing?.a() // expected-error {{value of optional type 'Int??' must be unwrapped to a value of type 'Int?'}}
+// expected-note@-1{{coalesce}}
+// expected-note@-2{{force-unwrap}}
+let _: Int? = thing?.b // expected-error {{value of optional type 'Int??' must be unwrapped to a value of type 'Int?'}}
+// expected-note@-1{{coalesce}}
+// expected-note@-2{{force-unwrap}}
+let _: Int?? = thing?.c() // expected-error {{value of optional type 'Int???' must be unwrapped to a value of type 'Int??'}}
+// expected-note@-1{{coalesce}}
+// expected-note@-2{{force-unwrap}}
+let _: Int?? = thing?.d // expected-error {{value of optional type 'Int???' must be unwrapped to a value of type 'Int??'}}
+// expected-note@-1{{coalesce}}
+// expected-note@-2{{force-unwrap}}
+let _: Int = thing?.e?.a() // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
+// expected-note@-1{{coalesce}}
+// expected-note@-2{{force-unwrap}}
+let _: Int? = thing?.e?.b // expected-error {{value of optional type 'Int??' must be unwrapped to a value of type 'Int?'}}
+// expected-note@-1{{coalesce}}
+// expected-note@-2{{force-unwrap}}

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -160,9 +160,7 @@ struct S1116 {
 }
 
 let a1116: [S1116] = []
-var s1116 = Set(1...10).subtracting(a1116.map({ $0.s })) // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-                                                        // expected-note@-1{{force-unwrap}}
-                                                       // expected-note@-2{{coalesce}}
+var s1116 = Set(1...10).subtracting(a1116.map({ $0.s })) // expected-error {{cannot convert value of type '[Int?]' to expected argument type 'Set<Int>'}}
 
 
 func moreComplexUnwrapFixes() {
@@ -204,16 +202,22 @@ func moreComplexUnwrapFixes() {
   // expected-note@-4{{force-unwrap using '!'}}{{17-17=!}}
 
   takeNon(os?.value) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-  // expected-note@-1{{force-unwrap using '!'}}{{21-21=!}}
+  // expected-note@-1{{force-unwrap using '!'}}{{13-14=!}}
   // expected-note@-2{{coalesce}}
   takeNon(os?.optValue) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-  // expected-note@-1{{force-unwrap using '!'}}{{24-24=!}}
+  // expected-note@-1{{force-unwrap using '!'}}{{11-11=(}} {{23-23=)!}}
   // expected-note@-2{{coalesce}}
 
   func sample(a: Int?, b: Int!) {
     let aa = a
+    // expected-note@-1{{short-circuit using 'guard'}}{{5-5=guard }} {{15-15= else \{ return \}}}
+    // expected-note@-2{{force-unwrap}}
+    // expected-note@-3{{coalesce}}
 
-    let bb = b
+    let bb = b // expected-note{{value inferred to be type 'Int?' when initialized with an implicitly unwrapped value}}
+    // expected-note@-1{{short-circuit using 'guard'}}{{5-5=guard }} {{15-15= else \{ return \}}}
+    // expected-note@-2{{force-unwrap}}
+    // expected-note@-3{{coalesce}}
 
     let cc = a
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -93,7 +93,7 @@ func extraCall() {
   var i = 7
   i = i() // expected-error{{cannot call value of non-function type 'Int'}}{{8-10=}}
 
-  maybeFn()(5) // expected-error{{value of optional type 'Optional<((Int) -> Int)>' must be unwrapped to a value of type '(Int) -> Int'}}
+  maybeFn()(5) // expected-error{{value of optional type '((Int) -> Int)?' must be unwrapped to a value of type '(Int) -> Int'}}
   // expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}}
   // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
 }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -291,7 +291,9 @@ switch staticMembers {
   case .init(0): break
   case .init(_): break // expected-error{{'_' can only appear in a pattern}}
   case .init(let x): break // expected-error{{cannot appear in an expression}}
-  case .init(opt: 0): break // expected-error{{pattern cannot match values of type 'StaticMembers'}}
+  case .init(opt: 0): break // expected-error{{value of optional type 'StaticMembers?' must be unwrapped to a value of type 'StaticMembers'}}
+                           // expected-note@-1{{coalesce}}
+                           // expected-note@-2{{force-unwrap}}
 
   case .prop: break
   // TODO: repeated error message
@@ -308,7 +310,9 @@ switch staticMembers {
   case .method(withLabel: let x): break // expected-error{{cannot appear in an expression}}
 
   case .optMethod: break // expected-error{{cannot match}}
-  case .optMethod(0): break // expected-error{{pattern cannot match values of type 'StaticMembers'}}
+  case .optMethod(0): break // expected-error{{value of optional type 'StaticMembers?' must be unwrapped to a value of type 'StaticMembers'}}
+                           // expected-note@-1{{coalesce}}
+                          // expected-note@-2{{force-unwrap}}
 }
 
 _ = 0

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -46,7 +46,7 @@ struct HasClosure {
 var _: HasClosure = .factoryNormal(0)
 var _: HasClosure = .factoryReturnOpt(1)!
 var _: HasClosure = .factoryIUO(2)
-var _: HasClosure = .factoryOpt(3) // expected-error {{value of optional type 'Optional<((Int) -> HasClosure)>' must be unwrapped to a value of type '(Int) -> HasClosure'}}
+var _: HasClosure = .factoryOpt(3) // expected-error {{value of optional type '((Int) -> HasClosure)?' must be unwrapped to a value of type '(Int) -> HasClosure'}}
                                   // expected-note@-1{{coalesce}}
                                  // expected-note@-2{{force-unwrap}}
 var _: HasClosure = .factoryOpt!(4) // expected-error {{type of expression is ambiguous without more context}}

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -46,5 +46,7 @@ struct HasClosure {
 var _: HasClosure = .factoryNormal(0)
 var _: HasClosure = .factoryReturnOpt(1)!
 var _: HasClosure = .factoryIUO(2)
-var _: HasClosure = .factoryOpt(3) // expected-error {{static property 'factoryOpt' is not a function}}
+var _: HasClosure = .factoryOpt(3) // expected-error {{value of optional type 'Optional<((Int) -> HasClosure)>' must be unwrapped to a value of type '(Int) -> HasClosure'}}
+                                  // expected-note@-1{{coalesce}}
+                                 // expected-note@-2{{force-unwrap}}
 var _: HasClosure = .factoryOpt!(4) // expected-error {{type of expression is ambiguous without more context}}

--- a/test/expr/postfix/dot/optional_context_member.swift
+++ b/test/expr/postfix/dot/optional_context_member.swift
@@ -13,15 +13,18 @@ func nonOptContext() -> Foo {
   case ():
     return .someVar
   case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
-    // FIXME: Customize this diagnostic for the optional case.
-    return .someOptVar // expected-error 1 {{member 'someOptVar' in 'Foo' produces result of type 'Foo?', but context expects 'Foo'}}
+    return .someOptVar // expected-error {{value of optional type 'Foo?' must be unwrapped to a value of type 'Foo'}}
+                      // expected-note@-1 {{coalesce}}
+                     // expected-note@-2 {{force-unwrap}}
   // TODO
   //case ():
   //  return .someOptVar!
   case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someFunc()
   case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
-    return .someOptFunc() // expected-error{{member 'someOptFunc' in 'Foo' produces result of type 'Foo?', but context expects 'Foo'}}
+    return .someOptFunc() // expected-error {{value of optional type 'Foo?' must be unwrapped to a value of type 'Foo'}}
+                         // expected-note@-1 {{coalesce}}
+                        // expected-note@-2 {{force-unwrap}}
   // TODO
   //case ():
   //  return .someOptFunc()!


### PR DESCRIPTION
This PR resolves an issue where incorrect diagnostics would be generated when diagnosing optional unwrapping.

```swift
struct Foo {
  func bar() -> String??? { return "bar" }
}

let foo: Foo? = Foo()

// incorrect error: Value of optional type 'String??' must be unwrapped to a value of type 'String?'
let _: String?? = foo?.bar()
```

Resolves [SR-9201](https://bugs.swift.org/browse/SR-9201).
