### PR TITLE
[Type checker] Ensure that we record archetype anchors.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -602,6 +602,8 @@ Type TypeChecker::resolveTypeInContext(
           if (resolution.getStage() == TypeResolutionStage::Structural) {
             return resolution.resolveSelfAssociatedType(
               selfType, foundDC, typeDecl->getName());
+          } else if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
+            typeDecl = assocType->getAssociatedTypeAnchor();
           }
         }
       }

--- a/test/Generics/associated_type_anchor_rdar47605019.swift
+++ b/test/Generics/associated_type_anchor_rdar47605019.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// Ensure that the superclass's generid argument canonicalizes to
+// Sequence.Element.
+
+// CHECK: @"symbolic _____y7ElementSTQzG
+
+public protocol ElementTypeProtocol: RandomAccessCollection {
+    typealias ElementType = Element
+}
+extension Array: ElementTypeProtocol {}
+
+private class WrapperBase<T> {}
+private final class WrapperDerived<C: ElementTypeProtocol>: WrapperBase<C.ElementType> {
+    init(base: C) {
+        let _ = base
+    }
+}


### PR DESCRIPTION
When we aren't going through proper resolution of an associated type
of 'Self', at least record an archetype anchor. Narrow fix for
rdar://problem/47605019.
