### PR TITLE
[Sema] Refactor `Differentiable` derived conformances and fix bugs.

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -99,7 +99,7 @@ static Type getVectorNumericScalarAssocType(VarDecl *decl, DeclContext *DC) {
   return scalarType;
 }
 
-// Returns the `Scalar` associated type for a nominal type with the given
+// Return the `Scalar` associated type for a nominal type with the given
 // members, or nullptr if `Scalar` cannot be derived.
 static Type deriveVectorNumeric_Scalar(ArrayRef<VarDecl *> members,
                                        DeclContext *DC) {
@@ -126,7 +126,7 @@ static Type deriveVectorNumeric_Scalar(ArrayRef<VarDecl *> members,
   return sameScalarType;
 }
 
-// Returns the `Scalar` associated type for a nominal type with the given
+// Return the `Scalar` associated type for a nominal type with the given
 // members, or nullptr if `Scalar` cannot be derived.
 static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal,
                                        DeclContext *DC) {
@@ -142,21 +142,21 @@ static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal,
   return deriveVectorNumeric_Scalar(storedProps, DC);
 }
 
-// Returns true if a `VectorNumeric` requirement can be derived for the given
+// Return true if a `VectorNumeric` requirement can be derived for the given
 // members of a nominal type.
 bool DerivedConformance::canDeriveVectorNumeric(ArrayRef<VarDecl *> members,
                                                 DeclContext *DC) {
   return (bool)deriveVectorNumeric_Scalar(members, DC);
 }
 
-// Returns true if given nominal type has a `let` stored with an initial value.
+// Return true if given nominal type has a `let` stored with an initial value.
 static bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   return llvm::any_of(nominal->getStoredProperties(), [&](VarDecl *v) {
     return v->isLet() && v->hasInitialValue();
   });
 }
 
-// Returns true if an `AdditiveArithmetic` requirement can be derived for the
+// Return true if an `AdditiveArithmetic` requirement can be derived for the
 // given members of a nominal type.
 bool DerivedConformance::canDeriveAdditiveArithmetic(
     ArrayRef<VarDecl *> members, DeclContext *DC) {

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -78,64 +78,100 @@ static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
 
 // Return the `Scalar` associated type for a ValueDecl if it conforms to
 // `VectorNumeric` in the given context.
-// If the decl does not conform to `VectorNumeric`, return a null `Type`.
+// If the decl does not conform to `VectorNumeric`, return nullptr.
 static Type getVectorNumericScalarAssocType(VarDecl *decl, DeclContext *DC) {
   auto &C = decl->getASTContext();
   auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
   if (!decl->hasType())
     C.getLazyResolver()->resolveDeclSignature(decl);
   if (!decl->hasType())
-    return Type();
+    return nullptr;
   auto declType = decl->getType()->hasArchetype()
                       ? decl->getType()
                       : DC->mapTypeIntoContext(decl->getType());
   auto conf = TypeChecker::conformsToProtocol(declType, vectorNumericProto, DC,
                                               ConformanceCheckFlags::Used);
   if (!conf)
-    return Type();
+    return nullptr;
   Type scalarType = ProtocolConformanceRef::getTypeWitnessByName(
       declType, *conf, C.Id_Scalar, C.getLazyResolver());
   assert(scalarType && "'Scalar' associated type not found");
   return scalarType;
 }
 
-static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal,
+// Returns the `Scalar` associated type for a nominal type with the given
+// members, or nullptr if `Scalar` cannot be derived.
+static Type deriveVectorNumeric_Scalar(ArrayRef<VarDecl *> members,
                                        DeclContext *DC) {
-  // Nominal type must be a struct. (Zero stored properties is okay.)
-  auto *structDecl = dyn_cast<StructDecl>(nominal);
-  auto &C = nominal->getASTContext();
-  if (!structDecl)
-    return Type();
-  // If all stored properties conform to `VectorNumeric` and have the same
-  // `Scalar` associated type, return that `Scalar` associated type.
-  // Otherwise, the `Scalar` type cannot be derived.
+  auto &C = DC->getASTContext();
   Type sameScalarType;
-  for (auto member : structDecl->getStoredProperties()) {
+  for (auto member : members) {
     if (!member->hasInterfaceType())
       C.getLazyResolver()->resolveDeclSignature(member);
     if (!member->hasInterfaceType())
       return Type();
     auto scalarType = getVectorNumericScalarAssocType(member, DC);
-    // If stored property does not conform to `VectorNumeric`, return null
-    // `Type`.
+    // If stored property does not conform to `VectorNumeric`, return nullptr.
     if (!scalarType)
-      return Type();
+      return nullptr;
     // If same `Scalar` type has not been set, set it for the first time.
     if (!sameScalarType) {
       sameScalarType = scalarType;
       continue;
     }
-    // If stored property `Scalar` types do not match, return null `Type`.
+    // If stored property `Scalar` types do not match, return nullptr.
     if (!scalarType->isEqual(sameScalarType))
-      return Type();
+      return nullptr;
   }
   return sameScalarType;
+}
+
+// Returns the `Scalar` associated type for a nominal type with the given
+// members, or nullptr if `Scalar` cannot be derived.
+static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal,
+                                       DeclContext *DC) {
+  // Nominal type must be a struct. (Zero stored properties is okay.)
+  if (!isa<StructDecl>(nominal))
+    return nullptr;
+  // If all stored properties conform to `VectorNumeric` and have the same
+  // `Scalar` associated type, return that `Scalar` associated type.
+  // Otherwise, the `Scalar` type cannot be derived.
+  SmallVector<VarDecl *, 4> storedProps;
+  storedProps.append(nominal->getStoredProperties().begin(),
+                     nominal->getStoredProperties().end());
+  return deriveVectorNumeric_Scalar(storedProps, DC);
+}
+
+// Returns true if a `VectorNumeric` requirement can be derived for the given
+// members of a nominal type.
+bool DerivedConformance::canDeriveVectorNumeric(ArrayRef<VarDecl *> members,
+                                                DeclContext *DC) {
+  return (bool)deriveVectorNumeric_Scalar(members, DC);
 }
 
 // Returns true if given nominal type has a `let` stored with an initial value.
 static bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   return llvm::any_of(nominal->getStoredProperties(), [&](VarDecl *v) {
     return v->isLet() && v->hasInitialValue();
+  });
+}
+
+// Returns true if an `AdditiveArithmetic` requirement can be derived for the
+// given members of a nominal type.
+bool DerivedConformance::canDeriveAdditiveArithmetic(
+    ArrayRef<VarDecl *> members, DeclContext *DC) {
+  auto &C = DC->getASTContext();
+  auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
+  return llvm::all_of(members, [&](VarDecl *v) {
+    if (!v->hasInterfaceType() || !v->getType())
+      C.getLazyResolver()->resolveDeclSignature(v);
+    if (!v->hasInterfaceType() || !v->getType())
+      return false;
+    auto declType = v->getType()->hasArchetype()
+        ? v->getType()
+        : DC->mapTypeIntoContext(v->getType());
+    return (bool)TypeChecker::conformsToProtocol(declType, addArithProto, DC,
+                                                 ConformanceCheckFlags::Used);
   });
 }
 
