### PR TITLE
[5.0] Improve RemoteAST support for private types in LLDB

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2851,9 +2851,17 @@ public:
   /// recorded in the metadata.
   ConstTargetPointer<Runtime, char> getMangledName() const {
     if (!hasMangledName())
-      return nullptr;
+      return ConstTargetPointer<Runtime, char>();
 
     return this->template getTrailingObjects<MangledContextName>()->name;
+  }
+
+  /// Retrieve a pointer to the mangled context name structure.
+  const MangledContextName *getMangledContextName() const {
+    if (!hasMangledName())
+      return nullptr;
+
+    return this->template getTrailingObjects<MangledContextName>();
   }
 
 private:
@@ -2872,6 +2880,7 @@ public:
     return cd->getKind() == ContextDescriptorKind::Anonymous;
   }
 };
+using AnonymousContextDescriptor = TargetAnonymousContextDescriptor<InProcess>;
 
 /// A protocol descriptor.
 ///

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2808,17 +2808,66 @@ public:
 using ExtensionContextDescriptor = TargetExtensionContextDescriptor<InProcess>;
 
 template<typename Runtime>
+struct TargetMangledContextName {
+  /// The mangled name of the context.
+  TargetRelativeDirectPointer<Runtime, const char, /*nullable*/ false> name;
+};
+
+template<typename Runtime>
 struct TargetAnonymousContextDescriptor final
     : TargetContextDescriptor<Runtime>,
-      TrailingGenericContextObjects<TargetAnonymousContextDescriptor<Runtime>>
+      TrailingGenericContextObjects<TargetAnonymousContextDescriptor<Runtime>,
+                                    TargetGenericContextDescriptorHeader,
+                                    TargetMangledContextName<Runtime>>
 {
 private:
   using TrailingGenericContextObjects
-    = TrailingGenericContextObjects<TargetAnonymousContextDescriptor<Runtime>>;
+    = TrailingGenericContextObjects<TargetAnonymousContextDescriptor<Runtime>,
+                                    TargetGenericContextDescriptorHeader,
+                                    TargetMangledContextName<Runtime>>;
+  using TrailingObjects =
+    typename TrailingGenericContextObjects::TrailingObjects;
+  friend TrailingObjects;
 
 public:
-  using TrailingGenericContextObjects::getGenericContext;
+  using MangledContextName = TargetMangledContextName<Runtime>;
 
+  using TrailingGenericContextObjects::getGenericContext;
+  using TrailingGenericContextObjects::getGenericContextHeader;
+  using TrailingGenericContextObjects::getFullGenericContextHeader;
+  using TrailingGenericContextObjects::getGenericParams;
+
+  AnonymousContextDescriptorFlags getAnonymousContextDescriptorFlags() const {
+    return AnonymousContextDescriptorFlags(this->Flags.getKindSpecificFlags());
+  }
+
+  /// Whether this anonymous context descriptor contains a full mangled name,
+  /// which can be used to match the anonymous type to its textual form.
+  bool hasMangledName() const {
+    return getAnonymousContextDescriptorFlags().hasMangledName();
+  }
+
+  /// Retrieve the mangled name of this context, or NULL if it was not
+  /// recorded in the metadata.
+  ConstTargetPointer<Runtime, char> getMangledName() const {
+    if (!hasMangledName())
+      return nullptr;
+
+    return this->template getTrailingObjects<MangledContextName>()->name;
+  }
+
+private:
+  template<typename T>
+  using OverloadToken =
+    typename TrailingGenericContextObjects::template OverloadToken<T>;
+
+  using TrailingGenericContextObjects::numTrailingObjects;
+
+  size_t numTrailingObjects(OverloadToken<MangledContextName>) const {
+    return this->hasMangledNam() ? 1 : 0;
+  }
+
+public:
   static bool classof(const TargetContextDescriptor<Runtime> *cd) {
     return cd->getKind() == ContextDescriptorKind::Anonymous;
   }

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1344,6 +1344,23 @@ public:
                                  setSpecialProtocol)
 };
 
