### PR TITLE
Add 20-round Threefry32x2 to TensorFlow Random.swift

### DIFF
--- a/stdlib/public/TensorFlow/Random.swift
+++ b/stdlib/public/TensorFlow/Random.swift
@@ -111,6 +111,179 @@ public struct ARC4RandomNumberGenerator: SeedableRandomNumberGenerator {
   }
 }
 
+/// An implementation of `SeedableRandomNumberGenerator` using Threefry.
+/// Salmon et al. SC 2011. Parallel random numbers: as easy as 1, 2, 3.
+/// http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
+///
+/// This struct implements a 20-rotation Threefry32x2 PRNG. It must be seeded
+/// with a 64-bit value.
+///
+/// An individual generator is not thread-safe, but distinct generators do not
+/// share state. The random data generated is of high-quality, but is not
+/// suitable for cryptographic applications.
+@_fixed_layout
+public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
+  private typealias ThreefryArray = (UInt32, UInt32)
+
+  private static let rot:
+    (UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32)
+    = (13, 15, 26, 6, 17, 29, 16, 24)
+
+  private static func rotl32(value: UInt32, n: UInt32) -> UInt32 {
+    return (value << (n & 31)) | (value >> ((32 - n) & 31))
+  }
+
+  private var ctr: UInt64 = 0
+  private let key: ThreefryArray
+
+  private static func split(_ value: UInt64) -> ThreefryArray {
+    let msb = UInt32(truncatingIfNeeded: (value & 0xFFFF_FFFF_0000_0000) >> 32)
+    let lsb = UInt32(truncatingIfNeeded: value & 0x0000_0000_FFFF_FFFF)
+    return (msb, lsb)
+  }
+
+  private static func combine(_ value: ThreefryArray) -> UInt64 {
+    return (UInt64(value.0) << 32) + UInt64(value.1)
+  }
+
+  private static func calculateRandom(ctr: ThreefryArray, key: ThreefryArray) -> ThreefryArray {
+    let skeinKsParity32: UInt32 = 0x1BD11BDA
+
+    let ks0 = key.0
+    let ks1 = key.1
+    let ks2 = skeinKsParity32 ^ key.0 ^ key.1
+    var X0 = ctr.0
+    var X1 = ctr.1
+
+    // 20 rounds
+    // Key injection
+    X0 &+= ks0
+    X1 &+= ks1
+    // R1
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.0)
+    X1 ^= X0
+    // R2
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.1)
+    X1 ^= X0
+    // R3
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.2)
+    X1 ^= X0
+    // R4
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.3)
+    X1 ^= X0
+    // Key injection (r = 1)
+    X0 &+= ks1
+    X1 &+= (ks2 + 1)
+    // R5
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.4)
+    X1 ^= X0
+    // R6
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.5)
+    X1 ^= X0
+    // R7
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.6)
+    X1 ^= X0
+    // R8
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.7)
+    X1 ^= X0
+    // Key injection (r = 2)
+    X0 &+= ks2
+    X1 &+= (ks0 + 2)
+    // R9
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.0)
+    X1 ^= X0
+    // R10
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.1)
+    X1 ^= X0
+    // R11
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.2)
+    X1 ^= X0
+    // R12
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.3)
+    X1 ^= X0
+    // Key injection (r = 3)
+    X0 &+= ks0
+    X1 &+= (ks1 + 3)
+    // R13
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.4)
+    X1 ^= X0
+    // R14
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.5)
+    X1 ^= X0
+    // R15
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.6)
+    X1 ^= X0
+    // R16
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.7)
+    X1 ^= X0
+    // Key injection (r = 4)
+    X0 &+= ks1
+    X1 &+= (ks2 + 4)
+    // R17
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.0)
+    X1 ^= X0
+    // R18
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.1)
+    X1 ^= X0
+    // R19
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.2)
+    X1 ^= X0
+    // R20
+    X0 &+= X1
+    X1 = rotl32(value: X1, n: rot.3)
+    X1 ^= X0
+    // Key injection (r = 5)
+    X0 &+= ks2
+    X1 &+= (ks0 + 5)
+
+    return (X0, X1)
+  }
+
+  init(uint64seed seed: UInt64) {
+    key = ThreefryRandomNumberGenerator.split(seed)
+  }
+
+  public init(seed: [UInt8]) {
+    precondition(seed.count > 0, "Length of seed must be positive")
+    precondition(seed.count <= 8, "Length of seed must be at most 8")
+    var combinedSeed: UInt64 = 0
+    for i in 0..<seed.count {
+      combinedSeed += UInt64(seed[i]) << UInt64(8 * i)
+    }
+    self.init(uint64seed: combinedSeed)
+  }
+
+  public mutating func next() -> UInt64 {
+    let value = ThreefryRandomNumberGenerator.combine(
+      ThreefryRandomNumberGenerator.calculateRandom(
+        ctr: ThreefryRandomNumberGenerator.split(ctr),
+        key: key
+      )
+    )
+    ctr += 1
+    return value
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Distributions
 //===----------------------------------------------------------------------===//
@@ -183,7 +356,7 @@ public final class BetaDistribution {
 
   public func next<G: RandomNumberGenerator>(using rng: inout G) -> Float {
     // Generate a sample using Cheng's sampling algorithm from:
-    // R. C. H. Cheng, "Generating beta variates with nonintegral shape 
+    // R. C. H. Cheng, "Generating beta variates with nonintegral shape
     // parameters.". Communications of the ACM, 21, 317-322, 1978.
     let a = min(alpha, beta)
     let b = max(alpha, beta)
@@ -194,7 +367,7 @@ public final class BetaDistribution {
     }
   }
 
-  /// Returns one sample from a Beta(alpha, beta) distribution using Cheng's BB 
+  /// Returns one sample from a Beta(alpha, beta) distribution using Cheng's BB
   /// algorithm, when both alpha and beta are greater than 1.
   ///
   /// - Parameters:
@@ -205,9 +378,9 @@ public final class BetaDistribution {
   ///
   /// - Returns: Sample obtained using Cheng's BB algorithm.
   private static func chengsAlgorithmBB<G: RandomNumberGenerator>(
-    _ alpha0: Float, 
-    _ a: Float, 
-    _ b: Float, 
+    _ alpha0: Float,
+    _ a: Float,
+    _ b: Float,
     using rng: inout G
   ) -> Float {
     let alpha = a + b
@@ -241,7 +414,7 @@ public final class BetaDistribution {
     return a == alpha0 ? w / (b + w) : b / (b + w)
   }
 
-  /// Returns one sample from a Beta(alpha, beta) distribution using Cheng's BC 
+  /// Returns one sample from a Beta(alpha, beta) distribution using Cheng's BC
   /// algorithm, when at least one of alpha and beta is less than 1.
   ///
   /// - Parameters:
@@ -252,9 +425,9 @@ public final class BetaDistribution {
   ///
   /// - Returns: Sample obtained using Cheng's BB algorithm.
   private static func chengsAlgorithmBC<G: RandomNumberGenerator>(
-    _ alpha0: Float, 
-    _ a: Float, 
-    _ b: Float, 
+    _ alpha0: Float,
+    _ a: Float,
+    _ b: Float,
     using rng: inout G
   ) -> Float {
     let alpha = a + b
@@ -264,7 +437,7 @@ public final class BetaDistribution {
     let k2    = 0.25 + (0.5 + 0.25 / delta) * b
 
     var w: Float = 0.0
-    
+
     while true {
       let u1 = Float.random(in: 0.0...1.0, using: &rng)
       let u2 = Float.random(in: 0.0...1.0, using: &rng)


### PR DESCRIPTION
This PR adds a new Threefry-based PRNG implementation to the TensorFlow standard library.

`ThreefryRandomNumberGenerator` is expected to be anywhere between 2.8x and 7x faster than `ARC4RandomNumberGenerator`, depending on how the TensorFlow standard library is built, and can be more easily parallelized for future applications which require the generation of multiple pseudorandom values (i.e. to fill a buffer).

The PRNG has been manually validated against the C reference implementation available [here](http://www.deshawresearch.com/resources_random123.html) to generate the same values given the same seeds.

Future work will introduce a Philox-based generator, as well as a generator representing access to TensorFlow RNG ops.

@rxwei 