### PR TITLE
[Sema] Derived conformances fixes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2446,6 +2446,9 @@ ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
+ERROR(broken_differentiable_generic_signature,none,
+      "'Differentiable' protocol derived conformances is broken; fix by "
+      "explicitly conforming %0 to 'AdditiveArithmetic'", (Type))
 WARNING(differentiable_implicit_noderivative_fixit,none,
       "stored property has no derivative because it does not conform to "
       "'Differentiable'; add '@noDerivative' to make it explicit", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2448,7 +2448,7 @@ ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
 ERROR(differentiable_need_explicit_addarith_conformance,none,
       "synthesizing a conformance to 'Differentiable' requires an explicit "
-      "%0 : 'AdditiveArithmetic' conformance constraint", (Type))
+      "'%0' conformance constraint", (StringRef))
 WARNING(differentiable_implicit_noderivative_fixit,none,
       "stored property has no derivative because it does not conform to "
       "'Differentiable'; add '@noDerivative' to make it explicit", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2446,9 +2446,9 @@ ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
-ERROR(broken_differentiable_generic_signature,none,
-      "'Differentiable' protocol derived conformances is broken; fix by "
-      "explicitly conforming %0 to 'AdditiveArithmetic'", (Type))
+ERROR(differentiable_need_explicit_addarith_conformance,none,
+      "synthesizing a conformance to 'Differentiable' requires an explicit "
+      "%0 : 'AdditiveArithmetic' conformance constraint", (Type))
 WARNING(differentiable_implicit_noderivative_fixit,none,
       "stored property has no derivative because it does not conform to "
       "'Differentiable'; add '@noDerivative' to make it explicit", ())

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -76,29 +76,28 @@ static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
   return lookup[0];
 }
 
-// Return the `Scalar` associated type for a ValueDecl if it conforms to
-// `VectorNumeric` in the given context.
-// If the decl does not conform to `VectorNumeric`, return nullptr.
-static Type getVectorNumericScalarAssocType(VarDecl *decl, DeclContext *DC) {
-  auto &C = decl->getASTContext();
+// Return the `Scalar` associated type for the given `ValueDecl` if it conforms
+// to `VectorNumeric` in the given context. Otherwise, return `nullptr`.
+static Type getVectorNumericScalarAssocType(VarDecl *varDecl, DeclContext *DC) {
+  auto &C = varDecl->getASTContext();
   auto *vectorNumericProto = C.getProtocol(KnownProtocolKind::VectorNumeric);
-  if (!decl->hasInterfaceType())
-    C.getLazyResolver()->resolveDeclSignature(decl);
-  if (!decl->hasInterfaceType())
+  if (!varDecl->hasInterfaceType())
+    C.getLazyResolver()->resolveDeclSignature(varDecl);
+  if (!varDecl->hasInterfaceType())
     return nullptr;
-  auto declType = DC->mapTypeIntoContext(decl->getValueInterfaceType());
-  auto conf = TypeChecker::conformsToProtocol(declType, vectorNumericProto, DC,
+  auto varType = DC->mapTypeIntoContext(varDecl->getValueInterfaceType());
+  auto conf = TypeChecker::conformsToProtocol(varType, vectorNumericProto, DC,
                                               ConformanceCheckFlags::Used);
   if (!conf)
     return nullptr;
   Type scalarType = ProtocolConformanceRef::getTypeWitnessByName(
-      declType, *conf, C.Id_Scalar, C.getLazyResolver());
+      varType, *conf, C.Id_Scalar, C.getLazyResolver());
   assert(scalarType && "'Scalar' associated type not found");
   return scalarType;
 }
 
-// Return the `Scalar` associated type for a nominal type with the given
-// members, or nullptr if `Scalar` cannot be derived.
+// Return the `Scalar` associated type for the given nominal type in the given
+// context, or `nullptr` if `Scalar` cannot be derived.
 static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal,
                                        DeclContext *DC) {
   auto &C = DC->getASTContext();
@@ -113,7 +112,7 @@ static Type deriveVectorNumeric_Scalar(NominalTypeDecl *nominal,
     if (!member->hasInterfaceType())
       C.getLazyResolver()->resolveDeclSignature(member);
     if (!member->hasInterfaceType())
-      return Type();
+      return nullptr;
     auto scalarType = getVectorNumericScalarAssocType(member, DC);
     // If stored property does not conform to `VectorNumeric`, return nullptr.
     if (!scalarType)
@@ -157,8 +156,8 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
       C.getLazyResolver()->resolveDeclSignature(v);
     if (!v->hasInterfaceType())
       return false;
-    auto declType = DC->mapTypeIntoContext(v->getValueInterfaceType());
-    return (bool)TypeChecker::conformsToProtocol(declType, addArithProto, DC,
+    auto varType = DC->mapTypeIntoContext(v->getValueInterfaceType());
+    return (bool)TypeChecker::conformsToProtocol(varType, addArithProto, DC,
                                                  ConformanceCheckFlags::Used);
   });
 }
