### PR TITLE
Remote: use the qualified name for `NodePointer`

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1480,7 +1480,7 @@ private:
       return nullptr;
 
     // Dig out the name of the entity.
-    NodePointer nameChild = mangledNode->getChild(1);
+    swift::Demangle::NodePointer nameChild = mangledNode->getChild(1);
     if ((nameChild->getKind() != Node::Kind::PrivateDeclName &&
          nameChild->getKind() != Node::Kind::LocalDeclName) ||
         nameChild->getNumChildren() < 2)


### PR DESCRIPTION
Use the qualified name for the `NodePointer`.  The unqualified name
causes ambiguity when building on Windows.  This repairs the Windows
build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
