### PR TITLE
[5.0][TypeChecker] Drop @autoclosure attribute from invalid parameters

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -489,6 +489,10 @@ mapParsedParameters(Parser &parser,
       // belongs to both type flags and declaration.
       if (auto *ATR = dyn_cast<AttributedTypeRepr>(type)) {
         auto &attrs = ATR->getAttrs();
+        // At this point we actually don't know if that's valid to mark
+        // this parameter declaration as `autoclosure` because type has
+        // not been resolved yet - it should either be a function type
+        // or typealias with underlying function type.
         param->setAutoClosure(attrs.has(TypeAttrKind::TAK_autoclosure));
       }
     } else if (paramContext != Parser::ParameterContextKind::Closure) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -773,6 +773,13 @@ static bool validateParameterType(ParamDecl *decl, TypeResolution resolution,
     }
   }
 
+  // If this parameter declaration is marked as `@autoclosure`
+  // let's make sure that its parameter type is indeed a function,
+  // this decision couldn't be made based on type representative
+  // alone because it may be later resolved into an invalid type.
+  if (decl->isAutoClosure())
+    hadError |= !(Ty && Ty->is<FunctionType>());
+
   if (hadError)
     TL.setInvalidType(TC.Context);
 

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -234,3 +234,16 @@ func rdar_30906031(in arr: [Int], fn: @autoclosure () -> Int) -> Bool {
     arr.lazy.filter { $0 >= escapableF() }.isEmpty
   }
 }
+
+func rdar_47586626() {
+  struct S {}
+  typealias F = () -> S
+
+  func foo(_: @autoclosure S) {} // expected-error {{@autoclosure attribute only applies to function types}}
+  func bar(_: @autoclosure F) {} // expected-error {{@autoclosure attribute only applies to function types}}
+
+  let s = S()
+
+  foo(s) // ok
+  bar(s) // ok
+}


### PR DESCRIPTION
While forming/validating parameters make sure that the type is indeed
a function type before marking it as `autoclosure` based on type
representative attributes, because parser doesn't change attributes
even after the error has been found and diagnosed.

Resolves: rdar://problem/47586626
(cherry picked from commit 9da67c1897893e5885df56642510a6b4e2071e64)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
