### PR TITLE
[test] Add s390x support for two IRGen tests

### DIFF
--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -60,3 +60,6 @@ public func use_global() -> Int {
 // aarch64:        str [[REG2]], [sp]
 // aarch64:        bl swift_endAccess
 // aarch64:        ldr x0, [sp]
+
+// s390x-LABEL: $s4main10use_globalSiyF:
+// s390x:        lgrl    %[[REG1:r[0-9]+]], ($s4main6globalSivp)

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
@@ -8,7 +8,7 @@ public func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
 public struct CGFloat {
 #if arch(i386) || arch(arm)
   public typealias UnderlyingType = Float
-#elseif arch(x86_64) || arch(arm64)
+#elseif arch(x86_64) || arch(arm64) || arch(s390x)
   public typealias UnderlyingType = Double
 #endif
 


### PR DESCRIPTION
This commit adds s390x support for two IRGen tests to swift-5.0-branch. Each individual fix is already approved and merged in master branch. 
 https://github.com/apple/swift/pull/22130
 https://github.com/apple/swift/pull/22068