### PR TITLE
Disable TSan in coroutine functions

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1226,13 +1226,17 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
   }
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
     auto declContext = f->getDeclContext();
-    if (declContext && isa<DestructorDecl>(declContext))
+    if (f->getLoweredFunctionType()->isCoroutine()) {
+      // Disable TSan in coroutines; the instrumentation currently interferes
+      // with coroutine structural invariants.
+    } else if (declContext && isa<DestructorDecl>(declContext)) {
       // Do not report races in deinit and anything called from it
       // because TSan does not observe synchronization between retain
       // count dropping to '0' and the object deinitialization.
       CurFn->addFnAttr("sanitize_thread_no_checking_at_run_time");
-    else
+    } else {
       CurFn->addFnAttr(llvm::Attribute::SanitizeThread);
+    }
   }
 
   // Disable inlining of coroutine functions until we split.

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -1,12 +1,26 @@
 // This test verifies that we add the function attributes used by TSan.
 
-// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
+// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
 
 // TSan is currently only supported on 64 bit mac and simulators.
 // (We do not test the simulators here.)
 // REQUIRES: CPU=x86_64, OS=macosx
 
-func test() {
+// TSAN: define {{.*}} @"$s4main4testyyF"() [[DEFAULT_ATTRS:#[0-9]+]]
+public func test() {
 }
 
-// TSAN: Function Attrs: sanitize_thread
+// TSAN: define {{.*}} @"$s4main1xSivr"({{.*}}) [[COROUTINE_ATTRS:#[0-9]+]]
+public var x: Int {
+  _read {
+    yield 0
+  }
+}
+
+// TSAN: attributes [[DEFAULT_ATTRS]] =
+// TSAN-SAME: sanitize_thread
+// TSAN-SAME: }
+
+// TSAN: attributes [[COROUTINE_ATTRS]] =
+// TSAN-NOT: sanitize_address
+// TSAN-SAME: }


### PR DESCRIPTION
Fixes rdar://47491307.

I've filed rdar://47642395 to track re-enabling TSan in coroutines.