### PR TITLE
[TypeChecker] Drop @autoclosure attribute from invalid parameters

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -489,6 +489,10 @@ mapParsedParameters(Parser &parser,
       // belongs to both type flags and declaration.
       if (auto *ATR = dyn_cast<AttributedTypeRepr>(type)) {
         auto &attrs = ATR->getAttrs();
+        // At this point we actually don't know if that's valid to mark
+        // this parameter declaration as `autoclosure` because type has
+        // not been resolved yet - it should either be a function type
+        // or typealias with underlying function type.
         param->setAutoClosure(attrs.has(TypeAttrKind::TAK_autoclosure));
       }
     } else if (paramContext != Parser::ParameterContextKind::Closure) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -773,6 +773,13 @@ static bool validateParameterType(ParamDecl *decl, TypeResolution resolution,
     }
   }
 
+  // If this parameter declaration is marked as `@autoclosure`
+  // let's make sure that its parameter type is indeed a function,
+  // this decision couldn't be made based on type representative
+  // alone because it may be later resolved into an invalid type.
+  if (decl->isAutoClosure())
+    hadError |= !(Ty && Ty->is<FunctionType>());
+
   if (hadError)
     TL.setInvalidType(TC.Context);
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2293,10 +2293,6 @@ bool TypeResolver::resolveASTFunctionTypeParams(
       variadic = true;
     }
 
-    bool autoclosure = false;
-    if (auto *ATR = dyn_cast<AttributedTypeRepr>(eltTypeRepr))
-      autoclosure = ATR->getAttrs().has(TAK_autoclosure);
-
     Type ty = resolveType(eltTypeRepr, thisElementOptions);
     if (!ty) return true;
 
@@ -2308,6 +2304,16 @@ bool TypeResolver::resolveASTFunctionTypeParams(
     // Parameters of polymorphic functions speak in terms of interface types.
     if (requiresMappingOut) {
       ty = ty->mapTypeOutOfContext();
+    }
+
+    bool autoclosure = false;
+    if (auto *ATR = dyn_cast<AttributedTypeRepr>(eltTypeRepr)) {
+      // Make sure that parameter itself is of a function type, otherwise
+      // the problem would already be diagnosed by `resolveAttributedType`
+      // but attributes would stay unchanged. So as a recovery let's drop
+      // 'autoclosure' attribute from the resolved parameter.
+      autoclosure =
+          ty->is<FunctionType>() && ATR->getAttrs().has(TAK_autoclosure);
     }
 
     ValueOwnership ownership;

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -245,3 +245,16 @@ class Bar {
   typealias BarClosure = (String) -> String
   func barFunction(closure: @autoclosure BarClosure) {} // expected-error {{argument type of @autoclosure parameter must be '()'}}
 }
+
+func rdar_47586626() {
+  struct S {}
+  typealias F = () -> S
+
+  func foo(_: @autoclosure S) {} // expected-error {{@autoclosure attribute only applies to function types}}
+  func bar(_: @autoclosure F) {} // Ok
+
+  let s = S()
+
+  foo(s) // ok
+  bar(s) // ok
+}


### PR DESCRIPTION
While forming/validating parameters make sure that the type is indeed
a function type before marking it as `autoclosure` based on type
representative attributes, because parser doesn't change attributes
even after the error has been found and diagnosed.

Resolves: rdar://problem/47586626

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
