### PR TITLE
[AutoDiff] Remap types more consistently during AdjointGen.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2602,12 +2602,13 @@ private:
       : kind(kind), type(type), value(value) {
   }
 
-public:
+protected:
   AdjointValue(SILValue materializedValue)
       : AdjointValue(Kind::Materialized, materializedValue->getType(),
                      materializedValue) {}
   AdjointValue(SingleValueInstruction *svi) : AdjointValue(SILValue(svi)) {}
 
+public:
   Kind getKind() const { return kind; }
   SILType getType() const { return type; }
   CanType getSwiftType() const { return type.getASTType(); }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2834,7 +2834,7 @@ private:
         AutoDiffAssociatedVectorSpaceKind::Cotangent,
         LookUpConformanceInModule(getModule().getSwiftModule()));
     // The adjoint value must be in the cotangent space.
-    assert(cotanSpace && remapType(adjointValue.getType()).getASTType()
+    assert(cotanSpace && adjointValue.getType().getASTType()
                == cotanSpace->getCanonicalType());
 #endif
     auto insertion = adjointMap.try_emplace(originalValue, adjointValue);
@@ -3074,10 +3074,9 @@ public:
     // Construct the pullback arguments.
     SmallVector<SILValue, 8> args;
     auto seed = getAdjointValue(ai);
-    auto seedType = remapType(seed.getType());
-    auto *seedBuf = builder.createAllocStack(loc, seedType);
+    auto *seedBuf = builder.createAllocStack(loc, seed.getType());
     materializeAdjointIndirect(seed, seedBuf);
-    if (seedType.isAddressOnly(getModule()))
+    if (seed.getType().isAddressOnly(getModule()))
       args.push_back(seedBuf);
     else {
       auto access = builder.createBeginAccess(
@@ -3085,7 +3084,7 @@ public:
           /*noNestedConflict*/ true,
           /*fromBuiltin*/ false);
       SILValue seedEltAddr;
-      if (auto tupleTy = seedType.getAs<TupleType>())
+      if (auto tupleTy = seed.getType().getAs<TupleType>())
         seedEltAddr = builder.createTupleElementAddr(
             loc, access, applyInfo.indices.source);
       else
@@ -3206,7 +3205,7 @@ public:
       assert(!getModule().Types.getTypeLowering(cotangentVectorTy)
                  .isAddressOnly());
       auto cotangentVectorSILTy =
-          remapType(SILType::getPrimitiveObjectType(cotangentVectorTy));
+          SILType::getPrimitiveObjectType(cotangentVectorTy);
       auto *cotangentVectorDecl =
           cotangentVectorTy->getStructOrBoundGenericStruct();
       assert(cotangentVectorDecl);


### PR DESCRIPTION
Remaps archetypes from original function's generic signature to
adjoint's generic signature.

Fixes crashers exposed in high-level API library.
Not adding tests to save time - compilation of the high-level API library
will soon act as a test.