### PR TITLE
[Autodiff] Add error messages for differentiation initiated by SILDifferentiableAttr.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -402,6 +402,8 @@ NOTE(autodiff_value_defined_here,none,
      "value defined here", ())
 NOTE(autodiff_when_differentiating_function_call,none,
      "when differentiating this function call", ())
+NOTE(autodiff_when_differentiating_function_definition,none,
+     "when differentiating this function definition", ())
 NOTE(autodiff_expression_is_not_differentiable,none,
      "expression is not differentiable", ())
 NOTE(autodiff_nested_function_call_multiple_return_active,none,

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -115,3 +115,30 @@ func if_else(_ x: Float, _ flag: Bool) -> Float {
 _ = gradient(at: 0) { x in if_else(0, true) }
 
 #endif
+
+//===----------------------------------------------------------------------===//
+// @differentiable attributes
+//===----------------------------------------------------------------------===//
+var a: Float = 3.0
+protocol P {
+  @differentiable
+  func foo(x: Float) -> Float
+}
+
+enum T : P {
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-error @+1 {{function is not differentiable}}
+  @differentiable func foo(x: Float) -> Float {
+    // expected-note @+1 {{cannot differentiate writes to global variables}}
+    a = a + x
+    return a
+  }
+}
+
+// expected-note @+2 {{when differentiating this function definition}}
+// expected-error @+1 {{function is not differentiable}}
+@differentiable func foo(x: Float) -> Float {
+  // expected-note @+1 {{cannot differentiate writes to global variables}}
+  a = a + x
+  return a
+}


### PR DESCRIPTION
This should be a resolution for: SR-9788

Here is an example of the error that is added (fallback is no-highlight):

```
diff_proto_problem.swift:29:2: error: function is not differentiable
@differentiable func foo(x: Float) -> Float {
 ^                   ~~~
```