### PR TITLE
[sil-passmanager] Stash a SILOptions reference in SILPassPipeline.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -17,27 +17,19 @@
 /// PASSPIPELINE(NAME, DESCRIPTION)
 ///
 ///   A pipeline with Name NAME and description DESCRIPTION. PassPipelinePlan
-///   constructor is assumed to not take a SILOptions value.
+///   constructor is assumed to take a SILOptions value.
 #ifndef PASSPIPELINE
 #define PASSPIPELINE(NAME, DESCRIPTION)
 #endif
 
-/// PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)
-///
-///   A pipeline with Name NAME and description DESCRIPTION. PassPipelinePlan
-///   constructor is assumed to take a SILOptions value.
-#ifndef PASSPIPELINE_WITH_OPTIONS
-#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION) PASSPIPELINE(NAME, DESCRIPTION)
-#endif
-
-PASSPIPELINE_WITH_OPTIONS(Diagnostic, "Guaranteed Passes")
+PASSPIPELINE(Diagnostic, "Guaranteed Passes")
 PASSPIPELINE(OwnershipEliminator, "Utility pass to just run the ownership eliminator pass")
-PASSPIPELINE_WITH_OPTIONS(SILOptPrepare, "Passes that prepare SIL for -O")
-PASSPIPELINE_WITH_OPTIONS(Performance, "Passes run at -O")
+PASSPIPELINE(SILOptPrepare, "Passes that prepare SIL for -O")
+PASSPIPELINE(Performance, "Passes run at -O")
 PASSPIPELINE(Onone, "Passes run at -Onone")
 PASSPIPELINE(InstCount, "Utility pipeline to just run the inst count pass")
 PASSPIPELINE(Lowering, "SIL Address Lowering")
-PASSPIPELINE_WITH_OPTIONS(IRGenPrepare, "Pipeline to run during IRGen")
+PASSPIPELINE(IRGenPrepare, "Pipeline to run during IRGen")
 
 #undef PASSPIPELINE_WITH_OPTIONS
 #undef PASSPIPELINE

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -41,13 +41,18 @@ enum class PassPipelineKind {
 };
 
 class SILPassPipelinePlan final {
+  const SILOptions &Options;
   std::vector<PassKind> Kinds;
   std::vector<SILPassPipeline> PipelineStages;
 
 public:
-  SILPassPipelinePlan() = default;
+  SILPassPipelinePlan(const SILOptions &Options)
+      : Options(Options), Kinds(), PipelineStages() {}
+
   ~SILPassPipelinePlan() = default;
   SILPassPipelinePlan(const SILPassPipelinePlan &) = default;
+
+  const SILOptions &getOptions() const { return Options; }
 
 // Each pass gets its own add-function.
 #define PASS(ID, TAG, NAME)                                                    \
@@ -60,13 +65,13 @@ public:
   void addPasses(ArrayRef<PassKind> PassKinds);
 
 #define PASSPIPELINE(NAME, DESCRIPTION)                                        \
-  static SILPassPipelinePlan get##NAME##PassPipeline();
-#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)                           \
   static SILPassPipelinePlan get##NAME##PassPipeline(const SILOptions &Options);
 #include "swift/SILOptimizer/PassManager/PassPipeline.def"
 
-  static SILPassPipelinePlan getPassPipelineForKinds(ArrayRef<PassKind> Kinds);
-  static SILPassPipelinePlan getPassPipelineFromFile(StringRef Filename);
+  static SILPassPipelinePlan getPassPipelineForKinds(const SILOptions &Options,
+                                                     ArrayRef<PassKind> Kinds);
+  static SILPassPipelinePlan getPassPipelineFromFile(const SILOptions &Options,
+                                                     StringRef Filename);
 
   /// Our general format is as follows:
   ///

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -753,5 +753,5 @@ void swift::performSILDeadFunctionElimination(SILModule *M) {
   SILPassManager PM(M);
   llvm::SmallVector<PassKind, 1> Pass = {PassKind::DeadFunctionElimination};
   PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineForKinds(Pass));
+      SILPassPipelinePlan::getPassPipelineForKinds(M->getOptions(), Pass));
 }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -79,8 +79,7 @@ static void addDefiniteInitialization(SILPassPipelinePlan &P) {
   P.addRawSILInstLowering();
 }
 
