### PR TITLE
[ownership] Add a specialized version of ome that skips transparent f…

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -226,6 +226,9 @@ PASS(Outliner, "outliner",
      "Function Outlining Optimization")
 PASS(OwnershipModelEliminator, "ownership-model-eliminator",
      "Eliminate Ownership Annotation of SIL")
+PASS(NonTransparentFunctionOwnershipModelEliminator,
+     "non-transparent-func-ownership-model-eliminator",
+     "Eliminate Ownership Annotations from non-transparent SIL Functions")
 PASS(RCIdentityDumper, "rc-id-dumper",
      "Print Reference Count Identities")
 PASS(PerfInliner, "inline",

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -287,6 +287,11 @@ bool OwnershipModelEliminatorVisitor::visitDestructureTupleInst(
 namespace {
 
 struct OwnershipModelEliminator : SILModuleTransform {
+  bool SkipTransparent;
+
+  OwnershipModelEliminator(bool SkipTransparent)
+      : SkipTransparent(SkipTransparent) {}
+
   void run() override {
     if (DumpBefore.size()) {
       getModule()->dump(DumpBefore.c_str());
@@ -295,6 +300,11 @@ struct OwnershipModelEliminator : SILModuleTransform {
     for (auto &F : *getModule()) {
       // If F does not have ownership, skip it. We have no further work to do.
       if (!F.hasOwnership())
+        continue;
+
+      // If we were asked to not strip ownership from transparent functions,
+      // continue.
+      if (SkipTransparent && F.isTransparent())
         continue;
 
       // Set F to have unqualified ownership.
@@ -334,5 +344,9 @@ struct OwnershipModelEliminator : SILModuleTransform {
 } // end anonymous namespace
 
 SILTransform *swift::createOwnershipModelEliminator() {
-  return new OwnershipModelEliminator();
+  return new OwnershipModelEliminator(false /*skip transparent*/);
+}
+
+SILTransform *swift::createNonTransparentFunctionOwnershipModelEliminator() {
+  return new OwnershipModelEliminator(true /*skip transparent*/);
 }

--- a/test/SILOptimizer/non_transparent_ome.sil
+++ b/test/SILOptimizer/non_transparent_ome.sil
@@ -1,0 +1,19 @@
+// RUN: %target-sil-opt -enable-sil-ownership -non-transparent-func-ownership-model-eliminator %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+// CHECK-LABEL: sil [transparent] [ossa] @foo : $@convention(thin) () -> () {
+sil [transparent] [ossa] @foo : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @bar : $@convention(thin) () -> () {
+sil [ossa] @bar : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…unctions.

This will let me strip ownership from non-transparent functions at the beginning
of the perf pipeline. Then after we serialize, I will run OME on the transparent
functions. Otherwise, we can not perform mandatory inlining successfully since
we can not inline ossa into non-ossa functions.
