### PR TITLE
IRGen: Don't emit debug info for dependent member types

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -179,8 +179,7 @@ public:
                                      bool IsLocalToUnit, bool InFixedBuffer,
                                      Optional<SILLocation> Loc);
   void emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,
-                        unsigned Depth, unsigned Index, StringRef ArchetypeName,
-                        StringRef AssocType);
+                        unsigned Depth, unsigned Index, StringRef Name);
 
   /// Return the DIBuilder.
   llvm::DIBuilder &getBuilder() { return DBuilder; }
@@ -2256,8 +2255,7 @@ void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
 void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
                                           llvm::Value *Metadata, unsigned Depth,
                                           unsigned Index,
-                                          StringRef ArchetypeName,
-                                          StringRef AssocType) {
+                                          StringRef Name) {
   if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::LineTables)
     return;
 
@@ -2269,9 +2267,9 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
   llvm::SmallString<8> Buf;
   static const char *Tau = u8"\u03C4";
   llvm::raw_svector_ostream OS(Buf);
-  OS << '$' << Tau << '_' << Depth << '_' << Index << AssocType;
+  OS << '$' << Tau << '_' << Depth << '_' << Index;
   auto DbgTy = DebugTypeInfo::getArchetype(
-      getMetadataType(ArchetypeName)->getDeclaredInterfaceType().getPointer(),
+      getMetadataType(Name)->getDeclaredInterfaceType().getPointer(),
       Metadata->getType(), Size(CI.getTargetInfo().getPointerWidth(0)),
       Alignment(CI.getTargetInfo().getPointerAlign(0)));
   emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
@@ -2394,10 +2392,9 @@ void IRGenDebugInfo::emitGlobalVariableDeclaration(
 
 void IRGenDebugInfo::emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,
                                       unsigned Depth, unsigned Index,
-                                      StringRef ArchetypeName,
-                                      StringRef AssocType) {
+                                      StringRef Name) {
   static_cast<IRGenDebugInfoImpl *>(this)->emitTypeMetadata(
-    IGF, Metadata, Depth, Index, ArchetypeName, AssocType);
+    IGF, Metadata, Depth, Index, Name);
 }
 
 llvm::DIBuilder &IRGenDebugInfo::getBuilder() {

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -149,8 +149,7 @@ public:
 
   /// Emit debug metadata for type metadata (for generic types). So meta.
   void emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,
-                        unsigned Depth, unsigned Index, StringRef ArchetypeName,
-                        StringRef AssocType);
+                        unsigned Depth, unsigned Index, StringRef Name);
 
   /// Return the DIBuilder.
   llvm::DIBuilder &getBuilder();

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -332,17 +332,17 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
   if (key.Kind != LocalTypeDataKind::forFormalTypeMetadata())
     return;
 
-  // Only for archetypes, and not for opened archetypes.
-  auto type = dyn_cast<ArchetypeType>(key.Type);
+  // Only for primary archetypes.
+  auto type = dyn_cast<PrimaryArchetypeType>(key.Type);
   if (!type)
     return;
-  if (isa<OpenedArchetypeType>(type))
-    return;
+
+  auto *typeParam = type->getInterfaceType()->castTo<GenericTypeParamType>();
+  auto name = typeParam->getName().str();
 
   llvm::Value *data = value.getMetadata();
 
   // At -O0, create an alloca to keep the type alive.
-  auto name = type->getFullName();
   if (!IGF.IGM.IRGen.Opts.shouldOptimize()) {
     auto alloca =
         IGF.createAlloca(data->getType(), IGF.IGM.getPointerAlignment(), name);
@@ -354,19 +354,10 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
   if (!IGF.IGM.DebugInfo)
     return;
 
-  // Emit debug info for the metadata.
-  llvm::SmallString<8> AssocType;
-  auto *oocTy = type->mapTypeOutOfContext().getPointer();
-  {
-    llvm::raw_svector_ostream OS(AssocType);
-    while (auto *dependentMemberType = dyn_cast<DependentMemberType>(oocTy)) {
-      OS << '.' << dependentMemberType->getName();
-      oocTy = dependentMemberType->getBase().getPointer();
-    }
-  }
-  auto *typeParam = cast<GenericTypeParamType>(oocTy);
-  IGF.IGM.DebugInfo->emitTypeMetadata(IGF, data, typeParam->getDepth(),
-                                      typeParam->getIndex(), name, AssocType);
+  IGF.IGM.DebugInfo->emitTypeMetadata(IGF, data,
+                                      typeParam->getDepth(),
+                                      typeParam->getIndex(),
+                                      name);
 }
 
 void

--- a/test/DebugInfo/inlined-generics.swift
+++ b/test/DebugInfo/inlined-generics.swift
@@ -12,11 +12,11 @@ func foo1<T:P>(_ t: T, _ dt: T.DT1) -> T.DT1 {
 
 // CHECK: define {{.*}}@"$s4main4foo2yyxAA1PRzlF"
 public func foo2<S:P>(_ s: S) {
-  // CHECK: call void @llvm.dbg.value(metadata %swift.type* %S.DT1,
+  // CHECK: call void @llvm.dbg.value(metadata %swift.type* %S,
   // CHECK-SAME:                     metadata ![[META:[0-9]+]]
   foo1(s, s.getDT())
-  // T.DT1 should get substituted with S.DT1.
-  // CHECK: ![[META]] = !DILocalVariable(name: "$\CF\84_0_0.DT1"
+  // T should get substituted with S
+  // CHECK: ![[META]] = !DILocalVariable(name: "$\CF\84_0_0"
 }
 
 

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -77,14 +77,12 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 //         Note that we actually look things up in T, which is going to prove unfortunate.
 // CHECK: [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.Runcible, %swift.type* %T, %swift.protocol_requirement* getelementptr{{.*}}i32 12), i32 -1), %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types8RuncibleMp", i32 0, i32 14)) [[NOUNWIND_READNONE:#.*]]
 // CHECK-NEXT: %T.RuncerType = extractvalue %swift.metadata_response [[T2]], 0
-// CHECK-NEXT: store %swift.type*
 //   2. Get the witness table for U.RuncerType.Runcee : Speedy
 //     2a. Get the protocol witness table for U.RuncerType : FastRuncer.
 // CHECK-NEXT: %T.RuncerType.FastRuncer = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %U.FastRuncible, %swift.type* %U, %swift.type* %T.RuncerType
 //     1c. Get the type metadata for U.RuncerType.Runcee.
 // CHECK-NEXT: [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, {{.*}}, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types10FastRuncerMp", i32 0, i32 10))
 // CHECK-NEXT: %T.RuncerType.Runcee = extractvalue %swift.metadata_response [[T2]], 0
-// CHECK-NEXT: store %swift.type*
 //     2b. Get the witness table for U.RuncerType.Runcee : Speedy.
 // CHECK-NEXT: %T.RuncerType.Runcee.Speedy = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, %swift.type* %T.RuncerType.Runcee
 //   3. Perform the actual call.

--- a/test/SILGen/weak_linked_attribute.swift
+++ b/test/SILGen/weak_linked_attribute.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// CHECK-LABEL: sil [_weakLinked] [ossa] @$s21weak_linked_attribute0A8FunctionyyF : $@convention(thin) () -> ()
+@_weakLinked public func weakFunction() {}


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift-lldb/pull/1259.