### PR TITLE
[TF] [lit] Gardening.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -264,7 +264,7 @@ foreach(SDK ${SWIFT_SDKS})
       endif()
       if(SWIFT_ENABLE_TENSORFLOW_GPU)
         list(APPEND LIT_ARGS
-            "--param" "swift_tensorflow_gpu=true")
+            "--param" "swift_tensorflow_gpu")
       endif()
 
       execute_process(COMMAND

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -328,19 +328,21 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # SWIFT_ENABLE_TENSORFLOW
-swift_tensorflow_test_run_extra_options = ""
-swift_tensorflow_extra_options = ""
+swift_tensorflow_test_run_extra_options = ''
+swift_tensorflow_extra_options = ''
+if 'tensorflow' in config.available_features:
+    swift_tensorflow_extra_options += (' -ltensorflow -ltensorflow_framework')
 swift_tensorflow_path = lit_config.params.get('swift_tensorflow_path', None)
 if swift_tensorflow_path:
-    swift_tensorflow_extra_options += ('-L%s -ltensorflow -ltensorflow_framework' % swift_tensorflow_path)
+    swift_tensorflow_extra_options += (' -L %s' % os.path.abspath(swift_tensorflow_path))
 swift_tensorflow_gpu = lit_config.params.get('swift_tensorflow_gpu', None)
 # Can use #if on CUDA to selectively disable tests for GPU.
-if swift_tensorflow_gpu:
+if swift_tensorflow_gpu is not None:
     swift_tensorflow_extra_options += ' -Xllvm -tf-target-gpu -DCUDA'
-    swift_tensorflow_test_run_extra_options += "--target=gpu"
-    config.substitutions.append( ('%filecheck-tensorflow-extra-options', ' --check-prefix=CHECK-GPU --check-prefix=CHECK' ) )
+    swift_tensorflow_test_run_extra_options += ' --target=gpu'
+    config.substitutions.append( ('%filecheck-tensorflow-extra-options', ' --check-prefix=CHECK-GPU --check-prefix=CHECK') )
 else:
-    config.substitutions.append( ('%filecheck-tensorflow-extra-options', "") )
+    config.substitutions.append( ('%filecheck-tensorflow-extra-options', '') )
 config.substitutions.append( ('%swift-tensorflow-extra-options', swift_tensorflow_extra_options) )
 config.substitutions.append( ('%swift-tensorflow-test-run-extra-options', swift_tensorflow_test_run_extra_options) )
 


### PR DESCRIPTION
`TensorFlowRuntime` tests can now be run directly without additional flags:
`llvm/utils/lit/lit.py build/.../TensorFlowRuntime`

Previously, specifying `--param swift_tensorflow_path=...` was necessary.

- Add `-ltensorflow -ltensorflow_framework` flags if `tensorflow` feature is available.
  - Previously, flags were added based on the `lit` parameter `swift_tensorflow_path`,
    which must be manually specified.
  - The new condition is precise and doesn't require manual specification.
- Minor edits, unify code style.