### PR TITLE
Guard returns of limited-availability cases in init(rawValue:)

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1447,6 +1447,11 @@ public:
   isUnavailableInSwiftVersion(const version::Version &effectiveVersion) const;
 
   /// Returns the first @available attribute that indicates
+  /// a declaration is unavailable, or the first one that indicates it's
+  /// potentially unavailable, or null otherwise.
+  const AvailableAttr *getPotentiallyUnavailable(const ASTContext &ctx) const;
+
+  /// Returns the first @available attribute that indicates
   /// a declaration is unavailable, or null otherwise.
   const AvailableAttr *getUnavailable(const ASTContext &ctx) const;
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -147,7 +147,7 @@ const AvailableAttr *DeclAttributes::getPotentiallyUnavailable(
         continue;
 
       // Definitely not available.
-      if (AvAttr->isUnconditionallyDeprecated())
+      if (AvAttr->isUnconditionallyUnavailable())
         return AvAttr;
 
       switch (AvAttr->getVersionAvailability(ctx)) {
@@ -164,6 +164,7 @@ const AvailableAttr *DeclAttributes::getPotentiallyUnavailable(
         case AvailableVersionComparison::Unavailable:
         case AvailableVersionComparison::Obsoleted:
           conditional = AvAttr;
+          break;
       }
     }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -131,8 +131,8 @@ DeclAttributes::isUnavailableInSwiftVersion(
   return false;
 }
 
-const AvailableAttr *DeclAttributes::getPotentiallyUnavailable(
-                          const ASTContext &ctx) const {
+const AvailableAttr *
+DeclAttributes::getPotentiallyUnavailable(const ASTContext &ctx) const {
   const AvailableAttr *potential = nullptr;
   const AvailableAttr *conditional = nullptr;
 
@@ -151,20 +151,20 @@ const AvailableAttr *DeclAttributes::getPotentiallyUnavailable(
         return AvAttr;
 
       switch (AvAttr->getVersionAvailability(ctx)) {
-        case AvailableVersionComparison::Available:
-          // Doesn't limit the introduced version.
-          break;
+      case AvailableVersionComparison::Available:
+        // Doesn't limit the introduced version.
+        break;
 
-        case AvailableVersionComparison::PotentiallyUnavailable:
-          // We'll return this if we don't see something that proves it's
-          // not available in this version.
-          potential = AvAttr;
-          break;
+      case AvailableVersionComparison::PotentiallyUnavailable:
+        // We'll return this if we don't see something that proves it's
+        // not available in this version.
+        potential = AvAttr;
+        break;
 
-        case AvailableVersionComparison::Unavailable:
-        case AvailableVersionComparison::Obsoleted:
-          conditional = AvAttr;
-          break;
+      case AvailableVersionComparison::Unavailable:
+      case AvailableVersionComparison::Obsoleted:
+        conditional = AvAttr;
+        break;
       }
     }
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -214,9 +214,8 @@ struct RuntimeVersionCheck {
     auto otherSpec = new (C) OtherPlatformAvailabilitySpec(SourceLoc());
 
     // availableInfo = "#available(\(platformSpec), \(otherSpec))"
-    auto availableInfo = PoundAvailableInfo::create(C, SourceLoc(),
-                                              { platformSpec, otherSpec },
-                                                    SourceLoc());
+    auto availableInfo = PoundAvailableInfo::create(
+        C, SourceLoc(), { platformSpec, otherSpec }, SourceLoc());
 
     // This won't be filled in by TypeCheckAvailability because we have
     // invalid SourceLocs in this area of the AST.
@@ -242,8 +241,8 @@ struct RuntimeVersionCheck {
 /// be available, returns true. If it will sometimes be available, adds
 /// information about the runtime check needed to ensure it is available to
 /// \c versionCheck and returns true.
-static bool checkAvailability(EnumElementDecl* elt, ASTContext &C,
-                              Optional<RuntimeVersionCheck> &versionCheck) {
+static bool checkAvailability(const EnumElementDecl* elt, ASTContext &C,
+    Optional<RuntimeVersionCheck> &versionCheck) {
   auto *attr = elt->getAttrs().getPotentiallyUnavailable(C);
 
   // Is it always available?
@@ -261,7 +260,11 @@ static bool checkAvailability(EnumElementDecl* elt, ASTContext &C,
     return false;
 
   // It's conditionally available; create a version constraint and return true.
+  assert(attr->getPlatformAgnosticAvailability() ==
+             PlatformAgnosticAvailabilityKind::None &&
+         "can only express #available(somePlatform version) checks");
   versionCheck.emplace(attr->Platform, *attr->Introduced);
+
   return true;
 }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2311,7 +2311,7 @@ class AvailabilityWalker : public ASTWalker {
            init->isImplicit() &&
            init->getParameters()->size() == 1 &&
            init->getParameters()->get(0)->getArgumentName() ==
-                   DC->getASTContext().Id_rawValue;
+                   TC.Context.Id_rawValue;
   }
 
 public:
@@ -2604,11 +2604,11 @@ AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
   if (!isAccessorWithDeprecatedStorage)
     TC.diagnoseIfDeprecated(R, DC, D, call);
 
-  if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol)
-        && isa<ProtocolDecl>(D))
+  if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailable))
     return false;
 
-  if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailable))
+  if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol)
+        && isa<ProtocolDecl>(D))
     return false;
 
   // Diagnose (and possibly signal) for potential unavailability

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -38,6 +38,7 @@ enum class DeclAvailabilityFlag : uint8_t {
   AllowPotentiallyUnavailableProtocol = 1 << 0,
   ContinueOnPotentialUnavailability = 1 << 1,
   ForInout = 1 << 2,
+  AllowPotentiallyUnavailable = 1 << 3,
 };
 using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -17,6 +17,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
