### PR TITLE
Update `tensorflow-swift-bindings`.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -241,7 +241,7 @@
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "icu": "release-61-1",
                 "tensorflow": "a6924e6affd935f537cdaf8977094df0e15a7957",
-                "tensorflow-swift-bindings": "6389cbcf37552f161c4f1f6aeb9dfcd4ef04d254",
+                "tensorflow-swift-bindings": "10e591340134c37a6c3a1df735a7334a77d5cbc7",
                 "tensorflow-swift-apis": "731ce402ce0bd7459b898b112deb89379bbda893"
             }
         }


### PR DESCRIPTION
The latest change suppresses resilience-related warnings.