### PR TITLE
[5.0] Add new runtime functions for handling dependencies when initializing class metadata

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -597,6 +597,14 @@ void swift_initClassMetadata(ClassMetadata *self,
                              const TypeLayout * const *fieldTypes,
                              size_t *fieldOffsets);
 
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataDependency
+swift_initClassMetadata2(ClassMetadata *self,
+                         ClassLayoutFlags flags,
+                         size_t numFields,
+                         const TypeLayout * const *fieldTypes,
+                         size_t *fieldOffsets);
+
 #if SWIFT_OBJC_INTEROP
 /// Initialize various fields of the class metadata.
 ///
@@ -612,6 +620,14 @@ void swift_updateClassMetadata(ClassMetadata *self,
                                size_t numFields,
                                const TypeLayout * const *fieldTypes,
                                size_t *fieldOffsets);
+
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataDependency
+swift_updateClassMetadata2(ClassMetadata *self,
+                           ClassLayoutFlags flags,
+                           size_t numFields,
+                           const TypeLayout * const *fieldTypes,
+                           size_t *fieldOffsets);
 #endif
 
 /// Given class metadata, a class descriptor and a method descriptor, look up

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -808,6 +808,34 @@ FUNCTION(UpdateClassMetadata,
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind))
 
+// struct FieldInfo { size_t Size; size_t AlignMask; };
+// MetadataDependency swift_initClassMetadata2(Metadata *self,
+//                                             ClassLayoutFlags flags,
+//                                             size_t numFields,
+//                                             TypeLayout * const *fieldTypes,
+//                                             size_t *fieldOffsets);
+FUNCTION(InitClassMetadata2,
+         swift_initClassMetadata2, SwiftCC,
+         RETURNS(TypeMetadataDependencyTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
+              Int8PtrPtrTy->getPointerTo(),
+              SizeTy->getPointerTo()),
+         ATTRS(NoUnwind))
+
+// struct FieldInfo { size_t Size; size_t AlignMask; };
+// MetadataDependency swift_updateClassMetadata2(Metadata *self,
+//                                               ClassLayoutFlags flags,
+//                                               size_t numFields,
+//                                               TypeLayout * const *fieldTypes,
+//                                               size_t *fieldOffsets);
+FUNCTION(UpdateClassMetadata2,
+         swift_updateClassMetadata2, SwiftCC,
+         RETURNS(TypeMetadataDependencyTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
+              Int8PtrPtrTy->getPointerTo(),
+              SizeTy->getPointerTo()),
+         ATTRS(NoUnwind))
+
 // void *swift_lookUpClassMethod(Metadata *metadata,
 //                               ClassDescriptor *description,
 //                               MethodDescriptor *method);

--- a/stdlib/public/runtime/CompatibilityOverride.cpp
+++ b/stdlib/public/runtime/CompatibilityOverride.cpp
@@ -38,7 +38,7 @@ using namespace swift;
 struct OverrideSection {
   uintptr_t version;
   
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
 #include "CompatibilityOverride.def"
 };
@@ -61,7 +61,7 @@ static OverrideSection *getOverrideSectionPtr() {
   return OverrideSectionPtr;
 }
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name swift::getOverride_ ## name() {                 \
     auto *Section = getOverrideSectionPtr();                        \
     if (Section == nullptr)                                         \

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -145,17 +145,19 @@ OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))
 
-OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , , swift::,
-                        (Demangler &demangler,
+OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , SWIFT_CC(swift), swift::,
+                        (MetadataRequest request,
+                         Demangler &demangler,
                          Demangle::NodePointer node,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
-                        (demangler, node, substGenericParam, substWitnessTable))
-OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , , swift::,
-                        (StringRef typeName,
+                        (request, demangler, node, substGenericParam, substWitnessTable))
+OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , SWIFT_CC(swift), swift::,
+                        (MetadataRequest request,
+                         StringRef typeName,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
-                        (typeName, substGenericParam, substWitnessTable))
+                        (request, typeName, substGenericParam, substWitnessTable))
 
 OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
                       SWIFT_RUNTIME_STDLIB_INTERNAL, SWIFT_CC(swift), swift::,

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -69,7 +69,7 @@
 #  endif
 #endif
 
