### PR TITLE
[SR-9740][SourceKit] Mark types inside enum case decl as typeidentifiers

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -892,6 +892,13 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
           SourceRange NameRange = SourceRange(EnumElemD->getNameLoc(),
                                               ParamList->getSourceRange().End);
           SN.NameRange = charSourceRangeFromSourceRange(SM, NameRange);
+
+          for (auto Param : ParamList->getArray()) {
+            auto TL = Param->getTypeLoc();
+            CharSourceRange TR = charSourceRangeFromSourceRange(SM,
+                                                                TL.getSourceRange());
+            passNonTokenNode({SyntaxNodeKind::TypeId, TR});
+          }
         } else {
           SN.NameRange = CharSourceRange(EnumElemD->getNameLoc(),
                                          EnumElemD->getName().getLength());

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -4,7 +4,7 @@
 enum List<T> {
   case Nil
   // rdar://21927124
-  // CHECK: <attr-builtin>indirect</attr-builtin> <kw>case</kw> Cons(T, List)
+  // CHECK: <attr-builtin>indirect</attr-builtin> <kw>case</kw> Cons(<type>T</type>, <type>List</type>)
   indirect case Cons(T, List)
 }
 

--- a/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
+++ b/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
@@ -57,3 +57,10 @@ func testArgumentLabels(in class: Int, _ case: (_ default: Int) -> Void) -> (in:
 
 // https://bugs.swift.org/browse/SR-9576
 func someFunc(input :Int?, completion: () throws -> Void) rethrows {}
+
+// https://bugs.swift.org/browse/SR-9740
+enum A {
+    case noArguments
+    case namedArguments(param1: String, param2: Int)
+    case mutedArguments(String, Int)
+}

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 1161,
+  key.length: 1325,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -622,6 +622,91 @@
       key.kind: source.lang.swift.syntaxtype.keyword,
       key.offset: 1149,
       key.length: 8
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 1162,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment.url,
+      key.offset: 1165,
+      key.length: 37
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 1202,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1203,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1208,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1216,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1221,
+      key.length: 11
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1237,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1242,
+      key.length: 14
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1257,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 1265,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1273,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 1281,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1290,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1295,
+      key.length: 14
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 1310,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 1318,
+      key.length: 3
     }
   ]
 }


### PR DESCRIPTION
Before this patch, types inside an enum case declaration wouldn't be marked as typeidentifier:

```swift
enum A {
    case b(c: String)
}
```

Running `sourcekitten syntax --file file.swift`

```json
[
  {
    "length" : 4,
    "offset" : 0,
    "type" : "source.lang.swift.syntaxtype.keyword"
  },
  {
    "length" : 1,
    "offset" : 5,
    "type" : "source.lang.swift.syntaxtype.identifier"
  },
  {
    "length" : 4,
    "offset" : 13,
    "type" : "source.lang.swift.syntaxtype.keyword"
  },
  {
    "length" : 1,
    "offset" : 18,
    "type" : "source.lang.swift.syntaxtype.identifier"
  },
  {
    "length" : 1,
    "offset" : 20,
    "type" : "source.lang.swift.syntaxtype.identifier"
  },
  {
    "length" : 6,
    "offset" : 23,
    "type" : "source.lang.swift.syntaxtype.identifier"
  }
]
```

Resolves [SR-9740](https://bugs.swift.org/browse/SR-9740).

cc @nkcsgexi 