### PR TITLE
[AutoDiff] Fix AD primal value struct linkage.

### DIFF
--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -33,8 +33,7 @@ func testOwnedVector(_ x: Vector) -> Vector {
 _ = pullback(at: Vector.zero, in: testOwnedVector)
 
 // CHECK-VJP-LABEL: struct {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 {
-// CHECK-VJP-NEXT:   @_hasStorage @usableFromInline
-// CHECK-VJP-NEXT:   var pullback_0: (Vector) -> (Vector, Vector)
+// CHECK-VJP-NEXT:   @_hasStorage var pullback_0: (Vector) -> (Vector, Vector)
 // CHECK-VJP-NEXT: }
 
 // The primal should not release primal values.


### PR DESCRIPTION
Make the primal value struct copy the original function's linkage. This won't fix the current deserialization failure [SR-9741](https://bugs.swift.org/browse/SR-9741), but will make things more consistent.