### PR TITLE
 [AutoDiff] Diagnose indirect VJP applications.

### DIFF
--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -21,7 +21,7 @@ func one_to_one_0(_ x: Float) -> Float {
 _ = gradient(at: 0, in: one_to_one_0) // okay!
 
 //===----------------------------------------------------------------------===//
-// Generics
+// Indirect parameters/results (generics)
 //===----------------------------------------------------------------------===//
 
 // expected-note @+3 {{differentiating functions with parameters or result of unknown size is not supported yet}}
@@ -29,6 +29,19 @@ _ = gradient(at: 0, in: one_to_one_0) // okay!
 @differentiable()
 func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
   return x + 1
+}
+
+struct Tensor<Scalar> {
+  static func + (_ lhs: Tensor, rhs: Scalar) -> Tensor { return lhs }
+}
+extension Tensor : Differentiable where Scalar : Differentiable & FloatingPoint {}
+extension Tensor where Scalar : BinaryFloatingPoint {
+  // expected-note @+3 {{differentiating functions with parameters or result of unknown size is not supported yet}}
+  // expected-error @+2 {{function is not differentiable}}
+  @differentiable(wrt: (self) where Scalar : Differentiable)
+  func TF_6(_ x: Float) -> Tensor {
+    return self + Scalar(x)
+  }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Differentiation currently cannot handle functions with indirect passing.
Previously, only indirect original functions were diagnosed.
Now, calls to indirect VJPs in the primal are also diagnosed.

Resolves [TF-6](https://bugs.swift.org/browse/TF-6) (by emitting an error instead of crashing).
Differentiation support for indirect passing will be the robust solution.

---

This PR depends on https://github.com/apple/swift/pull/22327, whose changes are squashed.
The new changes start from commit https://github.com/apple/swift/commit/ef037011ad66a3d42c232f112dcbe5d70a3084f2.