### PR TITLE
[upstream-update] Update LLVMPasses for new objc arc intrinsics.

### DIFF
--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -194,6 +194,10 @@ public:
   }
 
   bool isNonAtomic(CallInst *I) {
+    // If we have an intrinsic, we know it must be an objc intrinsic. All objc
+    // intrinsics are atomic today.
+    if (I->getIntrinsicID() != llvm::Intrinsic::not_intrinsic)
+      return false;
     return (I->getCalledFunction()->getName().find("nonatomic") !=
             llvm::StringRef::npos);
   }

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -413,7 +413,7 @@ static bool performLocalRetainMotion(CallInst &Retain, BasicBlock &BB,
   BasicBlock::iterator BBI = Retain.getIterator(),
                        BBE = BB.getTerminator()->getIterator();
 
-  bool isObjCRetain = Retain.getCalledFunction()->getName() == "objc_retain";
+  bool isObjCRetain = Retain.getIntrinsicID() == llvm::Intrinsic::objc_retain;
 
   bool MadeProgress = false;
 

--- a/lib/LLVMPasses/LLVMARCOpts.h
+++ b/lib/LLVMPasses/LLVMARCOpts.h
@@ -14,9 +14,10 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Config.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/Function.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
 
 namespace swift {
 
@@ -25,8 +26,8 @@ enum RT_Kind {
 #include "LLVMSwift.def"
 };
 
-/// classifyInstruction - Take a look at the specified instruction and classify
-/// it into what kind of runtime entrypoint it is, if any.
+/// Take a look at the specified instruction and classify it into what kind of
+/// runtime entrypoint it is, if any.
 inline RT_Kind classifyInstruction(const llvm::Instruction &I) {
   if (!I.mayReadOrWriteMemory())
     return RT_NoMemoryAccessed;
@@ -34,14 +35,31 @@ inline RT_Kind classifyInstruction(const llvm::Instruction &I) {
   // Non-calls or calls to indirect functions are unknown.
   auto *CI = dyn_cast<llvm::CallInst>(&I);
   if (CI == 0) return RT_Unknown;
+
+  // First check if we have an objc intrinsic.
+  auto intrinsic = CI->getIntrinsicID();
+  switch (intrinsic) {
+  // This is an intrinsic that we do not understand. It can not be one of our
+  // "special" runtime functions as well... so return RT_Unknown early.
+  default:
+    return RT_Unknown;
+  case llvm::Intrinsic::not_intrinsic:
+    // If we do not have an intrinsic, break and move onto runtime functions
+    // that we identify by name.
+    break;
+#define OBJC_FUNC(Name, MemBehavior, TextualName)                              \
+  case llvm::Intrinsic::objc_##TextualName:                                    \
+    return RT_##Name;
+#include "LLVMSwift.def"
+  }
+
   llvm::Function *F = CI->getCalledFunction();
-  if (F == 0) return RT_Unknown;
+  if (F == nullptr)
+    return RT_Unknown;
 
   return llvm::StringSwitch<RT_Kind>(F->getName())
 #define SWIFT_FUNC(Name, MemBehavior, TextualName) \
     .Case("swift_" #TextualName, RT_ ## Name)
-#define OBJC_FUNC(Name, MemBehavior, TextualName) \
-    .Case("objc_" #TextualName, RT_ ## Name)
 #define SWIFT_INTERNAL_FUNC_NEVER_NONATOMIC(Name, MemBehavior, TextualName) \
     .Case("__swift_" #TextualName, RT_ ## Name)
 #include "LLVMSwift.def"

--- a/lib/LLVMPasses/LLVMSwift.def
+++ b/lib/LLVMPasses/LLVMSwift.def
@@ -1,4 +1,4 @@
-//===--- LLVMSwift.def ----------------------------------------------------===//
+//===--- LLVMSwift.def ----------------------------------*- C++ -*---------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -142,7 +142,6 @@ SWIFT_INTERNAL_FUNC_NEVER_NONATOMIC(EndBorrow, ModRef, endBorrow)
 /// or is a call to something we don't care about.
 KIND(Unknown, ModRef)
 
-#undef OBJC_NEVER_NONATOMIC_FUNC
 #undef SWIFT_INTERNAL_FUNC_NEVER_NONATOMIC
 #undef SWIFT_NEVER_NONATOMIC_FUNC
 #undef OBJC_FUNC

--- a/test/LLVMPasses/allocation-deletion.ll
+++ b/test/LLVMPasses/allocation-deletion.ll
@@ -5,10 +5,7 @@ target triple = "x86_64-apple-macosx10.9"
 
 %swift.refcounted = type { %swift.heapmetadata*, i64 }
 %swift.heapmetadata = type { i64 (%swift.refcounted*)*, i64 (%swift.refcounted*)* }
-%objc_object = type opaque
 
-declare %objc_object* @objc_retain(%objc_object*)
-declare void @objc_release(%objc_object*)
 declare %swift.refcounted* @swift_allocObject(%swift.heapmetadata* , i64, i64) nounwind
 declare void @swift_release(%swift.refcounted* nocapture)
 declare void @swift_retain(%swift.refcounted* ) nounwind

--- a/test/LLVMPasses/disable_llvm_optzns.ll
+++ b/test/LLVMPasses/disable_llvm_optzns.ll
@@ -13,8 +13,8 @@ target triple = "x86_64-apple-macosx10.9"
 
 declare %swift.refcounted* @swift_unknownObjectRetain(%swift.refcounted* returned)
 declare void @swift_unknownObjectRelease(%swift.refcounted*)
-declare %objc_object* @objc_retain(%objc_object*)
-declare void @objc_release(%objc_object*)
+declare i8* @llvm.objc.retain(i8*)
+declare void @llvm.objc.release(i8*)
 declare %swift.refcounted* @swift_allocObject(%swift.heapmetadata* , i64, i64) nounwind
 declare void @swift_release(%swift.refcounted* nocapture)
 declare %swift.refcounted* @swift_retain(%swift.refcounted* returned) nounwind
@@ -23,7 +23,7 @@ declare void @swift_bridgeObjectRelease(%swift.bridge*)
 declare %swift.refcounted* @swift_retainUnowned(%swift.refcounted* returned)
 
 declare void @user(%swift.refcounted *) nounwind
-declare void @user_objc(%objc_object*) nounwind
+declare void @user_objc(i8*) nounwind
 declare void @unknown_func()
 
 ; CHECK-LABEL: @trivial_retain_release(
@@ -37,7 +37,7 @@ declare void @unknown_func()
 ; NEGATIVE-NEXT: entry:
 ; NEGATIVE-NEXT: call void @user(
 ; NEGATIVE-NEXT: ret void
-define void @trivial_retain_release(%swift.refcounted* %P, %objc_object* %O, %swift.bridge * %B) {
+define void @trivial_retain_release(%swift.refcounted* %P, i8* %O, %swift.bridge * %B) {
 entry:
   call %swift.refcounted* @swift_retain(%swift.refcounted* %P)
   call void @swift_release(%swift.refcounted* %P) nounwind


### PR DESCRIPTION
We used to represent these just as normal LLVM functions, e.x.:

  declare objc_object* @objc_retain(objc_object*)
  declare void @objc_release(objc_object*)

Recently, special objc intrinsics were added to LLVM. This pass updates these
small (old) passes to use the new intrinsics.

This turned out to not be too difficult since we never create these
instructions. We only analyze them, move them, and delete them.

rdar://47852297
