### PR TITLE
[tests] Standarize the checks for Darwin, Glibc and MSVCRT.

### DIFF
--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -1,12 +1,14 @@
 // RUN: %target-typecheck-verify-swift
 // UNSUPPORTED: OS=windows-msvc
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
   typealias JumpBuffer = Int32
-#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
   typealias JumpBuffer = jmp_buf
+#else
+#error("Unsupported platform")
 #endif
 
 func test_unavailable_returns_twice_function() {

--- a/test/ClangImporter/clang_builtins.swift
+++ b/test/ClangImporter/clang_builtins.swift
@@ -1,11 +1,13 @@
 // RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-runtime %s
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 func test() {

--- a/test/Fuzzing/fuzzer_test.swift
+++ b/test/Fuzzing/fuzzer_test.swift
@@ -8,10 +8,14 @@
 // XFAIL: OS=watchos
 // CHECK: Crash!
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 @_cdecl("LLVMFuzzerTestOneInput") public func fuzzOneInput(Data: UnsafePointer<CChar>, Size: CLong) -> CInt {

--- a/test/Fuzzing/fuzzer_test_simpler.swift
+++ b/test/Fuzzing/fuzzer_test_simpler.swift
@@ -8,10 +8,14 @@
 // XFAIL: OS=tvos
 // XFAIL: OS=watchos
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 @_cdecl("LLVMFuzzerTestOneInput") public func fuzzOneInput(Data: UnsafePointer<CChar>, Size: CLong) -> CInt {

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,11 +1,13 @@
 // RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-os
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-import Darwin
-#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
-import MSVCRT
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 // Make sure we use an intrinsic for functions such as exp.

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -8,12 +8,14 @@
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
 // RUN: %target-swift-frontend -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-import Darwin
-#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
-import MSVCRT
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 // FIXME: We should have a reliable way of triggering an indirect call in the

--- a/test/Interpreter/SDK/libc.swift
+++ b/test/Interpreter/SDK/libc.swift
@@ -9,12 +9,14 @@
 // TODO: rdar://problem/33388782
 // REQUIRES: CPU=x86_64
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 let sourcePath = CommandLine.arguments[1]

--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -53,13 +53,15 @@ import Module1
 
 import StdlibUnittest
 
-#if os(Linux)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
   import WinSDK
 #else
-  import Darwin
+#error("Unsupported platform")
 #endif
 
 var DynamicallyReplaceable = TestSuite("DynamicallyReplaceable")

--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -22,13 +22,15 @@ import A
 
 import StdlibUnittest
 
-#if os(Linux)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
   import WinSDK
 #else
-  import Darwin
+#error("Unsupported platform")
 #endif
 
 var DynamicallyReplaceable = TestSuite("DynamicallyReplaceableChaining")

--- a/test/Interpreter/dynamic_replacement_dlclose.swift
+++ b/test/Interpreter/dynamic_replacement_dlclose.swift
@@ -9,13 +9,15 @@ import Module1
 
 import StdlibUnittest
 
-#if os(Linux)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
   import WinSDK
 #else
-  import Darwin
+#error("Unsupported platform")
 #endif
 
 var DynamicallyReplaceable = TestSuite("DynamicallyReplaceable")

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -17,12 +17,14 @@
 // REQUIRES: CPU=x86_64
 
 import StdlibUnittest
-#if os(Windows)
-import MSVCRT
-#elseif os(Linux) || os(Android)
-import Glibc
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-import Darwin
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 extension FixedWidthInteger {

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -10,10 +10,14 @@
 // don't support TSan.
 // UNSUPPORTED: remote_run
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 // Make sure we can handle swifterror and don't bail during the LLVM

--- a/test/stdlib/FloatConstants.swift
+++ b/test/stdlib/FloatConstants.swift
@@ -1,11 +1,13 @@
 // RUN: %target-typecheck-verify-swift
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
-import MSVCRT
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 _ = FLT_RADIX // expected-warning {{is deprecated}}

--- a/test/stdlib/MathConstants.swift
+++ b/test/stdlib/MathConstants.swift
@@ -1,11 +1,13 @@
 // RUN: %target-typecheck-verify-swift
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
-import MSVCRT
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 _ = M_PI // expected-warning {{is deprecated}}

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -3,10 +3,12 @@
 // UNSUPPORTED: OS=windows-msvc
 
 import StdlibUnittest
-#if os(Linux) || os(Android)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #else
-  import Darwin
+#error("Unsupported platform")
 #endif
 
 chdir(CommandLine.arguments[1])

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -7,12 +7,14 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-  import Glibc
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
   import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 // It takes about an hour to run the Float formatter over all 2 billion

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -10,13 +10,15 @@ import Swift
 import StdlibUnittest
 import SwiftShims
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
-import MSVCRT
-import WinSDK
+  import MSVCRT
+  import WinSDK
+#else
+#error("Unsupported platform")
 #endif
 
 @_silgen_name("swift_demangle")

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -4,18 +4,20 @@
 import Swift
 
 #if _runtime(_ObjC)
-import Darwin
-import CoreGraphics
-#elseif os(Linux) || os(FreeBSD) || os(Android) || os(Haiku) || os(PS4)
-import Glibc
-typealias CGFloat = Double
+  import Darwin
+  import CoreGraphics
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+  typealias CGFloat = Double
 #elseif os(Windows)
-import MSVCRT
-#if arch(x86_64) || arch(arm64)
-typealias CGFloat = Double
+  import MSVCRT
+  #if arch(x86_64) || arch(arm64)
+    typealias CGFloat = Double
+  #else
+    typealias CGFloat = Float
+  #endif
 #else
-typealias CGFloat = Float
-#endif
+#error("Unsupported platform")
 #endif
 
 func my_printf(_ format: String, _ arguments: CVarArg...) {

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -3,10 +3,12 @@
 // UNSUPPORTED: OS=windows-msvc
 
 import StdlibUnittest
-#if os(Linux) || os(Android)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #else
-  import Darwin
+#error("Unsupported platform")
 #endif
 
 var MMapTests = TestSuite("MMaptests")

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -17,12 +17,14 @@
 // RUN: %line-directive %t/tgmath.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin.C.tgmath
-#elseif os(Linux) || os(android) || os(FreeBSD) || os(Haiku) || os(PS4)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 #if (arch(i386) || arch(x86_64)) && !os(Windows)

--- a/test/stdlib/tgmath_optimized.swift
+++ b/test/stdlib/tgmath_optimized.swift
@@ -4,12 +4,14 @@
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-  import Glibc
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #elseif os(Windows)
   import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 import StdlibUnittest
 

--- a/validation-test/StdlibUnittest/AtomicInt.swift
+++ b/validation-test/StdlibUnittest/AtomicInt.swift
@@ -9,10 +9,14 @@
 import SwiftPrivate
 import StdlibUnittest
 
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 final class HeapBool {

--- a/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildCrashesDuringShutdown.swift
+++ b/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildCrashesDuringShutdown.swift
@@ -4,10 +4,14 @@
 // UNSUPPORTED: OS=watchos
 
 import StdlibUnittest
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Windows)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
 #else
-import Darwin
+#error("Unsupported platform")
 #endif
 
 _setTestSuiteFailedCallback() { print("abort()") }

--- a/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildExitsDuringShutdown.swift
+++ b/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildExitsDuringShutdown.swift
@@ -2,10 +2,14 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Windows)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
 #else
-import Darwin
+#error("Unsupported platform")
 #endif
 
 _setTestSuiteFailedCallback() { print("abort()") }

--- a/validation-test/StdlibUnittest/ChildProcessShutdown/PassIfChildCrashedDuringTestExecution.swift
+++ b/validation-test/StdlibUnittest/ChildProcessShutdown/PassIfChildCrashedDuringTestExecution.swift
@@ -2,10 +2,14 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Windows)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
 #else
-import Darwin
+#error("Unsupported platform")
 #endif
 
 //

--- a/validation-test/StdlibUnittest/RaceTest.swift
+++ b/validation-test/StdlibUnittest/RaceTest.swift
@@ -5,10 +5,14 @@
 
 import SwiftPrivate
 import StdlibUnittest
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 

--- a/validation-test/StdlibUnittest/Stdin.swift
+++ b/validation-test/StdlibUnittest/Stdin.swift
@@ -4,10 +4,14 @@
 import StdlibUnittest
 
 
-#if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
-import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Windows)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 func simple_getline() -> [UInt8]? {

--- a/validation-test/stdlib/POSIXErrorCode.swift
+++ b/validation-test/stdlib/POSIXErrorCode.swift
@@ -11,10 +11,12 @@
 import Swift
 import StdlibUnittest
 
-#if os(Linux) || os(Android)
-  import Glibc
-#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#else
+#error("Unsupported platform")
 #endif
 
 var POSIXErrorCodeTestSuite = TestSuite("POSIXErrorCode")

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1201,8 +1201,8 @@ StringTests.test("Conversions") {
 }
 
 
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-import Glibc
+#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
 #endif
 
 StringTests.test("lowercased()") {

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -4,10 +4,14 @@
 
 import StdlibUnittest
 import SwiftPrivateThreadExtras
-#if os(OSX) || os(iOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
 #endif
 
 


### PR DESCRIPTION
Different tests used different os checks for importing Darwin, Glibc and
MSVCRT. This commit use the same pattern for importing those libraries,
in order to avoid the #else branches of the incorrect patterns to be
applied to the wrong platform. This was very normal for Android, which
normally should follow the Linux branches, but sometimes was trying to
import Darwin or not importing anything.

The standarized pattern imports Darwin for macOS, iOS, tvOS and watchOS.
It imports Glibc for Linux, FreeBSD, PS4, Android, Cygwin and Haiku; and
imports MSVCRT for Windows. If a new platform is introduced, the else
branch will report an error, so the new platform can be added to one of
the branches (or maybe add a new specific branch).

In some cases  the standard pattern was modified because some test required
it (importing extra modules, or extra type aliases), and in some other
cases some branches were removed because the test will not have used
them (but it is not exhaustive, so there might be some unnecessary
branches).

This should, at least, fix three tests for Android (the three
dynamic_replacement*.swift ones).

/cc @compnerd 