### PR TITLE
Bring the Swift frontend's handling of DIFiles in synch with CFE.

### DIFF
--- a/test/DebugInfo/ClangPathDots.swift
+++ b/test/DebugInfo/ClangPathDots.swift
@@ -5,8 +5,10 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs -o - \
 // RUN:   -module-cache-path %t.cache | %FileCheck %s --check-prefix=CACHED
 
-// FIRST: !DIFile(filename: "NSObject.h", directory: {{.*}}/include/objc")
-// CACHED: !DIFile(filename: "NSObject.h", directory: {{.*}}/include/objc")
+// Test that the paths have no extra "./" components on rebuild.
+
+// FIRST: !DIFile(filename: "{{.*}}/include/objc/NSObject.h",
+// CACHED: !DIFile(filename: "{{.*}}/include/objc/NSObject.h",
 
 import ObjectiveC
 

--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -7,8 +7,8 @@
 
 // CHECK-DAG: ![[FOOMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Foo", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[FOOMODULE]]
-// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "Imports.swift", directory: "{{.*}}test{{/|\\5C}}DebugInfo")
-// CHECK-DAG: ![[SWIFTFILE:[0-9]+]] = !DIFile(filename: "Swift.swiftmodule"
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\5C}}DebugInfo{{/|\\5C}}Imports.swift",
+// CHECK-DAG: ![[SWIFTFILE:[0-9]+]] = !DIFile(filename: "{{.*}}Swift.swiftmodule"
 // CHECK-DAG: ![[SWIFTMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Swift"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[SWIFTMODULE]]
 // CHECK-DAG: ![[BASICMODULE:[0-9]+]] = !DIModule({{.*}}, name: "basic"

--- a/test/DebugInfo/ImportsStdlib.swift
+++ b/test/DebugInfo/ImportsStdlib.swift
@@ -11,9 +11,9 @@
 
 // CHECK-DAG: ![[MODULE:[0-9]+]] = !DIModule({{.*}}, name: "NotTheStdlib", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[MODULE]]
-// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "ImportsStdlib.swift", directory: "{{.*}}test{{/|\\5C}}DebugInfo")
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\5C}}DebugInfo{{/|\\5C}}ImportsStdlib.swift"
 
-// NEGATIVE-NOT: !DIFile(filename: "Swift.swiftmodule"
+// NEGATIVE-NOT: !DIFile(filename: "{{.*}}Swift.swiftmodule"
 // NEGATIVE-NOT: !DIModule({{.*}}, name: "Swift"
 
 // DWARF: .debug_info

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -3,8 +3,9 @@
 // Verify that we don't emit any debug info by default.
 // RUN: %target-swift-frontend %s -emit-ir -o - \
 // RUN:   | %FileCheck %s --check-prefix NDEBUG
+// NDEBUG: source_filename
 // NDEBUG-NOT: !dbg
-// NDEBUG-NOT: DW_TAG
+// NDEBUG-NOT: DICompileUnit
 // --------------------------------------------------------------------
 // Verify that we don't emit any debug info with -gnone.
 // RUN: %target-swift-frontend %s -emit-ir -gnone -o - \
@@ -14,9 +15,9 @@
 // RUN: %target-swift-frontend %s -emit-ir -gline-tables-only -o - \
 // RUN:   | %FileCheck %s --check-prefix CHECK-LINETABLES
 // CHECK: !dbg
-// CHECK-LINETABLES-NOT: DW_TAG_{{.*}}variable
+// CHECK-LINETABLES-NOT: DI{{.*}}Variable
 // CHECK-LINETABLES-NOT: DW_TAG_structure_type
-// CHECK-LINETABLES-NOT: DW_TAG_basic_type
+// CHECK-LINETABLES-NOT: DIBasicType
 // --------------------------------------------------------------------
 // Now check that we do generate line+scope info with -g.
 // RUN: %target-swift-frontend %/s -emit-ir -g -o - \
@@ -71,9 +72,8 @@ func foo(_ a: Int64, _ b: Int64) -> Int64 {
      }
 }
 
