### PR TITLE
`@objc extension` makes even 'private' members '@objc'

### DIFF
--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2325,4 +2325,18 @@ extension MyObjCClass {
         }
         set {}
     }
+
+    // CHECK: {{^}} @objc private dynamic func stillExposedToObjCDespiteBeingPrivate()
+    private func stillExposedToObjCDespiteBeingPrivate() {}
 }
+
+@objc private extension MyObjCClass {
+  // CHECK: {{^}} @objc dynamic func alsoExposedToObjCDespiteBeingPrivate()
+  func alsoExposedToObjCDespiteBeingPrivate() {}
+}
+
+@objcMembers class VeryObjCClass: NSObject {
+  // CHECK: {{^}} private func notExposedToObjC()
+  private func notExposedToObjC() {}
+}
+


### PR DESCRIPTION
This regressed in #21657, when we started using a helper function in more places.

rdar://problem/47869562