### PR TITLE
test: correct a couple of tests for Windows

### DIFF
--- a/test/IRGen/empty_enum.swift
+++ b/test/IRGen/empty_enum.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 
 // CHECK: @"$s10empty_enum6JamaisOMf" =
-//   CHECK-SAME: @"$sytWV"
+//   CHECK-SAME: {{@"\$sytWV"|i8\*\* getelementptr inbounds \(%swift.enum_vwtable, %swift.enum_vwtable\* @"\$s10empty_enum6JamaisOWV", i32 0, i32 0\)}}
 
 enum Jamais {}

--- a/test/multifile/nested_types.swift
+++ b/test/multifile/nested_types.swift
@@ -2,10 +2,10 @@
 
 // Make sure we generate the outer metadata.
 
-// CHECK-DAG: @"$s4test5OuterVMf" = internal constant {{.*}} @"$sytWV"{{.*}}@"$s4test5OuterVMn"
-// CHECK-DAG: @"$s4test6Outer2VMf" = internal constant {{.*}} @"$sytWV"{{.*}}@"$s4test6Outer2VMn"
-// CHECK-DAG: @"$s4test6Outer3VMf" = internal constant {{.*}} @"$sytWV"{{.*}}@"$s4test6Outer3VMn"
-// CHECK-DAG: @"$s4test6Outer4VMf" = internal constant {{.*}} @"$sytWV"{{.*}}@"$s4test6Outer4VMn"
+// CHECK-DAG: @"$s4test5OuterVMf" = internal constant {{.*}} {{@"\$sytWV"|i8\*\* getelementptr inbounds \(%swift.vwtable, %swift.vwtable\* @"\$s4test5OuterVWV", i32 0, i32 0\)}}, {{.*}} @"$s4test5OuterVMn"
+// CHECK-DAG: @"$s4test6Outer2VMf" = internal constant {{.*}} {{@"\$sytWV"|i8\*\* getelementptr inbounds \(%swift.vwtable, %swift.vwtable\* @"\$s4test6Outer2VWV", i32 0, i32 0\)}}, {{.*}} @"$s4test6Outer2VMn"
+// CHECK-DAG: @"$s4test6Outer3VMf" = internal constant {{.*}} {{@"\$sytWV"|i8\*\* getelementptr inbounds \(%swift.vwtable, %swift.vwtable\* @"\$s4test6Outer3VWV", i32 0, i32 0\)}}, {{.*}} @"$s4test6Outer3VMn"
+// CHECK-DAG: @"$s4test6Outer4VMf" = internal constant {{.*}} {{@"\$sytWV"|i8\*\* getelementptr inbounds \(%swift.vwtable, %swift.vwtable\* @"\$s4test6Outer4VWV", i32 0, i32 0\)}}, {{.*}} @"$s4test6Outer4VMn"
 
 class C<T> { }
 


### PR DESCRIPTION
On Windows, we do not emit the base type pointer and instead will fill
that in at runtime just like the resilient strategy.  Permit this in the
IRGen checks.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
