### PR TITLE
Rename @autodiff to @differentiable.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5442,8 +5442,8 @@ autodiff_function
     with {%1 : $(T) -> (T) -> T, %2 : $(T) -> (T) -> T}
 
 Bundles a function with its associated differentiation functions up to a
-specified differentiation order into an ``@autodiff`` function. There are 2
-associated functions per differentiation order: a Jacobian-vector products
+specified differentiation order into an ``@differentiable`` function. There are
+2 associated functions per differentiation order: a Jacobian-vector products
 (JVP) function and a vector-Jacobian products (VJP) function.
 
 ``[wrt ...]`` specifies parameter indices that the original function is
@@ -5477,13 +5477,13 @@ autodiff_function_extract
   sil-autodiff-function-differentiation-order ::= '[' 'order' [0-9]+ ']'
 
 
-  autodiff_function_extract [original] %0 : $@autodiff (T) -> T
-  autodiff_function_extract [jvp] [order 1] %0 : $@autodiff (T) -> T
-  autodiff_function_extract [vjp] [order 1] %0 : $@autodiff (T) -> T
+  autodiff_function_extract [original] %0 : $@differentiable (T) -> T
+  autodiff_function_extract [jvp] [order 1] %0 : $@differentiable (T) -> T
+  autodiff_function_extract [vjp] [order 1] %0 : $@differentiable (T) -> T
 
 Extracts the original function or an associated function from the given
-``@autodiff`` function at a specific differentiation order. It must be provided
-with an extractee: ``[original]``, ``[jvp]`` or ``[vjp]``.
+``@differentiable`` function at a specific differentiation order. It must be
+provided with an extractee: ``[original]``, ``[jvp]`` or ``[vjp]``.
 
 .. SWIFT_ENABLE_TENSORFLOW
 

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -53,6 +53,7 @@ TYPE_ATTR(noreturn)
 TYPE_ATTR(noescape)
 TYPE_ATTR(escaping)
 // SWIFT_ENABLE_TENSORFLOW
+TYPE_ATTR(differentiable)
 TYPE_ATTR(autodiff)
 TYPE_ATTR(nondiff)
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -395,7 +395,7 @@ NOTE(autodiff_function_assoc_func_requirements_unmet,none,
      "function call is not differentiable because generic requirements are not "
      "met", ())
 NOTE(autodiff_opaque_function_not_differentiable,none,
-     "opaque non-'@autodiff' function is not differentiable", ())
+     "opaque non-'@differentiable' function is not differentiable", ())
 NOTE(autodiff_property_not_differentiable,none,
      "property is not differentiable", ())
 NOTE(autodiff_value_defined_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3713,11 +3713,11 @@ ERROR(unreferenced_generic_parameter,none,
 // Function differentiability
 ERROR(autodiff_attr_argument_not_differentiable,none,
       "argument is not differentiable, but the enclosing function type is "
-      "marked '@autodiff'; did you want to add '@nondiff' to this argument?",
+      "marked '@differentiable'; did you want to add '@nondiff' to this argument?",
       ())
 ERROR(autodiff_attr_result_not_differentiable,none,
       "result is not differentiable, but the function type is marked "
-      "'@autodiff'", ())
+      "'@differentiable'", ())
 ERROR(nondiff_attr_invalid_on_nondifferentiable_function,none,
       "'nondiff' cannot be applied to arguments of a non-differentiable "
       "function", ())

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3096,9 +3096,9 @@ public:
   /// Given `indices`, `differentiationOrder`, and `kind`, calculates the type
   /// of the corresponding autodiff associated function.
   ///
-  /// \note The original function type (`self`) need not be `@autodiff`, and the
-  /// resulting function will preserve all `ExtInfo` of the original function,
-  /// including `@autodiff`.
+  /// \note The original function type (`self`) need not be `@differentiable`,
+  /// and the resulting function will preserve all `ExtInfo` of the original
+  /// function, including `@differentiable`.
   AnyFunctionType *getAutoDiffAssociatedFunctionType(
       AutoDiffParameterIndices *indices, unsigned resultIndex,
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7627,7 +7627,7 @@ class TryApplyInst final
 
 // SWIFT_ENABLE_TENSORFLOW
 /// `autodiff_function` - given a function and differentiation indices and its
-/// associated differentiation functions, create an `@autodiff` function that
+/// associated differentiation functions, create an `@differentiable` function that
 /// represents a bundle of these functions and configurations.
 class AutoDiffFunctionInst final :
     public InstructionBaseWithTrailingOperands<
@@ -7694,7 +7694,7 @@ public:
                                  AutoDiffAssociatedFunctionKind kind) const;
 };
 
-/// `autodiff_function_extract` - given an `@autodiff` function representing a
+/// `autodiff_function_extract` - given an `@differentiable` function representing a
 /// bundle of the original function and associated functions, extract the
 /// specified function.
 class AutoDiffFunctionExtractInst
@@ -7724,7 +7724,7 @@ private:
   /// The differentiation order. A zero value is only legal when the extractee
   /// is the original function, and it is a private representation only.
   unsigned differentiationOrder;
-  /// The list containing the `@autodiff` function operand.
+  /// The list containing the `@differentiable` function operand.
   FixedOperandList<1> operands;
 
   static SILType

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3627,9 +3627,9 @@ public:
       return;
 
     // SWIFT_ENABLE_TENSORFLOW
