### PR TITLE
[SourceKit][IDE] Update for feedback

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2416,7 +2416,7 @@ public:
   bool isUsableFromInline() const;
 
   /// Returns \c true if this declaration is *not* intended to be used directly
-  /// by application developers despite of the visibility.
+  /// by application developers despite the visibility.
   bool shouldHideFromEditor() const;
 
   bool hasAccess() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2550,8 +2550,6 @@ bool ValueDecl::isUsableFromInline() const {
   return false;
 }
 
-/// Returns \c true if this declaration is *not* intended to be used directly
-/// by application developers despite of the visibility.
 bool ValueDecl::shouldHideFromEditor() const {
   // Hide private stdlib declarations.
   if (isPrivateStdlibDecl(/*treatNonBuiltinProtocolsAsPublic*/ false) ||

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -39,16 +39,16 @@ public:
 
   // Ignore callbacks for suffix completions
   // {
-  void completeDotExpr(Expr *E, SourceLoc DotLoc) override{};
-  void completePostfixExpr(Expr *E, bool hasSpace) override{};
-  void completeExprSuper(SuperRefExpr *SRE) override{};
-  void completeExprSuperDot(SuperRefExpr *SRE) override{};
+  void completeDotExpr(Expr *E, SourceLoc DotLoc) override {};
+  void completePostfixExpr(Expr *E, bool hasSpace) override {};
+  void completeExprSuper(SuperRefExpr *SRE) override {};
+  void completeExprSuperDot(SuperRefExpr *SRE) override {};
   // }
 
   // Ignore non-expression callbacks.
   // {
-  void completeInPrecedenceGroup(SyntaxKind SK) override{};
-  void completePoundAvailablePlatform() override{};
+  void completeInPrecedenceGroup(SyntaxKind SK) override {};
+  void completePoundAvailablePlatform() override {};
   void completeExprKeyPath(KeyPathExpr *KPE, SourceLoc DotLoc) override {}
   void completeTypeSimpleBeginning() override {}
   void completeTypeIdentifierWithDot(IdentTypeRepr *ITR) override {}
@@ -65,15 +65,15 @@ public:
   void completePlatformCondition() override {}
   void completeGenericParams(TypeLoc TL) override {}
   void completeAfterIfStmt(bool hasElse) override {}
-  void completeAccessorBeginning() override{};
+  void completeAccessorBeginning() override {};
   // }
 
-  void completeStmtOrExpr() override{};
+  void completeStmtOrExpr() override {};
   void completePostfixExprBeginning(CodeCompletionExpr *E) override;
   void completeForEachSequenceBeginning(CodeCompletionExpr *E) override;
   void completeCaseStmtBeginning() override;
 
-  void completeAssignmentRHS(AssignExpr *E) override{};
+  void completeAssignmentRHS(AssignExpr *E) override {};
   void completeCallArg(CodeCompletionExpr *E) override;
   void completeReturnStmt(CodeCompletionExpr *E) override;
   void completeYieldStmt(CodeCompletionExpr *E,

--- a/test/SourceKit/CompileNotifications/type-context-info.swift
+++ b/test/SourceKit/CompileNotifications/type-context-info.swift
@@ -1,0 +1,12 @@
+// RUN: %sourcekitd-test -req=track-compiles == -req=typecontextinfo %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// COMPILE_1: {
+// COMPILE_1:  key.notification: source.notification.compile-will-start,
+// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}type-context-info.swift",
+// COMPILE_1:  key.compileid: [[CID1:".*"]]
+// COMPILE_1: }
+// COMPILE_1: {
+// COMPILE_1:   key.notification: source.notification.compile-did-finish,
+// COMPILE_1:   key.compileid: [[CID1]]
+// COMPILE_1: }
+// COMPILE_1-NOT: compile-will-start
+// COMPILE_1-NOT: compile-did-finish


### PR DESCRIPTION
Update for feedback on #21377 .

* Update comment
* Space between `override` and `{}`
* Enable trace logging for `typecontextinfo` request