### PR TITLE
[5.0] Fix getAccessedStorageFromAddress to handle AddressToPointer.

### DIFF
--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -374,7 +374,9 @@ static AccessedStorageResult getAccessedStorageFromAddress(SILValue sourceAddr) 
 
   // Access to a Builtin.RawPointer. Treat this like the inductive cases
   // above because some RawPointers originate from identified locations. See
-  // the special case for global addressors, which return RawPointer, above.
+  // the special case for global addressors, which return RawPointer,
+  // above. AddressToPointer is also handled because it results from inlining a
+  // global addressor without folding the AddressToPointer->PointerToAddress.
   //
   // If the inductive search does not find a valid addressor, it will
   // eventually reach the default case that returns in invalid location. This
@@ -393,6 +395,7 @@ static AccessedStorageResult getAccessedStorageFromAddress(SILValue sourceAddr) 
   // marks debug VarDecl access as 'Unsafe' and SIL passes don't need the
   // AccessedStorage for 'Unsafe' access.
   case ValueKind::PointerToAddressInst:
+  case ValueKind::AddressToPointerInst:
     return AccessedStorageResult::incomplete(
       cast<SingleValueInstruction>(sourceAddr)->getOperand(0));
 
@@ -432,6 +435,8 @@ AccessedStorage swift::findAccessedStorage(SILValue sourceAddr) {
       storage = result.getStorage();
       continue;
     }
+    // `storage` may still be invalid. If both `storage` and `result` are
+    // invalid, this check passes, but we return an invalid storage below.
     if (!accessingIdenticalLocations(storage.getValue(), result.getStorage()))
       return AccessedStorage();
   }

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -661,3 +661,41 @@ bb3(%phi : $*Float):
   %v = tuple ()
   return %v : $()
 }
+
+// Test an inlined global variable addressor after simplify-cfg has
+// cloned the call to the addressor.
+// <rdar://problem/47555992> SIL verification failed: Unknown formal access pattern
+// CHECK-LABEL: @testClonedGlobalAddressor
+// CHECK: [read] [no_nested_conflict] Global // gvar
+// CHECK: sil_global hidden @gvar
+var gvar: Int64
+
+public func foo() -> Int64
+
+sil_global hidden @gvar : $Int64 = {
+  %0 = integer_literal $Builtin.Int64, 0
+  %initval = struct $Int (%0 : $Builtin.Int64)
+}
+
+sil @testClonedGlobalAddressor : $@convention(thin) () -> Int64 {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %1 = global_addr @gvar : $*Int64
+  %2 = address_to_pointer %1 : $*Int64 to $Builtin.RawPointer
+  br bb3(%2 : $Builtin.RawPointer)
+
+bb2:
+  %4 = global_addr @gvar : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  br bb3(%5 : $Builtin.RawPointer)
+
+// %7
+bb3(%7 : $Builtin.RawPointer):
+  %8 = pointer_to_address %7 : $Builtin.RawPointer to [strict] $*Int64
+  %9 = begin_access [read] [dynamic] [no_nested_conflict] %8 : $*Int64
+  %10 = load %9 : $*Int64
+  end_access %9 : $*Int64
+  return %10 : $Int64
+}


### PR DESCRIPTION
This pattern is normally folded away:

  %ga = global_addr @gvar : $*Int64
  %ptr = address_to_pointer %ga : $*Int64 to $Builtin.RawPointer
  %adr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*Int64
  %access = begin_access [read] [dynamic] [no_nested_conflict] %adr : $*Int64

However, now that we handle address type phi arguments in the SIL
verifier, we could see this pattern. [In the long term, when
address-type phis are universally prohibited, all of this stuff
becomes irrelevant.]

Fixes <rdar://47555992> [Source Compat] AudioKit: SIL verification
failed: Unknown formal access pattern: storage.