@@ -178,7 +177,8 @@ bool DerivedConformance::canDeriveVectorNumeric(NominalTypeDecl *nominal,
 // Synthesize body for the given math operator.
 static void deriveBodyMathOperator(AbstractFunctionDecl *funcDecl,
                                    MathOperator op) {
-  auto *nominal = funcDecl->getDeclContext()->getSelfNominalTypeDecl();
+  auto *parentDC = funcDecl->getParent();
+  auto *nominal = parentDC->getSelfNominalTypeDecl();
   auto &C = nominal->getASTContext();
 
   // Create memberwise initializer: `Nominal.init(...)`.
@@ -206,7 +206,7 @@ static void deriveBodyMathOperator(AbstractFunctionDecl *funcDecl,
   auto createMemberOpExpr = [&](VarDecl *member) -> Expr * {
     auto module = nominal->getModuleContext();
     auto memberType =
-        nominal->mapTypeIntoContext(member->getValueInterfaceType());
+        parentDC->mapTypeIntoContext(member->getValueInterfaceType());
     auto confRef = module->lookupConformance(memberType, proto);
     assert(confRef && "Member does not conform to math protocol");
 
@@ -289,8 +289,8 @@ deriveBodyVectorNumeric_scalarMultiply(AbstractFunctionDecl *funcDecl) {
 static ValueDecl *deriveMathOperator(DerivedConformance &derived,
                                      MathOperator op) {
   auto nominal = derived.Nominal;
-  auto &C = derived.TC.Context;
   auto parentDC = derived.getConformanceContext();
+  auto &C = derived.TC.Context;
   auto selfInterfaceType = parentDC->getDeclaredInterfaceType();
 
   // Return tuple of the lhs and rhs parameter types for the given math
@@ -355,7 +355,8 @@ static ValueDecl *deriveMathOperator(DerivedConformance &derived,
 
 // Synthesize body for the `AdditiveArithmetic.zero` computed property getter.
 static void deriveBodyAdditiveArithmetic_zero(AbstractFunctionDecl *funcDecl) {
-  auto *nominal = funcDecl->getDeclContext()->getSelfNominalTypeDecl();
+  auto *parentDC = funcDecl->getParent();
+  auto *nominal = parentDC->getSelfNominalTypeDecl();
   auto &C = nominal->getASTContext();
 
   auto *memberwiseInitDecl = nominal->getMemberwiseInitializer();
@@ -372,10 +373,10 @@ static void deriveBodyAdditiveArithmetic_zero(AbstractFunctionDecl *funcDecl) {
 
   auto createMemberZeroExpr = [&](VarDecl *member) -> Expr * {
     auto memberType =
-        nominal->mapTypeIntoContext(member->getValueInterfaceType());
+        parentDC->mapTypeIntoContext(member->getValueInterfaceType());
     auto *memberTypeExpr = TypeExpr::createImplicit(memberType, C);
     auto module = nominal->getModuleContext();
-    auto confRef = module->lookupConformance(member->getType(), addArithProto);
+    auto confRef = module->lookupConformance(memberType, addArithProto);
     assert(confRef && "Member does not conform to 'AdditiveArithmetic'");
     // If conformance reference is not concrete, then concrete witness
     // declaration for `zero` cannot be resolved. Return reference to `zero`
@@ -408,7 +409,8 @@ static void deriveBodyAdditiveArithmetic_zero(AbstractFunctionDecl *funcDecl) {
 
 // Synthesize the static property declaration for `AdditiveArithmetic.zero`.
 static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
-  auto nominal = derived.Nominal;
+  auto *nominal = derived.Nominal;
+  auto *parentDC = derived.getConformanceContext();
   auto &TC = derived.TC;
   auto &C = TC.Context;
 
@@ -423,8 +425,7 @@ static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
   }
 
   auto returnInterfaceTy = nominal->getDeclaredInterfaceType();
-  auto returnTy =
-      derived.getConformanceContext()->mapTypeIntoContext(returnInterfaceTy);
+  auto returnTy = parentDC->mapTypeIntoContext(returnInterfaceTy);
 
   // Create `zero` static property declaration.
   VarDecl *zeroDecl;

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -73,7 +73,7 @@ static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
                               }),
                lookup.end());
   assert(lookup.size() == 1 && "Ambiguous protocol requirement");
-  return lookup[0];
+  return lookup.front();
 }
 
 // Return the `Scalar` associated type for the given `ValueDecl` if it conforms

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -699,7 +699,8 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
                                    ConformanceCheckFlags::Used)) {
           // Diagnose error types only once.
           if (errorMemberAssocTypes.insert(memberAssocType).second)
-            TC.diagnose(member, diag::broken_differentiable_generic_signature,
+            TC.diagnose(member,
+                        diag::differentiable_need_explicit_addarith_conformance,
                         memberAssocType);
         }
       }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -698,10 +698,13 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
         if (!TC.conformsToProtocol(memberAssocType, addArithProto, parentDC,
                                    ConformanceCheckFlags::Used)) {
           // Diagnose error types only once.
-          if (errorMemberAssocTypes.insert(memberAssocType).second)
+          if (errorMemberAssocTypes.insert(memberAssocType).second) {
+            auto requirementString =
+                memberAssocType->getString() + " : AdditiveArithmetic";
             TC.diagnose(member,
                         diag::differentiable_need_explicit_addarith_conformance,
-                        memberAssocType);
+                        requirementString);
+          }
         }
       }
       return {nullptr, false};

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -5,9 +5,6 @@ public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable {
   public var x: Float
   public var y: Float
 
-  public typealias TangentVector = Vector
-  public typealias Scalar = Float
-
   public static var zero: Vector {
     return Vector(0)
   }

--- a/test/Sema/struct_additive_arithmetic.swift
+++ b/test/Sema/struct_additive_arithmetic.swift
@@ -10,6 +10,10 @@ func testAdditiveArithmetic<T : AdditiveArithmetic>(
   x -= x - zero
 }
 
+struct Empty : AdditiveArithmetic {}
+var empty = Empty()
+testAdditiveArithmetic(&empty)
+
 struct Int2: AdditiveArithmetic {
   var a: Int
   var b: Int
@@ -59,3 +63,15 @@ func testGenericContext<T, U, V>() -> A<T>.B<U, V>.GenericContextNested {
   testAdditiveArithmetic(&genericNested)
   return genericNested
 }
+
+// Test extension.
+struct Extended {
+  var x: Int
+}
+extension Extended : Equatable, AdditiveArithmetic {}
+
+// Test extension of generic type.
+struct GenericExtended<T> {
+  var x: T
+}
+extension GenericExtended : Equatable, AdditiveArithmetic where T : AdditiveArithmetic {}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -191,7 +191,7 @@ struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differen
 struct GenericSynthesizeAllStructs<T> : Differentiable
   where T : Differentiable
 {
-  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
+  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector : AdditiveArithmetic' conformance constraint}}
   var w: T
   var b: T
 }
@@ -203,7 +203,7 @@ struct GenericSynthesizeAllStructs<T> : Differentiable
 struct GenericNotAdditiveArithmetic<T> : Differentiable
   where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
 {
-  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T' : 'AdditiveArithmetic' conformance constraint}}
+  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T : AdditiveArithmetic' conformance constraint}}
   var w: T
   var b: T
 }
@@ -217,9 +217,9 @@ struct A<T : Differentiable> {
     struct InGenericContext : Differentiable {
       @noDerivative var a: A
       var b: B
-      // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
+      // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector : AdditiveArithmetic' conformance constraint}}
       var t: T
-      // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'U.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
+      // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'U.TangentVector : AdditiveArithmetic' conformance constraint}}
       var u: U
     }
   }
@@ -235,7 +235,7 @@ extension Extended : Differentiable {}
 // FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
 // due to `Differentiable` protocol generic signature minimization bug.
 struct GenericExtended<T> {
-  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
+  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector : AdditiveArithmetic' conformance constraint}}
   var x: T
 }
 // expected-error @+1 {{type 'GenericExtended<T>' does not conform to protocol 'Differentiable'}}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -191,7 +191,7 @@ struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differen
 struct GenericSynthesizeAllStructs<T> : Differentiable
   where T : Differentiable
 {
-  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T.TangentVector' to 'AdditiveArithmetic'}}
+  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
   var w: T
   var b: T
 }
@@ -203,7 +203,7 @@ struct GenericSynthesizeAllStructs<T> : Differentiable
 struct GenericNotAdditiveArithmetic<T> : Differentiable
   where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
 {
-  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T' to 'AdditiveArithmetic'}}
+  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T' : 'AdditiveArithmetic' conformance constraint}}
   var w: T
   var b: T
 }
@@ -217,9 +217,9 @@ struct A<T : Differentiable> {
     struct InGenericContext : Differentiable {
       @noDerivative var a: A
       var b: B
-      // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T.TangentVector' to 'AdditiveArithmetic'}}
+      // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
       var t: T
-      // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'U.TangentVector' to 'AdditiveArithmetic'}}
+      // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'U.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
       var u: U
     }
   }
@@ -235,7 +235,7 @@ extension Extended : Differentiable {}
 // FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
 // due to `Differentiable` protocol generic signature minimization bug.
 struct GenericExtended<T> {
-  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T.TangentVector' to 'AdditiveArithmetic'}}
+  // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector' : 'AdditiveArithmetic' conformance constraint}}
   var x: T
 }
 // expected-error @+1 {{type 'GenericExtended<T>' does not conform to protocol 'Differentiable'}}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -191,7 +191,7 @@ struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differen
 struct GenericSynthesizeAllStructs<T> : Differentiable
   where T : Differentiable
 {
-  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; please explicitly conform 'T.TangentVector' to 'AdditiveArithmetic'}}
+  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T.TangentVector' to 'AdditiveArithmetic'}}
   var w: T
   var b: T
 }
@@ -203,7 +203,7 @@ struct GenericSynthesizeAllStructs<T> : Differentiable
 struct GenericNotAdditiveArithmetic<T> : Differentiable
   where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
 {
-  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; please explicitly conform 'T' to 'AdditiveArithmetic'}}
+  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T' to 'AdditiveArithmetic'}}
   var w: T
   var b: T
 }
