### PR TITLE
[perf-inliner] Do not inline non-ossa funcs into ossa transparent funcs.

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -891,7 +891,16 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
     if (!Callee->shouldOptimize()) {
       continue;
     }
-    
+
+    // If we have a callee that doesn't have ownership, but the caller does have
+    // ownership... do not inline. The two modes are incompatible. Today this
+    // should only happen with transparent functions.
+    if (!Callee->hasOwnership() && Caller->hasOwnership()) {
+      assert(Caller->isTransparent() &&
+             "Should only happen with transparent functions");
+      continue;
+    }
+
     SmallVector<SILValue, 8> Args;
     for (const auto &Arg : AI.getArguments())
       Args.push_back(Arg);

--- a/test/SILOptimizer/devirt_ctors_ownership.sil
+++ b/test/SILOptimizer/devirt_ctors_ownership.sil
@@ -13,8 +13,8 @@ class ABC {
 
 
 // This is our c'tor.
-sil @_TFC4main3ABCcfMS0_FT1ySi_S0_ : $@convention(method) (Int64, @owned ABC) -> @owned ABC {
-bb0(%0 : $Int64, %1 : $ABC):
+sil [ossa] @_TFC4main3ABCcfMS0_FT1ySi_S0_ : $@convention(method) (Int64, @owned ABC) -> @owned ABC {
+bb0(%0 : $Int64, %1 : @owned $ABC):
   return %1 : $ABC                                // id: %38
 }
 

--- a/test/SILOptimizer/performance_inliner_ownership.sil
+++ b/test/SILOptimizer/performance_inliner_ownership.sil
@@ -1,0 +1,41 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// Make sure that we do not try to inline non-ossa functions into ossa
+// functions. This can only occur with transparent functions today.
+
+// We do not need a filecheck here since if we inline, the strong_release will
+// hit assertions since strong_release is a non-ossa instruction that can never
+// be in an ossa function.
+sil [transparent] [ossa] @ossa_transparent_caller : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = function_ref @non_ossa_callee : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %1(%0) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We put in this filecheck test to make sure that without the [ossa] bit, we
+// /would/ inline.
+//
+// CHECK-LABEL: sil [transparent]  @non_ossa_caller : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: strong_release
+// CHECK: } // end sil function 'non_ossa_caller'
+sil [transparent] @non_ossa_caller : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = function_ref @non_ossa_callee : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %1(%0) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @non_ossa_callee : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_release %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This is a temporary restriction for this round of ownership work until I update
the perf pipeline for ownership.
