### PR TITLE
Remove useless optional unwrap from Unsafe[Raw]BufferPointer subscript.

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -270,18 +270,19 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position![i]
+      return _position._unsafelyUnwrappedUnchecked[i]
     }
 %if Mutable:
     nonmutating _modify {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      yield &_position![i]
+      yield &_position._unsafelyUnwrappedUnchecked[i]
     }
 %end
   }
 
   // Skip all debug and runtime checks
+
   @inlinable // unsafe-performance
   internal subscript(_unchecked i: Int) -> Element {
     get {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -185,13 +185,13 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position!.load(fromByteOffset: i, as: UInt8.self)
+      return _position._unsafelyUnwrappedUnchecked.load(fromByteOffset: i, as: UInt8.self)
     }
 %  if mutable:
     nonmutating set {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
+      _position._unsafelyUnwrappedUnchecked.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
     }
 %  end # mutable
   }

--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -45,3 +45,52 @@ public func testCount(_ x: UnsafeBufferPointer<UInt>) -> Int {
   return x.count
 }
 
+// Within the loop, there should be no extra checks.
+// CHECK-LABEL: define {{.*}} float {{.*}}testSubscript
+// The only unconditional branch is into the loop.
+// CHECK: br label %[[LOOP:[0-9]+]]
+//
+// For some reason, LLVM lays out the exit before the loop.
+// CHECK: .loopexit: ; preds = %[[LOOP]]
+// CHECK: ret float
+//
+// CHECK: ; <label>:[[LOOP]]:
+// CHECK: phi float [ 0.000000e+00
+// CHECK: add nuw i64 %{{.*}}, 1
+// CHECK: load float, float*
+// CHECK: fadd float
+// CHECK: [[CMP:%[0-9]+]] = icmp eq i64 %{{.*}}, %{{.*}}
+// CHECK: br i1 [[CMP]], label %.loopexit, label %[[LOOP]]
+public func testSubscript(_ ubp: UnsafeBufferPointer<Float>) -> Float {
+  var sum: Float = 0
+  for i in 0 ..< ubp.count {
+    sum += ubp[i]
+  }
+  return sum
+}
+
+// Within the loop, there should be no extra checks.
+// CHECK-LABEL: define {{.*}} i64 {{.*}}testSubscript
+// The only unconditional branch is into the loop.
+// CHECK: br label %[[LOOP:[0-9]+]]
+//
+// For some reason, LLVM lays out the exit before the loop.
+// CHECK: [[RET:.*]]: ; preds = %[[LOOP]], %entry
+// CHECK: ret i64
+//
+// CHECK: ; <label>:[[LOOP]]:
+// CHECK: phi i64 [ 0
+// CHECK: phi i64 [ 0
+// CHECK: add nuw i64 %{{.*}}, 1
+// CHECK: load i8, i8*
+// CHECK: zext i8 %{{.*}} to i64
+// CHECK: add i64
+// CHECK: [[CMP:%[0-9]+]] = icmp eq i64 %{{.*}}, %{{.*}}
+// CHECK: br i1 [[CMP]], label %[[RET]], label %[[LOOP]]
+public func testSubscript(_ ubp: UnsafeRawBufferPointer) -> Int {
+  var sum: Int = 0
+  for i in 0 ..< ubp.count {
+    sum &+= Int(ubp[i])
+  }
+  return sum
+}


### PR DESCRIPTION
It is unfortunate that `Unsafe[Raw]BufferPointer._pointer` and
`baseAddress` are declared Optional. This leaves extra runtime checks
in the code in the most performance critical paths. Contrast this with
Array, which uses an sentinal pointer for the empty representation.

This forces us to use _unsafelyUnwrappedUnchecked whenever we just
want to dereference a non-empty buffer pointer.

Fixes SR-9809: swiftc appears to make some sub-optimal optimization choices
