### PR TITLE
correct source file name in lib/AST/CMakeLists.txt

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -112,6 +112,6 @@ else()
   set(swift_ast_verifier_flag " -DSWIFT_DISABLE_AST_VERIFIER=1")
 endif()
 
-set_property(SOURCE Verifier.cpp APPEND_STRING PROPERTY COMPILE_FLAGS
+set_property(SOURCE ASTVerifier.cpp APPEND_STRING PROPERTY COMPILE_FLAGS
   "${swift_ast_verifier_flag}")
 

--- a/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
@@ -5,5 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// This test no longer crashes the compiler, but it does produce an AST that
+// the verifier doesn't like.
+// REQUIRES: swift_ast_verifier
+
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 switch{case.b(u){


### PR DESCRIPTION
This filename went out of sync with the real filename at https://github.com/apple/swift/commit/8954f3c14d68c3b8f394926fc9bab8b0b87a0668, preventing `SWIFT_DISABLE_AST_VERIFIER` from ever getting set.