### PR TITLE
[ConstraintSystem] Detect invalid implicit ref to initializer on non-…

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -474,6 +474,11 @@ bool Expr::isTypeReference(
       continue;
     }
 
+    if (auto *USE = dyn_cast<UnresolvedSpecializeExpr>(expr)) {
+      expr = USE->getSubExpr();
+      continue;
+    }
+
     // Anything else is not statically derived.
     return false;
   } while (true);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1530,3 +1530,11 @@ bool InitOnProtocolMetatypeFailure::diagnoseAsError() {
 
   return true;
 }
+
+bool ImplicitInitOnNonConstMetatypeFailure::diagnoseAsError() {
+  auto *apply = cast<ApplyExpr>(getRawAnchor());
+  auto loc = apply->getArg()->getStartLoc();
+  emitDiagnostic(loc, diag::missing_init_on_metatype_initialization)
+      .fixItInsert(loc, ".init");
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -771,6 +771,25 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an attempt to construct an instance using non-constant
+/// metatype base without explictly specifying `init`:
+///
+/// ```swift
+/// let foo = Int.self
+/// foo(0) // should be `foo.init(0)`
+/// ```
+class ImplicitInitOnNonConstMetatypeFailure final
+    : public InvalidInitRefFailure {
+public:
+  ImplicitInitOnNonConstMetatypeFailure(Expr *root, ConstraintSystem &cs,
+                                        Type baseTy,
+                                        const ConstructorDecl *init,
+                                        ConstraintLocator *locator)
+      : InvalidInitRefFailure(root, cs, baseTy, init, SourceRange(), locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -290,6 +290,12 @@ bool AllowInvalidInitRef::diagnose(Expr *root, bool asNote) const {
                                           getLocator());
     return failure.diagnose(asNote);
   }
+
+  case RefKind::NonConstMetatype: {
+    ImplicitInitOnNonConstMetatypeFailure failure(root, getConstraintSystem(),
+                                                  BaseType, Init, getLocator());
+    return failure.diagnose(asNote);
+  }
   }
 }
 
@@ -306,6 +312,14 @@ AllowInvalidInitRef *AllowInvalidInitRef::onProtocolMetatype(
     ConstraintLocator *locator) {
   return create(RefKind::ProtocolMetatype, cs, baseTy, init,
                 isStaticallyDerived, baseRange, locator);
+}
+
+AllowInvalidInitRef *
+AllowInvalidInitRef::onNonConstMetatype(ConstraintSystem &cs, Type baseTy,
+                                        ConstructorDecl *init,
+                                        ConstraintLocator *locator) {
+  return create(RefKind::NonConstMetatype, cs, baseTy, init,
+                /*isStaticallyDerived=*/false, SourceRange(), locator);
 }
 
 AllowInvalidInitRef *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -543,7 +543,11 @@ public:
 };
 
 class AllowInvalidInitRef final : public ConstraintFix {
-  enum class RefKind { DynamicOnMetatype, ProtocolMetatype } Kind;
+  enum class RefKind {
+    DynamicOnMetatype,
+    ProtocolMetatype,
+    NonConstMetatype,
+  } Kind;
 
   Type BaseType;
   const ConstructorDecl *Init;
@@ -572,6 +576,11 @@ public:
   onProtocolMetatype(ConstraintSystem &cs, Type baseTy, ConstructorDecl *init,
                      bool isStaticallyDerived, SourceRange baseRange,
                      ConstraintLocator *locator);
+
+  static AllowInvalidInitRef *onNonConstMetatype(ConstraintSystem &cs,
+                                                 Type baseTy,
+                                                 ConstructorDecl *init,
+                                                 ConstraintLocator *locator);
 
 private:
   static AllowInvalidInitRef *create(RefKind kind, ConstraintSystem &cs,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1752,6 +1752,16 @@ static void validateInitializerRef(ConstraintSystem &cs, ConstructorDecl *init,
   } else if (auto *CE = dyn_cast<CallExpr>(anchor)) {
     baseExpr = CE->getFn();
     baseType = getType(baseExpr);
+    // If this is an initializer call without explicit mention
+    // of `.init` on metatype value.
+    if (auto *MTT = baseType->getAs<MetatypeType>()) {
+      auto instanceType = MTT->getInstanceType();
+      if (!cs.isTypeReference(baseExpr) && !instanceType->isExistentialType()) {
+        (void)cs.recordFix(AllowInvalidInitRef::onNonConstMetatype(
+            cs, baseType, init, locator));
+        return;
+      }
+    }
   // Initializer reference which requires contextual base type e.g. `.init(...)`.
   } else if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor)) {
     // We need to find type variable which represents contextual base.

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -172,3 +172,8 @@ SR_5245(s: SR_5245.S(f: [.e1, .e2]))
 
 // rdar://problem/34670592 - Compiler crash on heterogeneous collection literal
 _ = Array([1, "hello"]) // Ok
+
+func init_via_non_const_metatype(_ s1: S1.Type) {
+  _ = s1(i: 42) // expected-error {{initializing from a metatype value must reference 'init' explicitly}} {{9-9=.init}}
+  _ = s1.init(i: 42) // ok
+}


### PR DESCRIPTION
…const metatype

Situations like:

```swift
struct S {}
func foo(_ s: S.Type) {
  _ = s()
}
```

Used to be diagnosed in solution application phase, which means that
solver was allowed to formed an incorrect solution.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
