### PR TITLE
[5.0][CSDiagnostics] NFC: Fallback diagnostic shouldn't ask for the project

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2824,7 +2824,7 @@ ERROR(specific_type_of_expression_is_ambiguous,none,
 
 ERROR(failed_to_produce_diagnostic,Fatal,
       "failed to produce diagnostic for expression; "
-      "please file a bug report with your project", ())
+      "please file a bug report", ())
 
 
 ERROR(missing_protocol,none,

--- a/test/Sema/rdar38885760.swift
+++ b/test/Sema/rdar38885760.swift
@@ -3,7 +3,7 @@
 // RUN: not %target-swift-frontend -typecheck %s -parse-stdlib 2>%t/fallback_diagnostic.txt
 // RUN: %FileCheck %s --check-prefix FALLBACK-DIAGNOSTIC <%t/fallback_diagnostic.txt
 //
-// FALLBACK-DIAGNOSTIC: error: failed to produce diagnostic for expression; please file a bug report with your project
+// FALLBACK-DIAGNOSTIC: error: failed to produce diagnostic for expression; please file a bug report
 
 import Swift
 


### PR DESCRIPTION
(cherry picked from commit 52024681e0d6cbfb25f3c2d03407717f7e2c1ced)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
