### PR TITLE
test/stdlib/KVOKeyPaths.swift fails i386 and blocks PR testing

### DIFF
--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: objc_interop
 
+// SR-9838 Disable because it blocks PR testing.
+// UNSUPPORTED: CPU=i386
+
 import Foundation
 
 struct Guts {


### PR DESCRIPTION
SR-9838
rdar://47735786