-OVERRIDE_CASTING(dynamicCast, bool, , swift::,
+OVERRIDE_CASTING(dynamicCast, bool, , , swift::,
                  (OpaqueValue *dest, OpaqueValue *src,
                   const Metadata *srcType,
                   const Metadata *targetType,
@@ -77,13 +77,13 @@ OVERRIDE_CASTING(dynamicCast, bool, , swift::,
                  (dest, src, srcType, targetType, flags))
 
 
-OVERRIDE_CASTING(dynamicCastClass, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastClass, const void *, , , swift::,
                  (const void *object,
                   const ClassMetadata *targetType),
                  (object, targetType))
 
 
-OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , , swift::,
                  (const void *object,
                   const ClassMetadata *targetType,
                   const char *file, unsigned line, unsigned column),
@@ -91,74 +91,74 @@ OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , swift::,
 
 
 
-OVERRIDE_CASTING(dynamicCastUnknownClass, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastUnknownClass, const void *, , , swift::,
                  (const void *object, const Metadata *targetType),
                  (object, targetType))
 
 
-OVERRIDE_CASTING(dynamicCastUnknownClassUnconditional, const void *, , swift::,
+OVERRIDE_CASTING(dynamicCastUnknownClassUnconditional, const void *, , , swift::,
                  (const void *object, const Metadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (object, targetType, file, line, column))
 
 
-OVERRIDE_CASTING(dynamicCastMetatype, const Metadata *, , swift::,
+OVERRIDE_CASTING(dynamicCastMetatype, const Metadata *, , , swift::,
                  (const Metadata *sourceType,
                   const Metadata *targetType),
                  (sourceType, targetType))
 
 
-OVERRIDE_CASTING(dynamicCastMetatypeUnconditional, const Metadata *, , swift::,
+OVERRIDE_CASTING(dynamicCastMetatypeUnconditional, const Metadata *, , , swift::,
                  (const Metadata *sourceType,
                   const Metadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (sourceType, targetType, file, line, column))
 
 
-OVERRIDE_FOREIGN(dynamicCastForeignClassMetatype, const ClassMetadata *, , swift::,
+OVERRIDE_FOREIGN(dynamicCastForeignClassMetatype, const ClassMetadata *, , , swift::,
                  (const ClassMetadata *sourceType,
                   const ClassMetadata *targetType),
                  (sourceType, targetType))
 
 
 OVERRIDE_FOREIGN(dynamicCastForeignClassMetatypeUnconditional,
-                 const ClassMetadata *, , swift::,
+                 const ClassMetadata *, , , swift::,
                  (const ClassMetadata *sourceType,
                   const ClassMetadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (sourceType, targetType, file, line, column))
 
 
-OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , swift::,
+OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , , swift::,
                              (const Metadata * const type,
                               const ProtocolDescriptor *protocol),
                              (type, protocol))
 
 OVERRIDE_PROTOCOLCONFORMANCE(conformsToSwiftProtocol,
-                             const ProtocolConformanceDescriptor *, , swift::,
+                             const ProtocolConformanceDescriptor *, , , swift::,
                              (const Metadata * const type,
                               const ProtocolDescriptor *protocol,
                               StringRef moduleName),
                              (type, protocol, moduleName))
 
-OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , swift::,
+OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))
 
-OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , swift::,
+OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , , swift::,
                         (Demangler &demangler,
                          Demangle::NodePointer node,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
                         (demangler, node, substGenericParam, substWitnessTable))
-OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , swift::,
+OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , , swift::,
                         (StringRef typeName,
                          SubstGenericParameterFn substGenericParam,
                          SubstDependentWitnessTableFn substWitnessTable),
                         (typeName, substGenericParam, substWitnessTable))
 
 OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
-                      SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
+                      SWIFT_RUNTIME_STDLIB_INTERNAL, SWIFT_CC(swift), swift::,
                       (MetadataRequest request, WitnessTable *wtable,
                        const Metadata *conformingType,
                        const ProtocolRequirement *reqBase,
@@ -166,7 +166,7 @@ OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
                       (request, wtable, conformingType, reqBase, assocType))
 
 OVERRIDE_WITNESSTABLE(getAssociatedConformanceWitnessSlow, const WitnessTable *,
-                      SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
+                      SWIFT_RUNTIME_STDLIB_INTERNAL, SWIFT_CC(swift), swift::,
                       (WitnessTable *wtable, const Metadata *conformingType,
                        const Metadata *assocType,
                        const ProtocolRequirement *reqBase,
@@ -175,37 +175,37 @@ OVERRIDE_WITNESSTABLE(getAssociatedConformanceWitnessSlow, const WitnessTable *,
                                assocConformance))
 #if SWIFT_OBJC_INTEROP
 
-OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , , swift::,
               (const void *object,
                const ClassMetadata *targetType),
               (object, targetType))
 
 
-OVERRIDE_OBJC(dynamicCastObjCClassUnconditional, const void *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClassUnconditional, const void *, , , swift::,
               (const void *object,
                const ClassMetadata *targetType,
                const char *file, unsigned line, unsigned column),
               (object, targetType, file, line, column))
 
-OVERRIDE_OBJC(dynamicCastObjCClassMetatype, const ClassMetadata *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClassMetatype, const ClassMetadata *, , , swift::,
               (const ClassMetadata *sourceType,
                const ClassMetadata *targetType),
               (sourceType, targetType))
 
 
-OVERRIDE_OBJC(dynamicCastObjCClassMetatypeUnconditional, const ClassMetadata *, , swift::,
+OVERRIDE_OBJC(dynamicCastObjCClassMetatypeUnconditional, const ClassMetadata *, , , swift::,
               (const ClassMetadata *sourceType, const ClassMetadata *targetType,
                const char *file, unsigned line, unsigned column),
               (sourceType, targetType, file, line, column))
 
 
-OVERRIDE_FOREIGN(dynamicCastForeignClass, const void *, , swift::,
+OVERRIDE_FOREIGN(dynamicCastForeignClass, const void *, , , swift::,
                  (const void *object,
                   const ForeignClassMetadata *targetType),
                  (object, targetType))
 
 
-OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , swift::,
+OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , , swift::,
                  (const void *object, const ForeignClassMetadata *targetType,
                   const char *file, unsigned line, unsigned column),
                  (object, targetType, file, line, column))

--- a/stdlib/public/runtime/CompatibilityOverride.h
+++ b/stdlib/public/runtime/CompatibilityOverride.h
@@ -26,16 +26,16 @@ namespace swift {
 
 #define COMPATIBILITY_UNPAREN(...) __VA_ARGS__
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  typedef ret (*Original_ ## name) typedArgs;
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Original_ ## name) typedArgs;
 #include "CompatibilityOverride.def"
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  typedef ret (*Override_ ## name)(COMPATIBILITY_UNPAREN typedArgs, \
-                                   Original_ ## name originalImpl);
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Override_ ## name)(COMPATIBILITY_UNPAREN typedArgs, \
+                                           Original_ ## name originalImpl);
 #include "CompatibilityOverride.def"
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name getOverride_ ## name();
 #include "CompatibilityOverride.def"
 
@@ -44,8 +44,8 @@ namespace swift {
 /// OVERRIDE macro from CompatibilityOverride.def to this macro, then includes
 /// the file to generate the override points. The original implementation of the
 /// functionality must be available as swift_funcNameHereImpl.
-#define COMPATIBILITY_OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  attrs ret namespace swift_ ## name typedArgs {                                  \
+#define COMPATIBILITY_OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  attrs ccAttrs ret namespace swift_ ## name typedArgs {                          \
     static Override_ ## name Override;                                            \
     static swift_once_t Predicate;                                                \
     swift_once(&Predicate, [](void *) {                                           \

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4139,6 +4139,7 @@ static StringRef findAssociatedTypeName(const ProtocolDescriptor *protocol,
   return StringRef();
 }
 
+SWIFT_CC(swift)
 static MetadataResponse
 swift_getAssociatedTypeWitnessSlowImpl(
                                       MetadataRequest request,
@@ -4275,6 +4276,7 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
                                             reqBase, assocType);
 }
 
+SWIFT_CC(swift)
 static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
                                   WitnessTable *wtable,
                                   const Metadata *conformingType,

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1208,18 +1208,30 @@ public:
 
 }
 
+SWIFT_CC(swift)
 static TypeInfo swift_getTypeByMangledNodeImpl(
+                              MetadataRequest request,
                               Demangler &demangler,
                               Demangle::NodePointer node,
                               SubstGenericParameterFn substGenericParam,
                               SubstDependentWitnessTableFn substWitnessTable) {
+  // TODO: propagate the request down to the builder instead of calling
+  // swift_checkMetadataState after the fact.
   DecodedMetadataBuilder builder(demangler, substGenericParam,
                                  substWitnessTable);
   auto type = Demangle::decodeMangledType(builder, node);
-  return {type, builder.getReferenceOwnership()};
+  if (!type) {
+    return {MetadataResponse{nullptr, MetadataState::Complete},
+            TypeReferenceOwnership()};
+  }
+
+  return {swift_checkMetadataState(request, type),
+          builder.getReferenceOwnership()};
 }
 
-TypeInfo swift_getTypeByMangledNameImpl(
+SWIFT_CC(swift)
+static TypeInfo swift_getTypeByMangledNameImpl(
+                              MetadataRequest request,
                               StringRef typeName,
                               SubstGenericParameterFn substGenericParam,
                               SubstDependentWitnessTableFn substWitnessTable) {
@@ -1267,7 +1279,7 @@ TypeInfo swift_getTypeByMangledNameImpl(
       return TypeInfo();
   }
 
-  return swift_getTypeByMangledNode(demangler, node, substGenericParam,
+  return swift_getTypeByMangledNode(request, demangler, node, substGenericParam,
                                     substWitnessTable);
 }
 
@@ -1280,11 +1292,8 @@ swift_getTypeByMangledNameInEnvironment(
                         const void * const *genericArgs) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   SubstGenericParametersFromMetadata substitutions(environment, genericArgs);
-  auto metadata = swift_getTypeByMangledName(typeName, substitutions,
-                                             substitutions);
-  if (!metadata) return nullptr;
-
-  return swift_checkMetadataState(MetadataState::Complete, metadata).Value;
+  return swift_getTypeByMangledName(MetadataState::Complete, typeName,
+                                    substitutions, substitutions).getMetadata();
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
@@ -1296,11 +1305,8 @@ swift_getTypeByMangledNameInContext(
                         const void * const *genericArgs) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   SubstGenericParametersFromMetadata substitutions(context, genericArgs);
-  auto metadata = swift_getTypeByMangledName(typeName, substitutions,
-                                             substitutions);
-  if (!metadata) return nullptr;
-
-  return swift_checkMetadataState(MetadataState::Complete, metadata).Value;
+  return swift_getTypeByMangledName(MetadataState::Complete, typeName,
+                                    substitutions, substitutions).getMetadata();
 }
 
 /// Demangle a mangled name, but don't allow symbolic references.
@@ -1314,10 +1320,8 @@ swift_stdlib_getTypeByMangledNameUntrusted(const char *typeNameStart,
       return nullptr;
   }
   
-  auto metadata = swift_getTypeByMangledName(typeName, {}, {});
-  if (!metadata) return nullptr;
-
-  return swift_checkMetadataState(MetadataState::Complete, metadata).Value;
+  return swift_getTypeByMangledName(MetadataState::Complete, typeName,
+                                    {}, {}).getMetadata();
 }
 
 #if SWIFT_OBJC_INTEROP
@@ -1637,8 +1641,9 @@ void swift::gatherWrittenGenericArgs(
       SubstGenericParametersFromWrittenArgs substitutions(allGenericArgs,
                                                           genericParamCounts);
       allGenericArgs[*lhsFlatIndex] =
-          swift_getTypeByMangledName(req.getMangledTypeName(), substitutions,
-                                     substitutions);
+          swift_getTypeByMangledName(MetadataState::Abstract,
+                                     req.getMangledTypeName(), substitutions,
+                                     substitutions).getMetadata();
       continue;
     }
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -55,16 +55,22 @@ public:
 /// since we don't represent ownership attributes in the metadata
 /// itself related info has to be bundled with it.
 class TypeInfo {
-  const Metadata *Type;
+  MetadataResponse Response;
   TypeReferenceOwnership ReferenceOwnership;
 
 public:
-  TypeInfo() : Type(nullptr), ReferenceOwnership() {}
+  TypeInfo()
+    : Response{nullptr, MetadataState::Abstract}, ReferenceOwnership() {}
 
+  TypeInfo(MetadataResponse response, TypeReferenceOwnership ownership)
+    : Response(response), ReferenceOwnership(ownership) {}
+
+  // FIXME: remove this constructor and require a response in all cases.
   TypeInfo(const Metadata *type, TypeReferenceOwnership ownership)
-      : Type(type), ReferenceOwnership(ownership) {}
+    : Response{type, MetadataState::Abstract}, ReferenceOwnership(ownership) {}
 
-  operator const Metadata *() { return Type; }
+  const Metadata *getMetadata() const { return Response.Value; }
+  MetadataResponse getResponse() const { return Response; }
 
   bool isWeak() const { return ReferenceOwnership.isWeak(); }
   bool isUnowned() const { return ReferenceOwnership.isUnowned(); }
@@ -322,7 +328,9 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
+  SWIFT_CC(swift)
   TypeInfo swift_getTypeByMangledNode(
+                               MetadataRequest request,
                                Demangler &demangler,
                                Demangle::NodePointer node,
                                SubstGenericParameterFn substGenericParam,
@@ -334,7 +342,9 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
+  SWIFT_CC(swift)
   TypeInfo swift_getTypeByMangledName(
+                               MetadataRequest request,
                                StringRef typeName,
                                SubstGenericParameterFn substGenericParam,
                                SubstDependentWitnessTableFn substWitnessTable);

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -635,8 +635,9 @@ bool swift::_checkGenericRequirements(
 
     // Resolve the subject generic parameter.
     const Metadata *subjectType =
-      swift_getTypeByMangledName(req.getParam(), substGenericParam,
-                                 substWitnessTable);
+      swift_getTypeByMangledName(MetadataState::Abstract,
+                                 req.getParam(), substGenericParam,
+                                 substWitnessTable).getMetadata();
     if (!subjectType)
       return true;
 
@@ -660,8 +661,9 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::SameType: {
       // Demangle the second type under the given substitutions.
       auto otherType =
-        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
-                                   substWitnessTable);
+        swift_getTypeByMangledName(MetadataState::Abstract,
+                                   req.getMangledTypeName(), substGenericParam,
+                                   substWitnessTable).getMetadata();
       if (!otherType) return true;
 
       assert(!req.getFlags().hasExtraArgument());
@@ -687,8 +689,9 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::BaseClass: {
       // Demangle the base type under the given substitutions.
       auto baseType =
-        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
-                                   substWitnessTable);
+        swift_getTypeByMangledName(MetadataState::Complete,
+                                   req.getMangledTypeName(), substGenericParam,
+                                   substWitnessTable).getMetadata();
       if (!baseType) return true;
 
       // Check whether it's dynamically castable, which works as a superclass

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -175,14 +175,15 @@ TEST_F(CompatibilityOverrideTest, test_swift_conformsToSwiftProtocol) {
 
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledNode) {
   Demangler demangler;
-  auto Result = swift_getTypeByMangledNode(demangler, nullptr, nullptr,
-                                           nullptr);
-  ASSERT_EQ((const Metadata *)Result, nullptr);
+  auto Result = swift_getTypeByMangledNode(MetadataState::Abstract,
+                                           demangler, nullptr, nullptr,nullptr);
+  ASSERT_EQ(Result.getMetadata(), nullptr);
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledName) {
-  auto Result = swift_getTypeByMangledName("", nullptr, nullptr);
-  ASSERT_EQ((const Metadata *)Result, nullptr);
+  auto Result = swift_getTypeByMangledName(MetadataState::Abstract,
+                                           "", nullptr, nullptr);
+  ASSERT_EQ(Result.getMetadata(), nullptr);
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_getAssociatedTypeWitnessSlow) {

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -41,13 +41,13 @@ namespace  {
   }
 }
 
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
-  static ret name ## Override(COMPATIBILITY_UNPAREN typedArgs,      \
-                          Original_ ## name originalImpl) {         \
-    if (!EnableOverride)                                            \
-      return originalImpl namedArgs;                                \
-    Ran = true;                                                     \
-    return getEmptyValue<ret>();                                    \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  static ccAttrs ret name ## Override(COMPATIBILITY_UNPAREN typedArgs,       \
+                                       Original_ ## name originalImpl) {     \
+    if (!EnableOverride)                                                     \
+      return originalImpl namedArgs;                                         \
+    Ran = true;                                                              \
+    return getEmptyValue<ret>();                                             \
   }
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 
@@ -55,14 +55,14 @@ namespace  {
 struct OverrideSection {
   uintptr_t version;
   
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 };
 
 OverrideSection Overrides __attribute__((section("__DATA,__swift_hooks"))) = {
   0,
-#define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   name ## Override,
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 };


### PR DESCRIPTION
This is part of the fix for the race condition identified in rdar://47549859. The fix in #22381 is too naive because we cannot stage it in; instead we need to make a runtime-only change to add new runtime functions, then switch the compiler to use them only when the compiler entrypoints can be safely presumed to exist.

This is the 5.0 version of #22386.