### PR TITLE
Fix build-script on macOS after PR #22228

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2541,16 +2541,17 @@ for host in "${ALL_HOSTS[@]}"; do
                       -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
                   )
 
-                  if [[ ${LLDB_BUILD_ON_MACOS} ]] ; then
+                  case "${host}" in
+                  macosx-*)
                     cmake_options+=(
                       -DLLDB_BUILD_FRAMEWORK:BOOL=TRUE
-                      -DLLDB_CODESIGN_IDENTITY=""
+                      -DLLDB_CODESIGN_IDENTITY:STRING=""
                     )
-                    if "${ENABLE_ASAN}" ]] ; then
+                    if [[ "${ENABLE_ASAN}" ]] ; then
                       # Limit the number of parallel tests
                       LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --threads=$(sysctl hw.physicalcpu | awk '{ print $2 }')"
                     fi
-                  fi
+                  esac
                 fi
                 ;;
             llbuild)


### PR DESCRIPTION
A change on build-script [1] broke a number of build bots [2][3], because the `LLDB_BUILD_ON_MACOS` variable it used doesn't actually exist.

[1] https://github.com/apple/swift/pull/22228/commits/b3b9de72420fbcef0a69b19e5d1181de5c734da0 
[2] https://ci.swift.org/job/oss-lldb-incremental-osx-cmake/
[3] https://ci.swift.org/job/oss-lldb-asan-osx/