### PR TITLE
fix a new cross-cell differentiation error

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1942,7 +1942,12 @@ ADContext::createPrimalValueStruct(const DifferentiationTask *task,
     pvStruct->setAccess(AccessLevel::FilePrivate);
     break;
   default:
-    llvm_unreachable("The original function cannot have external linkage");
+    // When the original function has external linkage, we create an internal
+    // struct for use by our own module. This is neccessary for cross-cell
+    // differentiation in Jupyter.
+    // TODO: Add a test in the compiler that exercises a similar situation as
+    // cross-cell differentiation in Jupyter.
+    pvStruct->setAccess(AccessLevel::Internal);
   }
   pvStruct->computeType();
   file.addVisibleDecl(pvStruct);


### PR DESCRIPTION
This error was recently introduced in https://github.com/apple/swift/pull/22095.

A test in the compiler repo would be nice but right now I just want to get a fix in so I added a TODO for a fix.