### PR TITLE
[Sema] Prune and update `@differentiable` attribute diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2709,7 +2709,7 @@ ERROR(differentiable_attr_specified_not_function,none,
       "%0 is not a function to be used as associated differentiation function",
       (DeclName))
 ERROR(differentiable_attr_ambiguous_function_identifier,none,
-      "ambiguous or overloaded identifier %0 cannot be used in @differentiable "
+      "ambiguous or overloaded identifier %0 cannot be used in '@differentiable' "
       "attribute", (DeclName))
 ERROR(differentiable_attr_invalid_access,none,
       "associated differentiation function %0 is required to either be public "
@@ -2722,15 +2722,11 @@ ERROR(differentiable_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
 ERROR(differentiable_attr_empty_where_clause,none,
-      "empty 'where' clause in @differentiable attribute", ())
+      "empty 'where' clause in '@differentiable' attribute", ())
 ERROR(differentiable_attr_nongeneric_trailing_where,none,
-      "trailing 'where' clause in @differentiable attribute of non-generic function %0", (DeclName))
-ERROR(differentiable_attr_only_generic_param_req,none,
-      "only requirements on generic parameters are supported by @differentiable attribute", ())
-ERROR(differentiable_attr_non_protocol_type_constraint_req,none,
-      "only conformances to protocol types are supported by @differentiable attribute", ())
+      "trailing 'where' clause in '@differentiable' attribute of non-generic function %0", (DeclName))
 ERROR(differentiable_attr_unsupported_req_kind,none,
-      "layout requirement are not supported by @differentiable attribute", ())
+      "layout requirement are not supported by '@differentiable' attribute", ())
 
 // @differentiang
 ERROR(differentiating_attr_expected_result_tuple,none,

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -85,6 +85,18 @@ func jvpNonDiffResult2(x: Float) -> (Float, Int) {
   return (x, Int(x))
 }
 
+// expected-error @+1 {{ambiguous or overloaded identifier 'jvpAmbiguousVJP' cannot be used in '@differentiable' attribute}}
+@differentiable(jvp: jvpAmbiguousVJP)
+func jvpAmbiguous(x: Float) -> Float {
+  return x
+}
+func jvpAmbiguousVJP(_ x: Float) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+func jvpAmbiguousVJP(x: Float) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+
 struct JVPStruct {
   let p: Float
 
@@ -342,6 +354,19 @@ extension VJPStruct {
   }
 }
 
+// expected-error @+2 {{empty 'where' clause in '@differentiable' attribute}}
+// expected-error @+1 {{expected type}}
+@differentiable(where)
+func emptyWhereClause<T>(x: T) -> T {
+  return x
+}
+
+// expected-error @+1 {{trailing 'where' clause in '@differentiable' attribute of non-generic function 'nongenericWhereClause(x:)'}}
+@differentiable(where T : Differentiable)
+func nongenericWhereClause(x: Float) -> Float {
+  return x
+}
+
 @differentiable(jvp: jvpWhere1, vjp: vjpWhere1 where T : Differentiable)
 func where1<T>(x: T) -> T {
   return x
@@ -411,7 +436,7 @@ func invalidRequirementConformance<Scalar>(x: Scalar) -> Scalar {
 }
 
 // expected-error @+2 {{layout constraints are only allowed inside '_specialize' attributes}}
-// expected-error @+1 {{empty 'where' clause in @differentiable attribute}}
+// expected-error @+1 {{empty 'where' clause in '@differentiable' attribute}}
 @differentiable(where Scalar : _Trivial)
 func invalidRequirementLayout<Scalar>(x: Scalar) -> Scalar {
   return x


### PR DESCRIPTION
Prune some unused `@differentiable` diagnostics.
Add tests for diagnostics that are used but don't have tests.

Attribute names should be single-quoted in user-facing diagnostics.
Follows from https://github.com/apple/swift/pull/22225, which uses single quotes around `@differentiating` in diagnostics.