### PR TITLE
Remangler round-tripping fixes

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -76,6 +76,15 @@ public:
   ASTMangler(bool DWARFMangling = false)
     : DWARFMangling(DWARFMangling) {}
 
+  void addTypeSubstitution(Type type) {
+    type = dropProtocolsFromAssociatedTypes(type);
+    addSubstitution(type.getPointer());
+  }
+  bool tryMangleTypeSubstitution(Type type) {
+    type = dropProtocolsFromAssociatedTypes(type);
+    return tryMangleSubstitution(type.getPointer());
+  }
+
   std::string mangleClosureEntity(const AbstractClosureExpr *closure,
                                   SymbolKind SKind);
 
@@ -260,6 +269,9 @@ protected:
   void appendGenericSignatureParts(TypeArrayView<GenericTypeParamType> params,
                                    unsigned initialParamDepth,
                                    ArrayRef<Requirement> requirements);
+
+  DependentMemberType *dropProtocolFromAssociatedType(DependentMemberType *dmt);
+  Type dropProtocolsFromAssociatedTypes(Type type);
 
   void appendAssociatedTypeName(DependentMemberType *dmt);
 

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -564,7 +564,10 @@ const char *getNodeKindString(swift::Demangle::Node::Kind k);
 /// Useful for debugging.
 std::string getNodeTreeAsString(NodePointer Root);
 
+bool nodeConsumesGenericArgs(Node *node);
+
 bool isSpecialized(Node *node);
+
 NodePointer getUnspecialized(Node *node, NodeFactory &Factory);
 std::string archetypeName(Node::IndexType index, Node::IndexType depth);
 

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -180,19 +180,9 @@ void Mangler::verify(StringRef nameStr) {
   if (Remangled == nameStr)
     return;
 
-  // There are cases (e.g. with dependent associated types) which results in
-  // different remangled names. See ASTMangler::appendAssociatedTypeName.
-  // This is no problem for the compiler, but we have to be more tolerant for
-  // those cases. Instead we try to re-de-mangle the remangled name.
-  NodePointer RootOfRemangled = Dem.demangleSymbol(Remangled);
-  std::string ReDemangled = mangleNode(RootOfRemangled);
-  if (Remangled == ReDemangled)
-    return;
-
   llvm::errs() << "Remangling failed:\n"
                   "original     = " << nameStr << "\n"
-                  "remangled    = " << Remangled << "\n"
-                  "re-demangled = " << ReDemangled << '\n';
+                  "remangled    = " << Remangled << "\n";
   abort();
 #endif
 }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1458,6 +1458,20 @@ NodePointer Demangler::demangleBoundGenericType() {
   return NTy;
 }
 
