### PR TITLE
AST: fix build with newer clang

### DIFF
--- a/lib/AST/ExperimentalDependencies.cpp
+++ b/lib/AST/ExperimentalDependencies.cpp
@@ -273,8 +273,8 @@ StringRef ScalarTraits<size_t>::input(StringRef scalar, void *ctxt,
 }
 #endif
 
-void ScalarEnumerationTraits<NodeKind>::enumeration(
-    IO &io, swift::experimental_dependencies::NodeKind &value) {
+void ScalarEnumerationTraits<swift::experimental_dependencies::NodeKind>::
+    enumeration(IO &io, swift::experimental_dependencies::NodeKind &value) {
   using NodeKind = swift::experimental_dependencies::NodeKind;
   io.enumCase(value, "topLevel", NodeKind::topLevel);
   io.enumCase(value, "nominal", NodeKind::nominal);


### PR DESCRIPTION
Elaborate the `NodeKind` typename to avoid ambiguity with `llvm::yaml::NodeKind`
and `swift::experimental_dependencies::NodeKind`.  This fixes the build with
newer compilers.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
