### PR TITLE
[Build System: CMake] Correctly set the Darwin deployment targets when building the overlay projects (master-convergence branch).

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -60,7 +60,7 @@ precondition(TOOLCHAIN_DIR)
 
 # Some overlays include the runtime's headers,
 # and some of those headers are generated at build time.
-add_subdirectory("${SWIFT_SOURCE_DIR}/include" "swift/include")
+add_subdirectory("${SWIFT_SOURCE_DIR}/include" "${SWIFT_SOURCE_DIR}/include")
 
 # Without this line, installing components is broken. This needs refactoring.
 swift_configure_components()


### PR DESCRIPTION
Copy of #22133 for the master-convergence branch.

rdar://47558666