### PR TITLE
[Autodiff] Add checks that @autodiff annotated functions are well-formed.

### DIFF
--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -9,9 +9,9 @@ let _: @autodiff (Float) throws -> Float
 
 struct NonDiffType { var x: Int }
 // FIXME: Properly type-check parameters and the result's differentiability
-// xpected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'}} {{19-19=@nondiff }}
 let _: @autodiff (NonDiffType) -> Float
-// xpected-error @+1 {{result is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+// expected-error @+1 {{result is not differentiable, but the function type is marked '@autodiff'}}
 let _: @autodiff (Float) -> NonDiffType
 
 //
@@ -23,3 +23,15 @@ let _: (@nondiff Float, Float) -> Float
 
 let _: @autodiff (Float, @nondiff Float) -> Float // okay
 
+func foo<T: Differentiable, U: Differentiable>(x: T) -> U {
+  let fn: (@autodiff (T) -> U)? = nil
+  return fn!(x)
+}
+
+func test1<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> @autodiff (U) -> Float) {}
+func test2<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> (U) -> Float) {}
+// expected-error @+2 {{result is not differentiable, but the function type is marked '@autodiff'}}
+// expected-error @+1 {{result is not differentiable, but the function type is marked '@autodiff'}}
+func test3<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> @autodiff (U) -> Int) {}
+// expected-error @+1 {{result is not differentiable, but the function type is marked '@autodiff'}}
+func test4<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> (U) -> Int) {}


### PR DESCRIPTION
Well formedness involves:
- All argument parameters should be differentiable or labeled @nondiff
- The result type should be differentiable.
- Types are considered differentiable if they have a tangent associated vector space.

This should resolve SR-9448 and SR-9097.

Here is an example of the output from these checks:

```
let _: @autodiff (NonDiffType) -> Float
                  ^
                  @nondiff
test3.swift:5:29: error: result is not differentiable, but the function type is marked '@autodiff'
let _: @autodiff (Float) -> NonDiffType
                            ^~~~~~~~~~~
```