### PR TITLE
[benchmark] Janitor Duty: Sisyphus Legacy

### DIFF
--- a/benchmark/single-source/SequenceAlgos.swift
+++ b/benchmark/single-source/SequenceAlgos.swift
@@ -1,4 +1,4 @@
-//===--- ArrayAppend.swift ------------------------------------------------===//
+//===--- SequenceAlgos.swift ----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -18,13 +18,34 @@ import TestsUtils
 // To avoid too many little micro benchmarks, it measures them all together
 // for each sequence type.
 
+let t: [BenchmarkCategory] = [.validation, .api]
+
 public let SequenceAlgos = [
-  BenchmarkInfo(name: "SequenceAlgosList", runFunction: run_SequenceAlgosList, tags: [.validation, .api], setUpFunction: { buildWorkload() }, tearDownFunction: nil),
-  BenchmarkInfo(name: "SequenceAlgosArray", runFunction: run_SequenceAlgosArray, tags: [.validation, .api], setUpFunction: { buildWorkload() }, tearDownFunction: nil),
-  BenchmarkInfo(name: "SequenceAlgosContiguousArray", runFunction: run_SequenceAlgosContiguousArray, tags: [.validation, .api], setUpFunction: { buildWorkload() }, tearDownFunction: nil),
-  BenchmarkInfo(name: "SequenceAlgosRange", runFunction: run_SequenceAlgosRange, tags: [.validation, .api], setUpFunction: { buildWorkload() }, tearDownFunction: nil),
-  BenchmarkInfo(name: "SequenceAlgosUnfoldSequence", runFunction: run_SequenceAlgosUnfoldSequence, tags: [.validation, .api], setUpFunction: { buildWorkload() }, tearDownFunction: nil),
-  BenchmarkInfo(name: "SequenceAlgosAnySequence", runFunction: run_SequenceAlgosAnySequence, tags: [.validation, .api], setUpFunction: { buildWorkload() }, tearDownFunction: nil),
+  BenchmarkInfo(name: "SequenceAlgosList", runFunction: { for _ in 0..<$0 {
+      benchmarkSequenceAlgos(s: l, n: n)
+      benchmarkEquatableSequenceAlgos(s: l, n: n)
+    }}, tags: t, setUpFunction: { blackHole(l) }, legacyFactor: 10),
+  BenchmarkInfo(name: "SequenceAlgosArray", runFunction: { for _ in 0..<$0 {
+      benchmarkSequenceAlgos(s: a, n: a.count)
+      benchmarkEquatableSequenceAlgos(s: a, n: a.count)
+    }}, tags: t, setUpFunction: { blackHole(a) }, legacyFactor: 10),
+  BenchmarkInfo(name: "SequenceAlgosContiguousArray",
+    runFunction: { for _ in 0..<$0 {
+        benchmarkSequenceAlgos(s: c, n: c.count)
+        benchmarkEquatableSequenceAlgos(s: c, n: c.count)
+      }}, tags: t, setUpFunction: { blackHole(c) }, legacyFactor: 10),
+  BenchmarkInfo(name: "SequenceAlgosRange", runFunction: { for _ in 0..<$0 {
+      benchmarkSequenceAlgos(s: r, n: r.count)
+      benchmarkEquatableSequenceAlgos(s: r, n: r.count)
+    }}, tags: t, legacyFactor: 10),
+  BenchmarkInfo(name: "SequenceAlgosUnfoldSequence",
+    runFunction: { for _ in 0..<$0 {
+        benchmarkSequenceAlgos(s: s, n: n)
+      }}, tags: t, setUpFunction: { blackHole(s) }, legacyFactor: 10),
+  BenchmarkInfo(name: "SequenceAlgosAnySequence",
+    runFunction: { for _ in 0..<$0 {
+        benchmarkSequenceAlgos(s: y, n: n/10)
+      }}, tags: t, setUpFunction: { blackHole(y) }, legacyFactor: 100),
 ]
 
 extension List: Sequence {
@@ -55,79 +76,25 @@ func benchmarkSequenceAlgos<S: Sequence>(s: S, n: Int) where S.Element == Int {
   CheckResults(s.starts(with: s))
 }
 
-let n = 10_000
+let n = 1_000
 let r = 0..<(n*100)
 let l = List(0..<n)
 let c = ContiguousArray(0..<(n*100))
 let a = Array(0..<(n*100))
-let y = AnySequence(0..<n)
+let y = AnySequence(0..<n/10)
 let s = sequence(first: 0, next: { $0 < n&-1 ? $0&+1 : nil})
 
-func buildWorkload() {
-  blackHole(l.makeIterator())
-  blackHole(c.makeIterator())
-  blackHole(a.makeIterator())
-  blackHole(y.makeIterator())
-  blackHole(s.makeIterator())
-}
-
-func benchmarkEquatableSequenceAlgos<S: Sequence>(s: S, n: Int) where S.Element == Int, S: Equatable {
+func benchmarkEquatableSequenceAlgos<S: Sequence>(s: S, n: Int)
+  where S.Element == Int, S: Equatable {
   CheckResults(repeatElement(s, count: 1).contains(s))
   CheckResults(!repeatElement(s, count: 1).contains { $0 != s })
-}
-
-@inline(never)
-public func run_SequenceAlgosRange(_ N: Int) {
-  for _ in 0..<N {
-    benchmarkSequenceAlgos(s: r, n: r.count)
-    benchmarkEquatableSequenceAlgos(s: r, n: r.count)
-  }
-}
-
-@inline(never)
-public func run_SequenceAlgosArray(_ N: Int) {
-  for _ in 0..<N {
-    benchmarkSequenceAlgos(s: a, n: a.count)
-    benchmarkEquatableSequenceAlgos(s: a, n: a.count)
-  }
-}
-
-@inline(never)
-public func run_SequenceAlgosContiguousArray(_ N: Int) {
-  for _ in 0..<N {
-    benchmarkSequenceAlgos(s: c, n: c.count)
-    benchmarkEquatableSequenceAlgos(s: c, n: c.count)
-  }
-}
-
-@inline(never)
-public func run_SequenceAlgosAnySequence(_ N: Int) {
-  for _ in 0..<N {
-    benchmarkSequenceAlgos(s: y, n: n)
-  }
-}
-
-@inline(never)
-public func run_SequenceAlgosUnfoldSequence(_ N: Int) {
-  for _ in 0..<N {
-    benchmarkSequenceAlgos(s: s, n: n)
-  }
-}
-
-@inline(never)
-public func run_SequenceAlgosList(_ N: Int) {
-  for _ in 0..<N {
-    benchmarkSequenceAlgos(s: l, n: n)
-    benchmarkEquatableSequenceAlgos(s: l, n: n)
-  }
 }
 
 enum List<Element> {
   case end
   indirect case node(Element, List<Element>)
-  
+
   init<S: BidirectionalCollection>(_ elements: S) where S.Element == Element {
     self = elements.reversed().reduce(.end) { .node($1,$0) }
   }
 }
-

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -296,29 +296,29 @@ public let SetTests = [
   // Legacy benchmarks, kept for continuity with previous releases.
   BenchmarkInfo(
     name: "SetExclusiveOr", // ~"SetSymmetricDifferenceInt0"
-    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 100 * n) },
+    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 10 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
+    setUpFunction: { blackHole([setAB, setCD]) }, legacyFactor: 10),
   BenchmarkInfo(
     name: "SetExclusiveOr_OfObjects", // ~"SetSymmetricDifferenceBox0"
-    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOCD, countABCD, 100 * n) },
+    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOCD, countABCD, 10 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOCD]) }),
+    setUpFunction: { blackHole([setOAB, setOCD]) }, legacyFactor: 10),
   BenchmarkInfo(
     name: "SetIntersect", // ~"SetIntersectionInt0"
-    runFunction: { n in run_SetIntersectionInt(setAB, setCD, 0, 100 * n) },
+    runFunction: { n in run_SetIntersectionInt(setAB, setCD, 0, 10 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
+    setUpFunction: { blackHole([setAB, setCD]) }, legacyFactor: 10),
   BenchmarkInfo(
     name: "SetUnion", // ~"SetUnionInt0"
-    runFunction: { n in run_SetUnionInt(setAB, setCD, countABCD, 100 * n) },
+    runFunction: { n in run_SetUnionInt(setAB, setCD, countABCD, 10 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
+    setUpFunction: { blackHole([setAB, setCD]) }, legacyFactor: 10),
   BenchmarkInfo(
     name: "SetUnion_OfObjects", // ~"SetUnionBox0"
-    runFunction: { n in run_SetUnionBox(setOAB, setOCD, countABCD, 100 * n) },
+    runFunction: { n in run_SetUnionBox(setOAB, setOCD, countABCD, 10 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOCD]) }),
+    setUpFunction: { blackHole([setOAB, setOCD]) }, legacyFactor: 10),
 ]
 
 @inline(never)

--- a/benchmark/single-source/SortIntPyramids.swift
+++ b/benchmark/single-source/SortIntPyramids.swift
@@ -8,11 +8,13 @@ public let SortIntPyramids = [
   BenchmarkInfo(
     name: "SortIntPyramid",
     runFunction: run_SortIntPyramid,
-    tags: [.validation, .api, .algorithm]),
+    tags: [.validation, .api, .algorithm],
+    legacyFactor: 5),
   BenchmarkInfo(
     name: "SortAdjacentIntPyramids",
     runFunction: run_SortAdjacentIntPyramids,
-    tags: [.validation, .api, .algorithm]),
+    tags: [.validation, .api, .algorithm],
+    legacyFactor: 5),
 ]
 
 // let A - array sorted in ascending order,
