### PR TITLE
Demangler: Print BuiltinFloatType as "FPIEEE<size>" not "Float<size>"

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -58,7 +58,7 @@ constexpr static const char BUILTIN_TYPE_NAME_INT512[] = "Builtin.Int512";
 constexpr static const char BUILTIN_TYPE_NAME_INTLITERAL[] =
     "Builtin.IntLiteral";
 /// The name of the Builtin type for Float
-constexpr static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.Float";
+constexpr static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.FPIEEE";
 /// The name of the Builtin type for NativeObject
 constexpr static const char BUILTIN_TYPE_NAME_NATIVEOBJECT[] =
     "Builtin.NativeObject";

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -1810,7 +1810,7 @@ private:
         if (demangleBuiltinSize(size)) {
           return Factory.createNode(
               Node::Kind::BuiltinTypeName,
-              std::move(DemanglerPrinter() << "Builtin.Float" << size).str());
+              std::move(DemanglerPrinter() << "Builtin.FPIEEE" << size).str());
         }
       }
       if (c == 'i') {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1350,7 +1350,7 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
     Out << 'w';
   } else if (stripPrefix(text, "Builtin.Int")) {
     Out << 'i' << text << '_';
-  } else if (stripPrefix(text, "Builtin.Float")) {
+  } else if (stripPrefix(text, "Builtin.FPIEEE")) {
     Out << 'f' << text << '_';
   } else if (stripPrefix(text, "Builtin.Vec")) {
     // Avoid using StringRef::split because its definition is not

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -709,7 +709,7 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
     auto element = text.substr(splitIdx).substr(1);
     if (element == "RawPointer") {
       Buffer << 'p';
-    } else if (element.consume_front("Float")) {
+    } else if (element.consume_front("FPIEEE")) {
       Buffer << 'f' << element << '_';
     } else if (element.consume_front("Int")) {
       Buffer << 'i' << element << '_';

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -1,5 +1,11 @@
-_TtBf80_ ---> Builtin.Float80
+_TtBf32_ ---> Builtin.FPIEEE32
+_TtBf64_ ---> Builtin.FPIEEE64
+_TtBf80_ ---> Builtin.FPIEEE80
 _TtBi32_ ---> Builtin.Int32
+$sBf32_ ---> Builtin.FPIEEE32
+$sBf64_ ---> Builtin.FPIEEE64
+$sBf80_ ---> Builtin.FPIEEE80
+$sBi32_ ---> Builtin.Int32
 _TtBw ---> Builtin.Word
 _TtBO ---> Builtin.UnknownObject
 _TtBo ---> Builtin.NativeObject

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -1,4 +1,4 @@
-_TtBf80_ ---> Builtin.Float80
+_TtBf80_ ---> Builtin.FPIEEE80
 _TtBi32_ ---> Builtin.Int32
 _TtBw ---> Builtin.Word
 _TtBO ---> Builtin.UnknownObject

--- a/test/SourceKit/Demangle/demangle.swift
+++ b/test/SourceKit/Demangle/demangle.swift
@@ -1,7 +1,7 @@
 // RUN: %sourcekitd-test -req=demangle unmangled _TtBf80_  _TtP3foo3bar_ '$s3Foo11AppDelegateC29applicationDidFinishLaunchingyy10Foundation12NotificationVF' | %FileCheck %s
 // CHECK:      START DEMANGLE
 // CHECK-NEXT: <empty>
-// CHECK-NEXT: Builtin.Float80
+// CHECK-NEXT: Builtin.FPIEEE80
 // CHECK-NEXT: foo.bar
 // CHECK-NEXT: Foo.AppDelegate.applicationDidFinishLaunching(Foundation.Notification) -> ()
 // CHECK-NEXT: END DEMANGLE
@@ -9,7 +9,7 @@
 // RUN: %sourcekitd-test -req=demangle unmangled _TtBf80_  _TtP3foo3bar_ '$s3Foo11AppDelegateC29applicationDidFinishLaunchingyy10Foundation12NotificationVF' -simplified-demangling | %FileCheck %s -check-prefix=SIMPLIFIED
 // SIMPLIFIED:      START DEMANGLE
 // SIMPLIFIED-NEXT: <empty>
-// SIMPLIFIED-NEXT: Builtin.Float80
+// SIMPLIFIED-NEXT: Builtin.FPIEEE80
 // SIMPLIFIED-NEXT: bar
 // SIMPLIFIED-NEXT: AppDelegate.applicationDidFinishLaunching(_:)
 // SIMPLIFIED-NEXT: END DEMANGLE


### PR DESCRIPTION
The type checker calls these types `Builtin.FPIEEE<size>`; the demangler
should too.

This is just cosmetic at the moment, but it was causing problems when
I added support for builtin types to the TypeDecoder.