### PR TITLE
Initial tracing support for functions (referred to as `tracee functions`) 

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -99,9 +99,6 @@ private class TraceContext {
   // (TF_Function) upon finalizing.
   let graph = TF_NewGraph()
 
-  // Used to create unique trace graph node names and graph function names.
-  var traceGraphObjectCounter = 0
-
   // The list of inputs to the trace graph function.
   //
   // These symbolic tensors corresond to PlaceHolder nodes in the trace graph,
@@ -158,8 +155,8 @@ private class TraceContext {
     // Finish building the trace graph function.
     let eagerContext = _TFCGetGlobalEagerContext()
 
-    let tracedFunctionName = "\(traceeBasicName)_\(traceGraphObjectCounter)"
-    traceGraphObjectCounter += 1
+    let tracedFunctionName = "\(traceeBasicName)_\(_RuntimeConfig.traceGraphFunctionCounter)"
+    _RuntimeConfig.traceGraphFunctionCounter += 1
     debugLog("""
                Finalizing trace graph func \(tracedFunctionName), with \
                \(inputs.count) tracee inputs, and \
@@ -275,6 +272,9 @@ private enum TracingState {
 public enum _RuntimeConfig {
   // TODO: change this and subsequent properties from static to thread local.
   fileprivate static var traceState: TracingState = .notTracing
+
+  // Used to create unique trace graph function names.
+  fileprivate static var traceGraphFunctionCounter = 0
 
   /// When false, tensorflow runtime will be initialized before running any
   /// tensor program in this process.
@@ -648,7 +648,7 @@ public extension TensorGroup {
   }
 }
 
-// TODO: assess if this protocol should be foled into TensorArrayProtocol.
+// TODO: assess if this protocol should be folded into TensorArrayProtocol.
 public protocol TensorArrayProtocolEnhanced : TensorArrayProtocol {
   // Create an instance based on `inputs`, which can be symbolic (e.g. when
   // creating a symbolic input to tracee) or concrete (e.g. when creating a

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -582,8 +582,9 @@ public final class _ExecutionContext {
 // Elements in `outputs` can come from two sources:
 // a) Symbolic tensors produced by tensor ops, and added as trace graph nodes.
 // b) Concrete tensors produced by host code (e.g. Tensor(1.0)).
-fileprivate func finalizeTraceFn(_ name: String,
-                                 outputs: [CTensorHandle]) -> TraceContext {
+fileprivate func finalizeTraceFunction(_ name: String,
+                                       outputs: [CTensorHandle]
+) -> TraceContext {
   guard let traceContext = _RuntimeConfig.traceState.context else {
     fatalError("Not in tracing mode!.")
   }
@@ -703,8 +704,8 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
   debugLog("Finalizing trace graph function.")
   // TAP means tensor array protocol.
   let opType = "MyTraceFn_TAP"
-  let traceContext = finalizeTraceFn(opType,
-                                     outputs: outputTensorHandles)
+  let traceContext = finalizeTraceFunction(opType,
+                                           outputs: outputTensorHandles)
 
   // The result is a closure that captures and executes the trace graph
   // function in the trace context.

--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -18,7 +18,7 @@ typealias Data = Tensor<Float>
 
 typealias Result = Tensor<Float>
 
-extension Tensor : TensorArrayProtocolEnhanced {
+extension Tensor : _TensorArrayProtocolEnhanced {
   public func _makeInstance<C: Collection>(owning inputs: C) -> Tensor
     where C.Element == CTensorHandle {
     assert(inputs.count == 1)
@@ -40,7 +40,7 @@ TracerTests.testAllBackends("Basic") {
   _RuntimeConfig.printsDebugLog = true
   let state = Tensor<Float>(2.0)
   let data = Tensor<Float>(3.0)
-  let tracedFn = trace(with: state, in: tracee)
+  let tracedFn = _graph(with: state, in: tracee)
   let (newState, result) = tracedFn(state, data)
   
   _hostOp(newState)

--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -48,6 +48,16 @@ TracerTests.testAllBackends("Basic") {
 
   _hostOp(result)
   expectNearlyEqualWithScalarTensor(3.0, result)
+
+  // A second call to `tracedFn` with different input data.
+  let data2 = Tensor<Float>(1.0)
+  let (newState2, result2) = tracedFn(newState, data2)
+
+  _hostOp(newState2)
+  expectNearlyEqualWithScalarTensor(6.0, newState2)
+
+  _hostOp(result2)
+  expectNearlyEqualWithScalarTensor(1.0, result2)
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -1,0 +1,52 @@
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Tracer tests.
+
+import TensorFlow
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var TracerTests = TestSuite("Tracer")
+
+typealias Data = Tensor<Float>
+
+typealias Result = Tensor<Float>
+
+extension Tensor : TensorArrayProtocolEnhanced {
+  public func createInstance(_owning inputs: [CTensorHandle]) -> Tensor {
+    assert(inputs.count == 1)
+    return Tensor(handle: TensorHandle<Scalar>(_owning: inputs[0]))
+  }
+}
+
+TracerTests.testAllBackends("Basic") {
+  func tracee(state: Tensor<Float>, data: Data) -> (Tensor<Float>, Result) {
+    return (state + data, data)
+  }
+
+  // TODO: if we instead write Tensor(2.0), which defaults to Tensor<Double>,
+  // the resulting error message is hard to understand:
+  // error: cannot convert value of type '(Tensor<Float>, Data) ->
+  // (Tensor<Float>, Result)' (aka '(Tensor<Float>, Tensor<Float>) ->
+  // (Tensor<Float>, Tensor<Float>)') to expected argument type '(_, _) -> (_,
+  // _)'
+  _RuntimeConfig.printsDebugLog = true
+  let state = Tensor<Float>(2.0)
+  let data = Tensor<Float>(3.0)
+  let tracedFn = trace(with: state, in: tracee)
+  let (newState, result) = tracedFn(state, data)
+  
+  _hostOp(newState)
+  expectNearlyEqualWithScalarTensor(5.0, newState)
+
+  _hostOp(result)
+  expectNearlyEqualWithScalarTensor(3.0, result)
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -19,9 +19,10 @@ typealias Data = Tensor<Float>
 typealias Result = Tensor<Float>
 
 extension Tensor : TensorArrayProtocolEnhanced {
-  public func createInstance(_owning inputs: [CTensorHandle]) -> Tensor {
+  public func _makeInstance<C: Collection>(owning inputs: C) -> Tensor
+    where C.Element == CTensorHandle {
     assert(inputs.count == 1)
-    return Tensor(handle: TensorHandle<Scalar>(_owning: inputs[0]))
+    return Tensor(handle: TensorHandle<Scalar>(_owning: inputs.first!))
   }
 }
 


### PR DESCRIPTION
with the following signature: `(State, Data) -> (State, Result)`

This is designed to support the computation of a training step, where the
function takes and returns a Model (aka "state"), containing a collection of
trainable parameters. The function also takes as input a Data batch.

The additional output of `Result` can be used for the training step to produce
metrics (e.g. loss value).
