### PR TITLE
[SIL] Eliminate SILFunctionType::getDefaultWitnessMethodProtocol().

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4007,11 +4007,6 @@ public:
 
   CanType getSelfInstanceType() const;
 
-  /// If this is a @convention(witness_method) function with a protocol
-  /// constrained self parameter, return the protocol constraint for
-  /// the Self type.
-  ProtocolDecl *getDefaultWitnessMethodProtocol() const;
-
   /// If this is a @convention(witness_method) function with a class
   /// constrained self parameter, return the class constraint for the
   /// Self type.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4010,7 +4010,7 @@ public:
   /// If this is a @convention(witness_method) function with a class
   /// constrained self parameter, return the class constraint for the
   /// Self type.
-  ClassDecl *getWitnessMethodClass(ModuleDecl &M) const;
+  ClassDecl *getWitnessMethodClass() const;
 
   /// If this is a @convention(witness_method) function, return the conformance
   /// for which the method is a witness.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -329,8 +329,7 @@ void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
                        MetadataSource::InvalidSourceIndex,
                        selfTy);
 
-  if (fnType->getDefaultWitnessMethodProtocol() ||
-      fnType->getWitnessMethodClass(M)) {
+  if (fnType->getSelfInstanceType()->is<GenericTypeParamType>()) {
     // The Self type is abstract, so we can fulfill its metadata from
     // the Self metadata parameter.
     addSelfMetadataFulfillment(selfTy);

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -98,28 +98,6 @@ CanType SILFunctionType::getSelfInstanceType() const {
   return selfTy;
 }
 
-ProtocolDecl *
-SILFunctionType::getDefaultWitnessMethodProtocol() const {
-  assert(getRepresentation() == SILFunctionTypeRepresentation::WitnessMethod);
-  auto selfTy = getSelfInstanceType();
-  if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {
-    assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
-    auto superclass = GenericSig->getSuperclassBound(paramTy);
-    if (superclass)
-      return nullptr;
-
-    assert(!GenericSig->getRequirements().empty());
-    assert(GenericSig->getRequirements().front().getKind() ==
-             RequirementKind::Conformance);
-    assert(GenericSig->getRequirements().front().getFirstType()
-             ->isEqual(paramTy));
-    return GenericSig->getRequirements().front().getSecondType()
-             ->castTo<ProtocolType>()->getDecl();
-  }
-
-  return nullptr;
-}
-
 ClassDecl *
 SILFunctionType::getWitnessMethodClass(ModuleDecl &M) const {
   auto selfTy = getSelfInstanceType();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -107,9 +107,14 @@ SILFunctionType::getDefaultWitnessMethodProtocol() const {
     auto superclass = GenericSig->getSuperclassBound(paramTy);
     if (superclass)
       return nullptr;
-    auto protos = GenericSig->getConformsTo(paramTy);
-    assert(protos.size() == 1);
-    return protos[0];
+
+    assert(!GenericSig->getRequirements().empty());
+    assert(GenericSig->getRequirements().front().getKind() ==
+             RequirementKind::Conformance);
+    assert(GenericSig->getRequirements().front().getFirstType()
+             ->isEqual(paramTy));
+    return GenericSig->getRequirements().front().getSecondType()
+             ->castTo<ProtocolType>()->getDecl();
   }
 
   return nullptr;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -99,7 +99,7 @@ CanType SILFunctionType::getSelfInstanceType() const {
 }
 
 ClassDecl *
-SILFunctionType::getWitnessMethodClass(ModuleDecl &M) const {
+SILFunctionType::getWitnessMethodClass() const {
   auto selfTy = getSelfInstanceType();
   auto genericSig = getGenericSignature();
   if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2542,10 +2542,9 @@ public:
             selfRequirement->getKind() == RequirementKind::Conformance,
             "first non-same-typerequirement should be conformance requirement");
     auto conformsTo = genericSig->getConformsTo(selfGenericParam);
-    require(conformsTo.size() == 1,
-            "requirement Self parameter must conform to exactly one protocol");
-    require(conformsTo[0] == protocol,
-            "requirement Self parameter should be constrained by protocol");
+    require(std::find(conformsTo.begin(), conformsTo.end(), protocol)
+              != conformsTo.end(),
+            "requirement Self parameter must conform to called protocol");
 
     auto lookupType = AMI->getLookupType();
     if (getOpenedArchetypeOf(lookupType)) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -5027,8 +5027,6 @@ void SILWitnessTable::verify(const SILModule &M) const {
     assert(getEntries().empty() &&
            "A witness table declaration should not have any entries.");
 
-  auto *protocol = getConformance()->getProtocol();
-
   for (const Entry &E : getEntries())
     if (E.getKind() == SILWitnessTable::WitnessKind::Method) {
       SILFunction *F = E.getMethodWitness().Witness;
@@ -5044,15 +5042,6 @@ void SILWitnessTable::verify(const SILModule &M) const {
         assert(F->getLoweredFunctionType()->getRepresentation() ==
                SILFunctionTypeRepresentation::WitnessMethod &&
                "Witnesses must have witness_method representation.");
-        auto *witnessSelfProtocol = F->getLoweredFunctionType()
-            ->getDefaultWitnessMethodProtocol();
-        assert((witnessSelfProtocol == nullptr ||
-                witnessSelfProtocol == protocol) &&
-               "Witnesses must either have a concrete Self, or an "
-               "an abstract Self that is constrained to their "
-               "protocol.");
-        (void)protocol;
-        (void)witnessSelfProtocol;
       }
     }
 }
@@ -5077,12 +5066,6 @@ void SILDefaultWitnessTable::verify(const SILModule &M) const {
     assert(F->getLoweredFunctionType()->getRepresentation() ==
            SILFunctionTypeRepresentation::WitnessMethod &&
            "Default witnesses must have witness_method representation.");
-
-    auto *witnessSelfProtocol = F->getLoweredFunctionType()
-        ->getDefaultWitnessMethodProtocol();
-    assert(witnessSelfProtocol == getProtocol() &&
-           "Default witnesses must have an abstract Self parameter "
-           "constrained to their protocol.");
   }
 #endif
 }

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -870,7 +870,8 @@ swift::tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
 /// \param requirementSig The generic signature of the requirement
 /// \param witnessThunkSig The generic signature of the witness method
 /// \param origSubMap The substitutions from the call instruction
-/// \param isDefaultWitness True if this is a default witness method
+/// \param isSelfAbstract True if the Self type of the witness method is
+/// still abstract (i.e., not a concrete type).
 /// \param classWitness The ClassDecl if this is a class witness method
 static SubstitutionMap
 getWitnessMethodSubstitutions(
@@ -879,13 +880,13 @@ getWitnessMethodSubstitutions(
     GenericSignature *requirementSig,
     GenericSignature *witnessThunkSig,
     SubstitutionMap origSubMap,
-    bool isDefaultWitness,
+    bool isSelfAbstract,
     ClassDecl *classWitness) {
 
   if (witnessThunkSig == nullptr)
     return SubstitutionMap();
 
-  if (isDefaultWitness)
+  if (isSelfAbstract && !classWitness)
     return origSubMap;
 
   assert(!conformanceRef.isAbstract());
@@ -947,14 +948,13 @@ swift::getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
   SubstitutionMap origSubs = AI.getSubstitutionMap();
 
   auto *mod = Module.getSwiftModule();
-  bool isDefaultWitness =
-    (witnessFnTy->getDefaultWitnessMethodProtocol()
-      == CRef.getRequirement());
+  bool isSelfAbstract =
+    witnessFnTy->getSelfInstanceType()->is<GenericTypeParamType>();
   auto *classWitness = witnessFnTy->getWitnessMethodClass(*mod);
 
   return ::getWitnessMethodSubstitutions(mod, CRef, requirementSig,
                                          witnessThunkSig, origSubs,
-                                         isDefaultWitness, classWitness);
+                                         isSelfAbstract, classWitness);
 }
 
 /// Generate a new apply of a function_ref to replace an apply of a

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -950,7 +950,7 @@ swift::getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
   auto *mod = Module.getSwiftModule();
   bool isSelfAbstract =
     witnessFnTy->getSelfInstanceType()->is<GenericTypeParamType>();
-  auto *classWitness = witnessFnTy->getWitnessMethodClass(*mod);
+  auto *classWitness = witnessFnTy->getWitnessMethodClass();
 
   return ::getWitnessMethodSubstitutions(mod, CRef, requirementSig,
                                          witnessThunkSig, origSubs,

--- a/test/IRGen/witness_method_default.swift
+++ b/test/IRGen/witness_method_default.swift
@@ -13,7 +13,7 @@ public protocol SIMDScalarStub {
  func abs() -> Self
 }
 
-// CHECK: define swiftcc void @"$s22witness_method_default7callAbs1sxx_tAA14SIMDScalarStubRzlF
+// CHECK: define {{.*}}swiftcc void @"$s22witness_method_default7callAbs1sxx_tAA14SIMDScalarStubRzlF
 public func callAbs<T: SIMDScalarStub>(s: T) -> T {
   // CHECK: [[ABS_PTR:%[0-9]+]] = getelementptr inbounds i8*, i8** %T.SIMDScalarStub, i32 3
   // CHECK-NEXT: [[ABS_VALUE:%[0-9]+]] = load i8*, i8** [[ABS_PTR]]

--- a/test/IRGen/witness_method_default.swift
+++ b/test/IRGen/witness_method_default.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck --check-prefix=CHECK %s -DINT=i%target-ptrsize
+
+public protocol DummyProtocol { }
+
+public protocol SIMDStorageStub {
+ associatedtype Scalar : DummyProtocol
+}
+
+public protocol SIMDScalarStub {
+ associatedtype SIMD2Storage : SIMDStorageStub
+   where SIMD2Storage.Scalar == Self
+ 
+ func abs() -> Self
+}
+
+// CHECK: define swiftcc void @"$s22witness_method_default7callAbs1sxx_tAA14SIMDScalarStubRzlF
+public func callAbs<T: SIMDScalarStub>(s: T) -> T {
+  // CHECK: [[ABS_PTR:%[0-9]+]] = getelementptr inbounds i8*, i8** %T.SIMDScalarStub, i32 3
+  // CHECK-NEXT: [[ABS_VALUE:%[0-9]+]] = load i8*, i8** [[ABS_PTR]]
+  // CHECK-NEXT: [[ABS:%[0-9]+]] = bitcast i8* [[ABS_VALUE]]
+  // CHECK-NEXT: call swiftcc void [[ABS]]
+ return s.abs()
+}


### PR DESCRIPTION
This method wasn’t returning the protocol on which the that the witness
method would satisfy, as documented. Rather, it was returning the protocol
to which the `Self` type conforms, which could be completely unrelated. For
example, in IndexingIterator’s conformance to IteratorProtocol, this method
would produce the protocol “Collection”, because that’s where the witness
itself was implemented. However, there isn’t necessarily a single such
protocol, so checking for/returning a single protocol was incorrect.

It turns out that there were only a few SIL verifier assertions of it
(that are trivially true) and two actual uses in code:
(1) The devirtualizer was using this computation to decide when it didn’t
need to perform any additional substitutions, but it’s predicate for doing
so was essentially incorrect. Instead, it really wanted to check whether
the Self type is still a type parameter. 
(2) Our polymorphic convention was using it to essentially check whether 
the ’Self’ instance type of a witness_method was a GenericTypeParamType,
which we can check directly.

The new test case illustrates a case where the "single protocol to which
`Self` conforms" assumption is incorrect. It both triggered the assertions
in the SIL verifier and, when assertions are disabled, could miscompile
in the devirtualizer.

Fixes SR-9848 / rdar://problem/47767506.
