### PR TITLE
AST: remove `ScalarTraits<size_t>` on Windows

### DIFF
--- a/include/swift/AST/ExperimentalDependencies.h
+++ b/include/swift/AST/ExperimentalDependencies.h
@@ -939,8 +939,9 @@ private:
 // MARK: Declarations for YAMLTraits for reading/writing of SourceFileDepGraph
 //==============================================================================
 
-// This introduces a redefinition for Linux.
-#if !defined(__linux__)
+// This introduces a redefinition where ever std::is_same_t<size_t, uint64_t>
+// holds
+#if !(defined(__linux__) || defined(_WIN64))
 LLVM_YAML_DECLARE_SCALAR_TRAITS(size_t, QuotingType::None)
 #endif
 LLVM_YAML_DECLARE_ENUM_TRAITS(swift::experimental_dependencies::NodeKind)

--- a/lib/AST/ExperimentalDependencies.cpp
+++ b/lib/AST/ExperimentalDependencies.cpp
@@ -262,7 +262,7 @@ void SourceFileDepGraph::verifySame(const SourceFileDepGraph &other) const {
 namespace llvm {
 namespace yaml {
 // This introduces a redefinition for Linux.
-#if !defined(__linux__)
+#if !(defined(__linux__) || defined(_WIN64))
 void ScalarTraits<size_t>::output(const size_t &Val, void *, raw_ostream &out) {
   out << Val;
 }


### PR DESCRIPTION
Because `size_t` is the same as `uint64_t` on Windows, this results in a
conflicting definition of the `ScalarTraits`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
