### PR TITLE
Reflection: Fix definition of swift_layout_kind to line up with Swift 4.2 [5.0]

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -108,9 +108,9 @@ typedef enum swift_layout_kind {
 
   // References to other objects in the heap.
   SWIFT_STRONG_REFERENCE,
-#define REF_STORAGE(Name, name, NAME) \
-  SWIFT_##NAME##_REFERENCE,
-#include "swift/AST/ReferenceStorage.def"
+  SWIFT_UNOWNED_REFERENCE,
+  SWIFT_WEAK_REFERENCE,
+  SWIFT_UNMANAGED_REFERENCE,
 
   // Layouts of heap objects. These are only ever returned from
   // swift_reflection_infoFor{Instance,Metadata}(), and not


### PR DESCRIPTION
Internally we have some code that dlopen()s different versions of the
reflection library, so the constants must match across supported
versions.

Fixes <rdar://problem/46830173>.