### PR TITLE
[Name lookup] Implement name shadowing rule for Data.withUnsafeBytes.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -271,6 +271,42 @@ static void recordShadowedDeclsAfterSignatureMatch(
         }
       }
 
+      // The Foundation overlay introduced Data.withUnsafeBytes, which is
+      // treated as being ambiguous with SwiftNIO's Data.withUnsafeBytes
+      // extension. Apply a special-case name shadowing rule to use the
+      // latter rather than the former, which be the consequence of a more
+      // significant change to name shadowing in the future.
+      if (auto owningStruct1
+            = firstDecl->getDeclContext()->getSelfStructDecl()) {
+        if (auto owningStruct2
+              = secondDecl->getDeclContext()->getSelfStructDecl()) {
+          if (owningStruct1 == owningStruct2 &&
+              owningStruct1->getName().is("Data") &&
+              isa<FuncDecl>(firstDecl) && isa<FuncDecl>(secondDecl) &&
+              firstDecl->getFullName() == secondDecl->getFullName() &&
+              firstDecl->getBaseName().userFacingName() == "withUnsafeBytes") {
+            // If the second module is the Foundation module and the first
+            // is the NIOFoundationCompat module, the second is shadowed by the
+            // first.
+            if (firstDecl->getModuleContext()->getName()
+                  .is("NIOFoundationCompat") &&
+                secondDecl->getModuleContext()->getName().is("Foundation")) {
+              shadowed.insert(secondDecl);
+              continue;
+            }
+
+            // If it's the other way around, the first declaration is shadowed
+            // by the second.
+            if (secondDecl->getModuleContext()->getName()
+                  .is("NIOFoundationCompat") &&
+                firstDecl->getModuleContext()->getName().is("Foundation")) {
+              shadowed.insert(firstDecl);
+              break;
+            }
+          }
+        }
+      }
+
       // Prefer declarations in an overlay to similar declarations in
       // the Clang module it customizes.
       if (firstDecl->hasClangNode() != secondDecl->hasClangNode()) {

--- a/test/NameBinding/Inputs/NIOFoundationCompat.swift
+++ b/test/NameBinding/Inputs/NIOFoundationCompat.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Data {
+  @_inlineable
+  public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    let r: R? = nil
+    return r!
+  }
+}

--- a/test/NameBinding/nio_shadowing.swift
+++ b/test/NameBinding/nio_shadowing.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/NIOFoundationCompat.swift
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify
+
+// REQUIRES: objc_interop
+import Foundation
+import NIOFoundationCompat
+
+func test(data: Data) {
+  data.withUnsafeBytes { x in print(x) }
+}


### PR DESCRIPTION
Address an annoying source compatibility issue with the introduction
of Data.withUnsafeBytes, which is ambiguous with Swift NIO's
implementatio of the same function. Do so with a narrow hackish name
shadowing rule (the Swift NIO version shadows the Foundation version)
that we will eventually generalize to something sensible.

Fixes rdar://problem/46850346.
