### PR TITLE
[ParseableInterfaces] Print @_show_in_interface

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -258,6 +258,7 @@ struct PrintOptions {
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {DAK_Transparent, DAK_Effects,
                                               DAK_FixedLayout,
+                                              DAK_ShowInInterface,
                                               DAK_ImplicitlyUnwrappedOptional};
 
   /// List of attribute kinds that should be printed exclusively.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -374,7 +374,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_RawDocComment:
   case DAK_ObjCBridged:
   case DAK_SynthesizedProtocol:
-  case DAK_ShowInInterface:
   case DAK_Rethrows:
   case DAK_Infix:
     return false;

--- a/test/ParseableInterface/show-in-interface.swift
+++ b/test/ParseableInterface/show-in-interface.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck %s -parse-stdlib -emit-parseable-module-interface-path - | %FileCheck %s
+
+// CHECK: @_show_in_interface public protocol _UnderscoredProtocol {}
+@_show_in_interface
+public protocol _UnderscoredProtocol {}

--- a/test/ParseableInterface/show-in-interface.swift
+++ b/test/ParseableInterface/show-in-interface.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -parse-stdlib -emit-parseable-module-interface-path - | %FileCheck %s
 
-// CHECK: @_show_in_interface public protocol _UnderscoredProtocol {}
+// CHECK: @_show_in_interface public protocol _UnderscoredProtocol {
+// CHECK-NEXT: }
 @_show_in_interface
 public protocol _UnderscoredProtocol {}


### PR DESCRIPTION
This attribute needs to be preserved in the .swiftmodule, otherwise these declarations will stop showing up in the interface. Print it in the parseable interface.