### PR TITLE
correct source file name in lib/AST/CMakeLists.txt

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -126,6 +126,6 @@ else()
   set(swift_ast_verifier_flag " -DSWIFT_DISABLE_AST_VERIFIER=1")
 endif()
 
-set_property(SOURCE Verifier.cpp APPEND_STRING PROPERTY COMPILE_FLAGS
+set_property(SOURCE ASTVerifier.cpp APPEND_STRING PROPERTY COMPILE_FLAGS
   "${swift_ast_verifier_flag}")
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1926,9 +1926,6 @@ test
 test-optimized
 validation-test
 
-# See discussion in https://github.com/apple/swift/pull/22441
-swift-enable-ast-verifier=1
-
 # Enables Tensorflow and runs all the Swift tests (including long tests). Sets
 # certain flags that are necessary for tests to pass.
 [preset: tensorflow_test,long_test]

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1926,6 +1926,9 @@ test
 test-optimized
 validation-test
 
+# See discussion in https://github.com/apple/swift/pull/22441
+swift-enable-ast-verifier=1
+
 # Enables Tensorflow and runs all the Swift tests (including long tests). Sets
 # certain flags that are necessary for tests to pass.
 [preset: tensorflow_test,long_test]

--- a/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// TODO: Re-enable after the situation discussed in https://github.com/apple/swift/pull/22440#issuecomment-461300284 is resolved.
+// UN: not --crash %target-swift-frontend %s -emit-ir
 switch{case.b(u){

--- a/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// TODO: Re-enable after the situation discussed in https://github.com/apple/swift/pull/22440#issuecomment-461300284 is resolved.
-// UN: not --crash %target-swift-frontend %s -emit-ir
+// TODO: Remove REQUIRES in https://github.com/apple/swift/pull/22440#issuecomment-461300284 is resolved.
+// REQUIRES: swift_ast_verifier
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 switch{case.b(u){


### PR DESCRIPTION
This filename went out of sync with the real filename at 8954f3c, preventing SWIFT_DISABLE_AST_VERIFIER from ever getting set.

(I have also sent this patch to `master` in https://github.com/apple/swift/pull/22440, but it's crashing the autocompleter, so I'd like to get it into `tensorflow` before the next time we pull changes from `master`).