### PR TITLE
[AutoDiff] Fix "Unhandled use of FunctionRefInst" with `autodiff_function`.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7692,10 +7692,6 @@ public:
 
   SILValue getAssociatedFunction(unsigned differentiationOrder,
                                  AutoDiffAssociatedFunctionKind kind) const;
-
-  static bool classof(const SILNode *N) {
-    return N->getKind() == SILNodeKind::AutoDiffFunctionInst;
-  }
 };
 
 /// `autodiff_function_extract` - given an `@autodiff` function representing a
@@ -7764,10 +7760,6 @@ public:
 
   MutableArrayRef<Operand> getAllOperands() {
     return operands.asArray();
-  }
-
-  static bool classof(const SILNode *N) {
-    return N->getKind() == SILNodeKind::AutoDiffFunctionExtractInst;
   }
 };
 

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2639,6 +2639,25 @@ void LoadableByAddress::recreateConvInstrs() {
           instr->getLoc(), instr->getValue(), instr->getBase());
       break;
     }
+    // SWIFT_ENABLE_TENSORFLOW
+    case SILInstructionKind::AutoDiffFunctionInst: {
+      auto instr = cast<AutoDiffFunctionInst>(convInstr);
+      SmallVector<SILValue, 2> associatedFunctions;
+      for (auto &assocFn : instr->getAssociatedFunctions())
+        associatedFunctions.push_back(assocFn.get());
+      newInstr = convBuilder.createAutoDiffFunction(
+          instr->getLoc(), instr->getParameterIndices(),
+          instr->getDifferentiationOrder(), instr->getOriginalFunction(),
+          associatedFunctions);
+      break;
+    }
+    case SILInstructionKind::AutoDiffFunctionExtractInst: {
+      auto instr = cast<AutoDiffFunctionExtractInst>(convInstr);
+      newInstr = convBuilder.createAutoDiffFunctionExtract(
+          instr->getLoc(), instr->getExtractee(),
+          instr->getDifferentiationOrder(), instr->getFunctionOperand());
+      break;
+    }
      default:
       llvm_unreachable("Unexpected conversion instruction");
     }
@@ -2725,7 +2744,10 @@ void LoadableByAddress::run() {
               case SILInstructionKind::ConvertEscapeToNoEscapeInst:
               case SILInstructionKind::MarkDependenceInst:
               case SILInstructionKind::ThinFunctionToPointerInst:
-              case SILInstructionKind::ThinToThickFunctionInst: {
+              // SWIFT_ENABLE_TENSORFLOW
+              case SILInstructionKind::ThinToThickFunctionInst:
+              case SILInstructionKind::AutoDiffFunctionInst:
+              case SILInstructionKind::AutoDiffFunctionExtractInst: {
                 conversionInstrs.insert(
                               cast<SingleValueInstruction>(currInstr));
                 break;
@@ -2792,6 +2814,10 @@ void LoadableByAddress::run() {
           if (modApplies.count(PAI) == 0) {
             modApplies.insert(PAI);
           }
+        } else if (auto *ADFI = dyn_cast<AutoDiffFunctionInst>(&I)) {
+          conversionInstrs.insert(ADFI);
+        } else if (auto *ADFEI = dyn_cast<AutoDiffFunctionExtractInst>(&I)) {
+          conversionInstrs.insert(ADFEI);
         }
       }
     }


### PR DESCRIPTION
Fixes [SR-9717](https://bugs.swift.org/browse/SR-9717) by handing `autodiff_function` and `autodiff_function_extract` in [lib/IRGen/LoadableByAddress.cpp](/lib/IRGen/LoadableByAddress.cpp).