### PR TITLE
TypeDecoder: disable test on iOS because it is failing

### DIFF
--- a/test/TypeDecoder/foreign_types.swift
+++ b/test/TypeDecoder/foreign_types.swift
@@ -5,6 +5,7 @@
 // RUN: %lldb-moduleimport-test-with-sdk %t/foreign_types -type-from-mangled=%t/input | %FileCheck %s
 
 // REQUIRES: objc_interop
+// REQUIRES: SR9782
 
 import Foundation
 import CoreCooling


### PR DESCRIPTION
Disable this test until it can be looked into.  SR-9782

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
