### PR TITLE
test: fix some IRGen tests on Windows

### DIFF
--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -140,8 +140,8 @@ entry:
 // CHECK-32:[[ALIGNMASK:%.*]] = and i32 [[FLAGS]], 255
 // CHECK-16:[[T0:%.*]] = trunc i32 [[FLAGS]] to i16
 // CHECK-16:[[ALIGNMASK:%.*]] = and i16 [[T0]], 255
-// CHECK:   [[HEADERSIZEPLUSALIGN:%.*]] = add {{(i64 16|i32 8)}}, [[ALIGNMASK]]
-// CHECK:   [[NOTALIGNMASK:%.*]] = xor {{(i64|i32)}} [[ALIGNMASK]], -1
+// CHECK-DAG:   [[HEADERSIZEPLUSALIGN:%.*]] = add {{(i64 16|i32 8)}}, [[ALIGNMASK]]
+// CHECK-DAG:   [[NOTALIGNMASK:%.*]] = xor {{(i64|i32)}} [[ALIGNMASK]], -1
 // CHECK:   [[ALIGNEDSTART:%.*]] = and {{(i64|i32)}} [[HEADERSIZEPLUSALIGN]], [[NOTALIGNMASK]]
 // CHECK:   [[HEAPSIZE:%.*]] = add {{(i64|i32)}} [[ALIGNEDSTART]], [[SIZE]]
 // CHECK:   [[ALIGNMASK_ATLEASTPOINTER:%.*]] = or {{(i64|i32)}} [[ALIGNMASK]], {{(7|3)}}
@@ -187,8 +187,8 @@ bb0(%0 : $*Existential):
 // CHECK-32:[[ALIGNMASK:%.*]] = and i32 [[FLAGS]], 255
 // CHECK-16:[[T0:%.*]] = trunc i32 [[FLAGS]] to i16
 // CHECK-16:[[ALIGNMASK:%.*]] = and i16 [[T0]], 255
-// CHECK:   [[HEADERSIZEPLUSALIGN:%.*]] = add {{(i64 16|i32 8)}}, [[ALIGNMASK]]
-// CHECK:   [[NOTALIGNMASK:%.*]] = xor {{(i64|i32)}} [[ALIGNMASK]], -1
+// CHECK-DAG:   [[HEADERSIZEPLUSALIGN:%.*]] = add {{(i64 16|i32 8)}}, [[ALIGNMASK]]
+// CHECK-DAG:   [[NOTALIGNMASK:%.*]] = xor {{(i64|i32)}} [[ALIGNMASK]], -1
 // CHECK:   [[ALIGNEDSTART:%.*]] = and {{(i64|i32)}} [[HEADERSIZEPLUSALIGN]], [[NOTALIGNMASK]]
 // CHECK:   [[HEAPOBJ:%.*]] = bitcast %swift.refcounted* %9 to i8*
 // CHECK:   [[STARTOFVALUE:%.*]] = getelementptr inbounds i8, i8* [[HEAPOBJ]], {{(i64|i32)}} [[ALIGNEDSTART]]
@@ -321,8 +321,8 @@ bb0(%0 : $*Existential):
 // CHECK:   br i1 [[ISINLINE]], label %match-inline, label %match-outline
 //
 // CHECK: match-inline:
-// CHECK:   [[DEST_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
-// CHECK:   [[SRC_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[DEST_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[SRC_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.opaque*
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[DEST_TYPE]] to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -367,8 +367,8 @@ bb0(%0 : $*Existential):
 // CHECK:   br i1 [[DEST_ISINLINE]], label %dest-inline, label %dest-outline
 //
 // CHECK: dest-inline:
-// CHECK:   [[TMPBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[TMPBUFFER]] to %swift.opaque*
-// CHECK:   [[DESTBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[TMPBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[TMPBUFFER]] to %swift.opaque*
+// CHECK-DAG:   [[DESTBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[DEST_TYPE]] to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -379,8 +379,8 @@ bb0(%0 : $*Existential):
 // CHECK:   br i1 [[SRC_ISINLINE]], label %dest-inline-src-inline, label %dest-inline-src-outline
 //
 // CHECK: dest-inline-src-inline:
