### PR TITLE
Windows: extend WinSDK module further

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -11,6 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 module WinSDK [system] [extern_c] {
+  module WinSock2 {
+    header "WinSock2.h"
+    header "WS2tcpip.h"
+    export *
+  }
+
   module core {
     // api-ms-win-core-errhandling-l1-1-0.dll
     module errhandling {
@@ -39,6 +45,11 @@ module WinSDK [system] [extern_c] {
     // api-ms-win-core-interlocked-l1-1-0.dll
     module interlocked {
       header "interlockedapi.h"
+      export *
+    }
+
+    module iphlp {
+      header "iphlpapi.h"
       export *
     }
 


### PR DESCRIPTION
This extends the WinSDK modulemap to cover Winsock2 and IPHelp API Set.
These are used in Foundation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
