### PR TITLE
[ome] Run even on deserialized functions.

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -293,10 +293,6 @@ struct OwnershipModelEliminator : SILModuleTransform {
     }
 
     for (auto &F : *getModule()) {
-      // Don't rerun early lowering on deserialized functions.
-      if (F.wasDeserializedCanonical())
-        continue;
-
       // If F does not have ownership, skip it. We have no further work to do.
       if (!F.hasOwnership())
         continue;

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -281,3 +281,21 @@ bb0:
   () = destructure_tuple %1 : $()
   return %1 : $()
 }
+
+// CHECK-LABEL: sil [canonical] @test_destructure_struct_tuple_canonical : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Builtin.Int32, TestArrayStorage) {
+// CHECK: bb0([[TUPLE:%.*]] : $(Builtin.NativeObject, Builtin.Int32), [[STRUCT:%.*]] : $TestArray2):
+// CHECK:   [[TUP_ELT_0:%.*]] = tuple_extract [[TUPLE]] : $(Builtin.NativeObject, Builtin.Int32), 0
+// CHECK:   [[TUP_ELT_1:%.*]] = tuple_extract [[TUPLE]] : $(Builtin.NativeObject, Builtin.Int32), 1
+// CHECK:   [[STRUCT_FIELD_0:%.*]] = struct_extract [[STRUCT]] : $TestArray2, #TestArray2.storage
+// CHECK:   [[STRUCT_FIELD_1:%.*]] = struct_extract [[STRUCT]] : $TestArray2, #TestArray2.someValue
+// CHECK:   [[STRUCT_FIELD_2:%.*]] = struct_extract [[STRUCT]] : $TestArray2, #TestArray2.storage2
+// CHECK:   [[RESULT:%.*]] = tuple ([[TUP_ELT_0]] : {{.*}}, [[TUP_ELT_1]] : {{.*}}, [[STRUCT_FIELD_0]] : {{.*}}, [[STRUCT_FIELD_1]] : {{.*}}, [[STRUCT_FIELD_2]] : {{.*}})
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function 'test_destructure_struct_tuple_canonical'
+sil [canonical] [ossa] @test_destructure_struct_tuple_canonical : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Builtin.Int32, TestArrayStorage) {
+bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2):
+  (%2, %3) = destructure_tuple %0 : $(Builtin.NativeObject, Builtin.Int32)
+  (%4, %5, %6) = destructure_struct %1 : $TestArray2
+  %7 = tuple(%2 : $Builtin.NativeObject, %3 : $Builtin.Int32, %4 : $TestArrayStorage, %5 : $Builtin.Int32, %6 : $TestArrayStorage)
+  return %7 : $(Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Builtin.Int32, TestArrayStorage)
+}


### PR DESCRIPTION
This is needed since we are going to start eliminating ownership after SIL is
serialized. So we need to make sure that we strip those as well.

In terms of compile time, this shouldn't have much of an effect since we already
skip functions that already have ownership stripped.
