### PR TITLE
[sil] Delete dead code.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -67,35 +67,6 @@ struct ErrorBehaviorKind {
 
 } // end namespace ownership
 
-/// This class is a higher level interface to the ownership checker meant for
-/// use with SILPasses. It uses the actual checker as an internal PImpl detail
-/// so types/etc do not leak.
-struct OwnershipChecker {
-  /// The list of regular users from the last run of the checker.
-  SmallVector<SILInstruction *, 16> regularUsers;
-
-  /// The list of regular users from the last run of the checker.
-  SmallVector<SILInstruction *, 16> lifetimeEndingUsers;
-
-  /// The live blocks for the SILValue we processed. This can be used to
-  /// determine if a block is in the "live" region of our SILInstruction.
-  SmallPtrSet<SILBasicBlock *, 32> liveBlocks;
-
-  /// The list of implicit regular users from the last run of the checker.
-  ///
-  /// This is used to encode end of scope like instructions.
-  SmallVector<SILInstruction *, 4> endScopeRegularUsers;
-
-  /// The module that we are in.
-  SILModule &mod;
-
-  /// A cache of dead-end basic blocks that we use to determine if we can
-  /// ignore "leaks".
-  DeadEndBlocks &deadEndBlocks;
-
-  bool checkValue(SILValue Value);
-};
-
 /// Returns true if:
 ///
 /// 1. No consuming uses are reachable from any other consuming use, from any

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -724,32 +724,3 @@ void SILValue::verifyOwnership(SILModule &mod,
   }
 #endif
 }
-
-bool OwnershipChecker::checkValue(SILValue value) {
-  regularUsers.clear();
-  lifetimeEndingUsers.clear();
-  liveBlocks.clear();
-
-  // Since we do not have SILUndef, we now know that getFunction() should return
-  // a real function. Assert in case this assumption is no longer true.
-  SILFunction *f = value->getFunction();
-  assert(f && "Instructions and arguments should have a function");
-
-  // If the given function has unqualified ownership, there is nothing further
-  // to verify.
-  if (!f->hasOwnership())
-    return false;
-
-  ErrorBehaviorKind errorBehavior(ErrorBehaviorKind::ReturnFalse);
-  SILValueOwnershipChecker checker(mod, deadEndBlocks, value, errorBehavior,
-                                   liveBlocks);
-  if (!checker.check()) {
-    return false;
-  }
-
-  // TODO: Make this more efficient.
-  copy(checker.getRegularUsers(), std::back_inserter(regularUsers));
-  copy(checker.getLifetimeEndingUsers(),
-       std::back_inserter(lifetimeEndingUsers));
-  return true;
-}


### PR DESCRIPTION
Originally I wanted to try to use this code to optimize on ownership sil without
assuming verification passed (since the utility would check verification). In
the end, this was not useful.
