### PR TITLE
[AutoDiff] Fix externally-defined JVP/VJP resolution.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -293,7 +293,7 @@ struct AutoDiffAssociatedFunctionKind {
 class AutoDiffAssociatedFunctionIdentifier : public llvm::FoldingSetNode {
   const AutoDiffAssociatedFunctionKind kind;
   const unsigned differentiationOrder;
-  AutoDiffParameterIndices * const parameterIndices;
+  AutoDiffParameterIndices *const parameterIndices;
 
   AutoDiffAssociatedFunctionIdentifier(
       AutoDiffAssociatedFunctionKind kind, unsigned differentiationOrder,

--- a/include/swift/SIL/SILFunctionBuilder.h
+++ b/include/swift/SIL/SILFunctionBuilder.h
@@ -98,10 +98,6 @@ class SILFunctionBuilder {
                  SILFunction *InsertBefore = nullptr,
                  const SILDebugScope *DebugScope = nullptr);
 
-  // SWIFT_ENABLE_TENSORFLOW
-  // `addFunctionAttributes` edited because @differentiable attribute
-  // propagation requires access to original function declaration (via
-  // SILDeclRef).
   void addFunctionAttributes(SILFunction *F, DeclAttributes &Attrs,
                              SILModule &M, SILDeclRef constant = SILDeclRef());
 };

--- a/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
+++ b/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
@@ -1,9 +1,10 @@
 // RUN: %target-swift-frontend -emit-silgen -verify %s | %FileCheck %s
+// SIL `[differentiable]` should have jvp/vjp names only if the AST `@differentiable` attribute does.
 
 _ = gradient(at: Float(1)) { x in x + x * x }
 
 // CHECK-LABEL: // static Float.* infix(_:_:)
-// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 
 // CHECK-LABEL: // static Float.+ infix(_:_:)
-// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float

--- a/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
+++ b/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
@@ -1,10 +1,17 @@
-// RUN: %target-swift-frontend -emit-silgen -verify %s | %FileCheck %s
-// SIL `[differentiable]` should have jvp/vjp names only if the AST `@differentiable` attribute does.
+// RUN: %target-swift-frontend -emit-silgen -verify %s | %FileCheck %s -check-prefix=CHECK-SILGEN
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
+
+// After SILGen, SIL `[differentiable]` should have jvp/vjp names only if the AST `@differentiable` attribute does.
+// The differentiation pass is guaranteed to fill in jvp/vjp names.
 
 _ = gradient(at: Float(1)) { x in x + x * x }
 
-// CHECK-LABEL: // static Float.* infix(_:_:)
-// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-SILGEN-LABEL: // static Float.* infix(_:_:)
+// CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-SIL-LABEL: // static Float.* infix(_:_:)
+// CHECK-SIL-NEXT: sil public_external [transparent] [serialized] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf12_vjpMultiply3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 
-// CHECK-LABEL: // static Float.+ infix(_:_:)
-// CHECK-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-SILGEN-LABEL: // static Float.+ infix(_:_:)
+// CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-SIL-LABEL: // static Float.+ infix(_:_:)
+// CHECK-SIL-NEXT: sil public_external [transparent] [serialized] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @$sSf7_vjpAdd3lhs3rhsSf_Sf_SftSfctSf_SftFZ] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float


### PR DESCRIPTION
Previously, `SILFunctionBuilder` created `SILDifferentiableAttr` with the
expected mangled JVP/VJP names even if they weren't specified in the original
`@differentiable` attribute, when the original function is from a different
SIL module. This enabled the differentiation pass to find externally defined
JVP/VJPs.

However, this logic was hacky/unreliable. Now, `SILFunctionBuilder` simply
propagates JVP/VJP names if they are specified in the original `@differentiable`
attribute. The differentiation pass then declares external JVP/VJP functions
when the original function is an external declaration.

Resolves [SR-9791](https://bugs.swift.org/browse/SR-9791). Done with guidance and initial work from @rxwei.