### PR TITLE
[IDE] Fix SyntaxModel to corretly walk sequence expression correctly

### DIFF
--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -282,3 +282,8 @@ completion(a: 1) { (x: Any, y: Int) -> Int in
 // CHECK: <call><name>completion</name>(<arg><name>a</name>: 1</arg>) <arg><closure>{ (<param>x: <type>Any</type></param>, <param>y: <type>Int</type></param>) -> <type>Int</type> in
 // CHECK:    return x as! Int + y
 // CHECK: }</closure></arg></call>
+
+myFunc(foo: 0,
+       bar: baz == 0)
+// CHECK: <call><name>myFunc</name>(<arg><name>foo</name>: 0</arg>,
+// CHECK:        <arg><name>bar</name>: baz == 0</arg>)</call>


### PR DESCRIPTION
This is 5.0 regression introduced in https://github.com/apple/swift/pull/18663 .

* Handle sequence expression at call argument position (i.e. move the block after the call argument handling logic)
* Set the sequence expression as the `Parent` when walking into its sub
  expressions
* Correctly call `walkToExprPost()` to the sequence expression

rdar://problem/47603866 / https://bugs.swift.org/browse/SR-9776