### PR TITLE
[DNM][ownership] Move OME out of the diagnostics pipeline.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -226,6 +226,9 @@ PASS(Outliner, "outliner",
      "Function Outlining Optimization")
 PASS(OwnershipModelEliminator, "ownership-model-eliminator",
      "Eliminate Ownership Annotation of SIL")
+PASS(NonTransparentFunctionOwnershipModelEliminator,
+     "non-transparent-func-ownership-model-eliminator",
+     "Eliminate Ownership Annotations from non-transparent SIL Functions")
 PASS(RCIdentityDumper, "rc-id-dumper",
      "Print Reference Count Identities")
 PASS(PerfInliner, "inline",

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -265,8 +265,13 @@ class ARCSequenceOpts : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
     auto *F = getFunction();
+
     // If ARC optimizations are disabled, don't optimize anything and bail.
     if (!getOptions().EnableARCOptimizations)
+      return;
+
+    // FIXME: We should support ownership.
+    if (F->hasOwnership())
       return;
 
     if (!EnableLoopARC) {

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -63,13 +63,16 @@ class ExistentialSpecializer : public SILFunctionTransform {
   ClassHierarchyAnalysis *CHA;
 public:
   void run() override {
-
     auto *F = getFunction();
 
     /// Don't optimize functions that should not be optimized.
     if (!F->shouldOptimize() || !F->getModule().getOptions().ExistentialSpecializer) {
       return;
     }
+
+    // FIXME: This pass should be able to support ownership.
+    if (F->hasOwnership())
+      return;
 
     /// Get CallerAnalysis information handy.
     CA = PM->getAnalysis<CallerAnalysis>();

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -581,6 +581,9 @@ void LetPropertiesOpt::run(SILModuleTransform *T) {
     // properties.
     bool NonRemovable = !F.shouldOptimize();
 
+    // FIXME: We should be able to handle ownership.
+    NonRemovable &= !F.hasOwnership();
+
     for (auto &BB : F) {
       for (auto &I : BB)
         // Look for any instructions accessing let properties.

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -1288,6 +1288,9 @@ public:
 
     SILFunction *F = getFunction();
     assert(F);
+    // FIXME: Update for ownership.
+    if (F->hasOwnership())
+      return;
     SILLoopInfo *LI = LA->get(F);
     assert(LI);
     DominanceInfo *DT = DA->get(F);

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1160,6 +1160,10 @@ namespace {
 
 class COWArrayOptPass : public SILFunctionTransform {
   void run() override {
+    // FIXME: Update for ownership.
+    if (getFunction()->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "COW Array Opts in Func "
                             << getFunction()->getName() << "\n");
 
@@ -1846,6 +1850,10 @@ class SwiftArrayOptPass : public SILFunctionTransform {
       return;
 
     auto *Fn = getFunction();
+
+    // FIXME: Add support for ownership.
+    if (Fn->hasOwnership())
+      return;
 
     // Don't hoist array property calls at Osize.
     if (Fn->optimizeForSize())

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -421,6 +421,10 @@ class LoopRotation : public SILFunctionTransform {
 
     SILFunction *F = getFunction();
     assert(F);
+    // FIXME: Add ownership support.
+    if (F->hasOwnership())
+      return;
+
     SILLoopInfo *LI = LA->get(F);
     assert(LI);
     DominanceInfo *DT = DA->get(F);

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -345,6 +345,10 @@ class SILCombine : public SILFunctionTransform {
   
   /// The entry point to the transformation.
   void run() override {
+    // FIXME: We should be able to handle ownership.
+    if (getFunction()->hasOwnership())
+      return;
+
     auto *AA = PM->getAnalysis<AliasAnalysis>();
     auto *DA = PM->getAnalysis<DominanceAnalysis>();
     auto *PCA = PM->getAnalysis<ProtocolConformanceAnalysis>();

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -1151,6 +1151,10 @@ public:
     if (!F->shouldOptimize())
       return;
 
+    // FIXME: Support ownership.
+    if (F->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "*** ARCCM on function: " << F->getName()
                             << " ***\n");
 

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -1130,6 +1130,10 @@ struct AccessEnforcementOpts : public SILFunctionTransform {
     if (F->empty())
       return;
 
+    // FIXME: Support ownership.
+    if (F->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "Running local AccessEnforcementOpts on "
                             << F->getName() << "\n");
 

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -217,6 +217,10 @@ struct AccessEnforcementReleaseSinking : public SILFunctionTransform {
     if (F->empty())
       return;
 
+    // FIXME: Support ownership.
+    if (F->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "Running AccessEnforcementReleaseSinking on "
                             << F->getName() << "\n");
 

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -184,6 +184,11 @@ public:
 
   void run() override {
     auto &Fn = *getFunction();
+
+    // FIXME: Add ownership support.
+    if (Fn.hasOwnership())
+      return;
+
     bool Changed = false;
     SmallVector<ApplyInst *, 16> DeadArrayCountCalls;
     // Propagate the count of array allocations to array.count users.

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -344,6 +344,10 @@ public:
   void run() override {
     auto &Fn = *getFunction();
 
+    // FIXME: Update for ownership.
+    if (Fn.hasOwnership())
+      return;
+
     // Propagate the elements an of array value to its users.
     llvm::SmallVector<ArrayAllocation::GetElementReplacement, 16>
       GetElementReplacements;

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -105,6 +105,11 @@ private:
     bool Changed = false;
 
     SILFunction *F = getFunction();
+
+    // FIXME: Add ownership support.
+    if (F->hasOwnership())
+      return;
+
     for (SILBasicBlock &BB : *F) {
       if (auto *SEI = dyn_cast<SwitchEnumInst>(BB.getTerminator())) {
         Changed |= tryOptimize(SEI);

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -1474,6 +1474,10 @@ class CopyForwardingPass : public SILFunctionTransform
     if (!EnableCopyForwarding && !EnableDestroyHoisting)
       return;
 
+    // FIXME: We should be able to support [ossa].
+    if (getFunction()->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "Copy Forwarding in Func "
                             << getFunction()->getName() << "\n");
 
@@ -1569,6 +1573,9 @@ class TempRValueOptPass : public SILFunctionTransform {
 
 /// The main entry point of the pass.
 void TempRValueOptPass::run() {
+  if (getFunction()->hasOwnership())
+    return;
+
   LLVM_DEBUG(llvm::dbgs() << "Copy Peephole in Func "
                           << getFunction()->getName() << "\n");
 

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -111,6 +111,10 @@ class DCE : public SILFunctionTransform {
 
     SILFunction *F = getFunction();
 
+    // FIXME: Support ownership.
+    if (F->hasOwnership())
+      return;
+
     auto *DA = PM->getAnalysis<PostDominanceAnalysis>();
     PDT = DA->get(F);
 

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -677,6 +677,10 @@ class DeadObjectElimination : public SILFunctionTransform {
   }
 
   void run() override {
+    // FIXME: We should support ownership eventually.
+    if (getFunction()->hasOwnership())
+      return;
+
     if (processFunction(*getFunction())) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::CallsAndInstructions);
     }

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -1229,6 +1229,10 @@ public:
   void run() override {
     auto *Fun = getFunction();
 
+    // We do not support [ossa] now.
+    if (Fun->hasOwnership())
+      return;
+
     // Only outline if we optimize for size.
     if (!Fun->optimizeForSize())
       return;

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -287,6 +287,11 @@ bool OwnershipModelEliminatorVisitor::visitDestructureTupleInst(
 namespace {
 
 struct OwnershipModelEliminator : SILModuleTransform {
+  bool SkipTransparent;
+
+  OwnershipModelEliminator(bool SkipTransparent)
+      : SkipTransparent(SkipTransparent) {}
+
   void run() override {
     if (DumpBefore.size()) {
       getModule()->dump(DumpBefore.c_str());
@@ -299,6 +304,11 @@ struct OwnershipModelEliminator : SILModuleTransform {
 
       // If F does not have ownership, skip it. We have no further work to do.
       if (!F.hasOwnership())
+        continue;
+
+      // If we were asked to not strip ownership from transparent functions,
+      // continue.
+      if (SkipTransparent && F.isTransparent())
         continue;
 
       // Set F to have unqualified ownership.
@@ -338,5 +348,9 @@ struct OwnershipModelEliminator : SILModuleTransform {
 } // end anonymous namespace
 
 SILTransform *swift::createOwnershipModelEliminator() {
-  return new OwnershipModelEliminator();
+  return new OwnershipModelEliminator(false /*skip transparent*/);
+}
+
+SILTransform *swift::createNonTransparentFunctionOwnershipModelEliminator() {
+  return new OwnershipModelEliminator(true /*skip transparent*/);
 }

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -1641,6 +1641,10 @@ public:
   /// The entry point to the transformation.
   void run() override {
     SILFunction *F = getFunction();
+    // FIXME: Handle ownership.
+    if (F->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "*** RLE on function: " << F->getName()
                             << " ***\n");
 

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -276,6 +276,9 @@ class SILLowerAggregate : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
     SILFunction *F = getFunction();
+    // FIXME: Can we support ownership?
+    if (F->hasOwnership())
+      return;
     LLVM_DEBUG(llvm::dbgs() << "***** LowerAggregate on function: " <<
           F->getName() << " *****\n");
     bool Changed = processFunction(*F);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -940,6 +940,11 @@ class SILMem2Reg : public SILFunctionTransform {
 
   void run() override {
     SILFunction *F = getFunction();
+
+    // FIXME: We should be able to support ownership.
+    if (F->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "** Mem2Reg on function: " << F->getName()
                             << " **\n");
 

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -332,6 +332,11 @@ class SILSROA : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
     SILFunction *F = getFunction();
+
+    // FIXME: We should be able to handle ownership.
+    if (F->hasOwnership())
+      return;
+
     LLVM_DEBUG(llvm::dbgs() << "***** SROA on function: " << F->getName()
                             << " *****\n");
 

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3591,6 +3591,10 @@ namespace {
 class SimplifyCFGPass : public SILFunctionTransform {
 public:
   void run() override {
+    // FIXME: We should be able to handle ownership.
+    if (getFunction()->hasOwnership())
+      return;
+
     if (SimplifyCFG(*getFunction(), *this, getOptions().VerifyAll,
                     /*EnableJumpThread=*/false)
             .run())
@@ -3608,6 +3612,9 @@ namespace {
 class JumpThreadSimplifyCFGPass : public SILFunctionTransform {
 public:
   void run() override {
+    // FIXME: Handle ownership.
+    if (getFunction()->hasOwnership())
+      return;
     if (SimplifyCFG(*getFunction(), *this, getOptions().VerifyAll,
                     /*EnableJumpThread=*/true)
             .run())

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -54,6 +54,10 @@ private:
 
 void StackPromotion::run() {
   SILFunction *F = getFunction();
+  // FIXME: We should be able to support ownership.
+  if (F->hasOwnership())
+    return;
+
   LLVM_DEBUG(llvm::dbgs() << "** StackPromotion in " << F->getName() << " **\n");
 
   auto *EA = PM->getAnalysis<EscapeAnalysis>();


### PR DESCRIPTION
This moves ownership stripping out of the diagnostics pipeline.

At -Onone it now runs /after/ we serialize, but before we print SIL (this
ensures I can update tests in a subsequent PR).

At -O, to temporarily work around serialization issues with transparent
functions, we strip ownership from all but transparent functions at the
beginning of the performance pipeline, serialize, and then strip ownership from
transparent functions. For this to work, I needed to make sure that the
performance pipeline passes that do not support ownership SIL, just skip such
functions. So the transparent functions will arrive (mostly) untouched in
serialized SIL and the rest of the pipeline will optimize non-transparent
functions as they should.

----

NOTE: This is DNM since I need to benchmark still and fix one bug that I found running this offline.