### PR TITLE
[benchmark] RomanNumbers Reloaded

### DIFF
--- a/benchmark/single-source/RomanNumbers.swift
+++ b/benchmark/single-source/RomanNumbers.swift
@@ -12,84 +12,63 @@
 
 import TestsUtils
 
-//
 // Mini benchmark implementing roman numeral conversions to/from integers.
-// Measures performance of Substring.starts(with:) and String.append(),
+// Measures performance of Substring.starts(with:), dropFirst and String.append
 // with very short string arguments.
-//
+
+let t: [BenchmarkCategory] = [.api, .String, .algorithm]
+let N = 270
 
 public let RomanNumbers = [
   BenchmarkInfo(
-    name: "RomanNumbers",
-    runFunction: run_RomanNumbers,
-    tags: [.api, .String, .algorithm])
+    name: "Roman.Substring.startsWith.dropFirst",
+    runFunction: {
+      checkId($0, upTo: N, { $0.romanNumeral }, Int.init(romanSSsWdF:)) },
+    tags: t),
 ]
 
+@inline(__always)
+func checkId(_ n: Int, upTo limit: Int, _ itor: (Int) -> String,
+  _ rtoi: (String) -> Int?) {
+  for _ in 1...n {
+   CheckResults(
+     zip(1...limit, (1...limit).map(itor).map(rtoi)).allSatisfy { $0 == $1 })
+  }
+}
+
 let romanTable: KeyValuePairs<String, Int> = [
-  "M": 1000,
-  "CM": 900,
-  "D": 500,
-  "CD": 400,
-  "C": 100,
-  "XC": 90,
-  "L": 50,
-  "XL": 40,
-  "X": 10,
-  "IX": 9,
-  "V": 5,
-  "IV": 4,
+  "M": 1000, "CM": 900, "D": 500, "CD": 400,
+  "C": 100_, "XC": 90_, "L": 50_, "XL": 40_,
+  "X": 10__, "IX": 9__, "V": 5__, "IV": 4__,
   "I": 1,
 ]
 
 extension BinaryInteger {
+  // Imperative Style
+  // See https://www.rosettacode.org/wiki/Roman_numerals/Encode#Swift
+  // See https://www.rosettacode.org/wiki/Roman_numerals/Decode#Swift
+
   var romanNumeral: String {
     var result = ""
-    var value = self
-  outer:
-    while value > 0 {
-      var position = 0
-      for (i, (key: s, value: v)) in romanTable[position...].enumerated() {
-        if value >= v {
-          result += s
-          value -= Self(v)
-          position = i
-          continue outer
-        }
+    var n = self
+    for (numeral, value) in romanTable {
+      while n >= value {
+        result += numeral
+        n -= Self(value)
       }
-      fatalError("Unreachable")
     }
     return result
   }
 
-  init?(romanNumeral: String) {
+  init?(romanSSsWdF number: String) {
     self = 0
-    var input = Substring(romanNumeral)
-  outer:
-    while !input.isEmpty {
-      var position = 0
-      for (i, (key: s, value: v)) in romanTable[position...].enumerated() {
-        if input.starts(with: s) {
-          self += Self(v)
-          input = input.dropFirst(s.count)
-          position = i
-          continue outer
-        }
+    var raw = Substring(number)
+    for (numeral, value) in romanTable {
+      while raw.starts(with: numeral) {
+        self += Self(value)
+        raw = raw.dropFirst(numeral.count)
       }
-      return nil
     }
-  }
-}
-
-@inline(never)
-func checkRomanNumerals(upTo limit: Int) {
-  for i in 0 ..< limit {
-    CheckResults(Int(romanNumeral: identity(i.romanNumeral)) == i)
-  }
-}
-
-@inline(never)
-public func run_RomanNumbers(_ N: Int) {
-  for _ in 0 ..< 10 * N {
-    checkRomanNumerals(upTo: 1100)
+    guard raw.isEmpty else { return nil }
   }
 }

--- a/benchmark/single-source/RomanNumbers.swift
+++ b/benchmark/single-source/RomanNumbers.swift
@@ -21,7 +21,7 @@ let N = 270
 
 public let RomanNumbers = [
   BenchmarkInfo(
-    name: "Roman.Substring.startsWith.dropFirst",
+    name: "RomanNumbers2",
     runFunction: {
       checkId($0, upTo: N, { $0.romanNumeral }, Int.init(romanSSsWdF:)) },
     tags: t),


### PR DESCRIPTION
Reverts apple/swift#22300. To avoid the need to mess with `lit` tests due to renamed benchmark, let's just add the customary suffix `2` for the bug-fixed version. We'll fight the proper renaming battle another day... The benchmark code change was reviewed and approved by @eeckstein in #22227, so I'll merge this myself when the full tests pass, verifying the build remains green. Original description follows:

----

During the Swift Benchmark Suite clean-up, I wasn't able to easily lower the workload and apply `legacyFactor` to the `RomanNumbers` benchmark. Upon closer inspection, I've realized there was a bug in how the `position` was always reset to `0` after `continue outer`.

This PR rewrites the benchmark by swapping the `while` and `for-in` loops into more natural order, which also eliminates the need for using `position` at all. This is based on examples from [Rosetta Code](https://www.rosettacode.org/wiki/Roman_numerals/Decode#Swift).

The benchmark name is changed to `RomanNumbers2` because of the bug-fix and lowered workload (to run in less than 1000 μs).

