### PR TITLE
[AutoDiff] Fix `partial_apply` substitution map logic.

### DIFF
--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -25,16 +25,16 @@ ModelADTests.testAllBackends("SimpleLayerAD") {
 
 ModelADTests.testAllBackends("XORTraining") {
   struct Classifier: Layer {
-      var l1, l2: Dense<Float>
-      init(hiddenSize: Int) {
-          l1 = Dense<Float>(inputSize: 2, outputSize: hiddenSize, activation: relu)
-          l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
-      }
-      @differentiable(wrt: (self, input))
-      func applied(to input: Tensor<Float>) -> Tensor<Float> {
-          let h1 = l1.applied(to: input)
-          return l2.applied(to: h1)
-      }
+    var l1, l2: Dense<Float>
+    init(hiddenSize: Int) {
+        l1 = Dense<Float>(inputSize: 2, outputSize: hiddenSize, activation: relu)
+        l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+    }
+    @differentiable(wrt: (self, input))
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        let h1 = l1.applied(to: input)
+        return l2.applied(to: h1)
+    }
   }
   var classifier = Classifier(hiddenSize: 4)
   let optimizer = SGD<Classifier, Float>()


### PR DESCRIPTION
Propagate derivative's substitution map in `reapplyFunctionConversion` for
`partial_apply` instructions. When reapplying a `partial_apply` instruction,
the associated derivative function's substitution map should be used, not
the original function's. This is because the derivative function may have
more generic requirements than the original function.

Revamp `test/TensorFlowRuntime/model_autodiff_runtime.swift` to use imported
TensorFlow high-level APIs (layers and optimizers).
This file acts as CI for `tensorflow-swift-apis`.

Resolves [SR-9799](https://bugs.swift.org/browse/SR-9799). Exposes a new crasher: [SR-9806](https://bugs.swift.org/browse/SR-9806).