### PR TITLE
SILGen: make `main` hidden

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -527,7 +527,7 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
 
   SILGenFunctionBuilder builder(*this);
   return builder.createFunction(
-      SILLinkage::Public, SWIFT_ENTRY_POINT_FUNCTION, topLevelType, nullptr,
+      SILLinkage::Hidden, SWIFT_ENTRY_POINT_FUNCTION, topLevelType, nullptr,
       Loc, IsBare, IsNotTransparent, IsNotSerialized, IsNotDynamic,
       ProfileCounter(), IsNotThunk, SubclassScope::NotApplicable);
 }

--- a/test/SILGen/main.swift
+++ b/test/SILGen/main.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-emit-silgen -module-name main %s | %FileCheck %s
+
+_ = true
+
+// CHECK-LABEL: sil hidden [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32
+


### PR DESCRIPTION
The `main` entry point does not need to be made SILPublic (external linkage,
default visibility, export DLL storage) as it is internal to the application and
will be invoked by the C runtime.  Make it hidden instead (external linkage,
hidden visibility, default DLL storage).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
