### PR TITLE
[Autodiff] fix an error in checking @differentiable attributes.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1510,16 +1510,7 @@ public:
   }
 
   bool parametersMatch(const DifferentiableAttr &other) const {
-    auto a = getParsedParameters();
-    auto b = other.getParsedParameters();
-    if (a.size() != b.size())
-      return false;
-
-    for (unsigned i = 0, n = b.size(); i < n; ++i) {
-      if (!a[i].isEqual(b[i]))
-        return false;
-    }
-    return true;
+    return ParameterIndices->parameters == other.ParameterIndices->parameters;
   }
 };
 


### PR DESCRIPTION
The problem is that getParsedParameters() were not serialized during
modular compilation. Switching to ParameterIndices->parameters which
will be serialized.