+/// Flags for anonymous type context descriptors. These values are used as the
+/// kindSpecificFlags of the ContextDescriptorFlags for the anonymous context.
+class AnonymousContextDescriptorFlags : public FlagSet<uint16_t> {
+  enum {
+    /// Whether this anonymous context descriptor is followed by its
+    /// mangled name, which can be used to match the descriptor at runtime.
+    HasMangledName = 0,
+  };
+
+public:
+  explicit AnonymousContextDescriptorFlags(uint16_t bits) : FlagSet(bits) {}
+  constexpr AnonymousContextDescriptorFlags() {}
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS(HasMangledName, hasMangledName,
+                                setHasMangledName)
+};
+
 enum class GenericParamKind : uint8_t {
   /// A type parameter.
   Type = 0,

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -165,6 +165,9 @@ public:
   /// Emit names of struct stored properties and enum cases.
   unsigned EnableReflectionNames : 1;
 
+  /// Emit mangled names of anonymous context descriptors.
+  unsigned EnableAnonymousContextMangledNames : 1;
+
   /// Enables resilient class layout.
   unsigned EnableClassResilience : 1;
 
@@ -224,7 +227,8 @@ public:
         EmitStackPromotionChecks(false), PrintInlineTree(false),
         EmbedMode(IRGenEmbedMode::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),
-        EnableReflectionNames(true), EnableClassResilience(false),
+        EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
+        EnableClassResilience(false),
         EnableResilienceBypass(false), LazyInitializeClassMetadata(false),
         UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -272,6 +272,10 @@ def disable_llvm_value_names : Flag<["-"], "disable-llvm-value-names">,
 def enable_llvm_value_names : Flag<["-"], "enable-llvm-value-names">,
   HelpText<"Add names to local values in LLVM IR">;
 
+def enable_anonymous_context_mangled_names :
+  Flag<["-"], "enable-anonymous-context-mangled-names">,
+  HelpText<"Enable emission of mangled names in anonymous context descriptors">;
+
 def disable_reflection_metadata : Flag<["-"], "disable-reflection-metadata">,
   HelpText<"Disable emission of reflection metadata for nominal types">;
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1013,8 +1013,11 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
   case Node::Kind::AnonymousContext:
     if (Options.QualifyEntities && Options.DisplayExtensionContexts) {
       print(Node->getChild(1));
-      Printer << ".(unknown context at " << Node->getChild(0)->getText() << ")";
-      if (Node->getChild(2)->getNumChildren() > 0) {
+      Printer << ".(unknown context at ";
+      print(Node->getChild(0));
+      Printer << ")";
+      if (Node->getNumChildren() >= 3 &&
+          Node->getChild(2)->getNumChildren() > 0) {
         Printer << '<';
         print(Node->getChild(2));
         Printer << '>';

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -243,6 +243,12 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
     arguments.push_back(inputArgs.MakeArgString(workingDirectory));
   }
 
+  // -g implies -enable-anonymous-context-mangled-names, because the extra
+  // metadata aids debugging.
+  if (inputArgs.hasArg(options::OPT_g)) {
+    arguments.push_back("-enable-anonymous-context-mangled-names");
+  }
+
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1041,6 +1041,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableReflectionNames = false;
   }
 
+  if (Args.hasArg(OPT_enable_anonymous_context_mangled_names))
+    Opts.EnableAnonymousContextMangledNames = true;
+
   if (Args.hasArg(OPT_disable_reflection_names)) {
     Opts.EnableReflectionNames = false;
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -511,6 +511,7 @@ namespace {
     void layout() {
       super::layout();
       asImpl().addGenericSignature();
+      asImpl().addMangledName();
     }
   
     ConstantReference getParent() {
@@ -528,6 +529,26 @@ namespace {
     
     bool isUniqueDescriptor() {
       return true;
+    }
+
+    uint16_t getKindSpecificFlags() {
+      AnonymousContextDescriptorFlags flags{};
+      flags.setHasMangledName(
+        IGM.IRGen.Opts.EnableAnonymousContextMangledNames);
+
+      return flags.getOpaqueValue();
+    }
+
+    void addMangledName() {
+      if (!IGM.IRGen.Opts.EnableAnonymousContextMangledNames)
+        return;
+
+      IRGenMangler mangler;
+      auto mangledName = mangler.mangleContext(DC);
+      auto mangledNameConstant =
+        IGM.getAddrOfGlobalString(mangledName,
+                                  /*willBeRelativelyAddressed*/ true);
+      B.addRelativeAddress(mangledNameConstant);
     }
 
     void emit() {

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -153,7 +153,13 @@ public:
     appendOperator("MXX");
     return finalize();
   }
-  
+
+  std::string mangleContext(const DeclContext *DC) {
+    beginMangling();
+    appendContext(DC);
+    return finalize();
+  }
+
   std::string mangleBareProtocol(const ProtocolDecl *Decl) {
     beginMangling();
     appendProtocolName(Decl, /*allowStandardSubstitution=*/false);

--- a/test/Driver/debug_anonymous_context_metadata.swift
+++ b/test/Driver/debug_anonymous_context_metadata.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swiftc_driver -### -g %s 2>&1 | %FileCheck %s
+
+// CHECK: -enable-anonymous-context-mangled-names
+

--- a/test/IRGen/anonymous_context_descriptors.sil
+++ b/test/IRGen/anonymous_context_descriptors.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s -check-prefix CHECK-MANGLED
 
 import Builtin
 import Swift
@@ -9,15 +10,30 @@ class Blah<T: P> {
   private struct Inner<U: P> { }
 }
 
+// Mangled name of the anonymous descriptor
+// CHECK-NOT: private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
+// CHECK-MANGLED: [[INNER_MANGLED:@[0-9]+]] = private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
+
 // Anonymous descriptor
 // CHECK: @"$s29anonymous_context_descriptors4BlahC5Inner33{{.*}}MXX" =
+// CHECK-MANGLED: @"$s29anonymous_context_descriptors4BlahC5Inner33{{.*}}MXX" =
 
 // Flags: anonymous (2) + generic (0x80) + unique (0x40)
 // CHECK-SAME: i32 194
 
+// Flags: anonymous (2) + generic (0x80) + unique (0x40) + has mangled name (0x10000)
+// CHECK-MANGLED-SAME: i32 65730
+
 // Parent
 // CHECK-SAME: $s29anonymous_context_descriptors4BlahCMn
+// CHECK-MANGLED-SAME: $s29anonymous_context_descriptors4BlahCMn
 
 // # generic header
 // CHECK-SAME: i16 2, i16 2
 // CHECK-SAME: i16 4, i16 0
+
+// CHECK-MANGLED-SAME: i16 2, i16 2
+// CHECK-MANGLED-SAME: i16 4, i16 0
+
+// # mangled name
+// CHECK-MANGLED-SAME: [[INNER_MANGLED]]

--- a/test/RemoteAST/nominal_types.swift
+++ b/test/RemoteAST/nominal_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-remoteast-test %s | %FileCheck %s
+// RUN: %target-swift-remoteast-test -enable-anonymous-context-mangled-names %s | %FileCheck %s
 
 // REQUIRES: swift-remoteast-test
 
@@ -92,3 +92,37 @@ printType(JK.self)
 // CHECK: found type: J & K
 printType(KJ.self)
 // CHECK: found type: J & K
+
+struct L {
+  private struct PrivateInner { }
+  private struct PrivateInnerGeneric<T> { }
+
+  static func testPrivate() {
+    // CHECK: L.PrivateInner
+    printType(L.PrivateInner.self)
+
+    // CHECK: L.PrivateInnerGeneric<Int>
+    printType(L.PrivateInnerGeneric<Int>.self)
+
+    // CHECK: L.PrivateInnerGeneric<String>
+    printType(L.PrivateInnerGeneric<String>.self)
+  }
+}
+L.testPrivate()
+
+struct M<T, U> {
+  private struct Inner { }
+  private struct InnerGeneric<V> { }
+
+  static func testPrivate() {
+    // CHECK: M<Int, String>.Inner
+    printType(Inner.self)
+
+    // CHECK: M<Int, String>.InnerGeneric<Double>
+    printType(InnerGeneric<Double>.self)
+
+    // CHECK: M<Int, String>.InnerGeneric<(String, Int)>
+    printType(InnerGeneric<(U, T)>.self)
+  }
+}
+M<Int, String>.testPrivate()


### PR DESCRIPTION
Under `-g`, start emitting mangled names into anonymous context descriptors.
When an anonymous context descriptor provides a mangled name, use that
mangled name to provide the private declaration name for its child context.
This allows us to resolve private type names correctly when the corresponding
anonymous context has its mangled name.

Fixes rdar://problem/38231646.