### PR TITLE
test: make incrParse tests pass on Win32

### DIFF
--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -108,8 +108,8 @@ def parseLine(line, line_no, test_case, incremental_edit_args, reparse_args,
 def prepareForIncrParse(test_file, test_case, pre_edit_file, post_edit_file,
                         incremental_edit_args, reparse_args):
     with open(test_file, mode='r') as test_file_handle, \
-            open(pre_edit_file, mode='w+') as pre_edit_file_handle, \
-            open(post_edit_file, mode='w+') as post_edit_file_handle:
+            open(pre_edit_file, mode='w+b') as pre_edit_file_handle, \
+            open(post_edit_file, mode='w+b') as post_edit_file_handle:
 
         current_reparse_start = None
 


### PR DESCRIPTION
Use `w+b` mode for the files to avoid EOL style conversions on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
