### PR TITLE
vim: add `open` and `mutating` keywords to SIL

### DIFF
--- a/utils/vim/syntax/sil.vim
+++ b/utils/vim/syntax/sil.vim
@@ -45,7 +45,9 @@ syn keyword silAttributes contained containedin=silAttribute
       \ exact
       \ init
       \ modify
+      \ mutating
       \ objc
+      \ open
       \ read
       \ rootself
       \ stack


### PR DESCRIPTION
Add a couple of missing modififers to the syntax highlighting for SIL in
vim.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
