### PR TITLE
[5.0] sourcekitd/format: avoid performing sibling-based indentation for PrefixUnaryExpr.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -575,8 +575,12 @@ class FormatWalker : public SourceEntityWalker {
       };
 
       if (auto AE = dyn_cast_or_null<ApplyExpr>(Node.dyn_cast<Expr *>())) {
-        collect(AE->getArg());
-        return;
+        // PrefixUnaryExpr shouldn't be syntacticly considered as a funtion call
+        // for sibling alignment.
+        if (!isa<PrefixUnaryExpr>(AE)) {
+          collect(AE->getArg());
+          return;
+        }
       }
 
       if (auto PE = dyn_cast_or_null<ParenExpr>(Node.dyn_cast<Expr *>())) {

--- a/test/SourceKit/CodeFormat/indent-if.swift
+++ b/test/SourceKit/CodeFormat/indent-if.swift
@@ -1,0 +1,22 @@
+if condition,
+        !condition,
+         condition,
+    condition,
+    !condition,
+              condition {
+}
+
+
+// RUN: %sourcekitd-test -req=format -line=2 -length=1 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=6 -length=1 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "    !condition,"
+// CHECK: key.sourcetext: "    condition,"
+// CHECK: key.sourcetext: "    condition,"
+// CHECK: key.sourcetext: "    !condition,"
+// CHECK: key.sourcetext: "    condition {"


### PR DESCRIPTION
rdar://47659949
