### PR TITLE
[TF] Disable `-enable-large-loadable-types` by default.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -133,7 +133,10 @@ public:
   bool EnableMandatorySemanticARCOpts = false;
 
   /// \brief Enable large loadable types IRGen pass.
-  bool EnableLargeLoadableTypes = true;
+  // bool EnableLargeLoadableTypes = true;
+  // FIXME(TF-11, SR-9849): Disabled because LoadableByAddress cannot handle
+  // some functions that return closures that take/return large loadable types.
+  bool EnableLargeLoadableTypes = false;
 
   /// The name of the file to which the backend should save YAML optimization
   /// records.

--- a/test/DebugInfo/LoadableByAddress.swift
+++ b/test/DebugInfo/LoadableByAddress.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend %s -module-name A -emit-ir -g -o - | %FileCheck %s
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
+// RUN: %target-swift-frontend %s -module-name A -emit-ir -enable-large-loadable-types -g -o - | %FileCheck %s
 // REQUIRES: CPU=x86_64
 public struct Continuation<A> {
    private let magicToken = "Hello World"

--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -parse-sil -emit-ir %s | %FileCheck %s
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
+// RUN: %target-swift-frontend -parse-sil -emit-ir -enable-large-loadable-types %s | %FileCheck %s
 // REQUIRES: OS=macosx
 
 // Make sure that we are using type lowering and that we are handling the return

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -enable-large-loadable-types | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s
 import Swift
 import Builtin
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend %s -emit-ir -assume-parsing-unqualified-ownership-sil | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
+// RUN: %target-swift-frontend %s -emit-ir -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -enable-large-loadable-types | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
+// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns %s -enable-large-loadable-types | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 import Builtin
 import Swift

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-eager-swift
-//
 // REQUIRES: executable_test
+//
+// FIXME: `XORTraining` segfaults with `-O`, possibly due to AD refcounting bugs.
+// UNSUPPORTED: swift_test_mode_optimize
 //
 // Machine learning API AD runtime tests.
 
@@ -38,14 +40,11 @@ ModelADTests.testAllBackends("XORTraining") {
   let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
   let y: Tensor<Float> = [0, 1, 1, 0]
   for _ in 0..<1000 {
-      // FIXME: Segfaults when run with `-O -Xllvm -tf-dynamic-compilation`.
-      /*
       let (loss, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
           let ŷ = classifier.applied(to: x)
           return meanSquaredError(predicted: ŷ, expected: y)
       }
       optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
-      */
   }
   print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
 }

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -38,11 +38,14 @@ ModelADTests.testAllBackends("XORTraining") {
   let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
   let y: Tensor<Float> = [0, 1, 1, 0]
   for _ in 0..<1000 {
+      // FIXME: Segfaults when run with `-O -Xllvm -tf-dynamic-compilation`.
+      /*
       let (loss, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
           let ŷ = classifier.applied(to: x)
           return meanSquaredError(predicted: ŷ, expected: y)
       }
       optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
+      */
   }
   print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
 }

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -13,14 +13,11 @@ var ModelADTests = TestSuite("ModelAD")
 ModelADTests.testAllBackends("SimpleLayerAD") {
   let ones = Tensor<Float>(ones: [2, 2])
   let dense = Dense<Float>(inputSize: 2, outputSize: 2, activation: { $0 })
-  // FIXME: Differentiation blocked by SR-9806.
-  /*
   let grad = gradient(at: dense) { dense in
     dense.applied(to: ones).sum()
   }
-  expectEqual(ones * 2, grad.weight)
-  expectEqual(ones, grad.bias)
-  */
+  expectEqual([[2, 2], [2, 2]], grad.weight)
+  expectEqual([2, 2], grad.bias)
 }
 
 ModelADTests.testAllBackends("XORTraining") {
@@ -38,8 +35,6 @@ ModelADTests.testAllBackends("XORTraining") {
   }
   var classifier = Classifier(hiddenSize: 4)
   let optimizer = SGD<Classifier, Float>()
-  // FIXME: Differentiation blocked by SR-9806.
-  /*
   let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
   let y: Tensor<Float> = [0, 1, 1, 0]
   for _ in 0..<1000 {
@@ -50,7 +45,6 @@ ModelADTests.testAllBackends("XORTraining") {
       optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
   }
   print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
-  */
 }
 
 runAllTests()


### PR DESCRIPTION
The `LoadableByAddress` pass lowers loadable SIL types.
It is problematic for differentiation because it does not handle functions that
return closures that take/return large loadable types (e.g. JVPs/VJPs).

Critical hot-fix for [TF-11](https://bugs.swift.org/browse/TF-11) (and [SR-9849](https://bugs.swift.org/browse/SR-9849)), unblocking differentiation.

Enable machine learning API differentiation tests.

---

A few different fixes were considered; this was the simplest.
- [ ] Fix `LoadableByAddress` to handle such functions correctly.
  - This is non-trivial and seems to require creating thunks for a large number of possible permutations (original/target function types may have indirect/direct parameters/results).
  - WIP exploration at [pschuh/swift:thunk_generation](https://github.com/pschuh/swift/tree/thunk_generation).
- [ ] Disable `LoadableByAddress` only for (some superset of) problematic cases (i.e. functions returning functions that take/return large loadable types).
  - I attempted this but only got reproducer programs to pass when `LoadableByAddress` was disabled for all functions. (Disabling only for functions returning function results didn't work.)
  - This causes many IRGen tests to fail.
- [x] Change `-enable-large-loadable-types` default to `false`.
  - This allows all IRGen tests to pass (by explicitly specifying the flag) while enabling differentiation to work by default. However, never running `LoadableByAddress` may have negative implications (e.g. larger code size).