-    if (!Options.excludeAttrKind(TAK_autodiff) && info.isDifferentiable()) {
+    if (!Options.excludeAttrKind(TAK_differentiable) && info.isDifferentiable()) {
       // FIXME(rxwei): Print differentiation order.
-      Printer << "@autodiff ";
+      Printer << "@differentiable ";
     }
 
     if (Options.PrintFunctionRepresentationAttrs &&
@@ -3681,9 +3681,9 @@ public:
       return;
 
     // SWIFT_ENABLE_TENSORFLOW
-    if (!Options.excludeAttrKind(TAK_autodiff) && info.isDifferentiable()) {
+    if (!Options.excludeAttrKind(TAK_differentiable) && info.isDifferentiable()) {
       // FIXME(rxwei): Print differentiation order.
-      Printer << "@autodiff ";
+      Printer << "@differentiable ";
     }
 
     if (Options.PrintFunctionRepresentationAttrs &&

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1034,10 +1034,10 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
   assert(arity >= 1);
   assert(order == 1 && "higher-order differentiation is not supported yet");
   // JVP:
-  //   <...T...(arity), R> (@autodiff (...T) throws -> R, ...T)
+  //   <...T...(arity), R> (@differentiable (...T) throws -> R, ...T)
   //       rethrows -> (R, (...T.TangentVector) -> R.TangentVector)
   // VJP:
-  //   <...T...(arity), R> (@autodiff (...T) throws -> R, ...T)
+  //   <...T...(arity), R> (@differentiable (...T) throws -> R, ...T)
   //       rethrows -> (R, (R.CotangentVector) -> ...T.CotangentVector)
   unsigned numGenericParams = 1 + arity + (isMethod ? 1 : 0);
   BuiltinGenericSignatureBuilder builder(Context, numGenericParams);
@@ -1060,7 +1060,7 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
     selfArgGen = makeGenericParam(arity + 1);
     builder.addConformanceRequirement(*selfArgGen, diffableProto);
   }
-  // Generator for the first argument, i.e. the @autodiff function.
+  // Generator for the first argument, i.e. the @differentiable function.
   BuiltinGenericSignatureBuilder::LambdaGenerator firstArgGen {
     // Generator for the function type at the argument position, i.e. the
     // function being differentiated.

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -1,4 +1,4 @@
-//===--- GenDiffFunc.cpp - Swift IR Generation For @autodiff Functions ---===//
+//===- GenDiffFunc.cpp - Swift IR Generation For @differentiable Functions ===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -95,7 +95,7 @@ public:
 
   void initializeFromParams(IRGenFunction &IGF, Explosion &params, Address src,
                             SILType T, bool isOutlined) const override {
-    llvm_unreachable("unexploded @autodiff function as argument?");
+    llvm_unreachable("unexploded @differentiable function as argument?");
   }
 
   void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
@@ -130,7 +130,7 @@ public:
 
   TypeInfo *createFixed(ArrayRef<DiffFuncFieldInfo> fields,
                         StructLayout &&layout) {
-    llvm_unreachable("@autodiff functions are always loadable");
+    llvm_unreachable("@differentiable functions are always loadable");
   }
 
   DiffFuncTypeInfo *createLoadable(ArrayRef<DiffFuncFieldInfo> fields,
@@ -145,7 +145,7 @@ public:
   TypeInfo *createNonFixed(ArrayRef<DiffFuncFieldInfo> fields,
                            FieldsAreABIAccessible_t fieldsAccessible,
                            StructLayout &&layout) {
-    llvm_unreachable("@autodiff functions are always loadable");
+    llvm_unreachable("@differentiable functions are always loadable");
   }
 
   DiffFuncFieldInfo getFieldInfo(unsigned index, DiffFuncIndex field,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2360,6 +2360,9 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
   // SWIFT_ENABLE_TENSORFLOW
   // @autodiff(...) attribute.
   case TAK_autodiff:
+  // SWIFT_ENABLE_TENSORFLOW
+  // @differentiable(...) attribute.
+  case TAK_differentiable:
     break;
   }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -172,9 +172,9 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
   validateSubclassScope(classSubclassScope, isThunk, nullptr);
 
   // SWIFT_ENABLE_TENSORFLOW
-  // Function type cannot be @autodiff.
+  // Function type cannot be @differentiable.
   assert(!LoweredType->isDifferentiable() &&
-         "SIL function declarations cannot have an @autodiff type");
+         "SIL function declarations cannot have an @differentiable type");
 
   if (InsertBefore)
     Module.functions.insert(SILModule::iterator(InsertBefore), this);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1238,7 +1238,7 @@ public:
         adfi->getOriginalFunction()->getType().getAs<SILFunctionType>();
     require(origTy, "The original function must have a function type");
     require(!origTy->isDifferentiable(),
-            "The original function must not be @autodiff");
+            "The original function must not be @differentiable");
     if (F.getModule().getStage() == SILStage::Canonical ||
         adfi->hasAssociatedFunctions()) {
       for (auto order : range(1, adfi->getDifferentiationOrder() + 1)) {
@@ -1246,7 +1246,7 @@ public:
         auto jvpType = pair.first->getType().getAs<SILFunctionType>();
         require(jvpType, "The JVP function must have a function type");
         require(!jvpType->isDifferentiable(),
-                "The JVP function must not be @autodiff");
+                "The JVP function must not be @differentiable");
         auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
             adfi->getParameterIndices(), /*resultIndex*/ 0, order,
             AutoDiffAssociatedFunctionKind::JVP, F.getModule(),
@@ -1255,7 +1255,7 @@ public:
         auto vjpType = pair.second->getType().getAs<SILFunctionType>();
         require(vjpType, "The VJP function must have a function type");
         require(!vjpType->isDifferentiable(),
-                "The VJP function must not be @autodiff");
+                "The VJP function must not be @differentiable");
         auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
             adfi->getParameterIndices(), /*resultIndex*/ 0, order,
             AutoDiffAssociatedFunctionKind::VJP, F.getModule(),
@@ -1277,7 +1277,7 @@ public:
     auto fnTy = adfei->getFunctionOperand()->getType().getAs<SILFunctionType>();
     require(fnTy, "The function operand must have a function type");
     require(fnTy->isDifferentiable(),
-            "The function operand must be an '@autodiff' function");
+            "The function operand must be an '@differentiable' function");
   }
 
   void verifyLLVMIntrinsic(BuiltinInst *BI, llvm::Intrinsic::ID ID) {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -155,7 +155,7 @@ namespace {
       auto extInfo = type->getExtInfo();
       auto nondiffExtInfo = extInfo.withDifferentiable(false);
       auto origTy = type->getWithExtInfo(nondiffExtInfo);
-      // TODO: Use the parameter indices and diff order in the @autodiff
+      // TODO: Use the parameter indices and diff order in the @differentiable
       // function type.
       auto jvpTy = origTy->getAutoDiffAssociatedFunctionType(
           SmallBitVector(type->getNumParameters(), true), /*resultIndex*/ 0,
@@ -239,7 +239,7 @@ namespace {
       case AnyFunctionType::Representation::Block:
         // SWIFT_ENABLE_TENSORFLOW
         // TODO: Are there cases where we have to lower this differently when it
-        // is @autodiff?
+        // is @differentiable?
         return asImpl().handleReference(type);
 
       // SWIFT_ENABLE_TENSORFLOW

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3201,7 +3201,7 @@ static ManagedValue createThunk(SILGenFunction &SGF,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-/// Create a reabstraction thunk for an @autodiff function.
+/// Create a reabstraction thunk for an @differentiable function.
 static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
                                         SILLocation loc,
                                         ManagedValue fn,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6765,7 +6765,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       assert(toType->is<FunctionType>());
       // SWIFT_ENABLE_TENSORFLOW
       auto fromEI = fromFunc->getExtInfo();
-      // Handle implicit conversion from @autodiff.
+      // Handle implicit conversion from @differentiable.
       if (fromEI.isDifferentiable() && !toEI.isDifferentiable()) {
         fromFunc = fromFunc->withExtInfo(fromEI.withDifferentiable(false))
                 ->castTo<FunctionType>();
@@ -6827,9 +6827,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                               FunctionConversionExpr(expr,
                                                      toFuncNoADConversion));
 
-      // Make the conversion to @autodiff happen after all other conversions,
+      // Make the conversion to @differentiable happen after all other conversions,
       // because some of the other conversions are not currently supported on
-      // @autodiff functions. (e.g. escape_to_noescape).
+      // @differentiable functions. (e.g. escape_to_noescape).
       // After we do support those conversions, the order will no longer matter.
       if (!fromEI.isDifferentiable() && toEI.isDifferentiable()) {
         expr = cs.cacheType(new (tc.Context)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1944,7 +1944,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     TAK_convention, TAK_noreturn, TAK_pseudogeneric,
     TAK_callee_owned, TAK_callee_guaranteed, TAK_noescape, TAK_autoclosure,
     // SWIFT_ENABLE_TENSORFLOW
-    TAK_escaping, TAK_autodiff, TAK_yield_once, TAK_yield_many
+    TAK_escaping, TAK_autodiff, TAK_differentiable, TAK_yield_once, TAK_yield_many
   };
 
   auto checkUnsupportedAttr = [&](TypeAttrKind attr) {
@@ -2047,7 +2047,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     SILFunctionType::ExtInfo extInfo(rep, attrs.has(TAK_pseudogeneric),
                                      // SWIFT_ENABLE_TENSORFLOW
                                      attrs.has(TAK_noescape),
-                                     attrs.has(TAK_autodiff));
+                                     attrs.has(TAK_autodiff) || attrs.has(TAK_differentiable));
 
     ty = resolveSILFunctionType(fnRepr, options, coroutineKind,
                                 extInfo, calleeConvention,
@@ -2108,7 +2108,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                                   attrs.has(TAK_noescape),
                                   // SWIFT_ENABLE_TENSORFLOW
                                   fnRepr->throws(),
-                                  attrs.has(TAK_autodiff));
+                                  attrs.has(TAK_autodiff) || attrs.has(TAK_differentiable));
 
     ty = resolveASTFunctionType(fnRepr, options, extInfo);
     if (!ty || ty->hasError()) return ty;
@@ -2413,7 +2413,7 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  // If the function is marked as `@autodiff`, the result must be a
+  // If the function is marked as `@differentiable`, the result must be a
   // differentiable type.
   if (extInfo.isDifferentiable() &&
       resolution.getStage() != TypeResolutionStage::Structural) {

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -47,14 +47,14 @@ infix operator .> : ComparisonPrecedence
 public extension Differentiable {
   @inlinable
   func gradient<R : Differentiable & FloatingPoint>(
-    in f: @autodiff (Self) -> Tensor<R>
+    in f: @differentiable (Self) -> Tensor<R>
   ) -> CotangentVector {
     return self.pullback(in: f)(Tensor<R>(1))
   }
 
   @inlinable
   func valueWithGradient<R : Differentiable & FloatingPoint>(
-    in f: @autodiff (Self) -> Tensor<R>
+    in f: @differentiable (Self) -> Tensor<R>
   ) -> (value: Tensor<R>, gradient: CotangentVector) {
     let (y, pb) = self.valueWithPullback(in: f)
     return (y, pb(Tensor<R>(1)))
@@ -62,14 +62,14 @@ public extension Differentiable {
 
   @inlinable
   func gradient<T : Differentiable, R : Differentiable & FloatingPoint>(
-    at x: T, in f: @autodiff (Self, T) -> Tensor<R>
+    at x: T, in f: @differentiable (Self, T) -> Tensor<R>
   ) -> (CotangentVector, T.CotangentVector) {
     return self.pullback(at: x, in: f)(Tensor<R>(1))
   }
 
   @inlinable
   func valueWithGradient<T : Differentiable, R>(
-    at x: T, in f: @autodiff (Self, T) -> Tensor<R>
+    at x: T, in f: @differentiable (Self, T) -> Tensor<R>
   ) -> (value: Tensor<R>, gradient: (CotangentVector, T.CotangentVector))
     where R : Differentiable & FloatingPoint {
     let (y, pb) = self.valueWithPullback(at: x, in: f)
@@ -85,7 +85,7 @@ public extension Differentiable {
 
 @inlinable
 public func valueWithGradient<T, R>(
-  at x: T, in f: @autodiff (T) -> Tensor<R>
+  at x: T, in f: @differentiable (T) -> Tensor<R>
 ) -> (value: Tensor<R>, gradient: T.CotangentVector)
 where T : Differentiable, R : Differentiable & FloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, in: f)
@@ -94,7 +94,7 @@ where T : Differentiable, R : Differentiable & FloatingPoint {
 
 @inlinable
 public func valueWithGradient<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T, U) -> Tensor<R>
+  at x: T, _ y: U, in f: @differentiable (T, U) -> Tensor<R>
 ) -> (value: Tensor<R>, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
         R : Differentiable & FloatingPoint {
@@ -104,7 +104,7 @@ public func valueWithGradient<T, U, R>(
 
 @inlinable
 public func valueWithGradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> Tensor<R>
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> Tensor<R>
 ) -> (value: Tensor<R>,
       gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
@@ -117,7 +117,7 @@ public func valueWithGradient<T, U, V, R>(
 
 @inlinable
 public func valueWithGradient<T, R>(
-  of f: @escaping @autodiff (T) -> Tensor<R>
+  of f: @escaping @differentiable (T) -> Tensor<R>
 ) -> (T) -> (value: Tensor<R>, gradient: T.CotangentVector)
   where T : Differentiable, R : Differentiable & FloatingPoint {
   return { x in valueWithGradient(at: x, in: f) }
@@ -125,7 +125,7 @@ public func valueWithGradient<T, R>(
 
 @inlinable
 public func valueWithGradient<T, U, R>(
-  of f: @escaping @autodiff (T, U) -> Tensor<R>
+  of f: @escaping @differentiable (T, U) -> Tensor<R>
 ) -> (T, U)
     -> (value: Tensor<R>, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
@@ -135,7 +135,7 @@ public func valueWithGradient<T, U, R>(
 
 @inlinable
 public func valueWithGradient<T, U, V, R>(
-  of f: @escaping @autodiff (T, U, V) -> Tensor<R>
+  of f: @escaping @differentiable (T, U, V) -> Tensor<R>
 ) -> (T, U, V)
     -> (value: Tensor<R>,
         gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
@@ -148,7 +148,7 @@ public func valueWithGradient<T, U, V, R>(
 
 @inlinable
 public func gradient<T, R>(
-  at x: T, in f: @autodiff (T) -> Tensor<R>
+  at x: T, in f: @differentiable (T) -> Tensor<R>
 ) -> T.CotangentVector
   where T : Differentiable, R : Differentiable & FloatingPoint {
   return pullback(at: x, in: f)(Tensor<R>(1))
@@ -156,7 +156,7 @@ public func gradient<T, R>(
 
 @inlinable
 public func gradient<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T, U) -> Tensor<R>
+  at x: T, _ y: U, in f: @differentiable (T, U) -> Tensor<R>
 ) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
         R : Differentiable & FloatingPoint {
@@ -165,7 +165,7 @@ public func gradient<T, U, R>(
 
 @inlinable
 public func gradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> Tensor<R>
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> Tensor<R>
 ) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : Differentiable & FloatingPoint {
@@ -176,7 +176,7 @@ public func gradient<T, U, V, R>(
 
 @inlinable
 public func gradient<T, R>(
-  of f: @escaping @autodiff (T) -> Tensor<R>
+  of f: @escaping @differentiable (T) -> Tensor<R>
 ) -> (T) -> T.CotangentVector
   where T : Differentiable, R : Differentiable & FloatingPoint {
   return { x in gradient(at: x, in: f) }
@@ -184,7 +184,7 @@ public func gradient<T, R>(
 
 @inlinable
 public func gradient<T, U, R>(
-  of f: @escaping @autodiff (T, U) -> Tensor<R>
+  of f: @escaping @differentiable (T, U) -> Tensor<R>
 ) -> (T, U) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
         R : Differentiable & FloatingPoint {
@@ -193,7 +193,7 @@ public func gradient<T, U, R>(
 
 @inlinable
 public func gradient<T, U, V, R>(
-  of f: @escaping @autodiff (T, U, V) -> Tensor<R>
+  of f: @escaping @differentiable (T, U, V) -> Tensor<R>
 ) -> (T, U, V) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : Differentiable & FloatingPoint {

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -115,7 +115,7 @@ public extension Differentiable
 public func differentiableFunction<T : Differentiable, R : Differentiable>(
   from vjp: @escaping (T)
            -> (value: R, pullback: (R.CotangentVector) -> T.CotangentVector)
-) -> @autodiff (T) -> R {
+) -> @differentiable (T) -> R {
   @differentiable(vjp: _vjp)
   func original(_ x: T) -> R {
     return vjp(x).value
@@ -132,7 +132,7 @@ public func differentiableFunction<T, U, R>(
   from vjp: @escaping (T, U)
            -> (value: R, pullback: (R.CotangentVector)
              -> (T.CotangentVector, U.CotangentVector))
-) -> @autodiff (T, U) -> R
+) -> @differentiable (T, U) -> R
   where T : Differentiable, U : Differentiable, R : Differentiable {
   @differentiable(vjp: _vjp)
   func original(_ x: T, _ y: U) -> R {
@@ -149,8 +149,8 @@ public func differentiableFunction<T, U, R>(
 /// traditional automatic differentiation.
 @inlinable
 public func withRecomputationInPullbacks<T, U>(
-  _ body: @escaping @autodiff (T) -> U
-) -> @autodiff (T) -> U where T : Differentiable, U : Differentiable {
+  _ body: @escaping @differentiable (T) -> U
+) -> @differentiable (T) -> U where T : Differentiable, U : Differentiable {
   return differentiableFunction { x in
     (value: body(x), pullback: { v in pullback(at: x, in: body)(v) })
   }
@@ -162,14 +162,14 @@ public func withRecomputationInPullbacks<T, U>(
 //   @inlinable
 //   @differentiable(wrt: self, vjp: _vjp_withRecomputationInPullbacks)
 //   func withRecomputationInPullbacks<Result : Differentiable>(
-//     _ body: @escaping @autodiff (Self) -> Result
+//     _ body: @escaping @differentiable (Self) -> Result
 //   ) -> Result {
 //     return body(self)
 //   }
 // 
 //   @usableFromInline
 //   internal func _vjp_withRecomputationInPullbacks<Result : Differentiable>(
-//     _ body: @escaping @autodiff (Self) -> Result
+//     _ body: @escaping @differentiable (Self) -> Result
 //   ) -> (Result, (Result.CotangentVector) -> CotangentVector) {
 //     return valueWithPullback(in: Swift.withRecomputationInPullbacks(body))
 //   }
@@ -182,21 +182,21 @@ public func withRecomputationInPullbacks<T, U>(
 public extension Differentiable {
   @inlinable
   func valueWithPullback<R : Differentiable>(
-    in f: @autodiff (Self) -> R
+    in f: @differentiable (Self) -> R
   ) -> (value: R, pullback: (R.CotangentVector) -> CotangentVector) {
     return Builtin.autodiffApply_vjp_arity1(f, self)
   }
 
   @inlinable
   func pullback<R : Differentiable>(
-    in f: @autodiff (Self) -> R
+    in f: @differentiable (Self) -> R
   ) -> (R.CotangentVector) -> CotangentVector {
     return Builtin.autodiffApply_vjp_arity1(f, self).1
   }
 
   @inlinable
   func gradient<R : Differentiable>(
-    in f: @autodiff (Self) -> R
+    in f: @differentiable (Self) -> R
   ) -> CotangentVector
     where R : FloatingPoint, R.CotangentVector == R {
     return self.pullback(in: f)(R(1))
@@ -204,7 +204,7 @@ public extension Differentiable {
 
   @inlinable
   func valueWithGradient<R : Differentiable>(
-    in f: @autodiff (Self) -> R
+    in f: @differentiable (Self) -> R
   ) -> (value: R, gradient: CotangentVector)
     where R : FloatingPoint, R.CotangentVector == R {
     let (y, pb) = self.valueWithPullback(in: f)
@@ -213,7 +213,7 @@ public extension Differentiable {
 
   @inlinable
   func valueWithPullback<T : Differentiable, R : Differentiable>(
-    at x: T, in f: @autodiff (Self, T) -> R
+    at x: T, in f: @differentiable (Self, T) -> R
   ) -> (value: R,
         pullback: (R.CotangentVector) -> (CotangentVector, T.CotangentVector)) {
     return Builtin.autodiffApply_vjp_arity2(f, self, x)
@@ -221,14 +221,14 @@ public extension Differentiable {
 
   @inlinable
   func pullback<T : Differentiable, R : Differentiable>(
-    at x: T, in f: @autodiff (Self, T) -> R
+    at x: T, in f: @differentiable (Self, T) -> R
   ) -> (R.CotangentVector) -> (CotangentVector, T.CotangentVector) {
     return Builtin.autodiffApply_vjp_arity2(f, self, x).1
   }
 
   @inlinable
   func gradient<T : Differentiable, R : Differentiable>(
-    at x: T, in f: @autodiff (Self, T) -> R
+    at x: T, in f: @differentiable (Self, T) -> R
   ) -> (CotangentVector, T.CotangentVector)
     where R : FloatingPoint, R.CotangentVector == R {
     return self.pullback(at: x, in: f)(R(1))
@@ -236,7 +236,7 @@ public extension Differentiable {
 
   @inlinable
   func valueWithGradient<T : Differentiable, R : Differentiable>(
-    at x: T, in f: @autodiff (Self, T) -> R
+    at x: T, in f: @differentiable (Self, T) -> R
   ) -> (value: R, gradient: (CotangentVector, T.CotangentVector))
     where R : FloatingPoint, R.CotangentVector == R {
     let (y, pb) = self.valueWithPullback(at: x, in: f)
@@ -252,7 +252,7 @@ public extension Differentiable {
 
 @inlinable
 public func valueWithPullback<T, R>(
-  at x: T, in f: @autodiff (T) -> R
+  at x: T, in f: @differentiable (T) -> R
 ) -> (value: R, pullback: (R.CotangentVector) -> T.CotangentVector)
   where T : Differentiable, R : Differentiable {
   return Builtin.autodiffApply_vjp(f, x)
@@ -260,7 +260,7 @@ public func valueWithPullback<T, R>(
 
 @inlinable
 public func valueWithPullback<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T, U) -> R
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
 ) -> (value: R,
       pullback: (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable, R : Differentiable {
@@ -269,7 +269,7 @@ public func valueWithPullback<T, U, R>(
 
 @inlinable
 public func valueWithPullback<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
 ) -> (value: R,
       pullback: (R.CotangentVector)
         -> (T.CotangentVector, U.CotangentVector, V.CotangentVector))
@@ -282,7 +282,7 @@ public func valueWithPullback<T, U, V, R>(
 // TODO: Remove this once we flesh out differentiability for curried functions.
 @inlinable
 public func _valueWithPullback<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T) -> (U) -> R
+  at x: T, _ y: U, in f: @differentiable (T) -> (U) -> R
 ) -> (value: R, pullback: (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable, R : Differentiable {
   return Builtin.autodiffApply_vjp_method(f, x, y)
@@ -292,7 +292,7 @@ public func _valueWithPullback<T, U, R>(
 
 @inlinable
 public func pullback<T, R>(
-  at x: T, in f: @autodiff (T) -> R
+  at x: T, in f: @differentiable (T) -> R
 ) -> (R.CotangentVector) -> T.CotangentVector
   where T : Differentiable, R : Differentiable {
   return Builtin.autodiffApply_vjp(f, x).1
@@ -300,7 +300,7 @@ public func pullback<T, R>(
 
 @inlinable
 public func pullback<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T, U) -> R
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
 ) -> (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable, R : Differentiable {
   return Builtin.autodiffApply_vjp_arity2(f, x, y).1
@@ -308,7 +308,7 @@ public func pullback<T, U, R>(
 
 @inlinable
 public func pullback<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
 ) -> (R.CotangentVector)
     -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
@@ -320,7 +320,7 @@ public func pullback<T, U, V, R>(
 
 @inlinable
 public func valueWithGradient<T, R>(
-  at x: T, in f: @autodiff (T) -> R
+  at x: T, in f: @differentiable (T) -> R
 ) -> (value: R, gradient: T.CotangentVector)
   where T : Differentiable, R : FloatingPoint & Differentiable,
         R.CotangentVector == R {
@@ -330,7 +330,7 @@ public func valueWithGradient<T, R>(
 
 @inlinable
 public func valueWithGradient<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T, U) -> R
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
 ) -> (value: R, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
         R : FloatingPoint & Differentiable, R.CotangentVector == R {
@@ -340,7 +340,7 @@ public func valueWithGradient<T, U, R>(
 
 @inlinable
 public func valueWithGradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
 ) -> (value: R,
       gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
@@ -353,7 +353,7 @@ public func valueWithGradient<T, U, V, R>(
 
 @inlinable
 public func valueWithGradient<T, R>(
-  of f: @escaping @autodiff (T) -> R
+  of f: @escaping @differentiable (T) -> R
 ) -> (T) -> (value: R, gradient: T.CotangentVector)
   where T : Differentiable, R : FloatingPoint & Differentiable,
         R.CotangentVector == R {
@@ -362,7 +362,7 @@ public func valueWithGradient<T, R>(
 
 @inlinable
 public func valueWithGradient<T, U, R>(
-  of f: @escaping @autodiff (T, U) -> R
+  of f: @escaping @differentiable (T, U) -> R
 ) -> (T, U) -> (value: R, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
         R : FloatingPoint & Differentiable,
@@ -372,7 +372,7 @@ public func valueWithGradient<T, U, R>(
 
 @inlinable
 public func valueWithGradient<T, U, V, R>(
-  of f: @escaping @autodiff (T, U, V) -> R
+  of f: @escaping @differentiable (T, U, V) -> R
 ) -> (T, U, V)
     -> (value: R,
         gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
@@ -386,7 +386,7 @@ public func valueWithGradient<T, U, V, R>(
 
 @inlinable
 public func gradient<T, R>(
-  at x: T, in f: @autodiff (T) -> R
+  at x: T, in f: @differentiable (T) -> R
 ) -> T.CotangentVector
   where T : Differentiable, R : FloatingPoint & Differentiable,
         R.CotangentVector == R {
@@ -395,7 +395,7 @@ public func gradient<T, R>(
 
 @inlinable
 public func gradient<T, U, R>(
-  at x: T, _ y: U, in f: @autodiff (T, U) -> R
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
 ) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
         R : FloatingPoint & Differentiable, R.CotangentVector == R {
@@ -404,7 +404,7 @@ public func gradient<T, U, R>(
 
 @inlinable
 public func gradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @autodiff (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
 ) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : FloatingPoint & Differentiable, R.CotangentVector == R {
@@ -415,7 +415,7 @@ public func gradient<T, U, V, R>(
 
 @inlinable
 public func gradient<T, R>(
-  of f: @escaping @autodiff (T) -> R
+  of f: @escaping @differentiable (T) -> R
 ) -> (T) -> T.CotangentVector
   where T : Differentiable, R : FloatingPoint & Differentiable,
         R.CotangentVector == R {
@@ -424,7 +424,7 @@ public func gradient<T, R>(
 
 @inlinable
 public func gradient<T, U, R>(
-  of f: @escaping @autodiff (T, U) -> R
+  of f: @escaping @differentiable (T, U) -> R
 ) -> (T, U) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
         R : FloatingPoint & Differentiable,
@@ -434,7 +434,7 @@ public func gradient<T, U, R>(
 
 @inlinable
 public func gradient<T, U, V, R>(
-  of f: @escaping @autodiff (T, U, V) -> R
+  of f: @escaping @differentiable (T, U, V) -> R
 ) -> (T, U, V) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : FloatingPoint & Differentiable,

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -4,7 +4,7 @@
 // Top-level (before primal/adjoint synthesis)
 //===----------------------------------------------------------------------===//
 
-// expected-note @+1 {{opaque non-'@autodiff' function is not differentiable}}
+// expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
 func foo(_ f: (Float) -> Float) -> Float {
   // expected-error @+1 {{function is not differentiable}}
   return gradient(at: 0, in: f)

--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -37,24 +37,24 @@ bb0(%0 : @trivial $Float):
   return %5 : $(Float, @callee_guaranteed (Float) -> Float)
 }
 
-sil @make_diff_func : $@convention(thin) () -> @autodiff @convention(thin) (Float) -> Float {
+sil @make_diff_func : $@convention(thin) () -> @differentiable @convention(thin) (Float) -> Float {
 bb0:
   %orig = function_ref @foo : $@convention(thin) (Float) -> Float
   %undiffedFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float
   %vjp = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %diffFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
-  %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
-  %extractedOriginal = autodiff_function_extract [original] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
+  %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@differentiable @convention(thin) (Float) -> Float
+  %extractedOriginal = autodiff_function_extract [original] %diffFunc : $@differentiable @convention(thin) (Float) -> Float
   %copied = copy_value %extractedOriginal : $@convention(thin) (Float) -> Float
-  return %undiffedFunc : $@autodiff @convention(thin) (Float) -> Float
+  return %undiffedFunc : $@differentiable @convention(thin) (Float) -> Float
 }
 
-// CHECK-LABEL: @make_diff_func : $@convention(thin) () -> @autodiff @convention(thin) (Float) -> Float
+// CHECK-LABEL: @make_diff_func : $@convention(thin) () -> @differentiable @convention(thin) (Float) -> Float
 // CHECK:   [[FOO:%.*]] = function_ref @foo : $@convention(thin) (Float) -> Float
 // CHECK:   [[UNDIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float
 // CHECK:   [[FOO_VJP:%.*]] = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // CHECK:   [[DIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), [[FOO_VJP]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
-// CHECK:   [[EXTRACTED_VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
-// CHECK:   [[EXTRACTED_ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
+// CHECK:   [[EXTRACTED_VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED_FOO]] : $@differentiable @convention(thin) (Float) -> Float
+// CHECK:   [[EXTRACTED_ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_FOO]] : $@differentiable @convention(thin) (Float) -> Float
 // CHECK:   copy_value [[EXTRACTED_ORIG]] : $@convention(thin) (Float) -> Float
-// CHECK:   return [[UNDIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
+// CHECK:   return [[UNDIFFED_FOO]] : $@differentiable @convention(thin) (Float) -> Float

--- a/test/AutoDiff/autodiff_function_inst_irgen.sil
+++ b/test/AutoDiff/autodiff_function_inst_irgen.sil
@@ -37,8 +37,8 @@ bb0:
   %orig = function_ref @foo : $@convention(thin) (Float) -> Float
   %vjp = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %diffFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
-  %extractedOrig = autodiff_function_extract [original] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
-  %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
+  %extractedOrig = autodiff_function_extract [original] %diffFunc : $@differentiable @convention(thin) (Float) -> Float
+  %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@differentiable @convention(thin) (Float) -> Float
   %tuple = tuple (%extractedOrig : $@convention(thin) (Float) -> Float, %extractedVJP : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
   return %tuple : $(@convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
 }

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -4,8 +4,8 @@
 
 func thin(x: Float) -> Float { return x }
 
-func myfunction(_ f: @escaping @autodiff (Float) -> (Float)) -> (Float) -> Float {
-  // @autodiff functions should be callable.
+func myfunction(_ f: @escaping @differentiable (Float) -> (Float)) -> (Float) -> Float {
+  // @differentiable functions should be callable.
   _ = f(.zero)
   return f
 }
@@ -17,25 +17,25 @@ func apply() {
 // CHECK-AST-LABEL:  (func_decl {{.*}} "myfunction(_:)"
 // CHECK-AST:          (call_expr type='(Float)'
 // CHECK-AST:            (autodiff_function_extract_original implicit type='(Float) -> (Float)'
-// CHECK-AST:              (declref_expr type='@autodiff (Float) -> (Float)'
+// CHECK-AST:              (declref_expr type='@differentiable (Float) -> (Float)'
 // CHECK-AST:          (return_stmt
 // CHECK-AST:            (function_conversion_expr implicit type='(Float) -> Float'
 // CHECK-AST:              (autodiff_function_extract_original implicit type='(Float) -> (Float)'
-// CHECK-AST:                (declref_expr type='@autodiff (Float) -> (Float)'
+// CHECK-AST:                (declref_expr type='@differentiable (Float) -> (Float)'
 // CHECK-AST-LABEL:  (func_decl {{.*}} "apply()"
-// CHECK-AST:          (autodiff_function implicit type='@autodiff (Float) -> (Float)'
+// CHECK-AST:          (autodiff_function implicit type='@differentiable (Float) -> (Float)'
 // CHECK-AST:            (function_conversion_expr implicit type='(Float) -> (Float)'
 // CHECK-AST:              (declref_expr type='(Float) -> Float'
 
 // CHECK-SILGEN-LABEL: @{{.*}}myfunction{{.*}}
-// CHECK-SILGEN: bb0([[DIFFED:%.*]] : @guaranteed $@autodiff @callee_guaranteed (Float) -> Float):
-// CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@autodiff @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_COPY]] : $@autodiff @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN: bb0([[DIFFED:%.*]] : @guaranteed $@differentiable @callee_guaranteed (Float) -> Float):
+// CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_COPY]] : $@differentiable @callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   [[BORROWED_ORIG:%.*]] = begin_borrow [[ORIG]] : $@callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   apply [[BORROWED_ORIG]]({{%.*}}) : $@callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   destroy_value [[ORIG]] : $@callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@autodiff @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_COPY]] : $@autodiff @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_COPY]] : $@differentiable @callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   return [[ORIG]] : $@callee_guaranteed (Float) -> Float
 
 // CHECK-SILGEN-LABEL: @{{.*}}apply{{.*}}
@@ -44,4 +44,4 @@ func apply() {
 // CHECK-SILGEN-NEXT:  [[DIFFED:%.*]] = autodiff_function [wrt 0] [order 1] [[ORIG_THICK]] : $@callee_guaranteed (Float) -> Float
 
 // CHECK-SIL:  [[DIFFED:%.*]] = autodiff_function [wrt 0] [order 1] {{%.*}} : $@callee_guaranteed (Float) -> Float
-// CHECK-SIL:  release_value [[DIFFED]] : $@autodiff @callee_guaranteed (Float) -> Float
+// CHECK-SIL:  release_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float

--- a/test/AutoDiff/autodiff_sil_function_type_parse.sil
+++ b/test/AutoDiff/autodiff_sil_function_type_parse.sil
@@ -14,22 +14,22 @@ bb0:
   %0 = function_ref @examplefunc : $@convention(thin) (Float, Float, Float) -> Float
 
   %1 = autodiff_function [wrt 0 1 2] [order 1] %0 : $@convention(thin) (Float, Float, Float) -> Float
-  // CHECK: %2 = autodiff_function_extract [vjp] [order 1] %1 : $@autodiff @convention(thin) (Float, Float, Float) -> Float
-  %2 = autodiff_function_extract [vjp] [order 1] %1 : $@autodiff @convention(thin) (Float, Float, Float) -> Float
+  // CHECK: %2 = autodiff_function_extract [vjp] [order 1] %1 : $@differentiable @convention(thin) (Float, Float, Float) -> Float
+  %2 = autodiff_function_extract [vjp] [order 1] %1 : $@differentiable @convention(thin) (Float, Float, Float) -> Float
 
   %3 = autodiff_function [wrt 0] [order 1] %0 : $@convention(thin) (Float, Float, Float) -> Float
-  // CHECK: %4 = autodiff_function_extract [vjp] [order 1] %3 : $@autodiff @convention(thin) (Float, @nondiff Float, @nondiff Float) -> Float
-  %4 = autodiff_function_extract [vjp] [order 1] %3 : $@autodiff @convention(thin) (Float, @nondiff Float, @nondiff Float) -> Float
+  // CHECK: %4 = autodiff_function_extract [vjp] [order 1] %3 : $@differentiable @convention(thin) (Float, @nondiff Float, @nondiff Float) -> Float
+  %4 = autodiff_function_extract [vjp] [order 1] %3 : $@differentiable @convention(thin) (Float, @nondiff Float, @nondiff Float) -> Float
 
   %5 = function_ref @examplemethod : $@convention(method) (Float, Float, Float) -> Float
 
   %6 = autodiff_function [wrt 0 1 2] [order 1] %5 : $@convention(method) (Float, Float, Float) -> Float
-  // CHECK: %7 = autodiff_function_extract [vjp] [order 1] %6 : $@autodiff @convention(method) (Float, Float, Float) -> Float
-  %7 = autodiff_function_extract [vjp] [order 1] %6 : $@autodiff @convention(method) (Float, Float, Float) -> Float
+  // CHECK: %7 = autodiff_function_extract [vjp] [order 1] %6 : $@differentiable @convention(method) (Float, Float, Float) -> Float
+  %7 = autodiff_function_extract [vjp] [order 1] %6 : $@differentiable @convention(method) (Float, Float, Float) -> Float
 
   %8 = autodiff_function [wrt 0] [order 1] %5 : $@convention(method) (Float, Float, Float) -> Float
-  // CHECK: %9 = autodiff_function_extract [vjp] [order 1] %8 : $@autodiff @convention(method) (Float, @nondiff Float, @nondiff Float) -> Float
-  %9 = autodiff_function_extract [vjp] [order 1] %8 : $@autodiff @convention(method) (Float, @nondiff Float, @nondiff Float) -> Float
+  // CHECK: %9 = autodiff_function_extract [vjp] [order 1] %8 : $@differentiable @convention(method) (Float, @nondiff Float, @nondiff Float) -> Float
+  %9 = autodiff_function_extract [vjp] [order 1] %8 : $@differentiable @convention(method) (Float, @nondiff Float, @nondiff Float) -> Float
 
   %ret = tuple ()
   return %ret : $()

--- a/test/AutoDiff/bad_reabstraction.swift
+++ b/test/AutoDiff/bad_reabstraction.swift
@@ -7,7 +7,7 @@ protocol FloatTangent : Differentiable
   where TangentVector == Float, CotangentVector == Float {}
 
 func gradient<T: Differentiable, R: FloatTangent>(
-  of f: @autodiff (T) -> R, at x: T
+  of f: @differentiable (T) -> R, at x: T
 ) -> T.CotangentVector {
   fatalError("unimplemented")
 }

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -2,7 +2,7 @@
 
 struct Foo {
   var x: Float
-  var f: @autodiff (Float) -> Float
+  var f: @differentiable (Float) -> Float
 }
 func diffableClosureInStruct(s: Foo) {
   _ = gradient(of: s.f)
@@ -10,8 +10,8 @@ func diffableClosureInStruct(s: Foo) {
 
 // CHECK-LABEL: @{{.*}}diffableClosureInStruct{{.*}} : $@convention(thin) (@guaranteed Foo) -> () {
 // CHECK:   [[CLOSURE:%.*]] = struct_extract {{%.*}} : $Foo, #Foo.f
-// CHECK:   retain_value [[CLOSURE]] : $@autodiff @callee_guaranteed (Float) -> Float
-// CHECK:   autodiff_function_extract [original] [[CLOSURE]] : $@autodiff @callee_guaranteed (Float) -> Float
+// CHECK:   retain_value [[CLOSURE]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK:   autodiff_function_extract [original] [[CLOSURE]] : $@differentiable @callee_guaranteed (Float) -> Float
 
 
 public func closureCaptureMutable() {

--- a/test/AutoDiff/core_builtins.swift
+++ b/test/AutoDiff/core_builtins.swift
@@ -3,16 +3,16 @@
 
 import Swift
 
-func evaldiff<T: Differentiable, U: Differentiable>(_ f: @autodiff (T) -> U, _ x: T) -> (U, (T.TangentVector) -> U.TangentVector)
+func evaldiff<T: Differentiable, U: Differentiable>(_ f: @differentiable (T) -> U, _ x: T) -> (U, (T.TangentVector) -> U.TangentVector)
   where T == T.TangentVector {
   return Builtin.autodiffApply_jvp(f, x)
 }
 
 // CHECK-SIL-LABEL: @{{.*}}evaldiff{{.*}}
-// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : @trivial $*U, [[ORIG_FN:%.*]] : @trivial $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U, [[ORIG_FN_ARG:%.*]] : @trivial $*T):
+// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : @trivial $*U, [[ORIG_FN:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @out U, [[ORIG_FN_ARG:%.*]] : @trivial $*T):
 // CHECK-SIL:   [[ORIG_FN_ARG_COPY:%.*]] = alloc_stack $T
 // CHECK-SIL:   copy_addr [[ORIG_FN_ARG]] to [initialization] [[ORIG_FN_ARG_COPY]] : $*T
-// CHECK-SIL:   [[JVP_FN:%.*]] = autodiff_function_extract [jvp] [order 1] [[ORIG_FN]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
+// CHECK-SIL:   [[JVP_FN:%.*]] = autodiff_function_extract [jvp] [order 1] [[ORIG_FN]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
 // CHECK-SIL:   [[JVP_RES_BUF:%.*]] = alloc_stack $(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector)
 // CHECK-SIL:   [[JVP_RES_BUF_0:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector), 0
 // CHECK-SIL:   [[DIFFERENTIAL:%.*]] = apply [[JVP_FN]]([[JVP_RES_BUF_0]], [[ORIG_FN_ARG_COPY]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector)
@@ -27,28 +27,28 @@ func evaldiff<T: Differentiable, U: Differentiable>(_ f: @autodiff (T) -> U, _ x
 // CHECK-SIL:   dealloc_stack [[ORIG_FN_ARG_COPY]] : $*T
 // CHECK-SIL:   return [[DIFFERENTIAL]] : $@callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector
 
-func evaldiff2<T: Differentiable, U: Differentiable, V: Differentiable>(_ f: @autodiff (T, U) -> V, _ x: T, _ y: U) -> (V, (T.TangentVector, U.TangentVector) -> V.TangentVector)
+func evaldiff2<T: Differentiable, U: Differentiable, V: Differentiable>(_ f: @differentiable (T, U) -> V, _ x: T, _ y: U) -> (V, (T.TangentVector, U.TangentVector) -> V.TangentVector)
   where T == T.TangentVector, U == U.TangentVector {
   return Builtin.autodiffApply_jvp_arity2(f, x, y)
 }
 
 // CHECK-LABEL: @{{.*}}evaldiff2{{.*}}
-// CHECK: bb0({{.*}} : @trivial $*V, [[DIFFED:%.*]] : @trivial $@autodiff @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V, {{.*}} : @trivial $*T, {{.*}} : @trivial $*U):
-// CHECK:   autodiff_function_extract [jvp] [order 1] [[DIFFED]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V // user: %14
+// CHECK: bb0({{.*}} : @trivial $*V, [[DIFFED:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V, {{.*}} : @trivial $*T, {{.*}} : @trivial $*U):
+// CHECK:   autodiff_function_extract [jvp] [order 1] [[DIFFED]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V // user: %14
 
-func methoddiff<T: Differentiable, U: Differentiable, R: Differentiable>(_ f: @autodiff (T) -> (U) -> R, _ x: T, _ y: U)
+func methoddiff<T: Differentiable, U: Differentiable, R: Differentiable>(_ f: @differentiable (T) -> (U) -> R, _ x: T, _ y: U)
     -> (R, (T.TangentVector, U.TangentVector) -> R.TangentVector)
   where T == T.TangentVector, U == U.TangentVector {
   return Builtin.autodiffApply_jvp_method(f, x, y)
 }
 
 // CHECK-SIL-LABEL: @{{.*}}methoddiff{{.*}}
-// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : @trivial $*R, [[ORIG_FN:%.*]] : @trivial $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> @out R, [[ORIG_FN_ARG1:%.*]] : @trivial $*T, [[ORIG_FN_ARG2:%.*]] : @trivial $*U):
+// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : @trivial $*R, [[ORIG_FN:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> @out R, [[ORIG_FN_ARG1:%.*]] : @trivial $*T, [[ORIG_FN_ARG2:%.*]] : @trivial $*U):
 // CHECK-SIL:   [[ORIG_FN_ARG1_COPY:%.*]] = alloc_stack $T
 // CHECK-SIL:   copy_addr [[ORIG_FN_ARG1]] to [initialization] [[ORIG_FN_ARG1_COPY]] : $*T
 // CHECK-SIL:   [[ORIG_FN_ARG2_COPY:%.*]] = alloc_stack $U
 // CHECK-SIL:   copy_addr [[ORIG_FN_ARG2]] to [initialization] [[ORIG_FN_ARG2_COPY]] : $*U
-// CHECK-SIL:   [[JVP_FN:%.*]] = autodiff_function_extract [jvp] [order 1] [[ORIG_FN]] : $@autodiff @noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> @out R
+// CHECK-SIL:   [[JVP_FN:%.*]] = autodiff_function_extract [jvp] [order 1] [[ORIG_FN]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> @out R
 // CHECK-SIL:   [[JVP_FN_PARTIAL_APPLIED:%.*]] = apply [[JVP_FN]]([[ORIG_FN_ARG1_COPY]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> (@out R, @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector)
 // CHECK-SIL:   destroy_addr [[ORIG_FN_ARG1_COPY]]
 // CHECK-SIL:   [[JVP_RES_BUF:%.*]] = alloc_stack $(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector)

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -30,7 +30,7 @@ CustomDerivativesTests.test("differentiableFunction-unary") {
     (value: unary(x), pullback: { v in v * x * 2 })
   }
   expectEqual(20, gradient(at: 10, in: diffableUnary))
-  // Test differentiation of @autodiff function.
+  // Test differentiation of @differentiable function.
   expectEqual(20, gradient(at: 10, in: { diffableUnary($0) }))
   expectEqual(40, gradient(at: 10, in: { diffableUnary($0) * 2 }))
 }
@@ -40,7 +40,7 @@ CustomDerivativesTests.test("differentiableFunction-binary") {
     (value: binary(x, y), pullback: { v in (v * y, v * x) })
   }
   expectEqual((10, 5), gradient(at: 5, 10, in: diffableBinary))
-  // Test differentiation of @autodiff function.
+  // Test differentiation of @differentiable function.
   expectEqual((10, 5), gradient(at: 5, 10, in: { diffableBinary($0, $1) }))
   expectEqual((20, 10), gradient(at: 5, 10, in: { diffableBinary($0, $1) * 2 }))
 }

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -22,7 +22,7 @@ public struct Foo : Differentiable {
 struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
   var a: Float
 }
-let _: @autodiff (AdditiveTangentIsSelf) -> Float = { x in
+let _: @differentiable (AdditiveTangentIsSelf) -> Float = { x in
   x.a + x.a
 }
 

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
-let _: @autodiff (Float) -> Float
-let _: @autodiff (Float) throws -> Float
+let _: @differentiable (Float) -> Float
+let _: @differentiable (Float) throws -> Float
 
 //
 // Type differentiability
@@ -9,10 +9,10 @@ let _: @autodiff (Float) throws -> Float
 
 struct NonDiffType { var x: Int }
 // FIXME: Properly type-check parameters and the result's differentiability
-// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'}} {{19-19=@nondiff }}
-let _: @autodiff (NonDiffType) -> Float
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@autodiff'}}
-let _: @autodiff (Float) -> NonDiffType
+// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@differentiable'}} {{25-25=@nondiff }}
+let _: @differentiable (NonDiffType) -> Float
+// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+let _: @differentiable (Float) -> NonDiffType
 
 //
 // Argument selection (@nondiff)
@@ -21,17 +21,17 @@ let _: @autodiff (Float) -> NonDiffType
 // expected-error @+1 {{'nondiff' cannot be applied to arguments of a non-differentiable function}}
 let _: (@nondiff Float, Float) -> Float
 
-let _: @autodiff (Float, @nondiff Float) -> Float // okay
+let _: @differentiable (Float, @nondiff Float) -> Float // okay
 
 func foo<T: Differentiable, U: Differentiable>(x: T) -> U {
-  let fn: (@autodiff (T) -> U)? = nil
+  let fn: (@differentiable (T) -> U)? = nil
   return fn!(x)
 }
 
-func test1<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> @autodiff (U) -> Float) {}
-func test2<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> (U) -> Float) {}
-// expected-error @+2 {{result is not differentiable, but the function type is marked '@autodiff'}}
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@autodiff'}}
-func test3<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> @autodiff (U) -> Int) {}
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@autodiff'}}
-func test4<T: Differentiable, U: Differentiable>(_: @autodiff (T) -> (U) -> Int) {}
+func test1<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> @differentiable (U) -> Float) {}
+func test2<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> (U) -> Float) {}
+// expected-error @+2 {{result is not differentiable, but the function type is marked '@differentiable'}}
+// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+func test3<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> @differentiable (U) -> Int) {}
+// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+func test4<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> (U) -> Int) {}

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -5,7 +5,7 @@ import StdlibUnittest
 var ProtocolRequirementAutodiffTests = TestSuite("ProtocolRequirementAutodiff")
 
 func _pullback<T, U, R>(
-  at x: (T, U), in f: @autodiff (T) -> (U) -> R
+  at x: (T, U), in f: @differentiable (T) -> (U) -> R
 ) -> (R.CotangentVector) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable, R : Differentiable {
   // Builtin.autodiffApply_vjp_method(f, x.0, x.1).1

--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -6,25 +6,25 @@ func simpleStoreLoad(x: Float) -> Float {
   y = x + y
   return y
 }
-let _: @autodiff (Float) -> Float = simpleStoreLoad(x:)
+let _: @differentiable (Float) -> Float = simpleStoreLoad(x:)
 
 var global: Float = 10
 
 // Test differentiation of write to non-useful global variable.
-let _: @autodiff (Float) -> Float = { x in
+let _: @differentiable (Float) -> Float = { x in
   global = x
   return x * x
 }
 
 // Test differentiation of write to non-useful local variable.
-let _: @autodiff (Float) -> Float = { x in
+let _: @differentiable (Float) -> Float = { x in
   var local = x // expected-warning {{initialization of variable 'local' was never used}}
   return x + x
 }
 
 // Test differentiation of write to useful global variable.
 // expected-error @+1 {{function is not differentiable}}
-let _: @autodiff (Float) -> Float = { x in
+let _: @differentiable (Float) -> Float = { x in
   // expected-note @+1 {{cannot differentiate writes to global variables}}
   global = x
   return global + x
@@ -34,7 +34,7 @@ let _: @autodiff (Float) -> Float = { x in
 func testMutableCaptures() {
   var y: Float = 10
   // expected-error @+1 {{function is not differentiable}}
-  let _: @autodiff (Float) -> Float = { x in
+  let _: @differentiable (Float) -> Float = { x in
     // expected-note @+1 {{cannot differentiate writes to mutable captures}}
     y = x
     return y + x
@@ -42,7 +42,7 @@ func testMutableCaptures() {
 }
 
 // Test differentiation of write to useful local variable.
-let _: @autodiff (Float) -> Float = { x in
+let _: @differentiable (Float) -> Float = { x in
   var local = x // expected-warning {{variable 'local' was never mutated}}
   return local + x
 }

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -80,7 +80,7 @@ SimpleMathTests.test("GlobalLet") {
   expectEqual(2, gradient(at: 1, in: foo))
 }
 
-var foo_diffable: @autodiff (Float) -> (Float)
+var foo_diffable: @differentiable (Float) -> (Float)
   = differentiableFunction { x in (x * x, { v in 2 * x * v }) }
 SimpleMathTests.test("GlobalDiffableFunc") {
   expectEqual(2, gradient(at: 1, in: foo_diffable))

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -33,14 +33,14 @@ SupersetVJPTests.test("CrossModuleClosure") {
   expectEqual(1, gradient(at: Float(1)) { x in x + 2 })
 }
 
-// FIXME: The expression `(+) as @autodiff (Float, @nondiff Float) -> Float)`
-// forms a curry thunk of `Float.+` before conversion to @autodiff, and AD
+// FIXME: The expression `(+) as @differentiable (Float, @nondiff Float) -> Float)`
+// forms a curry thunk of `Float.+` before conversion to @differentiable, and AD
 // doesn't know how to differentiate the curry thunk, so it produces a
 // "function is not differentiable" error.
 // FIXME: Propagate wrt indices correctly so that this actually takes the
 // gradient wrt only the first parameter, as intended.
 // SupersetVJPTests.test("CrossModule") {
-//   expectEqual(1, gradient(at: 1, 2, in: (+) as @autodiff (Float, @nondiff Float) -> Float))
+//   expectEqual(1, gradient(at: 1, 2, in: (+) as @differentiable (Float, @nondiff Float) -> Float))
 // }
 
 // FIXME: Unbreak this one.

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -37,7 +37,7 @@ struct S : Proto, VectorNumeric {
   // CHECK: [[JVP1_ORIG_FNREF:%.*]] = function_ref {{.*}}function1{{.*}} : $@convention(method) (Float, Float, S) -> Float
   // CHECK: [[JVP1_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function1{{.*}}__vjp_src_0_wrt_0_1
   // CHECK: [[JVP1_ADFUNC:%.*]] = autodiff_function [wrt 0 1] [order 1] [[JVP1_ORIG_FNREF]] : {{.*}} with {{{%.*}} : {{.*}}, [[JVP1_VJP_FNREF]] : {{.*}}}
-  // CHECK: [[JVP1:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP1_ADFUNC]] : $@autodiff @convention(method) (Float, Float, @nondiff S) -> Float
+  // CHECK: [[JVP1:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP1_ADFUNC]] : $@differentiable @convention(method) (Float, Float, @nondiff S) -> Float
   // CHECK: apply [[JVP1]]
   // CHECK: } // end sil function 'AD__{{.*}}function1{{.*}}_jvp_SSU'
 
@@ -45,7 +45,7 @@ struct S : Proto, VectorNumeric {
   // CHECK: [[VJP1_ORIG_FNREF:%.*]] = function_ref {{.*}}function1{{.*}} : $@convention(method) (Float, Float, S) -> Float
   // CHECK: [[VJP1_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function1{{.*}}__vjp_src_0_wrt_0_1
   // CHECK: [[VJP1_ADFUNC:%.*]] = autodiff_function [wrt 0 1] [order 1] [[VJP1_ORIG_FNREF]] : {{.*}} with {{{%.*}} : {{.*}}, [[VJP1_VJP_FNREF]] : {{.*}}}
-  // CHECK: [[VJP1:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP1_ADFUNC]] : $@autodiff @convention(method) (Float, Float, @nondiff S) -> Float
+  // CHECK: [[VJP1:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP1_ADFUNC]] : $@differentiable @convention(method) (Float, Float, @nondiff S) -> Float
   // CHECK: apply [[VJP1]]
   // CHECK: } // end sil function 'AD__{{.*}}function1{{.*}}_vjp_SSU'
 
@@ -58,7 +58,7 @@ struct S : Proto, VectorNumeric {
   // CHECK: [[JVP2_ORIG_FNREF:%.*]] = function_ref {{.*}}function2{{.*}} : $@convention(method) (Float, Float, S) -> Float
   // CHECK: [[JVP2_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function2{{.*}}__vjp_src_0_wrt_0_1_2
   // CHECK: [[JVP2_ADFUNC:%.*]] = autodiff_function [wrt 0 1 2] [order 1] [[JVP2_ORIG_FNREF]] : {{.*}} with {{{%.*}} : {{.*}}, [[JVP2_VJP_FNREF]] : {{.*}}}
-  // CHECK: [[JVP2:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP2_ADFUNC]] : $@autodiff @convention(method) (Float, Float, S) -> Float
+  // CHECK: [[JVP2:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP2_ADFUNC]] : $@differentiable @convention(method) (Float, Float, S) -> Float
   // CHECK: apply [[JVP2]]
   // CHECK: } // end sil function 'AD__{{.*}}function2{{.*}}_jvp_SSS'
 
@@ -66,7 +66,7 @@ struct S : Proto, VectorNumeric {
   // CHECK: [[VJP2_ORIG_FNREF:%.*]] = function_ref {{.*}}function2{{.*}} : $@convention(method) (Float, Float, S) -> Float
   // CHECK: [[VJP2_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function2{{.*}}__vjp_src_0_wrt_0_1_2
   // CHECK: [[VJP2_ADFUNC:%.*]] = autodiff_function [wrt 0 1 2] [order 1] [[VJP2_ORIG_FNREF]] : {{.*}} with {{{%.*}} : {{.*}}, [[VJP2_VJP_FNREF]] : {{.*}}}
-  // CHECK: [[VJP2:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP2_ADFUNC]] : $@autodiff @convention(method) (Float, Float, S) -> Float
+  // CHECK: [[VJP2:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP2_ADFUNC]] : $@differentiable @convention(method) (Float, Float, S) -> Float
   // CHECK: apply [[VJP2]]
   // CHECK: } // end sil function 'AD__{{.*}}function2{{.*}}_vjp_SSS'
 
@@ -79,7 +79,7 @@ struct S : Proto, VectorNumeric {
   // CHECK: [[JVP3_ORIG_FNREF:%.*]] = function_ref {{.*}}function3{{.*}} : $@convention(method) (Float, Float, S) -> Float
   // CHECK: [[JVP3_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function3{{.*}}__vjp_src_0_wrt_1
   // CHECK: [[JVP3_ADFUNC:%.*]] = autodiff_function [wrt 1] [order 1] [[JVP3_ORIG_FNREF]] : {{.*}} with {{{%.*}} : {{.*}}, [[JVP3_VJP_FNREF]] : {{.*}}}
-  // CHECK: [[JVP3:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP3_ADFUNC]] : $@autodiff @convention(method) (@nondiff Float, Float, @nondiff S) -> Float
+  // CHECK: [[JVP3:%.*]] = autodiff_function_extract [jvp] [order 1] [[JVP3_ADFUNC]] : $@differentiable @convention(method) (@nondiff Float, Float, @nondiff S) -> Float
   // CHECK: apply [[JVP3]]
   // CHECK: } // end sil function 'AD__{{.*}}function3{{.*}}_jvp_USU'
 
@@ -87,7 +87,7 @@ struct S : Proto, VectorNumeric {
   // CHECK: [[VJP3_ORIG_FNREF:%.*]] = function_ref {{.*}}function3{{.*}} : $@convention(method) (Float, Float, S) -> Float
   // CHECK: [[VJP3_VJP_FNREF:%.*]] = function_ref @AD__{{.*}}function3{{.*}}__vjp_src_0_wrt_1
   // CHECK: [[VJP3_ADFUNC:%.*]] = autodiff_function [wrt 1] [order 1] [[VJP3_ORIG_FNREF]] : {{.*}} with {{{%.*}} : {{.*}}, [[VJP3_VJP_FNREF]] : {{.*}}}
-  // CHECK: [[VJP3:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP3_ADFUNC]] : $@autodiff @convention(method) (@nondiff Float, Float, @nondiff S) -> Float
+  // CHECK: [[VJP3:%.*]] = autodiff_function_extract [vjp] [order 1] [[VJP3_ADFUNC]] : $@differentiable @convention(method) (@nondiff Float, Float, @nondiff S) -> Float
   // CHECK: apply [[VJP3]]
   // CHECK: } // end sil function 'AD__{{.*}}function3{{.*}}_vjp_USU'
 }

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -163,7 +163,7 @@ TensorADTests.testAllBackends("Differentiate global") {
 }
 
 TensorADTests.testAllBackends("Side effects") {
-  let foo: @autodiff (Tensor<Float>) -> Tensor<Float> = { x in
+  let foo: @differentiable (Tensor<Float>) -> Tensor<Float> = { x in
     var a = x
     a = a + x
     a = a + x


### PR DESCRIPTION
note: @autodiff is left in still enabled so that downstream packages will not be broken. (It gets auto-converted to @differentiable

We can make this a warning and then an error later.