### PR TITLE
SourceKit: simplify and modernise CMake for tests

### DIFF
--- a/unittests/SourceKit/SwiftLang/CMakeLists.txt
+++ b/unittests/SourceKit/SwiftLang/CMakeLists.txt
@@ -1,16 +1,9 @@
 if(NOT SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_EMBEDDED_VARIANTS}")
-
   add_swift_unittest(SourceKitSwiftLangTests
     CursorInfoTest.cpp
     EditingTest.cpp
     )
-
-  target_link_libraries(SourceKitSwiftLangTests
-    PRIVATE
-    SourceKitSwiftLang
-    )
-
-  set_property(TARGET SourceKitSwiftLangTests APPEND_STRING PROPERTY COMPILE_FLAGS
-    " '-DSWIFTLIB_DIR=\"${SWIFTLIB_DIR}\"'")
-
+  target_link_libraries(SourceKitSwiftLangTests PRIVATE SourceKitSwiftLang)
+  target_compile_definitions(SourceKitSwiftLangTests PRIVATE
+    SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")
 endif()


### PR DESCRIPTION
Use `target_compile_definitions` to fix the quoting.  This is particularly
important when running under a non-sh shell (e.g. Windows) where the quoting
rules are different.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
