### PR TITLE
AST: ASTMangler should not depend on ASTDemangler

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -158,8 +158,7 @@ public:
                                       GenericSignature *signature,
                                       ResilienceExpansion expansion);
 
-  std::string mangleTypeForDebugger(Type decl, const DeclContext *DC,
-                                    bool verify=false);
+  std::string mangleTypeForDebugger(Type decl, const DeclContext *DC);
 
   std::string mangleDeclType(const ValueDecl *decl);
   


### PR DESCRIPTION
ASTDemangler depends on ClangImporter, etc.