### PR TITLE
Address TF-102. Dummy Decls should be set to have a type in order not to crash.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -94,8 +94,10 @@ static void createEntryArguments(SILFunction *f) {
         f->mapTypeIntoContext(indResultTy).getAddressType(),
         createDummyParamDecl());
   for (auto paramTy : conv.getParameterSILTypes()) {
-    entry->createFunctionArgument(f->mapTypeIntoContext(paramTy),
-                                  createDummyParamDecl());
+    auto *decl = createDummyParamDecl();
+    auto ty = f->mapTypeIntoContext(paramTy);
+    decl->setType(ty.getASTType());
+    entry->createFunctionArgument(ty, decl);
   }
 }
 

--- a/test/TensorFlow/tensor_autodiff.swift
+++ b/test/TensorFlow/tensor_autodiff.swift
@@ -22,3 +22,11 @@ public func test2() {
 }
 
 // CHECK: @{{.*}}selfmin{{.*}}__vjp_src_0_wrt_0
+
+// Test that print compiles fine.
+// Addresses TF-102.
+@differentiable
+func printSideEffectsAreOk(value: Tensor<Float>) -> Tensor<Float> {
+  print(value)
+  return value
+}


### PR DESCRIPTION
Previously, the Decl would reach IRGen without a decl and crash there.