### PR TITLE
[Sema] Add dedicated fix-it for NSObject.hashValue overrides

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4245,9 +4245,13 @@ WARNING(non_exhaustive_switch_unknown_only,none,
         "switch covers known cases, but %0 may have additional unknown values"
         "%select{|, possibly added in future versions}1", (Type, bool))
 
-WARNING(override_nsobject_hashvalue,none,
+WARNING(override_nsobject_hashvalue_warning,none,
         "override of 'NSObject.hashValue' is deprecated; "
-        "override 'NSObject.hash' to get consistent hashing behavior", ())
+        "did you mean to override 'NSObject.hash'?", ())
+ERROR(override_nsobject_hashvalue_error,none,
+      "'NSObject.hashValue' is not overridable; "
+      "did you mean to override 'NSObject.hash'?", ())
+
 WARNING(hashvalue_implementation,none,
         "'Hashable.hashValue' is deprecated as a protocol requirement; "
         "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -110,7 +110,8 @@ class CallbackSubC : CallbackBase {
 
 //
 class MyHashableNSObject: NSObject {
-  override var hashValue: Int { // expected-error{{overriding non-open property outside of its defining module}} expected-error{{overriding non-@objc declarations from extensions is not supported}}
+  override var hashValue: Int {
+    // expected-error@-1 {{'NSObject.hashValue' is not overridable; did you mean to override 'NSObject.hash'?}}
     return 0
   }
 }

--- a/test/Migrator/fixit-NSObject-hashValue.swift
+++ b/test/Migrator/fixit-NSObject-hashValue.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/fixit-NSObject-hashValue.result
+// RUN: diff -u %s.expected %t/fixit-NSObject-hashValue.result
+// RUN: %target-swift-frontend -typecheck %s.expected
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
+
+class MyClass: NSObject {
+  override var hashValue: Int {
+    return 42
+  }
+}

--- a/test/Migrator/fixit-NSObject-hashValue.swift.expected
+++ b/test/Migrator/fixit-NSObject-hashValue.swift.expected
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/fixit-NSObject-hashValue.result
+// RUN: diff -u %s.expected %t/fixit-NSObject-hashValue.result
+// RUN: %target-swift-frontend -typecheck %s.expected
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
+
+class MyClass: NSObject {
+  override var hash: Int {
+    return 42
+  }
+}

--- a/test/stdlib/NSObject-hashing.swift
+++ b/test/stdlib/NSObject-hashing.swift
@@ -6,10 +6,13 @@
 import ObjectiveC
 
 class Foo: NSObject {
-  override var hashValue: Int { // expected-error {{overriding non-open property outside of its defining module}} expected-error {{overriding non-@objc declarations from extensions is not supported}}
+  override var hashValue: Int {
+    // expected-error@-1 {{'NSObject.hashValue' is not overridable; did you mean to override 'NSObject.hash'?}}
     return 0
   }
 
-  override func hash(into hasher: inout Hasher) { // expected-error {{overriding non-open instance method outside of its defining module}} expected-error {{overriding declarations in extensions is not supported}}
+  override func hash(into hasher: inout Hasher) {
+    // expected-error@-1 {{overriding non-open instance method outside of its defining module}}
+    // expected-error@-2 {{overriding declarations in extensions is not supported}}
   }
 }


### PR DESCRIPTION
(Note: I intend to submit this for inclusion in 5.0, too.)

`NSObject.hashValue` used to be declared `@objc open` by historical accident. Unfortunately, overrides of `NSObject.hashValue` never worked correctly. 

Swift 4.2 deprecated such overrides (https://github.com/apple/swift/pull/18407), and the property has been corrected to `@nonobjc public` in Swift 5.0 (https://github.com/apple/swift/pull/20129).

Help migration of existing code by adding a dedicated error message for overrides of `NSObject.hashValue`, with a nice fix-it directing people to override `NSObject.hash` instead.

```swift
// smash.swift
import Foundation

class Foo: NSObject {
  override var hashValue: Int {
    return 42
  }
}
```

**Before:**

```
$ swiftc smash.swift
smash.swift:4:16: error: overriding non-open property outside of its defining module
  override var hashValue: Int {
               ^
smash.swift:4:16: error: overriding non-@objc declarations from extensions is not supported
  override var hashValue: Int {
               ^
ObjectiveC.NSObject:3:25: note: add '@objc' to make this declaration overridable
    @nonobjc public var hashValue: Int { get }
                        ^
```

**After:**

```
$ swiftc smash.swift
smash.swift:4:16: error: 'NSObject.hashValue' is not overridable; did you mean to override 'NSObject.hash'?
  override var hashValue: Int {
               ^~~~~~~~~
               hash
```

rdar://problem/45674813