### PR TITLE
[test] verify_all_overlays doesn't actually fail on watchOS

### DIFF
--- a/validation-test/SIL/verify_all_overlays.sil
+++ b/validation-test/SIL/verify_all_overlays.sil
@@ -7,5 +7,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// XFAIL: OS=macosx || OS=ios || OS=tvos || OS=watchos
+// XFAIL: OS=macosx || OS=ios || OS=tvos
 // https://bugs.swift.org/browse/SR-9847


### PR DESCRIPTION
Further fix-up for #22325.

rdar://problem/47824324