### PR TITLE
[ownership] Add support for cloning unmanaged_{retain,release}_value …

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1610,6 +1610,13 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitUnmanagedRetainValueInst(
     UnmanagedRetainValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  if (!getBuilder().hasOwnership()) {
+    return recordClonedInstruction(
+        Inst, getBuilder().createRetainValue(getOpLocation(Inst->getLoc()),
+                                             getOpValue(Inst->getOperand()),
+                                             Inst->getAtomicity()));
+  }
+
   recordClonedInstruction(Inst, getBuilder().createUnmanagedRetainValue(
                                     getOpLocation(Inst->getLoc()),
                                     getOpValue(Inst->getOperand()),
@@ -1653,6 +1660,12 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitUnmanagedReleaseValueInst(
     UnmanagedReleaseValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  if (!getBuilder().hasOwnership()) {
+    return recordClonedInstruction(
+        Inst, getBuilder().createReleaseValue(getOpLocation(Inst->getLoc()),
+                                              getOpValue(Inst->getOperand()),
+                                              Inst->getAtomicity()));
+  }
   recordClonedInstruction(Inst, getBuilder().createUnmanagedReleaseValue(
                                     getOpLocation(Inst->getLoc()),
                                     getOpValue(Inst->getOperand()),

--- a/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa.sil
+++ b/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa.sil
@@ -204,3 +204,30 @@ bb0(%0 : $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// Test out functionality that we use to work around weird semantics of
+// destructors.
+sil [ossa] [transparent] @unmanaged_rr_callee : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  unmanaged_retain_value %0 : $Builtin.NativeObject
+  unmanaged_release_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @unmanaged_rr_caller : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK-NEXT: retain_value [[ARG]]
+// CHECK-NEXT: release_value [[ARG]]
+// CHECK-NEXT: tuple
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'unmanaged_rr_caller'
+sil @unmanaged_rr_caller : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = function_ref @unmanaged_rr_callee : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %1(%0) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
…from ossa => non-ossa code.

Just an oversight on my part. I double checked that the only remaining
difference is in how we handle checked_cast_br and switch_enum. I have a
separate patch that fixes that.
