### PR TITLE
Added some debug logging for numpy->swift conversion.

### DIFF
--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -28,16 +28,22 @@ extension ShapedArray : ConvertibleFromNumpyArray
   public init?(numpy numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
+      debugLog("numpy array is not an ndarray.")
       return nil
     }
     // Check if the dtype of the `ndarray` is compatible with the `Scalar`
     // type.
     guard Scalar.numpyScalarTypes.contains(numpyArray.dtype) else {
+      debugLog("""
+                 ndarray dtype \(numpyArray.dtype) cannot be mapped to Swift \
+                 type \(Scalar.self).
+                 """)
       return nil
     }
 
     let pyShape = numpyArray.__array_interface__["shape"]
     guard let shape = Array<Int>(pyShape) else {
+      debugLog("unknown numpy array shape.")
       return nil
     }
 
@@ -47,6 +53,7 @@ extension ShapedArray : ConvertibleFromNumpyArray
 
     guard let ptrVal =
       UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
+      debugLog("cannot get the data pointer of the numpy array.")
       return nil
     }
     // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape

--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -23,27 +23,34 @@ import Python
 // a Python import error until it is first used.
 private let np = Python.import("numpy")
 
+private func debugLogNumpyError(_ message: String) {
+  debugLog("NumPy conversion error: " + message)
+}
+
 extension ShapedArray : ConvertibleFromNumpyArray
   where Scalar : NumpyScalarCompatible {
   public init?(numpy numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
-      debugLog("numpy array is not an ndarray.")
+      debugLogNumpyError("""
+        PythonObject input has type '\(Python.type(numpyArray))' and is not \
+        an instance of 'numpy.ndarray'.
+        """)
       return nil
     }
     // Check if the dtype of the `ndarray` is compatible with the `Scalar`
     // type.
     guard Scalar.numpyScalarTypes.contains(numpyArray.dtype) else {
-      debugLog("""
-                 ndarray dtype \(numpyArray.dtype) cannot be mapped to Swift \
-                 type \(Scalar.self).
-                 """)
+      debugLogNumpyError("""
+        'numpy.ndarray' dtype '\(numpyArray.dtype)' is incompatible with \
+        Swift type '\(Scalar.self)'.
+        """)
       return nil
     }
 
     let pyShape = numpyArray.__array_interface__["shape"]
     guard let shape = Array<Int>(pyShape) else {
-      debugLog("unknown numpy array shape.")
+      debugLogNumpyError("cannot access shape of 'numpy.ndarray' instance.")
       return nil
     }
 
@@ -53,13 +60,13 @@ extension ShapedArray : ConvertibleFromNumpyArray
 
     guard let ptrVal =
       UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
-      debugLog("cannot get the data pointer of the numpy array.")
+      debugLogNumpyError("cannot access data of 'numpy.ndarray' instance.")
       return nil
     }
     // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
     // of `(0,)`).
     guard let ptr = UnsafePointer<Scalar>(bitPattern: ptrVal) else {
-      fatalError("numpy.ndarray data pointer was nil")
+      fatalError("'numpy.ndarray' data pointer was nil")
     }
     // This code avoids calling `init<S : Sequence>(shape: [Int], scalars: S)`,
     // which inefficiently copies scalars one by one. Instead,
@@ -83,16 +90,25 @@ extension Tensor : ConvertibleFromNumpyArray
   public init?(numpy numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
+      debugLogNumpyError("""
+        PythonObject input has type '\(Python.type(numpyArray))' and is not \
+        an instance of 'numpy.ndarray'.
+        """)
       return nil
     }
     // Check if the dtype of the `ndarray` is compatible with the `Scalar`
     // type.
     guard Scalar.numpyScalarTypes.contains(numpyArray.dtype) else {
+      debugLogNumpyError("""
+        'numpy.ndarray' dtype '\(numpyArray.dtype)' is incompatible with \
+        Swift type '\(Scalar.self)'.
+        """)
       return nil
     }
 
     let pyShape = numpyArray.__array_interface__["shape"]
     guard let dimensions = Array<Int32>(pyShape) else {
+      debugLogNumpyError("cannot access shape of 'numpy.ndarray' instance.")
       return nil
     }
     let shape = TensorShape(dimensions)
@@ -103,12 +119,13 @@ extension Tensor : ConvertibleFromNumpyArray
 
     guard let ptrVal =
       UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
+      debugLogNumpyError("cannot access data of 'numpy.ndarray' instance.")
       return nil
     }
     // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
     // of `(0,)`).
     guard let ptr = UnsafePointer<Scalar>(bitPattern: ptrVal) else {
-      fatalError("numpy.ndarray data pointer was nil")
+      fatalError("'numpy.ndarray' data pointer was nil")
     }
     let buffPtr = UnsafeBufferPointer(start: ptr,
                                       count: Int(shape.contiguousSize))


### PR DESCRIPTION
e.g. If the numpy array has dtype float64, but we write: `Tensor<Float>(numpy:
numpy)`, the output will be nil.

After turning on debug log, we will see that the correct code is `Tensor<Double>(numpy: numpy)`.
