### PR TITLE
Reserve a vector where we know the size.

### DIFF
--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -770,6 +770,7 @@ public:
 
   std::vector<sma::TypeName> collectProtocolConformances(NominalTypeDecl *NTD) {
     std::vector<sma::TypeName> Result;
+    Result.reserve(NTD->getAllProtocols().size());
     for (const auto *PD : NTD->getAllProtocols()) {
       Result.emplace_back(convertToTypeName(PD->getDeclaredType()));
     }

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -769,9 +769,10 @@ public:
   }
 
   std::vector<sma::TypeName> collectProtocolConformances(NominalTypeDecl *NTD) {
+    const auto AllProtocols = NTD->getAllProtocols();
     std::vector<sma::TypeName> Result;
-    Result.reserve(NTD->getAllProtocols().size());
-    for (const auto *PD : NTD->getAllProtocols()) {
+    Result.reserve(AllProtocols.size());
+    for (const auto *PD : AllProtocols) {
       Result.emplace_back(convertToTypeName(PD->getDeclaredType()));
     }
     return Result;


### PR DESCRIPTION
Saving reallocation cost (sorry this is too minor but it bothered me that we weren't reserving when we know the size in advance.).