### PR TITLE
[LoadableByAddress] handle functions that return a closure in a tuple

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1603,6 +1603,8 @@ private:
                            SmallVectorImpl<SILInstruction *> &Delete);
   bool recreateApply(SILInstruction &I,
                      SmallVectorImpl<SILInstruction *> &Delete);
+  bool recreateTupleInstr(SILInstruction &I,
+                          SmallVectorImpl<SILInstruction *> &Delete);
   bool recreateConvInstr(SILInstruction &I,
                          SmallVectorImpl<SILInstruction *> &Delete);
   bool recreateBuiltinInstr(SILInstruction &I,
@@ -2613,6 +2615,34 @@ bool LoadableByAddress::fixStoreToBlockStorageInstr(
   return true;
 }
 
+bool LoadableByAddress::recreateTupleInstr(
+    SILInstruction &I, SmallVectorImpl<SILInstruction *> &Delete) {
+  auto *tupleInstr = dyn_cast<TupleInst>(&I);
+  if (!tupleInstr)
+    return false;
+
+  // Check if we need to recreate the tuple:
+  auto *F = tupleInstr->getFunction();
+  auto *currIRMod = getIRGenModule()->IRGen.getGenModule(F);
+  GenericEnvironment *genEnv = F->getGenericEnvironment();
+  auto resultTy = tupleInstr->getType();
+  auto newResultTy = MapperCache.getNewSILType(genEnv, resultTy, *currIRMod);
+  if (resultTy == newResultTy)
+    return true;
+
+  // The tuple type have changed based on its members.
+  // For example if one or more of them are ‘large’ loadable types
+  SILBuilderWithScope tupleBuilder(tupleInstr);
+  SmallVector<SILValue, 8> elems;
+  for (auto elem : tupleInstr->getElements()) {
+    elems.push_back(elem);
+  }
+  auto *newTuple = tupleBuilder.createTuple(tupleInstr->getLoc(), elems);
+  tupleInstr->replaceAllUsesWith(newTuple);
+  Delete.push_back(tupleInstr);
+  return true;
+}
+
 bool LoadableByAddress::recreateConvInstr(SILInstruction &I,
                          SmallVectorImpl<SILInstruction *> &Delete) {
   auto *convInstr = dyn_cast<SingleValueInstruction>(&I);
@@ -2851,7 +2881,9 @@ void LoadableByAddress::run() {
     SmallVector<SILInstruction *, 32> Delete;
     for (SILBasicBlock &BB : CurrF) {
       for (SILInstruction &I : BB) {
-        if (recreateConvInstr(I, Delete))
+        if (recreateTupleInstr(I, Delete))
+          continue;
+        else if (recreateConvInstr(I, Delete))
           continue;
         else if (recreateBuiltinInstr(I, Delete))
           continue;

--- a/validation-test/compiler_crashers_2_fixed/sr9849.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr9849.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -Xllvm -sil-verify-after-pass=loadable-address -emit-ir -o %t.ll %s
+
+// Just make sure we don't crash.
+
+
+struct Large {
+  var a: Int = 1
+  var b: Int = 1
+  var c: Int = 1
+  var d: Int = 1
+  var e: Int = 1
+  var f: Int = 1
+  var g: Int = 1
+  var h: Int = 1
+}
+
+func test(_ x: Large) -> (Large, (Large) -> Large) {
+  return (x, {$0})
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-9849

If we have a tuple-creation instruction that takes in a large type, we have to re-create it because the 'stale' saved type is no longer correct. said stale type is propagated to return instructions which will have an invalid type.