### PR TITLE
[Sema] Improve diagnostics for `variable_never_mutated` in case of for-each loop's binding.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4181,8 +4181,8 @@ WARNING(immutable_value_never_used_but_assigned, none,
         (Identifier))
 WARNING(variable_never_mutated, none,
         "%select{variable|parameter}1 %0 was never mutated; "
-        "consider changing to 'let' constant",
-        (Identifier, unsigned))
+        "consider %select{removing 'var' to make it|changing to 'let'}2 constant",
+        (Identifier, unsigned, bool))
 WARNING(variable_never_read, none,
         "%select{variable|parameter}1 %0 was written to, but never read",
         (Identifier, unsigned))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2708,9 +2708,10 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
 
       // If this is a parameter explicitly marked 'var', remove it.
       unsigned varKind = isa<ParamDecl>(var);
-      if (FixItLoc.isInvalid())
+      if (FixItLoc.isInvalid()) {
         Diags.diagnose(var->getLoc(), diag::variable_never_mutated,
-                       var->getName(), varKind);
+                       var->getName(), varKind, true);
+      }
       else {
         bool suggestLet = true;
         if (auto *stmt = var->getParentPatternStmt()) {
@@ -2721,7 +2722,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         }
 
         auto diag = Diags.diagnose(var->getLoc(), diag::variable_never_mutated,
-                                   var->getName(), varKind);
+                                   var->getName(), varKind, suggestLet);
 
         if (suggestLet)
           diag.fixItReplace(FixItLoc, "let");

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1065,7 +1065,7 @@ let _: KeyPath<R32101765, Float> = \R32101765.prop32101765.unknown
 // expected-error@-1 {{type 'Int' has no member 'unknown'}}
 
 // rdar://problem/32390726 - Bad Diagnostic: Don't suggest `var` to `let` when binding inside for-statement
-for var i in 0..<10 { // expected-warning {{variable 'i' was never mutated; consider changing to 'let' constant}} {{5-9=}}
+for var i in 0..<10 { // expected-warning {{variable 'i' was never mutated; consider removing 'var' to make it constant}} {{5-9=}}
   _ = i + 1
 }
 

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -197,7 +197,7 @@ func testFixitsInStatementsWithPatterns(_ a : Int?) {
     _ = b2
   }
   
-  for var b in [42] { // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}} {{7-11=}}
+  for var b in [42] { // expected-warning {{variable 'b' was never mutated; consider removing 'var' to make it constant}} {{7-11=}}
     _ = b
   }
 


### PR DESCRIPTION
The diagnostics for `variable_never_mutated` always suggests changing `var` to `let`, which is misleading in case of for-each loops where explicitly immutable context applies. This patch adds some variety to the message to make it appropriate, as shown in the following example.

```diff
for var x in [1,2,3] { _ = x }
    ~~~~^
- warning: variable 'x' was never mutated; consider changing to 'let' constant
+ warning: variable 'x' was never mutated; consider removing 'var' to make it constant
```


Resolves [SR-9732](https://bugs.swift.org/browse/SR-9732).