### PR TITLE
[Sema] Resolve interface types during `Differentiable` derived confor…

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -864,6 +864,8 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
   auto *diffableProto =
       TC.Context.getProtocol(KnownProtocolKind::Differentiable);
   for (auto *vd : nominal->getStoredProperties()) {
+    if (!vd->hasInterfaceType())
+      TC.resolveDeclSignature(vd);
     auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
     if (vd->getAttrs().hasAttribute<NoDerivativeAttr>() ||
         TC.conformsToProtocol(varType, diffableProto, nominal,

--- a/test/AutoDiff/noderivative-attr.swift
+++ b/test/AutoDiff/noderivative-attr.swift
@@ -11,3 +11,14 @@ struct Foo {
 struct Bar : Differentiable {
   @noDerivative var flag: Bool
 }
+
+// Test TF-152: derived conformances "no interface type set" crasher.
+struct TF_152: Differentiable {
+  @differentiable(wrt: bar)
+  func applied(to input: Float, bar: TF_152_Bar) -> Float {
+    return input
+  }
+}
+struct TF_152_Bar: Differentiable {
+  @noDerivative let dense: Float
+}


### PR DESCRIPTION
…mances.

Check and resolve `VarDecl` interface types before attempting to access them in
`checkAndDiagnoseImplicitNoDerivative`.

Resolves [TF-152](https://bugs.swift.org/browse/TF-152).