### PR TITLE
[5.0] Address a nullability bug in CKQuerySubscription.recordType

### DIFF
--- a/stdlib/public/SDK/CloudKit/TypealiasStrings.swift
+++ b/stdlib/public/SDK/CloudKit/TypealiasStrings.swift
@@ -111,6 +111,15 @@ extension CKDatabase {
 @available(macOS 10.10, iOS 8.0, *) @available(watchOS, unavailable)
 extension CKSubscription {
     @available(swift 4.2)
+    @available(macOS, deprecated: 10.12, message: "Use CKQuerySubscription instead")
+    @available(iOS, deprecated: 10.0, message: "Use CKQuerySubscription instead")
+    @available(tvOS, deprecated: 10.0, message: "Use CKQuerySubscription instead")
+    @available(watchOS, unavailable)
+    public var compatibilityRecordType: CKRecord.RecordType? {
+        get { return self.__recordType }
+    }
+
+    @available(swift 4.2)
     public var subscriptionID: CKSubscription.ID {
         get { return self.__subscriptionID }
     }
@@ -121,7 +130,7 @@ extension CKSubscription {
 extension CKQuerySubscription {
     /// The record type that this subscription watches
     @available(swift 4.2)
-    public var recordType: CKRecord.RecordType? {
+    public var recordType: CKRecord.RecordType {
         get { return self.__recordType }
     }
 }


### PR DESCRIPTION
* Explanation: This change fixes an unfortunate nullability but in the
overlay.
* Risk: The change is source-breaking, but makes the API what it should
have been all along.
* Reviewed By: CloudKit team
* Testing: Automatesd test suite
* Directions for QA: N/A
* Radar: <rdar://problem/47683705>