### PR TITLE
Always use legacy layouts

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -434,6 +434,16 @@ function(_compile_swift_files
   string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
   file(WRITE "${file_path}" "'${source_files_quoted}'")
   
+  # If this platform/architecture combo supports backward deployment to old
+  # Objective-C runtimes, we need to copy a YAML file with legacy type layout
+  # information to the build directory so that the compiler can find it.
+  #
+  # See stdlib/CMakeLists.txt and TypeConverter::TypeConverter() in
+  # lib/IRGen/GenType.cpp.
+  set(SWIFTFILE_PLATFORM "${SWIFT_SDK_${SWIFTFILE_SDK}_LIB_SUBDIR}")
+  set(copy_legacy_layouts_dep
+      "copy-legacy-layouts-${SWIFTFILE_PLATFORM}-${SWIFTFILE_ARCHITECTURE}")
+
   add_custom_command_target(
       dependency_target
       COMMAND
@@ -447,6 +457,7 @@ function(_compile_swift_files
         ${file_path} ${source_files} ${SWIFTFILE_DEPENDS}
         ${swift_ide_test_dependency}
         ${obj_dirs_dependency_target}
+        ${copy_legacy_layouts_dep}
       COMMENT "Compiling ${first_output}")
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -179,7 +179,7 @@ public:
   unsigned LazyInitializeClassMetadata : 1;
 
   /// The path to load legacy type layouts from.
-  StringRef ReadTypeInfoPath;
+  StringRef ReadLegacyTypeInfoPath;
 
   /// Should we try to build incrementally by not emitting an object file if it
   /// has the same IR hash as the module that we are preparing to emit?

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -178,6 +178,11 @@ public:
   /// Used on Windows to avoid cross-module references.
   unsigned LazyInitializeClassMetadata : 1;
 
+  /// Normally if the -read-legacy-type-info flag is not specified, we look for
+  /// a file named "legacy-<arch>.yaml" in SearchPathOpts.RuntimeLibraryPath.
+  /// Passing this flag completely disables this behavior.
+  unsigned DisableLegacyTypeInfo : 1;
+
   /// The path to load legacy type layouts from.
   StringRef ReadLegacyTypeInfoPath;
 
@@ -233,6 +238,7 @@ public:
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
         EnableClassResilience(false),
         EnableResilienceBypass(false), LazyInitializeClassMetadata(false),
+        DisableLegacyTypeInfo(false),
         UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false),

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -168,9 +168,6 @@ public:
   /// Emit mangled names of anonymous context descriptors.
   unsigned EnableAnonymousContextMangledNames : 1;
 
-  /// Enables resilient class layout.
-  unsigned EnableClassResilience : 1;
-
   /// Bypass resilience when accessing resilient frameworks.
   unsigned EnableResilienceBypass : 1;
 
@@ -236,7 +233,6 @@ public:
         EmbedMode(IRGenEmbedMode::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
-        EnableClassResilience(false),
         EnableResilienceBypass(false), LazyInitializeClassMetadata(false),
         DisableLegacyTypeInfo(false),
         UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -177,6 +177,9 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
    HelpText<"Enable resilient layout for classes containing resilient value types">;
 
+def disable_legacy_type_info : Flag<["-"], "disable-legacy-type-info">,
+  HelpText<"Completely disable legacy type layout">;
+
 def read_legacy_type_info_path_EQ : Joined<["-"], "read-legacy-type-info-path=">,
   HelpText<"Read legacy type layout from the given path instead of default path">;
 }

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -177,8 +177,8 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
    HelpText<"Enable resilient layout for classes containing resilient value types">;
 
-def read_type_info_path_EQ : Joined<["-"], "read-type-info-path=">,
-  HelpText<"Read legacy type layout from the given path">;
+def read_legacy_type_info_path_EQ : Joined<["-"], "read-legacy-type-info-path=">,
+  HelpText<"Read legacy type layout from the given path instead of default path">;
 }
 
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -174,9 +174,6 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
    HelpText<"Compile the module to export resilient interfaces for all "
             "public declarations by default">;
 
-def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
-   HelpText<"Enable resilient layout for classes containing resilient value types">;
-
 def disable_legacy_type_info : Flag<["-"], "disable-legacy-type-info">,
   HelpText<"Completely disable legacy type layout">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1067,10 +1067,6 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableReflectionNames = false;
   }
 
