### PR TITLE
[AutoDiff] Remove original parameters and results from adjoint type signature.

### DIFF
--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -28,5 +28,5 @@ public func closureCaptureMutable() {
 // CHECK:   [[PRIMAL:%.*]] = function_ref @AD__{{.*}}closureCaptureMutable{{.*}}___primal_src_0_wrt_0
 // CHECK:   {{.*}} = apply [[PRIMAL]]({{.*}}, [[BOXED_ARG]])
 // CHECK:   [[ADJOINT:%.*]] = function_ref @AD__{{.*}}closureCaptureMutabley{{.*}}___adjoint_src_0_wrt_0
-// CHECK:   {{.*}} = partial_apply [callee_guaranteed] [[ADJOINT]]({{.*}}, {{.*}}, {{.*}}, [[BOXED_ARG]])
+// CHECK:   {{.*}} = partial_apply [callee_guaranteed] [[ADJOINT]]({{.*}})
 

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -48,7 +48,7 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // The adjoint should not release primal values because they are passed in as @guaranteed.
 //
 // CHECK-VJP-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
-// CHECK-VJP: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, {{%.*}} : $Vector, {{%.*}} : $Vector):
+// CHECK-VJP: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0):
 // CHECK-VJP:   [[PULLBACK0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.pullback_0
 // CHECK-VJP-NOT:   release_value [[PULLBACK0]]
 // CHECK-VJP-NOT:   release_value [[PRIMAL_VALUES]]
@@ -62,7 +62,7 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // The adjoint should not release primal values because they are passed in as @guaranteed.
 //
 // CHECK-NOVJP-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
-// CHECK-NOVJP: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, {{%.*}} : $Vector, {{%.*}} : $Vector):
+// CHECK-NOVJP: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0):
 // CHECK-NOVJP:   [[PV0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.v_0
 // CHECK-NOVJP-NOT:   release_value [[PV0]]
 // CHECK-NOVJP-NOT:   release_value [[PRIMAL_VALUES]]


### PR DESCRIPTION
Original arguments and results are not needed or used by the adjoint because the adjoint is just a pullback with an explicit closure context.  Saves more memory.

This has been on my list for quite some time. :)