### PR TITLE
test: correct paths in DebugInfo/line-directive (NFC)

### DIFF
--- a/test/DebugInfo/line-directive.swift
+++ b/test/DebugInfo/line-directive.swift
@@ -12,7 +12,7 @@ func f() {
   markUsed("jump directly to def")
 }
 
-// RUN: %target-swift-frontend -primary-file %s -S -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %/s -S -g -o - | %FileCheck %s
 // CHECK: .file	[[MAIN:.*]] "{{.*}}line-directive.swift"
 // CHECK: .loc	[[MAIN]] 1
 // CHECK: .file	[[ABC:.*]] "abc.swift"
@@ -24,8 +24,8 @@ func f() {
 // CHECK: .asciz "{{.*}}test/DebugInfo"
 
 // RUN: %empty-directory(%t)
-// RUN: sed -e "s:LINE_DIRECTIVE_DIR:%S:g" %S/Inputs/vfsoverlay.yaml > %t/overlay.yaml
-// RUN: %target-swift-frontend -vfsoverlay %t/overlay.yaml -primary-file %S/vfs-relocated-line-directive.swift -S -g -o - | %FileCheck -check-prefix=VFS %s
+// RUN: sed -e "s|LINE_DIRECTIVE_DIR|%/S|g" %S/Inputs/vfsoverlay.yaml > %t/overlay.yaml
+// RUN: %target-swift-frontend -vfsoverlay %t/overlay.yaml -primary-file %/S/vfs-relocated-line-directive.swift -S -g -o - | %FileCheck -check-prefix=VFS %s
 // VFS: .file  [[MAIN:.*]] "{{.*}}vfs-relocated-line-directive.swift"
 // VFS: .loc  [[MAIN]] 1
 // VFS: .file  [[ABC:.*]] "abc.swift"


### PR DESCRIPTION
Adjust the test for Windows path separator.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