+bool Demangle::nodeConsumesGenericArgs(Node *node) {
+  switch (node->getKind()) {
+    case Node::Kind::Variable:
+    case Node::Kind::Subscript:
+    case Node::Kind::ImplicitClosure:
+    case Node::Kind::ExplicitClosure:
+    case Node::Kind::DefaultArgumentInitializer:
+    case Node::Kind::Initializer:
+      return false;
+    default:
+      return true;
+  }
+}
+
 NodePointer Demangler::demangleBoundGenericArgs(NodePointer Nominal,
                                     const Vector<NodePointer> &TypeLists,
                                     size_t TypeListIdx) {
@@ -1493,18 +1507,7 @@ NodePointer Demangler::demangleBoundGenericArgs(NodePointer Nominal,
     return nullptr;
   NodePointer Context = Nominal->getFirstChild();
 
-  bool consumesGenericArgs = true;
-  switch (Nominal->getKind()) {
-    case Node::Kind::Variable:
-    case Node::Kind::ExplicitClosure:
-    case Node::Kind::Subscript:
-      // Those nodes can appear in the context but do not "consume" a generic
-      // argument type list.
-      consumesGenericArgs = false;
-      break;
-    default:
-      break;
-  }
+  bool consumesGenericArgs = nodeConsumesGenericArgs(Nominal);
 
   NodePointer args = TypeLists[TypeListIdx];
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -39,6 +39,18 @@ static void unreachable(const char *Message) {
   std::abort();
 }
 
+static StringRef getTextForSubstitution(Node *node, std::string &tmp) {
+  switch (node->getKind()) {
+    case Node::Kind::InfixOperator:
+    case Node::Kind::PrefixOperator:
+    case Node::Kind::PostfixOperator:
+      tmp = Mangle::translateOperator(node->getText());
+      return tmp;
+    default:
+      return node->getText();
+  }
+}
+
 namespace {
 
 class SubstitutionEntry {
@@ -66,8 +78,11 @@ private:
       return false;
     if (lhs.treatAsIdentifier != rhs.treatAsIdentifier)
       return false;
-    if (lhs.treatAsIdentifier)
-      return lhs.TheNode->getText() == rhs.TheNode->getText();
+    if (lhs.treatAsIdentifier) {
+      std::string tmp1, tmp2;
+      return (getTextForSubstitution(lhs.TheNode, tmp1) ==
+              getTextForSubstitution(rhs.TheNode, tmp2));
+    }
     return lhs.deepEquals(lhs.TheNode, rhs.TheNode);
   }
 
@@ -84,7 +99,8 @@ private:
   void deepHash(Node *node) {
     if (treatAsIdentifier) {
       combineHash((size_t) Node::Kind::Identifier);
-      combineHash(node->getText());
+      std::string tmp;
+      combineHash(getTextForSubstitution(node, tmp));
       return;
     }
     combineHash((size_t) node->getKind());
@@ -279,7 +295,8 @@ class Remangler {
 
   void mangleAnyNominalType(Node *node);
   void mangleAnyGenericType(Node *node, StringRef TypeOp);
-  void mangleGenericArgs(Node *node, char &Separator);
+  void mangleGenericArgs(Node *node, char &Separator,
+                         bool fullSubstitutionMap=false);
   void mangleAnyConstructor(Node *node, char kindOp);
   void mangleAbstractStorage(Node *node, StringRef accessorCode);
   void mangleAnyProtocolConformance(Node *node);
@@ -473,29 +490,49 @@ void Remangler::mangleAnyNominalType(Node *node) {
   }
 }
 
-void Remangler::mangleGenericArgs(Node *node, char &Separator) {
+void Remangler::mangleGenericArgs(Node *node, char &Separator,
+                                  bool fullSubstitutionMap) {
   switch (node->getKind()) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
     case Node::Kind::TypeAlias:
+      if (node->getKind() == Node::Kind::TypeAlias)
+        fullSubstitutionMap = true;
+
+      mangleGenericArgs(node->getChild(0), Separator,
+                        fullSubstitutionMap);
+      Buffer << Separator;
+      Separator = '_';
+      break;
+
     case Node::Kind::Function:
     case Node::Kind::Getter:
     case Node::Kind::Setter:
     case Node::Kind::WillSet:
     case Node::Kind::DidSet:
+    case Node::Kind::ReadAccessor:
+    case Node::Kind::ModifyAccessor:
+    case Node::Kind::UnsafeAddressor:
+    case Node::Kind::UnsafeMutableAddressor:
+    case Node::Kind::Allocator:
     case Node::Kind::Constructor:
     case Node::Kind::Destructor:
-      mangleGenericArgs(node->getChild(0), Separator);
-      Buffer << Separator;
-      Separator = '_';
-      break;
-
     case Node::Kind::Variable:
     case Node::Kind::Subscript:
     case Node::Kind::ExplicitClosure:
     case Node::Kind::ImplicitClosure:
-      mangleGenericArgs(node->getChild(0), Separator);
+    case Node::Kind::DefaultArgumentInitializer:
+    case Node::Kind::Initializer:
+      if (!fullSubstitutionMap)
+        break;
+
+      mangleGenericArgs(node->getChild(0), Separator,
+                        fullSubstitutionMap);
+      if (Demangle::nodeConsumesGenericArgs(node)) {
+        Buffer << Separator;
+        Separator = '_';
+      }
       break;
 
     case Node::Kind::BoundGenericOtherNominalType:
@@ -504,11 +541,15 @@ void Remangler::mangleGenericArgs(Node *node, char &Separator) {
     case Node::Kind::BoundGenericClass:
     case Node::Kind::BoundGenericProtocol:
     case Node::Kind::BoundGenericTypeAlias: {
+      if (node->getKind() == Node::Kind::BoundGenericTypeAlias)
+        fullSubstitutionMap = true;
+
       NodePointer unboundType = node->getChild(0);
       assert(unboundType->getKind() == Node::Kind::Type);
       NodePointer nominalType = unboundType->getChild(0);
       NodePointer parentOrModule = nominalType->getChild(0);
-      mangleGenericArgs(parentOrModule, Separator);
+      mangleGenericArgs(parentOrModule, Separator,
+                        fullSubstitutionMap);
       Buffer << Separator;
       Separator = '_';
       mangleChildNodes(node->getChild(1));
@@ -516,11 +557,14 @@ void Remangler::mangleGenericArgs(Node *node, char &Separator) {
     }
       
     case Node::Kind::BoundGenericFunction: {
+      fullSubstitutionMap = true;
+
       NodePointer unboundFunction = node->getChild(0);
       assert(unboundFunction->getKind() == Node::Kind::Function ||
              unboundFunction->getKind() == Node::Kind::Constructor);
       NodePointer parentOrModule = unboundFunction->getChild(0);
-      mangleGenericArgs(parentOrModule, Separator);
+      mangleGenericArgs(parentOrModule, Separator,
+                        fullSubstitutionMap);
       Buffer << Separator;
       Separator = '_';
       mangleChildNodes(node->getChild(1));
@@ -528,7 +572,8 @@ void Remangler::mangleGenericArgs(Node *node, char &Separator) {
     }
 
     case Node::Kind::Extension:
-      mangleGenericArgs(node->getChild(1), Separator);
+      mangleGenericArgs(node->getChild(1), Separator,
+                        fullSubstitutionMap);
       break;
 
     default:
@@ -578,17 +623,22 @@ void Remangler::mangleAssociatedTypeDescriptor(Node *node) {
 }
 
 void Remangler::mangleAssociatedConformanceDescriptor(Node *node) {
-  mangleChildNodes(node);
+  mangle(node->getChild(0));
+  mangle(node->getChild(1));
+  manglePureProtocol(node->getChild(2));
   Buffer << "Tn";
 }
 
 void Remangler::mangleDefaultAssociatedConformanceAccessor(Node *node) {
-  mangleChildNodes(node);
+  mangle(node->getChild(0));
+  mangle(node->getChild(1));
+  manglePureProtocol(node->getChild(2));
   Buffer << "TN";
 }
 
 void Remangler::mangleBaseConformanceDescriptor(Node *node) {
-  mangleChildNodes(node);
+  mangle(node->getChild(0));
+  manglePureProtocol(node->getChild(1));
   Buffer << "Tb";
 }
 
@@ -1795,7 +1845,7 @@ void Remangler::mangleProtocolWitness(Node *node) {
 }
 
 void Remangler::mangleProtocolSelfConformanceWitnessTable(Node *node) {
-  mangleSingleChildNode(node);
+  manglePureProtocol(node->getChild(0));
   Buffer << "WS";
 }
 
@@ -2295,16 +2345,23 @@ bool Demangle::isSpecialized(Node *node) {
     case Node::Kind::OtherNominalType:
     case Node::Kind::Protocol:
     case Node::Kind::Function:
+    case Node::Kind::Allocator:
     case Node::Kind::Constructor:
     case Node::Kind::Destructor:
     case Node::Kind::Variable:
     case Node::Kind::Subscript:
     case Node::Kind::ExplicitClosure:
     case Node::Kind::ImplicitClosure:
+    case Node::Kind::Initializer:
+    case Node::Kind::DefaultArgumentInitializer:
     case Node::Kind::Getter:
     case Node::Kind::Setter:
     case Node::Kind::WillSet:
     case Node::Kind::DidSet:
+    case Node::Kind::ReadAccessor:
+    case Node::Kind::ModifyAccessor:
+    case Node::Kind::UnsafeAddressor:
+    case Node::Kind::UnsafeMutableAddressor:
       return isSpecialized(node->getChild(0));
 
     case Node::Kind::Extension:
@@ -2323,12 +2380,19 @@ NodePointer Demangle::getUnspecialized(Node *node, NodeFactory &Factory) {
     case Node::Kind::Setter:
     case Node::Kind::WillSet:
     case Node::Kind::DidSet:
+    case Node::Kind::ReadAccessor:
+    case Node::Kind::ModifyAccessor:
+    case Node::Kind::UnsafeAddressor:
+    case Node::Kind::UnsafeMutableAddressor:
+    case Node::Kind::Allocator:
     case Node::Kind::Constructor:
     case Node::Kind::Destructor:
     case Node::Kind::Variable:
     case Node::Kind::Subscript:
     case Node::Kind::ExplicitClosure:
     case Node::Kind::ImplicitClosure:
+    case Node::Kind::Initializer:
+    case Node::Kind::DefaultArgumentInitializer:
       NumToCopy = node->getNumChildren();
       LLVM_FALLTHROUGH;
     case Node::Kind::Structure:

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -162,8 +162,7 @@ public:
 
   std::string mangleBareProtocol(const ProtocolDecl *Decl) {
     beginMangling();
-    appendProtocolName(Decl, /*allowStandardSubstitution=*/false);
-    appendOperator("P");
+    appendAnyGenericType(Decl);
     return finalize();
   }
 

--- a/test/SILGen/keypath_witness_overrides.swift
+++ b/test/SILGen/keypath_witness_overrides.swift
@@ -13,8 +13,8 @@ where OS.Index: Hashable {
   // CHECK-SAME: id #OverridesSetter.subscript!getter.1
   // CHECK-SAME: getter @$s18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcipAA15OverridesSetterRzSHAGRQlxxTK
   // CHECK-SAME: setter @$s18protocol_overrides10AddsSetterPy7ElementQz5IndexQzcipAA09OverridesD0RzSHAGRQlxxTk
-  // CHECK-SAME: indices_equals @$s5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTH
-  // CHECK-SAME: indices_hash @$s5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTh
+  // CHECK-SAME: indices_equals @$s5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAARpzlTH
+  // CHECK-SAME: indices_hash @$s5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAARpzlTh
   let keypath = \OS.[index]
   return keypath
 }


### PR DESCRIPTION
It would be really nice if `remangle(demangle(X)) == X` for all valid manglings X. Previously we only enforced that `remangle(demangle(remangle(demangle(X)))) == remangle(demangle(X))`, which masked bugs.

Follow-up to https://github.com/apple/swift/pull/22078, because this also fixes parts of the remangler that I need for the next step in the type reconstruction rewrite.