### PR TITLE
[CSDiagnostics] Diagnose invalid partial application

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1479,11 +1479,22 @@ bool MissingMemberFailure::diagnoseAsError() {
 }
 
 bool PartialApplicationFailure::diagnoseAsError() {
+  auto &cs = getConstraintSystem();
   auto *anchor = cast<UnresolvedDotExpr>(getRawAnchor());
+
+  RefKind kind = RefKind::MutatingMethod;
+
+  // If this is initializer delegation chain, we have a tailored message.
+  if (getOverloadChoiceIfAvailable(cs.getConstraintLocator(
+          anchor, ConstraintLocator::ConstructorMember))) {
+    kind = anchor->getBase()->isSuperExpr() ? RefKind::SuperInit
+                                            : RefKind::SelfInit;
+  }
+
   auto diagnostic = CompatibilityWarning
                         ? diag::partial_application_of_function_invalid_swift4
                         : diag::partial_application_of_function_invalid;
 
-  emitDiagnostic(anchor->getNameLoc(), diagnostic, RefKind::MutatingMethod);
+  emitDiagnostic(anchor->getNameLoc(), diagnostic, kind);
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1477,3 +1477,13 @@ bool MissingMemberFailure::diagnoseAsError() {
   corrections.noteAllCandidates();
   return true;
 }
+
+bool PartialApplicationFailure::diagnoseAsError() {
+  auto *anchor = cast<UnresolvedDotExpr>(getRawAnchor());
+  auto diagnostic = CompatibilityWarning
+                        ? diag::partial_application_of_function_invalid_swift4
+                        : diag::partial_application_of_function_invalid;
+
+  emitDiagnostic(anchor->getNameLoc(), diagnostic, RefKind::MutatingMethod);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -674,6 +674,23 @@ private:
                                           DeclName memberName);
 };
 
+class PartialApplicationFailure final : public FailureDiagnostic {
+  enum RefKind : unsigned {
+    MutatingMethod,
+    SuperInit,
+    SelfInit,
+  };
+
+  bool CompatibilityWarning;
+
+public:
+  PartialApplicationFailure(Expr *root, bool warning, ConstraintSystem &cs,
+                            ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator), CompatibilityWarning(warning) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -258,3 +258,14 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
   return new (cs.getAllocator())
       DefineMemberBasedOnUse(cs, baseType, member, locator);
 }
+
+bool AllowInvalidPartialApplication::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+AllowInvalidPartialApplication *
+AllowInvalidPartialApplication::create(bool isWarning, ConstraintSystem &cs,
+                                       ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowInvalidPartialApplication(isWarning, cs, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -260,7 +260,9 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
 }
 
 bool AllowInvalidPartialApplication::diagnose(Expr *root, bool asNote) const {
-  return false;
+  auto failure = PartialApplicationFailure(root, isWarning(),
+                                           getConstraintSystem(), getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowInvalidPartialApplication *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -104,6 +104,14 @@ enum class FixKind : uint8_t {
   /// fix this issue by pretending that member exists and matches
   /// given arguments/result types exactly.
   DefineMemberBasedOnUse,
+
+  /// Allow expressions where 'mutating' method is only partially applied,
+  /// which means either not applied at all e.g. `Foo.bar` or only `Self`
+  /// is applied e.g. `foo.bar` or `Foo.bar(&foo)`.
+  ///
+  /// Allow expressions where initializer call (either `self.init` or
+  /// `super.init`) is only partially applied.
+  AllowInvalidPartialApplication,
 };
 
 class ConstraintFix {
@@ -499,6 +507,24 @@ public:
   static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
                                         DeclName member,
                                         ConstraintLocator *locator);
+};
+
+class AllowInvalidPartialApplication final : public ConstraintFix {
+public:
+  AllowInvalidPartialApplication(bool isWarning, ConstraintSystem &cs,
+                                 ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowInvalidPartialApplication, locator,
+                      isWarning) {}
+
+  std::string getName() const override {
+    return "allow partially applied 'mutating' method";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static AllowInvalidPartialApplication *create(bool isWarning,
+                                                ConstraintSystem &cs,
+                                                ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1633,7 +1633,7 @@ namespace {
                                      expr->getFunctionRefKind(),
                                      expr->getOuterAlternatives());
     }
-    
+
     Type visitUnresolvedSpecializeExpr(UnresolvedSpecializeExpr *expr) {
       auto baseTy = CS.getType(expr->getSubExpr());
       

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5502,6 +5502,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AutoClosureForwarding:
   case FixKind::RemoveUnwrap:
   case FixKind::DefineMemberBasedOnUse:
+  case FixKind::AllowInvalidPartialApplication:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1775,6 +1775,12 @@ public:
   ConstraintLocator *
   getConstraintLocator(const ConstraintLocatorBuilder &builder);
 
+  /// Lookup and return parent associated with given expression.
+  Expr *getParentExpr(Expr *expr) const {
+    auto e = ExprWeights.find(expr);
+    return e != ExprWeights.end() ? e->second.second : nullptr;
+  }
+
 public:
 
   /// Whether we should attempt to fix problems.

--- a/test/Constraints/mutating_members.swift
+++ b/test/Constraints/mutating_members.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -swift-version 5 %s
 
+protocol P {}
+
 struct Foo {
   mutating func boom() {}
 }
@@ -20,3 +22,15 @@ func fromLocalContext2(x: inout Foo, y: Bool) -> () -> () {
   }
 }
 
+func bar() -> P.Type { fatalError() }
+func bar() -> Foo.Type { fatalError() }
+
+_ = bar().boom       // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom(&y)() // ok
+
+func foo(_ foo: Foo.Type) {
+  _ = foo.boom       // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom(&y)() // ok
+}

--- a/test/Constraints/mutating_members_compat.swift
+++ b/test/Constraints/mutating_members_compat.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -swift-version 4 %s
 
+protocol P {}
+
 struct Foo {
   mutating func boom() {}
 }
@@ -20,3 +22,15 @@ func fromLocalContext2(x: inout Foo, y: Bool) -> () -> () {
   }
 }
 
+func bar() -> P.Type { fatalError() }
+func bar() -> Foo.Type { fatalError() }
+
+_ = bar().boom       // expected-warning{{partial application of 'mutating' method}}
+_ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom(&y)() // ok
+
+func foo(_ foo: Foo.Type) {
+  _ = foo.boom       // expected-warning{{partial application of 'mutating' method}}
+  _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom(&y)() // ok
+}


### PR DESCRIPTION
Detect and diagnose invalid partial application of 'mutating' methods and constructor delegation.

This used to be diagnosed by `MiscDiagnostics` when invalid solution is already applied to AST,
moving these diagnostics to constraint system allows to detect failures like that early and makes
other diagnostics easier e.g. missing or extraneous metatype base in member reference.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
