### PR TITLE
[DebugInfo] Make modulecache test windows-compatible

### DIFF
--- a/test/DebugInfo/modulecache.swift
+++ b/test/DebugInfo/modulecache.swift
@@ -15,7 +15,8 @@ import ClangModule
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -c -g -o %t.o -module-cache-path %t -I %S/Inputs
-// RUN: file %t/*/ClangModule-*.pcm | egrep -q '(Mach-O|ELF)'
+// RUN: llvm-readobj -h %t/*/ClangModule-*.pcm | %FileCheck %s
+// CHECK: Format: {{(Mach-O|ELF|COFF)}}
 
 // 3. Test that swift-ide-check will not share swiftc's module cache.
 


### PR DESCRIPTION
`file` is not available on windows except through GnuWin32, and that
`file` was identifying the ClangModule as an ACB Archive file instead of
a COFF file.

Instead of using `file`, it is easier and more portable to use
llvm-readobj. I also converted the egrep usage into FileCheck while
adding COFF support.

cc @adrian-prantl @compnerd 
