### PR TITLE
[test] Add s390x support for test/IRGen/objc_properties_jit.swift

### DIFF
--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
@@ -8,7 +8,7 @@ public func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
 public struct CGFloat {
 #if arch(i386) || arch(arm)
   public typealias UnderlyingType = Float
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64le)
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64le) || arch(s390x)
   public typealias UnderlyingType = Double
 #endif
 


### PR DESCRIPTION
Typealias type `UnderlyingType` as `Double` type in `test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift` for s390x platform, so that `test/IRGen/objc_properties_jit.swift` got passed.