### PR TITLE
[IDE] Fix sourcerange for assoc types with default values

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3383,9 +3383,11 @@ TypeLoc &AssociatedTypeDecl::getDefaultDefinitionLoc() {
 
 SourceRange AssociatedTypeDecl::getSourceRange() const {
   SourceLoc endLoc;
-  if (auto TWC = getTrailingWhereClause())
+  if (auto TWC = getTrailingWhereClause()) {
     endLoc = TWC->getSourceRange().End;
-  else if (!getInherited().empty()) {
+  } else if (getDefaultDefinitionLoc().hasLocation()) {
+    endLoc = getDefaultDefinitionLoc().getSourceRange().End;
+  } else if (!getInherited().empty()) {
     endLoc = getInherited().back().getSourceRange().End;
   } else {
     endLoc = getNameLoc();

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -245,6 +245,12 @@ protocol FooProtocol {
   // CHECK:  <associatedtype>associatedtype <name>Baz</name>: Equatable</associatedtype>
   associatedtype Qux where Qux: Equatable
   // CHECK:  <associatedtype>associatedtype <name>Qux</name> where Qux: Equatable</associatedtype>
+  associatedtype Bar2 = Int
+  // CHECK:  <associatedtype>associatedtype <name>Bar2</name> = Int</associatedtype>
+  associatedtype Baz2: Equatable = Int
+  // CHECK:  <associatedtype>associatedtype <name>Baz2</name>: Equatable = Int</associatedtype>
+  associatedtype Qux2 = Int where Qux2: Equatable
+  // CHECK:  <associatedtype>associatedtype <name>Qux2</name> = Int where Qux2: Equatable</associatedtype>
 }
 
 // CHECK: <struct>struct <name>Generic</name><<generic-param><name>T</name>: <inherited><elem-typeref>Comparable</elem-typeref></inherited></generic-param>, <generic-param><name>X</name></generic-param>> {


### PR DESCRIPTION
This fixes the `SourceRange` for associated types to include any default value, adds tests.

This makes eg. the offset/length from SourceKit structure more accurate.

@rintaro could you take a look please?