### PR TITLE
Add vjps for exp, log, tan, sin, cos in the standard library.

### DIFF
--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -91,6 +91,42 @@ public func ldexp(_ x: ${T}, _ n : Int) -> ${T} {
 
 %end
 
+// SWIFT_ENABLE_TENSORFLOW
+%for T in ['Float', 'Double', 'Float80']:
+%   if T == 'Float80':
+#if (arch(i386) || arch(x86_64)) && !os(Windows)
+%   end
+@usableFromInline
+func _vjpExp(_ x: ${T}) -> (${T}, (${T}) -> ${T}) {
+  let value = exp(x)
+  return (value, { v in value * v })
+}
+
+@usableFromInline
+func _vjpLog(_ x: ${T}) -> (${T}, (${T}) -> ${T}) {
+  return (log(x), { v in v / x })
+}
+
+@usableFromInline
+func _vjpSin(_ x: ${T}) -> (${T}, (${T}) -> ${T}) {
+  return (sin(x), { v in v * cos(x) })
+}
+
+@usableFromInline
+func _vjpCos(_ x: ${T}) -> (${T}, (${T}) -> ${T}) {
+  return (cos(x), { v in -v * sin(x) })
+}
+
+@usableFromInline
+func _vjpTan(_ x: ${T}) -> (${T}, (${T}) -> ${T}) {
+  let value = tan(x)
+  return (value, { v in v * (1 + value * value) })
+}
+%   if T == 'Float80':
+#endif
+%   end
+%end
+
 //  Floating-point properties that are exposed as functions in the C math
 //  library. Mark those function names unavailable and direct users to the
 //  properties instead.
@@ -180,8 +216,11 @@ OtherFunctions = [
     'scalbn', 'lgamma', 'remquo', 'nan', 'jn', 'yn'
 ]
 
+# SWIFT_ENABLE_TENSORFLOW
 # These functions are imported correctly as-is.
 OkayFunctions = ['j0', 'j1', 'y0', 'y1']
+
+HasVJP = ["exp", "log", "tan", "cos", "sin"]
 
 # These functions are not supported for various reasons.
 UnhandledFunctions = [
@@ -225,6 +264,10 @@ def TypedBinaryFunctions():
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
 %  end
 @_transparent
+// SWIFT_ENABLE_TENSORFLOW
+%   if ufunc in HasVJP:
+@differentiable(vjp: _vjp${ufunc.capitalize()}(_:))
+%   end
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return ${T}(${ufunc}${f}(${CT}(x)))
 }
@@ -242,6 +285,10 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
 %  end
 @_transparent
+// SWIFT_ENABLE_TENSORFLOW
+%   if ufunc in HasVJP:
+@differentiable(vjp: _vjp${ufunc.capitalize()}(_:))
+%   end
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return _${ufunc}(x)
 }
@@ -261,6 +308,10 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
 %   end
 @_transparent
+// SWIFT_ENABLE_TENSORFLOW
+%   if ufunc in HasVJP:
+@differentiable(vjp: _vjp${ufunc.capitalize()}(_:))
+%   end
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return ${T}(${ufunc}${f}(${CT}(x)))
 }

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -366,7 +366,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 func _vjpLog<T : Differentiable & FloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-  return (x, { v in v / x })
+  return (log(x), { v in v / x })
 }
 
 @inlinable
@@ -440,7 +440,7 @@ func _vjpSqrt<T : Differentiable & FloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = sqrt(x)
-  return (sqrt(x), { v in v / (2 * value) })
+  return (value, { v in v / (2 * value) })
 }
 
 @inlinable

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -206,4 +206,15 @@ MathTests.test("${T}") {
 % end
 %end
 
+// SWIFT_ENABLE_TENSORFLOW
+% for T in ['Float', 'Float80']:
+MathTests.test("gradient_${T}") {
+  expectEqualWithTolerance(7.3890560989306502274, gradient(at: 2.0 as ${T}, in: exp), ulps:16)
+  expectEqualWithTolerance(0.5, gradient(at: 2.0 as ${T}, in: log), ulps:16)
+  expectEqualWithTolerance(5.774399204041917612, gradient(at: 2.0 as ${T}, in: tan), ulps:16)
+  expectEqualWithTolerance(-0.416146836547142387, gradient(at: 2.0 as ${T}, in: sin), ulps:16)
+  expectEqualWithTolerance(-0.9092974268256816954, gradient(at: 2.0 as ${T}, in: cos), ulps:16)
+}
+%end
+
 runAllTests()


### PR DESCRIPTION
This is just a stopgap until we get retroactive differentiation.

Note: "Double" versions of these functions re-export the builtin definitions and thus cannot have derivatives defined. There is a comment about Foundation preventing these from being "overlays" as well.

Made some improvements to: stdlib/public/TensorFlow/Gradients.swift