### PR TITLE
[5.0][String] Add UTF-8 fast-paths for Foundation initializers

### DIFF
--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -42,12 +42,10 @@ extension String {
     return storage.asString
   }
 
-  @usableFromInline
-  internal static func _tryFromUTF8(
-    _ input: UnsafeBufferPointer<UInt8>
-  ) -> String? {
+  public // SPI(Foundation)
+  static func _tryFromUTF8(_ input: UnsafeBufferPointer<UInt8>) -> String? {
     guard case .success(let extraInfo) = validateUTF8(input) else {
-        return nil
+      return nil
     }
 
     return String._uncheckedFromUTF8(input, isASCII: extraInfo.isASCII)

--- a/stdlib/public/core/StringUTF8Validation.swift
+++ b/stdlib/public/core/StringUTF8Validation.swift
@@ -36,6 +36,10 @@ extension UTF8ValidationResult: Equatable {}
 private struct UTF8ValidationError: Error {}
 
 internal func validateUTF8(_ buf: UnsafeBufferPointer<UInt8>) -> UTF8ValidationResult {
+  if _allASCII(buf) {
+    return .success(UTF8ExtraInfo(isASCII: true))
+  }
+
   var iter = buf.makeIterator()
   var lastValidIndex = buf.startIndex
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

5.0 cherry-pick of https://github.com/apple/swift/pull/21959

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

https://bugs.swift.org/browse/SR-7869

<rdar://problem/47463294>

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->