### PR TITLE
[5.0][ConstraintSystem] Skip literal protocols without default types from …

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar47266563.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar47266563.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+print(true ? "readline" : nil)


### PR DESCRIPTION
…minimalization

After collecting possible conformances and types for each argument,
`ArgumentInfoCollector` attempts literal protocol minimalization
to reduce the set of possible types argument could assume. Let's
exclude literal protocols without default types like
`ExpressibleByNilLiteral` from consideration by that algorithm.

Resolves: rdar://problem/47266563
(cherry picked from commit e26fc1efff7315adaaa4fcb97aea4d60aaafcb66)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
