### PR TITLE
[ConstraintSystem] Decouple `designated types` feature from Swift ver…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1897,10 +1897,10 @@ Constraint *ConstraintSystem::selectDisjunction() {
   // disjunctions that we may not be able to short-circuit, allowing
   // us to eliminate behavior that is exponential in the number of
   // operators in the expression.
-  if (getASTContext().isSwiftVersionAtLeast(5) ||
-      TC.getLangOpts().SolverEnableOperatorDesignatedTypes)
+  if (TC.getLangOpts().SolverEnableOperatorDesignatedTypes) {
     if (auto *disjunction = selectApplyDisjunction())
       return disjunction;
+  }
 
   if (auto *disjunction = selectBestBindingDisjunction(*this, disjunctions))
     return disjunction;

--- a/validation-test/Sema/type_checker_perf/fast/rdar47492691.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar47492691.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: objc_interop
+
+import CoreGraphics
+import simd
+
+func test(foo: CGFloat, bar: CGFloat) {
+  _ = CGRect(x: 0.0 + 1.0, y: 0.0 + foo, width: 3.0 - 1 - 1 - 1.0, height: bar)
+}


### PR DESCRIPTION
…sion

`selectApplyDisjunction` only makes sense in conjunction with
designated types feature because it's going to prioritize disjunctions
with arguments which are known to conform to literal protocols.

Prioritization like that is harmful without designated types feature
because it doesn't always lead to better constraint system splits,
and could prioritize bigger disjunctions which harms chances to
short-circuit solving.

Resolves: rdar://problem/47492691

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
