### PR TITLE
[cast-opt] Add a new callback: ReplaceValueUsesAction.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CastOptimizer.h
+++ b/include/swift/SILOptimizer/Utils/CastOptimizer.h
@@ -34,19 +34,25 @@ class SILOptFunctionBuilder;
 class CastOptimizer {
   SILOptFunctionBuilder &FunctionBuilder;
 
-  // Callback to be called when uses of an instruction should be replaced.
-  std::function<void(SingleValueInstruction *I, ValueBase *V)>
+  /// Callback that replaces the first SILValue's uses with a use of the second
+  /// value.
+  std::function<void(SILValue, SILValue)> ReplaceValueUsesAction;
+
+  /// Callback that replaces a SingleValueInstruction with a ValueBase after
+  /// updating any status in the caller.
+  std::function<void(SingleValueInstruction *, ValueBase *)>
       ReplaceInstUsesAction;
 
-  // Callback to call when an instruction needs to be erased.
+  /// Callback that erases an instruction and performs any state updates in the
+  /// caller required.
   std::function<void(SILInstruction *)> EraseInstAction;
 
-  // Callback to call after an optimization was performed based on the fact
-  // that a cast will succeed.
+  /// Callback to call after an optimization was performed based on the fact
+  /// that a cast will succeed.
   std::function<void()> WillSucceedAction;
 
-  // Callback to call after an optimization was performed based on the fact
-  // that a cast will fail.
+  /// Callback to call after an optimization was performed based on the fact
+  /// that a cast will fail.
   std::function<void()> WillFailAction;
 
   /// Optimize a cast from a bridged ObjC type into
@@ -69,12 +75,15 @@ class CastOptimizer {
 
 public:
   CastOptimizer(SILOptFunctionBuilder &FunctionBuilder,
-                std::function<void(SingleValueInstruction *I, ValueBase *V)>
+                std::function<void(SILValue, SILValue)> ReplaceValueUsesAction,
+                std::function<void(SingleValueInstruction *, ValueBase *)>
                     ReplaceInstUsesAction,
                 std::function<void(SILInstruction *)> EraseAction,
                 std::function<void()> WillSucceedAction,
                 std::function<void()> WillFailAction = []() {})
-      : FunctionBuilder(FunctionBuilder), ReplaceInstUsesAction(ReplaceInstUsesAction),
+      : FunctionBuilder(FunctionBuilder),
+        ReplaceValueUsesAction(ReplaceValueUsesAction),
+        ReplaceInstUsesAction(ReplaceInstUsesAction),
         EraseInstAction(EraseAction), WillSucceedAction(WillSucceedAction),
         WillFailAction(WillFailAction) {}
 
@@ -84,11 +93,13 @@ public:
   // arguments. It seems the number of the default argument with lambda is
   // limited.
   CastOptimizer(SILOptFunctionBuilder &FunctionBuilder,
+                std::function<void(SILValue, SILValue)> ReplaceValueUsesAction,
                 std::function<void(SingleValueInstruction *I, ValueBase *V)>
                     ReplaceInstUsesAction,
                 std::function<void(SILInstruction *)> EraseAction =
                     [](SILInstruction *) {})
-      : CastOptimizer(FunctionBuilder, ReplaceInstUsesAction, EraseAction, []() {}, []() {}) {}
+      : CastOptimizer(FunctionBuilder, ReplaceValueUsesAction,
+                      ReplaceInstUsesAction, EraseAction, []() {}, []() {}) {}
 
   /// Simplify checked_cast_br. It may change the control flow.
   SILInstruction *simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst);

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -279,6 +279,15 @@ void SILCombiner::replaceInstUsesWith(SingleValueInstruction &I, ValueBase *V) {
   I.replaceAllUsesWith(V);
 }
 
+void SILCombiner::replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
+  Worklist.addUsersToWorklist(oldValue); // Add all modified instrs to worklist.
+
+  LLVM_DEBUG(llvm::dbgs() << "SC: Replacing " << oldValue << "\n"
+                          << "    with " << newValue << '\n');
+
+  oldValue->replaceAllUsesWith(newValue);
+}
+
 /// Replace all of the results of the old instruction with the
 /// corresponding results of the new instruction.
 void SILCombiner::replaceInstUsesPairwiseWith(SILInstruction *oldI,

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1934,20 +1934,26 @@ bool SimplifyCFG::simplifyCheckedCastBranchBlock(CheckedCastBranchInst *CCBI) {
   auto ThisBB = CCBI->getParent();
 
   bool MadeChange = false;
-  CastOptimizer CastOpt(FuncBuilder,
-      [&MadeChange](SILInstruction *I,
-                    ValueBase *V) {  /* ReplaceInstUsesAction */
+  CastOptimizer CastOpt(
+      FuncBuilder,
+      /* ReplaceValueUsesAction */
+      [&MadeChange](SILValue oldValue, SILValue newValue) {
         MadeChange = true;
       },
-      [&MadeChange](SILInstruction *I) { /* EraseInstAction */
+      /* ReplaceInstUsesAction */
+      [&MadeChange](SILInstruction *I, ValueBase *V) { MadeChange = true; },
+      /* EraseInstAction */
+      [&MadeChange](SILInstruction *I) {
         MadeChange = true;
         I->eraseFromParent();
       },
-      [&]() { /* WillSucceedAction */
+      /* WillSucceedAction */
+      [&]() {
         MadeChange |= removeIfDead(FailureBB);
         addToWorklist(ThisBB);
       },
-      [&]() { /* WillFailAction */
+      /* WillFailAction */
+      [&]() {
         MadeChange |= removeIfDead(SuccessBB);
         addToWorklist(ThisBB);
       });
@@ -1965,21 +1971,26 @@ bool SimplifyCFG::simplifyCheckedCastValueBranchBlock(
   bool MadeChange = false;
   CastOptimizer CastOpt(
       FuncBuilder,
-      [&MadeChange](SILInstruction *I,
-                    ValueBase *V) { /* ReplaceInstUsesAction */
-                                    MadeChange = true;
+      /* ReplaceValueUsesAction */
+      [&MadeChange](SILValue oldValue, SILValue newValue) {
+        MadeChange = true;
       },
-      [&MadeChange](SILInstruction *I) { /* EraseInstAction */
-                                         MadeChange = true;
-                                         I->eraseFromParent();
+      /* ReplaceInstUsesAction */
+      [&MadeChange](SILInstruction *I, ValueBase *V) { MadeChange = true; },
+      /* EraseInstAction */
+      [&MadeChange](SILInstruction *I) {
+        MadeChange = true;
+        I->eraseFromParent();
       },
-      [&]() { /* WillSucceedAction */
-              MadeChange |= removeIfDead(FailureBB);
-              addToWorklist(ThisBB);
+      /* WillSucceedAction */
+      [&]() {
+        MadeChange |= removeIfDead(FailureBB);
+        addToWorklist(ThisBB);
       },
-      [&]() { /* WillFailAction */
-              MadeChange |= removeIfDead(SuccessBB);
-              addToWorklist(ThisBB);
+      /* WillFailAction */
+      [&]() {
+        MadeChange |= removeIfDead(SuccessBB);
+        addToWorklist(ThisBB);
       });
 
   MadeChange |= bool(CastOpt.simplifyCheckedCastValueBranchInst(CCBI));
@@ -1994,19 +2005,24 @@ simplifyCheckedCastAddrBranchBlock(CheckedCastAddrBranchInst *CCABI) {
   auto ThisBB = CCABI->getParent();
 
   bool MadeChange = false;
-  CastOptimizer CastOpt(FuncBuilder,
-      [&MadeChange](SILInstruction *I, ValueBase *V) {
-        MadeChange = true;
-      }, /* ReplaceInstUsesAction */
-      [&MadeChange](SILInstruction *I) { /* EraseInstAction */
+  CastOptimizer CastOpt(
+      FuncBuilder,
+      /* ReplaceValueUsesAction */
+      [&MadeChange](SILValue, SILValue) { MadeChange = true; },
+      /* ReplaceInstUsesAction */
+      [&MadeChange](SILInstruction *I, ValueBase *V) { MadeChange = true; },
+      /* EraseInstAction */
+      [&MadeChange](SILInstruction *I) {
         MadeChange = true;
         I->eraseFromParent();
       },
-      [&]() { /* WillSucceedAction */
+      /* WillSucceedAction */
+      [&]() {
         MadeChange |= removeIfDead(FailureBB);
         addToWorklist(ThisBB);
       },
-      [&]() { /* WillFailAction */
+      /* WillFailAction */
+      [&]() {
         MadeChange |= removeIfDead(SuccessBB);
         addToWorklist(ThisBB);
       });

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1439,26 +1439,34 @@ ConstantFolder::processWorkList() {
   llvm::DenseSet<SILInstruction *> ErrorSet;
   llvm::SetVector<SILInstruction *> FoldedUsers;
   CastOptimizer CastOpt(FuncBuilder,
-      [&](SingleValueInstruction *I, ValueBase *V) { /* ReplaceInstUsesAction */
+                        /* ReplaceValueUsesAction */
+                        [&](SILValue oldValue, SILValue newValue) {
+                          InvalidateInstructions = true;
+                          oldValue->replaceAllUsesWith(newValue);
+                        },
+                        /* ReplaceInstUsesAction */
+                        [&](SingleValueInstruction *I, ValueBase *V) {
+                          InvalidateInstructions = true;
+                          I->replaceAllUsesWith(V);
+                        },
+                        /* EraseAction */
+                        [&](SILInstruction *I) {
+                          auto *TI = dyn_cast<TermInst>(I);
 
-        InvalidateInstructions = true;
-        I->replaceAllUsesWith(V);
-      },
-      [&](SILInstruction *I) { /* EraseAction */
-        auto *TI = dyn_cast<TermInst>(I);
+                          if (TI) {
+                            // Invalidate analysis information related to
+                            // branches. Replacing
+                            // unconditional_check_branch type instructions
+                            // by a trap will also invalidate branches/the
+                            // CFG.
+                            InvalidateBranches = true;
+                          }
 
-        if (TI) {
-          // Invalidate analysis information related to branches. Replacing
-          // unconditional_check_branch type instructions by a trap will also
-          // invalidate branches/the CFG.
-          InvalidateBranches = true;
-        }
+                          InvalidateInstructions = true;
 
-        InvalidateInstructions = true;
-
-        WorkList.remove(I);
-        I->eraseFromParent();
-      });
+                          WorkList.remove(I);
+                          I->eraseFromParent();
+                        });
 
   while (!WorkList.empty()) {
     SILInstruction *I = WorkList.pop_back_val();


### PR DESCRIPTION
This is the first in a series of patches to update the cast optimizer for
ownership and multiple value instructions.

This specific patch is NFC.