@@ -217,9 +217,9 @@ struct A<T : Differentiable> {
     struct InGenericContext : Differentiable {
       @noDerivative var a: A
       var b: B
-      // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; please explicitly conform 'T.TangentVector' to 'AdditiveArithmetic'}}
+      // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T.TangentVector' to 'AdditiveArithmetic'}}
       var t: T
-      // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; please explicitly conform 'U.TangentVector' to 'AdditiveArithmetic'}}
+      // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'U.TangentVector' to 'AdditiveArithmetic'}}
       var u: U
     }
   }
@@ -235,7 +235,7 @@ extension Extended : Differentiable {}
 // FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
 // due to `Differentiable` protocol generic signature minimization bug.
 struct GenericExtended<T> {
-  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; please explicitly conform 'T.TangentVector' to 'AdditiveArithmetic'}}
+  // expected-error @+1 {{'Differentiable' protocol derived conformances is broken; fix by explicitly conforming 'T.TangentVector' to 'AdditiveArithmetic'}}
   var x: T
 }
 // expected-error @+1 {{type 'GenericExtended<T>' does not conform to protocol 'Differentiable'}}

--- a/test/Sema/struct_vector_numeric.swift
+++ b/test/Sema/struct_vector_numeric.swift
@@ -65,6 +65,18 @@ func testGenericContext<T, U, V>() -> A<T>.B<U, V>.GenericContextNested {
   return genericNested
 }
 
