### PR TITLE
build-script-impl: collapse similar cases

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2451,64 +2451,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 LLDB_BUILD_DATE=$(date +%Y-%m-%d)
 
                 case "${host}" in
-                    linux-*)
-                        cmake_options=(
-                            "${cmake_options[@]}"
-                            -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
-                            -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
-                            -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
-                            -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
-                            -DLLDB_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_CLANG_SOURCE:PATH="${CLANG_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_LLVM_BUILD:PATH="${llvm_build_dir}"
-                            -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
-                            -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
-                            -DLLDB_PATH_TO_CMARK_BUILD:PATH="${cmark_build_dir}"
-                            -DLLDB_IS_BUILDBOT_BUILD="${LLDB_IS_BUILDBOT_BUILD}"
-                            -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
-                            -DLLDB_ALLOW_STATIC_BINDINGS=1
-                        )
-                        ;;
-                    freebsd-*)
-                        cmake_options=(
-                            "${cmake_options[@]}"
-                            -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
-                            -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
-                            -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
-                            -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
-                            -DLLDB_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_CLANG_SOURCE:PATH="${CLANG_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_LLVM_BUILD:PATH="${llvm_build_dir}"
-                            -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
-                            -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
-                            -DLLDB_PATH_TO_CMARK_BUILD:PATH="${cmark_build_dir}"
-                            -DLLDB_IS_BUILDBOT_BUILD="${LLDB_IS_BUILDBOT_BUILD}"
-                            -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
-                            -DLLDB_ALLOW_STATIC_BINDINGS=1
-                        )
-                        ;;
-                    cygwin-*)
-                        cmake_options=(
-                            "${cmake_options[@]}"
-                            -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
-                            -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
-                            -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
-                            -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
-                            -DLLDB_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_CLANG_SOURCE:PATH="${CLANG_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
-                            -DLLDB_PATH_TO_LLVM_BUILD:PATH="${llvm_build_dir}"
-                            -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
-                            -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
-                            -DLLDB_PATH_TO_CMARK_BUILD:PATH="${cmark_build_dir}"
-                            -DLLDB_IS_BUILDBOT_BUILD="${LLDB_IS_BUILDBOT_BUILD}"
-                            -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
-                            -DLLDB_ALLOW_STATIC_BINDINGS=1
-                        )
-                        ;;
-                    haiku-*)
+                    cygwin-*|freebsd-*|haiku-*|linux-*)
                         cmake_options=(
                             "${cmake_options[@]}"
                             -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"


### PR DESCRIPTION
Collapse the various lldb build configuration into a single one where
the invocation is exactly the same.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
