### PR TITLE
[cmake] Rather than using CMAKE_{C,CXX}_COMPILER and CMAKE_{C,CXX}_CO…

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -30,8 +30,8 @@ else()
     set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
   endif()
 
-  set(CMAKE_CXX_COMPILER_ARG1 "")
-  set(CMAKE_C_COMPILER_ARG1 "")
+  set(CMAKE_C_COMPILER_LAUNCHER "")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "")
   # The sanitizers require using the same version of the compiler for
   # everything and there are various places where we link runtime code with
   # code built by the host compiler. Disable sanitizers for the runtime for

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1551,21 +1551,6 @@ eval COMMON_CMAKE_OPTIONS=(${COMMON_CMAKE_OPTIONS})
 eval EXTRA_CMAKE_OPTIONS=(${EXTRA_CMAKE_OPTIONS})
 eval BUILD_ARGS=(${BUILD_ARGS})
 
-if [[ -n "${DISTCC}" ]]; then
-    if [[ "$(uname -s)" == "Darwin" ]] ; then
-        # These are normally deduced by CMake, but when the compiler is set to
-        # distcc which is installed elsewhere, we need to set them explicitly.
-        COMMON_CMAKE_OPTIONS=(
-            "${COMMON_CMAKE_OPTIONS[@]}" "-DCMAKE_AR=$(xcrun_find_tool ar)"
-            "-DCMAKE_LINKER=$(xcrun_find_tool ld)"
-            "-DCMAKE_NM=$(xcrun_find_tool nm)"
-            "-DCMAKE_OBJDUMP=$(xcrun_find_tool objdump)"
-            "-DCMAKE_RANLIB=$(xcrun_find_tool ranlib)"
-            "-DCMAKE_STRIP=$(xcrun_find_tool strip)"
-        )
-    fi
-fi
-
 eval CMAKE_BUILD=("${DISTCC_PUMP}" "${CMAKE}" "--build")
 
 

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -104,14 +104,12 @@ class CMake(object):
             define("CMAKE_EXPORT_COMPILE_COMMANDS", "ON")
 
         if args.distcc:
-            define("CMAKE_C_COMPILER:PATH", toolchain.distcc)
-            define("CMAKE_C_COMPILER_ARG1", toolchain.cc)
-            define("CMAKE_CXX_COMPILER:PATH", toolchain.distcc)
-            define("CMAKE_CXX_COMPILER_ARG1", toolchain.cxx)
-        else:
-            define("CMAKE_C_COMPILER:PATH", toolchain.cc)
-            define("CMAKE_CXX_COMPILER:PATH", toolchain.cxx)
-            define("CMAKE_LIBTOOL:PATH", toolchain.libtool)
+            define("CMAKE_C_COMPILER_LAUNCHER:PATH", toolchain.distcc)
+            define("CMAKE_CXX_COMPILER_LAUNCHER:PATH", toolchain.distcc)
+
+        define("CMAKE_C_COMPILER:PATH", toolchain.cc)
+        define("CMAKE_CXX_COMPILER:PATH", toolchain.cxx)
+        define("CMAKE_LIBTOOL:PATH", toolchain.libtool)
 
         if args.cmake_generator == 'Xcode':
             define("CMAKE_CONFIGURATION_TYPES",

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -205,10 +205,11 @@ class CMakeTestCase(unittest.TestCase):
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Ninja",
-             "-DCMAKE_C_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_C_COMPILER_ARG1=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++",
+             "-DCMAKE_C_COMPILER_LAUNCHER:PATH=" + self.mock_distcc_path(),
+             "-DCMAKE_CXX_COMPILER_LAUNCHER:PATH=" + self.mock_distcc_path(),
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_xcode(self):
@@ -290,10 +291,11 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Xcode",
              "-DLLVM_USE_SANITIZER=Address;Undefined",
              "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-             "-DCMAKE_C_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_C_COMPILER_ARG1=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++",
+             "-DCMAKE_C_COMPILER_LAUNCHER:PATH=" + self.mock_distcc_path(),
+             "-DCMAKE_CXX_COMPILER_LAUNCHER:PATH=" + self.mock_distcc_path(),
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo",
              "-DLLVM_VERSION_MAJOR:STRING=9",


### PR DESCRIPTION
…MPILER_ARG1 for distcc, use CMAKE_{C,CXX}_COMPILER_LAUNCHER.

This is a cleaner, more principled way of adding "compiler launcher" support and
ensures that cmake understands that distcc is not the "actual" compiler.

This ensures that when we compile SwiftRemoteMirrors for the host, we do not try
to compile using distcc without needing to reset CMAKE_{C,CXX}_COMPILER_ARG1
(which is unset when compiling things in the stdlib).
