### PR TITLE
[CMake] Remove logic to set unused macro __SWIFT_CURRENT_DYLIB

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -74,10 +74,6 @@ function(handle_swift_sources
     # <rdar://problem/15972329>
     list(APPEND swift_compile_flags "-force-single-frontend-invocation")
 
-    if(SWIFTSOURCES_IS_STDLIB_CORE)
-      list(APPEND swift_compile_flags "-Xcc" "-D__SWIFT_CURRENT_DYLIB=swiftCore")
-    endif()
-
     _compile_swift_files(
         dependency_target
         module_dependency_target

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -18,9 +18,6 @@ if(SWIFT_RUNTIME_ENABLE_LEAK_CHECKER)
   set(swift_runtime_leaks_sources Leaks.mm)
 endif()
 
-list(APPEND swift_runtime_compile_flags
-     "-D__SWIFT_CURRENT_DYLIB=swiftCore")
-
 set(swift_runtime_objc_sources
     ErrorObject.mm
     SwiftObject.mm


### PR DESCRIPTION
Once upon a time we tried to use this to limit the visibility of symbols in the Swift runtime in a way that didn't really make sense. Dave Z removed it last year in #14165.

No functionality change.