-  if (Args.hasArg(OPT_enable_class_resilience)) {
-    Opts.EnableClassResilience = true;
-  }
-
   if (Args.hasArg(OPT_enable_resilience_bypass)) {
     Opts.EnableResilienceBypass = true;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1079,8 +1079,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // (e.g. NativeObject).  Force the lazy initialization of the VWT always.
   Opts.LazyInitializeClassMetadata = Triple.isOSBinFormatCOFF();
 
-  if (const Arg *A = Args.getLastArg(OPT_read_type_info_path_EQ)) {
-    Opts.ReadTypeInfoPath = A->getValue();
+  if (const Arg *A = Args.getLastArg(OPT_read_legacy_type_info_path_EQ)) {
+    Opts.ReadLegacyTypeInfoPath = A->getValue();
   }
 
   for (const auto &Lib : Args.getAllArgValues(options::OPT_autolink_library))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1079,6 +1079,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // (e.g. NativeObject).  Force the lazy initialization of the VWT always.
   Opts.LazyInitializeClassMetadata = Triple.isOSBinFormatCOFF();
 
+  if (Args.hasArg(OPT_disable_legacy_type_info)) {
+    Opts.DisableLegacyTypeInfo = true;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_read_legacy_type_info_path_EQ)) {
     Opts.ReadLegacyTypeInfoPath = A->getValue();
   }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -376,9 +376,9 @@ namespace {
         // Lower the field type.
         auto *eltType = &IGM.getTypeInfo(type);
         if (CompletelyFragileLayout && !eltType->isFixedSize()) {
-          // For staging purposes, only do the new thing if the path flag
-          // is provided.
-          auto mode = (IGM.IRGen.Opts.ReadLegacyTypeInfoPath.empty()
+          // For staging purposes, only do the new thing if we're going
+          // to load a YAML file describing legacy type layouts.
+          auto mode = (IGM.IRGen.Opts.DisableLegacyTypeInfo
                        ? TypeConverter::Mode::CompletelyFragile
                        : TypeConverter::Mode::Legacy);
           LoweringModeScope scope(IGM, mode);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -378,7 +378,7 @@ namespace {
         if (CompletelyFragileLayout && !eltType->isFixedSize()) {
           // For staging purposes, only do the new thing if the path flag
           // is provided.
-          auto mode = (IGM.IRGen.Opts.ReadTypeInfoPath.empty()
+          auto mode = (IGM.IRGen.Opts.ReadLegacyTypeInfoPath.empty()
                        ? TypeConverter::Mode::CompletelyFragile
                        : TypeConverter::Mode::Legacy);
           LoweringModeScope scope(IGM, mode);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -376,12 +376,7 @@ namespace {
         // Lower the field type.
         auto *eltType = &IGM.getTypeInfo(type);
         if (CompletelyFragileLayout && !eltType->isFixedSize()) {
-          // For staging purposes, only do the new thing if we're going
-          // to load a YAML file describing legacy type layouts.
-          auto mode = (IGM.IRGen.Opts.DisableLegacyTypeInfo
-                       ? TypeConverter::Mode::CompletelyFragile
-                       : TypeConverter::Mode::Legacy);
-          LoweringModeScope scope(IGM, mode);
+          LoweringModeScope scope(IGM, TypeConverter::Mode::Legacy);
           eltType = &IGM.getTypeInfo(type);
         }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -528,12 +528,8 @@ const ClassLayout &
 ClassTypeInfo::getClassLayout(IRGenModule &IGM, SILType classType,
                               bool forBackwardDeployment) const {
   // Perform fragile layout only if Objective-C interop is enabled.
-  //
-  // FIXME: EnableClassResilience staging flag will go away once we can do
-  // in-place re-initialization of class metadata.
   bool completelyFragileLayout = (forBackwardDeployment &&
-                                  IGM.Context.LangOpts.EnableObjCInterop &&
-                                  !IGM.IRGen.Opts.EnableClassResilience);
+                                  IGM.Context.LangOpts.EnableObjCInterop);
 
   // Return the cached layout if available.
   auto &Layout = completelyFragileLayout ? FragileLayout : ResilientLayout;

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -21,11 +21,13 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Platform.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Path.h"
 #include "clang/CodeGen/SwiftCallingConv.h"
 
 #include "EnumPayload.h"
@@ -1114,6 +1116,30 @@ TypeConverter::getLegacyTypeInfo(NominalTypeDecl *decl) const {
   return found->second;
 }
 
+static llvm::StringLiteral platformsWithLegacyLayouts[][2] = {
+  {"appletvos", "arm64"},
+  {"appletvsimulator", "x86_64"},
+  {"iphoneos", "armv7"},
+  {"iphoneos", "armv7s"},
+  {"iphoneos", "arm64"},
+  {"iphonesimulator", "i386"},
+  {"iphonesimulator", "x86_64"},
+  {"macosx", "x86_64"},
+  {"watchos", "armv7k"},
+  {"watchsimulator", "i386"}
+};
+
+static bool doesPlatformUseLegacyLayouts(StringRef platformName,
+                                         StringRef archName) {
+  for (auto platformArchPair : platformsWithLegacyLayouts) {
+    if (platformName == platformArchPair[0] &&
+        archName == platformArchPair[1]) {
+      return true;
+    }
+  }
+
+  return false;
+}
 TypeConverter::TypeConverter(IRGenModule &IGM)
   : IGM(IGM),
     FirstType(invalidTypeInfo()) {
@@ -1125,13 +1151,34 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   if (IGM.IRGen.Opts.EnableResilienceBypass)
     LoweringMode = Mode::CompletelyFragile;
 
+  // We have a bunch of -parse-stdlib tests that pass a -target in the test
+  // suite. To prevent these from failing when the user hasn't build the
+  // standard library for that target, we pass -disable-legacy-type-info to
+  // disable trying to load the legacy type info.
+  if (IGM.IRGen.Opts.DisableLegacyTypeInfo)
+    return;
+
+  auto platformName = getPlatformNameForTriple(IGM.Triple);
+  auto archName = getMajorArchitectureName(IGM.Triple);
+
+  if (!doesPlatformUseLegacyLayouts(platformName, archName))
+    return;
+
+  llvm::SmallString<128> defaultPath;
+
   StringRef path = IGM.IRGen.Opts.ReadLegacyTypeInfoPath;
-  if (!path.empty()) {
-    bool error = readLegacyTypeInfo(path);
-    if (error) {
-      llvm::report_fatal_error("Cannot read '" + path + "'");
-    }
+  if (path.empty()) {
+    defaultPath.append(IGM.Context.SearchPathOpts.RuntimeLibraryPath);
+    llvm::sys::path::append(defaultPath, "layouts-");
+    defaultPath.append(archName);
+    defaultPath.append(".yaml");
+
+    path = defaultPath;
   }
+
+  bool error = readLegacyTypeInfo(path);
+  if (error)
+    llvm::report_fatal_error("Cannot read '" + path + "'");
 }
 
 TypeConverter::~TypeConverter() {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1125,7 +1125,7 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   if (IGM.IRGen.Opts.EnableResilienceBypass)
     LoweringMode = Mode::CompletelyFragile;
 
-  StringRef path = IGM.IRGen.Opts.ReadTypeInfoPath;
+  StringRef path = IGM.IRGen.Opts.ReadLegacyTypeInfoPath;
   if (!path.empty()) {
     bool error = readLegacyTypeInfo(path);
     if (error) {

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -107,6 +107,48 @@ swift_create_stdlib_targets("swift-stdlib" "sibopt" TRUE)
 swift_create_stdlib_targets("swift-stdlib" "sibgen" TRUE)
 swift_create_stdlib_targets("swift-test-stdlib" "" FALSE)
 
+foreach(sdk ${SWIFT_SDKS})
+  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+    set(platform "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    set(input "${SWIFT_SOURCE_DIR}/stdlib/public/legacy_layouts/${platform}/layouts-${arch}.yaml")
+    set(output "${SWIFTLIB_DIR}/${platform}/layouts-${arch}.yaml")
+
+    if(EXISTS "${input}")
+      # Copy the input file to the build directory.
+      add_custom_command(
+        OUTPUT "${output}"
+        DEPENDS "${input}"
+        COMMAND
+          "${CMAKE_COMMAND}" -E copy
+          "${input}"
+          "${output}")
+
+      # Define a target for this so that we can depend on it when
+      # building Swift sources.
+      add_custom_target(
+        "copy-legacy-layouts-${platform}-${arch}"
+        DEPENDS "${output}"
+        SOURCES "${input}")
+
+      # Make sure we ultimately always do this as part of building the
+      # standard library. In practice we'll do this earlier if at least
+      # one Swift source file has changed.
+      add_dependencies(
+        "swift-stdlib-${platform}-${arch}"
+        "copy-legacy-layouts-${platform}-${arch}")
+
+      swift_install_in_component(stdlib
+          FILES ${input}
+          DESTINATION "lib/swift/${platform}/")
+    else()
+      # Add a dummy target that does nothing so we can still depend on it
+      # later without checking if the input files exist.
+      add_custom_target(
+        "copy-legacy-layouts-${platform}-${arch}")
+    endif()
+  endforeach()
+endforeach()
+
 add_subdirectory(public)
 add_subdirectory(private)
 add_subdirectory(tools)

--- a/stdlib/public/legacy_layouts/appletvos/layouts-arm64.yaml
+++ b/stdlib/public/legacy_layouts/appletvos/layouts-arm64.yaml
@@ -1,0 +1,420 @@
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10URLRequestV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12CharacterSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12URLQueryItemV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation13URLComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation14DateComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            25
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation3URLV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483643
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 12
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8TimeZoneV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            SS10FoundationE8EncodingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            89
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            57
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            90
+    Alignment:       8
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11IPv4AddressV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV
+    Size:            56
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            224
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...

--- a/stdlib/public/legacy_layouts/appletvsimulator/layouts-x86_64.yaml
+++ b/stdlib/public/legacy_layouts/appletvsimulator/layouts-x86_64.yaml
@@ -1,0 +1,420 @@
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10URLRequestV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12CharacterSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12URLQueryItemV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation13URLComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation14DateComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            25
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation3URLV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483643
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8TimeZoneV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            SS10FoundationE8EncodingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            89
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            57
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            90
+    Alignment:       8
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11IPv4AddressV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV
+    Size:            56
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            224
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...

--- a/stdlib/public/legacy_layouts/iphoneos/layouts-arm64.yaml
+++ b/stdlib/public/legacy_layouts/iphoneos/layouts-arm64.yaml
@@ -1,0 +1,452 @@
+---
+Name:            ARKit
+Decls:           
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 248
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So8ARCameraC5ARKitE13TrackingStateO6ReasonO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+...
+---
+Name:            AVFoundation
+Decls:           
+  - Name:            So35AVCaptureSynchronizedDataCollectionC12AVFoundationE8IteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10URLRequestV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12CharacterSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12URLQueryItemV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation13URLComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation14DateComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            25
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation3URLV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483643
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 12
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8TimeZoneV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            SS10FoundationE8EncodingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 254
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            89
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            57
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            90
+    Alignment:       8
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11IPv4AddressV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV
+    Size:            56
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            224
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...

--- a/stdlib/public/legacy_layouts/iphoneos/layouts-armv7.yaml
+++ b/stdlib/public/legacy_layouts/iphoneos/layouts-armv7.yaml
@@ -1,0 +1,452 @@
+---
+Name:            ARKit
+Decls:           
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 248
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So8ARCameraC5ARKitE13TrackingStateO6ReasonO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+...
+---
+Name:            AVFoundation
+Decls:           
+  - Name:            So35AVCaptureSynchronizedDataCollectionC12AVFoundationE8IteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+...
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10URLRequestV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12CharacterSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12URLQueryItemV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation13URLComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation14DateComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            13
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation3URLV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4092
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            52
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            20
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8TimeZoneV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            SS10FoundationE8EncodingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 2
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            61
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            41
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            62
+    Alignment:       4
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            45
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network11IPv4AddressV
+    Size:            28
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network11IPv6AddressV
+    Size:            40
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            144
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+...

--- a/stdlib/public/legacy_layouts/iphoneos/layouts-armv7s.yaml
+++ b/stdlib/public/legacy_layouts/iphoneos/layouts-armv7s.yaml
@@ -1,0 +1,452 @@
+---
+Name:            ARKit
+Decls:           
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 248
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So8ARCameraC5ARKitE13TrackingStateO6ReasonO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+...
+---
+Name:            AVFoundation
+Decls:           
+  - Name:            So35AVCaptureSynchronizedDataCollectionC12AVFoundationE8IteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+...
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10URLRequestV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12CharacterSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12URLQueryItemV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation13URLComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation14DateComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            13
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation3URLV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4092
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            52
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            20
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8TimeZoneV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            SS10FoundationE8EncodingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 2
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            61
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            41
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            62
+    Alignment:       4
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            45
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network11IPv4AddressV
+    Size:            28
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network11IPv6AddressV
+    Size:            40
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            144
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+...

--- a/stdlib/public/legacy_layouts/iphonesimulator/layouts-i386.yaml
+++ b/stdlib/public/legacy_layouts/iphonesimulator/layouts-i386.yaml
@@ -1,0 +1,452 @@
+---
+Name:            ARKit
+Decls:           
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 248
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So8ARCameraC5ARKitE13TrackingStateO6ReasonO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+...
+---
+Name:            AVFoundation
+Decls:           
+  - Name:            So35AVCaptureSynchronizedDataCollectionC12AVFoundationE8IteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+...
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10URLRequestV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12CharacterSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12URLQueryItemV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation13URLComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation14DateComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            13
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation3URLV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4092
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            52
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            20
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8TimeZoneV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            SS10FoundationE8EncodingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 2
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            61
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            41
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            62
+    Alignment:       4
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            45
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            7Network11IPv4AddressV
+    Size:            28
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network11IPv6AddressV
+    Size:            40
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4095
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            144
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+...

--- a/stdlib/public/legacy_layouts/iphonesimulator/layouts-x86_64.yaml
+++ b/stdlib/public/legacy_layouts/iphonesimulator/layouts-x86_64.yaml
@@ -1,0 +1,452 @@
+---
+Name:            ARKit
+Decls:           
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 248
+  - Name:            So13ARPlaneAnchorC5ARKitE14ClassificationO6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So8ARCameraC5ARKitE13TrackingStateO6ReasonO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+...
+---
+Name:            AVFoundation
+Decls:           
+  - Name:            So35AVCaptureSynchronizedDataCollectionC12AVFoundationE8IteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10URLRequestV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12CharacterSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12URLQueryItemV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation13URLComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation14DateComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            25
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation3URLV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483643
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8TimeZoneV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            SS10FoundationE8EncodingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 254
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            89
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            57
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            90
+    Alignment:       8
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11IPv4AddressV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV
+    Size:            56
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            224
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...

--- a/stdlib/public/legacy_layouts/macosx/layouts-x86_64.yaml
+++ b/stdlib/public/legacy_layouts/macosx/layouts-x86_64.yaml
@@ -1,0 +1,432 @@
+---
+Name:            AppKit
+Decls:           
+  - Name:            So7NSEventC6AppKitE10SpecialKeyV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation10URLRequestV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483645
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12CharacterSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation12URLQueryItemV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation13URLComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation14DateComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation15AffineTransformV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            25
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            217
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation3URLV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483643
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            24
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8TimeZoneV
+    Size:            9
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            17
+    Alignment:       8
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            32
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            SS10FoundationE8EncodingV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...
+---
+Name:            Network
+Decls:           
+  - Name:            7Network10NWEndpointO
+    Size:            89
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4HostO
+    Size:            57
+    Alignment:       8
+    ExtraInhabitants: 253
+  - Name:            7Network10NWEndpointO4PortV
+    Size:            2
+    Alignment:       2
+    ExtraInhabitants: 0
+  - Name:            7Network10NWListenerC25ServiceRegistrationChangeO
+    Size:            90
+    Alignment:       8
+    ExtraInhabitants: 254
+  - Name:            7Network10NWListenerC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network10NWListenerC7ServiceV
+    Size:            64
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11IPv4AddressV
+    Size:            48
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV
+    Size:            56
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network11IPv6AddressV5ScopeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network11NWInterfaceV
+    Size:            40
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network11NWInterfaceV13InterfaceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 251
+  - Name:            7Network12NWConnectionC14SendCompletionO
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483646
+  - Name:            7Network12NWConnectionC5StateO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 61
+  - Name:            7Network12NWParametersC12ServiceClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            7Network12NWParametersC18ExpiredDNSBehaviorO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network12NWParametersC20MultipathServiceTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC3ECNO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            7Network12NWProtocolIPC7OptionsC7VersionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network6NWPathV
+    Size:            224
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+  - Name:            7Network6NWPathV6StatusO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            7Network7NWErrorO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 253
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 2147483647
+...

--- a/stdlib/public/legacy_layouts/watchos/layouts-armv7k.yaml
+++ b/stdlib/public/legacy_layouts/watchos/layouts-armv7k.yaml
@@ -1,0 +1,344 @@
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit14CKSubscriptionO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10URLRequestV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12CharacterSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12URLQueryItemV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation13URLComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation14DateComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            13
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation3URLV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4092
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            52
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            20
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8TimeZoneV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            SS10FoundationE8EncodingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 2
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+...

--- a/stdlib/public/legacy_layouts/watchsimulator/layouts-i386.yaml
+++ b/stdlib/public/legacy_layouts/watchsimulator/layouts-i386.yaml
@@ -1,0 +1,344 @@
+---
+Name:            CloudKit
+Decls:           
+  - Name:            8CloudKit14CKSubscriptionO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            8CloudKit24CKRecordKeyValueIteratorV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            So11CKContainerC8CloudKitE11ApplicationO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So7CKShareC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE10SystemTypeO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            So8CKRecordC8CloudKitE14SystemFieldKeyO
+    Size:            0
+    Alignment:       1
+    ExtraInhabitants: 0
+...
+---
+Name:            CoreAudio
+Decls:           
+  - Name:            9CoreAudio013UnsafeMutableB17BufferListPointerV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+...
+---
+Name:            CoreGraphics
+Decls:           
+  - Name:            12CoreGraphics14CGPathFillRuleO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+...
+---
+Name:            Dispatch
+Decls:           
+  - Name:            8Dispatch0A12DataIteratorV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A12TimeIntervalO
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 251
+  - Name:            8Dispatch0A13WorkItemFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A3QoSV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A3QoSV0B6SClassO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 250
+  - Name:            8Dispatch0A4DataV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            8Dispatch0A4TimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A8WallTimeV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            8Dispatch0A9PredicateO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 1
+  - Name:            So14OS_dispatch_ioC8DispatchE10CloseFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So14OS_dispatch_ioC8DispatchE10StreamTypeO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            So14OS_dispatch_ioC8DispatchE13IntervalFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE10AttributesV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So17OS_dispatch_queueC8DispatchE19GlobalQueuePriorityO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            So17OS_dispatch_queueC8DispatchE20AutoreleaseFrequencyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 253
+  - Name:            So18OS_dispatch_sourceC8DispatchE10TimerFlagsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE12ProcessEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE13MachSendEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE15FileSystemEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            So18OS_dispatch_sourceC8DispatchE19MemoryPressureEventV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Foundation
+Decls:           
+  - Name:            10Foundation10CocoaErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10CocoaErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation10POSIXErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation10URLRequestV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation11JSONDecoderC19KeyDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DataDecodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONDecoderC20DateDecodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONDecoderC34NonConformingFloatDecodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11JSONEncoderC16OutputFormattingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation11JSONEncoderC19KeyEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DataEncodingStrategyO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4094
+  - Name:            10Foundation11JSONEncoderC20DateEncodingStrategyO
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation11JSONEncoderC34NonConformingFloatEncodingStrategyO
+    Size:            36
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation11MeasurementV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12CharacterSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12DateIntervalV
+    Size:            16
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation12NotificationV
+    Size:            24
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation12URLQueryItemV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation13URLComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation14DateComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation16ErrorUserInfoKeyV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+  - Name:            10Foundation17URLResourceValuesV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation18NSIndexSetIteratorV
+    Size:            13
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation20PersonNameComponentsV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation25NSFastEnumerationIteratorV
+    Size:            109
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation3URLV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation4DataV11DeallocatorO
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4092
+  - Name:            10Foundation4DataV8IteratorV
+    Size:            52
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation4DateV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            10Foundation4UUIDV
+    Size:            16
+    Alignment:       1
+    ExtraInhabitants: 0
+  - Name:            10Foundation6LocaleV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV
+    Size:            8
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8CalendarV10IdentifierO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8CalendarV14MatchingPolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 252
+  - Name:            10Foundation8CalendarV15SearchDirectionO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV18RepeatedTimePolicyO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 254
+  - Name:            10Foundation8CalendarV9ComponentO
+    Size:            1
+    Alignment:       1
+    ExtraInhabitants: 240
+  - Name:            10Foundation8IndexSetV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8IndexSetV0B0V
+    Size:            20
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation8IndexSetV9RangeViewV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8TimeZoneV
+    Size:            5
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            10Foundation8URLErrorV4CodeV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+  - Name:            10Foundation9IndexPathV
+    Size:            9
+    Alignment:       4
+    ExtraInhabitants: 252
+  - Name:            10Foundation9MachErrorV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            8Dispatch0A4DataV10FoundationE6RegionV
+    Size:            16
+    Alignment:       4
+    ExtraInhabitants: 4096
+  - Name:            SS10FoundationE8EncodingV
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...
+---
+Name:            Intents
+Decls:           
+  - Name:            7Intents10INShortcutO
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 2
+...
+---
+Name:            os
+Decls:           
+  - Name:            2os12OSSignpostIDV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+  - Name:            So9OS_os_logC0B0E8CategoryV
+    Size:            12
+    Alignment:       4
+    ExtraInhabitants: 253
+...

--- a/test/DebugInfo/compiler-flags-macosx.swift
+++ b/test/DebugInfo/compiler-flags-macosx.swift
@@ -2,8 +2,8 @@
 // a Darwin target and set the RC_DEBUG_OPTIONS environment variable. This
 // matches the behavior found in Clang.
 
-// RUN: %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck %s
-// RUN: env RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
+// RUN: %swiftc_driver %s -emit-ir -g -Xfrontend -disable-legacy-type-info -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck %s
+// RUN: env RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -Xfrontend -disable-legacy-type-info -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
 // CHECK:               !DICompileUnit({{.*}} producer: "{{(Apple )?Swift version [^"]+}}"
 // CHECK-NOT:                          flags: "
 // CHECK-VAR-SET:       !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"

--- a/test/IRGen/alloc.sil
+++ b/test/IRGen/alloc.sil
@@ -1,9 +1,9 @@
-// RUN: %swift -target x86_64-apple-macosx10.9 -module-name main %s -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target i386-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target armv7-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target arm64-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-unknown-linux-gnu %s -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -module-name main %s -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target i386-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target armv7-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target arm64-apple-ios7.0 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-unknown-linux-gnu %s -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/autolink-coff-x86.swift
+++ b/test/IRGen/autolink-coff-x86.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %swift -target x86_64--windows-gnu -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
-// RUN: %swift -target x86_64--windows-gnu -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-GNU-IR
-// RUN: %swift -target x86_64--windows-gnu -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -S -o - %s | %FileCheck %s -check-prefix CHECK-GNU-ASM
+// RUN: %swift -target x86_64--windows-gnu -parse-as-library -disable-legacy-type-info -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
+// RUN: %swift -target x86_64--windows-gnu -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-GNU-IR
+// RUN: %swift -target x86_64--windows-gnu -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -S -o - %s | %FileCheck %s -check-prefix CHECK-GNU-ASM
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/autolink-coff.swift
+++ b/test/IRGen/autolink-coff.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %swift -target thumbv7--windows-itanium -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
-// RUN: %swift -target thumbv7--windows-itanium -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-IR
-// RUN: %swift -target thumbv7--windows-itanium -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -S -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-ASM
+// RUN: %swift -target thumbv7--windows-itanium -parse-as-library -disable-legacy-type-info -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
+// RUN: %swift -target thumbv7--windows-itanium -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-IR
+// RUN: %swift -target thumbv7--windows-itanium -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -S -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-ASM
 
-// RUN: %swift -target thumbv7--windows-msvc -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
-// RUN: %swift -target thumbv7--windows-msvc -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-IR
-// RUN: %swift -target thumbv7--windows-msvc -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -S -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-ASM
+// RUN: %swift -target thumbv7--windows-msvc -parse-as-library -disable-legacy-type-info -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
+// RUN: %swift -target thumbv7--windows-msvc -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-IR
+// RUN: %swift -target thumbv7--windows-msvc -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -S -o - %s | %FileCheck %s -check-prefix CHECK-MSVC-ASM
 
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/autolink-force-link.swift
+++ b/test/IRGen/autolink-force-link.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %swift -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir %s %S/../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-WMO %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir %s %S/../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-WMO %s
 
 // CHECK-WMO: source_filename = "-"
 // CHECK-WMO: define void @"_swift_FORCE_LOAD_$_TEST"()
 // CHECK-WMO-NOT: source_filename
 
 
-// RUN: %swift -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir -num-threads 1 %s %S/../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-WMO-THREADED %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir -num-threads 1 %s %S/../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-WMO-THREADED %s
 
 // CHECK-WMO-THREADED: source_filename = "-"
 // CHECK-WMO-THREADED: define void @"_swift_FORCE_LOAD_$_TEST"()
@@ -16,8 +16,8 @@
 // CHECK-WMO-THREADED-NOT: source_filename
 
 
-// RUN: %swift -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir -primary-file %s %S/../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-SINGLE-FILE-FIRST %s
-// RUN: %swift -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir %S/../Inputs/empty.swift -primary-file %s | %FileCheck -check-prefix=CHECK-SINGLE-FILE-SECOND %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir -primary-file %s %S/../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-SINGLE-FILE-FIRST %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -parse-stdlib -autolink-force-load -module-name TEST -module-link-name TEST -emit-ir %S/../Inputs/empty.swift -primary-file %s | %FileCheck -check-prefix=CHECK-SINGLE-FILE-SECOND %s
 
 // CHECK-SINGLE-FILE-FIRST: source_filename = "-"
 // CHECK-SINGLE-FILE-FIRST: define void @"_swift_FORCE_LOAD_$_TEST"()

--- a/test/IRGen/autolink-psei.swift
+++ b/test/IRGen/autolink-psei.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift -target x86_64-scei-ps4 -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
-// RUN: %swift -target x86_64-scei-ps4 -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-IR
+// RUN: %swift -target x86_64-scei-ps4 -parse-as-library -disable-legacy-type-info -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
+// RUN: %swift -target x86_64-scei-ps4 -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-IR
 
 #if MAIN_MODULE
 import module

--- a/test/IRGen/autolink_elf.swift
+++ b/test/IRGen/autolink_elf.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name Empty -module-link-name swiftEmpty %S/../Inputs/empty.swift
-// RUN: %swift -target x86_64-unknown-linux-gnu %s -I %t -parse-stdlib -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name Empty -module-link-name swiftEmpty %S/../Inputs/empty.swift
+// RUN: %swift -disable-legacy-type-info -target x86_64-unknown-linux-gnu %s -I %t -parse-stdlib -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/autorelease_optimized_aarch64.sil
+++ b/test/IRGen/autorelease_optimized_aarch64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -gnone -O -target arm64-apple-ios7 -emit-assembly %s -o - | %FileCheck %s
+// RUN: %swift -gnone -O -disable-legacy-type-info -target arm64-apple-ios7 -emit-assembly %s -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=AArch64
 

--- a/test/IRGen/autorelease_optimized_x86_64.sil
+++ b/test/IRGen/autorelease_optimized_x86_64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -gnone -O -target x86_64-apple-macosx10.9 -emit-assembly %s -o - | %FileCheck %s
+// RUN: %swift -gnone -O -disable-legacy-type-info -target x86_64-apple-macosx10.9 -emit-assembly %s -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/bridge_object_arm64.sil
+++ b/test/IRGen/bridge_object_arm64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -module-name bridge_object -emit-ir -target arm64-apple-ios8.0 %s | %FileCheck %s
+// RUN: %swift -module-name bridge_object -emit-ir -disable-legacy-type-info -target arm64-apple-ios8.0 %s | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=AArch64
 

--- a/test/IRGen/bridge_object_x86_64.sil
+++ b/test/IRGen/bridge_object_x86_64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -module-name bridge_object -emit-ir -target x86_64-apple-macosx10.9 %s | %FileCheck %s
+// RUN: %swift -module-name bridge_object -emit-ir -disable-legacy-type-info -target x86_64-apple-macosx10.9 %s | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/builtin_word.sil
+++ b/test/IRGen/builtin_word.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -target x86_64-apple-macosx10.9 %s -gnone -emit-ir -o - | %FileCheck %s -check-prefix=INTEL
-// RUN: %swift -target armv7-apple-ios7 %s -gnone -emit-ir -o - | %FileCheck %s -check-prefix=ARM32
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 %s -gnone -emit-ir -o - | %FileCheck %s -check-prefix=INTEL
+// RUN: %swift -disable-legacy-type-info -target armv7-apple-ios7 %s -gnone -emit-ir -o - | %FileCheck %s -check-prefix=ARM32
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/class_resilience.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience -O %t/class_resilience.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %t/class_resilience.swift
 
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = hidden global [[INT]] 0
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyC5colors5Int32VvpWvd" = hidden global [[INT]] 0

--- a/test/IRGen/completely_fragile_class_layout.sil
+++ b/test/IRGen/completely_fragile_class_layout.sil
@@ -1,11 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
-
 // RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience %s -read-legacy-type-info-path=%S/Inputs/legacy_type_info/a.yaml | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
-
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience -O %s
+// RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience -O %s -read-legacy-type-info-path=%S/Inputs/legacy_type_info/a.yaml
 
 // We only use fragile class layouts when Objective-C interop is enabled.
 

--- a/test/IRGen/completely_fragile_class_layout.sil
+++ b/test/IRGen/completely_fragile_class_layout.sil
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience %s -read-type-info-path=%S/Inputs/legacy_type_info/a.yaml | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience %s -read-legacy-type-info-path=%S/Inputs/legacy_type_info/a.yaml | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 // RUN: %target-swift-frontend  -I %t -emit-ir -enable-resilience -O %s
 

--- a/test/IRGen/dependent-library.swift
+++ b/test/IRGen/dependent-library.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target i686-unknown-windows-msvc -emit-ir -parse-as-library -parse-stdlib -module-name dependent -autolink-library oldnames -autolink-library msvcrt %s -o - | %FileCheck %s
+// RUN: %swift -target i686-unknown-windows-msvc -emit-ir -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name dependent -autolink-library oldnames -autolink-library msvcrt %s -o - | %FileCheck %s
 
 // CHECK: !llvm.linker.options = !{![[oldnames:[0-9]+]], ![[msvcrtd:[0-9]+]]}
 // CHECK: ![[oldnames]] = !{!"/DEFAULTLIB:oldnames.lib"}

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -parse-stdlib -module-name dllexport %s -o - | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
-// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -parse-stdlib -module-name dllexport %s -o - | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
+// RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name dllexport %s -o - | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
+// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name dllexport %s -o - | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
 
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -parse-stdlib -module-name dllimport %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
-// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -parse-stdlib -module-name dllimport -primary-file %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
+// RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name dllimport %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
+// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -disable-legacy-type-info -parse-stdlib -module-name dllimport -primary-file %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
 
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/enum_32_bit.sil
+++ b/test/IRGen/enum_32_bit.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -target i386-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
-// RUN: %swift -target armv7-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target i386-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target armv7-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/enum_top_bits_reserved.sil
+++ b/test/IRGen/enum_top_bits_reserved.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -module-name test -emit-ir -target arm64-apple-ios10.0 %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-arm64
-// RUN: %swift -module-name test -emit-ir -target x86_64-apple-macosx10.12 %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-x86_64
+// RUN: %swift -module-name test -emit-ir -disable-legacy-type-info -target arm64-apple-ios10.0 %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-arm64
+// RUN: %swift -module-name test -emit-ir -disable-legacy-type-info -target x86_64-apple-macosx10.12 %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-x86_64
 
 class NativeClass {}
 sil_vtable NativeClass {}

--- a/test/IRGen/fixed_layout_class.swift
+++ b/test/IRGen/fixed_layout_class.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/class_resilience.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/fixed_layout_class.swiftmodule -module-name=fixed_layout_class -I %t %S/../Inputs/fixed_layout_class.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience -O %t/class_resilience.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/fixed_layout_class.swiftmodule -module-name=fixed_layout_class -I %t %S/../Inputs/fixed_layout_class.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %t/class_resilience.swift
 
 // This tests @_fixed_layout classes in resilient modules.
 import fixed_layout_class

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -1,9 +1,9 @@
-// RUN: %swift -target x86_64-apple-macosx10.9 -module-name function_types %s -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target i386-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target armv7-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target arm64-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-unknown-linux-gnu -disable-objc-interop %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -module-name function_types %s -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target i386-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target armv7-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target arm64-apple-ios7.1 %s -module-name function_types -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-unknown-linux-gnu -disable-objc-interop %s -module-name function_types -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -1,17 +1,15 @@
 
-// RUN: %swift -module-name generic_metatypes -target x86_64-apple-macosx10.9  -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
-// RUN: %swift -module-name generic_metatypes -target i386-apple-ios7.0        -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
-// RUN: %swift -module-name generic_metatypes -target x86_64-apple-ios7.0      -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
-// RUN: %swift -module-name generic_metatypes -target i386-apple-tvos9.0       -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32  %s
-// RUN: %swift -module-name generic_metatypes -target x86_64-apple-tvos9.0     -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
-// RUN: %swift -module-name generic_metatypes -target i386-apple-watchos2.0    -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32  %s
-// RUN: %swift -module-name generic_metatypes -target x86_64-unknown-linux-gnu -disable-objc-interop -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-apple-macosx10.9  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target i386-apple-ios7.0        -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-apple-ios7.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-apple-tvos9.0     -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
+// RUN: %swift -module-name generic_metatypes -target i386-apple-watchos2.0    -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32  %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-unknown-linux-gnu -disable-objc-interop -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
 
-// RUN: %swift -module-name generic_metatypes -target armv7-apple-ios7.0       -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
-// RUN: %swift -module-name generic_metatypes -target arm64-apple-ios7.0       -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
-// RUN: %swift -module-name generic_metatypes -target armv7-apple-tvos9.0      -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
-// RUN: %swift -module-name generic_metatypes -target arm64-apple-tvos9.0      -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
-// RUN: %swift -module-name generic_metatypes -target armv7k-apple-watchos2.0  -emit-ir -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
+// RUN: %swift -module-name generic_metatypes -target armv7-apple-ios7.0       -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
+// RUN: %swift -module-name generic_metatypes -target arm64-apple-ios7.0       -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target arm64-apple-tvos9.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target armv7k-apple-watchos2.0  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/nominal-type-section.swift
+++ b/test/IRGen/nominal-type-section.swift
@@ -1,6 +1,6 @@
-// RUN: %swift -target x86_64-apple-macosx10.10 -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | %FileCheck %s -check-prefix CHECK-MACHO
-// RUN: %swift -target x86_64-unknown-linux-gnu -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | %FileCheck %s -check-prefix CHECK-ELF
-// RUN: %swift -target x86_64-unknown-windows-itanium -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | %FileCheck %s -check-prefix CHECK-COFF
+// RUN: %swift -target x86_64-apple-macosx10.10 -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s -module-name main -o - | %FileCheck %s -check-prefix CHECK-MACHO
+// RUN: %swift -target x86_64-unknown-linux-gnu -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s -module-name main -o - | %FileCheck %s -check-prefix CHECK-ELF
+// RUN: %swift -target x86_64-unknown-windows-itanium -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s -module-name main -o - | %FileCheck %s -check-prefix CHECK-COFF
 
 // CHECK-MACHO: @"$s4main1sVMn" = constant {{.*}}, section "__TEXT,__const"
 // CHECK-ELF: @"$s4main1sVMn" = {{.*}}constant {{.*}}, section ".rodata"

--- a/test/IRGen/ordering_aarch64.sil
+++ b/test/IRGen/ordering_aarch64.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -target arm64-apple-ios7.1 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target arm64-apple-ios7.1 %s -module-name main -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=AArch64
 

--- a/test/IRGen/ordering_x86.sil
+++ b/test/IRGen/ordering_x86.sil
@@ -1,8 +1,8 @@
-// RUN: %swift -target x86_64-apple-macosx10.9 -module-name main %s -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target i386-apple-ios7.1 %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-apple-ios7.1 %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-unknown-linux-gnu -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %swift -target x86_64-apple-macosx10.9 -module-name main %s -emit-ir -o - | %FileCheck %s --check-prefix=X86_64
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -module-name main %s -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target i386-apple-ios7.1 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-ios7.1 %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-unknown-linux-gnu -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-apple-macosx10.9 -module-name main %s -emit-ir -o - | %FileCheck %s --check-prefix=X86_64
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/swift3-metadata-coff.swift
+++ b/test/IRGen/swift3-metadata-coff.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target thumbv7--windows-itanium -parse-stdlib -parse-as-library -module-name Swift -O -emit-ir %s -o - | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target thumbv7--windows-itanium -parse-stdlib -parse-as-library -module-name Swift -O -emit-ir %s -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/trivial-property-descriptors.swift
+++ b/test/IRGen/trivial-property-descriptors.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target x86_64-unknown-windows-msvc -parse-stdlib -module-name Swift -enable-resilience -S -emit-ir -o - %s | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target x86_64-unknown-windows-msvc -parse-stdlib -module-name Swift -enable-resilience -S -emit-ir -o - %s | %FileCheck %s
 
 public struct S {}
 extension S {

--- a/test/IRGen/unexploded-calls.swift
+++ b/test/IRGen/unexploded-calls.swift
@@ -1,6 +1,6 @@
-// RUN: %swift -target thumbv7-unknown-windows-msvc -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
-// RUN: %swift -target thumbv7-unknown-linux-gnueabihf -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
-// RUN: %swift -target thumbv7-unknown-linux-gnueabi -Xcc -mfloat-abi=hard -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target thumbv7-unknown-windows-msvc -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target thumbv7-unknown-linux-gnueabihf -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
+// RUN: %swift -disable-legacy-type-info -target thumbv7-unknown-linux-gnueabi -Xcc -mfloat-abi=hard -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/vtable_symbol_linkage.swift
+++ b/test/IRGen/vtable_symbol_linkage.swift
@@ -3,8 +3,8 @@
 // RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/%target-library-name(BaseModule)
 // RUN: %target-build-swift -I %t %s -o %t/a.out -L%t -lBaseModule
 
-// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/%target-library-name(BaseModule) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience
-// RUN: %target-build-swift -I %t %s -o %t/a.out -Xfrontend -enable-class-resilience -L%t -lBaseModule
+// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/%target-library-name(BaseModule) -Xfrontend -enable-resilience
+// RUN: %target-build-swift -I %t %s -o %t/a.out -L%t -lBaseModule
 
 // Check if the program can be linked without undefined symbol errors.
 

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main %target-rpath(%t)

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,29 +1,29 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(fixed_layout_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(fixed_layout_class)) -Xfrontend -enable-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(fixed_layout_class)
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -lfixed_layout_class -o %t/main -Xfrontend -enable-class-resilience %target-rpath(%t)
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -lfixed_layout_class -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_class) %t/%target-library-name(fixed_layout_class)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct_wmo)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_struct_wmo)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class_wmo)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class_wmo)) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(resilient_class_wmo)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(fixed_layout_class_wmo)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/%target-library-name(fixed_layout_class_wmo)) -Xfrontend -enable-resilience %S/../Inputs/fixed_layout_class.swift -emit-module -emit-module-path %t/fixed_layout_class.swiftmodule -module-name fixed_layout_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/%target-library-name(fixed_layout_class_wmo)
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -lfixed_layout_class_wmo -Xfrontend -enable-class-resilience -o %t/main2 %target-rpath(%t) -module-name main
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -lfixed_layout_class_wmo -o %t/main2 %target-rpath(%t) -module-name main
 // RUN: %target-codesign %t/main2
 
 // RUN: %target-run %t/main2 %t/%target-library-name(resilient_struct_wmo) %t/%target-library-name(resilient_class_wmo) %t/%target-library-name(fixed_layout_class_wmo)

--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main %target-rpath(%t)

--- a/test/Interpreter/resilient_metadata_cycles.swift
+++ b/test/Interpreter/resilient_metadata_cycles.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main %target-rpath(%t)

--- a/test/Misc/tbi.sil
+++ b/test/Misc/tbi.sil
@@ -2,12 +2,12 @@
 // driver is properly generated -enable-aarch64-tbi and also that the frontend
 // respects this option and that we get the proper tbi behavior.
 
-// RUN: %swiftc_driver -parse-sil -target arm64-apple-ios8.0 -target-cpu cyclone \
+// RUN: %swiftc_driver -parse-sil -Xfrontend -disable-legacy-type-info -target arm64-apple-ios8.0 -target-cpu cyclone \
 // RUN:   -O -S %s -parse-as-library -parse-stdlib -module-name Swift \
 // RUN:   -Xfrontend -enable-sil-ownership | \
 // RUN:   %FileCheck --check-prefix=TBI %s
 
-// RUN: %swiftc_driver -parse-sil -target arm64-apple-ios7.0 -target-cpu cyclone \
+// RUN: %swiftc_driver -parse-sil -Xfrontend -disable-legacy-type-info -target arm64-apple-ios7.0 -target-cpu cyclone \
 // RUN:     -O -S %s -parse-as-library -parse-stdlib -module-name Swift \
 // RUN:     -Xfrontend -enable-sil-ownership | \
 // RUN:   %FileCheck --check-prefix=NO_TBI %s

--- a/test/sil-llvm-gen/alloc.sil
+++ b/test/sil-llvm-gen/alloc.sil
@@ -1,9 +1,9 @@
-// RUN: %sil-llvm-gen -output-kind=llvm-as -target x86_64-apple-macosx10.9 -module-name main %s -o - | %FileCheck %s
-// RUN: %sil-llvm-gen -output-kind=llvm-as -target i386-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
-// RUN: %sil-llvm-gen -output-kind=llvm-as -target x86_64-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
-// RUN: %sil-llvm-gen -output-kind=llvm-as -target armv7-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
-// RUN: %sil-llvm-gen -output-kind=llvm-as -target arm64-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
-// RUN: %sil-llvm-gen -output-kind=llvm-as -target x86_64-unknown-linux-gnu %s -module-name main -o - | %FileCheck %s
+// RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target x86_64-apple-macosx10.9 -module-name main %s -o - | %FileCheck %s
+// RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target i386-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
+// RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target x86_64-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
+// RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target armv7-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
+// RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target arm64-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
+// RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target x86_64-unknown-linux-gnu %s -module-name main -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -100,6 +100,10 @@ static llvm::cl::opt<IRGenOutputKind>
                                            "object", "Emit an object file")),
                llvm::cl::init(IRGenOutputKind::ObjectFile));
 
+static llvm::cl::opt<bool>
+    DisableLegacyTypeInfo("disable-legacy-type-info",
+        llvm::cl::desc("Don't try to load backward deployment layouts"));
+
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
 // getMainExecutable (since some platforms don't support taking the
@@ -155,6 +159,7 @@ int main(int argc, char **argv) {
   // Setup the IRGen Options.
   IRGenOptions &Opts = Invocation.getIRGenOptions();
   Opts.OutputKind = OutputKind;
+  Opts.DisableLegacyTypeInfo = DisableLegacyTypeInfo;
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =

--- a/utils/rth
+++ b/utils/rth
@@ -83,7 +83,6 @@ class ResilienceTest(object):
             compiler_flags = ['-emit-library', '-emit-module',
                               '-swift-version', '4',
                               '-Xfrontend', '-enable-resilience',
-                              '-Xfrontend', '-enable-class-resilience',
                               '-D', config,
                               self.lib_src,
                               '-o', output_dylib]
@@ -146,7 +145,6 @@ class ResilienceTest(object):
 
             output_obj = os.path.join(self.config_dir_map[config], 'main.o')
             compiler_flags = ['-D', config, '-c', self.test_src,
-                              '-Xfrontend', '-enable-class-resilience',
                               '-I', self.config_dir_map[config],
                               '-o', output_obj]
             command = self.target_build_swift + \

--- a/validation-test/Runtime/Inputs/class-layout-from-objc/big.yaml
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/big.yaml
@@ -1,0 +1,8 @@
+---
+Name:            Resilient
+Decls:           
+  - Name:            9Resilient12GrowsToInt64V
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0
+...

--- a/validation-test/Runtime/Inputs/class-layout-from-objc/small.yaml
+++ b/validation-test/Runtime/Inputs/class-layout-from-objc/small.yaml
@@ -1,0 +1,8 @@
+---
+Name:            Resilient
+Decls:           
+  - Name:            9Resilient12GrowsToInt64V
+    Size:            4
+    Alignment:       4
+    ExtraInhabitants: 0
+...

--- a/validation-test/Runtime/class-layout-from-objc.m
+++ b/validation-test/Runtime/class-layout-from-objc.m
@@ -5,7 +5,7 @@
 // RUN: %target-build-swift -emit-library -emit-module -o %t/libResilient.dylib %S/Inputs/class-layout-from-objc/Resilient.swift -Xlinker -install_name -Xlinker @executable_path/libResilient.dylib -Xfrontend -enable-resilience -DSMALL
 
 // RUN: %target-clang -c %S/Inputs/class-layout-from-objc/OneWordSuperclass.m -fmodules -fobjc-arc -o %t/OneWordSuperclass.o
-// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %t -I %S/Inputs/class-layout-from-objc/ %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t
+// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %t -I %S/Inputs/class-layout-from-objc/ %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t -Xfrontend -read-legacy-type-info-path=%S/Inputs/class-layout-from-objc/small.yaml
 // RUN: %target-clang %s -I %S/Inputs/class-layout-from-objc/ -I %t -fmodules -fobjc-arc -o %t/main -lResilient -lClasses -L %t
 // RUN: %target-codesign %t/main %t/libResilient.dylib %t/libClasses.dylib
 // RUN: %target-run %t/main OLD %t/libResilient.dylib %t/libClasses.dylib
@@ -15,7 +15,7 @@
 // RUN: %target-run %t/main NEW %t/libResilient.dylib %t/libClasses.dylib
 
 // Try again when the class itself is also resilient.
-// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %S/Inputs/class-layout-from-objc/ -I %t %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t
+// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %S/Inputs/class-layout-from-objc/ -I %t %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t -Xfrontend -read-legacy-type-info-path=%S/Inputs/class-layout-from-objc/big.yaml
 // RUN: %target-codesign %t/libClasses.dylib
 // RUN: %target-run %t/main OLD %t/libResilient.dylib %t/libClasses.dylib
 


### PR DESCRIPTION
The layouts of resilient value types shipped in the Swift 5 standard library and overlays will forever be frozen in time for backward deployment to old Objective-C runtimes. This PR ensures that even if the layouts of these types evolve in the future, binaries built to run on the old runtime will continue to lay out class instances in a manner compatible with Swift 5.

Fixes <rdar://problem/45646886>.