### PR TITLE
[AutoDiff] Fix memory leaks.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4396,8 +4396,13 @@ void DifferentiationTask::createVJP() {
       // This assumes that the primal direct results correspond exactly to the
       // adjoint's direct parameters, an assumption that we check in assertions
       // above.
-      builder.createRetainValue(loc, primalDirectResults[dirResIdx],
-                                builder.getDefaultAtomicity());
+      //
+      // If this is not the primal value struct (index 0), it must be an
+      // original result. Retain it because we'll return original results
+      // alongside the pullback.
+      if (dirResIdx != 0)
+        builder.createRetainValue(loc, primalDirectResults[dirResIdx],
+                                  builder.getDefaultAtomicity());
       partialAdjointArgs.push_back(primalDirectResults[dirResIdx++]);
     } else {
       // This assumes that the primal indirect results correspond exactly to the


### PR DESCRIPTION
The primal value struct should not be retained before the partial application of the pullback because it's already `+1` and owned solely by the pullback. Original results should be retained because they are separately returned along with the pullback.

Resolves [SR-9665](https://bugs.swift.org/browse/SR-9665).