### PR TITLE
Revert "[ownership] Remove devirt test that can not work with ownersh…

### DIFF
--- a/test/SILOptimizer/devirt_alloc_ref_dynamic_ownership.sil
+++ b/test/SILOptimizer/devirt_alloc_ref_dynamic_ownership.sil
@@ -1,0 +1,43 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all %s -sil-combine -devirtualizer -dce | %FileCheck %s
+
+// REQUIRES: SR9831
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class A {
+  init(m: Int)
+  convenience init(n: Int)
+  func foo() -> Int32
+   deinit
+}
+
+// test.A.foo (test.A)() -> Swift.Int32
+sil hidden [noinline] [ossa] @_TFC4test1A3foofS0_FT_Vs5Int32 : $@convention(method) (@guaranteed A) -> Int32 {
+bb0(%0 : @guaranteed $A):
+  %2 = integer_literal $Builtin.Int32, 1
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+// CHECK-LABEL: @test_alloc_ref_dynamic_devirt
+// CHECK-NOT: class_method
+// CHECK: function_ref @_TFC4test1A3foofS0_FT_Vs5Int32
+// CHECK: apply
+// CHECK: return
+sil [ossa] @test_alloc_ref_dynamic_devirt : $@convention(thin) () -> Int32 {
+bb0:
+  %1 = metatype $@thick A.Type
+  %2 = alloc_ref_dynamic %1 : $@thick A.Type, $A
+  %8 = class_method %2 : $A, #A.foo!1 : (A) -> () -> Int32, $@convention(method) (@guaranteed A) -> Int32
+  %9 = apply %8(%2) : $@convention(method) (@guaranteed A) -> Int32
+  destroy_value %2 : $A
+  return %9 : $Int32
+}
+
+sil_vtable A {
+  #A.foo!1: @_TFC4test1A3foofS0_FT_Vs5Int32
+}


### PR DESCRIPTION
…ip without sil combine being updated."

This reverts commit ac0581092c12146280c1149052397aef9f973bc5.

Doug pointed out that I should just use a REQUIRES line so that we can regain
the test coverage when I update sil-combine for ownership.

I filed SR-9831 to track re-enabling the test.