### PR TITLE
[Diagnostics] Mark invalid ‘@testable import’ as fatal

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -761,7 +761,7 @@ ERROR(imported_decl_is_wrong_kind_typealias,none,
 ERROR(ambiguous_decl_in_module,none,
       "ambiguous name %0 in module %1", (Identifier, Identifier))
 
-ERROR(module_not_testable,none,
+ERROR(module_not_testable,Fatal,
       "module %0 was not compiled for testing", (Identifier))
 
 ERROR(module_not_compiled_for_private_import,none,

--- a/test/Frontend/invalid-testable-import.swift
+++ b/test/Frontend/invalid-testable-import.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/single_int.swiftmodule %S/Inputs/single_int.swift
+// RUN: not %target-swift-frontend -typecheck %s -I %t 2>&1 | %FileCheck %s
+
+@testable import single_int // CHECK: module 'single_int' was not compiled for testing
+
+x = 8 // CHECK-NOT: unresolved identifier

--- a/test/attr/testable.swift
+++ b/test/attr/testable.swift
@@ -1,14 +1,24 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-testing -o %t %S/../Inputs/empty.swift
-// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules %s -verify
-// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules %s -disable-testable-attr-requires-testable-module -DIMPORTS_ONLY
 
-@testable import Swift // expected-error {{module 'Swift' was not compiled for testing}}
+// Make sure we don't get any errors when importing the modules that were compiled for testing
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules %s -verify
+
+// Make sure no errors are thrown if we disable the @testable check
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules %s -verify -disable-testable-attr-requires-testable-module
+
+// Make sure we get the one fatal error for the stdlib not being compiled for testing
+// RUN: not %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules %s 2>&1 -DINCLUDE_STDLIB | %FileCheck %s
+
+
+#if INCLUDE_STDLIB
+// CHECK: module 'Swift' was not compiled for testing
+@testable import Swift
+#endif
+
+// CHECK-NOT: module 'empty' was not compiled for testing
 @testable import empty // no-error
+// CHECK-NOT: module 'Testable_ClangModule' was not compiled for testing
 @testable import Testable_ClangModule // no-error
 
 _ = clangGlobal
-
-#if !IMPORTS_ONLY
-@testable func foo() {} // expected-error {{@testable may only be used on 'import' declarations}} {{1-11=}}
-#endif

--- a/test/attr/testable_invalid_decl.swift
+++ b/test/attr/testable_invalid_decl.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+@testable func foo() {} // expected-error {{@testable may only be used on 'import' declarations}} {{1-11=}}


### PR DESCRIPTION
If this isn’t fatal, this will just end up cascading to a bunch of “could not find member … in …” errors, which hides the real issue.