-// CHECK-DAG: ![[FILE_CWD:[0-9]+]] = !DIFile(filename: "{{.*}}DebugInfo/basic.swift", directory: "{{.*}}")
-// CHECK-DAG: ![[MAINFILE:[0-9]+]] = !DIFile(filename: "basic.swift", directory: "{{.*}}DebugInfo")
-// CHECK-DAG: !DICompileUnit(language: DW_LANG_Swift, file: ![[FILE_CWD]],{{.*}} producer: "{{.*}}Swift version{{.*}},{{.*}}
+// CHECK-DAG: ![[MAINFILE:[0-9]+]] = !DIFile(filename: "{{.*}}DebugInfo/basic.swift", directory: "{{.*}}")
+// CHECK-DAG: !DICompileUnit(language: DW_LANG_Swift, file: ![[MAINFILE]],{{.*}} producer: "{{.*}}Swift version{{.*}},{{.*}}
 // CHECK-DAG: !DISubprogram(name: "main", {{.*}}file: ![[MAINFILE]],
 
 // Function type for foo.

--- a/test/DebugInfo/gsil.swift
+++ b/test/DebugInfo/gsil.swift
@@ -3,7 +3,7 @@
 // RUN: %FileCheck %s < %t/out.ir
 // RUN: %FileCheck %s --check-prefix=CHECK_OUT_SIL < %t/out.ir.gsil_0.sil
 
-// CHECK: [[F:![0-9]+]] = !DIFile(filename: "out.ir.gsil_0.sil", directory: "{{.+}}")
+// CHECK: [[F:![0-9]+]] = !DIFile(filename: "{{.+}}out.ir.gsil_0.sil",
 // CHECK: !DISubprogram(linkageName: "$s3out6testityyF", scope: !{{[0-9]+}}, file: [[F]], line: {{[1-9][0-9]+}},
 
 // CHECK_OUT_SIL: sil @$s3out6testityyF : $@convention(thin) () -> () {

--- a/test/DebugInfo/inlinescopes.swift
+++ b/test/DebugInfo/inlinescopes.swift
@@ -7,7 +7,7 @@
 
 // CHECK: define{{( dllexport)?}}{{( protected)?( signext)?}} i32 @main
 // CHECK: call {{.*}}noinline{{.*}}, !dbg ![[CALL:.*]]
-// CHECK-DAG: ![[TOPLEVEL:.*]] = !DIFile(filename: "inlinescopes.swift"
+// CHECK-DAG: ![[TOPLEVEL:.*]] = !DIFile(filename: "{{.*}}inlinescopes.swift"
 
 import FooBar
 

--- a/test/DebugInfo/line-directive.swift
+++ b/test/DebugInfo/line-directive.swift
@@ -8,18 +8,18 @@ func f() {
   markUsed("Test")
 #sourceLocation(file: "abc.swift", line: 142)
   markUsed("abc again")
-#sourceLocation(file: "def.swift", line:  142)
+#sourceLocation(file: "/absolute/path/def.swift", line:  142)
   markUsed("jump directly to def")
 }
 
 // RUN: %target-swift-frontend -primary-file %s -S -g -o - | %FileCheck %s
 // CHECK: .file	[[MAIN:.*]] "{{.*}}line-directive.swift"
 // CHECK: .loc	[[MAIN]] 1
-// CHECK: .file	[[ABC:.*]] "abc.swift"
+// CHECK: .file	[[ABC:.*]] "{{.*}}abc.swift"
 // CHECK: .loc	[[ABC]] 42
 // CHECK: .loc	[[MAIN]] 8
 // CHECK: .loc	[[ABC]] 142
-// CHECK: .file	[[DEF:.*]] "def.swift"
+// CHECK: .file	[[DEF:.*]] "/absolute/path/def.swift"
 // CHECK: .loc	[[DEF]] 142
 // CHECK: .asciz "{{.*}}test/DebugInfo"
 
