### PR TITLE
[AutoDiff] Do not retain an associated function when it's not refcounted.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4383,7 +4383,8 @@ bool Differentiation::processAutoDiffFunctionInst(AutoDiffFunctionInst *adfi,
            "FIXME: We could emit a thunk that converts the VJP to have the "
            "desired indices.");
     auto assocFn = assocFnAndIndices->first;
-    builder.createRetainValue(loc, assocFn, builder.getDefaultAtomicity());
+    if (assocFn->getType().isReferenceCounted(*getModule()))
+      builder.createRetainValue(loc, assocFn, builder.getDefaultAtomicity());
     assocFns.push_back(assocFnAndIndices->first);
   }
 


### PR DESCRIPTION
Associated functions should not be retained when they are not reference counted. Hot fix for unblocking TF APIs.