### PR TITLE
[5.0]  [Clang importer] Existentials do not conform to Hashable.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2436,9 +2436,13 @@ bool ClangImporter::Implementation::matchesHashableBound(Type type) {
   // Match generic parameters against their bounds.
   if (auto *genericTy = type->getAs<GenericTypeParamType>()) {
     if (auto *generic = genericTy->getDecl()) {
-      type = generic->getSuperclass();
-      if (!type)
-        return false;
+      auto genericSig =
+        generic->getDeclContext()->getGenericSignatureOfContext();
+      if (genericSig && genericSig->getConformsTo(type).empty()) {
+        type = genericSig->getSuperclassBound(type);
+        if (!type)
+          return false;
+      }
     }
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
@@ -2441,7 +2442,11 @@ bool ClangImporter::Implementation::matchesHashableBound(Type type) {
     }
   }
 
-  // Class type or existential that inherits from NSObject.
+  // Existentials cannot match the Hashable bound.
+  if (type->isAnyExistentialType())
+    return false;
+
+  // Class type that inherits from NSObject.
   if (NSObjectType->isExactSuperclassOf(type))
     return true;
 

--- a/test/ClangImporter/Inputs/custom-modules/ObjCBridgeNonconforming.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCBridgeNonconforming.h
@@ -27,3 +27,7 @@
 @interface ObjCBridgeGenericConstrainedExtra<Element: NSObject <ExtraElementProtocol> *> : NSObject
 @property NSSet<Element> * _Nonnull foo;
 @end
+
+@interface ObjCBridgeExistential : NSObject
+@property NSSet<NSObject<ExtraElementProtocol> *> * _Nonnull foo;
+@end

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -413,7 +413,7 @@ func testHashableGenerics(
   let _: Int = any.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
   let _: Int = constrained.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
   let _: Int = insufficient.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
-  let _: Int = extra.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
+  let _: Int = extra.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
   let _: Int = existential.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
 }
 

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -408,11 +408,13 @@ func testHashableGenerics(
     any: ObjCBridgeGeneric<ElementConcrete>,
     constrained: ObjCBridgeGenericConstrained<ElementConcrete>,
     insufficient: ObjCBridgeGenericInsufficientlyConstrained<ElementConcrete>,
-    extra: ObjCBridgeGenericConstrainedExtra<ElementConcrete>) {
+    extra: ObjCBridgeGenericConstrainedExtra<ElementConcrete>,
+    existential: ObjCBridgeExistential) {
   let _: Int = any.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
   let _: Int = constrained.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
   let _: Int = insufficient.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
   let _: Int = extra.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
+  let _: Int = existential.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
 }
 
 func testGenericsWithTypedefBlocks(hba: HasBlockArray) {


### PR DESCRIPTION
The Clang importer was importing Objective-C types such as `NSSet<NSObject<SomeProto> *> *` with a set of an existential type, e.g., `Set<NSObject & SomeProto>`. However, such existential types do not conform to the `Hashable` protocol, causing a crash in later stages of compilation. Detect these cases and instead import as `Set<AnyHashable>`.

Fixes rdar://problem/47564982.