### PR TITLE
[5.0] [Name lookup] Implement name shadowing rule for Data.withUnsafeBytes.

### DIFF
--- a/test/NameBinding/Inputs/NIOFoundationCompat.swift
+++ b/test/NameBinding/Inputs/NIOFoundationCompat.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Data {
+  @_inlineable
+  public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    let r: R? = nil
+    return r!
+  }
+}

--- a/test/NameBinding/nio_shadowing.swift
+++ b/test/NameBinding/nio_shadowing.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/NIOFoundationCompat.swift
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify
+
+// REQUIRES: objc_interop
+import Foundation
+import NIOFoundationCompat
+
+func test(data: Data) {
+  data.withUnsafeBytes { x in print(x) }
+}


### PR DESCRIPTION
Address an annoying source compatibility issue with the introduction
of Data.withUnsafeBytes, which is ambiguous with Swift NIO's
implementatio of the same function. Do so with a narrow hackish name
shadowing rule (the Swift NIO version shadows the Foundation version)
that we will eventually generalize to something sensible.

Fixes rdar://problem/46850346.
