### PR TITLE
Enable -enable-anonymous-context-mangled-names based on the

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -243,12 +243,6 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
     arguments.push_back(inputArgs.MakeArgString(workingDirectory));
   }
 
-  // -g implies -enable-anonymous-context-mangled-names, because the extra
-  // metadata aids debugging.
-  if (inputArgs.hasArg(options::OPT_g)) {
-    arguments.push_back("-enable-anonymous-context-mangled-names");
-  }
-
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -914,6 +914,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                      : "-gdwarf_types");
   }
 
+  // This flags aids debugging. The OptMode is initialized by ParseSILGenArgs().
+  if (Opts.OptMode == OptimizationMode::NoOptimization)
+    Opts.EnableAnonymousContextMangledNames = true;
+  
   for (auto A : Args.getAllArgValues(options::OPT_debug_prefix_map)) {
     auto SplitMap = StringRef(A).split('=');
     Opts.DebugPrefixMap.addMapping(SplitMap.first, SplitMap.second);

--- a/test/Driver/debug_anonymous_context_metadata.swift
+++ b/test/Driver/debug_anonymous_context_metadata.swift
@@ -1,4 +1,0 @@
-// RUN: %target-swiftc_driver -### -g %s 2>&1 | %FileCheck %s
-
-// CHECK: -enable-anonymous-context-mangled-names
-

--- a/test/IRGen/anonymous_context_descriptors.sil
+++ b/test/IRGen/anonymous_context_descriptors.sil
@@ -1,5 +1,6 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s -check-prefix CHECK-MANGLED
+// RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -Onone %s | %FileCheck %s -check-prefix CHECK-MANGLED
+// RUN: %target-swift-frontend -emit-ir -O -enable-anonymous-context-mangled-names %s | %FileCheck %s -check-prefix CHECK-MANGLED
 
 import Builtin
 import Swift

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -657,9 +657,9 @@
 
 // CHECK: TypesToReflect.HasFileprivateProtocol
 // CHECK: -------------------------------------
-// CHECK: x: TypesToReflect.(FileprivateProtocol in ${{[0-9a-fA-F]+}})
+// CHECK: x: TypesToReflect.(FileprivateProtocol in _{{[0-9a-fA-F]+}})
 // CHECK: (protocol_composition
-// CHECK-NEXT: (protocol TypesToReflect.(FileprivateProtocol in ${{[0-9a-fA-F]+}})))
+// CHECK-NEXT: (protocol TypesToReflect.(FileprivateProtocol in _{{[0-9a-fA-F]+}})))
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================


### PR DESCRIPTION
optimization level instead of whether debug info is enabled or not. The presence of `-g` is not supposed to affect the generated code.

rdar://problem/38231646

See the discussion in https://github.com/apple/swift-lldb/pull/1250 for more context. 