+// Test extension.
+struct Extended {
+  var x: Float
+}
+extension Extended : Equatable, AdditiveArithmetic, VectorNumeric {}
+
+// Test extension of generic type.
+struct GenericExtended<T> {
+  var x: T
+}
+extension GenericExtended : Equatable, AdditiveArithmetic, VectorNumeric where T : VectorNumeric {}
+
 // Test errors.
 
 struct Empty : VectorNumeric {} // expected-error {{type 'Empty' does not conform to protocol 'VectorNumeric'}}


### PR DESCRIPTION
Derived conformances fixes for `AdditiveArithmetic`, `VectorNumeric`, and `Differentiable`.

- Support derived conformances in extensions.
  - This requires using the conformance context instead of the nominal type
    declaration everywhere: adding synthesized members to the conformance context
    and consistently using contextual types from the conformance context.
- Diagnose `Differentiable` derived conformance crashes due to [SR-9595](https://bugs.swift.org/browse/SR-9595).
- Clean up.
  - Unify code style.
  - Consistently use `DC->mapTypeIntoContext(varDecl->getValueInterfaceType())`
        for getting `VarDecl` contextual types.
- Add tests for all fixes.

Unblocks [TF-6](https://bugs.swift.org/browse/TF-6). (TF-6 isn't related to/blocked by derived conformances, but the testcase I wrote is.)

---

Lower-priority todos:
- [TF-98](https://bugs.swift.org/browse/TF-98): Improve `Differentiable` derived conformances diagnostics.
  - `canDeriveDifferentiable` currently has strict checks. However, this leads to uninformative errors: users will always see `type 'Foo' does not conform to protocol 'Differentiable'`.
  - Other derived conformance code is intentionally lax in the `canDeriveXX` logic so that better diagnostics can be generated in the actual synthesis code.
  - (I feel this is kind of a deficiency in the derived conformances system, but the scope of addressing that is too big.)
- Fix [SR-9595](https://bugs.swift.org/browse/SR-9595): `Differentiable` protocol generic signature minimization bug.
  - This would enable `Differentiable` derived conformances to work seamlessly (when members have generic types).