### PR TITLE
[SILProfiler] Set up profiling for lazily-emitted functions

### DIFF
--- a/test/Profiler/coverage_private.swift
+++ b/test/Profiler/coverage_private.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_private %s | %FileCheck %s
+
+struct S {
+  func visible() {
+    hidden()
+  }
+
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_private.S.(hidden in {{.*}})() -> ()
+  // CHECK-NEXT:  [[@LINE+1]]:25 -> [[@LINE+2]]:4 : 0
+  private func hidden() {
+  }
+}
+
+S().visible()

--- a/test/Profiler/coverage_smoke.swift
+++ b/test/Profiler/coverage_smoke.swift
@@ -189,4 +189,20 @@ let _ = Class3()
 let _ = Struct1(field: 1)
 let _ = Struct1()
 
+struct Struct2 {
+  func visible() {
+    hidden()
+  }
+  private func hidden() {
+    var x: Int = 0 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    func helper() {
+      x += 1 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    }
+    helper() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+var s2 = Struct2()
+s2.visible()
+
 // CHECK-REPORT: TOTAL {{.*}} 100.00% {{.*}} 100.00%


### PR DESCRIPTION
A SIL function that's initially only emitted as a declaration may later
be prepared for definition. When this happens, set up a profiler for the
definition.

This makes code coverage visible for private methods (the frontend
follows a declare-then-define pattern for these).

rdar://47759243