### PR TITLE
[SR-9738][Sema] Improve @dynamicCallable Diagnostics for Incorrect Parameter Types

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2612,7 +2612,6 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   // non-function/non-metatype type, then we cannot call it!
   if (!isUnresolvedOrTypeVarType(fnType) &&
       !fnType->is<AnyFunctionType>() && !fnType->is<MetatypeType>()) {
-
     auto arg = callExpr->getArg();
     auto isDynamicCallable =
         CS.DynamicCallableCache[fnType->getCanonicalType()].isValid();
@@ -2625,7 +2624,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
           return funcDecl && funcDecl->isCallAsFunctionMethod();
         });
 
-    // Diagnose @dynamicCallable errors.
+    // Diagnose specific @dynamicCallable errors.
     if (isDynamicCallable) {
       auto dynamicCallableMethods =
         CS.DynamicCallableCache[fnType->getCanonicalType()];
@@ -2644,13 +2643,12 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       }
     }
 
-    if (fnType->is<ExistentialMetatypeType>()) {
+    auto isExistentialMetatypeType = fnType->is<ExistentialMetatypeType>();
+    if (isExistentialMetatypeType) {
       auto diag = diagnose(arg->getStartLoc(),
                            diag::missing_init_on_metatype_initialization);
       diag.highlight(fnExpr->getSourceRange());
-    }
-
-    if (!fnType->is<ExistentialMetatypeType>()) {
+    } else if (!isDynamicCallable) {
       auto diag = diagnose(arg->getStartLoc(),
                            diag::cannot_call_non_function_value, fnType);
       diag.highlight(fnExpr->getSourceRange());
@@ -2669,7 +2667,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     // the line after the callee, then it's likely the user forgot to
     // write "do" before their brace stmt.
     // Note that line differences of more than 1 are diagnosed during parsing.
-    if (auto *PE = dyn_cast<ParenExpr>(arg))
+    if (auto *PE = dyn_cast<ParenExpr>(arg)) {
       if (PE->hasTrailingClosure() && isa<ClosureExpr>(PE->getSubExpr())) {
         auto *closure = cast<ClosureExpr>(PE->getSubExpr());
         auto &SM = CS.getASTContext().SourceMgr;
@@ -2681,9 +2679,14 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
             .fixItInsert(closure->getStartLoc(), "do ");
         }
       }
+    }
 
-    if (!isDynamicCallable && !hasCallAsFunctionMethods)
+    // Use the existing machinery to provide more useful diagnostics for
+    // @dynamicCallable calls, rather than cannot_call_non_function_value.
+    if ((isExistentialMetatypeType || !isDynamicCallable) &&
+    	  !hasCallAsFunctionMethods) {
       return true;
+    }
   }
   
   bool hasTrailingClosure = callArgHasTrailingClosure(callExpr->getArg());

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -49,6 +49,15 @@ func testCallable(
   d(x1: 1, 2.0, x2: 3)
 }
 
+func testCallableDiagnostics(
+  a: Callable, b: DiscardableResult, c: Throwing, d: KeywordArgumentCallable
+) {
+  a("hello", "world") // expected-error {{cannot invoke 'a' with an argument list of type '(String, String)'}}
+  b("hello", "world") // expected-error {{cannot invoke 'b' with an argument list of type '(String, String)'}}
+  try? c(1, 2, 3, 4) // expected-error {{cannot invoke 'c' with an argument list of type '(Int, Int, Int, Int)'}}
+  d(x1: "hello", x2: "world") // expected-error {{cannot invoke 'd' with an argument list of type '(x1: String, x2: String)'}}
+}
+
 func testIUO(
   a: Callable!, b: DiscardableResult!, c: Throwing!, d: KeywordArgumentCallable!
 ) {


### PR DESCRIPTION
The previous implementation of specific `@dynamicCallable` diagnostics prevented more useful errors from being reported in certain cases. Previously, incorrect parameter types would emit `diag::cannot_call_non_function_value`. Such an error would now be correctly reported as an incorrect argument type for the dynamic call.

Resolves [SR-9738](https://bugs.swift.org/browse/SR-9738).