### PR TITLE
[Sema] Fix `Differentiable` derived conformances.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -662,6 +662,7 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   // members conform to `VectorNumeric` and share the same scalar type.
   Type sameScalarType;
   bool canDeriveVectorNumeric =
+      !diffProperties.empty() &&
       llvm::all_of(diffProperties, [&](VarDecl *var) {
         auto conf = TC.conformsToProtocol(getAssociatedType(var, nominal, id),
                                           vecNumProto, nominal,

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -208,13 +208,6 @@ public:
   Type deriveParameterGroup(AssociatedTypeDecl *assocType);
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Determine if an AdditiveArithmetic requirement can be derived for the
-  /// given members of a nominal type.
-  ///
-  /// \returns True if the requirement can be derived.
-  static bool canDeriveAdditiveArithmetic(ArrayRef<VarDecl *> members,
-                                          DeclContext *DC);
-
   /// Determine if an AdditiveArithmetic requirement can be derived for a type.
   ///
   /// \returns True if the requirement can be derived.
@@ -225,13 +218,6 @@ public:
   ///
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveAdditiveArithmetic(ValueDecl *requirement);
-
-  /// Determine if a VectorNumeric requirement can be derived for the given
-  /// members of a nominal type.
-  ///
-  /// \returns True if the requirement can be derived.
-  static bool canDeriveVectorNumeric(ArrayRef<VarDecl *> members,
-                                     DeclContext *DC);
 
   /// Determine if a VectorNumeric requirement can be derived for a type.
   ///

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -137,6 +137,8 @@ struct DifferentiableSubset : Differentiable {
   @noDerivative var flag: Bool
   @noDerivative let technicallyDifferentiable: Float = .pi
 }
+assertConformsToAdditiveArithmetic(DifferentiableSubset.AllDifferentiableVariables.self)
+assertConformsToVectorNumeric(DifferentiableSubset.AllDifferentiableVariables.self)
 assertAllDifferentiableVariablesEqualsCotangentVector(DifferentiableSubset.self)
 let tangentSubset = DifferentiableSubset.TangentVector(w: 1, b: 1)
 let cotangentSubset = DifferentiableSubset.CotangentVector(w: 1, b: 1)

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "a6924e6affd935f537cdaf8977094df0e15a7957",
                 "tensorflow-swift-bindings": "10e591340134c37a6c3a1df735a7334a77d5cbc7",
-                "tensorflow-swift-apis": "ece4a67ed844919b04d2aec9d131b098aee39413"
+                "tensorflow-swift-apis": "18cc613db5ff03a510e3ba835a8932531b4a1a84"
             }
         }
     }


### PR DESCRIPTION
Associated structs can inherit from `AdditiveArithmetic` or `VectorNumeric`
if their member's associated type inherit from the protocol, not the member's
type itself.

Revert unuseful refactoring from https://github.com/apple/swift/pull/22114.