### PR TITLE
[sil] Ban passing trivial values to copy_value, destroy_value.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1068,12 +1068,18 @@ public:
   }
 
   CopyValueInst *createCopyValue(SILLocation Loc, SILValue operand) {
+    assert(!operand->getType().isTrivial(getModule()) &&
+           "Should not be passing trivial values to this api. Use instead "
+           "emitCopyValueOperation");
     return insert(new (getModule())
                       CopyValueInst(getSILDebugLocation(Loc), operand));
   }
 
   DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand) {
     assert(isLoadableOrOpaque(operand->getType()));
+    assert(!operand->getType().isTrivial(getModule()) &&
+           "Should not be passing trivial values to this api. Use instead "
+           "emitDestroyValueOperation");
     return insert(new (getModule())
                       DestroyValueInst(getSILDebugLocation(Loc), operand));
   }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1936,6 +1936,8 @@ public:
   void checkCopyValueInst(CopyValueInst *I) {
     require(I->getOperand()->getType().isObject(),
             "Source value should be an object value");
+    require(!I->getOperand()->getType().isTrivial(I->getModule()),
+            "Source value should be non-trivial");
     require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
             "copy_value is only valid in functions with qualified "
             "ownership");
@@ -1944,6 +1946,8 @@ public:
   void checkDestroyValueInst(DestroyValueInst *I) {
     require(I->getOperand()->getType().isObject(),
             "Source value should be an object value");
+    require(!I->getOperand()->getType().isTrivial(I->getModule()),
+            "Source value should be non-trivial");
     require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
             "destroy_value is only valid in functions with qualified "
             "ownership");

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -362,7 +362,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     if (VD->isSettable(VD->getDeclContext())) {
       auto addr = SGF.emitTemporaryAllocation(VD, ty);
       // We have created a copy that needs to be destroyed.
-      val = SGF.B.createCopyValue(Loc, val);
+      val = SGF.B.emitCopyValueOperation(Loc, val);
       NeedToDestroyValueAtExit = true;
       lowering.emitStore(SGF.B, VD, val, addr, StoreOwnershipQualifier::Init);
       val = addr;

--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -16,17 +16,6 @@ struct Foo {
   var t3 : Builtin.Int32
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @trivial_arg(
-// CHECK-NEXT: entry
-// CHECK-NEXT: ret void
-sil [ossa] @trivial_arg : $@convention(thin) (Builtin.Int32) -> () {
-bb0(%0 : $Builtin.Int32):
-  %1 = copy_value %0 : $Builtin.Int32
-  destroy_value %1 : $Builtin.Int32
-  %2 = tuple()
-  return %2 : $()
-}
-
 // CHECK: define{{( protected)?}} swiftcc void @non_trivial(
 // CHECK: [[GEP1:%.*]] = getelementptr inbounds %T019copy_value_destroy_B03FooV, %T019copy_value_destroy_B03FooV* %1, i32 0, i32 2
 // CHECK-NEXT: [[VAL1:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP1]], align 8

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -842,3 +842,11 @@ func rdar37790062() {
   // CHECK: function_ref @$s8closures12rdar37790062yyF1SL_VyADyxGxyXE_xyXEtcfC
   _ = S({ faz(C2()) }, { bar() })
 }
+
+// Make sure that if we capture a trivial value, we do not try to copy it. This
+// violates SIL invariants and the SILVerifier will explode as such.
+func closeOverStructDontCopyTrivial() {
+  let a : StructWithMutatingMethod
+  a = StructWithMutatingMethod()
+  takeClosure { a.x }
+}

--- a/test/SILOptimizer/funcsig_opaque.sil
+++ b/test/SILOptimizer/funcsig_opaque.sil
@@ -7,7 +7,7 @@ struct R<T> {
 }
 
 struct S {
-  var val: Builtin.Int32
+  var val: Builtin.NativeObject
 }
 
 sil @testAggregateArgHelper : $@convention(thin) (@owned R<S>) -> ()


### PR DESCRIPTION
I also fixed a small violation in SILGenProlog/added a test for it.
