### PR TITLE
Make SIMD types Codable.

### DIFF
--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -73,3 +73,8 @@ Var _RawDictionaryStorage.empty has declared type change from _EmptyDictionarySi
 Var _RawSetStorage.empty has declared type change from _EmptySetSingleton to __EmptySetSingleton
 
 Func tryReallocateUniquelyReferenced(buffer:newMinimumCapacity:) has been removed
+
+Protocol SIMD has added inherited protocol Decodable
+Protocol SIMD has added inherited protocol Encodable
+Protocol SIMD has generic signature change from <τ_0_0 : CustomStringConvertible, τ_0_0 : ExpressibleByArrayLiteral, τ_0_0 : Hashable, τ_0_0 : SIMDStorage, τ_0_0.MaskStorage : SIMD, τ_0_0.MaskStorage.Scalar : FixedWidthInteger, τ_0_0.MaskStorage.Scalar : SignedInteger> to <τ_0_0 : CustomStringConvertible, τ_0_0 : Decodable, τ_0_0 : Encodable, τ_0_0 : ExpressibleByArrayLiteral, τ_0_0 : Hashable, τ_0_0 : SIMDStorage, τ_0_0.MaskStorage : SIMD, τ_0_0.MaskStorage.Scalar : FixedWidthInteger, τ_0_0.MaskStorage.Scalar : SignedInteger>
+Protocol SIMDStorage has generic signature change from <τ_0_0.Scalar : Hashable> to <τ_0_0.Scalar : Decodable, τ_0_0.Scalar : Encodable, τ_0_0.Scalar : Hashable>

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -1,1 +1,5 @@
 Func tryReallocateUniquelyReferenced(buffer:newMinimumCapacity:) has been removed
+Protocol SIMD has added inherited protocol Decodable
+Protocol SIMD has added inherited protocol Encodable
+Protocol SIMD has generic signature change from <Self : CustomStringConvertible, Self : ExpressibleByArrayLiteral, Self : Hashable, Self : SIMDStorage, Self.MaskStorage : SIMD, Self.MaskStorage.Scalar : FixedWidthInteger, Self.MaskStorage.Scalar : SignedInteger> to <Self : CustomStringConvertible, Self : Decodable, Self : Encodable, Self : ExpressibleByArrayLiteral, Self : Hashable, Self : SIMDStorage, Self.MaskStorage : SIMD, Self.MaskStorage.Scalar : FixedWidthInteger, Self.MaskStorage.Scalar : SignedInteger>
+Protocol SIMDStorage has generic signature change from <Self.Scalar : Hashable> to <Self.Scalar : Decodable, Self.Scalar : Encodable, Self.Scalar : Hashable>

--- a/test/stdlib/SIMD.swift
+++ b/test/stdlib/SIMD.swift
@@ -1,0 +1,55 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+let SIMDCodableTests = TestSuite("SIMDCodable")
+
+func testRoundTrip<T>(_ for: T.Type)
+where T : SIMD, T.Scalar : FixedWidthInteger {
+  let input = T.random(in: T.Scalar.min ... T.Scalar.max)
+  let encoder = JSONEncoder()
+  let decoder = JSONDecoder()
+  do {
+    let data = try encoder.encode(input)
+    let output = try decoder.decode(T.self, from: data)
+    assertEqual(input, output)
+  }
+  catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+// Very basic round-trip test. We can be much more sophisticated in the future,
+// but we want to at least exercise the API. Also need to add some negative
+// tests for the error paths, and test a more substantial set of types.
+SIMDCodableTests.test("roundTrip") {
+  testRoundTrip(SIMD2<Int8>.self)
+  testRoundTrip(SIMD3<Int8>.self)
+  testRoundTrip(SIMD4<Int8>.self)
+  testRoundTrip(SIMD2<UInt8>.self)
+  testRoundTrip(SIMD3<UInt8>.self)
+  testRoundTrip(SIMD4<UInt8>.self)
+  testRoundTrip(SIMD2<Int32>.self)
+  testRoundTrip(SIMD3<Int32>.self)
+  testRoundTrip(SIMD4<Int32>.self)
+  testRoundTrip(SIMD2<UInt32>.self)
+  testRoundTrip(SIMD3<UInt32>.self)
+  testRoundTrip(SIMD4<UInt32>.self)
+  testRoundTrip(SIMD2<Int>.self)
+  testRoundTrip(SIMD3<Int>.self)
+  testRoundTrip(SIMD4<Int>.self)
+  testRoundTrip(SIMD2<UInt>.self)
+  testRoundTrip(SIMD3<UInt>.self)
+  testRoundTrip(SIMD4<UInt>.self)
+  testRoundTrip(SIMD2<Float>.self)
+  testRoundTrip(SIMD3<Float>.self)
+  testRoundTrip(SIMD4<Float>.self)
+  testRoundTrip(SIMD2<Double>.self)
+  testRoundTrip(SIMD3<Double>.self)
+  testRoundTrip(SIMD4<Double>.self)
+}
+
+runAllTests()

--- a/test/stdlib/SIMD.swift
+++ b/test/stdlib/SIMD.swift
@@ -15,7 +15,7 @@ where T : SIMD, T.Scalar : FixedWidthInteger {
   do {
     let data = try encoder.encode(input)
     let output = try decoder.decode(T.self, from: data)
-    assertEqual(input, output)
+    expectEqual(input, output)
   }
   catch {
     expectUnreachableCatch(error)
@@ -31,7 +31,7 @@ where T : SIMD, T.Scalar : BinaryFloatingPoint,
   do {
     let data = try encoder.encode(input)
     let output = try decoder.decode(T.self, from: data)
-    assertEqual(input, output)
+    expectEqual(input, output)
   }
   catch {
     expectUnreachableCatch(error)

--- a/test/stdlib/SIMD.swift
+++ b/test/stdlib/SIMD.swift
@@ -22,6 +22,21 @@ where T : SIMD, T.Scalar : FixedWidthInteger {
   }
 }
 
+func testRoundTrip<T>(_ for: T.Type)
+where T : SIMD, T.Scalar : BinaryFloatingPoint {
+  let input = T.random(in: -16 ... (16 as T))
+  let encoder = JSONEncoder()
+  let decoder = JSONDecoder()
+  do {
+    let data = try encoder.encode(input)
+    let output = try decoder.decode(T.self, from: data)
+    assertEqual(input, output)
+  }
+  catch {
+    expectUnreachableCatch(error)
+  }
+}
+
 // Very basic round-trip test. We can be much more sophisticated in the future,
 // but we want to at least exercise the API. Also need to add some negative
 // tests for the error paths, and test a more substantial set of types.

--- a/test/stdlib/SIMD.swift
+++ b/test/stdlib/SIMD.swift
@@ -23,8 +23,9 @@ where T : SIMD, T.Scalar : FixedWidthInteger {
 }
 
 func testRoundTrip<T>(_ for: T.Type)
-where T : SIMD, T.Scalar : BinaryFloatingPoint {
-  let input = T.random(in: -16 ... (16 as T))
+where T : SIMD, T.Scalar : BinaryFloatingPoint,
+      T.Scalar.RawSignificand : FixedWidthInteger {
+  let input = T.random(in: -16 ..< 16)
   let encoder = JSONEncoder()
   let decoder = JSONDecoder()
   do {


### PR DESCRIPTION
We're considering this a bugfix, on the premise that any stdlib type that doesn't have a reason not to be Codable should be.