### PR TITLE
Several minor fixes to Windows build instructions

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -166,6 +166,7 @@ cmake -G Ninja^
  -DSWIFT_PATH_TO_LLVM_BUILD="S:\build\Ninja-DebugAssert\llvm-windows-amd64"^
  -DSWIFT_PATH_TO_CLANG_SOURCE="S:\clang"^
  -DSWIFT_PATH_TO_CLANG_BUILD="S:\build\Ninja-DebugAssert\llvm-windows-amd64"^
+ -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="S:\swift-corelibs-libdispatch"^
  -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE="S:\icu\include"^
  -DSWIFT_WINDOWS_x86_64_ICU_UC="S:\icu\lib64\icuuc.lib"^
  -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE="S:\icu\include"^


### PR DESCRIPTION
- Fix minor typos
- Add missing `git clone` for LLDB
- Fix inconsistent/missing quotes in code blocks
- A few other consistency fixups
- `SWIFT_PATH_TO_LIBDISPATCH_SOURCE` is only used on Linux
- Use `-A` and `-T` with modern CMake instead of `-DCMAKE_GENERATOR_PLATFORM`
- Add missing info on `libcurl` and `libxml2` requirements for `swift-corelibs-foundation`