### PR TITLE
build: attempt to repair Windows debug builds

### DIFF
--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -9,3 +9,19 @@ add_swift_target_library(swiftSwiftOnoneSupport ${SWIFT_STDLIB_LIBRARY_BUILD_TYP
   SWIFT_COMPILE_FLAGS "-parse-stdlib" "-Xllvm" "-sil-inline-generics=false" "-Xfrontend" "-validate-tbd-against-ir=none" "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)
+if(CMAKE_BUILD_TYPE STREQUAL Debug AND WINDOWS IN_LIST SWIFT_SDKS)
+  # When building in Debug mode, the standard library provides the symbols that
+  # we need and as such SwiftOnoneSupport does not need to provide any exported
+  # interfaces.  This results in the import library beinging elided.  However,
+  # we explicitly link against the SwiftOnoneSupport library when building
+  # programs in Debug mode, and need the import library to be generated even if
+  # nothing is exported.  Because we will still generate the DLL, create an
+  # empty import library.
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport.def
+    "LIBRARY SwiftOnoneSupport\n"
+    "EXPORTS")
+  foreach(architecture ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
+    target_sources(swiftSwiftOnoneSupport-windows-${architecture} PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport.def)
+  endforeach()
+endif()


### PR DESCRIPTION
The debug build of the standard library on Windows does not generate the
import library for SwiftOnoneSupport which prevents the build of debug
programs against the debug runtime.  Because the linker must find the
import library in order to satisfy the forced link that we emit for the
link against the SwiftOnoneSupport library, without this, the build is
not usable.  Furthermore, this requires a debug build of the runtime
since in the optimized build, the interfaces that this library provides
are not provided by swiftCore and this supplements the library to allow
building the debug program.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
