### PR TITLE
Update WindowsBuild.md

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -106,15 +106,15 @@ Warning: Creating the above links usually requires adminstrator privileges. The 
 - This must be done from within a developer command prompt. CMark is a fairly
   small project and should only take a few minutes to build.
 ```cmd
-mkdir "S:\build\Ninja-RelWithDebInfoAssert\cmark-windows-amd64"
-pushd "S:\build\Ninja-RelWithDebInfoAssert\cmark-windows-amd64"
+mkdir "S:\b\cmark"
+pushd "S:\b\cmark"
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DCMAKE_C_COMPILER=cl^
   -DCMAKE_CXX_COMPILER=cl^
   S:/cmark
 popd
-cmake --build "S:\build\Ninja-RelWithDebInfoAssert\cmark-windows-amd64"
+cmake --build "S:\b\cmark"
 ```
 
 ### 6. Build LLVM/Clang
@@ -123,8 +123,8 @@ cmake --build "S:\build\Ninja-RelWithDebInfoAssert\cmark-windows-amd64"
   type (e.g. `Debug`, `Release`, `RelWithDebInfoAssert`) for LLVM/Clang matches the
   build type for Swift.
 ```cmd
-mkdir "S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64"
-pushd "S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64"
+mkdir "S:\b\llvm"
+pushd "S:\b\llvm"
 cmake -G Ninja^
  -DCMAKE_BUILD_TYPE=Release^
  -DCMAKE_C_COMPILER=cl^
@@ -136,13 +136,13 @@ cmake -G Ninja^
  -DLLVM_TARGETS_TO_BUILD=X86^
  S:/llvm
 popd
-cmake --build "S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64"
+cmake --build "S:\b\llvm"
 ```
 
 - Update your path to include the LLVM tools.
 
 ```cmd
-PATH S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64\bin;%PATH%
+PATH S:\b\llvm\bin;%PATH%
 ```
 
 ### 7. Build Swift
@@ -151,8 +151,8 @@ PATH S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64\bin;%PATH%
 - You may need to adjust the `SWIFT_WINDOWS_LIB_DIRECTORY` parameter depending on
   your target platform or Windows SDK version.
 ```cmd
-mkdir "S:\build\Ninja-RelWithDebInfoAssert\swift-windows-amd64"
-pushd "S:\build\Ninja-RelWithDebInfoAssert\swift-windows-amd64"
+mkdir "S:\b\swift"
+pushd "S:\b\swift"
 cmake -G Ninja^
  -DCMAKE_BUILD_TYPE=RelWithDebInfo^
  -DCMAKE_C_COMPILER=clang-cl^
@@ -162,20 +162,20 @@ cmake -G Ninja^
  -DCMAKE_SHARED_LINKER_FLAGS:STRING="/INCREMENTAL:NO"^
  -DSWIFT_INCLUDE_DOCS=OFF^
  -DSWIFT_PATH_TO_CMARK_SOURCE="S:\cmark"^
- -DSWIFT_PATH_TO_CMARK_BUILD="S:\build\Ninja-RelWithDebInfoAssert\cmark-windows-amd64"^
+ -DSWIFT_PATH_TO_CMARK_BUILD="S:\b\cmark"^
  -DSWIFT_PATH_TO_LLVM_SOURCE="S:\llvm"^
- -DSWIFT_PATH_TO_LLVM_BUILD="S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64"^
+ -DSWIFT_PATH_TO_LLVM_BUILD="S:\b\llvm"^
  -DSWIFT_PATH_TO_CLANG_SOURCE="S:\clang"^
- -DSWIFT_PATH_TO_CLANG_BUILD="S:\build\Ninja-RelWithDebInfoAssert\llvm-windows-amd64"^
+ -DSWIFT_PATH_TO_CLANG_BUILD="S:\b\llvm"^
  -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="S:\swift-corelibs-libdispatch"^
- -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE="S:\icu\include"^
- -DSWIFT_WINDOWS_x86_64_ICU_UC="S:\icu\lib64\icuuc.lib"^
- -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE="S:\icu\include"^
- -DSWIFT_WINDOWS_x86_64_ICU_I18N="S:\icu\lib64\icuin.lib"^
+ -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE="S:/thirdparty/icu4c-63_1-Win64-MSVC2017/include"^
+ -DSWIFT_WINDOWS_x86_64_ICU_UC="S:/thirdparty/icu4c-63_1-Win64-MSVC2017/lib64/icuuc.lib"^
+ -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE="S:/thirdparty/icu4c-63_1-Win64-MSVC2017/include"^
+ -DSWIFT_WINDOWS_x86_64_ICU_I18N="S:/thirdparty/icu4c-63_1-Win64-MSVC2017/lib64/icuin.lib"^
  -DCMAKE_INSTALL_PREFIX="C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr"^
- S:/swift
+ S:\swift
 popd
-cmake --build "S:\build\Ninja-RelWithDebInfoAssert\swift-windows-amd64"
+cmake --build "S:\b\swift"
 ```
 
 - To create a Visual Studio project, you'll need to change the generator and,
