### PR TITLE
[AutoDiff] Retroactive differentiability: implement `@differentiating` attribute.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -410,7 +410,7 @@ SIMPLE_DECL_ATTR(_fieldwiseDifferentiable, FieldwiseDifferentiable,
 SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
                  OnVar, 88)
 DECL_ATTR(differentiating, Differentiating,
-  OnAccessor | OnFunc | LongAttribute | AllowMultipleAttributes,
+  OnFunc | LongAttribute | AllowMultipleAttributes,
   89)
 
 #undef TYPE_ATTR

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -398,20 +398,20 @@ DECL_ATTR(_private, PrivateImport,
 DECL_ATTR(differentiable, Differentiable,
   OnAccessor | OnFunc | OnVar | LongAttribute | AllowMultipleAttributes,
   83)
-SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
-                 OnAccessor | OnFunc | OnConstructor | OnSubscript,
-                 /* Not serialized */ 84)
-SIMPLE_DECL_ATTR(TensorFlowGraph, TensorFlowGraph,
-                 OnFunc, 85)
-SIMPLE_DECL_ATTR(TFParameter, TFParameter,
-                 OnVar, 86)
-SIMPLE_DECL_ATTR(_fieldwiseDifferentiable, FieldwiseDifferentiable,
-                 OnNominalType | UserInaccessible, 87)
-SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
-                 OnVar, 88)
 DECL_ATTR(differentiating, Differentiating,
   OnFunc | LongAttribute | AllowMultipleAttributes,
-  89)
+  84)
+SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
+                 OnAccessor | OnFunc | OnConstructor | OnSubscript,
+                 /* Not serialized */ 85)
+SIMPLE_DECL_ATTR(TensorFlowGraph, TensorFlowGraph,
+                 OnFunc, 86)
+SIMPLE_DECL_ATTR(TFParameter, TFParameter,
+                 OnVar, 87)
+SIMPLE_DECL_ATTR(_fieldwiseDifferentiable, FieldwiseDifferentiable,
+                 OnNominalType | UserInaccessible, 88)
+SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
+                 OnVar, 89)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -409,6 +409,9 @@ SIMPLE_DECL_ATTR(_fieldwiseDifferentiable, FieldwiseDifferentiable,
                  OnNominalType | UserInaccessible, 87)
 SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
                  OnVar, 88)
+DECL_ATTR(differentiating, Differentiating,
+  OnAccessor | OnFunc | LongAttribute | AllowMultipleAttributes,
+  89)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -64,9 +64,11 @@ public:
   }
 
   bool isEqual(const ParsedAutoDiffParameter &other) const {
-    if (getKind() == other.getKind() && getKind() == Kind::Named)
+    if (getKind() != other.getKind())
+      return false;
+    if (getKind() == Kind::Named)
       return getName() == other.getName();
-    return getKind() == other.getKind() && getKind() == Kind::Self;
+    return getKind() == Kind::Self;
   }
 };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1519,6 +1519,10 @@ ERROR(attr_differentiable_expected_colon_after_label,PointsToFirstBadToken,
 ERROR(attr_differentiable_expected_label,none,
       "expected a function specifier label, e.g. 'wrt:', 'jvp:', or 'vjp:'", ())
 
+// differentiating
+ERROR(attr_differentiating_expected_original_name,PointsToFirstBadToken,
+      "expected a qualified original function name", ())
+
 // [differentiable ...] (sil-decl attr)
 ERROR(sil_attr_differentiable_expected_keyword,PointsToFirstBadToken,
       "expected '%0' in 'differentiable' attribute", (StringRef))

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1505,7 +1505,7 @@ ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
 // SWIFT_ENABLE_TENSORFLOW
 // differentiable
 ERROR(attr_differentiable_expected_function_name,PointsToFirstBadToken,
-      "expected a qualified %0 function", (StringRef))
+      "expected a %0 function name", (StringRef))
 ERROR(attr_differentiable_expected_parameter_list,PointsToFirstBadToken,
       "expected a list of parameters to differentiate with respect to", ())
 ERROR(attr_differentiable_use_wrt_not_withrespectto,none,
@@ -1521,7 +1521,7 @@ ERROR(attr_differentiable_expected_label,none,
 
 // differentiating
 ERROR(attr_differentiating_expected_original_name,PointsToFirstBadToken,
-      "expected a qualified original function name", ())
+      "expected an original function name", ())
 
 // [differentiable ...] (sil-decl attr)
 ERROR(sil_attr_differentiable_expected_keyword,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2734,17 +2734,19 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
 
 // @differentiang
 ERROR(differentiating_attr_expected_result_tuple,none,
-      "@differentiating attribute requires function to return a two-element tuple (value and pullback/differential)", ())
+      "'@differentiating' attribute requires function to return a two-element tuple of type "
+      "'(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or "
+      "'(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'", ())
 ERROR(differentiating_attr_expected_result_tuple_value_label,none,
-      "@differentiating attribute requires function to return a two-element tuple (first element must have label 'value:')", ())
+      "'@differentiating' attribute requires function to return a two-element tuple (first element must have label 'value:')", ())
 ERROR(differentiating_attr_expected_result_tuple_func_label,none,
-      "@differentiating attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')", ())
+      "'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')", ())
 ERROR(differentiating_attr_result_value_not_differentiable,none,
-      "@differentiating attribute requires function to return a two-element tuple (first element type %0 must conform to 'Differentiable')", (Type))
+      "'@differentiating' attribute requires function to return a two-element tuple (first element type %0 must conform to 'Differentiable')", (Type))
 ERROR(differentiating_attr_result_func_invalid_parameter,none,
       "expected %0 to be a function with a single parameter of type %1", (Identifier, Type))
 ERROR(differentiating_attr_no_diff_parameters,none,
-      "@differentiating attribute requires function to have at least one differentiation parameter", ())
+      "'@differentiating' attribute requires function to have at least one differentiation parameter", ())
 ERROR(differentiating_attr_unexpected_diff_params_type,none,
       "unexpected differentiation parameters type; got %0, but expected %1", (Type, Type))
 ERROR(differentiating_attr_overload_not_found,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2680,6 +2680,7 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
       (DeclName, DeclName))
 
 // SWIFT_ENABLE_TENSORFLOW
