### PR TITLE
test: disable weak_import tests on Windows

### DIFF
--- a/test/IRGen/weak_import_native.sil
+++ b/test/IRGen/weak_import_native.sil
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage canonical
 
 // CHECK-DAG: define{{( protected)?}} swiftcc void @weakButDefined() {{#[0-9]+}} {

--- a/test/IRGen/weak_import_native.swift
+++ b/test/IRGen/weak_import_native.swift
@@ -3,6 +3,8 @@
 //
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: OS=windows-msvc
+
 import weak_import_native_helper
 
 // CHECK-DAG-LABEL: @"$s25weak_import_native_helper23ProtocolWithWeakMembersP1TAC_AA05OtherE0Tn" = extern_weak global %swift.protocol_requirement


### PR DESCRIPTION
`weak_import` is not support on PE/COFF, disable the tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