-static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
-                                    const SILOptions &Options) {
+static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("Guaranteed Passes");
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
@@ -99,6 +98,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   // pass. This will happen when OSSA is no longer eliminated before the
   // optimizer pipeline is run implying we can put a pass that requires OSSA
   // there.
+  const auto &Options = P.getOptions();
   if (Options.EnableMandatorySemanticARCOpts && Options.shouldOptimize()) {
     P.addSemanticARCOpts();
   }
@@ -130,7 +130,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
 
 SILPassPipelinePlan
 SILPassPipelinePlan::getDiagnosticPassPipeline(const SILOptions &Options) {
-  SILPassPipelinePlan P;
+  SILPassPipelinePlan P(Options);
 
   if (SILViewSILGenCFG) {
     addCFGPrinterPipeline(P, "SIL View SILGen CFG");
@@ -145,7 +145,7 @@ SILPassPipelinePlan::getDiagnosticPassPipeline(const SILOptions &Options) {
   }
 
   // Otherwise run the rest of diagnostics.
-  addMandatoryOptPipeline(P, Options);
+  addMandatoryOptPipeline(P);
 
   if (SILViewGuaranteedCFG) {
     addCFGPrinterPipeline(P, "SIL View Guaranteed CFG");
@@ -157,8 +157,9 @@ SILPassPipelinePlan::getDiagnosticPassPipeline(const SILOptions &Options) {
 //                       Ownership Eliminator Pipeline
 //===----------------------------------------------------------------------===//
 
-SILPassPipelinePlan SILPassPipelinePlan::getOwnershipEliminatorPassPipeline() {
-  SILPassPipelinePlan P;
+SILPassPipelinePlan SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(
+    const SILOptions &Options) {
+  SILPassPipelinePlan P(Options);
   addOwnershipModelEliminatorPipeline(P);
   return P;
 }
@@ -370,6 +371,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   // Get rid of apparently dead functions as soon as possible so that
   // we do not spend time optimizing them.
   P.addDeadFunctionElimination();
+
   // Start by cloning functions from stdlib.
   P.addPerformanceSILLinker();
 
@@ -399,11 +401,10 @@ static void addMidModulePassesStackPromotePassPipeline(SILPassPipelinePlan &P) {
   P.addStackPromotion();
 }
 
-static bool addMidLevelPassPipeline(SILPassPipelinePlan &P,
-                                    bool stopAfterSerialization) {
+static bool addMidLevelPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("MidLevel");
-  addSSAPasses(P, OptimizationLevelKind::MidLevel, stopAfterSerialization);
-  if (stopAfterSerialization)
+  addSSAPasses(P, OptimizationLevelKind::MidLevel);
+  if (P.getOptions().StopOptimizationAfterSerialization)
     return true;
 
   // Specialize partially applied functions with dead arguments as a preparation
@@ -538,8 +539,8 @@ static void addSILDebugInfoGeneratorPipeline(SILPassPipelinePlan &P) {
 /// Mandatory IRGen preparation. It is the caller's job to set the set stage to
 /// "lowered" after running this pipeline.
 SILPassPipelinePlan
-SILPassPipelinePlan::getLoweringPassPipeline() {
-  SILPassPipelinePlan P;
+SILPassPipelinePlan::getLoweringPassPipeline(const SILOptions &Options) {
+  SILPassPipelinePlan P(Options);
   P.startPipeline("Address Lowering");
   P.addIRGenPrepare();
   P.addAddressLowering();
@@ -549,7 +550,7 @@ SILPassPipelinePlan::getLoweringPassPipeline() {
 
 SILPassPipelinePlan
 SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
-  SILPassPipelinePlan P;
+  SILPassPipelinePlan P(Options);
   P.startPipeline("IRGen Preparation");
   // Insert SIL passes to run during IRGen.
   // Hoist generic alloc_stack instructions to the entry block to enable better
@@ -563,7 +564,7 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
 
 SILPassPipelinePlan
 SILPassPipelinePlan::getSILOptPreparePassPipeline(const SILOptions &Options) {
-  SILPassPipelinePlan P;
+  SILPassPipelinePlan P(Options);
 
   if (Options.DebugSerialization) {
     addPerfDebugSerializationPipeline(P);
@@ -578,7 +579,7 @@ SILPassPipelinePlan::getSILOptPreparePassPipeline(const SILOptions &Options) {
 
 SILPassPipelinePlan
 SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
-  SILPassPipelinePlan P;
+  SILPassPipelinePlan P(Options);
 
   if (Options.DebugSerialization) {
     addPerfDebugSerializationPipeline(P);
@@ -594,7 +595,7 @@ SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
   addMidModulePassesStackPromotePassPipeline(P);
 
   // Run an iteration of the mid-level SSA passes.
-  if (addMidLevelPassPipeline(P, Options.StopOptimizationAfterSerialization))
+  if (addMidLevelPassPipeline(P))
     return P;
 
   // Perform optimizations that specialize.
@@ -624,8 +625,9 @@ SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
 //                            Onone Pass Pipeline
 //===----------------------------------------------------------------------===//
 
-SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
-  SILPassPipelinePlan P;
+SILPassPipelinePlan
+SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
+  SILPassPipelinePlan P(Options);
 
   // First specialize user-code.
   P.startPipeline("Prespecialization");
@@ -649,8 +651,9 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
 //                          Inst Count Pass Pipeline
 //===----------------------------------------------------------------------===//
 
-SILPassPipelinePlan SILPassPipelinePlan::getInstCountPassPipeline() {
-  SILPassPipelinePlan P;
+SILPassPipelinePlan
+SILPassPipelinePlan::getInstCountPassPipeline(const SILOptions &Options) {
+  SILPassPipelinePlan P(Options);
   P.startPipeline("Inst Count");
   P.addInstCount();
   return P;
@@ -680,8 +683,9 @@ void SILPassPipelinePlan::addPasses(ArrayRef<PassKind> PassKinds) {
 }
 
 SILPassPipelinePlan
-SILPassPipelinePlan::getPassPipelineForKinds(ArrayRef<PassKind> PassKinds) {
-  SILPassPipelinePlan P;
+SILPassPipelinePlan::getPassPipelineForKinds(const SILOptions &Options,
+                                             ArrayRef<PassKind> PassKinds) {
+  SILPassPipelinePlan P(Options);
   P.startPipeline("Pass List Pipeline");
   P.addPasses(PassKinds);
   return P;
@@ -717,7 +721,8 @@ void SILPassPipelinePlan::print(llvm::raw_ostream &os) {
 }
 
 SILPassPipelinePlan
-SILPassPipelinePlan::getPassPipelineFromFile(StringRef Filename) {
+SILPassPipelinePlan::getPassPipelineFromFile(const SILOptions &Options,
+                                             StringRef Filename) {
   namespace yaml = llvm::yaml;
   LLVM_DEBUG(llvm::dbgs() << "Parsing Pass Pipeline from " << Filename << "\n");
 
@@ -736,7 +741,7 @@ SILPassPipelinePlan::getPassPipelineFromFile(StringRef Filename) {
   yaml::Node *N = DI->getRoot();
   assert(N && "Failed to find a root");
 
-  SILPassPipelinePlan P;
+  SILPassPipelinePlan P(Options);
 
   auto *RootList = cast<yaml::SequenceNode>(N);
   llvm::SmallVector<PassKind, 32> Passes;

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -78,7 +78,8 @@ bool swift::runSILOwnershipEliminatorPass(SILModule &Module) {
 
   SILPassManager PM(&Module);
   PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getOwnershipEliminatorPassPipeline());
+      SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(
+          Module.getOptions()));
 
   return Ctx.hadError();
 }
@@ -122,7 +123,8 @@ void swift::runSILPassesForOnone(SILModule &Module) {
   // We want to run the Onone passes also for function which have an explicit
   // Onone attribute.
   SILPassManager PM(&Module, "Onone", /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(SILPassPipelinePlan::getOnonePassPipeline());
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getOnonePassPipeline(Module.getOptions()));
 
   // Verify the module, if required.
   if (Module.getOptions().VerifyAll)
@@ -136,7 +138,7 @@ void swift::runSILOptimizationPassesWithFileSpecification(SILModule &M,
                                                           StringRef Filename) {
   SILPassManager PM(&M);
   PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineFromFile(Filename));
+      SILPassPipelinePlan::getPassPipelineFromFile(M.getOptions(), Filename));
 }
 
 /// Get the Pass ID enum value from an ID string.
@@ -187,7 +189,8 @@ StringRef swift::PassKindTag(PassKind Kind) {
 // same stage of lowering.
 void swift::runSILLoweringPasses(SILModule &Module) {
   SILPassManager PM(&Module, "LoweringPasses", /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(SILPassPipelinePlan::getLoweringPassPipeline());
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getLoweringPassPipeline(Module.getOptions()));
 
   assert(Module.getStage() == SILStage::Lowered);
 }

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -157,5 +157,5 @@ void swift::performSILInstCountIfNeeded(SILModule *M) {
     return;
   SILPassManager PrinterPM(M);
   PrinterPM.executePassPipelinePlan(
-      SILPassPipelinePlan::getInstCountPassPipeline());
+      SILPassPipelinePlan::getInstCountPassPipeline(M->getOptions()));
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -257,8 +257,8 @@ static void runCommandLineSelectedPasses(SILModule *Module,
 #include "swift/SILOptimizer/PassManager/Passes.def"
   }
 
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineForKinds(Passes));
+  PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
+      Module->getOptions(), Passes));
 
   if (Module->getOptions().VerifyAll)
     Module->verify();

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -56,11 +56,6 @@ int main(int argc, char **argv) {
   switch (PipelineKind) {
 #define PASSPIPELINE(NAME, DESCRIPTION)                                        \
   case PassPipelineKind::NAME: {                                               \
-    SILPassPipelinePlan::get##NAME##PassPipeline().print(llvm::outs());        \
-    break;                                                                     \
-  }
-#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)                           \
-  case PassPipelineKind::NAME: {                                               \
     SILPassPipelinePlan::get##NAME##PassPipeline(Opt).print(llvm::outs());     \
     break;                                                                     \
   }


### PR DESCRIPTION
This normalizes the creation of pass pipelines by ensuring that all pass
pipelines take a SILOption instead of only some. It also makes it so that we do
not need to propagate options through various pipeline creation helpers.
