### PR TITLE
[build-script] Add Product for libc++

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -730,6 +730,7 @@ install-libicu
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;license;sourcekit-inproc
 llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+install-libcxx
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
@@ -1082,6 +1083,7 @@ reconfigure
 
 swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+install-libcxx
 
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s

--- a/utils/build-script
+++ b/utils/build-script
@@ -841,6 +841,7 @@ class BuildScriptInvocation(object):
         product_classes = []
         product_classes.append(products.CMark)
         product_classes.append(products.LLVM)
+        product_classes.append(products.LibCXX)
         if self.args.build_libicu:
             product_classes.append(products.LibICU)
         product_classes.append(products.Swift)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -207,6 +207,7 @@ KNOWN_SETTINGS=(
     install-swiftevolve         ""               "whether to install the swift-evolve tool"
     install-xctest              ""               "whether to install xctest"
     install-foundation          ""               "whether to install foundation"
+    install-libcxx              ""               "whether to install libc++"
     install-libdispatch         ""               "whether to install libdispatch"
     install-libicu              ""               "whether to install libicu"
     install-playgroundsupport   ""               "whether to install PlaygroundSupport"
@@ -3504,6 +3505,9 @@ for host in "${ALL_HOSTS[@]}"; do
                 INSTALL_TARGETS=install-$(echo ${LLVM_INSTALL_COMPONENTS} | sed -E 's/;/ install-/g')
                 ;;
             libcxx)
+                if [[ -z "${INSTALL_LIBCXX}" ]] ; then
+                    continue
+                fi
                 INSTALL_TARGETS=install-cxx-headers
                 ;;
             swift)

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -13,6 +13,7 @@
 from .cmark import CMark
 from .foundation import Foundation
 from .libdispatch import LibDispatch
+from .libcxx import LibCXX
 from .libicu import LibICU
 from .llbuild import LLBuild
 from .lldb import LLDB
@@ -29,6 +30,7 @@ __all__ = [
     'Ninja',
     'Foundation',
     'LibDispatch',
+    'LibCXX',
     'LibICU',
     'LLBuild',
     'LLDB',

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -12,8 +12,8 @@
 
 from .cmark import CMark
 from .foundation import Foundation
-from .libdispatch import LibDispatch
 from .libcxx import LibCXX
+from .libdispatch import LibDispatch
 from .libicu import LibICU
 from .llbuild import LLBuild
 from .lldb import LLDB
@@ -29,8 +29,8 @@ __all__ = [
     'CMark',
     'Ninja',
     'Foundation',
-    'LibDispatch',
     'LibCXX',
+    'LibDispatch',
     'LibICU',
     'LLBuild',
     'LLDB',

--- a/utils/swift_build_support/swift_build_support/products/libcxx.py
+++ b/utils/swift_build_support/swift_build_support/products/libcxx.py
@@ -1,0 +1,17 @@
+# swift_build_support/products/libcxx.py -------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from . import product
+
+
+class LibCXX(product.Product):
+    pass


### PR DESCRIPTION
In a non-legacy-impl world, this is needed to trigger
building/installing libc++.

Resolves [SR-9861](https://bugs.swift.org/browse/SR-9861)