### PR TITLE
WinSDK: extend the module definition for Foundation

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -85,8 +85,24 @@ module WinSDK [system] [extern_c] {
     }
   }
 
+  // FIXME(compnerd) this is a hack for the HWND typedef for DbgHelp
+  module __DirectX {
+    header "directmanipulation.h"
+    export *
+  }
+
+  module DbgHelp {
+    header "DbgHelp.h"
+    export *
+  }
+
   module Shell {
     header "ShlObj.h"
+    export *
+  }
+
+  module WinCrypt {
+    header "wincrypt.h"
     export *
   }
 }


### PR DESCRIPTION
Update the module definition to extend it to support stack symbolication
for use in Foundation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
