### PR TITLE
build-script: create SwiftSyntax install directory if it doesn't exist.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3591,6 +3591,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     # We don't have a toolchain so we should install to the specified dir
                     DYLIB_DIR="${INSTALL_DESTDIR}"
                     MODULE_DIR="${INSTALL_DESTDIR}"
+                    # Create the install dir if it doesn't exist
+                    call mkdir -p "${INSTALL_DESTDIR}"
                     # Install libParser is necessary
                     rsync -a "$(build_directory ${host} swift)/lib/lib_InternalSwiftSyntaxParser.dylib" "${INSTALL_DESTDIR}"
                     # Install module map of libParser so client can import SwiftSyntax


### PR DESCRIPTION
We may install SwiftSyntax to other places instead of the just-built toolchain, so
this change is necessary.