-// CHECK:   [[DESTBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
-// CHECK:   [[SRCBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[DESTBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[SRCBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.opaque*
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[SRC_TYPE]] to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -415,8 +415,8 @@ bb0(%0 : $*Existential):
 // CHECK:   br i1 [[SRC_ISINLINE]], label %dest-outline-src-inline, label %dest-outline-src-outline
 //
 // CHECK: dest-outline-src-inline:
-// CHECK:   [[DESTBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
-// CHECK:   [[SRCBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[DESTBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.opaque*
+// CHECK-DAG:   [[SRCBUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.opaque*
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[SRC_TYPE]] to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]

--- a/test/IRGen/ivar_destroyer.sil
+++ b/test/IRGen/ivar_destroyer.sil
@@ -10,7 +10,7 @@
 // CHECK-SAME:    i8* null,
 // CHECK-SAME:    i8** {{@"\$sBoWV"|null}},
 // CHECK-SAME:    i64 ptrtoint ([[OBJCCLASS]]* @"$s14ivar_destroyer17NonTrivialDerivedCMm" to i64),
-// CHECK-SAME:    [[TYPE]]* bitcast (i64* getelementptr inbounds (<{ {{.*}} }>, <{ {{.*}} }>* @"$s14ivar_destroyer11TrivialBaseCMf", i32 0, i32 2) to [[TYPE]]*),
+// CHECK-SAME:    [[TYPE]]* {{null|bitcast (i64* getelementptr inbounds (<{ .* }>, <{ .* }>* @"$s14ivar_destroyer11TrivialBaseCMf", i32 0, i32 2) to [[TYPE]]*)}},
 // CHECK-SAME:    [[OPAQUE]]* @_objc_empty_cache,
 // CHECK-SAME:    [[OPAQUE]]* null,
 // CHECK-SAME:    i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC14ivar_destroyer17NonTrivialDerived to i64), i64 {{1|2}}),
@@ -24,7 +24,7 @@
 // CHECK-SAME:    <{ {{.*}} }>* @"$s14ivar_destroyer17NonTrivialDerivedCMn"
 // CHECK-SAME:    void (%T14ivar_destroyer17NonTrivialDerivedC*)* @"$s14ivar_destroyer17NonTrivialDerivedCfE",
 // CHECK-SAME:    %T14ivar_destroyer17NonTrivialDerivedC* ([[TYPE]]*)* @alloc_NonTrivialDerived
-// CHECK-SAME:    i64 16
+// CHECK-SAME:    i64 {{0|16}}
 // CHECK-SAME:  }>
 
 class Pachyderm {}

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -24,7 +24,7 @@ public struct S2 {
 // CHECK: %T18static_initializer1SV = type <{ %Ts5Int32V }>
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems0c = type { [1 x i64], %T18static_initializer16TestArrayStorageC_tailelems0 }
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems0 = type <{ %swift.refcounted, %Ts5Int32V, [4 x i8], %Ts5Int64V, %Ts5Int64V }>
-// CHECK: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [2 x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
+// CHECK: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [{{2|1}} x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems1 = type <{ %swift.refcounted, %Ts5Int32V, [12 x i8], %Ts7Float80V }>
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems3 = type <{ %swift.refcounted, %Ts5Int32V, [1 x i8], [1 x i8] }>
 

--- a/test/IRGen/weak_import_native.sil
+++ b/test/IRGen/weak_import_native.sil
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage canonical
 
 // CHECK-DAG: define{{( protected)?}} swiftcc void @weakButDefined() {{#[0-9]+}} {

--- a/test/IRGen/weak_import_native.swift
+++ b/test/IRGen/weak_import_native.swift
@@ -3,6 +3,8 @@
 //
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: OS=windows-msvc
+
 import weak_import_native_helper
 
 // CHECK-DAG-LABEL: @"$s25weak_import_native_helper23ProtocolWithWeakMembersP1TAC_AA05OtherE0Tn" = extern_weak global %swift.protocol_requirement


### PR DESCRIPTION
weak_import is not a semantic that is available on PE/COFF, disable the
tests.  Adjust the tests for the Windows object layout.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
