### PR TITLE
[Python] Improve Python interop usability.

### DIFF
--- a/stdlib/public/Python/NumpyConversion.swift
+++ b/stdlib/public/Python/NumpyConversion.swift
@@ -24,7 +24,7 @@ private let ctypes = Python.import("ctypes")
 /// A type that can be initialized from a `numpy.ndarray` instance represented
 /// as a `PythonObject`.
 public protocol ConvertibleFromNumpyArray {
-  init?(numpyArray: PythonObject)
+  init?(numpy: PythonObject)
 }
 
 /// A type that is bitwise compatible with one or more NumPy scalar types.
@@ -93,7 +93,7 @@ extension Double : NumpyScalarCompatible {
 
 extension Array : ConvertibleFromNumpyArray
   where Element : NumpyScalarCompatible {
-  public init?(numpyArray: PythonObject) {
+  public init?(numpy numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
       return nil

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -684,6 +684,18 @@ public struct PythonInterface {
   public subscript(dynamicMember name: String) -> PythonObject {
     return builtins[name]
   }
+
+  // The Python runtime version.
+  // Equivalent to `sys.version` in Python.
+  public var version: PythonObject {
+    return self.import("sys").version
+  }
+
+  // The Python runtime version information.
+  // Equivalent to `sys.version_info` in Python.
+  public var versionInfo: PythonObject {
+    return self.import("sys").version_info
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -25,7 +25,7 @@ private let np = Python.import("numpy")
 
 extension ShapedArray : ConvertibleFromNumpyArray
   where Scalar : NumpyScalarCompatible {
-  public init?(numpyArray: PythonObject) {
+  public init?(numpy numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
       return nil
@@ -73,7 +73,7 @@ extension ShapedArray : ConvertibleFromNumpyArray
 
 extension Tensor : ConvertibleFromNumpyArray
   where Scalar : NumpyScalarCompatible {
-  public init?(numpyArray: PythonObject) {
+  public init?(numpy numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
       return nil
@@ -106,26 +106,6 @@ extension Tensor : ConvertibleFromNumpyArray
     let buffPtr = UnsafeBufferPointer(start: ptr,
                                       count: Int(shape.contiguousSize))
     self.init(shape: shape, scalars: buffPtr)
-  }
-}
-
-extension ShapedArray where Scalar : NumpyScalarCompatible {
-  // Creates a `ShapedArray` instance from the given `PythonObject` if it is a
-  // `numpy.ndarray` instance with a matching scalar datatype.
-  // TODO: Generalize `init?(_: PythonObject)` to handle (potentially nested)
-  // Python lists.
-  public init?(_ pythonObject: PythonObject) {
-    self.init(numpyArray: pythonObject)
-  }
-}
-
-extension Tensor where Scalar : NumpyScalarCompatible {
-  // Creates a `Tensor` instance from the given `PythonObject` if it is a
-  // `numpy.ndarray` instance with a matching scalar datatype.
-  // TODO: Generalize `init?(_: PythonObject)` to handle (potentially nested)
-  // Python lists, where the scalar type conforms to `TensorFlowScalar`.
-  public init?(_ pythonObject: PythonObject) {
-    self.init(numpyArray: pythonObject)
   }
 }
 

--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -112,6 +112,8 @@ extension Tensor : ConvertibleFromNumpyArray
 extension ShapedArray where Scalar : NumpyScalarCompatible {
   // Creates a `ShapedArray` instance from the given `PythonObject` if it is a
   // `numpy.ndarray` instance with a matching scalar datatype.
+  // TODO: Generalize `init?(_: PythonObject)` to handle (potentially nested)
+  // Python lists.
   public init?(_ pythonObject: PythonObject) {
     self.init(numpyArray: pythonObject)
   }
@@ -120,6 +122,8 @@ extension ShapedArray where Scalar : NumpyScalarCompatible {
 extension Tensor where Scalar : NumpyScalarCompatible {
   // Creates a `Tensor` instance from the given `PythonObject` if it is a
   // `numpy.ndarray` instance with a matching scalar datatype.
+  // TODO: Generalize `init?(_: PythonObject)` to handle (potentially nested)
+  // Python lists, where the scalar type conforms to `TensorFlowScalar`.
   public init?(_ pythonObject: PythonObject) {
     self.init(numpyArray: pythonObject)
   }

--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -110,6 +110,22 @@ extension Tensor : ConvertibleFromNumpyArray
 }
 
 extension ShapedArray where Scalar : NumpyScalarCompatible {
+  // Creates a `ShapedArray` instance from the given `PythonObject` if it is a
+  // `numpy.ndarray` instance with a matching scalar datatype.
+  public init?(_ pythonObject: PythonObject) {
+    self.init(numpyArray: pythonObject)
+  }
+}
+
+extension Tensor where Scalar : NumpyScalarCompatible {
+  // Creates a `Tensor` instance from the given `PythonObject` if it is a
+  // `numpy.ndarray` instance with a matching scalar datatype.
+  public init?(_ pythonObject: PythonObject) {
+    self.init(numpyArray: pythonObject)
+  }
+}
+
+extension ShapedArray where Scalar : NumpyScalarCompatible {
   /// Creates a NumPy array with the same elements.
   ///
   /// - Precondition: The `numpy` Python package must have been installed.

--- a/test/Python/numpy_conversion.swift
+++ b/test/Python/numpy_conversion.swift
@@ -13,34 +13,34 @@ NumpyConversionTests.test("array-conversion") {
   guard let np = numpyModule else { return }
 
   let numpyArrayEmpty = np.array([] as [Float], dtype: np.float32)
-  if let array = expectNotNil(Array<Float>(numpyArray: numpyArrayEmpty)) {
+  if let array = expectNotNil(Array<Float>(numpy: numpyArrayEmpty)) {
     expectEqual([], array)
   }
 
   let numpyArrayBool = np.array([true, false, false, true])
-  if let array = expectNotNil(Array<Bool>(numpyArray: numpyArrayBool)) {
+  if let array = expectNotNil(Array<Bool>(numpy: numpyArrayBool)) {
     expectEqual([true, false, false, true], array)
   }
 
   let numpyArrayFloat = np.ones([6], dtype: np.float32)
-  if let array = expectNotNil(Array<Float>(numpyArray: numpyArrayFloat)) {
+  if let array = expectNotNil(Array<Float>(numpy: numpyArrayFloat)) {
     expectEqual(Array(repeating: 1, count: 6), array)
   }
 
   let numpyArrayInt32 = np.array([-1, 4, 25, 2018], dtype: np.int32)
-  if let array = expectNotNil(Array<Int32>(numpyArray: numpyArrayInt32)) {
+  if let array = expectNotNil(Array<Int32>(numpy: numpyArrayInt32)) {
     expectEqual([-1, 4, 25, 2018], array)
   }
 
   let numpyArray2D = np.ones([2, 3])
-  expectNil(Array<Float>(numpyArray: numpyArray2D))
+  expectNil(Array<Float>(numpy: numpyArray2D))
 
   let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
       Python.slice(Python.None), 1]
   // Assert that the array has a stride, so that we're certainly testing a
   // strided array.
   expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
-  if let array = expectNotNil(Array<Int32>(numpyArray: numpyArrayStrided)) {
+  if let array = expectNotNil(Array<Int32>(numpy: numpyArrayStrided)) {
     expectEqual([2, 2], array)
   }
 }

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -10,9 +10,11 @@ var PythonRuntimeTestSuite = TestSuite("PythonRuntime")
 PythonLibrary.useVersion(2, 7)
 
 PythonRuntimeTestSuite.test("CheckVersion") {
-  let sysModule = Python.import("sys")
-  let version = String(sysModule.version)!
+  let version = Python.version
   expectEqual("2.7.", version.prefix(4))
+  let versionInfo = Python.versionInfo
+  expectEqual(2, versionInfo.major)
+  expectEqual(7, versionInfo.minor)
 }
 
 PythonRuntimeTestSuite.test("PythonList") {

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -10,8 +10,7 @@ var PythonRuntimeTestSuite = TestSuite("PythonRuntime")
 PythonLibrary.useVersion(2, 7)
 
 PythonRuntimeTestSuite.test("CheckVersion") {
-  let version = Python.version
-  expectEqual("2.7.", version.prefix(4))
+  expectEqual("2.7.", String(Python.version)!.prefix(4))
   let versionInfo = Python.versionInfo
   expectEqual(2, versionInfo.major)
   expectEqual(7, versionInfo.minor)

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -24,30 +24,30 @@ NumpyConversionTests.test("shaped-array-conversion") {
   guard let np = numpyModule else { return }
 
   let numpyArrayEmpty = np.array([[]] as [[Float]], dtype: np.float32)
-  if let array = expectNotNil(ShapedArray<Float>(numpyArray: numpyArrayEmpty)) {
+  if let array = expectNotNil(ShapedArray<Float>(numpy: numpyArrayEmpty)) {
     expectEqual(ShapedArray(shape: [1, 0], scalars: []), array)
   }
 
   let numpyArrayBool = np.array([[true, false], [false, true]])
-  expectNil(ShapedArray<Int8>(numpyArray: numpyArrayBool))
-  expectNil(ShapedArray<Float>(numpyArray: numpyArrayBool))
-  if let array = expectNotNil(ShapedArray<Bool>(numpyArray: numpyArrayBool)) {
+  expectNil(ShapedArray<Int8>(numpy: numpyArrayBool))
+  expectNil(ShapedArray<Float>(numpy: numpyArrayBool))
+  if let array = expectNotNil(ShapedArray<Bool>(numpy: numpyArrayBool)) {
     expectEqual(ShapedArray(shape: [2, 2],
                             scalars: [true, false, false, true]),
                 array)
   }
 
   let numpyArrayFloat = np.ones([2, 3], dtype: np.float32)
-  expectNil(ShapedArray<Double>(numpyArray: numpyArrayFloat))
-  expectNil(ShapedArray<Int32>(numpyArray: numpyArrayFloat))
-  if let array = expectNotNil(ShapedArray<Float>(numpyArray: numpyArrayFloat)) {
+  expectNil(ShapedArray<Double>(numpy: numpyArrayFloat))
+  expectNil(ShapedArray<Int32>(numpy: numpyArrayFloat))
+  if let array = expectNotNil(ShapedArray<Float>(numpy: numpyArrayFloat)) {
     expectEqual(ShapedArray(shape: [2, 3], repeating: 1), array)
   }
 
   let numpyArrayInt32 = np.array([[[1, 2, 3], [4, 5, 6]]], dtype: np.int32)
-  expectNil(ShapedArray<Float>(numpyArray: numpyArrayInt32))
-  expectNil(ShapedArray<UInt32>(numpyArray: numpyArrayInt32))
-  if let array = expectNotNil(ShapedArray<Int32>(numpyArray: numpyArrayInt32)) {
+  expectNil(ShapedArray<Float>(numpy: numpyArrayInt32))
+  expectNil(ShapedArray<UInt32>(numpy: numpyArrayInt32))
+  if let array = expectNotNil(ShapedArray<Int32>(numpy: numpyArrayInt32)) {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 array)
   }
@@ -58,7 +58,7 @@ NumpyConversionTests.test("shaped-array-conversion") {
   // strided array.
   expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
   if let array = expectNotNil(
-      ShapedArray<Int32>(numpyArray: numpyArrayStrided)) {
+      ShapedArray<Int32>(numpy: numpyArrayStrided)) {
     expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), array)
   }
 }
@@ -67,30 +67,30 @@ NumpyConversionTests.test("tensor-conversion") {
   guard let np = numpyModule else { return }
 
   let numpyArrayEmpty = np.array([[]] as [[Float]], dtype: np.float32)
-  if let tensor = expectNotNil(Tensor<Float>(numpyArray: numpyArrayEmpty)) {
+  if let tensor = expectNotNil(Tensor<Float>(numpy: numpyArrayEmpty)) {
     expectEqual(ShapedArray(shape: [1, 0], scalars: []), tensor.array)
   }
 
   let numpyArrayBool = np.array([[true, false], [false, true]])
-  expectNil(Tensor<Int8>(numpyArray: numpyArrayBool))
-  expectNil(Tensor<Float>(numpyArray: numpyArrayBool))
-  if let tensor = expectNotNil(Tensor<Bool>(numpyArray: numpyArrayBool)) {
+  expectNil(Tensor<Int8>(numpy: numpyArrayBool))
+  expectNil(Tensor<Float>(numpy: numpyArrayBool))
+  if let tensor = expectNotNil(Tensor<Bool>(numpy: numpyArrayBool)) {
     expectEqual(ShapedArray(shape: [2, 2],
                             scalars: [true, false, false, true]),
                 tensor.array)
   }
 
   let numpyArrayFloat = np.ones([2, 3], dtype: np.float32)
-  expectNil(Tensor<Double>(numpyArray: numpyArrayFloat))
-  expectNil(Tensor<Int32>(numpyArray: numpyArrayFloat))
-  if let tensor = expectNotNil(Tensor<Float>(numpyArray: numpyArrayFloat)) {
+  expectNil(Tensor<Double>(numpy: numpyArrayFloat))
+  expectNil(Tensor<Int32>(numpy: numpyArrayFloat))
+  if let tensor = expectNotNil(Tensor<Float>(numpy: numpyArrayFloat)) {
     expectEqual(ShapedArray(shape: [2, 3], repeating: 1), tensor.array)
   }
 
   let numpyArrayInt32 = np.array([[[1, 2, 3], [4, 5, 6]]], dtype: np.int32)
-  expectNil(Tensor<Float>(numpyArray: numpyArrayInt32))
-  expectNil(Tensor<UInt32>(numpyArray: numpyArrayInt32))
-  if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayInt32)) {
+  expectNil(Tensor<Float>(numpy: numpyArrayInt32))
+  expectNil(Tensor<UInt32>(numpy: numpyArrayInt32))
+  if let tensor = expectNotNil(Tensor<Int32>(numpy: numpyArrayInt32)) {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 tensor.array)
   }
@@ -100,7 +100,7 @@ NumpyConversionTests.test("tensor-conversion") {
   // Assert that the array has a stride, so that we're certainly testing a
   // strided array.
   expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
-  if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayStrided)) {
+  if let tensor = expectNotNil(Tensor<Int32>(numpy: numpyArrayStrided)) {
     expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), tensor.array)
   }
 }
@@ -110,16 +110,13 @@ NumpyConversionTests.test("tensor-round-trip") {
   guard ctypesModule != nil else { return }
 
   let t1 = Tensor<Float>(shape: [1,2,3,4], repeating: 3.0)
-  expectEqual(t1, Tensor<Float>(numpyArray: t1.makeNumpyArray())!)
-  expectEqual(t1, Tensor<Float>(t1.makeNumpyArray())!)
+  expectEqual(t1, Tensor<Float>(numpy: t1.makeNumpyArray())!)
 
   let t2 = Tensor<UInt8>(shape: [2,3], scalars: [1, 2, 3, 4, 5, 6])
-  expectEqual(t2, Tensor<UInt8>(numpyArray: t2.makeNumpyArray())!)
-  expectEqual(t2, Tensor<UInt8>(t2.makeNumpyArray())!)
+  expectEqual(t2, Tensor<UInt8>(numpy: t2.makeNumpyArray())!)
 
   let t3 = Tensor<Int32>(shape: [8,5,4], repeating: 30)
-  expectEqual(t3, Tensor<Int32>(numpyArray: t3.makeNumpyArray())!)
-  expectEqual(t3, Tensor<Int32>(t3.makeNumpyArray())!)
+  expectEqual(t3, Tensor<Int32>(numpy: t3.makeNumpyArray())!)
 }
 #endif
 

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -111,12 +111,15 @@ NumpyConversionTests.test("tensor-round-trip") {
 
   let t1 = Tensor<Float>(shape: [1,2,3,4], repeating: 3.0)
   expectEqual(t1, Tensor<Float>(numpyArray: t1.makeNumpyArray())!)
+  expectEqual(t1, Tensor<Float>(t1.makeNumpyArray())!)
 
   let t2 = Tensor<UInt8>(shape: [2,3], scalars: [1, 2, 3, 4, 5, 6])
   expectEqual(t2, Tensor<UInt8>(numpyArray: t2.makeNumpyArray())!)
+  expectEqual(t2, Tensor<UInt8>(t2.makeNumpyArray())!)
 
   let t3 = Tensor<Int32>(shape: [8,5,4], repeating: 30)
   expectEqual(t3, Tensor<Int32>(numpyArray: t3.makeNumpyArray())!)
+  expectEqual(t3, Tensor<Int32>(t3.makeNumpyArray())!)
 }
 #endif
 


### PR DESCRIPTION
- Define `version` and `versionInfo` computed properties on `PythonInterface`
  for convenience.
- Define labelless failable initializers from `PythonObject`
  (representing `numpy.ndarray`) to `ShapedArray` and `Tensor`.
  - A labelless initializer was not created for `Array` because `Array` is
    always one-dimensional, so the nature of the conversion is semantically bigger.