### PR TITLE
[AutoDiff] Fix `@differentiable` attribute type-checking.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2434,7 +2434,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   }
 
   TC.resolveDeclSignature(original);
-  auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
+  auto *originalFnTy = original->getInterfaceType()->eraseDynamicSelfType()
+      ->castTo<AnyFunctionType>();
   auto isInstanceMethod = original->isInstanceMember();
 
   // If the original function has no parameters or returns the empty tuple
@@ -2725,6 +2726,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
       return false;
 
     // Check that parameter types match (disregards labels).
+    if (candidateFnTy.getParams().size() != required.getParams().size())
+      return false;
     for (auto paramPair : llvm::zip(candidateFnTy.getParams(),
                                     required.getParams()))
       if (std::get<0>(paramPair).getParameterType() !=

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -2041,8 +2041,8 @@ extension FloatingPoint where Self : Differentiable,
   /// The vector-Jacobian product function of `squareRoot`. Returns the original
   /// result and pullback of `squareRoot` with respect to `self`.
   @inlinable // FIXME(sil-serialize-all)
-  func _vjpSquareRoot(_ x: Self) -> (Self, (Self) -> Self) {
-    return (x.squareRoot(), { v in 2 * self * v })
+  func _vjpSquareRoot() -> (Self, (Self) -> Self) {
+    return (squareRoot(), { v in 2 * self * v })
   }
 }
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -391,6 +391,18 @@ extension FloatingPoint {
   }
 }
 
+protocol MethodDiffReq {
+  // expected-error @+1 {{'vjpFoo' does not have expected type '<Self where Self : Differentiable, Self : MethodDiffReq> (Self) -> () -> (Self, (Self.CotangentVector) -> Self.CotangentVector)'}}
+  @differentiable(wrt: (self), vjp: vjpFoo where Self : Differentiable)
+  func foo() -> Self
+}
+
+extension MethodDiffReq where Self : Differentiable {
+  func vjpFoo(x: Self) -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
+    return (self, { $0 })
+  }
+}
+
 // expected-error @+2 {{type 'Scalar' constrained to non-protocol, non-class type 'Float'}}
 // expected-error @+1 {{can only differentiate with respect to parameters that conform to 'Differentiable', but 'Scalar' does not conform to 'Differentiable'}}
 @differentiable(where Scalar : Float)
@@ -404,7 +416,6 @@ func invalidRequirementConformance<Scalar>(x: Scalar) -> Scalar {
 func invalidRequirementLayout<Scalar>(x: Scalar) -> Scalar {
   return x
 }
-
 
 protocol DiffReq : Differentiable {
   // expected-note @+2 {{protocol requires function 'f1'}}


### PR DESCRIPTION
- Check whether parameter counts match in `checkFunctionSignature`.
  - Previously, parameter types were zipped and checked for equality,
    but parameter count equality was neglected.
- Erase dynamic `Self` type during `@differentiable` attribute type-checking.
  - According to a doc comment, dynamic `Self` result types are relevant only
    for checking protocol conformances. Here, it disrupts associated type lookup
    and causes `getAutoDiffAssociatedVectorSpace` to fail.
- Add test, fix incorrect VJP definition in stdlib.