### PR TITLE
[5.0] Temporarily disable generation of static long Strings for macos.

### DIFF
--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -119,6 +119,12 @@ bool SILGlobalVariable::isValidStaticInitializerInst(const SILInstruction *I,
           // a pointer+offset relocation.
           // Note that StringObjectOr requires the or'd bits in the first
           // operand to be 0, so the operation is equivalent to an addition.
+  
+          // Temporarily disable static long Strings for macos.
+          // rdar://problem/47467102
+          if (M.getASTContext().LangOpts.Target.isMacOSX())
+            return false;
+  
           if (isa<IntegerLiteralInst>(bi->getArguments()[1]))
             return true;
           break;

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -103,25 +103,6 @@ sil_global @static_array_with_empty_element : $TestArrayStorage = {
 }
 // CHECK: @static_array_with_empty_element = {{( dllexport)?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems3c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems3 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef, [1 x i8] undef }> }, align 8
 
-struct MyString {
-  var buffer: Builtin.BridgeObject
-}
-
-sil_global [let] @string_with_offset : $MyString = {
-  %0 = integer_literal $Builtin.Int64, -9223372036854775808
-  %1 = integer_literal $Builtin.Int1, 0
-  %2 = integer_literal $Builtin.Int64, 32
-  %3 = string_literal utf8 "abc123asd3sdj3basfasdf"
-  %4 = builtin "ptrtoint_Word"(%3 : $Builtin.RawPointer) : $Builtin.Word
-  %5 = builtin "zextOrBitCast_Word_Int64"(%4 : $Builtin.Word) : $Builtin.Int64
-  %6 = builtin "usub_with_overflow_Int64"(%5 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %7 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 0
-  %8 = builtin "stringObjectOr_Int64"(%7 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int64
-  %9 = value_to_bridge_object %8 : $Builtin.Int64
-  %initval = struct $MyString (%9 : $Builtin.BridgeObject)
-}
-// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @0 to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
-
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i8* bitcast (%Ts5Int32V* @"$s2ch1xSiv" to i8*)

--- a/test/SILOptimizer/static_strings.swift
+++ b/test/SILOptimizer/static_strings.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck %s
-// RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck --check-prefix=CHECK-%target-cpu %s
 
 // RUN: %empty-directory(%t) 
 // RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
@@ -12,72 +12,88 @@
 // optimal code for static String variables.
 
 public struct S {
-  // CHECK: {{^@"}}[[SMALL:.*smallstr.*pZ]]" ={{.*}} global {{.*}} inttoptr
+  // CHECK-x86_64: {{^@"}}[[SMALL:.*smallstr.*pZ]]" ={{.*}} global {{.*}} inttoptr
+  // CHECK-arm64: {{^@"}}[[SMALL:.*smallstr.*pZ]]" ={{.*}} global {{.*}} inttoptr
   public static let smallstr = "abc123a"
-  // CHECK: {{^@"}}[[LARGE:.*largestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
+  // CHECK-arm64: {{^@"}}[[LARGE:.*largestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
   public static let largestr = "abc123asd3sdj3basfasdf"
-  // CHECK: {{^@"}}[[UNICODE:.*unicodestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
+  // CHECK-arm64: {{^@"}}[[UNICODE:.*unicodestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
   public static let unicodestr = "❄️gastroperiodyni"
 }
 
 // unsafeMutableAddressor for S.smallstr
-// CHECK: define {{.*smallstr.*}}u"
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   ret {{.*}} @"[[SMALL]]"
-// CHECK-NEXT: }
+// CHECK-arm64: define {{.*smallstr.*}}u"
+// CHECK-arm64-NEXT: entry:
+// CHECK-arm64-NEXT:   ret {{.*}} @"[[SMALL]]"
+// CHECK-arm64-NEXT: }
+
+// CHECK-x86_64: define {{.*smallstr.*}}u"
+// CHECK-x86_64-NEXT: entry:
+// CHECK-x86_64-NEXT:   ret {{.*}} @"[[SMALL]]"
+// CHECK-x86_64-NEXT: }
 
 // getter for S.smallstr
-// CHECK: define {{.*smallstr.*}}gZ"
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   ret {{.*}}
-// CHECK-NEXT: }
+// CHECK-arm64: define {{.*smallstr.*}}gZ"
+// CHECK-arm64-NEXT: entry:
+// CHECK-arm64-NEXT:   ret {{.*}}
+// CHECK-arm64-NEXT: }
+
+// CHECK-x86_64: define {{.*smallstr.*}}gZ"
+// CHECK-x86_64-NEXT: entry:
+// CHECK-x86_64-NEXT:   ret {{.*}}
+// CHECK-x86_64-NEXT: }
 
 // unsafeMutableAddressor for S.largestr
-// CHECK: define {{.*largestr.*}}u"
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   ret {{.*}} @"[[LARGE]]"
-// CHECK-NEXT: }
+// CHECK-arm64: define {{.*largestr.*}}u"
+// CHECK-arm64-NEXT: entry:
+// CHECK-arm64-NEXT:   ret {{.*}} @"[[LARGE]]"
+// CHECK-arm64-NEXT: }
 
 // getter for S.largestr
-// CHECK: define {{.*largestr.*}}gZ"
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   ret {{.*}}
-// CHECK-NEXT: }
+// CHECK-arm64: define {{.*largestr.*}}gZ"
+// CHECK-arm64-NEXT: entry:
+// CHECK-arm64-NEXT:   ret {{.*}}
+// CHECK-arm64-NEXT: }
 
 // unsafeMutableAddressor for S.unicodestr
-// CHECK: define {{.*unicodestr.*}}u"
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   ret {{.*}} @"[[UNICODE]]"
-// CHECK-NEXT: }
+// CHECK-arm64: define {{.*unicodestr.*}}u"
+// CHECK-arm64-NEXT: entry:
+// CHECK-arm64-NEXT:   ret {{.*}} @"[[UNICODE]]"
+// CHECK-arm64-NEXT: }
 
 // getter for S.unicodestr
-// CHECK: define {{.*unicodestr.*}}gZ"
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   ret {{.*}}
-// CHECK-NEXT: }
+// CHECK-arm64: define {{.*unicodestr.*}}gZ"
+// CHECK-arm64-NEXT: entry:
+// CHECK-arm64-NEXT:   ret {{.*}}
+// CHECK-arm64-NEXT: }
 
-// CHECK-LABEL: define {{.*}}get_smallstr
-// CHECK:      entry:
-// CHECK-NEXT:   ret {{.*}}
-// CHECK-NEXT: }
+// CHECK-arm64-LABEL: define {{.*}}get_smallstr
+// CHECK-arm64:      entry:
+// CHECK-arm64-NEXT:   ret {{.*}}
+// CHECK-arm64-NEXT: }
+
+// CHECK-x86_64-LABEL: define {{.*}}get_smallstr
+// CHECK-x86_64:      entry:
+// CHECK-x86_64-NEXT:   ret {{.*}}
+// CHECK-x86_64-NEXT: }
 @inline(never)
 public func get_smallstr() -> String {
   return S.smallstr
 }
 
-// CHECK-LABEL: define {{.*}}get_largestr
-// CHECK:      entry:
-// CHECK-NEXT:   ret {{.*}}
-// CHECK-NEXT: }
+// CHECK-arm64-LABEL: define {{.*}}get_largestr
+// CHECK-arm64:      entry:
+// CHECK-arm64-NEXT:   ret {{.*}}
+// CHECK-arm64-NEXT: }
 @inline(never)
 public func get_largestr() -> String {
   return S.largestr
 }
 
-// CHECK-LABEL: define {{.*}}get_unicodestr
-// CHECK:      entry:
-// CHECK-NEXT:   ret {{.*}}
-// CHECK-NEXT: }
+// CHECK-arm64-LABEL: define {{.*}}get_unicodestr
+// CHECK-arm64:      entry:
+// CHECK-arm64-NEXT:   ret {{.*}}
+// CHECK-arm64-NEXT: }
 @inline(never)
 public func get_unicodestr() -> String {
   return S.unicodestr


### PR DESCRIPTION
There is a problem with the generated relocation, which has to be resolved before we can enable this optimization again.

rdar://problem/47467102
