### PR TITLE
[Sema] Allow weak/unowned types when checking Hashable/Equatable conformance

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -78,7 +78,8 @@ static bool allStoredPropertiesConformToProtocol(DeclContext *DC,
     if (!propertyDecl->hasType())
       return false;
 
-    auto type = propertyDecl->getType()->mapTypeOutOfContext();
+    auto type = propertyDecl->getValueInterfaceType();
+
     if (!TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type),
                                          protocol, DC,
                                          ConformanceCheckFlags::Used)) {

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -315,6 +315,28 @@ class MixedClass: Hashable {
   var hashValue: Int { return -9000 }
 }
 
+// Ensure equatable and hashable works with weak/unowned properties as well
+struct Foo: Equatable, Hashable {
+    weak var foo: Bar?
+    unowned var bar: Bar
+}
+
+class Bar {
+   let bar: String
+
+   init(bar: String) {
+     self.bar = bar
+   }
+}
+
+extension Bar: Equatable, Hashable {
+  static func == (lhs: Bar, rhs: Bar) -> Bool {
+        return lhs.bar == rhs.bar
+  }
+
+  func hash(into hasher: inout Hasher) {}
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'


### PR DESCRIPTION
This PR fixes an issue with Equatable and Hashable conformance checking, where it won't look through a `ReferenceStorageType`.

The following code works as expected now:

```swift
struct Foo: Equatable, Hashable {
    weak var foo: Bar?
    unowned var bar: Bar
}

class Bar {
   let bar: String

   init(bar: String) {
     self.bar = bar
   }
}

extension Bar: Equatable, Hashable {
  static func == (lhs: Bar, rhs: Bar) -> Bool {
        return lhs.bar == rhs.bar
  }

  func hash(into hasher: inout Hasher) {}
}
```