### PR TITLE
 [ParseableInterfaces] Re-escape multi-line strings in attribute messages

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -207,6 +207,8 @@ public:
     return *this;
   }
 
+  void printEscapedStringLiteral(StringRef str);
+
   void printName(Identifier Name,
                  PrintNameContext Context = PrintNameContext::Normal);
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -270,6 +270,22 @@ void ASTPrinter::printTextImpl(StringRef Text) {
   printText(Text);
 }
 
+void ASTPrinter::printEscapedStringLiteral(StringRef str) {
+  SmallString<128> encodeBuf;
+  StringRef escaped =
+    Lexer::getEncodedStringSegment(str, encodeBuf,
+                                   /*isFirstSegment*/true,
+                                   /*isLastSegment*/true,
+                                   /*indentToStrip*/~0U /* sentinel */);
+
+  // FIXME: This is wasteful, but ASTPrinter is an abstract class that doesn't
+  //        have a directly-accessible ostream.
+  SmallString<128> escapeBuf;
+  llvm::raw_svector_ostream os(escapeBuf);
+  os << QuotedString(escaped);
+  printTextImpl(escapeBuf.str());
+}
+
 void ASTPrinter::printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name) {
   PrintNameContext Context = PrintNameContext::Normal;
   if (isa<GenericTypeParamDecl>(RefTo)) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -460,8 +460,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     // If there's no message, but this is specifically an imported
     // "unavailable in Swift" attribute, synthesize a message to look good in
     // the generated interface.
-    if (!Attr->Message.empty())
-      Printer << ", message: \"" << Attr->Message << "\"";
+    if (!Attr->Message.empty()) {
+      Printer << ", message: ";
+      Printer.printEscapedStringLiteral(Attr->Message);
+    }
     else if (Attr->getPlatformAgnosticAvailability()
                == PlatformAgnosticAvailabilityKind::UnavailableInSwift)
       Printer << ", message: \"Not available in Swift\"";

--- a/test/ParseableInterface/multiline-availability-message.swift
+++ b/test/ParseableInterface/multiline-availability-message.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -module-name Test -emit-parseable-module-interface-path %t/Test.swiftinterface %s
+// RUN: %FileCheck %s < %t/Test.swiftinterface
+// RUN: %target-swift-frontend -build-module-from-parseable-interface %t/Test.swiftinterface -o %t/Test.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-parseable-module-interface-path - %t/Test.swiftmodule -module-name Test | %FileCheck %s
+
+// CHECK: @available(*, unavailable, message: "First line.\nAnother line!")
+// CHECK: public func catastrophicFunction()
+@available(*,
+  unavailable,
+  message: """
+    First line.
+    Another line!
+    """)
+public func catastrophicFunction() {}
+
+// CHECK: @available(*, unavailable, message: "\n    First line.\n    Another line!")
+// CHECK: public func catastrophicFunction2()
+@available(*, unavailable, message: "\n    First line.\n    Another line!")
+public func catastrophicFunction2() {}


### PR DESCRIPTION
Previously, we would print multi-line string literals with single quotes, which were not re-parseable. Instead, re-escape their contents and print them out escaped.

rdar://47682919