### PR TITLE
[WIP/experiment/bad idea] Create space for synthesized code

### DIFF
--- a/include/swift/AST/DeclNameLoc.h
+++ b/include/swift/AST/DeclNameLoc.h
@@ -35,7 +35,13 @@ class DeclNameLoc {
   /// * The left parentheses location
   /// * The right parentheses location
   /// * The locations of each of the argument labels.
-  const void *LocationInfo;
+  union LocationInfoUnion {
+    SourceLoc SingleLoc;
+    SourceLoc *ManyLocs;
+    
+    LocationInfoUnion(SourceLoc Loc = SourceLoc()) : SingleLoc(Loc) {}
+    LocationInfoUnion(SourceLoc *Locs) : ManyLocs(Locs) {}
+  } LocationInfo;
 
   /// The number of argument labels stored in the name.
   unsigned NumArgumentLabels;
@@ -51,18 +57,18 @@ class DeclNameLoc {
   /// stored or to the array of source locations that was stored.
   SourceLoc const * getSourceLocs() const {
     if (NumArgumentLabels == 0) 
-      return reinterpret_cast<SourceLoc const *>(&LocationInfo);
+      return &LocationInfo.SingleLoc;
 
-    return reinterpret_cast<SourceLoc const *>(LocationInfo);
+    return LocationInfo.ManyLocs;
   }
 
 public:
   /// Create an invalid declaration name location.
-  DeclNameLoc() : LocationInfo(0), NumArgumentLabels(0) { }
+  DeclNameLoc() : LocationInfo(), NumArgumentLabels(0) { }
 
   /// Create declaration name location information for a base name.
   explicit DeclNameLoc(SourceLoc baseNameLoc)
-    : LocationInfo(baseNameLoc.getOpaquePointerValue()),
+    : LocationInfo(baseNameLoc),
       NumArgumentLabels(0) { }
 
   /// Create declaration name location information for a compound

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -136,6 +136,10 @@ ERROR(circular_class_inheritance,none,
 ERROR(circular_enum_inheritance,none,
       "%0 has a raw type that depends on itself", (Identifier))
 
+NOTE(diagnostic_in_synthesized_code,none,
+     "previous diagnostic occurs in code synthesized by the compiler; "
+     "please file a bug report with your project", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -94,7 +94,7 @@ protected:
   /// Return the given value for the 'implicit' flag if present, or if None,
   /// return true if the location is invalid.
   static bool getDefaultImplicitFlag(Optional<bool> implicit, SourceLoc keyLoc){
-    return implicit.hasValue() ? *implicit : keyLoc.isInvalid();
+    return implicit.hasValue() ? *implicit : (keyLoc.isInvalid() || keyLoc.isSynthetic());
   }
   
 public:

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -45,8 +45,8 @@ class SourceManager {
     std::string Name;
     int LineOffset;
   };
-  std::map<const char *, VirtualFile> VirtualFiles;
-  mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
+  std::map<SourceLoc, VirtualFile> VirtualFiles;
+  mutable std::pair<SourceLoc, const VirtualFile*> CachedVFile = {SourceLoc(), nullptr};
 
 public:
   SourceManager(llvm::IntrusiveRefCntPtr<clang::vfs::FileSystem> FS =
@@ -87,7 +87,7 @@ public:
 
   /// Returns true if \c LHS is before \c RHS in the source buffer.
   bool isBeforeInBuffer(SourceLoc LHS, SourceLoc RHS) const {
-    return LHS.isBefore(RHS);
+    return LHS < RHS;
   }
 
   /// Returns true if range \c R contains the location \c Loc.  The location

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -87,7 +87,7 @@ public:
 
   /// Returns true if \c LHS is before \c RHS in the source buffer.
   bool isBeforeInBuffer(SourceLoc LHS, SourceLoc RHS) const {
-    return LHS.Value.getPointer() < RHS.Value.getPointer();
+    return LHS.isBefore(RHS);
   }
 
   /// Returns true if range \c R contains the location \c Loc.  The location

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3432,6 +3432,17 @@ public:
     void checkSourceRanges(Expr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying ranges", E);
 
+      if (E->getStartLoc().isValid() != E->getEndLoc().isValid()) {
+        Out << "StartLoc and EndLoc validity do not match for expression: ";
+        E->dump(Out);
+        Out << "\nStartLoc: ";
+        E->getStartLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << ", EndLoc: ";
+        E->getEndLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << "\n";
+        abort();
+      }
+
       if (!E->getSourceRange().isValid()) {
         // We don't care about source ranges on implicitly-generated
         // expressions.
@@ -3457,6 +3468,17 @@ public:
 
     void checkSourceRanges(Stmt *S) {
       PrettyStackTraceStmt debugStack(Ctx, "verifying ranges", S);
+
+      if (S->getStartLoc().isValid() != S->getEndLoc().isValid()) {
+        Out << "StartLoc and EndLoc validity do not match for statement: ";
+        S->dump(Out);
+        Out << "\nStartLoc: ";
+        S->getStartLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << ", EndLoc: ";
+        S->getEndLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << "\n";
+        abort();
+      }
 
       if (!S->getSourceRange().isValid()) {
         // We don't care about source ranges on implicitly-generated
@@ -3544,6 +3566,17 @@ public:
     void checkSourceRanges(Pattern *P) {
       PrettyStackTracePattern debugStack(Ctx, "verifying ranges", P);
 
+      if (P->getStartLoc().isValid() != P->getEndLoc().isValid()) {
+        Out << "StartLoc and EndLoc validity do not match for expression: ";
+        P->print(Out);
+        Out << "\nStartLoc: ";
+        P->getStartLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << ", EndLoc: ";
+        P->getEndLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << "\n";
+        abort();
+      }
+
       // We don't care about source ranges on implicitly-generated
       // patterns.
       if (P->isImplicit())
@@ -3581,6 +3614,17 @@ public:
 
     void checkSourceRanges(Decl *D) {
       PrettyStackTraceDecl debugStack("verifying ranges", D);
+
+      if (D->getStartLoc().isValid() != D->getEndLoc().isValid()) {
+        Out << "StartLoc and EndLoc validity do not match for expression: ";
+        D->dump(Out);
+        Out << "\nStartLoc: ";
+        D->getStartLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << ", EndLoc: ";
+        D->getEndLoc().printLineAndColumn(Out, Ctx.SourceMgr);
+        Out << "\n";
+        abort();
+      }
 
       if (!D->getSourceRange().isValid()) {
         // We don't care about source ranges on implicitly-generated

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -705,12 +705,12 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
     return;
 
   // Figure out the source location.
-  SourceLoc loc = diagnostic.getLoc();
+  SourceLoc loc = SourceMgr.getDiagnosticLocation(diagnostic.getLoc());
   if (loc.isInvalid() && diagnostic.getDecl()) {
     const Decl *decl = diagnostic.getDecl();
     // If a declaration was provided instead of a location, and that declaration
     // has a location we can point to, use that location.
-    loc = decl->getLoc();
+    loc = SourceMgr.getDiagnosticLocation(decl->getLoc());
 
     if (loc.isInvalid()) {
       // There is no location we can point to. Pretty-print the declaration

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -240,8 +240,8 @@ void SourceLoc::printLineAndColumn(raw_ostream &OS, const SourceManager &SM,
 
   auto LineAndCol = SM.getLineAndColumn(*this, BufferID);
   OS << "line:" << LineAndCol.first << ':' << LineAndCol.second;
-  if (SyntheticLocation) {
-    OS << '(' << SyntheticLocation << ')';
+  if (SyntheticPredecessor) {
+    OS << "(-" << SyntheticPredecessor << ')';
   }
 }
 
@@ -262,8 +262,8 @@ void SourceLoc::print(raw_ostream &OS, const SourceManager &SM,
 
   auto LineAndCol = SM.getLineAndColumn(*this, BufferID);
   OS << ':' << LineAndCol.first << ':' << LineAndCol.second;
-  if (SyntheticLocation) {
-    OS << '(' << SyntheticLocation << ')';
+  if (SyntheticPredecessor) {
+    OS << "(-" << SyntheticPredecessor << ')';
   }
 }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2500,7 +2500,7 @@ void Lexer::lexImpl() {
 
 Token Lexer::getTokenAtLocation(const SourceManager &SM, SourceLoc Loc) {
   // Don't try to do anything with an invalid location.
-  if (!Loc.isValid())
+  if (!Loc.isValid() || !Loc.isPhysical())
     return Token();
 
   // Figure out which buffer contains this location.

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -30,6 +30,7 @@ class Type;
 class TypeChecker;
 class ValueDecl;
 class VarDecl;
+class SourceLoc;
 
 class DerivedConformance {
 public:
@@ -188,6 +189,26 @@ public:
   ///
   /// \param synthesizing The decl that is being synthesized.
   bool checkAndDiagnoseDisallowedContext(ValueDecl *synthesizing) const;
+  
+  class SourceLocSynthesizer {
+    SourceRange remaining;
+    
+  public:
+    SourceLocSynthesizer(SourceRange remaining)
+      : remaining(remaining) { }
+    
+    SourceLocSynthesizer(Decl *decl, SourceLoc base)
+      : SourceLocSynthesizer(
+          decl->getASTContext().SourceMgr.reserveSyntheticSourceRange(base)
+        )
+    { }
+    
+    SourceLoc makeNext() {
+      auto nextLoc = remaining.Start.getSyntheticLocBefore(remaining.End);
+      remaining.Start = nextLoc;
+      return nextLoc;
+    }
+  };
 };
 }
 


### PR DESCRIPTION
This is a hare-brained scheme to solve some of our problems with synthesized code. If it works, I think it could let us remove a bunch of hacks surrounding code synthesis. It may also improve diagnostics by emitting errors at legible locations instead of `<unknown>:0`.

The idea is to represent the positions of synthesized AST nodes as being "between" the `SourceLoc`s representing actual, physical code. To do this, we add an integer field to `SourceLoc` which is always zero for physical `SourceLoc`s but is used as a fallback during comparisons. We could then give the synthesized nodes `SourceLoc`s with locations reflecting their proper relative ordering.

This PR is super-early and mostly contains the parts that I think would have global time or space impacts. Basically, right now I just want to see whether this approach would destroy performance.