### PR TITLE
[cast-opt] Allow users to pass in a SILBuilderContext to the CastOpti…

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILOptFunctionBuilder.h
+++ b/include/swift/SILOptimizer/Utils/SILOptFunctionBuilder.h
@@ -55,6 +55,8 @@ public:
     pm.getModule()->eraseFunction(f);
   }
 
+  SILModule &getModule() const { return *getPassManager().getModule(); }
+
 private:
   SILPassManager &getPassManager() const {
     return *transform.getPassManager();

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -158,7 +158,7 @@ public:
               bool removeCondFails)
       : AA(AA), DA(DA), PCA(PCA), CHA(CHA), Worklist(), MadeChange(false),
         RemoveCondFails(removeCondFails), Iteration(0), Builder(B),
-        CastOpt(FuncBuilder,
+        CastOpt(FuncBuilder, nullptr /*SILBuilderContext*/,
                 /* ReplaceValueUsesAction */
                 [&](SILValue Original, SILValue Replacement) {
                   replaceValueUsesWith(Original, Replacement);

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1935,7 +1935,7 @@ bool SimplifyCFG::simplifyCheckedCastBranchBlock(CheckedCastBranchInst *CCBI) {
 
   bool MadeChange = false;
   CastOptimizer CastOpt(
-      FuncBuilder,
+      FuncBuilder, nullptr /*SILBuilderContext*/,
       /* ReplaceValueUsesAction */
       [&MadeChange](SILValue oldValue, SILValue newValue) {
         MadeChange = true;
@@ -1970,7 +1970,7 @@ bool SimplifyCFG::simplifyCheckedCastValueBranchBlock(
 
   bool MadeChange = false;
   CastOptimizer CastOpt(
-      FuncBuilder,
+      FuncBuilder, nullptr /*SILBuilderContext*/,
       /* ReplaceValueUsesAction */
       [&MadeChange](SILValue oldValue, SILValue newValue) {
         MadeChange = true;
@@ -2006,7 +2006,7 @@ simplifyCheckedCastAddrBranchBlock(CheckedCastAddrBranchInst *CCABI) {
 
   bool MadeChange = false;
   CastOptimizer CastOpt(
-      FuncBuilder,
+      FuncBuilder, nullptr /*SILBuilderContext*/,
       /* ReplaceValueUsesAction */
       [&MadeChange](SILValue, SILValue) { MadeChange = true; },
       /* ReplaceInstUsesAction */

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -98,7 +98,7 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   CanType CanBridgedTy = BridgedTargetTy->getCanonicalType();
   SILType SILBridgedTy = SILType::getPrimitiveObjectType(CanBridgedTy);
 
-  SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst, BuilderContext);
   SILValue SrcOp;
   SILInstruction *NewI = nullptr;
 
@@ -349,7 +349,7 @@ SILInstruction *CastOptimizer::optimizeBridgedSwiftToObjCCast(
   (void)Conf;
 
   // Generate code to invoke _bridgeToObjectiveC
-  SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst, BuilderContext);
 
   auto *NTD = Source.getNominalOrBoundGenericNominal();
   assert(NTD);
@@ -702,7 +702,7 @@ SILInstruction *CastOptimizer::simplifyCheckedCastAddrBranchInst(
   auto *FailureBB = Inst->getFailureBB();
   auto &Mod = Inst->getModule();
 
-  SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst, BuilderContext);
 
   // Try to determine the outcome of the cast from a known type
   // to a protocol type at compile-time.
@@ -816,7 +816,7 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
       return nullptr;
 
     // We know the dynamic type of the operand.
-    SILBuilderWithScope Builder(Inst);
+    SILBuilderWithScope Builder(Inst, BuilderContext);
     auto Loc = Inst->getLoc();
     auto *SuccessBB = Inst->getSuccessBB();
     auto *FailureBB = Inst->getFailureBB();
@@ -858,7 +858,7 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
   auto Feasibility = classifyDynamicCast(Mod.getSwiftModule(), SourceType,
                                          TargetType, isSourceTypeExact);
 
-  SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst, BuilderContext);
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     auto *NewI = Builder.createBranch(Loc, FailureBB);
@@ -943,7 +943,7 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
   auto Feasibility = classifyDynamicCast(Mod.getSwiftModule(), SourceType,
                                          TargetType, isSourceTypeExact);
 
-  SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst, BuilderContext);
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     auto *NewI = Builder.createBranch(Loc, FailureBB);
@@ -1065,7 +1065,7 @@ SILInstruction *CastOptimizer::optimizeCheckedCastAddrBranchInst(
             canUseScalarCheckedCastInstructions(
                 Inst->getModule(), MI->getType().getASTType(),
                 Inst->getTargetType())) {
-          SILBuilderWithScope B(Inst);
+          SILBuilderWithScope B(Inst, BuilderContext);
           auto NewI = B.createCheckedCastBranch(
               Loc, false /*isExact*/, MI, Dest->getType().getObjectType(),
               SuccessBB, FailureBB, Inst->getTrueBBCount(),
@@ -1114,7 +1114,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
   // checked_cast_br %0 to ...
   if (auto *IEMI = dyn_cast<InitExistentialMetatypeInst>(Op)) {
     if (auto *MI = dyn_cast<MetatypeInst>(IEMI->getOperand())) {
-      SILBuilderWithScope B(Inst);
+      SILBuilderWithScope B(Inst, BuilderContext);
       auto *NewI = B.createCheckedCastBranch(
           Loc, /* isExact */ false, MI, LoweredTargetType, SuccessBB, FailureBB,
           Inst->getTrueBBCount(), Inst->getFalseBBCount());
@@ -1177,7 +1177,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
                                          EMT->getRepresentation());
         auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
-        SILBuilderWithScope B(Inst);
+        SILBuilderWithScope B(Inst, BuilderContext);
         B.getOpenedArchetypes().addOpenedArchetypeOperands(
             FoundIEI->getTypeDependentOperands());
         auto *MI = B.createMetatype(FoundIEI->getLoc(), SILMetaTy);
@@ -1236,7 +1236,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
         auto *MetaTy = MetatypeType::get(ConcreteTy, EMT->getRepresentation());
         auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
-        SILBuilderWithScope B(Inst);
+        SILBuilderWithScope B(Inst, BuilderContext);
         B.getOpenedArchetypes().addOpenedArchetypeOperands(
             FoundIERI->getTypeDependentOperands());
         auto *MI = B.createMetatype(FoundIERI->getLoc(), SILMetaTy);
@@ -1271,7 +1271,7 @@ ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
-    SILBuilderWithScope Builder(Inst);
+    SILBuilderWithScope Builder(Inst, BuilderContext);
     auto *Trap = Builder.createBuiltinTrap(Loc);
     Inst->replaceAllUsesWithUndef();
     EraseInstAction(Inst);
@@ -1296,7 +1296,7 @@ ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
     }
   }
 
-  SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst, BuilderContext);
 
   // Try to apply the bridged casts optimizations
   auto SourceType = LoweredSourceType.getASTType();
@@ -1481,7 +1481,7 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
-    SILBuilderWithScope Builder(Inst);
+    SILBuilderWithScope Builder(Inst, BuilderContext);
     // mem2reg's invariants get unhappy if we don't try to
     // initialize a loadable result.
     auto DestType = Dest->getType();
@@ -1529,7 +1529,7 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
     }
 
     if (ResultNotUsed) {
-      SILBuilderWithScope B(Inst);
+      SILBuilderWithScope B(Inst, BuilderContext);
       B.createDestroyAddr(Inst->getLoc(), Inst->getSrc());
       if (DestroyDestInst)
         EraseInstAction(DestroyDestInst);
@@ -1561,7 +1561,7 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
     if (isBridgingCast(SourceType, TargetType))
       return nullptr;
 
-    SILBuilderWithScope Builder(Inst);
+    SILBuilderWithScope Builder(Inst, BuilderContext);
     if (!emitSuccessfulIndirectUnconditionalCast(Builder, Mod.getSwiftModule(),
                                                  Loc, Src, SourceType, Dest,
                                                  TargetType, Inst)) {
@@ -1596,19 +1596,21 @@ SILInstruction *CastOptimizer::optimizeMetatypeConversion(
     return NewCast;
   };
   if (auto *MI = dyn_cast<MetatypeInst>(Op)) {
-    return replaceCast(
-        SILBuilderWithScope(MCI).createMetatype(MCI->getLoc(), Ty));
+    return replaceCast(SILBuilderWithScope(MCI, BuilderContext)
+                           .createMetatype(MCI->getLoc(), Ty));
   }
   // For metatype instructions that require an operand, generate the new
   // metatype at the same position as the original to avoid extending the
   // lifetime of `Op` past its destroy.
   if (auto *VMI = dyn_cast<ValueMetatypeInst>(Op)) {
-    return replaceCast(SILBuilderWithScope(VMI).createValueMetatype(
-        MCI->getLoc(), Ty, VMI->getOperand()));
+    return replaceCast(
+        SILBuilderWithScope(VMI, BuilderContext)
+            .createValueMetatype(MCI->getLoc(), Ty, VMI->getOperand()));
   }
   if (auto *EMI = dyn_cast<ExistentialMetatypeInst>(Op)) {
-    return replaceCast(SILBuilderWithScope(EMI).createExistentialMetatype(
-        MCI->getLoc(), Ty, EMI->getOperand()));
+    return replaceCast(
+        SILBuilderWithScope(EMI, BuilderContext)
+            .createExistentialMetatype(MCI->getLoc(), Ty, EMI->getOperand()));
   }
   return nullptr;
 }

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1438,7 +1438,7 @@ ConstantFolder::processWorkList() {
   // instruction from different entry points in the WorkList.
   llvm::DenseSet<SILInstruction *> ErrorSet;
   llvm::SetVector<SILInstruction *> FoldedUsers;
-  CastOptimizer CastOpt(FuncBuilder,
+  CastOptimizer CastOpt(FuncBuilder, nullptr /*SILBuilderContext*/,
                         /* ReplaceValueUsesAction */
                         [&](SILValue oldValue, SILValue newValue) {
                           InvalidateInstructions = true;


### PR DESCRIPTION
…mizer.

NOTE: I changed all places that the CastOptimizer is created to just pass in
nullptr for now so this is NFC.

----

Right now the interface of the CastOptimizer is muddled and confused. Sometimes
it is returning a value that should be used by the caller, other times it is
returning an instruction that is meant to be reprocessed by the caller.

This series of patches is attempting to clean this up by switching to the
following model:

1. If we are optimizing a cast of a value, we return a SILValue. If the cast
fails, we return an empty SILValue().

2. If we are optimizing a cast of an address, we return a boolean value to show
success/failure and require the user to use the SILBuilderContext to get the
cast if they need to.
