### PR TITLE
IRGen: ensure ordering of instructions (NFC)

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -2108,10 +2108,9 @@ static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
         //  Size = ((sizeof(HeapObject) + align) & ~align) + size
         auto *heapHeaderSize = llvm::ConstantInt::get(
             IGF.IGM.SizeTy, IGM.RefCountedStructSize.getValue());
-        size = Builder.CreateAdd(
-            Builder.CreateAnd(Builder.CreateAdd(heapHeaderSize, alignmentMask),
-                              Builder.CreateNot(alignmentMask)),
-            size);
+        auto *Add = Builder.CreateAdd(heapHeaderSize, alignmentMask);
+        auto *Not = Builder.CreateNot(alignmentMask);
+        size = Builder.CreateAdd(Builder.CreateAnd(Add, Not), size);
 
         // At least pointer aligned.
         //  AlignmentMask = alignmentMask | alignof(void*) - 1
@@ -2202,9 +2201,9 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
           //  StartOffset = ((sizeof(HeapObject) + align) & ~align)
           auto *heapHeaderSize = llvm::ConstantInt::get(
               IGF.IGM.SizeTy, IGM.RefCountedStructSize.getValue());
-          auto *startOffset = Builder.CreateAnd(
-              Builder.CreateAdd(heapHeaderSize, alignmentMask),
-              Builder.CreateNot(alignmentMask));
+          auto *Add = Builder.CreateAdd(heapHeaderSize, alignmentMask);
+          auto *Not = Builder.CreateNot(alignmentMask);
+          auto *startOffset = Builder.CreateAnd(Add, Not);
           auto *addressInBox =
               IGF.emitByteOffsetGEP(boxReference, startOffset, IGM.OpaqueTy);
           IGF.Builder.CreateRet(addressInBox);


### PR DESCRIPTION
Split out the subconstructors to ensure guaranteed IR ordering irrespective of
order of evaluation of parameters which is not specified.  This is needed for
identical IRGen on Windows.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
