### PR TITLE
[TypeChecker] Classify `nil` literal and `.none` as non-contriburing to throws

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -389,7 +389,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
   auto &tc = getTypeChecker();
   bool hasNonDependentMemberRelationalConstraints = false;
   bool hasDependentMemberRelationalConstraints = false;
-  bool sawNilLiteral = false;
   for (auto constraint : constraints) {
     switch (constraint->getKind()) {
     case ConstraintKind::Bind:
@@ -507,7 +506,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       // supertype bindings.
       if (constraint->getProtocol()->isSpecificProtocol(
               KnownProtocolKind::ExpressibleByNilLiteral)) {
-        sawNilLiteral = true;
         addOptionalSupertypeBindings = true;
       }
 
@@ -746,32 +744,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       result.FullyBound = true;
     else
       result.Bindings.clear();
-  }
-
-  // Revise any optional-of-function-types we may try to nil literals
-  // to be non-throwing so they don't inadvertantly result in rethrows
-  // diagnostics.
-  if (sawNilLiteral) {
-    for (auto &binding : result.Bindings) {
-      auto nested = binding.BindingType->lookThroughAllOptionalTypes();
-      if (!nested)
-        continue;
-
-      if (!nested->is<FunctionType>())
-        continue;
-
-      // Remove throws from the nested function type.
-      binding.BindingType =
-          binding.BindingType.transform([&](Type inner) -> Type {
-            auto *fnTy = dyn_cast<FunctionType>(inner.getPointer());
-            if (!fnTy)
-              return inner;
-
-            auto extInfo = fnTy->getExtInfo().withThrows(false);
-            return FunctionType::get(fnTy->getParams(), fnTy->getResult(),
-                                     extInfo);
-          });
-    }
   }
 
   return result;

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -679,6 +679,16 @@ private:
   Classification classifyRethrowsArgument(Expr *arg, Type paramType) {
     arg = arg->getValueProvidingExpr();
 
+    // If this argument is `nil` literal or `.none`,
+    // it doesn't cause the call to throw.
+    if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(arg)) {
+      if (auto *DE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
+        auto &ctx = paramType->getASTContext();
+        if (DE->getDecl() == ctx.getOptionalNoneDecl())
+          return Classification();
+      }
+    }
+
     // If the parameter was structurally a tuple, try to look through the
     // various tuple operations.
     if (auto paramTupleType = dyn_cast<TupleType>(paramType.getPointer())) {

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -603,3 +603,12 @@ class RethrowingConstructor {
     }
   }
 }
+
+// default values -vs- throwing function inside optional
+func rdar_47550715() {
+  typealias A<T> = (T) -> Void
+  typealias F = () throws -> Void
+
+  func foo(_: A<F>? = nil) {} // Ok
+  func bar(_: A<F>? = .none) {} // Ok
+}


### PR DESCRIPTION
Original fix for SR-9102 stripped throws bit from the function types
nested inside optionals before attempting bindings, that doesn't
work with e.g. default parameter values because conversions from
throwing and non-throwing functions are only allowed in subtype
relationship but function types nested inside optionals are going
to be equated.

So this patch takes an alternative approach and attempts to pattern
match `nil` literal and `.none` use and classify argument as non-contributing
to throws.

Resolves: rdar://problem/47550715

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
