### PR TITLE
[5.0] [SIL] Fix potential miscompile in devirtualizer when same-type-to-Self constraints

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4004,11 +4004,6 @@ public:
 
   CanType getSelfInstanceType() const;
 
-  /// If this is a @convention(witness_method) function with a protocol
-  /// constrained self parameter, return the protocol constraint for
-  /// the Self type.
-  ProtocolDecl *getDefaultWitnessMethodProtocol() const;
-
   /// If this is a @convention(witness_method) function with a class
   /// constrained self parameter, return the class constraint for the
   /// Self type.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -327,8 +327,7 @@ void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
                        MetadataSource::InvalidSourceIndex,
                        selfTy);
 
-  if (fnType->getDefaultWitnessMethodProtocol() ||
-      fnType->getWitnessMethodClass(M)) {
+  if (fnType->getSelfInstanceType()->is<GenericTypeParamType>()) {
     // The Self type is abstract, so we can fulfill its metadata from
     // the Self metadata parameter.
     addSelfMetadataFulfillment(selfTy);

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -98,28 +98,6 @@ CanType SILFunctionType::getSelfInstanceType() const {
   return selfTy;
 }
 
-ProtocolDecl *
-SILFunctionType::getDefaultWitnessMethodProtocol() const {
-  assert(getRepresentation() == SILFunctionTypeRepresentation::WitnessMethod);
-  auto selfTy = getSelfInstanceType();
-  if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {
-    assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
-    auto superclass = GenericSig->getSuperclassBound(paramTy);
-    if (superclass)
-      return nullptr;
-
-    assert(!GenericSig->getRequirements().empty());
-    assert(GenericSig->getRequirements().front().getKind() ==
-             RequirementKind::Conformance);
-    assert(GenericSig->getRequirements().front().getFirstType()
-             ->isEqual(paramTy));
-    return GenericSig->getRequirements().front().getSecondType()
-             ->castTo<ProtocolType>()->getDecl();
-  }
-
-  return nullptr;
-}
-
 ClassDecl *
 SILFunctionType::getWitnessMethodClass(ModuleDecl &M) const {
   auto selfTy = getSelfInstanceType();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -107,9 +107,14 @@ SILFunctionType::getDefaultWitnessMethodProtocol() const {
     auto superclass = GenericSig->getSuperclassBound(paramTy);
     if (superclass)
       return nullptr;
-    auto protos = GenericSig->getConformsTo(paramTy);
-    assert(protos.size() == 1);
-    return protos[0];
+
+    assert(!GenericSig->getRequirements().empty());
+    assert(GenericSig->getRequirements().front().getKind() ==
+             RequirementKind::Conformance);
+    assert(GenericSig->getRequirements().front().getFirstType()
+             ->isEqual(paramTy));
+    return GenericSig->getRequirements().front().getSecondType()
+             ->castTo<ProtocolType>()->getDecl();
   }
 
   return nullptr;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -5012,8 +5012,6 @@ void SILWitnessTable::verify(const SILModule &M) const {
     assert(getEntries().empty() &&
            "A witness table declaration should not have any entries.");
 
-  auto *protocol = getConformance()->getProtocol();
-
   for (const Entry &E : getEntries())
     if (E.getKind() == SILWitnessTable::WitnessKind::Method) {
       SILFunction *F = E.getMethodWitness().Witness;
@@ -5029,15 +5027,6 @@ void SILWitnessTable::verify(const SILModule &M) const {
         assert(F->getLoweredFunctionType()->getRepresentation() ==
                SILFunctionTypeRepresentation::WitnessMethod &&
                "Witnesses must have witness_method representation.");
-        auto *witnessSelfProtocol = F->getLoweredFunctionType()
-            ->getDefaultWitnessMethodProtocol();
-        assert((witnessSelfProtocol == nullptr ||
-                witnessSelfProtocol == protocol) &&
-               "Witnesses must either have a concrete Self, or an "
-               "an abstract Self that is constrained to their "
-               "protocol.");
-        (void)protocol;
-        (void)witnessSelfProtocol;
       }
     }
 }
@@ -5062,12 +5051,6 @@ void SILDefaultWitnessTable::verify(const SILModule &M) const {
     assert(F->getLoweredFunctionType()->getRepresentation() ==
            SILFunctionTypeRepresentation::WitnessMethod &&
            "Default witnesses must have witness_method representation.");
-
-    auto *witnessSelfProtocol = F->getLoweredFunctionType()
-        ->getDefaultWitnessMethodProtocol();
-    assert(witnessSelfProtocol == getProtocol() &&
-           "Default witnesses must have an abstract Self parameter "
-           "constrained to their protocol.");
   }
 #endif
 }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2515,10 +2515,9 @@ public:
             selfRequirement->getKind() == RequirementKind::Conformance,
             "first non-same-typerequirement should be conformance requirement");
     auto conformsTo = genericSig->getConformsTo(selfGenericParam);
-    require(conformsTo.size() == 1,
-            "requirement Self parameter must conform to exactly one protocol");
-    require(conformsTo[0] == protocol,
-            "requirement Self parameter should be constrained by protocol");
+    require(std::find(conformsTo.begin(), conformsTo.end(), protocol)
+              != conformsTo.end(),
+            "requirement Self parameter must conform to called protocol");
 
     auto lookupType = AMI->getLookupType();
     if (getOpenedArchetypeOf(lookupType)) {

--- a/test/IRGen/witness_method_default.swift
+++ b/test/IRGen/witness_method_default.swift
@@ -13,7 +13,7 @@ public protocol SIMDScalarStub {
  func abs() -> Self
 }
 
-// CHECK: define swiftcc void @"$s22witness_method_default7callAbs1sxx_tAA14SIMDScalarStubRzlF
+// CHECK: define {{.*}}swiftcc void @"$s22witness_method_default7callAbs1sxx_tAA14SIMDScalarStubRzlF
 public func callAbs<T: SIMDScalarStub>(s: T) -> T {
   // CHECK: [[ABS_PTR:%[0-9]+]] = getelementptr inbounds i8*, i8** %T.SIMDScalarStub, i32 3
   // CHECK-NEXT: [[ABS_VALUE:%[0-9]+]] = load i8*, i8** [[ABS_PTR]]

--- a/test/IRGen/witness_method_default.swift
+++ b/test/IRGen/witness_method_default.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck --check-prefix=CHECK %s -DINT=i%target-ptrsize
+
+public protocol DummyProtocol { }
+
+public protocol SIMDStorageStub {
+ associatedtype Scalar : DummyProtocol
+}
+
+public protocol SIMDScalarStub {
+ associatedtype SIMD2Storage : SIMDStorageStub
+   where SIMD2Storage.Scalar == Self
+ 
+ func abs() -> Self
+}
+
+// CHECK: define swiftcc void @"$s22witness_method_default7callAbs1sxx_tAA14SIMDScalarStubRzlF
+public func callAbs<T: SIMDScalarStub>(s: T) -> T {
+  // CHECK: [[ABS_PTR:%[0-9]+]] = getelementptr inbounds i8*, i8** %T.SIMDScalarStub, i32 3
+  // CHECK-NEXT: [[ABS_VALUE:%[0-9]+]] = load i8*, i8** [[ABS_PTR]]
+  // CHECK-NEXT: [[ABS:%[0-9]+]] = bitcast i8* [[ABS_VALUE]]
+  // CHECK-NEXT: call swiftcc void [[ABS]]
+ return s.abs()
+}


### PR DESCRIPTION
The method `SILFunctionType::getDefaultWitnessMethodProtocol()` was assuming
that the `Self` type for any witness method could only have a single protocol
conformance, which is not always the case. With assertions enabled,
the compiler would crash (in the SIL verifier, then later in IRGen) when this
property didn't hold. With assertions disabled, it could result in a miscompile
in the devirtualizer.

The method itself didn't do what it stated, and its clients didn't want what it
did. Remove the method entirely and update the clients to check for what
they really wanted to know---whether the `Self` type of witness method was
still abstract and, therefore, what protocolS it conforms to.

Fixes SR-9848 / rdar://problem/47767506.