### PR TITLE
IRGen: Mask all spare bits in multi-payload enums when injecting the tag.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -4785,7 +4785,11 @@ namespace {
         Address payloadAddr = projectPayload(IGF, enumAddr);
         auto payload = EnumPayload::load(IGF, payloadAddr, PayloadSchema);
         
-        auto spareBitMask = ~PayloadTagBits.asAPInt();
+        // We need to mask not only the payload tag bits, but all spare bits,
+        // because the other spare bits may be used to tag a single-payload
+        // enum containing this enum as a payload. Single payload layout
+        // unfortunately assumes that tagging the payload case is a no-op.
+        auto spareBitMask = ~CommonSpareBits.asAPInt();
         APInt tagBitMask
           = interleaveSpareBits(IGM, PayloadTagBits, PayloadTagBits.size(),
                                 spareTagBits, 0);
@@ -4823,7 +4827,11 @@ namespace {
         auto payload = EnumPayload::load(IGF, payloadAddr, PayloadSchema);
 
         // Mask off the spare bits.
-        auto spareBitMask = ~PayloadTagBits.asAPInt();
+        // We need to mask not only the payload tag bits, but all spare bits,
+        // because the other spare bits may be used to tag a single-payload
+        // enum containing this enum as a payload. Single payload layout
+        // unfortunately assumes that tagging the payload case is a no-op.
+        auto spareBitMask = ~CommonSpareBits.asAPInt();
         payload.emitApplyAndMask(IGF, spareBitMask);
 
         // Store the tag into the spare bits.

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -570,8 +570,8 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SECOND_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 1
 // CHECK-NEXT: [[SECOND:%.*]] = load i64, i64* [[SECOND_ADDR]], align 8
 
-//   -- Mask off spare bits in the payload               -- 0x3fffffffffffffff
-// CHECK-NEXT: [[SECOND_PROJ:%.*]] = and i64 [[SECOND]], 4611686018427387903
+//   -- Mask off spare bits in the payload               -- 0x00fffffffffffff8
+// CHECK-NEXT: [[SECOND_PROJ:%.*]] = and i64 [[SECOND]], 72057594037927928
 
 //   -- Store the low bits of the tag in the spare bits of the payload
 // CHECK-NEXT: [[TAG:%.*]] = zext i32 [[TAG_TMP]] to i64


### PR DESCRIPTION
Single-payload enum layout unfortunately assumes that constructing the payload case is a no-op, such
as when building Optional.some(x) for a value x. For multi-payload enums, now that we use the unused
spare bits to form extra inhabitants when the enum is in turn wrapped in an Optional or other single-
payload enum, this means we have to zero all of those bits. The spare bits may have been selected from
intra-field or tail padding bytes that are undefined in the underlying payload types. Fixes
rdar://problem/47635801.