### PR TITLE
[stdlib] Remove a couple of obsoleted-in-4.0 methods

### DIFF
--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -244,26 +244,6 @@ extension String.UnicodeScalarView : _CustomPlaygroundQuickLookable {
 }
 
 //===--- Slicing Support --------------------------------------------------===//
-// In Swift 3.2, in the absence of type context,
-//
-//   someString.unicodeScalars[
-//     someString.unicodeScalars.startIndex
-//     ..< someString.unicodeScalars.endIndex]
-//
-// was deduced to be of type `String.UnicodeScalarView`.  Provide a
-// more-specific Swift-3-only `subscript` overload that continues to produce
-// `String.UnicodeScalarView`.
-extension String.UnicodeScalarView {
-  @available(swift, obsoleted: 4)
-  public subscript(bounds: Range<Index>) -> String.UnicodeScalarView {
-    Builtin.unreachable()
-  }
-
-  @available(swift, obsoleted: 4)
-  public subscript(bounds: ClosedRange<Index>) -> String.UnicodeScalarView {
-    Builtin.unreachable()
-  }
-}
 
 // @available(swift,deprecated: 5.0, renamed: "Unicode.UTF8")
 public typealias UTF8 = Unicode.UTF8
@@ -326,11 +306,6 @@ extension Substring {
       "String index range is out of bounds")
     _precondition(range.upperBound <= endIndex,
       "String index range is out of bounds")
-  }
-
-  @available(swift, obsoleted: 4)
-  public subscript(bounds: ClosedRange<Index>) -> String {
-    Builtin.unreachable()
   }
 }
 
@@ -566,13 +541,6 @@ extension Sequence {
     _ transform: (Element) throws -> ElementOfResult?
   ) rethrows -> [ElementOfResult] {
     return try _compactMap(transform)
-  }
-
-  @available(swift, obsoleted: 4)
-  public func flatMap(
-    _ transform: (Element) throws -> String
-  ) rethrows -> [String] {
-    return try map(transform)
   }
 }
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -78,3 +78,7 @@ Protocol SIMD has added inherited protocol Decodable
 Protocol SIMD has added inherited protocol Encodable
 Protocol SIMD has generic signature change from <τ_0_0 : CustomStringConvertible, τ_0_0 : ExpressibleByArrayLiteral, τ_0_0 : Hashable, τ_0_0 : SIMDStorage, τ_0_0.MaskStorage : SIMD, τ_0_0.MaskStorage.Scalar : FixedWidthInteger, τ_0_0.MaskStorage.Scalar : SignedInteger> to <τ_0_0 : CustomStringConvertible, τ_0_0 : Decodable, τ_0_0 : Encodable, τ_0_0 : ExpressibleByArrayLiteral, τ_0_0 : Hashable, τ_0_0 : SIMDStorage, τ_0_0.MaskStorage : SIMD, τ_0_0.MaskStorage.Scalar : FixedWidthInteger, τ_0_0.MaskStorage.Scalar : SignedInteger>
 Protocol SIMDStorage has generic signature change from <τ_0_0.Scalar : Hashable> to <τ_0_0.Scalar : Decodable, τ_0_0.Scalar : Encodable, τ_0_0.Scalar : Hashable>
+
+Func Sequence.flatMap(_:) has been removed
+Subscript String.UnicodeScalarView.subscript(_:) has been removed
+Subscript Substring.subscript(_:) has been removed


### PR DESCRIPTION
Now that 3.0 support was dropped. Missed these in #19008. Causing problems reported [here](https://forums.swift.org/t/swift-is-overly-worried-about-me-mixing-up-flatmap-and-compactmap/19801/5).

Note, the ABI checker changes are false positives. These have not been callable since ABI stability was declared, so not ABI.