@@ -193,23 +193,23 @@ cmake -G "Visual Studio 2017" -A x64 -T "host=x64"^ ...
 - This must be done from within a developer command prompt and could take hours
   depending on your system.
 ```cmd
-mkdir "S:/build/Ninja-RelWithDebInfoAssert/lldb-windows-amd64"
-pushd "S:/build/Ninja-RelWithDebInfoAssert/lldb-windows-amd64"
+mkdir "S:\b\lldb"
+pushd "S:\b\lldb"
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DLLDB_ALLOW_STATIC_BINDINGS=YES^
-  -DLLDB_PATH_TO_LLVM_SOURCE="S:/llvm"^
-  -DLLDB_PATH_TO_CLANG_SOURCE="S:/clang"^
-  -DLLDB_PATH_TO_SWIFT_SOURCE="S:/swift"^
-  -DLLDB_PATH_TO_CMARK_BUILD="S:/build/Ninja-RelWithDebInfoAssert/cmark-windows-amd64"^
-  -DLLDB_PATH_TO_CLANG_BUILD="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64"^
-  -DLLDB_PATH_TO_LLVM_BUILD="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64"^
-  -DLLDB_PATH_TO_SWIFT_BUILD="S:/build/Ninja-RelWithDebInfoAssert/swift-windows-amd64"^
+  -DLLDB_PATH_TO_LLVM_SOURCE="S:\llvm"^
+  -DLLDB_PATH_TO_CLANG_SOURCE="S:\clang"^
+  -DLLDB_PATH_TO_SWIFT_SOURCE="S:\swift"^
+  -DLLDB_PATH_TO_CMARK_BUILD="S:\b\cmark"^
+  -DLLDB_PATH_TO_CLANG_BUILD="S:\b\llvm"^
+  -DLLDB_PATH_TO_LLVM_BUILD="S:\b\llvm"^
+  -DLLDB_PATH_TO_SWIFT_BUILD="S:\b\swift"^
   -DLLVM_ENABLE_ASSERTIONS=ON^
   -DPYTHON_HOME=%ProgramFiles(x86)%\Microsoft Visual Studio\Shared\Python37_64^
-  S:/lldb
+  S:\lldb
 popd
-cmake --build "S:/build/Ninja-RelWithDebInfoAssert/lldb-windows-amd64"
+cmake --build S:\b\lldb
 ```
 
 ### 9. Running tests on Windows