@@ -28,10 +28,10 @@ func f() {
 // RUN: %target-swift-frontend -vfsoverlay %t/overlay.yaml -primary-file %S/vfs-relocated-line-directive.swift -S -g -o - | %FileCheck -check-prefix=VFS %s
 // VFS: .file  [[MAIN:.*]] "{{.*}}vfs-relocated-line-directive.swift"
 // VFS: .loc  [[MAIN]] 1
-// VFS: .file  [[ABC:.*]] "abc.swift"
+// VFS: .file  [[ABC:.*]] "{{.*}}abc.swift"
 // VFS: .loc  [[ABC]] 42
 // VFS: .loc  [[MAIN]] 8
 // VFS: .loc  [[ABC]] 142
-// VFS: .file  [[DEF:.*]] "def.swift"
+// VFS: .file  [[DEF:.*]] "/absolute/path/def.swift"
 // VFS: .loc  [[DEF]] 142
 // VFS: .asciz "{{.*}}test/DebugInfo"

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -17,7 +17,7 @@ class MyObject : NSObject {
   // LOC-CHECK: ret {{.*}}, !dbg ![[DBG:.*]]
   // LOC-CHECK: ret
   @objc var MyArr = NSArray()
-  // IMPORT-CHECK: filename: "test-foundation.swift"
+  // IMPORT-CHECK: filename: "{{.*}}test-foundation.swift"
   // IMPORT-CHECK-DAG: [[FOUNDATION:[0-9]+]] = !DIModule({{.*}} name: "Foundation",{{.*}} includePath: {{.*}}Foundation.framework
   // IMPORT-CHECK-DAG: [[OVERLAY:[0-9]+]] = !DIModule({{.*}} name: "Foundation",{{.*}} includePath: {{.*}}Foundation.swiftmodule
   // IMPORT-CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "NSArray", scope: ![[NSARRAY:[0-9]+]]

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -41,7 +41,7 @@ print(", \(glob_b)", terminator: "")
 print(", \(glob_s)", terminator: "")
 var unused: Int32 = -1
 
-// CHECK-DAG: ![[RT:[0-9]+]] ={{.*}}"Swift.swiftmodule"
+// CHECK-DAG: ![[RT:[0-9]+]] ={{.*}}"{{.*}}Swift.swiftmodule"
 
 
 // Stack variables.
@@ -114,4 +114,4 @@ func myprint(_ value: TriValue) {
 }
 myprint(unknown)
 
-// CHECK-DAG: !DIFile(filename: "variables.swift"
+// CHECK-DAG: !DIFile(filename: "{{.*}}variables.swift"

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -62,8 +62,8 @@ func callproto(_ p: MyProto) {
 
 // Check if the DI filename is correct and not "<unknown>".
 
-// CHECK-MAINLL: DICompileUnit(language: DW_LANG_Swift, file: [[F:![0-9]+]]
-// CHECK-MAINLL: [[F]] = !DIFile(filename: "{{.*}}IRGen/Inputs/multithread_module/main.swift", directory: "{{.*}}")
+// CHECK-MAINLL: [[F:![0-9]+]] = !DIFile(filename: "{{.*}}IRGen/Inputs/multithread_module/main.swift", directory: "{{.*}}")
+// CHECK-MAINLL: DICompileUnit(language: DW_LANG_Swift, file: [[F]],
 
-// CHECK-MODULELL: DICompileUnit(language: DW_LANG_Swift, file: [[F:![0-9]+]]
-// CHECK-MODULELL: [[F]] = !DIFile(filename: "{{.*}}IRGen/multithread_module.swift", directory: "{{.*}}")
+// CHECK-MODULELL: [[F:![0-9]]] = !DIFile(filename: "{{.*}}IRGen/multithread_module.swift", directory: "{{.*}}")
+// CHECK-MODULELL: DICompileUnit(language: DW_LANG_Swift, file: [[F]],


### PR DESCRIPTION
This applies the same changes from Clang CFE r349065 to the Swift
frontend to unify how filenames, cmpilation directories and absolute
paths in filenames and path remappings are handled.
