### PR TITLE
[ownership] Move OME out of the diagnostics pipeline behind a flag.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -135,6 +135,10 @@ public:
   /// Enable large loadable types IRGen pass.
   bool EnableLargeLoadableTypes = true;
 
+  /// Should the default pass pipelines strip ownership during the diagnostic
+  /// pipeline.
+  bool StripOwnershipDuringDiagnosticsPipeline = true;
+
   /// The name of the file to which the backend should save YAML optimization
   /// records.
   std::string OptRecordFile;

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -17,27 +17,19 @@
 /// PASSPIPELINE(NAME, DESCRIPTION)
 ///
 ///   A pipeline with Name NAME and description DESCRIPTION. PassPipelinePlan
-///   constructor is assumed to not take a SILOptions value.
+///   constructor is assumed to take a SILOptions value.
 #ifndef PASSPIPELINE
 #define PASSPIPELINE(NAME, DESCRIPTION)
 #endif
 
-/// PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)
-///
-///   A pipeline with Name NAME and description DESCRIPTION. PassPipelinePlan
-///   constructor is assumed to take a SILOptions value.
-#ifndef PASSPIPELINE_WITH_OPTIONS
-#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION) PASSPIPELINE(NAME, DESCRIPTION)
-#endif
-
-PASSPIPELINE_WITH_OPTIONS(Diagnostic, "Guaranteed Passes")
+PASSPIPELINE(Diagnostic, "Guaranteed Passes")
 PASSPIPELINE(OwnershipEliminator, "Utility pass to just run the ownership eliminator pass")
-PASSPIPELINE_WITH_OPTIONS(SILOptPrepare, "Passes that prepare SIL for -O")
-PASSPIPELINE_WITH_OPTIONS(Performance, "Passes run at -O")
+PASSPIPELINE(SILOptPrepare, "Passes that prepare SIL for -O")
+PASSPIPELINE(Performance, "Passes run at -O")
 PASSPIPELINE(Onone, "Passes run at -Onone")
 PASSPIPELINE(InstCount, "Utility pipeline to just run the inst count pass")
 PASSPIPELINE(Lowering, "SIL Address Lowering")
-PASSPIPELINE_WITH_OPTIONS(IRGenPrepare, "Pipeline to run during IRGen")
+PASSPIPELINE(IRGenPrepare, "Pipeline to run during IRGen")
 
 #undef PASSPIPELINE_WITH_OPTIONS
 #undef PASSPIPELINE

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -41,13 +41,18 @@ enum class PassPipelineKind {
 };
 
 class SILPassPipelinePlan final {
+  const SILOptions &Options;
   std::vector<PassKind> Kinds;
   std::vector<SILPassPipeline> PipelineStages;
 
 public:
-  SILPassPipelinePlan() = default;
+  SILPassPipelinePlan(const SILOptions &Options)
+      : Options(Options), Kinds(), PipelineStages() {}
+
   ~SILPassPipelinePlan() = default;
   SILPassPipelinePlan(const SILPassPipelinePlan &) = default;
+
+  const SILOptions &getOptions() const { return Options; }
 
 // Each pass gets its own add-function.
 #define PASS(ID, TAG, NAME)                                                    \
@@ -60,13 +65,13 @@ public:
   void addPasses(ArrayRef<PassKind> PassKinds);
 
 #define PASSPIPELINE(NAME, DESCRIPTION)                                        \
-  static SILPassPipelinePlan get##NAME##PassPipeline();
-#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)                           \
   static SILPassPipelinePlan get##NAME##PassPipeline(const SILOptions &Options);
 #include "swift/SILOptimizer/PassManager/PassPipeline.def"
 
-  static SILPassPipelinePlan getPassPipelineForKinds(ArrayRef<PassKind> Kinds);
-  static SILPassPipelinePlan getPassPipelineFromFile(StringRef Filename);
+  static SILPassPipelinePlan getPassPipelineForKinds(const SILOptions &Options,
+                                                     ArrayRef<PassKind> Kinds);
+  static SILPassPipelinePlan getPassPipelineFromFile(const SILOptions &Options,
+                                                     StringRef Filename);
 
   /// Our general format is as follows:
   ///

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -753,5 +753,5 @@ void swift::performSILDeadFunctionElimination(SILModule *M) {
   SILPassManager PM(M);
   llvm::SmallVector<PassKind, 1> Pass = {PassKind::DeadFunctionElimination};
   PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineForKinds(Pass));
+      SILPassPipelinePlan::getPassPipelineForKinds(M->getOptions(), Pass));
 }

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -78,7 +78,8 @@ bool swift::runSILOwnershipEliminatorPass(SILModule &Module) {
 
   SILPassManager PM(&Module);
   PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getOwnershipEliminatorPassPipeline());
