### PR TITLE
cmake: allow building the Swift compiler with Clang's Profile Guided Optimization (PGO)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,14 @@ option(SWIFT_ENABLE_PARSEABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
        TRUE)
 
+# Allow building Swift with Clang's Profile Guided Optimization
+if(SWIFT_PROFDATA_FILE AND EXISTS ${SWIFT_PROFDATA_FILE})
+  if(NOT CMAKE_C_COMPILER_ID MATCHES Clang)
+    message(FATAL_ERROR "SWIFT_PROFDATA_FILE can only be specified when compiling with clang")
+  endif()
+  add_definitions("-fprofile-instr-use=${SWIFT_PROFDATA_FILE}")
+endif()
+
 #
 # User-configurable Android specific options.
 #

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -266,7 +266,8 @@ KNOWN_SETTINGS=(
     user-config-args            ""               "**Renamed to --extra-cmake-options**: User-supplied arguments to cmake when used to do configuration."
     only-execute                       "all"     "Only execute the named action (see implementation)"
     llvm-lit-args                      ""        "If set, override the lit args passed to LLVM"
-    clang-profile-instr-use            ""        "If set, profile file to use for clang PGO"
+    clang-profile-instr-use            ""        "If set, profile file to use for clang PGO while building llvm/clang"
+    swift-profile-instr-use            ""        "If set, profile file to use for clang PGO while building swift"
     coverage-db                        ""        "If set, coverage database to use when prioritizing testing"
     build-toolchain-only               ""        "If set, only build the necessary tools to build an external toolchain"
     skip-local-host-install            ""        "If we are cross-compiling multiple targets, skip an install pass locally if the hosts match"
@@ -759,6 +760,11 @@ function set_build_options_for_host() {
         )
     fi
 
+    if [[ "${SWIFT_PROFILE_INSTR_USE}" ]]; then
+        swift_cmake_options+=(
+            -DSWIFT_PROFDATA_FILE="${SWIFT_PROFILE_INSTR_USE}"
+        )
+    fi
     swift_cmake_options+=(
         -DCOVERAGE_DB="${COVERAGE_DB}"
     )


### PR DESCRIPTION
Previously, Build script flag --clang-profile-instr-use is only used for building
clang and llvm. This patch extends PGO to the building of the Swift compiler.
