### PR TITLE
[SourceKit] Fix a crash in SwiftDocumentStructureWalker::getObjCSelectorName()

### DIFF
--- a/test/SourceKit/DocumentStructure/rdar47426948.swift
+++ b/test/SourceKit/DocumentStructure/rdar47426948.swift
@@ -1,0 +1,40 @@
+// RUN: %sourcekitd-test -req=structure %s -- %s | %FileCheck %s
+
+class C {
+  @IBAction init(foo: Void) {}
+  @IBAction init(bar: ()) {}
+  @IBAction init(baz: Int) {}
+  @IBAction func methodName(foo: ()) {}
+  @IBAction func methodName(bar: Void) {}
+  @IBAction func methodName(baz: Int) {}
+  @IBAction deinit {}
+}
+
+// CHECK: {
+// CHECK:   key.name: "init(foo:)",
+// CHECK-NOT:   key.selector_name
+// CHECK: }
+// CHECK: {
+// CHECK:   key.name: "init(bar:)",
+// CHECK-NOT:   key.selector_name
+// CHECK: }
+// CHECK: {
+// CHECK:   key.name: "init(baz:)",
+// CHECK-NOT:   key.selector_name
+// CHECK: }
+// CHECK: {
+// CHECK:   key.name: "methodName(foo:)",
+// CHECK:   key.selector_name: "methodNameWithFoo:"
+// CHECK: }
+// CHECK: {
+// CHECK:   key.name: "methodName(bar:)",
+// CHECK:   key.selector_name: "methodNameWithBar:"
+// CHECK: }
+// CHECK: {
+// CHECK:   key.name: "methodName(baz:)",
+// CHECK:   key.selector_name: "methodNameWithBaz:"
+// CHECK: }
+// CHECK: {
+// CHECK:   key.name: "deinit",
+// CHECK-NOT:   key.selector_name
+// CHECK: }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1271,8 +1271,8 @@ public:
   }
 
   StringRef getObjCSelectorName(const Decl *D, SmallString<64> &Buf) {
-    if (auto FuncD = dyn_cast_or_null<AbstractFunctionDecl>(D)) {
-      // We only vend the selector name for @IBAction methods.
+    // We only vend the selector name for @IBAction methods.
+    if (auto FuncD = dyn_cast_or_null<FuncDecl>(D)) {
       if (FuncD->getAttrs().hasAttribute<IBActionAttr>())
         return FuncD->getObjCSelector().getString(Buf);
     }


### PR DESCRIPTION
SourceKit document structure request used to crash if if there's initializer with single named parameter with `@IBAction` attribute.

This used to happen because `ConstructorDecl::isObjCZeroParameterWithLongSelector()` requires
interface type of the parameter but the constructor doesn't have it at this stage.

This PR fixes that by *not* vending ObjC name for constructor or destructors.

rdar://problem/47426948