+      SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(
+          Module.getOptions()));
 
   return Ctx.hadError();
 }
@@ -122,7 +123,8 @@ void swift::runSILPassesForOnone(SILModule &Module) {
   // We want to run the Onone passes also for function which have an explicit
   // Onone attribute.
   SILPassManager PM(&Module, "Onone", /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(SILPassPipelinePlan::getOnonePassPipeline());
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getOnonePassPipeline(Module.getOptions()));
 
   // Verify the module, if required.
   if (Module.getOptions().VerifyAll)
@@ -136,7 +138,7 @@ void swift::runSILOptimizationPassesWithFileSpecification(SILModule &M,
                                                           StringRef Filename) {
   SILPassManager PM(&M);
   PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineFromFile(Filename));
+      SILPassPipelinePlan::getPassPipelineFromFile(M.getOptions(), Filename));
 }
 
 /// Get the Pass ID enum value from an ID string.
@@ -187,7 +189,8 @@ StringRef swift::PassKindTag(PassKind Kind) {
 // same stage of lowering.
 void swift::runSILLoweringPasses(SILModule &Module) {
   SILPassManager PM(&Module, "LoweringPasses", /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(SILPassPipelinePlan::getLoweringPassPipeline());
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getLoweringPassPipeline(Module.getOptions()));
 
   assert(Module.getStage() == SILStage::Lowered);
 }

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -157,5 +157,5 @@ void swift::performSILInstCountIfNeeded(SILModule *M) {
     return;
   SILPassManager PrinterPM(M);
   PrinterPM.executePassPipelinePlan(
-      SILPassPipelinePlan::getInstCountPassPipeline());
+      SILPassPipelinePlan::getInstCountPassPipeline(M->getOptions()));
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -257,8 +257,8 @@ static void runCommandLineSelectedPasses(SILModule *Module,
 #include "swift/SILOptimizer/PassManager/Passes.def"
   }
 
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineForKinds(Passes));
+  PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
+      Module->getOptions(), Passes));
 
   if (Module->getOptions().VerifyAll)
     Module->verify();

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -56,11 +56,6 @@ int main(int argc, char **argv) {
   switch (PipelineKind) {
 #define PASSPIPELINE(NAME, DESCRIPTION)                                        \
   case PassPipelineKind::NAME: {                                               \
-    SILPassPipelinePlan::get##NAME##PassPipeline().print(llvm::outs());        \
-    break;                                                                     \
-  }
-#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)                           \
-  case PassPipelineKind::NAME: {                                               \
     SILPassPipelinePlan::get##NAME##PassPipeline(Opt).print(llvm::outs());     \
     break;                                                                     \
   }


### PR DESCRIPTION
Once the flag is flipped, ownership stripping will no longer be done in the
diagnostics pipeline. Instead what will happen is that:

* Onone: At -Onone, we run the entire diagnostics pipeline with ownership
enabled and do not strip ownership until after we serialize in the Onone
"optimization" pass pipeline plan.

* -O: At -O, to temporarily work around serialization issues with transparent
functions, we strip ownership from all but transparent functions at the
beginning of the performance pipeline, serialize, and then strip ownership from
transparent functions. For this to work, I needed to make sure that the
performance pipeline passes that do not support ownership SIL, just skip such
functions. So the transparent functions will arrive (mostly) untouched in
serialized SIL and the rest of the pipeline will optimize non-transparent
functions as they should.

The key thing about the -O change is that it /should/ be performance neutral
since after we serialize we re-run the entire pipeline so we can optimize
semantic functions that we only can inline after we serialize.