### PR TITLE
Fix storeEnumTagSinglePayload on big-endian systems

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -4202,12 +4202,12 @@ namespace {
       } else if (!CommonSpareBits.empty()) {
         // Otherwise the payload is just the index.
         payload = EnumPayload::zero(IGM, PayloadSchema);
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-        // Code produced above are of type IGM.Int32Ty
-        // However, payload is IGM.SizeTy in 64bit
-        if (numCaseBits >= 64)
-          tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
-#endif
+        if (!IGF.IGM.Triple.isLittleEndian()) {
+          if (IGF.IGM.Triple.isArch64Bit() && numCaseBits >= 64) {
+            // Need to set the full 64-bit chunk on big-endian systems.
+            tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
+          }
+	}
         // We know we won't use more than numCaseBits from tagIndex's value:
         // We made sure of this in the logic above.
         payload.insertValue(IGF, tagIndex, 0,

--- a/stdlib/public/runtime/EnumImpl.h
+++ b/stdlib/public/runtime/EnumImpl.h
@@ -170,14 +170,14 @@ inline void storeEnumTagSinglePayloadImpl(
 
     // Store into the value.
 #if defined(__BIG_ENDIAN__)
-  unsigned numPayloadTagBytes = std::min(size_t(4), payloadSize);
-  if (numPayloadTagBytes)
-    small_memcpy(valueAddr,
-                 reinterpret_cast<uint8_t *>(&payloadIndex) + 4 -
-                     numPayloadTagBytes,
-                 numPayloadTagBytes, true);
-  if (payloadSize > 4)
-	    memset(valueAddr + 4, 0, payloadSize - 4);
+  uint64_t payloadIndexBuf = static_cast<uint64_t>(payloadIndex);
+  if (payloadSize >= 8) {
+    memcpy(valueAddr, &payloadIndexBuf, 8);
+    memset(valueAddr + 8, 0, payloadSize - 8);
+  } else if (payloadSize > 0) {
+    payloadIndexBuf <<= (8 - payloadSize) * 8;
+    memcpy(valueAddr, &payloadIndexBuf, payloadSize);
+  }
   if (numExtraTagBytes)
     small_memcpy(extraTagBitAddr,
                  reinterpret_cast<uint8_t *>(&extraTagIndex) + 4 -


### PR DESCRIPTION
The part of the tag stored in the payload can currently be up to
8 bytes in size (though only the 'low' 4 bytes can be non-zero).
On little-endian machines this doesn't matter, we can always just
store up to 4 bytes and zero the remaining payload bytes. On big-
endian systems however we may need to store more than 4 bytes.

The store implementation now mirrors the runtime code that fetches
the tag on big-endian systems which already treats the payload tag
as an 8 byte integer.

This is a spot fix but longer term we might want to consider
refactoring this code to reduce the number of differences between
big- and little-endian implementations. For example, we could
centralise some of the copying logic and/or make the payload tag
a 4 byte field on all platforms.