@@ -223,26 +223,26 @@ Running the testsuite on Windows has additional external dependencies.  You must
   5. sed
   
 ```cmd
-set PATH=S:\build\Ninja-RelWithDebInfoAssert\swift-windows-amd64\bin;S:\build\Ninja-RelWithDebInfoAssert\swift-windows-amd64\libdispatch-prefix\bin;%PATH%;C:\Program Files (x86)\GnuWin32\bin
-ninja -C "S:/build/Ninja-RelWithDebInfoAssert/swift-windows-amd64" check-swift
+path S:\b\swift\bin;S:\b\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles(x86)%\GnuWin32\bin
+ninja -C S:\b\swift check-swift
 ```
 
 ### 10. Build swift-corelibs-libdispatch
 
 ```cmd
-mkdir "S:/build/Ninja-RelWithDebInfoAssert/swift-corelibs-libdispatch-windows-amd64"
-pushd "S:/build/Ninja-RelWithDebInfoAssert/swift-corelibs-libdispatch-windows-amd64"
+mkdir "S:\b\libdispatch"
+pushd "S:\b\libdispatch"
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
-  -DCMAKE_C_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64/bin/clang-cl.exe"^
-  -DCMAKE_CXX_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64/bin/clang-cl.exe"^
-  -DCMAKE_SWIFT_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/swift-windows-amd64/bin/swiftc.exe"^
-  -DSwift_DIR="S:/build/Ninja-RelWithDebInfoAssert/swift-windows-amd64/lib/cmake/swift"^
+  -DCMAKE_C_COMPILER=clang-cl^
+  -DCMAKE_CXX_COMPILER=clang-cl^
+  -DCMAKE_SWIFT_COMPILER=S:\b\swift\bin\swiftc.exe^
+  -DSwift_DIR=S:\b\swift\lib\cmake\swift^
   -DENABLE_SWIFT=ON^
   -DENABLE_TESTING=OFF^
-  S:/swift-corelibs-libdispatch
+  S:\swift-corelibs-libdispatch
 popd
-cmake --build
+cmake --build S:\b\libdispatch
 ```
 
 ### 11. Build swift-corelibs-foundation
@@ -253,21 +253,21 @@ To build Foundation you will need builds of:
 - `libcurl` (https://curl.haxx.se, download the source, `cd` into `winbuild`, and run `nmake /f Makefile.vc mode=static VC=15 MACHINE=x64`)
 
 ```cmd
-mkdir "S:/build/Ninja-RelWithDebInfoAsset/swift-corelibs-foundation-windows-amd64"
-pushd "S:/build/Ninja-RelWithDebInfoAssert/swift-corelibs-foundation-windows-amd64"
+mkdir "S:\b\foundation"
+pushd "S:\b\foundation
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
-  -DCMAKE_C_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64/bin/clang-cl.exe"^
-  -DCMAKE_SWIFT_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/swift-windows-amd64/bin/swiftc.exe"^
+  -DCMAKE_C_COMPILER=clang-cl^
+  -DCMAKE_SWIFT_COMPILER=S:\b\swift\bin\swiftc.exe^
   -DCURL_LIBRARY="S:/curl/builds/libcurl-vc15-x64-release-static-ipv6-sspi-winssl/lib/libcurl_a.lib"^
   -DCURL_INCLUDE_DIR="S:/curl/builds/libcurl-vc15-x64-release-static-ipv6-sspi-winssl/include"^
   -DICU_ROOT="S:/thirdparty/icu4c-63_1-Win64-MSVC2017"^
   -DLIBXML2_LIBRARY="S:/libxml2/win32/bin.msvc/libxml2_a.lib"^
   -DLIBXML2_INCLUDE_DIR="S:/libxml2/include"^
-  -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE="S:/swift-corelibs-libdispatch"^
-  -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD="S:/build/Ninja-RelWithDebInfoAssert/swift-corelibs-libdispatch-windows-amd64"^
-   S:/swift-corelibs-foundation
- cmake --build "S:/build/Ninja-RelWithDebInfoAssert/swift-corelibs-foundation-windows-amd64"
+  -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=S:\swift-corelibs-libdispatch^
+  -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=S:\b\libdispatch^
+   S:\swift-corelibs-foundation
+ cmake --build S:\b\foundation
 
 ```
 
@@ -276,7 +276,7 @@ cmake -G Ninja^
 - Run ninja install:
 
 ```cmd 
-ninja -C "S:/build/Ninja-RelWithDebInfoAssert/swift-windows-amd64" install
+ninja -C S:\b\swift install
 ```
 
 - Add the Swift on Windows binaries path (`C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin`)  to the `PATH` environment variable.


### PR DESCRIPTION
Add a workaround to try to reduce the path lengths a bit since it is unlikely that LLVM will accept changes to improve `lit` to support long paths on Windows.  There is strong opposition to improvements there from @rui314 and @nico at https://reviews.llvm.org/D57533 .

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
