### PR TITLE
[DNM] [5.0] [CMake] Generate swiftinterface files by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ option(SWIFT_FORCE_OPTIMIZED_TYPECHECKER "Override the optimization setting of
 
 option(SWIFT_ENABLE_PARSEABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
-       FALSE)
+       TRUE)
 
 #
 # User-configurable Android specific options.


### PR DESCRIPTION
Cherry-picked from commit 022fe5d682d571ac51494d9daabc15e9735d4cc0, the other part of #20784. (This PR is mostly for moving pieces within Apple; we're not actually planning to turn this on for the 5.0 release.)