### PR TITLE
Fix a race condition with the initialization of class metadata

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -590,12 +590,13 @@ swift_relocateClassMetadata(const ClassDescriptor *descriptor,
 /// - The class is generic.
 ///   In this case the class metadata was allocated from a generic
 ///   class metadata pattern by swift_allocateGenericClassMetadata().
-SWIFT_RUNTIME_EXPORT
-void swift_initClassMetadata(ClassMetadata *self,
-                             ClassLayoutFlags flags,
-                             size_t numFields,
-                             const TypeLayout * const *fieldTypes,
-                             size_t *fieldOffsets);
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataDependency
+swift_initClassMetadata(ClassMetadata *self,
+                        ClassLayoutFlags flags,
+                        size_t numFields,
+                        const TypeLayout * const *fieldTypes,
+                        size_t *fieldOffsets);
 
 #if SWIFT_OBJC_INTEROP
 /// Initialize various fields of the class metadata.
@@ -606,12 +607,13 @@ void swift_initClassMetadata(ClassMetadata *self,
 /// This means the class does not have generic or resilient ancestry,
 /// and is itself not generic. However, it might have fields whose
 /// size is not known at compile time.
-SWIFT_RUNTIME_EXPORT
-void swift_updateClassMetadata(ClassMetadata *self,
-                               ClassLayoutFlags flags,
-                               size_t numFields,
-                               const TypeLayout * const *fieldTypes,
-                               size_t *fieldOffsets);
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataDependency
+swift_updateClassMetadata(ClassMetadata *self,
+                          ClassLayoutFlags flags,
+                          size_t numFields,
+                          const TypeLayout * const *fieldTypes,
+                          size_t *fieldOffsets);
 #endif
 
 /// Given class metadata, a class descriptor and a method descriptor, look up

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -781,28 +781,28 @@ FUNCTION(RelocateClassMetadata,
          ATTRS(NoUnwind))
 
 // struct FieldInfo { size_t Size; size_t AlignMask; };
-// void swift_initClassMetadata(Metadata *self,
-//                              ClassLayoutFlags flags,
-//                              size_t numFields,
-//                              TypeLayout * const *fieldTypes,
-//                              size_t *fieldOffsets);
+// MetadataDependency swift_initClassMetadata(Metadata *self,
+//                                            ClassLayoutFlags flags,
+//                                            size_t numFields,
+//                                            TypeLayout * const *fieldTypes,
+//                                            size_t *fieldOffsets);
 FUNCTION(InitClassMetadata,
-         swift_initClassMetadata, C_CC,
-         RETURNS(VoidTy),
+         swift_initClassMetadata, SwiftCC,
+         RETURNS(TypeMetadataDependencyTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind))
 
 // struct FieldInfo { size_t Size; size_t AlignMask; };
-// void swift_updateClassMetadata(Metadata *self,
-//                                ClassLayoutFlags flags,
-//                                size_t numFields,
-//                                TypeLayout * const *fieldTypes,
-//                                size_t *fieldOffsets);
+// MetadataDependency swift_updateClassMetadata(Metadata *self,
+//                                              ClassLayoutFlags flags,
+//                                              size_t numFields,
+//                                              TypeLayout * const *fieldTypes,
+//                                              size_t *fieldOffsets);
 FUNCTION(UpdateClassMetadata,
-         swift_updateClassMetadata, C_CC,
-         RETURNS(VoidTy),
+         swift_updateClassMetadata, SwiftCC,
+         RETURNS(TypeMetadataDependencyTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1815,12 +1815,14 @@ static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
     if (!doesClassMetadataRequireRelocation(IGM, classDecl))
       flags |= ClassLayoutFlags::HasStaticVTable;
 
+    llvm::Value *dependency;
     if (doesClassMetadataRequireInitialization(IGM, classDecl)) {
       // Call swift_initClassMetadata().
-      IGF.Builder.CreateCall(IGM.getInitClassMetadataFn(),
-                             {metadata,
-                              IGM.getSize(Size(uintptr_t(flags))),
-                              numFields, fields.getAddress(), fieldVector});
+      dependency =
+        IGF.Builder.CreateCall(IGM.getInitClassMetadataFn(),
+                               {metadata,
+                                IGM.getSize(Size(uintptr_t(flags))),
+                                numFields, fields.getAddress(), fieldVector});
     } else {
       assert(doesClassMetadataRequireUpdate(IGM, classDecl));
       assert(IGM.Context.LangOpts.EnableObjCInterop);
@@ -1828,11 +1830,18 @@ static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
       // Call swift_updateClassMetadata(). Note that the static metadata
       // already references the superclass in this case, but we still want
       // to ensure the superclass metadata is initialized first.
-      IGF.Builder.CreateCall(IGM.getUpdateClassMetadataFn(),
-                             {metadata,
-                              IGM.getSize(Size(uintptr_t(flags))),
-                              numFields, fields.getAddress(), fieldVector});
+      dependency =
+        IGF.Builder.CreateCall(IGM.getUpdateClassMetadataFn(),
+                               {metadata,
+                                IGM.getSize(Size(uintptr_t(flags))),
+                                numFields, fields.getAddress(), fieldVector});
     }
+
+    // Collect any possible dependency from initializing the class; generally
+    // this involves the superclass.
+    assert(collector);
+    collector->collect(IGF, dependency);
+
   } else {
     assert(isa<StructDecl>(target));
 

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -430,14 +430,27 @@ public:
            "failed to finish MetadataDependencyCollector");
   }
 
-  /// Check the dependency.  This takes a metadata and state separately
-  /// instead of taking a MetadataResponse because it's quite important
-  /// that we not rely on anything from MetadataResponse that might assume
-  /// that we've already done dependency collection.
+  /// Given the result of fetching metadata, check whether it creates a
+  /// metadata dependency, and branch if so.
+  ///
+  /// This takes a metadata and state separately instead of taking a
+  /// MetadataResponse pair because it's quite important that we not rely on
+  /// anything from MetadataResponse that might assume that we've already
+  /// done dependency collection.
   void checkDependency(IRGenFunction &IGF, DynamicMetadataRequest request,
                        llvm::Value *metadata, llvm::Value *state);
 
+  /// Given an optional MetadataDependency value (e.g. the result of calling
+  /// a dependency-returning function, in which a dependency is signalled
+  /// by a non-null metadata value), check whether it indicates a dependency
+  /// and branch if so.
+  void collect(IRGenFunction &IGF, llvm::Value *dependencyPair);
+
   MetadataDependency finish(IRGenFunction &IGF);
+
+private:
+  void emitCheckBranch(IRGenFunction &IGF, llvm::Value *satisfied,
+                       llvm::Value *metadata, llvm::Value *requiredState);
 };
 
 enum class MetadataAccessStrategy {

--- a/stdlib/public/runtime/CompatibilityOverride.cpp
+++ b/stdlib/public/runtime/CompatibilityOverride.cpp
@@ -38,7 +38,7 @@ using namespace swift;
 struct OverrideSection {
   uintptr_t version;
   
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
 #include "CompatibilityOverride.def"
 };
@@ -61,7 +61,7 @@ static OverrideSection *getOverrideSectionPtr() {
   return OverrideSectionPtr;
 }
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name swift::getOverride_ ## name() {                 \
     auto *Section = getOverrideSectionPtr();                        \
     if (Section == nullptr)                                         \

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -69,7 +69,7 @@
 #  endif
 #endif
 
-OVERRIDE_CASTING(dynamicCast, bool, , swift::,
+OVERRIDE_CASTING(dynamicCast, bool, , , swift::,
                  (OpaqueValue *dest, OpaqueValue *src,
                   const Metadata *srcType,
                   const Metadata *targetType,
@@ -77,13 +77,13 @@ OVERRIDE_CASTING(dynamicCast, bool, , swift::,
                  (dest, src, srcType, targetType, flags))
 
 
-OVERRIDE_CASTING(dynamicCastClass, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastClass, const void *, , , swift::,
                  (const void *object,
                   const ClassMetadata *targetType),
                  (object, targetType))
 
 
-OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , , swift::,
                  (const void *object,
                   const ClassMetadata *targetType,
                   const char *file, unsigned line, unsigned column),
@@ -91,74 +91,76 @@ OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , swift::,
 
 
 
-OVERRIDE_CASTING(dynamicCastUnknownClass, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastUnknownClass, const void *, , , swift::,
                  (const void *object, const Metadata *targetType),
                  (object, targetType))
 
 
-OVERRIDE_CASTING(dynamicCastUnknownClassUnconditional, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastUnknownClassUnconditional, const void *, , , swift::,
                  (const void *object, const Metadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (object, targetType, file, line, column))
 
 
-OVERRIDE_CASTING(dynamicCastMetatype, const Metadata *, , swift::,
+OVERRIDE_CASTING(dynamicCastMetatype, const Metadata *, , , swift::,
                  (const Metadata *sourceType,
                   const Metadata *targetType),
                  (sourceType, targetType))
 
 
-OVERRIDE_CASTING(dynamicCastMetatypeUnconditional, const Metadata *, , swift::,
+OVERRIDE_CASTING(dynamicCastMetatypeUnconditional, const Metadata *, , , swift::,
                  (const Metadata *sourceType,
                   const Metadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (sourceType, targetType, file, line, column))
 
 
-OVERRIDE_FOREIGN(dynamicCastForeignClassMetatype, const ClassMetadata *, , swift::,
+OVERRIDE_FOREIGN(dynamicCastForeignClassMetatype, const ClassMetadata *, , , swift::,
                  (const ClassMetadata *sourceType,
                   const ClassMetadata *targetType),
                  (sourceType, targetType))
 
 
 OVERRIDE_FOREIGN(dynamicCastForeignClassMetatypeUnconditional,
-                 const ClassMetadata *, , swift::,
+                 const ClassMetadata *, , , swift::,
                  (const ClassMetadata *sourceType,
                   const ClassMetadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (sourceType, targetType, file, line, column))
 
 
-OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , swift::,
+OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , , swift::,
                              (const Metadata * const type,
                               const ProtocolDescriptor *protocol),
                              (type, protocol))
 
 OVERRIDE_PROTOCOLCONFORMANCE(conformsToSwiftProtocol,
-                             const ProtocolConformanceDescriptor *, , swift::,
+                             const ProtocolConformanceDescriptor *, , , swift::,
                              (const Metadata * const type,
                               const ProtocolDescriptor *protocol,
                               StringRef moduleName),
                              (type, protocol, moduleName))
 
-OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , swift::,
+OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))
 
-OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , swift::,
-                        (Demangler &demangler,
+OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , SWIFT_CC(swift), swift::,
+                        (MetadataRequest request,
+                         Demangler &demangler,
                          Demangle::NodePointer node,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
-                        (demangler, node, substGenericParam, substWitnessTable))
-OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , swift::,
-                        (StringRef typeName,
+                        (request, demangler, node, substGenericParam, substWitnessTable))
+OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , SWIFT_CC(swift), swift::,
+                        (MetadataRequest request,
+                         StringRef typeName,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
-                        (typeName, substGenericParam, substWitnessTable))
+                        (request, typeName, substGenericParam, substWitnessTable))
 
 OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
-                      SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
+                      SWIFT_RUNTIME_STDLIB_INTERNAL, SWIFT_CC(swift), swift::,
                       (MetadataRequest request, WitnessTable *wtable,
                        const Metadata *conformingType,
                        const ProtocolRequirement *reqBase,
@@ -166,7 +168,7 @@ OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
                       (request, wtable, conformingType, reqBase, assocType))
 
 OVERRIDE_WITNESSTABLE(getAssociatedConformanceWitnessSlow, const WitnessTable *,
-                      SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
+                      SWIFT_RUNTIME_STDLIB_INTERNAL, SWIFT_CC(swift), swift::,
                       (WitnessTable *wtable, const Metadata *conformingType,
                        const Metadata *assocType,
                        const ProtocolRequirement *reqBase,
@@ -175,37 +177,37 @@ OVERRIDE_WITNESSTABLE(getAssociatedConformanceWitnessSlow, const WitnessTable *,
                                assocConformance))
 #if SWIFT_OBJC_INTEROP
 
-OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , , swift::,
               (const void *object,
                const ClassMetadata *targetType),
               (object, targetType))
 
 
-OVERRIDE_OBJC(dynamicCastObjCClassUnconditional, const void *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClassUnconditional, const void *, , , swift::,
               (const void *object,
                const ClassMetadata *targetType,
                const char *file, unsigned line, unsigned column),
               (object, targetType, file, line, column))
 
-OVERRIDE_OBJC(dynamicCastObjCClassMetatype, const ClassMetadata *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClassMetatype, const ClassMetadata *, , , swift::,
               (const ClassMetadata *sourceType,
                const ClassMetadata *targetType),
               (sourceType, targetType))
 
 
-OVERRIDE_OBJC(dynamicCastObjCClassMetatypeUnconditional, const ClassMetadata *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClassMetatypeUnconditional, const ClassMetadata *, , , swift::,
               (const ClassMetadata *sourceType, const ClassMetadata *targetType,
                const char *file, unsigned line, unsigned column),
               (sourceType, targetType, file, line, column))
 
 
-OVERRIDE_FOREIGN(dynamicCastForeignClass, const void *, , swift::,
+OVERRIDE_FOREIGN(dynamicCastForeignClass, const void *, , , swift::,
                  (const void *object,
                   const ForeignClassMetadata *targetType),
                  (object, targetType))
 
 
-OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , swift::,
+OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , , swift::,
                  (const void *object, const ForeignClassMetadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (object, targetType, file, line, column))

--- a/stdlib/public/runtime/CompatibilityOverride.h
+++ b/stdlib/public/runtime/CompatibilityOverride.h
@@ -26,16 +26,16 @@ namespace swift {
 
 #define COMPATIBILITY_UNPAREN(...) __VA_ARGS__
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  typedef ret (*Original_ ## name) typedArgs;
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Original_ ## name) typedArgs;
 #include "CompatibilityOverride.def"
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  typedef ret (*Override_ ## name)(COMPATIBILITY_UNPAREN typedArgs, \
-                                   Original_ ## name originalImpl);
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Override_ ## name)(COMPATIBILITY_UNPAREN typedArgs, \
+                                           Original_ ## name originalImpl);
 #include "CompatibilityOverride.def"
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name getOverride_ ## name();
 #include "CompatibilityOverride.def"
 
@@ -44,8 +44,8 @@ namespace swift {
 /// OVERRIDE macro from CompatibilityOverride.def to this macro, then includes
 /// the file to generate the override points. The original implementation of the
 /// functionality must be available as swift_funcNameHereImpl.
-#define COMPATIBILITY_OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  attrs ret namespace swift_ ## name typedArgs {                                  \
+#define COMPATIBILITY_OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  attrs ccAttrs ret namespace swift_ ## name typedArgs {                          \
     static Override_ ## name Override;                                            \
     static swift_once_t Predicate;                                                \
     swift_once(&Predicate, [](void *) {                                           \

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -55,16 +55,22 @@ public:
 /// since we don't represent ownership attributes in the metadata
 /// itself related info has to be bundled with it.
 class TypeInfo {
-  const Metadata *Type;
+  MetadataResponse Response;
   TypeReferenceOwnership ReferenceOwnership;
 
 public:
-  TypeInfo() : Type(nullptr), ReferenceOwnership() {}
+  TypeInfo()
+    : Response{nullptr, MetadataState::Abstract}, ReferenceOwnership() {}
 
+  TypeInfo(MetadataResponse response, TypeReferenceOwnership ownership)
+    : Response(response), ReferenceOwnership() {}
+
+  // FIXME: remove this constructor and require a response in all cases.
   TypeInfo(const Metadata *type, TypeReferenceOwnership ownership)
-      : Type(type), ReferenceOwnership(ownership) {}
+    : Response{type, MetadataState::Abstract}, ReferenceOwnership(ownership) {}
 
-  operator const Metadata *() { return Type; }
+  const Metadata *getMetadata() const { return Response.Value; }
+  MetadataResponse getResponse() const { return Response; }
 
   bool isWeak() const { return ReferenceOwnership.isWeak(); }
   bool isUnowned() const { return ReferenceOwnership.isUnowned(); }
@@ -322,7 +328,9 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
+  SWIFT_CC(swift)
   TypeInfo swift_getTypeByMangledNode(
+                               MetadataRequest request,
                                Demangler &demangler,
                                Demangle::NodePointer node,
                                SubstGenericParameterFn substGenericParam,
@@ -334,7 +342,9 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
+  SWIFT_CC(swift)
   TypeInfo swift_getTypeByMangledName(
+                               MetadataRequest request,
                                StringRef typeName,
                                SubstGenericParameterFn substGenericParam,
                                SubstDependentWitnessTableFn substWitnessTable);

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -635,8 +635,9 @@ bool swift::_checkGenericRequirements(
 
     // Resolve the subject generic parameter.
     const Metadata *subjectType =
-      swift_getTypeByMangledName(req.getParam(), substGenericParam,
-                                 substWitnessTable);
+      swift_getTypeByMangledName(MetadataState::Abstract,
+                                 req.getParam(), substGenericParam,
+                                 substWitnessTable).getMetadata();
     if (!subjectType)
       return true;
 
@@ -660,8 +661,9 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::SameType: {
       // Demangle the second type under the given substitutions.
       auto otherType =
-        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
-                                   substWitnessTable);
+        swift_getTypeByMangledName(MetadataState::Abstract,
+                                   req.getMangledTypeName(), substGenericParam,
+                                   substWitnessTable).getMetadata();
       if (!otherType) return true;
 
       assert(!req.getFlags().hasExtraArgument());
@@ -687,8 +689,9 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::BaseClass: {
       // Demangle the base type under the given substitutions.
       auto baseType =
-        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
-                                   substWitnessTable);
+        swift_getTypeByMangledName(MetadataState::Complete,
+                                   req.getMangledTypeName(), substGenericParam,
+                                   substWitnessTable).getMetadata();
       if (!baseType) return true;
 
       // Check whether it's dynamically castable, which works as a superclass

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -400,7 +400,13 @@ extension ResilientGenericOutsideParent {
 // CHECK: dependency-satisfied:
 
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
-// CHECK:      void @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null
+// CHECK-NEXT: br i1 [[INITDEP_PRESENT]], label %dependency-satisfied1, label %metadata-dependencies.cont
+
+// CHECK: dependency-satisfied1:
 
 // CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
 // CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s16class_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd"
@@ -412,8 +418,8 @@ extension ResilientGenericOutsideParent {
 
 // CHECK: metadata-dependencies.cont:
 
-// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ null, %dependency-satisfied ]
-// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ 0, %dependency-satisfied ]
+// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ [[INITDEP_METADATA]], %dependency-satisfied ], [ null, %dependency-satisfied1 ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ [[INITDEP_STATUS]], %dependency-satisfied ], [ 0, %dependency-satisfied1 ]
 // CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
 // CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
 // CHECK-NEXT: ret %swift.metadata_response [[T1]]
@@ -448,7 +454,13 @@ extension ResilientGenericOutsideParent {
 // CHECK: dependency-satisfied:
 
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
-// CHECK:      call void @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null
+// CHECK-NEXT: br i1 [[INITDEP_PRESENT]], label %dependency-satisfied1, label %metadata-dependencies.cont
+
+// CHECK: dependency-satisfied1:
 
 // CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
 // CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s16class_resilience33ClassWithResilientlySizedPropertyC1r16resilient_struct9RectangleVvpWvd"
@@ -460,8 +472,8 @@ extension ResilientGenericOutsideParent {
 
 // CHECK: metadata-dependencies.cont:
 
-// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ null, %dependency-satisfied ]
-// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ 0, %dependency-satisfied ]
+// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ [[INITDEP_METADATA]], %dependency-satisfied ], [ null, %dependency-satisfied1 ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ [[INITDEP_STATUS]], %dependency-satisfied ], [ 0, %dependency-satisfied1 ]
 // CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
 // CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
 // CHECK-NEXT: ret %swift.metadata_response [[T1]]
@@ -481,7 +493,7 @@ extension ResilientGenericOutsideParent {
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s16class_resilience14ResilientChildCMr"(%swift.type*, i8*, i8**)
 
 // Initialize field offset vector...
-// CHECK:      call void @swift_initClassMetadata(%swift.type* %0, [[INT]] 0, [[INT]] 1, i8*** {{.*}}, [[INT]]* {{.*}})
+// CHECK:      call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* %0, [[INT]] 0, [[INT]] 1, i8*** {{.*}}, [[INT]]* {{.*}})
 
 // CHECK: ret %swift.metadata_response
 
@@ -519,7 +531,7 @@ extension ResilientGenericOutsideParent {
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s16class_resilience21ResilientGenericChildCMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**)
 
-// CHECK:              call void @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0,
+// CHECK:              call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0,
 // CHECK:              ret %swift.metadata_response
 
 

--- a/test/IRGen/completely_fragile_class_layout.sil
+++ b/test/IRGen/completely_fragile_class_layout.sil
@@ -230,7 +230,13 @@ bb0(%0 : $ClassWithResilientField):
 // CHECK: dependency-satisfied:
 
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
-// CHECK:      void @swift_updateClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_updateClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null
+// CHECK-NEXT: br i1 [[INITDEP_PRESENT]], label %dependency-satisfied1, label %metadata-dependencies.cont
+
+// CHECK: dependency-satisfied1:
 
 // CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
 // CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s31completely_fragile_class_layout23ClassWithResilientFieldC1s16resilient_struct4SizeVvpWvd"
@@ -242,8 +248,8 @@ bb0(%0 : $ClassWithResilientField):
 
 // CHECK: metadata-dependencies.cont:
 
-// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ null, %dependency-satisfied ]
-// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ 0, %dependency-satisfied ]
+// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ [[INITDEP_METADATA]], %dependency-satisfied ], [ null, %dependency-satisfied1 ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ [[INITDEP_STATUS]], %dependency-satisfied ], [ 0, %dependency-satisfied1 ]
 // CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
 // CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
 // CHECK-NEXT: ret %swift.metadata_response [[T1]]
@@ -262,9 +268,21 @@ bb0(%0 : $ClassWithResilientField):
 // CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [0 x i8**], [0 x i8**]* [[FIELDS]], i32 0, i32 0
 
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
-// CHECK:      void @swift_updateClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 0, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_updateClassMetadata(%swift.type* %0, [[INT]] 256, [[INT]] 0, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null
+// CHECK-NEXT: br i1 [[INITDEP_PRESENT]], label %dependency-satisfied, label %metadata-dependencies.cont
 
-// CHECK: ret %swift.metadata_response zeroinitializer
+// CHECK: dependency-satisfied:
+// CHECK:      br label %metadata-dependencies.cont
+
+// CHECK: metadata-dependencies.cont:
+// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[INITDEP_METADATA]], %entry ], [ null, %dependency-satisfied ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ [[INITDEP_STATUS]], %entry ], [ 0, %dependency-satisfied ]
+// CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
+// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
+// CHECK-NEXT: ret %swift.metadata_response [[T1]]
 
 // Metadata accessor for ClassWithResilientEnum looks like singleton initialization:
 

--- a/test/IRGen/concrete_inherits_generic_base.swift
+++ b/test/IRGen/concrete_inherits_generic_base.swift
@@ -83,4 +83,4 @@ presentBase(Base(x: 2))
 
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s3foo12SuperDerivedCMr"(%swift.type*, i8*, i8**)
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
-// CHECK:         call void @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, {{.*}})
+// CHECK:         call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, {{.*}})

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -345,7 +345,7 @@ entry(%c : $RootGeneric<Int32>):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$s15generic_classes11RootGenericCMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
 // -- initialize the dependent field offsets
-// CHECK:   call void @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 3, i8*** {{%.*}}, i64* {{%.*}})
+// CHECK:   call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s15generic_classes22RootGenericFixedLayoutCMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {
@@ -353,7 +353,7 @@ entry(%c : $RootGeneric<Int32>):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$s15generic_classes22RootGenericFixedLayoutCMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
-// CHECK:   call void @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 3, i8*** {{%.*}}, i64* {{%.*}})
+// CHECK:   call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s15generic_classes015GenericInheritsC0CMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {
@@ -385,9 +385,14 @@ entry(%c : $RootGeneric<Int32>):
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[FIELDS_ADDR]], i32 0
 // CHECK:   store i8** [[T0]], i8*** [[T1]], align 8
 
-// CHECK:   call void @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[FIELDS_ADDR]], i64* [[OFFSETS]])
-// CHECK:   [[DEP:%.*]] = phi %swift.type* [ [[B_CHECKED]], {{.*}} ], [ null, {{.*}} ]
-// CHECK:   [[DEP_REQ:%.*]] = phi i64 [ 63, {{.*}} ], [ 0, {{.*}} ]
+// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[FIELDS_ADDR]], i64* [[OFFSETS]])
+// CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null
+// CHECK-NEXT: br i1 [[INITDEP_PRESENT]],
+
+// CHECK:   [[DEP:%.*]] = phi %swift.type* [ [[B_CHECKED]], {{.*}} ], [ [[INITDEP_METADATA]], {{.*}} ], [ null, {{.*}} ]
+// CHECK:   [[DEP_REQ:%.*]] = phi i64 [ 63, {{.*}} ], [ [[INITDEP_STATUS]], {{.*}} ], [ 0, {{.*}} ]
 // CHECK:   [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[DEP]], 0
 // CHECK:   [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], i64 [[DEP_REQ]], 1
 // CHECK:   ret %swift.metadata_response [[T1]]

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -158,7 +158,7 @@ public class Concrete : Derived<Int> {
 
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s14generic_vtable7DerivedCMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
-// CHECK: call void @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0, {{.*}})
+// CHECK: call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0, {{.*}})
 
 // CHECK: ret %swift.metadata_response
 
@@ -171,5 +171,5 @@ public class Concrete : Derived<Int> {
 
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s14generic_vtable8ConcreteCMr"(%swift.type*, i8*, i8**)
 // -- ClassLayoutFlags is 256 / 0x100, HasStaticVTable
-// CHECK: call void @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, {{.*}})
+// CHECK: call swiftcc %swift.metadata_response @swift_initClassMetadata(%swift.type* %0, [[INT]] 256, {{.*}})
 // CHECK: ret %swift.metadata_response

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
@@ -92,8 +92,8 @@ public func invokeMethod(on holder: SubButtHolder) {
 }
 
 // CHECK-V4-LABEL: define internal swiftcc %swift.metadata_response @"$s4main13SubButtHolderCMr"(%swift.type*, i8*, i8**)
-// CHECK-V4:   call void @swift_initClassMetadata(
+// CHECK-V4:   call swiftcc %swift.metadata_response @swift_initClassMetadata(
 
 // CHECK-V4-LABEL: define internal swiftcc %swift.metadata_response @"$s4main03SubB10ButtHolderCMr"(%swift.type*, i8*, i8**)
-// CHECK-V4:   call void @swift_initClassMetadata(
+// CHECK-V4:   call swiftcc %swift.metadata_response @swift_initClassMetadata(
 

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -130,7 +130,7 @@ public class Base {
    var a: UInt32 = 0
 }
 // CHECK-LABEL: %swift.metadata_response @{{.*}}7DerivedCMr"(
-// CHECK: call void @swift_initClassMetadata
+// CHECK: call swiftcc %swift.metadata_response @swift_initClassMetadata
 // CHECK: ret
 public class Derived<T> : Base {
   var type : P.Type

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -41,13 +41,13 @@ namespace  {
   }
 }
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  static ret name ## Override(COMPATIBILITY_UNPAREN typedArgs,      \
-                          Original_ ## name originalImpl) {         \
-    if (!EnableOverride)                                            \
-      return originalImpl namedArgs;                                \
-    Ran = true;                                                     \
-    return getEmptyValue<ret>();                                    \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  static ccAttrs ret name ## Override(COMPATIBILITY_UNPAREN typedArgs,       \
+                                       Original_ ## name originalImpl) {     \
+    if (!EnableOverride)                                                     \
+      return originalImpl namedArgs;                                         \
+    Ran = true;                                                              \
+    return getEmptyValue<ret>();                                             \
   }
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 
@@ -55,14 +55,14 @@ namespace  {
 struct OverrideSection {
   uintptr_t version;
   
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 };
 
 OverrideSection Overrides __attribute__((section("__DATA,__swift_hooks"))) = {
   0,
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   name ## Override,
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 };
@@ -175,14 +175,15 @@ TEST_F(CompatibilityOverrideTest, test_swift_conformsToSwiftProtocol) {
 
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledNode) {
   Demangler demangler;
-  auto Result = swift_getTypeByMangledNode(demangler, nullptr, nullptr,
-                                           nullptr);
-  ASSERT_EQ((const Metadata *)Result, nullptr);
+  auto Result = swift_getTypeByMangledNode(MetadataState::Abstract,
+                                           demangler, nullptr, nullptr,nullptr);
+  ASSERT_EQ(Result.getMetadata(), nullptr);
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledName) {
-  auto Result = swift_getTypeByMangledName("", nullptr, nullptr);
-  ASSERT_EQ((const Metadata *)Result, nullptr);
+  auto Result = swift_getTypeByMangledName(MetadataState::Abstract,
+                                           "", nullptr, nullptr);
+  ASSERT_EQ(Result.getMetadata(), nullptr);
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_getAssociatedTypeWitnessSlow) {


### PR DESCRIPTION
In the initial approach for resolving metadata dependency cycles, superclass metadata was fetched (as non-transitively complete) by the initialization function and passed to `swift_initClassMetadata`.  That was changed so that `swift_initClassMetadata` instead fetched the superclass metadata via a demangling.  Unfortunately, it only fetched *abstract* metadata, which is not actually safe to pass to the ObjC runtime, which can manifest as a crash in either the runtime or (potentially) downstream of it.  Worse, `swift_initClassMetadata` has no way of reporting failure to its caller, and so we cannot fix this problem without using a blocking fetch and subverting the cyclic-metadata infrastructure.

The only way to solve this in the long term is to allow the runtime to report failure via a metadata dependency from `swift_initClassMetadata` (and `swift_updateClassMetadata`, which has an analogous issue).  This patch is a naive version of that fix which changes the ABI of the existing entrypoints to the ABI we need.  Because this is such a late-breaking fix, this may no longer be possible, and we may need to introduce new entrypoints with the right semantics.  If that is necessary, I will restructure this patch.

Fixed rdar://47549859.