### PR TITLE
SIL: add a trace for the construction of witness tables

### DIFF
--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -19,6 +19,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "sil-witness-table"
 #include "swift/SIL/SILWitnessTable.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
@@ -65,6 +66,8 @@ SILWitnessTable *SILWitnessTable::create(
 
   // Create the mangled name of our witness table...
   Identifier Name = M.getASTContext().getIdentifier(mangleConstant(Conformance));
+
+  LLVM_DEBUG(llvm::dbgs() << "SILWitnessTable Creating: " << Name.str() << '\n');
 
   // Allocate the witness table and initialize it.
   void *buf = M.allocate(sizeof(SILWitnessTable), alignof(SILWitnessTable));


### PR DESCRIPTION
Add an optional debug trace for the construction of Witness tables.  This was
helpful in diagnosing the out-of-order emission of witness tables on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
