### PR TITLE
Allow apply to directly apply @differentiable functions.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7566,17 +7566,6 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     }
   }
 
-  // SWIFT_ENABLE_TENSORFLOW
-  if (auto *fnTy = cs.getType(fn)->getAs<AnyFunctionType>()) {
-    if (fnTy->isDifferentiable()) {
-      auto fnTyNoDiff =
-          fnTy->withExtInfo(fnTy->getExtInfo().withDifferentiable(false));
-      fn = new (tc.Context) AutoDiffFunctionExtractOriginalExpr(fn, fnTyNoDiff);
-      cs.setType(fn, fnTyNoDiff);
-      cs.cacheExprTypes(fn);
-    }
-  }
-
   bool unwrapResult = false;
   if (auto *IUOFnTy = dyn_cast<ImplicitlyUnwrappedFunctionConversionExpr>(fn)) {
     unwrapResult = true;

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -16,8 +16,7 @@ func apply() {
 
 // CHECK-AST-LABEL:  (func_decl {{.*}} "myfunction(_:)"
 // CHECK-AST:          (call_expr type='(Float)'
-// CHECK-AST:            (autodiff_function_extract_original implicit type='(Float) -> (Float)'
-// CHECK-AST:              (declref_expr type='@differentiable (Float) -> (Float)'
+// CHECK-AST:            (declref_expr type='@differentiable (Float) -> (Float)'
 // CHECK-AST:          (return_stmt
 // CHECK-AST:            (function_conversion_expr implicit type='(Float) -> Float'
 // CHECK-AST:              (autodiff_function_extract_original implicit type='(Float) -> (Float)'
@@ -29,11 +28,10 @@ func apply() {
 
 // CHECK-SILGEN-LABEL: @{{.*}}myfunction{{.*}}
 // CHECK-SILGEN: bb0([[DIFFED:%.*]] : @guaranteed $@differentiable @callee_guaranteed (Float) -> Float):
-// CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_COPY]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[BORROWED_ORIG:%.*]] = begin_borrow [[ORIG]] : $@callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   apply [[BORROWED_ORIG]]({{%.*}}) : $@callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   destroy_value [[ORIG]] : $@callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[ORIG:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_ORIG:%.*]] = begin_borrow [[ORIG]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   apply [[BORROWED_ORIG]]({{%.*}}) : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   destroy_value [[ORIG]] : $@differentiable @callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   [[ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_COPY]] : $@differentiable @callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   return [[ORIG]] : $@callee_guaranteed (Float) -> Float


### PR DESCRIPTION
This is a resolution to TF-42. The more operations over functions can
respect the @differentiable attribute, the cleaner Differentiation.cpp
can be.