+#include "swift/Basic/OptionSet.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 
@@ -33,6 +34,13 @@ namespace swift {
 void diagAvailability(TypeChecker &TC, const Expr *E,
                       DeclContext *DC);
 
+enum class DeclAvailabilityFlag : uint8_t {
+  AllowPotentiallyUnavailableProtocol = 1 << 0,
+  ContinueOnPotentialUnavailability = 1 << 1,
+  ForInout = 1 << 2,
+};
+using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;
+
 /// Run the Availability-diagnostics algorithm otherwise used in an expr
 /// context, but for non-expr contexts such as TypeDecls referenced from
 /// TypeReprs.
@@ -40,9 +48,7 @@ bool diagnoseDeclAvailability(const ValueDecl *Decl,
                               TypeChecker &TC,
                               DeclContext *DC,
                               SourceRange R,
-                              bool AllowPotentiallyUnavailableProtocol,
-                              bool SignalOnPotentialUnavailability,
-                              bool ForInout);
+                              DeclAvailabilityFlags Options);
 
 void diagnoseUnavailableOverride(ValueDecl *override,
                                  const ValueDecl *base,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -35,9 +35,21 @@ void diagAvailability(TypeChecker &TC, const Expr *E,
                       DeclContext *DC);
 
 enum class DeclAvailabilityFlag : uint8_t {
+  /// Do not diagnose uses of protocols in versions before they were introduced.
+  /// Used when type-checking protocol conformances, since conforming to a
+  /// protocol that doesn't exist yet is allowed.
   AllowPotentiallyUnavailableProtocol = 1 << 0,
+
+  /// Diagnose uses of declarations in versions before they were introduced, but
+  /// do not return true to indicate that a diagnostic was emitted.
   ContinueOnPotentialUnavailability = 1 << 1,
+
+  /// If a diagnostic must be emitted, use a variant indicating that the usage
+  /// is inout and both the getter and setter must be available.
   ForInout = 1 << 2,
+
+  /// Do not diagnose uses of declarations in versions before they were
+  /// introduced. Used to work around availability-checker bugs.
   AllowPotentiallyUnavailable = 1 << 3,
 };
 using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1544,16 +1544,17 @@ static Type resolveIdentTypeComponent(
 static bool diagnoseAvailability(IdentTypeRepr *IdType,
                                  DeclContext *DC,
                                  bool AllowPotentiallyUnavailableProtocol) {
+  DeclAvailabilityFlags flags =
+    DeclAvailabilityFlag::ContinueOnPotentialUnavailability;
+  if (AllowPotentiallyUnavailableProtocol)
+    flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
   ASTContext &ctx = DC->getASTContext();
   auto componentRange = IdType->getComponentRange();
   for (auto comp : componentRange) {
     if (auto *typeDecl = comp->getBoundDecl()) {
       assert(ctx.getLazyResolver() && "Must have a type checker!");
       TypeChecker &tc = static_cast<TypeChecker &>(*ctx.getLazyResolver());
-      if (diagnoseDeclAvailability(typeDecl, tc, DC, comp->getIdLoc(),
-                                   AllowPotentiallyUnavailableProtocol,
-                                   /*SignalOnPotentialUnavailability*/false,
-                                   /*ForInout*/false)) {
+      if (diagnoseDeclAvailability(typeDecl, tc, DC, comp->getIdLoc(), flags)) {
         return true;
       }
     }

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -11,7 +11,7 @@ public enum E: Int {
   case sacrificial = -500
 
   case normal = -1000
-  @available(macOS 10.8, iOS 8, watchOS 1, tvOS 8, *)
+  @available(macOS 10.8, iOS 7, watchOS 1, tvOS 7, *)
   case alwaysAvailable = -2000
   @available(macOS 500.600.700, iOS 500.600.700, watchOS 500.600.700, tvOS 500.600.700, *)
   case potentiallyUnavailable = -3000

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -1,9 +1,16 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-emit-silgen -emit-sorted-sil %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience %s | %FileCheck %s
 
-// Really just requires a platform with meaningful runtime #available() tests.
-// REQUIRES: objc_interop
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -o %t.fragile.sil %s
+// RUN: %FileCheck %s < %t.fragile.sil
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t.fragile.sil
+
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience -o %t.resilient.sil %s
+// RUN: %FileCheck %s < %t.resilient.sil
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t.resilient.sil
+
+// This test just requires a platform with meaningful #available() checks, but
+// for simplicity, it's written for macOS only.
+// REQUIRES: OS=macosx
 
 public enum E: Int {
   // For some reason, we generate strange SIL for the first case that's
@@ -11,33 +18,28 @@ public enum E: Int {
   case sacrificial = -500
 
   case normal = -1000
-  @available(macOS 10.8, iOS 7, watchOS 1, tvOS 7, *)
+
+  @available(macOS 10.8, *)
   case alwaysAvailable = -2000
-  @available(macOS 500.600.700, iOS 500.600.700, watchOS 500.600.700, tvOS 500.600.700, *)
+
+  @available(macOS 500.600.700, *)
   case potentiallyUnavailable = -3000
-  @available(macOS, unavailable) @available(iOS, unavailable)
-  @available(watchOS, unavailable)  @available(tvOS, unavailable)
+
+  @available(macOS, unavailable)
   case neverAvailable = -4000
+
 }
 
-// CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC
-
-// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
+// CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s4main1EO8rawValueACSgSi_tcfC
 
 // CHECK: integer_literal $Builtin.IntLiteral, -1000
 // CHECK: cond_br {{[^,]+}}, [[normal:bb[0-9]+]]
 
-// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
-
 // CHECK: integer_literal $Builtin.IntLiteral, -2000
 // CHECK: cond_br {{[^,]+}}, [[alwaysAvailable:bb[0-9]+]]
 
-// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
-
 // CHECK: integer_literal $Builtin.IntLiteral, -3000
 // CHECK: cond_br {{[^,]+}}, [[potentiallyUnavailable:bb[0-9]+]]
-
-// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
 
 // CHECK: [[potentiallyUnavailable]]:
 // CHECK-NEXT: integer_literal $Builtin.Word, 500
@@ -45,8 +47,6 @@ public enum E: Int {
 // CHECK-NEXT: integer_literal $Builtin.Word, 700
 // CHECK: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
 // CHECK: cond_br {{[^,]+}}, [[potentiallyUnavailable_newEnough:bb[0-9]+]],
-
-// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
 
 // CHECK: [[potentiallyUnavailable_newEnough]]:
 // CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.potentiallyUnavailable!enumelt
@@ -59,9 +59,13 @@ public enum E: Int {
 // CHECK-NOT: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
 // CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.normal!enumelt
 
-// CHECK: end sil function '$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC'
+// CHECK: end sil function '$s4main1EO8rawValueACSgSi_tcfC'
 
-// CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s32enum_raw_representable_available1EO0B5ValueSivg
+// CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s4main1EO8rawValueSivg
 // CHECK: {{switch_enum %0 : \$E|switch_enum_addr %2 : \$\*E}}
 // CHECK-NOT: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
-// CHECK: end sil function '$s32enum_raw_representable_available1EO0B5ValueSivg'
+// CHECK: end sil function '$s4main1EO8rawValueSivg'
+
+// NEGATIVE-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s4main1EO8rawValueACSgSi_tcfC
+// NEGATIVE-NOT: integer_literal $Builtin.IntLiteral, -4000
+// NEGATIVE: end sil function '$s4main1EO8rawValueACSgSi_tcfC'

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -1,10 +1,10 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.52
 
-// RUN: %target-swift-emit-silgen -emit-sorted-sil -o %t.fragile.sil %s
+// RUN: %target-swift-emit-silgen -target x86_64-apple-macosx10.52 -emit-sorted-sil -o %t.fragile.sil %s
 // RUN: %FileCheck %s < %t.fragile.sil
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.fragile.sil
 
-// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience -o %t.resilient.sil %s
+// RUN: %target-swift-emit-silgen -target x86_64-apple-macosx10.52 -emit-sorted-sil -enable-resilience -o %t.resilient.sil %s
 // RUN: %FileCheck %s < %t.resilient.sil
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.resilient.sil
 
@@ -19,15 +19,20 @@ public enum E: Int {
 
   case normal = -1000
 
-  @available(macOS 10.8, *)
+  @available(macOS 10.51, *)
   case alwaysAvailable = -2000
 
-  @available(macOS 500.600.700, *)
+  @available(macOS 10.55, *)
   case potentiallyUnavailable = -3000
 
   @available(macOS, unavailable)
   case neverAvailable = -4000
 
+  @available(macOS, obsoleted: 10.99)
+  case notObsoleteYet = -5000
+
+  @available(macOS, obsoleted: 10.51)
+  case nowObsolete = -6000
 }
 
 // CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s4main1EO8rawValueACSgSi_tcfC
@@ -41,10 +46,17 @@ public enum E: Int {
 // CHECK: integer_literal $Builtin.IntLiteral, -3000
 // CHECK: cond_br {{[^,]+}}, [[potentiallyUnavailable:bb[0-9]+]]
 
+// CHECK: integer_literal $Builtin.IntLiteral, -5000
+// CHECK: cond_br {{[^,]+}}, [[notObsoleteYet:bb[0-9]+]]
+
+// CHECK: [[notObsoleteYet]]:
+// CHECK-NOT: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.notObsoleteYet!enumelt
+
 // CHECK: [[potentiallyUnavailable]]:
-// CHECK-NEXT: integer_literal $Builtin.Word, 500
-// CHECK-NEXT: integer_literal $Builtin.Word, 600
-// CHECK-NEXT: integer_literal $Builtin.Word, 700
+// CHECK-NEXT: integer_literal $Builtin.Word, 10
+// CHECK-NEXT: integer_literal $Builtin.Word, 55
+// CHECK-NEXT: integer_literal $Builtin.Word, 0
 // CHECK: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
 // CHECK: cond_br {{[^,]+}}, [[potentiallyUnavailable_newEnough:bb[0-9]+]],
 
@@ -67,5 +79,14 @@ public enum E: Int {
 // CHECK: end sil function '$s4main1EO8rawValueSivg'
 
 // NEGATIVE-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s4main1EO8rawValueACSgSi_tcfC
+
+// Should not try to match neverAvailable's raw value
 // NEGATIVE-NOT: integer_literal $Builtin.IntLiteral, -4000
+
+// Should not try to match nowObsolete's raw value
+// NEGATIVE-NOT: integer_literal $Builtin.IntLiteral, -6000
+
+// Should not have a version check for notObsoleteYet
+// NEGATIVE-NOT: integer_literal $Builtin.Word, 99
+
 // NEGATIVE: end sil function '$s4main1EO8rawValueACSgSi_tcfC'

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-emit-silgen -emit-sorted-sil %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+
+public enum E: Int {
+  case a, b
+  @available(macOS 500, iOS 500, watchOS 500, tvOS 500, *)
+  case c
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC
+// CHECK: integer_literal $Builtin.Word, 500
+// CHECK: end sil function '$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC'
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s32enum_raw_representable_available1EO0B5ValueSivg
+// CHECK: switch_enum %0 : $E
+// CHECK: end sil function '$s32enum_raw_representable_available1EO0B5ValueSivg'
+
+
+// CHECK-RESILIENT-DAG: sil [ossa] @$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC
+// CHECK-RESILIENT-DAG: sil [ossa] @$s32enum_raw_representable_available1EO0B5ValueSivg

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -2,6 +2,9 @@
 // RUN: %target-swift-emit-silgen -emit-sorted-sil %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
 
+// Really just requires a platform with meaningful runtime #available() tests.
+// REQUIRES: objc_interop
+
 public enum E: Int {
   case a, b
   @available(macOS 500, iOS 500, watchOS 500, tvOS 500, *)

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -1,24 +1,67 @@
 // RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-emit-silgen -emit-sorted-sil %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-resilience %s | %FileCheck %s
 
 // Really just requires a platform with meaningful runtime #available() tests.
 // REQUIRES: objc_interop
 
 public enum E: Int {
-  case a, b
-  @available(macOS 500, iOS 500, watchOS 500, tvOS 500, *)
-  case c
+  // For some reason, we generate strange SIL for the first case that's
+  // difficult to validate. This just gets that out of the way.
+  case sacrificial = -500
+
+  case normal = -1000
+  @available(macOS 10.8, iOS 8, watchOS 1, tvOS 8, *)
+  case alwaysAvailable = -2000
+  @available(macOS 500.600.700, iOS 500.600.700, watchOS 500.600.700, tvOS 500.600.700, *)
+  case potentiallyUnavailable = -3000
+  @available(macOS, unavailable) @available(iOS, unavailable)
+  @available(watchOS, unavailable)  @available(tvOS, unavailable)
+  case neverAvailable = -4000
 }
 
-// CHECK-LABEL: sil [serialized] [ossa] @$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC
-// CHECK: integer_literal $Builtin.Word, 500
+// CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC
+
+// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
+
+// CHECK: integer_literal $Builtin.IntLiteral, -1000
+// CHECK: cond_br {{[^,]+}}, [[normal:bb[0-9]+]]
+
+// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
+
+// CHECK: integer_literal $Builtin.IntLiteral, -2000
+// CHECK: cond_br {{[^,]+}}, [[alwaysAvailable:bb[0-9]+]]
+
+// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
+
+// CHECK: integer_literal $Builtin.IntLiteral, -3000
+// CHECK: cond_br {{[^,]+}}, [[potentiallyUnavailable:bb[0-9]+]]
+
+// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
+
+// CHECK: [[potentiallyUnavailable]]:
+// CHECK-NEXT: integer_literal $Builtin.Word, 500
+// CHECK-NEXT: integer_literal $Builtin.Word, 600
+// CHECK-NEXT: integer_literal $Builtin.Word, 700
+// CHECK: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK: cond_br {{[^,]+}}, [[potentiallyUnavailable_newEnough:bb[0-9]+]],
+
+// CHECK-NOT: integer_literal $Builtin.IntLiteral, -4000
+
+// CHECK: [[potentiallyUnavailable_newEnough]]:
+// CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.potentiallyUnavailable!enumelt
+
+// CHECK: [[alwaysAvailable]]:
+// CHECK-NOT: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.alwaysAvailable!enumelt
+
+// CHECK: [[normal]]:
+// CHECK-NOT: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.normal!enumelt
+
 // CHECK: end sil function '$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC'
 
-// CHECK-LABEL: sil [serialized] [ossa] @$s32enum_raw_representable_available1EO0B5ValueSivg
-// CHECK: switch_enum %0 : $E
+// CHECK-LABEL: sil {{(\[serialized\] )?}}[ossa] @$s32enum_raw_representable_available1EO0B5ValueSivg
+// CHECK: {{switch_enum %0 : \$E|switch_enum_addr %2 : \$\*E}}
+// CHECK-NOT: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
 // CHECK: end sil function '$s32enum_raw_representable_available1EO0B5ValueSivg'
-
-
-// CHECK-RESILIENT-DAG: sil [ossa] @$s32enum_raw_representable_available1EO0B5ValueACSgSi_tcfC
-// CHECK-RESILIENT-DAG: sil [ossa] @$s32enum_raw_representable_available1EO0B5ValueSivg


### PR DESCRIPTION
Suppose you tried to compile something like this with a minimum deployment target of iOS 9:

```swift
enum E: Int {
  @available(iOS 10, tvOS 10, *) case c
}
```

The compiler would try to synthesize an `init(rawValue:)` like this one:

```swift
  init?(rawValue: Int) {
    switch rawValue {
    case 0:
      return E.c
    default:
      return nil
    }
  }
```

However, that code would fail to compile; the availability checker would correctly notice that `E.c` is not available on all OSes where this code can run and this use was not guarded with an `#available` check, so it emits an error.

This change modifies `RawRepresentable` auto-derivation to synthesize this instead:

```swift
    case 0:
      guard #available(iOS 10, *) else { return nil }
      return E.c
```

That keeps `init(rawValue:)` from returning cases that aren't supported on the platform it's running on.

However, even though the generated code is now correct, the compiler still diagnoses an error. The availability checker is `SourceLoc`-based and skips over code with invalid `SourceLoc`s; changing that would require either a significant redesign of the availability checker (possibly with something like ASTScope) or augmenting `SourceLoc`s to represent the locations of synthesized code (something I explored in my free time in #22162—it's interesting, but definitely not ready). To get this fix out the door, I've added a targeted hack which disables potential availability checking in implicit `init(rawValue:)` implementations only.

Fixes rdar://problem/47488617.