### PR TITLE
[Sema] Fix `Differentiable` derived conformances crasher.

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -159,9 +159,7 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
       C.getLazyResolver()->resolveDeclSignature(v);
     if (!v->getType())
       return false;
-    auto declType = v->getType()->hasArchetype()
-        ? v->getType()
-        : DC->mapTypeIntoContext(v->getType());
+    auto declType = DC->mapTypeIntoContext(v->getType());
     return (bool)TypeChecker::conformsToProtocol(declType, addArithProto, DC,
                                                  ConformanceCheckFlags::Used);
   });

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -1,5 +1,5 @@
 // SWIFT_ENABLE_TENSORFLOW
-// RUN: %target-swift-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown %s
 
 // Verify that a `Differentiable` type upholds `AllDifferentiableVariables == CotangentVector`.
 func assertAllDifferentiableVariablesEqualsCotangentVector<T>(_: T.Type)
@@ -183,7 +183,6 @@ struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differen
   var x: Float
 }
 
-/*
 // Test type with generic members that conform to `Differentiable`.
 // Since it's not the case that
 // `T == T.TangentVector == T.CotangentVector`,
@@ -219,7 +218,6 @@ struct A<T : Differentiable> {
     }
   }
 }
-*/
 
 // Test errors.
 


### PR DESCRIPTION
Previously, `getUnderlyingAllDiffableVariables` called `ProtocolConformance::getConcrete()`
unconditionally, assuming that the `ProtocolConformance` is concrete. However, the
conformance may be abstract (for generic type parameter types, for instance).

Check whether conformance is concrete before calling `getConcrete`. Tidy up related code.

Enable `-verify-ignore-unknown` for `test/Sema/struct_differentiable.swift` to verify
generics don't trigger crashes. (Note that `Differentiable` derived conformances still
don't work with generics due to [SR-9595](https://bugs.swift.org/browse/SR-9595).)