### PR TITLE
[Driver] Accept `-serialize-diagnostics-path` for the interpret mode.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -55,10 +55,6 @@ def emit_reference_dependencies_path
   : Separate<["-"], "emit-reference-dependencies-path">, MetaVarName<"<path>">,
     HelpText<"Output Swift-style dependencies file to <path>">;
 
-def serialize_diagnostics_path
-  : Separate<["-"], "serialize-diagnostics-path">, MetaVarName<"<path>">,
-    HelpText<"Output serialized diagnostics to <path>">;
-
 def emit_fixits_path
   : Separate<["-"], "emit-fixits-path">, MetaVarName<"<path>">,
     HelpText<"Output compiler fixits as source edits to <path>">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -278,6 +278,13 @@ def emit_tbd_path_EQ : Joined<["-"], "emit-tbd-path=">,
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Serialize diagnostics in a binary format">;
+def serialize_diagnostics_path : Separate<["-"], "serialize-diagnostics-path">,
+  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  HelpText<"Emit a serialized diagnostics file to <path>">,
+  MetaVarName<"<path>">;
+def serialize_diagnostics_path_EQ: Joined<["-"], "serialize-diagnostics-path=">,
+  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Alias<serialize_diagnostics_path>;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -222,6 +222,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_dependencies);
   inputArgs.AddLastArg(arguments, options::OPT_package_description_version);
+  inputArgs.AddLastArg(arguments, options::OPT_serialize_diagnostics_path);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/test/Misc/serialized-diagnostics-batch-mode.swift
+++ b/test/Misc/serialized-diagnostics-batch-mode.swift
@@ -1,5 +1,12 @@
 // RUN: rm -f %t.*
 
+// The `-serialize-diagnostics-path` flag is not allowed for batch mode invoked by swiftc
+// RUN: not %target-swiftc_driver -serialize-diagnostics-path %t.notexpected.dia %s %S/Inputs/serialized-diagnostics-batch-mode-helper.swift -c -o %t.o 2>&1 | %FileCheck %s
+// CHECK: <unknown>:0: error: option '-serialize-diagnostics-path' is not supported by 'swiftc'; did you mean to use 'swift'?
+// RUN: not ls %t.notexpected.dia > /dev/null
+// RUN: not ls %t.o > /dev/null
+
+
 // RUN: not %target-swift-frontend -typecheck -primary-file %s  -serialize-diagnostics-path %t.main.dia -primary-file %S/Inputs/serialized-diagnostics-batch-mode-helper.swift  -serialize-diagnostics-path %t.helper.dia %S/Inputs/serialized-diagnostics-batch-mode-other.swift 2> %t.stderr.txt
 // RUN: %FileCheck -check-prefix=CHECK-STDERR %s < %t.stderr.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-STDERR %s < %t.stderr.txt

--- a/test/Misc/serialized-diagnostics-interpret-mode.swift
+++ b/test/Misc/serialized-diagnostics-interpret-mode.swift
@@ -1,0 +1,14 @@
+// RUN: rm -f %t.*
+
+// REQUIRES: swift_interpreter
+
+// RUN: %target-swift-frontend -typecheck -serialize-diagnostics-path %t.dia %s -verify
+// RUN: %target-swift-frontend -typecheck -serialize-diagnostics-path=%t_EQ.dia %s -verify
+// RUN: not %swift_driver -serialize-diagnostics-path %t_intepret_mode.dia %s
+// RUN: not %swift_driver -serialize-diagnostics-path=%t_EQ_intepret_mode.dia %s
+
+// RUN: diff %t.dia %t_EQ.dia
+// RUN: diff %t.dia %t_intepret_mode.dia
+// RUN: diff %t.dia %t_EQ_intepret_mode.dia
+
+var x = 1 x = 2   // expected-error {{consecutive statements on a line must be separated by ';'}} {{10-10=;}}


### PR DESCRIPTION
This patch allows `-serialize-diagnostics-path` for the interpret mode. There is one file compiled in such mode, so it makes sense to support this flag to specify an explicit output path for diagnostics emission, as illustrated in the following example:

```
$ swift -serialize-diagnostics-path=output.dia test.swift
```

Resolves [SR-9670](https://bugs.swift.org/browse/SR-9670).