+// @differentiable
 ERROR(differentiable_attr_no_parameters,none,
       "%0 has no parameters to differentiate with respect to", (DeclName))
 ERROR(differentiable_attr_void_result,none,
@@ -2731,6 +2732,25 @@ ERROR(differentiable_attr_non_protocol_type_constraint_req,none,
 ERROR(differentiable_attr_unsupported_req_kind,none,
       "layout requirement are not supported by @differentiable attribute", ())
 
+// @differentiang
+ERROR(differentiating_attr_expected_result_tuple,none,
+      "@differentiating attribute requires function to return a two-element tuple (value and pullback/differential)", ())
+ERROR(differentiating_attr_expected_result_tuple_value_label,none,
+      "@differentiating attribute requires function to return a two-element tuple (first element must have label 'value:')", ())
+ERROR(differentiating_attr_expected_result_tuple_func_label,none,
+      "@differentiating attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')", ())
+ERROR(differentiating_attr_result_value_not_differentiable,none,
+      "@differentiating attribute requires function to return a two-element tuple (first element type %0 must conform to 'Differentiable')", (Type))
+ERROR(differentiating_attr_result_func_invalid_parameter,none,
+      "expected %0 to be a function with a single parameter of type %1", (Identifier, Type))
+ERROR(differentiating_attr_no_diff_parameters,none,
+      "@differentiating attribute requires function to have at least one differentiation parameter", ())
+ERROR(differentiating_attr_unexpected_diff_params_type,none,
+      "unexpected differentiation parameters type; got %0, but expected %1", (Type, Type))
+ERROR(differentiating_attr_overload_not_found,none,
+      "%0 does not have expected type %1", (DeclName, Type))
+
+// @compilerEvaluable
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())
 ERROR(compiler_evaluable_loop,none,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2798,6 +2798,10 @@ public:
     /// Whether the parameter is marked 'owned'
     bool isOwned() const { return Flags.isOwned(); }
 
+    // SWIFT_ENABLE_TENSORFLOW
+    /// Whether the parameter is marked '@nondiff'
+    bool isNonDifferentiable() const { return Flags.isNonDifferentiable(); }
+
     ValueOwnership getValueOwnership() const {
       return Flags.getValueOwnership();
     }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2799,7 +2799,7 @@ public:
     bool isOwned() const { return Flags.isOwned(); }
 
     // SWIFT_ENABLE_TENSORFLOW
-    /// Whether the parameter is marked '@nondiff'
+    /// Whether the parameter is marked '@nondiff'.
     bool isNonDifferentiable() const { return Flags.isNonDifferentiable(); }
 
     ValueOwnership getValueOwnership() const {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -858,9 +858,13 @@ public:
   /// Parse the arguments inside the @differentiable attribute.
   bool parseDifferentiableAttributeArguments(
       SmallVectorImpl<ParsedAutoDiffParameter> &params,
-      Optional<DifferentiableAttr::DeclNameWithLoc> &jvpSpec,
-      Optional<DifferentiableAttr::DeclNameWithLoc> &vjpSpec,
+      Optional<DeclNameWithLoc> &jvpSpec, Optional<DeclNameWithLoc> &vjpSpec,
       TrailingWhereClause *&whereClause);
+
+  /// SWIFT_ENABLE_TENSORFLOW
+  /// Parse the @differentiating attribute.
+  ParserResult<DifferentiatingAttr>
+  parseDifferentiatingAttribute(SourceLoc AtLoc, SourceLoc Loc);
 
   /// Parse a specific attribute.
   bool parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc);

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1595,6 +1595,14 @@ namespace decls_block {
     BCArray<BCFixed<1>> // Differentiation parameter indices' bitvector.
   >;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  using DifferentiatingDeclAttrLayout = BCRecordLayout<
+    Differentiating_DECL_ATTR,
+    BCFixed<1>, // Implicit flag.
+    IdentifierIDField, // Original name.
+    DeclIDField // Original function declaration.
+  >;
+
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) \
   using CLASS##DeclAttrLayout = BCRecordLayout< \
     CLASS##_DECL_ATTR, \

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 469; // Last change: serialize differentiation indices
+const uint16_t SWIFTMODULE_VERSION_MINOR = 470; // Last change: serialize @differentiating attribute
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1226,6 +1226,7 @@ ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,
       MemberNameLoc(MemberNameLoc) {
 }
 
+
 ImplementsAttr *ImplementsAttr::create(ASTContext &Ctx, SourceLoc atLoc,
                                        SourceRange range,
                                        TypeLoc ProtocolType,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -565,7 +565,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     auto *original = dyn_cast_or_null<AbstractFunctionDecl>(D);
     if (auto *varDecl = dyn_cast_or_null<VarDecl>(D))
       original = varDecl->getGetter();
-    bool isMethod = original && original->getImplicitSelfDecl() ? true : false;
+    bool isMethod = original && original->hasImplicitSelfDecl();
 
     // Print comma if not leading clause.
     bool isLeadingClause = true;
@@ -649,7 +649,17 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
         Printer << ", ";
       });
     }
-    Printer << ")";
+    Printer << ')';
+    break;
+  }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  case DAK_Differentiating: {
+    Printer.printAttrName("@differentiating");
+    Printer << '(';
+    auto *attr = cast<DifferentiatingAttr>(this);
+    Printer << attr->getOriginal().Name;
+    Printer << ')';
     break;
   }
 
