### PR TITLE
[AutoDiff] Fix a minor memory leak.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1700,9 +1700,6 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
   if (auto *inst = original->getDefiningInstruction()) {
     if (auto *adfei = dyn_cast<AutoDiffFunctionExtractInst>(inst)) {
       if (adfei->getExtractee() == AutoDiffFunctionExtractee::Original) {
-        builder.createRetainValue(original.getLoc(),
-                                  adfei->getFunctionOperand(),
-                                  builder.getDefaultAtomicity());
         SILValue assocFn = builder.createAutoDiffFunctionExtract(
             original.getLoc(), kind, /*differentiationOrder*/ 1,
             adfei->getFunctionOperand());


### PR DESCRIPTION
When differentiating an indirect call to an `@autodiff` function by extracting and calling its JVP, do not retain the function.