### PR TITLE
Fix INParameter availability

### DIFF
--- a/stdlib/public/Darwin/Intents/INParameter.swift
+++ b/stdlib/public/Darwin/Intents/INParameter.swift
@@ -13,8 +13,8 @@
 @_exported import Intents
 import Foundation
 
-#if os(iOS) || os(watchOS)
-@available(iOS 11.0, watchOS 4.0, *)
+#if os(iOS)
+@available(iOS 11.0, *)
 extension INParameter {
   @nonobjc
   public convenience init?<Root, Value>(keyPath: KeyPath<Root, Value>) {


### PR DESCRIPTION
INParameter was incorrectly available on watchOS. This PR fixes that.