@@ -790,6 +800,8 @@ StringRef DeclAttribute::getAttrName() const {
   // SWIFT_ENABLE_TENSORFLOW
   case DAK_Differentiable:
     return "differentiable";
+  case DAK_Differentiating:
+    return "differentiating";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -1187,6 +1199,23 @@ void DifferentiableAttr::setRequirements(ASTContext &context,
   Requirements = context.AllocateCopy(requirements);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+DifferentiatingAttr::DifferentiatingAttr(ASTContext &context, bool implicit,
+                                         SourceLoc atLoc, SourceRange baseRange,
+                                         DeclNameWithLoc original)
+  : DeclAttribute(DAK_Differentiating, atLoc, baseRange, implicit),
+    Original(std::move(original)) {}
+
+DifferentiatingAttr *
+DifferentiatingAttr::create(ASTContext &context, bool implicit,
+                            SourceLoc atLoc, SourceRange baseRange,
+                            DeclNameWithLoc original) {
+  void *mem = context.Allocate(sizeof(DifferentiatingAttr),
+                               alignof(DifferentiatingAttr));
+  return new (mem) DifferentiatingAttr(context, implicit, atLoc, baseRange,
+                                       std::move(original));
+}
+
 ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,
                                TypeLoc ProtocolType,
                                DeclName MemberName,
@@ -1196,7 +1225,6 @@ ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,
       MemberName(MemberName),
       MemberNameLoc(MemberNameLoc) {
 }
-
 
 ImplementsAttr *ImplementsAttr::create(ASTContext &Ctx, SourceLoc atLoc,
                                        SourceRange range,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4093,8 +4093,7 @@ Type TypeBase::openAnyExistentialType(ArchetypeType *&opened) {
 // with `params` parameters and `retTy` return type.
 static AnyFunctionType *
 makeFunctionType(AnyFunctionType *copy, ArrayRef<AnyFunctionType::Param> params,
-                 Type retTy, GenericSignature *whereClauseGenSig) {
-  auto genericSignature = whereClauseGenSig;
+                 Type retTy, GenericSignature *genericSignature) {
   if (!genericSignature)
     if (auto *genericFunctionType = copy->getAs<GenericFunctionType>())
       genericSignature = genericFunctionType->getGenericSignature();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -814,7 +814,6 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   StringRef AttrName = "differentiable";
   SourceLoc lParenLoc = loc, rParenLoc = loc;
 
-  using DeclNameWithLoc = DifferentiableAttr::DeclNameWithLoc;
   SmallVector<ParsedAutoDiffParameter, 8> params;
   Optional<DeclNameWithLoc> jvpSpec;
   Optional<DeclNameWithLoc> vjpSpec;
@@ -842,8 +841,7 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
 
 bool Parser::parseDifferentiableAttributeArguments(
     SmallVectorImpl<ParsedAutoDiffParameter> &params,
-    Optional<DifferentiableAttr::DeclNameWithLoc> &jvpSpec,
-    Optional<DifferentiableAttr::DeclNameWithLoc> &vjpSpec,
+    Optional<DeclNameWithLoc> &jvpSpec, Optional<DeclNameWithLoc> &vjpSpec,
     TrailingWhereClause *&whereClause) {
   StringRef AttrName = "differentiable";
 
@@ -959,11 +957,10 @@ bool Parser::parseDifferentiableAttributeArguments(
       return errorAndSkipToEnd();
   }
 
-  using FuncSpec = DifferentiableAttr::DeclNameWithLoc;
   // Function that parses a label and a function specifier,
   // e.g. 'vjp: foo(_:)'.
   // Return true on error.
-  auto parseFuncSpec = [&](StringRef label, FuncSpec &result,
+  auto parseFuncSpec = [&](StringRef label, DeclNameWithLoc &result,
                            bool &terminateParsingArgs) -> bool {
     // Parse label.
     if (parseSpecificIdentifier(label,
@@ -991,7 +988,7 @@ bool Parser::parseDifferentiableAttributeArguments(
   if (Tok.is(tok::identifier) && Tok.getText() == "jvp") {
     SyntaxParsingContext JvpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
-    jvpSpec = FuncSpec();
+    jvpSpec = DeclNameWithLoc();
     if (parseFuncSpec("jvp", *jvpSpec, terminateParsingArgs))
       return errorAndSkipToEnd();
     if (terminateParsingArgs)
@@ -1004,7 +1001,7 @@ bool Parser::parseDifferentiableAttributeArguments(
   if (Tok.is(tok::identifier) && Tok.getText() == "vjp") {
     SyntaxParsingContext VjpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
-    vjpSpec = FuncSpec();
+    vjpSpec = DeclNameWithLoc();
     if (parseFuncSpec("vjp", *vjpSpec, terminateParsingArgs))
       return errorAndSkipToEnd();
     if (terminateParsingArgs)
@@ -1032,6 +1029,37 @@ bool Parser::parseDifferentiableAttributeArguments(
     whereClause = TrailingWhereClause::create(Context, whereLoc, requirements);
   }
   return false;
+}
+
+/// SWIFT_ENABLE_TENSORFLOW
+ParserResult<DifferentiatingAttr>
+Parser::parseDifferentiatingAttribute(SourceLoc atLoc, SourceLoc loc) {
+  StringRef AttrName = "differentiating";
+  SourceLoc lParenLoc = loc, rParenLoc = loc;
+  DeclNameWithLoc original;
+
+  // Parse '('.
+  if (!consumeIf(tok::l_paren, lParenLoc)) {
+    diagnose(getEndOfPreviousLoc(), diag::attr_expected_lparen, AttrName,
+             /*DeclModifier*/ false);
+    return makeParserError();
+  }
+  // Parse the name of the function.
+  original.Name =
+    parseUnqualifiedDeclName(/*afterDot*/ false, original.Loc,
+                             diag::attr_differentiating_expected_original_name,
+                             /*allowOperators*/ true,
+                             /*allowZeroArgCompoundNames*/ true);
+  // Parse ')'.
+  if (!consumeIf(tok::r_paren, rParenLoc)) {
+    diagnose(getEndOfPreviousLoc(), diag::attr_expected_rparen, AttrName,
+             /*DeclModifier*/ false);
+    return makeParserError();
+  }
+  return ParserResult<DifferentiatingAttr>(
+      DifferentiatingAttr::create(Context, /*implicit*/ false, atLoc,
+                                  SourceRange(loc, rParenLoc),
+                                  original));
 }
 
 void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,
@@ -1803,9 +1831,16 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   /// SWIFT_ENABLE_TENSORFLOW
   case DAK_Differentiable: {
     auto Attr = parseDifferentiableAttribute(AtLoc, Loc);
-    if (Attr.isNonNull()) {
+    if (Attr.isNonNull())
       Attributes.add(Attr.get());
-    }
+    break;
+  }
+
+  /// SWIFT_ENABLE_TENSORFLOW
+  case DAK_Differentiating: {
+    auto Attr = parseDifferentiatingAttribute(AtLoc, Loc);
+    if (Attr.isNonNull())
+      Attributes.add(Attr.get());
     break;
   }
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -806,6 +806,10 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
     if (!hasFunction(thunk))
       emitNativeToForeignThunk(thunk);
   }
+
+  // TODO: Handle SILGen for `@differentiating` attribute.
+  // Tentative solution: SILGen derivative function normally but also emit
+  // mangled redirection thunk for retroactive differentiation.
 }
 
 void SILGenModule::emitFunction(FuncDecl *fd) {

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2272,7 +2272,7 @@ public:
       assert(proto && "Expected protocol in generic signature requirement");
       auto reqType = req.getFirstType();
       // If requirement type can be substituted in original substutition map to
-      // form a non-archetype type, use the ssubstituted type.
+      // form a non-archetype type, use the substituted type.
       if (auto origFirstType = reqType.subst(origSubstMap))
         if (!origFirstType->hasArchetype())
           reqType = origFirstType;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -124,6 +124,7 @@ public:
   IGNORED_ATTR(PrivateImport)
   // SWIFT_ENABLE_TENSORFLOW
   IGNORED_ATTR(Differentiable)
+  IGNORED_ATTR(Differentiating)
   IGNORED_ATTR(CompilerEvaluable)
   IGNORED_ATTR(TensorFlowGraph)
   IGNORED_ATTR(TFParameter)
@@ -917,6 +918,7 @@ public:
 
   // SWIFT_ENABLE_TENSORFLOW
   void visitDifferentiableAttr(DifferentiableAttr *attr);
+  void visitDifferentiatingAttr(DifferentiatingAttr *attr);
   void visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr);
   void visitTensorFlowGraphAttr(TensorFlowGraphAttr *attr);
   void visitTFParameterAttr(TFParameterAttr *attr);
@@ -2325,9 +2327,8 @@ void AttributeChecker::visitNonOverrideAttr(NonOverrideAttr *attr) {
 
 // SWIFT_ENABLE_TENSORFLOW
 static FuncDecl *resolveAutoDiffAssociatedFunction(
-    TypeChecker &TC, DifferentiableAttr::DeclNameWithLoc specifier,
-    FuncDecl *original, Type expectedTy,
-    std::function<bool(FuncDecl *)> isValid) {
+    TypeChecker &TC, DeclNameWithLoc specifier, FuncDecl *original,
+    Type expectedTy, std::function<bool(FuncDecl *)> isValid) {
   auto nameLoc = specifier.Loc.getBaseNameLoc();
   auto overloadDiagnostic = [&]() {
     TC.diagnose(nameLoc, diag::differentiable_attr_overload_not_found,
@@ -2348,15 +2349,17 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
                 specifier.Name);
   };
 
-  // If the original function and the associated function have different
-  // parents, or if they both have no type context and are in different modules,
-  // then it's an error. Returns true on error.
+  // Returns true if the original function and associated function candidate
+  // are defined in compatible type contexts. If the original function and the
+  // associated function have different parents, or if they both have no type
+  // context and are in different modules, return false.
   std::function<bool(FuncDecl *)> hasValidTypeContext = [&](FuncDecl *func) {
-    // Check if both are top-level.
+    // Check if both functions are top-level.
     if (!original->getInnermostTypeContext() &&
         !func->getInnermostTypeContext() &&
         original->getParentModule() == func->getParentModule())
       return true;
+    // Check if both functions are defined in the same type context.
     if (auto typeCtx1 = original->getInnermostTypeContext())
       if (auto typeCtx2 = func->getInnermostTypeContext())
         return typeCtx1->getSelfNominalTypeDecl() ==
@@ -2405,6 +2408,56 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
   return candidate;
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+// Checks that the `candidate` function type equals the `required` function
+// type. Parameter labels are not checked.
+// `checkGenericSignature` is used to check generic signatures, if specified.
+// Otherwise, generic signatures are checked for equality.
+static bool checkFunctionSignature(
+    CanAnyFunctionType required, CanType candidate,
+    Optional<std::function<bool(GenericSignature *, GenericSignature *)>>
+        checkGenericSignature = None) {
+  // Check that candidate is actually a function.
+  CanAnyFunctionType candidateFnTy = dyn_cast<AnyFunctionType>(candidate);
+  if (!candidateFnTy)
+    return false;
+
+  // Check that generic signatures match.
+  auto requiredGenSig = required.getOptGenericSignature();
+  auto candidateGenSig = candidateFnTy.getOptGenericSignature();
+  // Call generic signature check function, if specified.
+  // Otherwise, check that generic signatures are equal.
+  if (!checkGenericSignature) {
+    if (candidateGenSig != requiredGenSig)
+      return false;
+  } else if (!(*checkGenericSignature)(requiredGenSig, candidateGenSig)) {
+    return false;
+  }
+
+  // Check that parameters match.
+  if (candidateFnTy.getParams().size() != required.getParams().size())
+    return false;
+  for (auto paramPair : llvm::zip(candidateFnTy.getParams(),
+                                  required.getParams())) {
+    // Check parameter types.
+    if (!std::get<0>(paramPair).getParameterType()->isEqual(
+            std::get<1>(paramPair).getParameterType()))
+      return false;
+  }
+
+  // If required result type is non-function, check that result types match
+  // exactly.
+  CanAnyFunctionType requiredResultFnTy =
+      dyn_cast<AnyFunctionType>(required.getResult());
+  if (!requiredResultFnTy)
+    return required.getResult()->eraseDynamicSelfType()->isEqual(
+        candidateFnTy.getResult()->eraseDynamicSelfType());
+
+  // Required result type is a function. Recurse.
+  return checkFunctionSignature(requiredResultFnTy, candidateFnTy.getResult());
+};
+
+// SWIFT_ENABLE_TENSORFLOW
 void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto &ctx = TC.Context;
   auto lookupConformance =
@@ -2535,7 +2588,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   }
 
   // Validate the 'wrt:' parameters.
-  bool isMethod = original->getImplicitSelfDecl() ? true : false;
+  bool isMethod = original->hasImplicitSelfDecl();
 
   // These are the parsed wrt param indices, which have not yet been checked.
   auto parsedWrtParams = attr->getParsedParameters();
@@ -2797,6 +2850,285 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     // Memorize the vjp reference in the attribute.
     attr->setVJPFunction(vjp);
   }
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+// Makes a function with the same generic signature and extinfo as `copy`, but
+// with `params` parameters and `retTy` return type.
+static AnyFunctionType *
+makeFunctionType(AnyFunctionType *copy, ArrayRef<AnyFunctionType::Param> params,
+                 Type retTy, GenericSignature *genericSignature) {
+  if (!genericSignature)
+    if (auto *genericFunctionType = copy->getAs<GenericFunctionType>())
+      genericSignature = genericFunctionType->getGenericSignature();
+  if (genericSignature)
+    return GenericFunctionType::get(genericSignature, params, retTy,
+                                    copy->getExtInfo());
+  return FunctionType::get(params, retTy, copy->getExtInfo());
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+// Return the original function type corresponding to the given derivative
+// function type.
+static AnyFunctionType *
+getAutoDiffOriginalFunctionType(AnyFunctionType *derivativeType) {
+  // Unwrap curry levels.
+  SmallVector<AnyFunctionType *, 2> curryLevels;
+  auto *currentLevel = derivativeType;
+  while (currentLevel != nullptr) {
+    curryLevels.push_back(currentLevel);
+    currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();
+  }
+
+  auto derivativeResult = curryLevels.back()->getResult()->getAs<TupleType>();
+  assert(derivativeResult && derivativeResult->getNumElements() == 2 &&
+         "Expected derivative result to be a two-element tuple");
+  auto originalResult = derivativeResult->getElement(0).getType();
+  auto genericSignature = derivativeType->getOptGenericSignature();
+  auto *originalType = makeFunctionType(
+      curryLevels.back(), curryLevels.back()->getParams(), originalResult,
+      curryLevels.size() == 1 ? genericSignature : nullptr);
+
+  // Wrap the associated function type in additional curry levels.
+  auto curryLevelsWithoutLast =
+  ArrayRef<AnyFunctionType *>(curryLevels).drop_back(1);
+  for (auto pair : enumerate(reversed(curryLevelsWithoutLast))) {
+    unsigned i = pair.index();
+    AnyFunctionType *curryLevel = pair.value();
+    originalType = makeFunctionType(
+        curryLevel, curryLevel->getParams(), originalType,
+        i == curryLevelsWithoutLast.size() - 1 ? genericSignature : nullptr);
+  }
+  return originalType;
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
+  auto &ctx = TC.Context;
+  FuncDecl *derivative = dyn_cast<FuncDecl>(D);
+  auto isMethod = derivative->hasImplicitSelfDecl();
+  auto isInstanceMethod = derivative->isInstanceMember();
+  auto lookupConformance =
+      LookUpConformanceInModule(D->getDeclContext()->getParentModule());
+  auto original = attr->getOriginal();
+
+  // If the original function has no parameters or returns the empty tuple
+  // type, there's nothing to differentiate from or with-respect-to.
+  auto &derivativeParams = *derivative->getParameters();
+  if (!isInstanceMethod && derivativeParams.size() == 0) {
+    TC.diagnose(attr->getLocation(), diag::differentiable_attr_no_parameters,
+                derivative->getName())
+    .highlight(derivative->getSourceRange());
+    attr->setInvalid();
+    return;
+  }
+  // The result type should be a two-element tuple.
+  // Either a value and pullback:
+  //     (value: R, pullback: (R.CotangentVector) -> (T.CotangentVector...)
+  // Or a value and differential:
+  //     (value: R, differential: (T.TangentVector...) -> (R.TangentVector)
+  auto derivativeResultType = derivative->getResultInterfaceType();
+  auto derivativeResultTupleType = derivativeResultType->getAs<TupleType>();
+  if (!derivativeResultTupleType ||
+      derivativeResultTupleType->getNumElements() != 2) {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_expected_result_tuple);
+    attr->setInvalid();
+    return;
+  }
+  auto valueResultElt = derivativeResultTupleType->getElement(0);
+  auto funcResultElt = derivativeResultTupleType->getElement(1);
+  // Get derivative kind and associated function identifier.
+  AutoDiffAssociatedFunctionKind kind;
+  Identifier autoDiffAssocTyId;
+  if (valueResultElt.getName().str() != "value") {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_expected_result_tuple_value_label);
+    attr->setInvalid();
+    return;
+  }
+  if (funcResultElt.getName().str() == "differential") {
+    kind = AutoDiffAssociatedFunctionKind::JVP;
+    autoDiffAssocTyId = ctx.Id_TangentVector;
+  } else if (funcResultElt.getName().str() == "pullback") {
+    kind = AutoDiffAssociatedFunctionKind::VJP;
+    autoDiffAssocTyId = ctx.Id_CotangentVector;
+  } else {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_expected_result_tuple_func_label);
+    attr->setInvalid();
+    return;
+  }
+  // `value: R` result tuple element must conform to `Differentiable`.
+  auto diffableProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
+  auto valueResultType = valueResultElt.getType();
+  if (valueResultType->hasTypeParameter())
+    valueResultType = derivative->mapTypeIntoContext(valueResultType);
+  auto valueResultConf = TC.conformsToProtocol(valueResultType, diffableProto,
+                                               derivative->getDeclContext(),
+                                               ConformanceCheckFlags::Used);
+  if (!valueResultConf) {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_result_value_not_differentiable,
+                valueResultElt.getType());
+    attr->setInvalid();
+    return;
+  }
+  // Function tuple result must take one parameter with type either
+  // `R.TangentVector` or `R.CotangentVector`.
+  auto seedTy = ProtocolConformanceRef::getTypeWitnessByName(
+      valueResultType, *valueResultConf, autoDiffAssocTyId,
+      ctx.getLazyResolver());
+  auto funcEltType = funcResultElt.getType()->getAs<AnyFunctionType>();
+  if (funcEltType->hasTypeParameter())
+    funcEltType = derivative->mapTypeIntoContext(
+        funcResultElt.getType())->getAs<AnyFunctionType>();
+  if (!funcEltType || funcEltType->getNumParams() != 1 ||
+      !funcEltType->getParams().front().getPlainType()->isEqual(seedTy)) {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_result_func_invalid_parameter,
+                funcResultElt.getName(), seedTy);
+    attr->setInvalid();
+    return;
+  }
+
+  // Gather inferred differentiation parameters.
+  SmallVector<TupleTypeElt, 4> diffParams;
+  auto addDiffParam = [&](Type paramType) {
+    auto conf = TC.conformsToProtocol(paramType, diffableProto, derivative,
+                                      ConformanceCheckFlags::Used);
+    if (!conf)
+      return;
+    auto diffParamType = ProtocolConformanceRef::getTypeWitnessByName(
+        paramType, *conf, autoDiffAssocTyId, ctx.getLazyResolver());
+    diffParams.push_back(TupleTypeElt(diffParamType));
+  };
+
+  auto *derivativeInterfaceType =
+      derivative->getInterfaceType()->castTo<AnyFunctionType>();
+  auto *derivativeType = isMethod
+      ? derivative->getMethodInterfaceType()->castTo<AnyFunctionType>()
+      : derivativeInterfaceType;
+  // If `derivative` is an instance method, check whether `Self` conforms to
+  // `Differentiable`.
+  if (isInstanceMethod) {
+    auto selfType = derivative->getImplicitSelfDecl()->getInterfaceType();
+    if (selfType->hasTypeParameter())
+      selfType = derivative->getParent()->mapTypeIntoContext(selfType);
+    addDiffParam(selfType);
+  }
+  // Check whether every parameter conforms to `Differentiable`.
+  for (auto param : derivativeType->getParams()) {
+    auto paramType = param.getPlainType();
+    if (param.isNonDifferentiable())
+      continue;
+    if (paramType->hasTypeParameter())
+      paramType = derivative->mapTypeIntoContext(paramType);
+    addDiffParam(paramType);
+  }
+  // There must be at least one differentiation parameter.
+  if (diffParams.empty()) {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_no_diff_parameters);
+    attr->setInvalid();
+    return;
+  }
+
+  // Check returned parameter derivatives type against expected type.
+  auto expectedDiffParamsType = TupleType::get(diffParams, ctx);
+  auto diffParamsType = funcEltType->getResult();
+  if (!diffParamsType || !diffParamsType->isEqual(expectedDiffParamsType)) {
+    TC.diagnose(attr->getLocation(),
+                diag::differentiating_attr_unexpected_diff_params_type,
+                diffParamsType, expectedDiffParamsType);
+    attr->setInvalid();
+    return;
+  }
+
+  auto *originalFnType =
+      getAutoDiffOriginalFunctionType(derivativeInterfaceType);;
+
+  std::function<bool(GenericSignature *, GenericSignature *)>
+    checkGenericSignatureSatisfied =
+        [&](GenericSignature *source, GenericSignature *target) {
+          // If target is null, then its requirements are satisfied.
+          if (!target)
+            return true;
+          // If source is null but target is not null, then target's
+          // requirements are not satisfied.
+          if (!source)
+            return false;
+          // Check if target's requirements are satisfied by source.
+          return TC.checkGenericArguments(
+                     derivative, original.Loc.getBaseNameLoc(),
+                     original.Loc.getBaseNameLoc(), Type(),
+                     source->getGenericParams(), target->getRequirements(),
+                     [](SubstitutableType *dependentType) {
+                       return Type(dependentType);
+                     }, lookupConformance) == RequirementCheckResult::Success;
+  };
+
+  auto isValidOriginal = [&](FuncDecl *originalCandidate) {
+    TC.validateDeclForNameLookup(originalCandidate);
+    return checkFunctionSignature(
+        cast<AnyFunctionType>(originalFnType->getCanonicalType()),
+        originalCandidate->getInterfaceType()->getCanonicalType(),
+        checkGenericSignatureSatisfied);
+  };
+
+  auto overloadDiagnostic = [&]() {
+    TC.diagnose(original.Loc, diag::differentiating_attr_overload_not_found,
+                original.Name, originalFnType);
+  };
+  auto ambiguousDiagnostic = [&]() {
+    TC.diagnose(original.Loc,
+                diag::differentiable_attr_ambiguous_function_identifier,
+                original.Name);
+  };
+  auto notFunctionDiagnostic = [&]() {
+    TC.diagnose(original.Loc, diag::differentiable_attr_specified_not_function,
+                original.Name);
+  };
+  std::function<void()> invalidTypeContextDiagnostic = [&]() {
+    TC.diagnose(original.Loc,
+                diag::differentiable_attr_function_not_same_type_context,
+                original.Name);
+  };
+
+  // Returns true if the derivative function and original function candidate
+  // are defined in compatible type contexts. If the derivative function and the
+  // original function candidate have different parents, return false.
+  std::function<bool(FuncDecl *)> hasValidTypeContext = [&](FuncDecl *func) {
+    // Check if both functions are top-level.
+    if (!derivative->getInnermostTypeContext() &&
+        !func->getInnermostTypeContext())
+      return true;
+    // Check if both functions are defined in the same type context.
+    if (auto typeCtx1 = derivative->getInnermostTypeContext())
+      if (auto typeCtx2 = func->getInnermostTypeContext()) {
+        return typeCtx1->getSelfNominalTypeDecl() ==
+            typeCtx2->getSelfNominalTypeDecl();
+      }
+    return derivative->getParent() == func->getParent();
+  };
+
+  auto lookupOptions = defaultMemberLookupOptions
+      | NameLookupFlags::IgnoreAccessControl;
+  auto derivativeTypeCtx = derivative->getInnermostTypeContext();
+  if (!derivativeTypeCtx) derivativeTypeCtx = derivative->getParent();
+  assert(derivativeTypeCtx);
+
+  // Look up original function.
+  auto *originalFn = TC.lookupFuncDecl(
+      original.Name, original.Loc.getBaseNameLoc(), /*baseType*/ Type(),
+      derivativeTypeCtx, isValidOriginal, overloadDiagnostic,
+      ambiguousDiagnostic, notFunctionDiagnostic, lookupOptions,
+      hasValidTypeContext, invalidTypeContextDiagnostic);
+  if (!originalFn) {
+    attr->setInvalid();
+    return;
+  }
+  attr->setOriginalFunction(originalFn);
 }
 
 static bool

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2891,7 +2891,7 @@ getAutoDiffOriginalFunctionType(AnyFunctionType *derivativeType) {
 
   // Wrap the associated function type in additional curry levels.
   auto curryLevelsWithoutLast =
-  ArrayRef<AnyFunctionType *>(curryLevels).drop_back(1);
+      ArrayRef<AnyFunctionType *>(curryLevels).drop_back(1);
   for (auto pair : enumerate(reversed(curryLevelsWithoutLast))) {
     unsigned i = pair.index();
     AnyFunctionType *curryLevel = pair.value();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1217,6 +1217,7 @@ namespace  {
 
     // SWIFT_ENABLE_TENSORFLOW
     UNINTERESTING_ATTR(Differentiable)
+    UNINTERESTING_ATTR(Differentiating)
     UNINTERESTING_ATTR(CompilerEvaluable)
     UNINTERESTING_ATTR(TensorFlowGraph)
     UNINTERESTING_ATTR(TFParameter)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2391,10 +2391,22 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
       indices.push_back(paramIndices->parameters[i]);
 
     DifferentiableDeclAttrLayout::emitRecord(
-      Out, ScratchRecord, abbrCode, attr->isImplicit(),
-      jvpName, jvpRef, vjpName, vjpRef, indices);
+        Out, ScratchRecord, abbrCode, attr->isImplicit(),
+        jvpName, jvpRef, vjpName, vjpRef, indices);
 
     writeGenericRequirements(attr->getRequirements(), DeclTypeAbbrCodes);
+    return;
+  }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  case DAK_Differentiating: {
+    auto abbrCode = DeclTypeAbbrCodes[DifferentiatingDeclAttrLayout::Code];
+    auto attr = cast<DifferentiatingAttr>(DA);
+    IdentifierID origName =
+        addDeclBaseNameRef(attr->getOriginal().Name.getBaseName());
+    DeclID origRef = addDeclRef(attr->getOriginalFunction());
+    DifferentiatingDeclAttrLayout::emitRecord(
+        Out, ScratchRecord, abbrCode, attr->isImplicit(), origName, origRef);
     return;
   }
   }

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -393,7 +393,7 @@ extension FloatingPoint {
 
 protocol MethodDiffReq {
   // expected-error @+1 {{'vjpFoo' does not have expected type '<Self where Self : Differentiable, Self : MethodDiffReq> (Self) -> () -> (Self, (Self.CotangentVector) -> Self.CotangentVector)'}}
-  @differentiable(wrt: (self), vjp: vjpFoo where Self : Differentiable)
+  @differentiable(wrt: self, vjp: vjpFoo where Self : Differentiable)
   func foo() -> Self
 }
 

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -1,0 +1,142 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// Test top-level functions.
+
+func sin(_ x: Float) -> Float {
+  return x // dummy implementation
+}
+
+@differentiating(sin) // ok
+func vjpSin(x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (x, { $0 })
+}
+@differentiating(sin)
+func jvpSin(x: @nondiff Float) -> (value: Float, differential: (Float) -> (Float)) {
+  return (x, { $0 })
+}
+@differentiating(sin) // expected-error {{@differentiating attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+func vjpSinWrongLabel(x: Float) -> (value: Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+@differentiating(sin) // expected-error {{@differentiating attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+func vjpSinResultNotDifferentiable(x: Int) -> (value: Int, pullback: (Int) -> Int) {
+  return (x, { $0 })
+}
+@differentiating(sin) // expected-error {{expected 'pullback' to be a function with a single parameter of type 'Float.CotangentVector' (aka 'Float')}}
+func vjpSinIncorrectSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
+  return (x, { $0 })
+}
+
+func generic<T : Differentiable>(_ x: T, _ y: T) -> T {
+  return x
+}
+@differentiating(generic) // ok
+func vjpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, pullback: (T.CotangentVector) -> (T.CotangentVector, T.CotangentVector)) {
+  return (x, { ($0, $0) })
+}
+@differentiating(generic)
+func jvpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, differential: (T.TangentVector) -> (T.TangentVector, T.TangentVector)) {
+  return (x, { ($0, $0) })
+}
+@differentiating(generic) // expected-error {{@differentiating attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+func vjpGenericWrongLabel<T : Differentiable>(x: T, y: T) -> (value: T, (T) -> (T, T)) {
+  return (x, { ($0, $0) })
+}
+@differentiating(generic) // expected-error {{unexpected differentiation parameters type; got '(T, T)', but expected 'T'}}
+func vjpGenericDiffParamMismatch<T : Differentiable>(x: T) -> (value: T, pullback: (T) -> (T, T)) where T == T.CotangentVector {
+  return (x, { ($0, $0) })
+}
+@differentiating(generic)
+func vjpGenericExtraGenericRequirements<T : Differentiable & FloatingPoint>(x: T, y: T) -> (value: T, pullback: (T) -> (T, T)) where T == T.CotangentVector {
+  return (x, { ($0, $0) })
+}
+
+func foo<T : FloatingPoint & Differentiable>(_ x: T) -> T { return x }
+
+// expected-error @+2 {{type 'T' does not conform to protocol 'FloatingPoint'}}
+// expected-error @+1 {{'foo' does not have expected type '<T where T : AdditiveArithmetic, T : Differentiable> (T) -> T'}}
+@differentiating(foo)
+func vjpFoo<T : AdditiveArithmetic & Differentiable>(_ x: T) -> (value: T, pullback: (T.CotangentVector) -> (T.CotangentVector)) {
+  return (x, { $0 })
+}
+@differentiating(foo)
+func vjpFoo<T : FloatingPoint & Differentiable>(_ x: T) -> (value: T, pullback: (T.CotangentVector) -> (T.CotangentVector)) {
+  return (x, { $0 })
+}
+@differentiating(foo)
+func vjpFooExtraGenericRequirements<T : FloatingPoint & Differentiable & BinaryInteger>(_ x: T) -> (value: T, pullback: (T) -> (T)) where T == T.CotangentVector {
+  return (x, { $0 })
+}
+
+// Test static methods.
+
+extension AdditiveArithmetic where Self : Differentiable {
+  @differentiating(+)
+  static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+extension FloatingPoint where Self : Differentiable, Self == Self.CotangentVector {
+  @differentiating(+)
+  static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+extension Differentiable where Self : AdditiveArithmetic {
+  // expected-error @+1 {{'+' is not defined in the current type context}}
+  @differentiating(+)
+  static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+extension AdditiveArithmetic where Self : Differentiable, Self == Self.CotangentVector {
+  // expected-error @+1 {{unexpected differentiation parameters type; got '(Self, Self)', but expected '(Self, Self, Self)'}}
+  @differentiating(+)
+  func vjpPlusInstanceMethod(x: Self, y: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+// Test instance methods.
+
+protocol InstanceMethod : Differentiable {
+  func foo(_ x: Self) -> Self
+}
+
+extension InstanceMethod {
+  // If `Self` conforms to `Differentiable`, then `Self` is currently always inferred to be a differentiation parameter.
+  // expected-error @+1 {{unexpected differentiation parameters type; got 'Self.CotangentVector', but expected '(Self.CotangentVector, Self.CotangentVector)'}}
+  @differentiating(foo)
+  func vjpFoo(x: Self) -> (value: Self, pullback: (Self.CotangentVector) -> Self.CotangentVector) {
+    return (x, { $0 })
+  }
+
+  @differentiating(foo)
+  func vjpFoo(x: Self) -> (value: Self, pullback: (Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)) {
+    return (x, { ($0, $0) })
+  }
+}
+
+extension InstanceMethod where Self == Self.CotangentVector {
+  @differentiating(foo)
+  func vjpFooExtraRequirements(x: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    return (x, { ($0, $0) })
+  }
+}
+
+protocol GenericInstanceMethod : Differentiable where Self == Self.TangentVector, Self == Self.CotangentVector {
+  func instanceMethod<T : Differentiable>(_ x: T) -> T
+}
+
+extension GenericInstanceMethod {
+  func jvpInstanceMethod<T : Differentiable>(_ x: T) -> (T, (T.TangentVector) -> (TangentVector, T.TangentVector)) {
+    return (x, { v in (self, v) })
+  }
+
+  func vjpInstanceMethod<T : Differentiable>(_ x: T) -> (T, (T.CotangentVector) -> (CotangentVector, T.CotangentVector)) {
+    return (x, { v in (self, v) })
+  }
+}

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -14,16 +14,20 @@ func vjpSin(x: Float) -> (value: Float, pullback: (Float) -> Float) {
 func jvpSin(x: @nondiff Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })
 }
-@differentiating(sin) // expected-error {{@differentiating attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
-func vjpSinWrongLabel(x: Float) -> (value: Float, (Float) -> Float) {
+@differentiating(sin) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple of type '(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'}}
+func jvpSinResultInvalid(x: @nondiff Float) -> Float {
+  return x
+}
+@differentiating(sin) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+func vjpSinResultWrongLabel(x: Float) -> (value: Float, (Float) -> Float) {
   return (x, { $0 })
 }
-@differentiating(sin) // expected-error {{@differentiating attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+@differentiating(sin) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
 func vjpSinResultNotDifferentiable(x: Int) -> (value: Int, pullback: (Int) -> Int) {
   return (x, { $0 })
 }
 @differentiating(sin) // expected-error {{expected 'pullback' to be a function with a single parameter of type 'Float.CotangentVector' (aka 'Float')}}
-func vjpSinIncorrectSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
+func vjpSinResultInvalidSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
   return (x, { $0 })
 }
 
@@ -38,7 +42,7 @@ func vjpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, pullback: (T.Cotan
 func jvpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, differential: (T.TangentVector) -> (T.TangentVector, T.TangentVector)) {
   return (x, { ($0, $0) })
 }
-@differentiating(generic) // expected-error {{@differentiating attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+@differentiating(generic) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
 func vjpGenericWrongLabel<T : Differentiable>(x: T, y: T) -> (value: T, (T) -> (T, T)) {
   return (x, { ($0, $0) })
 }

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -34,7 +34,7 @@
 func method(){}
 
 // SWIFT_ENABLE_TENSORFLOW
-// KEYWORD2:                  Begin completions, 14 items
+// KEYWORD2:                  Begin completions, 15 items
 // KEYWORD2-NEXT:             Keyword/None:                       available[#Func Attribute#]; name=available{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       objc[#Func Attribute#]; name=objc{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       noreturn[#Func Attribute#]; name=noreturn{{$}}
@@ -48,6 +48,7 @@ func method(){}
 // KEYWORD2-NEXT:             Keyword/None:                       discardableResult[#Func Attribute#]; name=discardableResult
 // SWIFT_ENABLE_TENSORFLOW
 // KEYWORD2-NEXT:             Keyword/None:                       differentiable[#Func Attribute#]; name=differentiable
+// KEYWORD2-NEXT:             Keyword/None:                       differentiating[#Func Attribute#]; name=differentiating
 // KEYWORD2-NEXT:             Keyword/None:                       compilerEvaluable[#Func Attribute#]; name=compilerEvaluable
 // KEYWORD2-NEXT:             Keyword/None:                       TensorFlowGraph[#Func Attribute#]; name=TensorFlowGraph
 // KEYWORD2-NEXT:             End completions
@@ -92,7 +93,7 @@ struct S{}
 @#^KEYWORD_LAST^#
 
 // SWIFT_ENABLE_TENSORFLOW
-// KEYWORD_LAST:                  Begin completions, 27 items
+// KEYWORD_LAST:                  Begin completions, 28 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       dynamicCallable[#Declaration Attribute#]; name=dynamicCallable
@@ -117,6 +118,7 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
 // SWIFT_ENABLE_TENSORFLOW
 // KEYWORD_LAST-NEXT:             Keyword/None:                       differentiable[#Declaration Attribute#]; name=differentiable
+// KEYWORD_LAST-NEXT:             Keyword/None:                       differentiating[#Declaration Attribute#]; name=differentiating
 // KEYWORD_LAST-NEXT:             Keyword/None:                       compilerEvaluable[#Declaration Attribute#]; name=compilerEvaluable
 // KEYWORD_LAST-NEXT:             Keyword/None:                       TensorFlowGraph[#Declaration Attribute#]; name=TensorFlowGraph
 // KEYWORD_LAST-NEXT:             Keyword/None:                       TFParameter[#Declaration Attribute#]; name=TFParameter

--- a/test/Sema/struct_vector_numeric.swift
+++ b/test/Sema/struct_vector_numeric.swift
@@ -67,6 +67,8 @@ func testGenericContext<T, U, V>() -> A<T>.B<U, V>.GenericContextNested {
 
 // Test errors.
 
+struct Empty : VectorNumeric {} // expected-error {{type 'Empty' does not conform to protocol 'VectorNumeric'}}
+
 // Test type whose members conform to `VectorNumeric`
 // but have different `Scalar` associated type.
 struct InvalidMixedScalar: VectorNumeric { // expected-error {{type 'InvalidMixedScalar' does not conform to protocol 'VectorNumeric'}}


### PR DESCRIPTION
The `@differentiating` attribute retroactively registers functions as
derivatives of other functions. It is declared on derivative functions
(JVPs and VJPs) and specifies the original function name.

This patch adds parsing/type-checking/serialization for `@differentiating`
attribute. Next steps are to add SIL support (SILGen and differentiation transform).