### PR TITLE
test: explicitly indicate interpreter for utils

### DIFF
--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | %utils/backtrace-check
+// RUN: not --crash %t/a.out 2>&1 | %{python} %utils/backtrace-check
 
 // This is not supported on watchos, ios, or tvos
 // UNSUPPORTED: OS=watchos

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | PYTHONPATH=%lldb-python-path %utils/symbolicate-linux-fatal %t/a.out - | %utils/backtrace-check -u
+// RUN: not --crash %t/a.out 2>&1 | PYTHONPATH=%lldb-python-path %{python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb

--- a/test/expr/primary/selector/fixits.swift
+++ b/test/expr/primary/selector/fixits.swift
@@ -20,7 +20,7 @@
 // RUN: %empty-directory(%t.remapping)
 // RUN: cp %s %t.sources/fixits.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -typecheck %t.sources/fixits.swift -fixit-all -emit-fixits-path %t.remapping/fixits.remap
-// RUN: %utils/apply-fixit-edits.py %t.remapping
+// RUN: %{python} %utils/apply-fixit-edits.py %t.remapping
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -typecheck %t.sources/fixits.swift 2> %t.result
 
 // RUN: %FileCheck %s < %t.result


### PR DESCRIPTION
This fixes the last couple of instances of the interpreter not being
passed to the python the scripts which makes them fail on OSes where
shebangs are not honoured (i.e. Windows)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
