### PR TITLE
[AutoDiff] AD reference counting hotfix.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2938,6 +2938,9 @@ public:
     auto adjParamArgs = getAdjoint().getArgumentsWithoutIndirectResults();
     seed = adjParamArgs[0];
     primalValueAggregateInAdj = adjParamArgs[1];
+    // NOTE: Retaining `seed` below is a temporary hotfix for SR-9804.
+    builder.setInsertionPoint(adjointEntry);
+    builder.createRetainValue(adjLoc, seed, builder.getDefaultAtomicity());
 
     // Assign adjoint to the return value.
     //   y = tuple (y0, ..., yn)

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -147,7 +147,14 @@ TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {
     return foo(foo(x))
   }
   let pb = pullback(at: Tensor(Float(10)), in: body)
-  expectEqual(Tensor(1.0), pb(Tensor(1)))
+  expectEqual(Tensor(1), pb(Tensor(1)))
+}
+
+TensorADTests.testAllBackends("SR-9804: AD refcounting") {
+  func f(_ x: Tensor<Float>) -> Tensor<Float> {
+    return x
+  }
+  expectEqual(Tensor(1), gradient(at: Tensor(0), in: f))
 }
 
 let cube: (Tensor<Float>) -> Tensor<Float> = { $0 * $0 * $0 }


### PR DESCRIPTION
Hotfix for [SR-9804](https://bugs.swift.org/browse/SR-9804) that unconditionally retains `seed`.
Note that this hotfix was not sufficient for undoing the `NO_ADJOINT(RetainValue)` hack.
[Some tests fail](https://gist.github.com/dan-zheng/bed409c19329b785d78573aff28bc30d) if `NO_ADJOINT(RetainValue)` is removed and `REFCOUNTING_ADJOINT(RetainValue, ReleaseValue)` is uncommentted.

[A more principled fix (changing `AdjointValue` to behave like `ManagedValue`)](https://bugs.swift.org/browse/SR-9804?focusedCommentId=43145&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-43145) is coming soon.

Temporarily resolves [SR-9804](https://bugs.swift.org/browse/SR-9804).