### PR TITLE
Prevent FunctionSignatureOptimization from rerunning on its own thunk.

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1191,9 +1191,8 @@ class COWArrayOptPass : public SILFunctionTransform {
     for (auto *L : Loops)
       HasChanged |= COWArrayOpt(RCIA, L, DA).run();
 
-      if (HasChanged) {
-        invalidateAnalysis(SILAnalysis::InvalidationKind::CallsAndInstructions);
-      }
+    if (HasChanged)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::CallsAndInstructions);
   }
 
 };


### PR DESCRIPTION
This is a bug fix that just bails out of FSO, which is exactly what we
should be doing in this case anyway.

This issue will be exposed in stdlib builds once I fix another bug in
the passmanager. Once the pass pipeline restart works as intended, we
will perform FSO on `F`, then devirtualization will discover a new
reference to `F`, causing it to be pushed back on the function pass
pipeline.