@@ -51,7 +53,7 @@ let adjacentPyramidsTemplate: [Int] = (1...aPH) + (1...aPH).reversed()
 
 @inline(never)
 public func run_SortIntPyramid(_ N: Int) {
-  for _ in 1...25*N {
+  for _ in 1...5*N {
     var pyramid = pyramidTemplate
 
     // sort pyramid in place.
@@ -64,7 +66,7 @@ public func run_SortIntPyramid(_ N: Int) {
 
 @inline(never)
 public func run_SortAdjacentIntPyramids(_ N: Int) {
-  for _ in 1...25*N {
+  for _ in 1...5*N {
     var adjacentPyramids = adjacentPyramidsTemplate
     adjacentPyramids.sort()
     // Check whether pyramid is sorted.

--- a/benchmark/single-source/SortLargeExistentials.swift
+++ b/benchmark/single-source/SortLargeExistentials.swift
@@ -17,7 +17,8 @@ import TestsUtils
 public let SortLargeExistentials = BenchmarkInfo(
   name: "SortLargeExistentials",
   runFunction: run_SortLargeExistentials,
-  tags: [.validation, .api, .algorithm])
+  tags: [.validation, .api, .algorithm],
+  legacyFactor: 100)
 
 protocol LetterKind {
   var value: String { get }
@@ -74,7 +75,7 @@ let lettersTemplate : [LetterKind] = [
 
 @inline(never)
 public func run_SortLargeExistentials(_ N: Int) {
-  for _ in 1...100*N {
+  for _ in 1...N {
     var letters = lettersTemplate
 
     letters.sort {

--- a/benchmark/single-source/SortStrings.swift
+++ b/benchmark/single-source/SortStrings.swift
@@ -11,14 +11,18 @@
 //===----------------------------------------------------------------------===//
 import TestsUtils
 
+let t: [BenchmarkCategory] = [.validation, .api, .algorithm, .String]
 // Sort an array of strings using an explicit sort predicate.
 public let SortStrings = [
-  BenchmarkInfo(name: "SortSortedStrings", runFunction: run_SortSortedStrings, tags: [.validation, .api, .algorithm, .String],
+  BenchmarkInfo(name: "SortSortedStrings",
+    runFunction: run_SortSortedStrings, tags: t,
     setUpFunction: { blackHole(sortedWords) }),
-  BenchmarkInfo(name: "SortStrings", runFunction: run_SortStrings, tags: [.validation, .api, .algorithm, .String],
+  BenchmarkInfo(name: "SortStrings",
+    runFunction: run_SortStrings, tags: t,
     setUpFunction: { blackHole(words) }),
-  BenchmarkInfo(name: "SortStringsUnicode", runFunction: run_SortStringsUnicode, tags: [.validation, .api, .algorithm, .String],
-    setUpFunction: { blackHole(unicodeWords) }),
+  BenchmarkInfo(name: "SortStringsUnicode",
+    runFunction: run_SortStringsUnicode, tags: t,
+    setUpFunction: { blackHole(unicodeWords) }, legacyFactor: 5),
 ]
 
 let sortedWords = words.sorted()
@@ -2050,7 +2054,7 @@ var unicodeWords: [String] = [
   ]
 
 public func run_SortStringsUnicode(_ N: Int) {
-  for _ in 1...5*N {
+  for _ in 1...N {
     benchSortStrings(unicodeWords)
   }
 }

--- a/benchmark/single-source/StackPromo.swift
+++ b/benchmark/single-source/StackPromo.swift
@@ -14,7 +14,8 @@ import TestsUtils
 public let StackPromo = BenchmarkInfo(
   name: "StackPromo",
   runFunction: run_StackPromo,
-  tags: [.regression])
+  tags: [.regression],
+  legacyFactor: 100)
 
 protocol Proto {
   func at() -> Int
@@ -43,17 +44,10 @@ class Foo : Proto {
 @inline(never)
 func work(_ f: Foo) -> Int {
   var r = 0
-  for _ in 0..<100_000 {
+  for _ in 0..<1_000 {
     r += testStackAllocation(f)
   }
   return r
-}
-
-@inline(never)
-func hole(_ use: Int, _ N: Int) {
-  if (N == 0) {
-    print("use: \(use)")
-  }
 }
 
 public func run_StackPromo(_ N: Int) {
@@ -66,5 +60,5 @@ public func run_StackPromo(_ N: Int) {
       r -= work(foo)
     }
   }
-  hole(r, N)
+  blackHole(r)
 }

--- a/benchmark/single-source/TwoSum.swift
+++ b/benchmark/single-source/TwoSum.swift
@@ -17,7 +17,8 @@ import TestsUtils
 public let TwoSum = BenchmarkInfo(
   name: "TwoSum",
   runFunction: run_TwoSum,
-  tags: [.validation, .api, .Dictionary, .Array, .algorithm])
+  tags: [.validation, .api, .Dictionary, .Array, .algorithm],
+  legacyFactor: 2)
 
 let array = [
   959,  81, 670, 727, 416, 171, 401, 398, 707, 596, 200,   9, 414,  98,  43,
@@ -61,7 +62,7 @@ public func run_TwoSum(_ N: Int) {
   var i1: Int?
   var i2: Int?
   var Dict: Dictionary<Int, Int> = [:]
-  for _ in 1...2*N {
+  for _ in 1...N {
     for Sum in 500..<600 {
       Dict = [:]
       i1 = nil

--- a/benchmark/single-source/WordCount.swift
+++ b/benchmark/single-source/WordCount.swift
@@ -27,37 +27,43 @@ public let WordCount = [
     name: "WordSplitASCII",
     runFunction: run_WordSplitASCII,
     tags: [.validation, .api, .String, .algorithm, .unstable],
-    setUpFunction: { buildWorkload() }
+    setUpFunction: { buildWorkload() },
+    legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "WordSplitUTF16",
     runFunction: run_WordSplitUTF16,
     tags: [.validation, .api, .String, .algorithm, .unstable],
-    setUpFunction: { buildWorkload() }
+    setUpFunction: { buildWorkload() },
+    legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "WordCountUniqueASCII",
     runFunction: run_WordCountUniqueASCII,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { buildWorkload() }
+    setUpFunction: { buildWorkload() },
+    legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "WordCountUniqueUTF16",
     runFunction: run_WordCountUniqueUTF16,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { buildWorkload() }
+    setUpFunction: { buildWorkload() },
+    legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "WordCountHistogramASCII",
     runFunction: run_WordCountHistogramASCII,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { buildWorkload() }
+    setUpFunction: { buildWorkload() },
+    legacyFactor: 100
   ),
   BenchmarkInfo(
     name: "WordCountHistogramUTF16",
     runFunction: run_WordCountHistogramUTF16,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { buildWorkload() }
+    setUpFunction: { buildWorkload() },
+    legacyFactor: 100
   ),
 ]
 
@@ -201,7 +207,7 @@ struct Words: IteratorProtocol, Sequence {
 
 @inline(never)
 public func run_WordSplitASCII(_ N: Int) {
-  for _ in 1...10*N {
+  for _ in 1...N {
     let words = Array(Words(identity(asciiText)))
     CheckResults(words.count == 280)
     blackHole(words)
@@ -210,7 +216,7 @@ public func run_WordSplitASCII(_ N: Int) {
 
 @inline(never)
 public func run_WordSplitUTF16(_ N: Int) {
-  for _ in 1...10*N {
+  for _ in 1...N {
     let words = Array(Words(identity(utf16Text)))
     CheckResults(words.count == 280)
     blackHole(words)
@@ -222,7 +228,7 @@ let utf16Words = Array(Words(utf16Text))
 
 @inline(never)
 public func run_WordCountUniqueASCII(_ N: Int) {
-  for _ in 1...100*N {
+  for _ in 1...10*N {
     let words = Set(identity(asciiWords))
     CheckResults(words.count == 168)
     blackHole(words)
@@ -231,7 +237,7 @@ public func run_WordCountUniqueASCII(_ N: Int) {
 
 @inline(never)
 public func run_WordCountUniqueUTF16(_ N: Int) {
-  for _ in 1...100*N {
+  for _ in 1...10*N {
     let words = Set(identity(utf16Words))
     CheckResults(words.count == 168)
     blackHole(words)
@@ -252,7 +258,7 @@ where S.Element == String {
 
 @inline(never)
 public func run_WordCountHistogramASCII(_ N: Int) {
-  for _ in 1...100*N {
+  for _ in 1...N {
     let words = histogram(for: identity(asciiWords))
     CheckResults(words.count == 168)
     CheckResults(words[0] == ("and", 15))
@@ -262,7 +268,7 @@ public func run_WordCountHistogramASCII(_ N: Int) {
 
 @inline(never)
 public func run_WordCountHistogramUTF16(_ N: Int) {
-  for _ in 1...100*N {
+  for _ in 1...N {
     let words = histogram(for: identity(utf16Words))
     CheckResults(words.count == 168)
     CheckResults(words[0] == ("and", 15))


### PR DESCRIPTION
This PR follows-up  #20861, #21413, #21516, #21794 and #22026 in clean-up efforts to enable [robust performance measurements](https://forums.swift.org/t/towards-robust-performance-measurement/11490) by adjusting workloads to run in reasonable time (< 1000 μs), minimizing the accumulated error. To maintain long-term performance tracking, it applies [legacy factor](https://github.com/apple/swift/pull/20212) where necessary.

This one's just the remainder of benchmarks wading through the rest of the alphabet. (There still might be some loose ends to tie later on...)