### PR TITLE
[Typechecker] Fix an issue with @escaping when used with a generic function

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2148,6 +2148,13 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   if (!ty) ty = resolveType(repr, instanceOptions);
   if (!ty || ty->hasError()) return ty;
 
+  // Type aliases inside protocols are not yet resolved in the structural
+  // stage of type resolution
+  if (ty->is<DependentMemberType>() &&
+      resolution.getStage() == TypeResolutionStage::Structural) {
+    return ty;
+  }
+
   // Handle @escaping
   if (hasFunctionAttr && ty->is<FunctionType>()) {
     if (attrs.has(TAK_escaping)) {

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -217,3 +217,16 @@ class HasIVarCaptures {
     })()
   }
 }
+
+// https://bugs.swift.org/browse/SR-9760
+protocol SR_9760 {
+  typealias F = () -> Void
+  typealias G<T> = (T) -> Void
+  func foo<T>(_: T, _: @escaping F) // Ok
+  func bar<T>(_: @escaping G<T>) // Ok
+}
+
+extension SR_9760 {
+  func fiz<T>(_: T, _: @escaping F) {} // Ok
+  func baz<T>(_: @escaping G<T>) {} // Ok
+}


### PR DESCRIPTION
This PR resolves an issue where using a type alias as an argument to @escaping on a generic function inside a protocol would trigger an error diagnostic. This is a regression in Swift 5.0, which is now fixed.

```swift
public protocol FooProtocol {
  typealias CompletionHandler = (Int) -> ()
  func doSomething<T>(with thing: T, then: @escaping CompletionHandler) // ok
}
```
Resolves [SR-9760](https://bugs.swift.org/browse/SR-9760).
Resolves rdar://problem/47550733
