### PR TITLE
Resolve SR-9230 by replacing type-check with the appropriate apply calls.

### DIFF
--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -253,4 +253,8 @@ PythonRuntimeTestSuite.test("PythonConvertible") {
   expectEqual(five, Double(5).pythonObject)
 }
 
+PythonRuntimeTestSuite.test("SR-9230") {
+  expectEqual(2, Python.len(Python.dict(a: "a", b: "b")))
+}
+
 runAllTests()


### PR DESCRIPTION
The existing code used to convert a dynamic callable into what parsing would construct, and then re-run type-checking. There were certain circumstances where typechecking could not be called twice. For example, Dictionary Literals were one of those cases. This led to type-checking problems on more complex dynamicCallable programs.