### PR TITLE
[api-digester] Don’t synthesize type nodes with no public members or conformances

### DIFF
--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -1,6 +1,7 @@
 Func _SmallString.computeIsASCII() has been removed
 Func _SmallString.withMutableCapacity(_:) has been removed
 Struct _StringObject.Discriminator has been removed
+Struct __swift_stdlib_UErrorCode has been removed
 Var _SmallString.discriminator has been removed
 Var _StringObject.CountAndFlags._storage has declared type change from UInt to UInt64
 Var _StringObject.CountAndFlags.countMask has declared type change from UInt to UInt64

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t.mod)
+// RUN: %empty-directory(%t.sdk)
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %swift -emit-module -o %t.mod/main.swiftmodule %s -parse-as-library -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %api-digester -dump-sdk -module main -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %FileCheck %s < %t.dump.json
+
+import cake
+
+// CHECK: publicSymbol
+public func publicSymbol() {}
+
+internal protocol InternalProto {}
+public protocol PublicProto {}
+
+// This internal extension doesn't declare any new members on S1, so it
+// shouldn't show up at all in the output.
+// CHECK-NOT: S1
+internal extension S1 {
+  var x: Int { return 4 }
+}
+
+// There should only be one conformance declared: the conformance of C0 to
+// PublicProto. InternalProto should not show up in the list.
+// CHECK:      "name": "C0",
+// CHECK:      "conformances": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "Conformance",
+// CHECK-NEXT:     "name": "PublicProto",
+// CHECK-NEXT:     "printedName": "PublicProto"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+extension C0: InternalProto {
+}
+extension C0: PublicProto {
+}

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -648,6 +648,8 @@ public:
 
   void printTopLevelNames();
 
+  /// Adds all conformances from the provided NominalTypeDecl to the provided
+  /// SDK node for that type decl.
   void addConformancesToTypeDecl(SDKNodeDeclType *Root, NominalTypeDecl* NTD);
   void addMembersToRoot(SDKNode *Root, IterableDeclContext *Context);
 


### PR DESCRIPTION
Upon seeing an extension for a type outside the current module, the digester creates a dummy type node and puts all the extensions’ members in that type. This allows us to track new API endpoints that are retroactively added.

Unfortunately, if there are no public members (only internal or private ones), the type itself ends up in the SDK dump without any public children. This causes an issue when you dump the SDK from a parseable interface, where the internal extension was not printed.

~Still needs a test.~