### PR TITLE
Fix test/TypeDecoder/foreign_types.swift for 32-bit

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/CoreCooling.h
+++ b/test/ClangImporter/Inputs/custom-modules/CoreCooling.h
@@ -57,3 +57,12 @@ void CCRefrigeratorGetItemUnaudited(CCRefrigeratorRef fridge, unsigned index, CC
 
 typedef void *CFNonConstVoidRef __attribute__((objc_bridge(id)));
 CFNonConstVoidRef CFNonConstBottom();
+
+typedef struct IceCube {
+    float width;
+    float height;
+    float depth;
+} IceCube;
+
+typedef IceCube IceCube;
+typedef IceCube BlockOfIce;

--- a/test/TypeDecoder/foreign_types.swift
+++ b/test/TypeDecoder/foreign_types.swift
@@ -19,7 +19,8 @@ do {
     let x5 = RenamedError.Code.good
     let x6 = Wrapper.MemberEnum.A
     let x7 = WrapperByAttribute(0)
-    let x8 = NSSize(width: 0, height: 0)
+    let x8 = IceCube(width: 0, height: 0, depth: 0)
+    let x9 = BlockOfIce(width: 0, height: 0, depth: 0)
 }
 
 do {
@@ -30,7 +31,8 @@ do {
     let x5 = RenamedError.Code.self
     let x6 = Wrapper.MemberEnum.self
     let x7 = WrapperByAttribute.self
-    let x8 = NSSize.self
+    let x8 = IceCube.self
+    let x9 = BlockOfIce.self
 }
 */
 
@@ -41,8 +43,8 @@ do {
 // DEMANGLE: $sSo14MyRenamedErrorLeVD
 // DEMANGLE: $sSo12MyMemberEnumVD
 // DEMANGLE: $sSo18WrapperByAttributeaD
-// DEMANGLE: $sSo6NSSizeaD
-// DEMANGLE: $sSo6CGSizeVD
+// DEMANGLE: $sSo7IceCubeVD
+// DEMANGLE: $sSo10BlockOfIceaD
 
 // CHECK: CCRefrigerator
 // CHECK: MyError.Code
@@ -51,8 +53,8 @@ do {
 // CHECK: RenamedError
 // CHECK: Wrapper.MemberEnum
 // CHECK: WrapperByAttribute
-// CHECK: NSSize
-// CHECK: CGSize
+// CHECK: IceCube
+// CHECK: BlockOfIce
 
 // DEMANGLE: $sSo17CCRefrigeratorRefamD
 // DEMANGLE: $sSo7MyErrorVmD
@@ -61,8 +63,8 @@ do {
 // DEMANGLE: $sSC14MyRenamedErrorLeVmD
 // DEMANGLE: $sSo12MyMemberEnumVmD
 // DEMANGLE: $sSo18WrapperByAttributeamD
-// DEMANGLE: $sSo6NSSizeamD
-// DEMANGLE: $sSo6CGSizeVmD
+// DEMANGLE: $sSo7IceCubeVmD
+// DEMANGLE: $sSo10BlockOfIceamD
 
 // CHECK: CCRefrigerator.Type
 // CHECK: MyError.Code.Type
@@ -71,5 +73,5 @@ do {
 // CHECK: RenamedError.Type
 // CHECK: Wrapper.MemberEnum.Type
 // CHECK: WrapperByAttribute.Type
-// CHECK: NSSize.Type
-// CHECK: CGSize.Type
+// CHECK: IceCube.Type
+// CHECK: BlockOfIce.Type


### PR DESCRIPTION
NSSize is not always aliased to CGSize; on 32-bit platforms it is its own type.
Instead, let's just define our own type.