### PR TITLE
[ParseableInterfaces] Refine cache keys and dependency checks

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -35,7 +35,6 @@ namespace swift {
     StringRef ModuleLinkName;
     ArrayRef<std::string> ExtraClangOptions;
 
-    /// Describes a dependency that 
     struct FileDependency {
       uint64_t Size;
       uint64_t ModificationTime;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -35,9 +35,10 @@ namespace swift {
     StringRef ModuleLinkName;
     ArrayRef<std::string> ExtraClangOptions;
 
+    /// Describes a dependency that 
     struct FileDependency {
       uint64_t Size;
-      uint64_t Hash;
+      uint64_t ModificationTime;
       std::string Path;
     };
     ArrayRef<FileDependency> Dependencies;

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -97,6 +97,19 @@ getBufferOfDependency(clang::vfs::FileSystem &FS,
   return std::move(DepBuf.get());
 }
 
+static Optional<clang::vfs::Status>
+getStatusOfDependency(clang::vfs::FileSystem &FS,
+                      StringRef ModulePath, StringRef DepPath,
+                      DiagnosticEngine &Diags, SourceLoc DiagLoc) {
+  auto Status = FS.status(DepPath);
+  if (!Status) {
+    Diags.diagnose(DiagLoc,
+                   diag::missing_dependency_of_parseable_module_interface,
+                   DepPath, ModulePath, Status.getError().message());
+    return None;
+  }
+  return Status.get();
+}
 /// Construct a cache key for the .swiftmodule being generated. There is a
 /// balance to be struck here between things that go in the cache key and
 /// things that go in the "up to date" check of the cache entry. We want to
@@ -195,6 +208,17 @@ void ParseableInterfaceModuleLoader::configureSubInvocationInputsAndOutputs(
   SubFEOpts.InputsAndOutputs.setMainAndSupplementaryOutputs({MainOut}, {SOPs});
 }
 
+// Checks that a dependency read from the cached module is up to date compared
+// to the interface file it represents.
+static bool dependencyIsUpToDate(clang::vfs::FileSystem &FS, FileDependency In,
+                                 StringRef ModulePath, DiagnosticEngine &Diags,
+                                 SourceLoc DiagLoc) {
+  auto Status = getStatusOfDependency(FS, ModulePath, In.Path, Diags, DiagLoc);
+  if (!Status) return false;
+  uint64_t mtime = Status->getLastModificationTime().time_since_epoch().count();
+  return Status->getSize() == In.Size && mtime == In.ModificationTime;
+}
+
 // Check that the output .swiftmodule file is at least as new as all the
 // dependencies it read when it was built last time.
 static bool
@@ -223,11 +247,7 @@ swiftModuleIsUpToDate(clang::vfs::FileSystem &FS,
   for (auto In : AllDeps) {
     if (OuterTracker)
       OuterTracker->addDependency(In.Path, /*IsSystem=*/false);
-    auto DepBuf = getBufferOfDependency(FS, OutPath, In.Path, Diags,
-                                        ModuleID.second);
-    if (!DepBuf ||
-        DepBuf->getBufferSize() != In.Size ||
-        xxHash64(DepBuf->getBuffer()) != In.Hash) {
+    if (!dependencyIsUpToDate(FS, In, OutPath, Diags, ModuleID.second)) {
       LLVM_DEBUG(llvm::dbgs() << "Dep " << In.Path
                  << " is directly out of date\n");
       return false;
@@ -263,13 +283,15 @@ collectDepsForSerialization(clang::vfs::FileSystem &FS,
     if (AllDepNames.insert(DepName).second && OuterTracker) {
         OuterTracker->addDependency(DepName, /*IsSystem=*/false);
     }
-    auto DepBuf = getBufferOfDependency(FS, InPath, DepName, Diags, DiagLoc);
-    if (!DepBuf) {
+    auto Status = getStatusOfDependency(FS, InPath, DepName, Diags, DiagLoc);
+    if (!Status)
       return true;
-    }
-    uint64_t Size = DepBuf->getBufferSize();
-    uint64_t Hash = xxHash64(DepBuf->getBuffer());
-    Deps.push_back(FileDependency{Size, Hash, DepName});
+    auto DepBuf = getBufferOfDependency(FS, InPath, DepName, Diags, DiagLoc);
+    if (!DepBuf)
+      return true;
+    uint64_t mtime =
+      Status->getLastModificationTime().time_since_epoch().count();
+    Deps.push_back(FileDependency{Status->getSize(), mtime, DepName});
 
     if (ModuleCachePath.empty())
       continue;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1058,7 +1058,9 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   }
 
   for (auto const &dep : options.Dependencies) {
-    FileDependency.emit(ScratchRecord, dep.Size, dep.Hash, dep.Path);
+    FileDependency.emit(ScratchRecord, dep.Size,
+                        dep.ModificationTime,
+                        dep.Path);
   }
 
   SmallVector<ModuleDecl::ImportedModule, 8> allImports;

--- a/test/ParseableInterface/ModuleCache/module-cache-effective-version-irrelevant.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-effective-version-irrelevant.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+//
+// Test will build a module TestModule that depends on OtherModule and LeafModule (built from other.swift and leaf.swift).
+//
+// RUN: echo 'public func LeafFunc() -> Int { return 10; }' >%t/leaf.swift
+//
+// RUN: echo 'import LeafModule' >%t/other.swift
+// RUN: echo 'public func OtherFunc() -> Int { return LeafFunc(); }' >>%t/other.swift
+//
+// Phase 1: build LeafModule into a .swiftinterface file with -swift-version 4:
+//
+// RUN: %target-swift-frontend -swift-version 4 -I %t -module-cache-path %t/modulecache -emit-parseable-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -typecheck
+//
+// Phase 2: build OtherModule into a .swiftinterface file with -swift-version 4.2:
+//
+// RUN: %target-swift-frontend -swift-version 4.2 -I %t -module-cache-path %t/modulecache -emit-parseable-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -enable-parseable-module-interface -typecheck
+//
+// Phase 3: build TestModule in -swift-version 5 and import both of these:
+//
+// RUN: %target-swift-frontend -swift-version 5 -I %t -module-cache-path %t/modulecache -module-name TestModule %s -enable-parseable-module-interface -typecheck
+//
+// Phase 4: make sure we only compiled LeafModule and OtherModule one time:
+//
+// RUN: NUM_LEAF_MODULES=$(find %t/modulecache -type f -name 'LeafModule-*.swiftmodule' | wc -l)
+// RUN: NUM_OTHER_MODULES=$(find %t/modulecache -type f -name 'OtherModule-*.swiftmodule' | wc -l)
+// RUN: if [ ! $NUM_LEAF_MODULES -eq 1 ]; then echo "Should only be 1 LeafModule, found $NUM_LEAF_MODULES"; exit 1; fi
+// RUN: if [ ! $NUM_OTHER_MODULES -eq 1 ]; then echo "Should only be 1 OtherModule, found $NUM_OTHER_MODULES"; exit 1; fi
+import LeafModule
+import OtherModule

--- a/test/ParseableInterface/ModuleCache/module-cache-intermediate-mtime-change-rebuilds-only-intermediate.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-intermediate-mtime-change-rebuilds-only-intermediate.swift
@@ -27,12 +27,11 @@
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
-// Actual test: Change a byte in OtherModule.swiftinterface, check we only rebuild its cached module.
+// Actual test: Change the mtime of OtherModule.swiftinterface, check we only rebuild its cached module.
 //
 // RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
-// RUN: sed -e 's/OtherFunc2/OtterFunc2/' -i.prev %t/OtherModule.swiftinterface
-// RUN: %{python} %S/Inputs/make-old.py %t/OtherModule.swiftinterface
+// RUN: touch %t/OtherModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ParseableInterface/ModuleCache/module-cache-leaf-mtime-change-rebuilds-all.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-leaf-mtime-change-rebuilds-all.swift
@@ -27,12 +27,11 @@
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule
 //
 //
-// Actual test: Change a byte in LeafModule.swiftinterface, check both cached modules get rebuilt.
+// Actual test: Change the mtime of LeafModule.swiftinterface, check both cached modules get rebuilt.
 //
 // RUN: %{python} %S/Inputs/check-is-old.py %t/OtherModule.swiftinterface %t/LeafModule.swiftinterface
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
-// RUN: sed -e 's/LeafFunc2/LoafFunc2/' -i.prev %t/LeafModule.swiftinterface
-// RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
+// RUN: touch %t/LeafModule.swiftinterface
 // RUN: rm %t/TestModule.swiftmodule
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -enable-parseable-module-interface -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/check-is-new.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule


### PR DESCRIPTION
Hashing the contents of the interface files for dependency checking is overkill. In practice, size and last modification time are enough to determine if a file has changed on disk, and therefore should be rebuilt.

As for cache keys, previously, we included the PCH hash components in the cache key. While they didn’t do any harm, they didn’t contribute any unique information about the module in question.

Additionally, passing the effective language version in means that each dependency that uses a different -swift-version would re-compile all of its dependencies. This is unfortunate, as that means the standard library is recompiled potentially several times.

rdar://46503065