### PR TITLE
[AutoDiff] Rewrite `AdjointEmitter`’s memory management.

### DIFF
--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -49,4 +49,26 @@ ModelADTests.testAllBackends("XORTraining") {
   print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
 }
 
+ModelADTests.testAllBackends("WithRespectToModel") {
+  struct Foo<Scalar>: Differentiable
+    where Scalar: FloatingPoint & Differentiable & TensorFlowScalar {
+  
+    var bar: Tensor<Scalar>
+    var baz: Tensor<Scalar>
+  
+    @differentiable(wrt: (self, input))
+    func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+        return bar + input
+    }
+  }
+  
+  let x = Tensor<Float>(0)
+  var model = Foo<Float>(bar: x, baz: x)
+  
+  let d = gradient(at: model) { model in
+      model.applied(to: x)
+  }
+  expectEqual(Foo<Float>.AllDifferentiableVariables(bar: Tensor(1.0), baz: Tensor(0.0)), d)
+}
+
 runAllTests()


### PR DESCRIPTION
- Make `AdjointValue` carry values with cleanup (`ValueWithCleanup`), and accumulate them to form a dag. For pullbacks’ return values, disable the top-level cleanup and recursively apply all cleanups.
- Make `AdjointValue` materializers in `AdjointEmitter` take rvalue references, since each `AdjointValue` is supposed to be materialized at most once.
- No longer “differentiate” reference counting instructions since they are easier managed separately.
- Separate lvalues (“adjoint buffers”) from rvalues (“adjoint values”).
- Use `AdditiveArithmetic.+=` for adjoint accumulation into buffers.

Resolves current memory leaks/hacks in AD.