### PR TITLE
Remove `import SwiftOnoneSupport` from test.

### DIFF
--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -8,9 +8,6 @@
 import TensorFlow
 import StdlibUnittest
 
-// TODO(SR-7983): Investigate why this is necessary.
-import SwiftOnoneSupport
-
 var ShapedArrayTests = TestSuite("ShapedArrayTests")
 
 // TODO: add full Collection scalar test suite.


### PR DESCRIPTION
Resolves [TF-122](https://bugs.swift.org/browse/TF-122) (originally [SR-7983](https://bugs.swift.org/browse/SR-7983)). The original linker errors are no longer reproducible.