### PR TITLE
[String] Fix crash when given null UBP

### DIFF
--- a/stdlib/public/core/ContiguouslyStored.swift
+++ b/stdlib/public/core/ContiguouslyStored.swift
@@ -42,7 +42,7 @@ extension UnsafeBufferPointer: _HasContiguousBytes {
   func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    let ptr = UnsafeRawPointer(self.baseAddress._unsafelyUnwrappedUnchecked)
+    let ptr = UnsafeRawPointer(self.baseAddress)
     let len = self.count &* MemoryLayout<Element>.stride
     return try body(UnsafeRawBufferPointer(start: ptr, count: len))
   }
@@ -52,7 +52,7 @@ extension UnsafeMutableBufferPointer: _HasContiguousBytes {
   func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    let ptr = UnsafeRawPointer(self.baseAddress._unsafelyUnwrappedUnchecked)
+    let ptr = UnsafeRawPointer(self.baseAddress)
     let len = self.count &* MemoryLayout<Element>.stride
     return try body(UnsafeRawBufferPointer(start: ptr, count: len))
   }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -261,6 +261,11 @@ extension _SmallString {
   // Direct from UTF-8
   @inlinable @inline(__always)
   internal init?(_ input: UnsafeBufferPointer<UInt8>) {
+    if input.isEmpty {
+      self.init()
+      return
+    }
+
     let count = input.count
     guard count <= _SmallString.capacity else { return nil }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -406,10 +406,9 @@ extension String {
        contigBytes._providesContiguousBytesNoCopy
     {
       self = contigBytes.withUnsafeBytes { rawBufPtr in
-        let ptr = rawBufPtr.baseAddress._unsafelyUnwrappedUnchecked
         return String._fromUTF8Repairing(
           UnsafeBufferPointer(
-            start: ptr.assumingMemoryBound(to: UInt8.self),
+            start: rawBufPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
             count: rawBufPtr.count)).0
       }
       return
@@ -837,7 +836,7 @@ extension String {
     }
     return codeUnits
   }
-  
+
   public // @testable
   func _withNFCCodeUnits(_ f: (UInt8) throws -> Void) rethrows {
     try _gutsSlice._withNFCCodeUnits(f)

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 internal func _allASCII(_ input: UnsafeBufferPointer<UInt8>) -> Bool {
+  if input.isEmpty { return true }
+
   // NOTE: Avoiding for-in syntax to avoid bounds checks
   //
   // TODO(String performance): SIMD-ize
@@ -146,9 +148,8 @@ extension String {
     _ body: (UnsafeBufferPointer<UTF8.CodeUnit>) throws -> R
   ) rethrows -> R {
     return try self.withUnsafeBytes { rawBufPtr in
-      let rawPtr = rawBufPtr.baseAddress._unsafelyUnwrappedUnchecked
       return try body(UnsafeBufferPointer(
-        start: rawPtr.assumingMemoryBound(to: UInt8.self),
+        start: rawBufPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
         count: rawBufPtr.count))
     }
   }

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+defer { runAllTests() }
+
+var StringCreateTests = TestSuite("StringCreateTests")
+
+enum SimpleString: String {
+  case smallASCII = "abcdefg"
+  case smallUnicode = "abéÏ𓀀"
+  case largeASCII = "012345678901234567890"
+  case largeUnicode = "abéÏ012345678901234567890𓀀"
+  case emoji = "😀😃🤢🤮👩🏿‍🎤🧛🏻‍♂️🧛🏻‍♂️👩‍👩‍👦‍👦"
+}
+
+let simpleStrings: [String] = [
+    SimpleString.smallASCII.rawValue,
+    SimpleString.smallUnicode.rawValue,
+    SimpleString.largeASCII.rawValue,
+    SimpleString.largeUnicode.rawValue,
+    SimpleString.emoji.rawValue,
+    "",
+]
+
+extension String {
+  var utf32: [UInt32] { return unicodeScalars.map { $0.value } }
+}
+
+StringCreateTests.test("String(decoding:as)") {
+  func validateDecodingAs(_ str: String) {
+    // Non-contiguous (maybe) storage
+    expectEqual(str, String(decoding: str.utf8, as: UTF8.self))
+    expectEqual(str, String(decoding: str.utf16, as: UTF16.self))
+    expectEqual(str, String(decoding: str.utf32, as: UTF32.self))
+
+    // Contiguous storage
+    expectEqual(str, String(decoding: Array(str.utf8), as: UTF8.self))
+    expectEqual(str, String(decoding: Array(str.utf16), as: UTF16.self))
+    expectEqual(str, String(decoding: Array(str.utf32), as: UTF32.self))
+
+  }
+
+  for str in simpleStrings {
+    validateDecodingAs(str)
+  }
+
+  // Corner-case: UBP with null pointer (https://bugs.swift.org/browse/SR-9869)
+  expectEqual(
+    "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF8.self))
+  expectEqual(
+    "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF16.self))
+  expectEqual(
+    "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF32.self))
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9869](https://bugs.swift.org/browse/SR-9869).

rdar://problem/47864610

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->