### PR TITLE
[Constant Evaluator] Add support for string appends and string equals to the constant evaluator

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -561,6 +561,7 @@ extension String {
 
   // String append
   @inlinable // Forward inlinability to append
+  @_semantics("string.append")
   public static func += (lhs: inout String, rhs: String) {
     lhs.append(rhs)
   }

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -67,6 +67,7 @@ extension StringProtocol {
 extension String : Equatable {
   @inlinable @inline(__always) // For the bitwise comparision
   @_effects(readonly)
+  @_semantics("string.equals")
   public static func == (lhs: String, rhs: String) -> Bool {
     return _stringCompare(lhs._guts, rhs._guts, expecting: .equal)
   }

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -458,19 +458,14 @@ func testStructPassedAsProtocols() {
 
 //===----------------------------------------------------------------------===//
 // Strings
-//
-// TODO: The constant evaluator does not implement string accesses/comparisons
-// so theses tests cannot test that the implemented string operations produce
-// correct values in the arrays. These tests only test that the implemented
-// string operations do not crash or produce unknown values. As soon as we have
-// string accesses/comparisons, modify these tests to check the values in the
-// strings.
 //===----------------------------------------------------------------------===//
 
 struct ContainsString {
   let x: Int
   let str: String
 }
+
+// Test string initialization
 
 func stringInitEmptyTopLevel() {
   let c = ContainsString(x: 1, str: "")
@@ -482,20 +477,113 @@ func stringInitNonEmptyTopLevel() {
   #assert(c.x == 1)
 }
 
-func stringInitEmptyFlowSensitive() -> ContainsString {
-  return ContainsString(x: 1, str: "")
+// Test string equality (==)
+
+func emptyString() -> String {
+  return ""
 }
 
-func invokeStringInitEmptyFlowSensitive() {
-  #assert(stringInitEmptyFlowSensitive().x == 1)
+func asciiString() -> String {
+  return "test string"
 }
 
-func stringInitNonEmptyFlowSensitive() -> ContainsString {
-  return ContainsString(x: 1, str: "hello world")
+func dollarSign() -> String {
+  return "dollar sign: \u{24}"
 }
 
-func invokeStringInitNonEmptyFlowSensitive() {
-  #assert(stringInitNonEmptyFlowSensitive().x == 1)
+func flag() -> String {
+  return "flag: \u{1F1FA}\u{1F1F8}"
+}
+
+func compareWithIdenticalStrings() {
+  #assert(emptyString() == "")
+  #assert(asciiString() == "test string")
+  #assert(dollarSign() == "dollar sign: $")
+  #assert(flag() == "flag: 🇺🇸")
+}
+
+func compareWithUnequalStrings() {
+  #assert(emptyString() == "Nonempty") // expected-error {{assertion failed}}
+  #assert(asciiString() == "")         // expected-error {{assertion failed}}
+  #assert(dollarSign() == flag())      // expected-error {{assertion failed}}
+  #assert(flag() == "flag: \u{1F496}") // expected-error {{assertion failed}}
+}
+
+// Test string appends (+=)
+
+// String.+= when used at the top-level of #assert cannot be folded as the
+// interpreter cannot extract the relevant instructions to interpret.
+// (This is because append is a mutating function and there will be more than
+// one writer to the string.) Nonetheless, flow-sensitive uses of String.+=
+// will be interpretable.
+func testStringAppendTopLevel() {
+  var a = "a"
+  a += "b"
+  #assert(a == "ab")  // expected-error {{#assert condition not constant}}
+                      // expected-note@-1 {{could not fold operation}}
+}
+
+func appendedAsciiString() -> String {
+  var str = "test "
+  str += "string"
+  return str
+}
+
+func appendedDollarSign() -> String {
+  var d = "dollar sign: "
+  d += "\u{24}"
+  return d
+}
+
+func appendedFlag() -> String {
+  var flag = "\u{1F1FA}"
+  flag += "\u{1F1F8}"
+  return flag
+}
+
+func testStringAppend() {
+  #assert(appendedAsciiString() == asciiString())
+  #assert(appendedDollarSign() == dollarSign())
+  #assert(appendedFlag() == "🇺🇸")
+
+  #assert(appendedAsciiString() == "") // expected-error {{assertion failed}}
+  #assert(appendedDollarSign() == "")  // expected-error {{assertion failed}}
+  #assert(appendedFlag() == "")        // expected-error {{assertion failed}}
+}
+
+func conditionalAppend(_ b: Bool, _ str1: String, _ str2: String) -> String {
+  let suffix = "One"
+  var result = ""
+  if b {
+    result = str1
+    result += suffix
+  } else {
+    result = str2
+    result += suffix
+  }
+  return result
+}
+
+func testConditionalAppend() {
+  let first = "first"
+  let second = "second"
+  #assert(conditionalAppend(true, first, second) == "firstOne")
+  #assert(conditionalAppend(false, first, second) == "secondOne")
+}
+
+struct ContainsMutableString {
+  let x: Int
+  var str: String
+}
+
+func appendOfStructProperty() -> ContainsMutableString {
+  var c = ContainsMutableString(x: 0, str: "broken")
+  c.str += " arrow"
+  return c
+}
+
+func testAppendOfStructProperty() {
+  #assert(appendOfStructProperty().str == "broken arrow")
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR adds support for string appends and string equals to the constant evaluator. It adds new @_semantics attributes to the standard library functions: `String.+=` and `String.==` and models these operations in the evaluator. 