### PR TITLE
utils: fix cmake build of lldb on macOS

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2541,12 +2541,12 @@ for host in "${ALL_HOSTS[@]}"; do
                       -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
                   )
 
-                  if [[ ${LLDB_BUILD_ON_MACOS} ]] ; then
+                  if [[ "$(uname -s)" == "Darwin" ]] ; then
                     cmake_options+=(
                       -DLLDB_BUILD_FRAMEWORK:BOOL=TRUE
                       -DLLDB_CODESIGN_IDENTITY=""
                     )
-                    if "${ENABLE_ASAN}" ]] ; then
+                    if [[ "${ENABLE_ASAN}" ]] ; then
                       # Limit the number of parallel tests
                       LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --threads=$(sysctl hw.physicalcpu | awk '{ print $2 }')"
                     fi


### PR DESCRIPTION
Fix the check for building on macOS, fix a syntax error in the script.
This should repair the macOS build of lldb with CMake.  Thanks to
@slavapestov for pointing out that this path had been broken!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