@@ -152,19 +188,10 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
   if (hasLetStoredPropertyWithInitialValue(nominal))
     return false;
   // All stored properties must conform to `AdditiveArithmetic`.
-  auto &C = nominal->getASTContext();
-  auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
-  return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
-    if (!v->hasInterfaceType() || !v->getType())
-      C.getLazyResolver()->resolveDeclSignature(v);
-    if (!v->hasInterfaceType() || !v->getType())
-      return false;
-    auto declType = v->getType()->hasArchetype()
-                        ? v->getType()
-                        : DC->mapTypeIntoContext(v->getType());
-    return (bool)TypeChecker::conformsToProtocol(declType, addArithProto, DC,
-                                                 ConformanceCheckFlags::Used);
-  });
+  SmallVector<VarDecl *, 4> storedProps;
+  storedProps.append(nominal->getStoredProperties().begin(),
+                     nominal->getStoredProperties().end());
+  return canDeriveAdditiveArithmetic(storedProps, DC);
 }
 
 bool DerivedConformance::canDeriveVectorNumeric(NominalTypeDecl *nominal,

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -425,7 +425,7 @@ deriveDifferentiable_tangentVector(DerivedConformance &derived) {
       deriveBodyDifferentiable_tangentVector);
 }
 
-// Returns the underlying `allDifferentiableVariables` of a VarDecl `x`.
+// Return the underlying `allDifferentiableVariables` of a VarDecl `x`.
 // If `x` conforms to `Differentiable`, return `allDifferentiableVariables`.
 // Otherwise, return `x`.
 static ValueDecl *getUnderlyingAllDiffableVariables(ModuleDecl *module,

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -208,6 +208,13 @@ public:
   Type deriveParameterGroup(AssociatedTypeDecl *assocType);
 
   // SWIFT_ENABLE_TENSORFLOW
+  /// Determine if an AdditiveArithmetic requirement can be derived for the
+  /// given members of a nominal type.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveAdditiveArithmetic(ArrayRef<VarDecl *> members,
+                                          DeclContext *DC);
+
   /// Determine if an AdditiveArithmetic requirement can be derived for a type.
   ///
   /// \returns True if the requirement can be derived.
@@ -218,6 +225,13 @@ public:
   ///
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveAdditiveArithmetic(ValueDecl *requirement);
+
+  /// Determine if a VectorNumeric requirement can be derived for the given
+  /// members of a nominal type.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveVectorNumeric(ArrayRef<VarDecl *> members,
+                                     DeclContext *DC);
 
   /// Determine if a VectorNumeric requirement can be derived for a type.
   ///


### PR DESCRIPTION
Fix inherited logic for synthesized associated structs for `Differentiable`.
Associated structs now correctly:
- Conform to `AdditiveArithmetic` even if they have no members.
- Conform to `VectorNumeric` if all members have the same `Scalar` type.

Generalize/centralize the logic for `canDerive(AdditiveArithmetic|VectorNumeric)`
by defining versions that take `ArrayRef<VarDecl *>`.

Resolves [SR-9756](https://bugs.swift.org/browse/SR-9756).