### PR TITLE
utils: adjust to support long paths on windows

### DIFF
--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -19,6 +19,7 @@ import datetime
 import itertools
 import json
 import os
+import platform
 import random
 import re
 
@@ -315,7 +316,13 @@ def load_stats_dir(path, select_module=[], select_stat=[],
                 continue
             jobargs = [mg["input"], mg["triple"], mg["out"], mg["opt"]]
 
-            with open(os.path.join(root, f)) as fp:
+            if platform.system() == 'Windows':
+                p = unicode(u"\\\\?\\%s" % os.path.abspath(os.path.join(root,
+                                                                        f)))
+            else:
+                p = os.path.join(root, f)
+
+            with open(p) as fp:
                 j = json.load(fp)
             dur_usec = 1
             stats = dict()


### PR DESCRIPTION
Windows restricts paths to 251 characters.  Using unicode paths will
allow us to go down the `_wfopen` path which permits the use of the NT
path to actually use long paths.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
