### PR TITLE
[REPL] When using the default resource directory, prefer loading Swift dylibs from /usr/lib/swift.

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -72,6 +72,9 @@ public:
 
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPath = false;
+  
+  /// Whether the runtime library path is set to the compiler-relative default.
+  bool RuntimeLibraryPathIsDefault = true;
 
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -182,7 +182,7 @@ public:
 
   void setMainExecutablePath(StringRef Path);
 
-  void setRuntimeResourcePath(StringRef Path);
+  void setRuntimeResourcePath(StringRef Path, bool IsDefault = false);
 
   void setSDKPath(const std::string &Path) {
     SearchPathOpts.SDKPath = Path;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -39,7 +39,7 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   llvm::sys::path::remove_filename(LibPath); // Remove /swift
   llvm::sys::path::remove_filename(LibPath); // Remove /bin
   llvm::sys::path::append(LibPath, "lib", "swift");
-  setRuntimeResourcePath(LibPath.str());
+  setRuntimeResourcePath(LibPath.str(), /*IsDefault=*/true);
 }
 
 static void updateRuntimeLibraryPath(SearchPathOptions &SearchPathOpts,
@@ -53,9 +53,11 @@ static void updateRuntimeLibraryPath(SearchPathOptions &SearchPathOpts,
   SearchPathOpts.RuntimeLibraryImportPath = LibPath.str();
 }
 
-void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {
+void CompilerInvocation::setRuntimeResourcePath(StringRef Path,
+                                                bool IsDefault) {
   SearchPathOpts.RuntimeResourcePath = Path;
   updateRuntimeLibraryPath(SearchPathOpts, LangOpts.Target);
+  SearchPathOpts.RuntimeLibraryPathIsDefault = IsDefault;
 }
 
 void CompilerInvocation::setTargetTriple(StringRef Triple) {

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -38,7 +38,8 @@ namespace immediate {
 /// calls or \c null if an error occurred.
 ///
 /// \param runtimeLibPath Path to search for compiler-relative stdlib dylibs.
-void *loadSwiftRuntime(StringRef runtimeLibPath);
+/// \param IsDefault If true, the path is the default compiler-relative path.
+void *loadSwiftRuntime(StringRef runtimeLibPath, bool IsDefault);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -968,7 +968,8 @@ public:
     ASTContext &Ctx = CI.getASTContext();
     Ctx.LangOpts.EnableAccessControl = false;
     if (!ParseStdlib) {
-      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPath)) {
+      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPath,
+                            Ctx.SearchPathOpts.RuntimeLibraryPathIsDefault)) {
         CI.getDiags().diagnose(SourceLoc(),
                                diag::error_immediate_mode_missing_stdlib);
         return;


### PR DESCRIPTION
rdar://problem/46355503