### PR TITLE
[Remote AST] Resolve extension context descriptors to demangle trees.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1547,10 +1547,10 @@ class TargetProtocolDescriptorRef {
   /// is clear).
   StoredPointer storage;
 
+public:
   constexpr TargetProtocolDescriptorRef(StoredPointer storage)
     : storage(storage) { }
 
-public:
   constexpr TargetProtocolDescriptorRef() : storage() { }
 
   TargetProtocolDescriptorRef(
@@ -2519,7 +2519,6 @@ public:
   /// The type that's constrained, described as a mangled name.
   RelativeDirectPointer<const char, /*nullable*/ false> Param;
 
-private:
   union {
     /// A mangled representation of the same-type or base class the param is
     /// constrained to.
@@ -2544,7 +2543,6 @@ private:
     GenericRequirementLayoutKind Layout;
   };
 
-public:
   constexpr GenericRequirementFlags getFlags() const {
     return Flags;
   }

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2784,6 +2784,7 @@ private:
   using TrailingGenericContextObjects
     = TrailingGenericContextObjects<TargetExtensionContextDescriptor<Runtime>>;
 
+public:
   /// A mangling of the `Self` type context that the extension extends.
   /// The mangled name represents the type in the generic context encoded by
   /// this descriptor. For example, a nongeneric nominal type extension will
@@ -2794,7 +2795,6 @@ private:
   /// extension is declared inside.
   RelativeDirectPointer<const char> ExtendedContext;
 
-public:
   using TrailingGenericContextObjects::getGenericContext;
 
   StringRef getMangledExtendedContext() const {

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -507,7 +507,13 @@ public:
                           std::function<SymbolicReferenceResolver_t> resolver) {
     SymbolicReferenceResolver = resolver;
   }
-  
+
+  /// Take the symbolic reference resolver.
+  std::function<SymbolicReferenceResolver_t> &&
+  takeSymbolicReferenceResolver() {
+    return std::move(SymbolicReferenceResolver);
+  }
+
   /// Demangle the given symbol and return the parse tree.
   ///
   /// \param MangledName The mangled symbol string, which start with the

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1521,6 +1521,7 @@ private:
     }
 
     // Install our own symbolic reference resolver
+    auto oldSymbolicReferenceResolver = dem.takeSymbolicReferenceResolver();
     dem.setSymbolicReferenceResolver([&](SymbolicReferenceKind kind,
                                          Directness directness,
                                          int32_t offset,
@@ -1562,7 +1563,7 @@ private:
       break;
     }
 
-    dem.setSymbolicReferenceResolver(nullptr);
+    dem.setSymbolicReferenceResolver(std::move(oldSymbolicReferenceResolver));
     return result;
   }
 

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -271,7 +271,10 @@ internal func sendStringLength() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
   let address = readUInt()
   let cString = UnsafePointer<CChar>(bitPattern: address)!
-  let count = String(validatingUTF8: cString)!.utf8.count
+  var count = 0
+  while cString[count] != CChar(0) {
+    count = count + 1
+  }
   sendValue(count)
 }
 

--- a/test/RemoteAST/extensions.swift
+++ b/test/RemoteAST/extensions.swift
@@ -11,3 +11,10 @@ extension Int {
 
 // CHECK: Int.Inner
 printType(Int.Inner.self)
+
+extension Int.Inner {
+  struct MoreInner { }
+}
+
+// CHECK: Int.Inner.MoreInner
+printType(Int.Inner.MoreInner.self)

--- a/test/RemoteAST/extensions.swift
+++ b/test/RemoteAST/extensions.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-remoteast-test %s | %FileCheck %s
+
+// REQUIRES: swift-remoteast-test
+
+@_silgen_name("printMetadataType")
+func printType(_: Any.Type)
+
+extension Int {
+  struct Inner { }
+}
+
+// CHECK: Int.Inner
+printType(Int.Inner.self)

--- a/test/RemoteAST/extensions.swift
+++ b/test/RemoteAST/extensions.swift
@@ -18,3 +18,61 @@ extension Int.Inner {
 
 // CHECK: Int.Inner.MoreInner
 printType(Int.Inner.MoreInner.self)
+
+protocol P {
+  associatedtype Assoc
+}
+
+struct A<T: P, U: P> { }
+
+extension Int: P {
+  typealias Assoc = Double
+}
+
+extension String: P {
+  typealias Assoc = Double
+}
+
+extension A where T.Assoc == U.Assoc {
+  struct ViaSameType { }
+}
+
+// CHECK: A<Int, String>.ViaSameType
+printType(A<Int, String>.ViaSameType.self)
+
+protocol Q { }
+extension Int: Q { }
+
+extension A where T: Q {
+  struct ViaProtocolConformance { }
+}
+
+// CHECK: A<Int, String>.ViaProtocolConformance
+printType(A<Int, String>.ViaProtocolConformance.self)
+
+class B { }
+
+class C: B { }
+
+extension B: P {
+  typealias Assoc = Int
+}
+
+extension A where U: B {
+  struct ViaBaseClass { }
+}
+
+// CHECK: A<Int, B>.ViaBaseClass
+printType(A<Int, B>.ViaBaseClass.self)
+
+// CHECK: A<Int, C>.ViaBaseClass
+printType(A<Int, C>.ViaBaseClass.self)
+
+extension A where T: AnyObject {
+  struct ViaAnyObject {
+    func wobble() {}
+  }
+}
+
+// CHECK: A<C, Int>.ViaAnyObject
+printType(A<C, Int>.ViaAnyObject.self)


### PR DESCRIPTION
Read the extended context mangled name from an extension context descriptor
so we can form a proper demangle tree for extensions. For example, this allows
types nested within extensions of types from different modules to be found, as
well as finding types defined within constrained extensions.
