### PR TITLE
Need to specify compilers when building lldb

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -201,6 +201,8 @@ cmake -G Ninja^
   -DLLDB_PATH_TO_LLVM_SOURCE="S:/llvm"^
   -DLLDB_PATH_TO_CLANG_SOURCE="S:/clang"^
   -DLLDB_PATH_TO_SWIFT_SOURCE="S:/swift"^
+  -DCMAKE_C_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64/bin/clang-cl.exe"^
+  -DCMAKE_CXX_COMPILER="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64/bin/clang-cl.exe"^
   -DLLDB_PATH_TO_CMARK_BUILD="S:/build/Ninja-RelWithDebInfoAssert/cmark-windows-amd64"^
   -DLLDB_PATH_TO_CLANG_BUILD="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64"^
   -DLLDB_PATH_TO_LLVM_BUILD="S:/build/Ninja-RelWithDebInfoAssert/llvm-windows-amd64"^


### PR DESCRIPTION
<!-- What's in this pull request? -->

Simple tweak to build script so clang-cl is specified when building lldb on windows

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
