### PR TITLE
[ownership] Strip ownership before running lowering passes in the repl.

### DIFF
--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -876,6 +876,7 @@ private:
       // non-whole-module generation.
       sil = performSILGeneration(*M->getFiles().front(), CI.getSILOptions());
       runSILDiagnosticPasses(*sil);
+      runSILOwnershipEliminatorPass(*sil);
       runSILLoweringPasses(*sil);
     }
 


### PR DESCRIPTION
This fixes most of the interpreter tests for ownership.
