### PR TITLE
SyntaxParser: set up a C API to get a hash value indicating the node declaration set

### DIFF
--- a/include/swift-c/SyntaxParser/SwiftSyntaxParser.h
+++ b/include/swift-c/SyntaxParser/SwiftSyntaxParser.h
@@ -221,6 +221,17 @@ swiftparse_parser_set_node_lookup(swiftparse_parser_t,
 SWIFTPARSE_PUBLIC swiftparse_client_node_t
 swiftparse_parse_string(swiftparse_parser_t, const char *source);
 
+/// Returns a constant string pointer for verification purposes.
+///
+/// Working as a hash value, the constant string is calculated during compilation
+/// time from syntax node declarations.
+///
+/// During runtime, SwiftSyntax client can compare its own version of the hash
+/// value with the result of the function call. Mismatch indicates the parser
+/// library isn't compatible with the client side, e.g. added/removed node
+/// declarations, etc.
+SWIFTPARSE_PUBLIC const char* swiftparse_syntax_structure_versioning_identifier(void);
+
 SWIFTPARSE_END_DECLS
 
 #endif

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -122,6 +122,10 @@ public:
 
 %   end
 % end
+
+/// Calculating an identifier for all syntax nodes' structures for verification
+/// purposes.
+const char* getSyntaxStructureVersioningIdentifier();
 }
 }
 

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -99,3 +99,7 @@ ${node.name} ${node.name}::with${child.name}(
 
 %   end
 % end
+
+const char* swift::syntax::getSyntaxStructureVersioningIdentifier() {
+  return "${calculate_node_hash()}";
+}

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -22,6 +22,7 @@
 #include "swift/Parse/Parser.h"
 #include "swift/Parse/SyntaxParseActions.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
+#include "swift/Syntax/SyntaxNodes.h"
 #include "swift/Subsystems.h"
 #include <Block.h>
 
@@ -229,4 +230,8 @@ swiftparse_client_node_t
 swiftparse_parse_string(swiftparse_parser_t c_parser, const char *source) {
   SynParser *parser = static_cast<SynParser*>(c_parser);
   return parser->parse(source);
+}
+
+const char* swiftparse_syntax_structure_versioning_identifier(void) {
+  return getSyntaxStructureVersioningIdentifier();
 }

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.exports
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.exports
@@ -3,3 +3,4 @@ swiftparse_parser_create
 swiftparse_parser_dispose
 swiftparse_parser_set_node_handler
 swiftparse_parser_set_node_lookup
+swiftparse_syntax_structure_versioning_identifier

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -139,3 +139,7 @@ def dedented_lines(description):
     if not description:
         return []
     return textwrap.dedent(description).split('\n')
+
+
+def calculate_node_hash():
+    return "abc"


### PR DESCRIPTION
To ensure SwiftSyntax calls a compatible parser library, this patch sets
up a C API that returns a constant string calculated during compilation time to indicate
the version of syntax node declarations. The same hash will be calculated
in the SwiftSyntax (client) side as well by using the same algorithm.

During runtime, SwiftSyntax will verify its hash value is identical to the
result of calling swiftparse_node_declaration_hash before actual
parsing happens.

This patch only sets the API up. The actual implementation of the
hashing algorithm will come later.
