### PR TITLE
Fix the mid-level pass pipeline

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -583,6 +583,32 @@ public:
 
 namespace llvm {
 
+template<>
+struct PointerLikeTypeTraits<swift::ApplySite> {
+public:
+  static inline void *getAsVoidPointer(swift::ApplySite apply) {
+    return (void*)apply.getInstruction();
+  }
+  static inline swift::ApplySite getFromVoidPointer(void *pointer) {
+    return swift::ApplySite((swift::SILInstruction*)pointer);
+  }
+  enum { NumLowBitsAvailable =
+         PointerLikeTypeTraits<swift::SILNode *>::NumLowBitsAvailable };
+};
+
+template<>
+struct PointerLikeTypeTraits<swift::FullApplySite> {
+public:
+  static inline void *getAsVoidPointer(swift::FullApplySite apply) {
+    return (void*)apply.getInstruction();
+  }
+  static inline swift::FullApplySite getFromVoidPointer(void *pointer) {
+    return swift::FullApplySite((swift::SILInstruction*)pointer);
+  }
+  enum { NumLowBitsAvailable =
+         PointerLikeTypeTraits<swift::SILNode *>::NumLowBitsAvailable };
+};
+
 // An ApplySite casts like a SILInstruction*.
 template <> struct simplify_type<const ::swift::ApplySite> {
   using SimpleType = ::swift::SILInstruction *;

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -45,6 +45,9 @@ enum class ArrayCallKind {
   kArrayUninitializedIntrinsic
 };
 
+/// Return true is the given function is an array semantics call.
+ArrayCallKind getArraySemanticsKind(SILFunction *f);
+
 /// Wrapper around array semantic calls.
 class ArraySemanticsCall {
   ApplyInst *SemanticsCall;

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -180,9 +180,6 @@ public:
 
   /// Could this array be backed by an NSArray.
   bool mayHaveBridgedObjectElementType() const;
-  
-  /// Can this function be inlined by the early inliner.
-  bool canInlineEarly() const;
 
   /// If this is a call to  ArrayUninitialized (or
   /// ArrayUninitializedInstrinsic), identify the instructions that store

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -258,16 +258,7 @@ public:
     }
   }
 
-  void executePassPipelinePlan(const SILPassPipelinePlan &Plan) {
-    for (const SILPassPipeline &Pipeline : Plan.getPipelines()) {
-      setStageName(Pipeline.Name);
-      resetAndRemoveTransformations();
-      for (PassKind Kind : Plan.getPipelinePasses(Pipeline)) {
-        addPass(Kind);
-      }
-      execute();
-    }
-  }
+  void executePassPipelinePlan(const SILPassPipelinePlan &Plan);
 
   void registerIRGenPass(PassKind Kind, SILTransform *Transform) {
     assert(IRGenPasses.find(unsigned(Kind)) == IRGenPasses.end() &&

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -87,7 +87,7 @@ public:
 
   void print(llvm::raw_ostream &os);
 
-  void startPipeline(StringRef Name = "");
+  void startPipeline(StringRef Name = "", bool isFunctionPassPipeline = false);
   using PipelineKindIterator = decltype(Kinds)::const_iterator;
   using PipelineKindRange = iterator_range<PipelineKindIterator>;
   iterator_range<PipelineKindIterator>
@@ -104,11 +104,14 @@ struct SILPassPipeline final {
   unsigned ID;
   StringRef Name;
   unsigned KindOffset;
+  bool isFunctionPassPipeline;
 };
 
-inline void SILPassPipelinePlan::startPipeline(StringRef Name) {
+inline void SILPassPipelinePlan::
+startPipeline(StringRef Name, bool isFunctionPassPipeline) {
   PipelineStages.push_back(SILPassPipeline{
-      unsigned(PipelineStages.size()), Name, unsigned(Kinds.size())});
+      unsigned(PipelineStages.size()), Name, unsigned(Kinds.size()),
+      isFunctionPassPipeline});
 }
 
 inline SILPassPipelinePlan::PipelineKindRange

--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -65,9 +65,11 @@ SubstitutionMap getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
 ///
 /// If this succeeds, the caller must call deleteDevirtualizedApply on
 /// the original apply site.
-ApplySite tryDevirtualizeApply(ApplySite AI,
-                               ClassHierarchyAnalysis *CHA,
-                               OptRemark::Emitter *ORE = nullptr);
+///
+/// Return the new apply and true if the CFG was also modified.
+std::pair<ApplySite, bool>
+tryDevirtualizeApply(ApplySite AI, ClassHierarchyAnalysis *CHA,
+                     OptRemark::Emitter *ORE = nullptr);
 bool canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA);
 bool canDevirtualizeClassMethod(FullApplySite AI, ClassDecl *CD,
                                 OptRemark::Emitter *ORE = nullptr,
@@ -79,21 +81,23 @@ CanType getSelfInstanceType(CanType ClassOrMetatypeType);
 /// Devirtualize the given apply site, which is known to be devirtualizable.
 ///
 /// The caller must call deleteDevirtualizedApply on the original apply site.
-FullApplySite devirtualizeClassMethod(FullApplySite AI,
-                                      SILValue ClassInstance,
-                                      ClassDecl *CD,
-                                      OptRemark::Emitter *ORE);
+///
+/// Return the new apply and true if the CFG was also modified.
+std::pair<FullApplySite, bool> devirtualizeClassMethod(FullApplySite AI,
+                                                       SILValue ClassInstance,
+                                                       ClassDecl *CD,
+                                                       OptRemark::Emitter *ORE);
 
 /// Attempt to devirtualize the given apply site, which is known to be
 /// of a class method.  If this fails, the returned FullApplySite will be null.
 ///
 /// If this succeeds, the caller must call deleteDevirtualizedApply on
 /// the original apply site.
-FullApplySite
-tryDevirtualizeClassMethod(FullApplySite AI,
-                           SILValue ClassInstance,
-                           ClassDecl *CD,
-                           OptRemark::Emitter *ORE,
+///
+/// Return the new apply and true if the CFG was also modified.
+std::pair<FullApplySite, bool>
+tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
+                           ClassDecl *CD, OptRemark::Emitter *ORE,
                            bool isEffectivelyFinalMethod = false);
 
 /// Attempt to devirtualize the given apply site, which is known to be
@@ -102,7 +106,9 @@ tryDevirtualizeClassMethod(FullApplySite AI,
 ///
 /// If this succeeds, the caller must call deleteDevirtualizedApply on
 /// the original apply site.
-ApplySite tryDevirtualizeWitnessMethod(ApplySite AI, OptRemark::Emitter *ORE);
+///
+/// Return the new apply and true if the CFG was also modified.
+std::pair<ApplySite, bool> tryDevirtualizeWitnessMethod(ApplySite AI, OptRemark::Emitter *ORE);
 
 /// Delete a successfully-devirtualized apply site.  This must always be
 /// called after devirtualizing an apply; not only is it not semantically

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -33,18 +33,25 @@ class SideEffectAnalysis;
 // Controls the decision to inline functions with @_semantics, @effect and
 // global_init attributes.
 enum class InlineSelection {
-  Everything,
-  NoGlobalInit, // and no availability semantics calls
-  NoSemanticsAndGlobalInit
+  PreModuleSerialization, // no @semantics, no @availability
+  RetainSemantics,        // Retain the lowest level of @semantic calls
+  Everything              // Full, including global init
 };
 
 // Returns the callee of an apply_inst if it is basically inlinable.
-SILFunction *getEligibleFunction(FullApplySite AI,
-                                 InlineSelection WhatToInline);
+SILFunction *
+getEligibleFunction(FullApplySite AI, InlineSelection WhatToInline,
+                    SmallPtrSetImpl<SILFunction *> &nestedSemanticFunctions);
 
 // Returns true if this is a pure call, i.e. the callee has no side-effects
 // and all arguments are constants.
 bool isPureCall(FullApplySite AI, SideEffectAnalysis *SEA);
+
+// Return true if the given function has a semantic annotation which may be
+// recognized by semantics passes. Such calls should only be inlined after all
+// semantic passes have been able to evaluate them.
+bool isOptimizableSemanticFunction(SILFunction *callee);
+
 } // end swift namespace
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -585,26 +585,6 @@ bool swift::ArraySemanticsCall::mayHaveBridgedObjectElementType() const {
   return true;
 }
 
-bool swift::ArraySemanticsCall::canInlineEarly() const {
-  switch (getKind()) {
-    default:
-      return false;
-    case ArrayCallKind::kAppendContentsOf:
-    case ArrayCallKind::kReserveCapacityForAppend:
-    case ArrayCallKind::kAppendElement:
-    case ArrayCallKind::kArrayUninitializedIntrinsic:
-      // append(Element) calls other semantics functions. Therefore it's
-      // important that it's inlined by the early inliner (which is before all
-      // the array optimizations). Also, this semantics is only used to lookup
-      // Array.append(Element), so inlining it does not prevent any other
-      // optimization.
-      //
-      // Early inlining array.uninitialized_intrinsic semantic call helps in
-      // stack promotion.
-      return true;
-  }
-}
-
 SILValue swift::ArraySemanticsCall::getInitializationCount() const {
   if (getKind() == ArrayCallKind::kArrayUninitialized) {
     // Can be either a call to _adoptStorage or _allocateUninitialized.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1901,6 +1901,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       !isa<BeginApplyInst>(I)) {
     ArraySemanticsCall ASC(FAS.getInstruction());
     switch (ASC.getKind()) {
+      // TODO: Model ReserveCapacityForAppend, AppendContentsOf, AppendElement.
       case ArrayCallKind::kArrayPropsIsNativeTypeChecked:
       case ArrayCallKind::kCheckSubscript:
       case ArrayCallKind::kCheckIndex:

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -630,18 +630,6 @@ bool FunctionSignatureTransform::run(bool hasCaller) {
       TransformDescriptor.hasOnlyDirectInModuleCallers;
   SILFunction *F = TransformDescriptor.OriginalFunction;
 
-  // Never repeat the same function signature optimization on the same function.
-  // Multiple function signature optimizations are composed by successively
-  // optmizing the newly created functions. Each optimization creates a new
-  // level of thunk. Those should all be ultimately inlined away.
-  //
-  // This happens, for example, when a new reference to the original function is
-  // discovered during devirtualization. That will cause the original function
-  // (now and FSO thunk) to be pushed back on the function pass pipeline.
-  if (F->isThunk() == IsSignatureOptimizedThunk) {
-    LLVM_DEBUG(llvm::dbgs() << "  FSO already performed on this thunk\n");
-    return false;
-  }
 
   // If we are asked to assume a caller for testing purposes, set the flag.
   hasCaller |= FSOOptimizeIfNotCalled;
@@ -800,6 +788,19 @@ public:
     if (OptForPartialApply &&
         !canSpecializeFunction(F, &FuncInfo, OptForPartialApply)) {
       LLVM_DEBUG(llvm::dbgs() << "  cannot specialize function -> abort\n");
+      return;
+    }
+
+    // Never repeat the same function signature optimization on the same
+    // function. Multiple function signature optimizations are composed by
+    // successively optmizing the newly created functions. Each optimization
+    // creates a new level of thunk which are all ultimately inlined away.
+    //
+    // This happens, for example, when a reference to the original function is
+    // discovered during devirtualization. That will cause the original function
+    // (now an FSO thunk) to be pushed back on the function pass pipeline.
+    if (F->isThunk() == IsSignatureOptimizedThunk) {
+      LLVM_DEBUG(llvm::dbgs() << "  FSO already performed on this thunk\n");
       return;
     }
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -192,7 +192,10 @@ static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount) {
         ++Cost;
       if (auto AI = FullApplySite::isa(&Inst)) {
         auto Callee = AI.getCalleeFunction();
-        if (Callee && getEligibleFunction(AI, InlineSelection::Everything)) {
+        SmallPtrSet<SILFunction *, 1> nestedSemanticFunctions;
+        if (Callee
+            && getEligibleFunction(AI, InlineSelection::Everything,
+                                   nestedSemanticFunctions)) {
           // If callee is rather big and potentialy inlinable, it may be better
           // not to unroll, so that the body of the calle can be inlined later.
           Cost += Callee->size() * InsnsPerBB;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -755,7 +755,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
 
 static SILInstruction *tryDevirtualizeApplyHelper(FullApplySite InnerAI,
                                                   ClassHierarchyAnalysis *CHA) {
-  auto NewInst = tryDevirtualizeApply(InnerAI, CHA);
+  auto NewInst = tryDevirtualizeApply(InnerAI, CHA).first;
   if (!NewInst)
     return InnerAI.getInstruction();
 

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -592,6 +592,19 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
   }
 }
 
+void SILPassManager::executePassPipelinePlan(const SILPassPipelinePlan &Plan) {
+  for (const SILPassPipeline &Pipeline : Plan.getPipelines()) {
+    setStageName(Pipeline.Name);
+    resetAndRemoveTransformations();
+    for (PassKind Kind : Plan.getPipelinePasses(Pipeline)) {
+      addPass(Kind);
+      assert(!Pipeline.isFunctionPassPipeline
+             || isa<SILFunctionTransform>(Transformations.back()));
+    }
+    execute();
+  }
+}
+
 void SILPassManager::execute() {
   const SILOptions &Options = getOptions();
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -290,14 +290,17 @@ void addFunctionPasses(SILPassPipelinePlan &P,
 
   // Cleanup, which is important if the inliner has restarted the pass pipeline.
   P.addPerformanceConstantPropagation();
-  P.addSimplifyCFG();
   P.addSILCombine();
+  addSimplifyCFGSILCombinePasses(P);
 
-  // Perform a round of array optimization in the mid-level pipeline after
-  // potentially inlining calls to Array append. In that situation, the
-  // high-level pipeline does ArrayElementPropagation and the mid-level pipeline
-  // handles uniqueness hoisting. Do this as late as possible before inlining
-  // because it must run between runs of the inliner when the pipeline restarts.
+  // Perform a round of loop/array optimization in the mid-level pipeline after
+  // potentially inlining semantic calls, e.g. Array append. The high level
+  // pipeline only optimizes semantic calls *after* inlining (see
+  // addHighLevelLoopOptPasses). For example, the high-level pipeline may
+  // performs ArrayElementPropagation and after inlining a level of semantic
+  // calls, the mid-level pipeline may handle uniqueness hoisting. Do this as
+  // late as possible before inlining because it must run between runs of the
+  // inliner when the pipeline restarts.
   if (OpLevel == OptimizationLevelKind::MidLevel) {
     P.addHighLevelLICM();
     P.addArrayCountPropagation();

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -353,9 +353,11 @@ bool SILPerformanceInliner::isProfitableToInline(
       if (FullApplySite FAI = FullApplySite::isa(&I)) {
         // Call sites into semantic calls need to be inlined into the parent
         // scope for optimization based on those semantics to kick in. This may
-        // mean the call can be hoisted out of a loop for example.
-        SILFunction *Callee = AI.getReferencedFunction();
-        if (Callee && Callee->hasSemanticsAttrs()) {
+        // mean the call can be hoisted out of a loop for example. Do this only
+        // after the top-level scope is fully specialized, otherwise it could
+        // actually prevent inlining of callers.
+        SILFunction *Callee = FAI.getReferencedFunctionOrNull();
+        if (!IsGeneric && Callee && Callee->hasSemanticsAttrs()) {
           BlockW.updateBenefit(Benefit, SemanticCallBenefit);
         }
 

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -494,7 +494,7 @@ bool SILPerformanceInliner::isProfitableToInline(
 
   // This is the final inlining decision.
   if (CalleeCost > Benefit) {
-    ORE.emit([&]() {
+    OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, &ORE, [&]() {
       using namespace OptRemark;
       return RemarkMissed("NoInlinedCost", *AI.getInstruction())
              << "Not profitable to inline function " << NV("Callee", Callee)
@@ -514,7 +514,7 @@ bool SILPerformanceInliner::isProfitableToInline(
                           << ", bb=" << Callee->size()
                           << ", c-bb=" << NumCallerBlocks
                           << "} " << Callee->getName() << '\n');
-  ORE.emit([&]() {
+  OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, &ORE, [&]() {
     using namespace OptRemark;
     return RemarkPassed("Inlined", *AI.getInstruction())
            << NV("Callee", Callee) << " inlined into "

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -67,6 +67,12 @@ class SILPerformanceInliner {
   llvm::DenseMap<SILFunction *, ShortestPathAnalysis *> SPAs;
   llvm::SpecificBumpPtrAllocator<ShortestPathAnalysis> SPAAllocator;
 
+  // Mark semantic functions that have nested semantic calls. This is
+  // effectively an immutable cache since we do not inline semantic calls into
+  // other semantic calls. This is computed bottom up--when checking a call
+  // site, we assume that a callee has already been evaluated.
+  llvm::SmallPtrSet<SILFunction *, 8> nestedSemanticFunctions;
+
   ColdBlockInfo CBI;
 
   OptRemark::Emitter &ORE;
@@ -778,7 +784,8 @@ void SILPerformanceInliner::collectAppliesToInline(
     // At this occasion we record additional weight increases.
     addWeightCorrection(FAS, WeightCorrections);
 
-    if (SILFunction *Callee = getEligibleFunction(FAS, WhatToInline)) {
+    if (SILFunction *Callee =
+            getEligibleFunction(FAS, WhatToInline, nestedSemanticFunctions)) {
       // Compute the shortest-path analysis for the callee.
       SILLoopInfo *CalleeLI = LA->get(Callee);
       ShortestPathAnalysis *CalleeSPA = getSPA(Callee, CalleeLI);
@@ -805,6 +812,8 @@ void SILPerformanceInliner::collectAppliesToInline(
   }
 #endif
 
+  bool semanticFunction = isOptimizableSemanticFunction(Caller);
+
   ConstantTracker constTracker(Caller);
   DominanceOrder domOrder(&Caller->front(), DT, Caller->size());
   int NumCallerBlocks = (int)Caller->size();
@@ -827,8 +836,13 @@ void SILPerformanceInliner::collectAppliesToInline(
 
       FullApplySite AI = FullApplySite(&*I);
 
-      auto *Callee = getEligibleFunction(AI, WhatToInline);
+      auto *Callee =
+          getEligibleFunction(AI, WhatToInline, nestedSemanticFunctions);
       if (Callee) {
+        // Mark nested semantic functions to guide inlining of callers.
+        if (semanticFunction && isOptimizableSemanticFunction(Callee))
+          nestedSemanticFunctions.insert(Caller);
+
         // Check if we have an always_inline or transparent function. If we do,
         // just add it to our final Applies list and continue.
         if (isInlineAlwaysCallSite(Callee)) {
@@ -906,6 +920,27 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
   if (AppliesToInline.empty())
     return false;
 
+  //!!!
+  bool trace = false;
+  if (Caller->hasName("$s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF")) {
+    //!!!llvm::dbgs() << "inlining into testInlineAppend\n";
+    //!!!trace = true;
+  }
+
+  llvm::SmallPtrSet<FullApplySite, 4> nestedSemanticCalls;
+  for (auto fullApply : AppliesToInline) {
+    //!!!
+    if (false
+        && nestedSemanticFunctions.count(
+            fullApply.getReferencedFunctionOrNull())) {
+      //!!!
+      if (trace)
+        llvm::dbgs() << "Nested: "
+                     << fullApply.getReferencedFunctionOrNull()->getName() << "\n";
+      nestedSemanticCalls.insert(fullApply);
+    }
+  }
+
   // Second step: do the actual inlining.
   for (auto AI : AppliesToInline) {
     SILFunction *Callee = AI.getReferencedFunctionOrNull();
@@ -913,6 +948,16 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
 
     if (!Callee->shouldOptimize()) {
       continue;
+    }
+
+    // If this function calls any nested semantics, only inline the nested
+    // semantic calls.
+    if (!nestedSemanticCalls.empty() && !nestedSemanticCalls.count(AI)) {
+      //!!!
+      if (trace)
+        llvm::dbgs() << "Non Nested: " << Callee->getName() << "\n";
+      if (ArraySemanticsCall(AI.getInstruction()))
+        continue;
     }
 
     // If we have a callee that doesn't have ownership, but the caller does have
@@ -965,7 +1010,8 @@ void SILPerformanceInliner::visitColdBlocks(
       if (!AI)
         continue;
 
-      auto *Callee = getEligibleFunction(AI, WhatToInline);
+      auto *Callee =
+          getEligibleFunction(AI, WhatToInline, nestedSemanticFunctions);
       if (Callee && decideInColdBlock(AI, Callee)) {
         AppliesToInline.push_back(AI);
       }
@@ -1025,16 +1071,17 @@ public:
 } // end anonymous namespace
 
 /// Create an inliner pass that does not inline functions that are marked with
-/// the @_semantics, @_effects or global_init attributes.
+/// the @_semantics, @_effects, availability, or global_init attributes.
 SILTransform *swift::createEarlyInliner() {
-  return new SILPerformanceInlinerPass(
-    InlineSelection::NoSemanticsAndGlobalInit, "Early");
+  return new SILPerformanceInlinerPass(InlineSelection::PreModuleSerialization,
+                                       "Early");
 }
 
-/// Create an inliner pass that does not inline functions that are marked with
-/// the global_init attribute or have an "availability" semantics attribute.
+// The mid-level inliner preserves the lowest level of semantic calls to avoid
+// pessimizing anlayses like EscapeAnlysis and SideEffectAnalysis.
 SILTransform *swift::createPerfInliner() {
-  return new SILPerformanceInlinerPass(InlineSelection::NoGlobalInit, "Middle");
+  return new SILPerformanceInlinerPass(InlineSelection::RetainSemantics,
+                                       "Middle");
 }
 
 /// Create an inliner pass that inlines all functions that are marked with

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3027,6 +3027,10 @@ bool SimplifyCFG::run() {
 
   LLVM_DEBUG(llvm::dbgs() << "### Run SimplifyCFG on " << Fn.getName() << '\n');
 
+  //!!!
+  if (Fn.hasName("$s32sil_combine_concrete_existential29testWitnessReturnOptionalSelfAA2PP_pSgyF")) {
+    llvm::dbgs() << "TEST WITNESS SIMPLIFYCFG\n";
+  }
   // Disable some expensive optimizations if the function is huge.
   isVeryLargeFunction = (Fn.size() > 10000);
 

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -229,7 +229,8 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
 
   // Devirtualize the apply instruction on the identical path.
   auto NewInst =
-    devirtualizeClassMethod(IdenAI, DownCastedClassInstance, CD, nullptr);
+      devirtualizeClassMethod(IdenAI, DownCastedClassInstance, CD, nullptr)
+          .first;
   assert(NewInst && "Expected to be able to devirtualize apply!");
   (void)NewInst;
 
@@ -414,7 +415,8 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
     // try to devirtualize it completely.
     ClassHierarchyAnalysis::ClassList Subs;
     if (isDefaultCaseKnown(CHA, AI, CD, Subs)) {
-      auto NewInst = tryDevirtualizeClassMethod(AI, SubTypeValue, CD, &ORE);
+      auto NewInst =
+          tryDevirtualizeClassMethod(AI, SubTypeValue, CD, &ORE).first;
       if (NewInst)
         deleteDevirtualizedApply(AI);
       return bool(NewInst);
@@ -574,7 +576,8 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
     ORE.emit(RB);
     return true;
   }
-  auto NewInst = tryDevirtualizeClassMethod(AI, SubTypeValue, CD, nullptr);
+  auto NewInst =
+      tryDevirtualizeClassMethod(AI, SubTypeValue, CD, nullptr).first;
   if (NewInst) {
     ORE.emit(RB);
     deleteDevirtualizedApply(AI);

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -482,12 +482,12 @@ static ApplyInst *replaceApplyInst(SILBuilder &builder, SILLocation loc,
   return newAI;
 }
 
-static TryApplyInst *replaceTryApplyInst(SILBuilder &builder, SILLocation loc,
-                                         TryApplyInst *oldTAI, SILValue newFn,
-                                         SubstitutionMap newSubs,
-                                         ArrayRef<SILValue> newArgs,
-                                         SILFunctionConventions conv,
-                                         ArrayRef<SILValue> newArgBorrows) {
+// Return the new try_apply and true if a cast required CFG modification.
+static std::pair<TryApplyInst *, bool>
+replaceTryApplyInst(SILBuilder &builder, SILLocation loc, TryApplyInst *oldTAI,
+                    SILValue newFn, SubstitutionMap newSubs,
+                    ArrayRef<SILValue> newArgs, SILFunctionConventions conv,
+                    ArrayRef<SILValue> newArgBorrows) {
   SILBasicBlock *normalBB = oldTAI->getNormalBB();
   SILBasicBlock *resultBB = nullptr;
 
@@ -537,7 +537,7 @@ static TryApplyInst *replaceTryApplyInst(SILBuilder &builder, SILLocation loc,
   }
 
   builder.setInsertionPoint(normalBB->begin());
-  return newTAI;
+  return {newTAI, resultCastRequired};
 }
 
 static BeginApplyInst *
@@ -599,17 +599,18 @@ replacePartialApplyInst(SILBuilder &builder, SILLocation loc,
   return newPAI;
 }
 
-static ApplySite replaceApplySite(SILBuilder &builder, SILLocation loc,
-                                  ApplySite oldAS, SILValue newFn,
-                                  SubstitutionMap newSubs,
-                                  ArrayRef<SILValue> newArgs,
-                                  SILFunctionConventions conv,
-                                  ArrayRef<SILValue> newArgBorrows) {
+// Return the new apply and true if the CFG was also modified.
+static std::pair<ApplySite, bool>
+replaceApplySite(SILBuilder &builder, SILLocation loc, ApplySite oldAS,
+                 SILValue newFn, SubstitutionMap newSubs,
+                 ArrayRef<SILValue> newArgs, SILFunctionConventions conv,
+                 ArrayRef<SILValue> newArgBorrows) {
   switch (oldAS.getKind()) {
   case ApplySiteKind::ApplyInst: {
     auto *oldAI = cast<ApplyInst>(oldAS);
-    return replaceApplyInst(builder, loc, oldAI, newFn, newSubs, newArgs,
-                            newArgBorrows);
+    return {replaceApplyInst(builder, loc, oldAI, newFn, newSubs, newArgs,
+                             newArgBorrows),
+            false};
   }
   case ApplySiteKind::TryApplyInst: {
     auto *oldTAI = cast<TryApplyInst>(oldAS);
@@ -618,14 +619,16 @@ static ApplySite replaceApplySite(SILBuilder &builder, SILLocation loc,
   }
   case ApplySiteKind::BeginApplyInst: {
     auto *oldBAI = dyn_cast<BeginApplyInst>(oldAS);
-    return replaceBeginApplyInst(builder, loc, oldBAI, newFn, newSubs, newArgs,
-                                 newArgBorrows);
+    return {replaceBeginApplyInst(builder, loc, oldBAI, newFn, newSubs, newArgs,
+                                  newArgBorrows),
+            false};
   }
   case ApplySiteKind::PartialApplyInst: {
     assert(newArgBorrows.empty());
     auto *oldPAI = cast<PartialApplyInst>(oldAS);
-    return replacePartialApplyInst(builder, loc, oldPAI, newFn, newSubs,
-                                   newArgs);
+    return {
+        replacePartialApplyInst(builder, loc, oldPAI, newFn, newSubs, newArgs),
+        false};
   }
   }
   llvm_unreachable("covered switch");
@@ -729,10 +732,12 @@ bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
 /// \p ClassOrMetatype is a class value or metatype value that is the
 ///    self argument of the apply we will devirtualize.
 /// return the result value of the new ApplyInst if created one or null.
-FullApplySite swift::devirtualizeClassMethod(FullApplySite applySite,
-                                             SILValue classOrMetatype,
-                                             ClassDecl *cd,
-                                             OptRemark::Emitter *ore) {
+///
+/// Return the new apply and true if the CFG was also modified.
+std::pair<FullApplySite, bool>
+swift::devirtualizeClassMethod(FullApplySite applySite,
+                               SILValue classOrMetatype, ClassDecl *cd,
+                               OptRemark::Emitter *ore) {
   LLVM_DEBUG(llvm::dbgs() << "    Trying to devirtualize : "
                           << *applySite.getInstruction());
 
@@ -793,8 +798,10 @@ FullApplySite swift::devirtualizeClassMethod(FullApplySite applySite,
     newArgs.push_back(arg);
     ++paramArgIter;
   }
-  ApplySite newAS = replaceApplySite(builder, loc, applySite, fri, subs,
-                                     newArgs, substConv, newArgBorrows);
+  ApplySite newAS;
+  bool modifiedCFG;
+  std::tie(newAS, modifiedCFG) = replaceApplySite(
+      builder, loc, applySite, fri, subs, newArgs, substConv, newArgBorrows);
   FullApplySite newAI = FullApplySite::isa(newAS.getInstruction());
   assert(newAI);
 
@@ -808,16 +815,14 @@ FullApplySite swift::devirtualizeClassMethod(FullApplySite applySite,
     });
   NumClassDevirt++;
 
-  return newAI;
+  return {newAI, modifiedCFG};
 }
 
-FullApplySite swift::tryDevirtualizeClassMethod(FullApplySite applySite,
-                                                SILValue classInstance,
-                                                ClassDecl *cd,
-                                                OptRemark::Emitter *ore,
-                                                bool isEffectivelyFinalMethod) {
+std::pair<FullApplySite, bool> swift::tryDevirtualizeClassMethod(
+    FullApplySite applySite, SILValue classInstance, ClassDecl *cd,
+    OptRemark::Emitter *ore, bool isEffectivelyFinalMethod) {
   if (!canDevirtualizeClassMethod(applySite, cd, ore, isEffectivelyFinalMethod))
-    return FullApplySite();
+    return {FullApplySite(), false};
   return devirtualizeClassMethod(applySite, classInstance, cd, ore);
 }
 
@@ -960,9 +965,12 @@ swift::getWitnessMethodSubstitutions(SILModule &module, ApplySite applySite,
 /// Generate a new apply of a function_ref to replace an apply of a
 /// witness_method when we've determined the actual function we'll end
 /// up calling.
-static ApplySite devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
-                                           ProtocolConformanceRef cRef,
-                                           OptRemark::Emitter *ore) {
+///
+/// Return the new apply and true if the CFG was also modified.
+static std::pair<ApplySite, bool>
+devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
+                          ProtocolConformanceRef cRef,
+                          OptRemark::Emitter *ore) {
   // We know the witness thunk and the corresponding set of substitutions
   // required to invoke the protocol method at this point.
   auto &module = applySite.getModule();
@@ -1017,7 +1025,9 @@ static ApplySite devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
   SILLocation loc = applySite.getLoc();
   auto *fri = applyBuilder.createFunctionRefFor(loc, f);
 
-  ApplySite newApplySite =
+  ApplySite newApplySite;
+  bool modifiedCFG;
+  std::tie(newApplySite, modifiedCFG) =
       replaceApplySite(applyBuilder, loc, applySite, fri, subMap, arguments,
                        substConv, borrowedArgs);
 
@@ -1029,7 +1039,7 @@ static ApplySite devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
              << "Devirtualized call to " << NV("Method", f);
     });
   NumWitnessDevirt++;
-  return newApplySite;
+  return {newApplySite, modifiedCFG};
 }
 
 static bool canDevirtualizeWitnessMethod(ApplySite applySite) {
@@ -1066,10 +1076,11 @@ static bool canDevirtualizeWitnessMethod(ApplySite applySite) {
 /// In the cases where we can statically determine the function that
 /// we'll call to, replace an apply of a witness_method with an apply
 /// of a function_ref, returning the new apply.
-ApplySite swift::tryDevirtualizeWitnessMethod(ApplySite applySite,
-                                              OptRemark::Emitter *ore) {
+std::pair<ApplySite, bool>
+swift::tryDevirtualizeWitnessMethod(ApplySite applySite,
+                                    OptRemark::Emitter *ore) {
   if (!canDevirtualizeWitnessMethod(applySite))
-    return ApplySite();
+    return {ApplySite(), false};
 
   SILFunction *f;
   SILWitnessTable *wt;
@@ -1088,9 +1099,11 @@ ApplySite swift::tryDevirtualizeWitnessMethod(ApplySite applySite,
 
 /// Attempt to devirtualize the given apply if possible, and return a
 /// new instruction in that case, or nullptr otherwise.
-ApplySite swift::tryDevirtualizeApply(ApplySite applySite,
-                                      ClassHierarchyAnalysis *cha,
-                                      OptRemark::Emitter *ore) {
+///
+/// Return the new apply and true if the CFG was also modified.
+std::pair<ApplySite, bool>
+swift::tryDevirtualizeApply(ApplySite applySite, ClassHierarchyAnalysis *cha,
+                            OptRemark::Emitter *ore) {
   LLVM_DEBUG(llvm::dbgs() << "    Trying to devirtualize: "
                           << *applySite.getInstruction());
 
@@ -1105,7 +1118,7 @@ ApplySite swift::tryDevirtualizeApply(ApplySite applySite,
   // TODO: check if we can also de-virtualize partial applies of class methods.
   FullApplySite fas = FullApplySite::isa(applySite.getInstruction());
   if (!fas)
-    return ApplySite();
+    return {ApplySite(), false};
 
   /// Optimize a class_method and alloc_ref pair into a direct function
   /// reference:
@@ -1151,7 +1164,7 @@ ApplySite swift::tryDevirtualizeApply(ApplySite applySite,
     return tryDevirtualizeClassMethod(fas, instance, cd, ore);
   }
 
-  return ApplySite();
+  return {ApplySite(), false};
 }
 
 bool swift::canDevirtualizeApply(FullApplySite applySite,

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -572,7 +572,7 @@ static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
   // Add here the checks for any specific @_semantics attributes that need
   // to be skipped during the early inlining pass.
   ArraySemanticsCall ASC(AI.getInstruction());
-  if (ASC && !ASC.canInlineEarly())
+  if (ASC)
     return true;
 
   SILFunction *Callee = AI.getReferencedFunctionOrNull();

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -13,6 +13,12 @@
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/AST/Module.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "llvm/Support/CommandLine.h"
+
+llvm::cl::opt<std::string>
+    SILInlineNeverFuns("sil-inline-never-functions", llvm::cl::init(""),
+                       llvm::cl::desc("Never inline functions whose name "
+                                      "includes this string."));
 
 //===----------------------------------------------------------------------===//
 //                               ConstantTracker
@@ -679,6 +685,10 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   if (Callee->getInlineStrategy() == NoInline) {
     return nullptr;
   }
+
+  if (!SILInlineNeverFuns.empty()
+      && Callee->getName().find(SILInlineNeverFuns, 0) != StringRef::npos)
+    return nullptr;
 
   if (!Callee->shouldOptimize()) {
     return nullptr;

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1027,6 +1027,7 @@ extension Array: RangeReplaceableCollection {
   /// the new capacity is calculated using `_growArrayCapacity`, but at least
   /// kept at `minimumCapacity`.
   @_alwaysEmitIntoClient
+  @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityImpl(
     minimumCapacity: Int, growForAppend: Bool
   ) {

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -664,6 +664,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   /// If a new buffer needs to be allocated and `growForAppend` is true,
   /// the new capacity is calculated using `_growArrayCapacity`.
   @_alwaysEmitIntoClient
+  @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityImpl(
     minimumCapacity: Int, growForAppend: Bool
   ) {

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -1,7 +1,16 @@
-// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil -Xllvm '-sil-inline-never-functions=$sSa6append' %s | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
-// This is an end-to-end test of the array(contentsOf) -> array(Element) optimization
+// This is an end-to-end test of the Array.append(contentsOf:) ->
+// Array.append(Element) optimization.
+//
+// To check that the optimization produces the expected
+// Array.append(Element) calls, the CHECK lines match those call
+// sites. The optimizer may subsequently inline Array.append(Element),
+// which is good, but to keep the test simple and specific to the
+// optimization, the RUN line prevents inlining Array.append(Element).
+// Likewise, negative test check for the existence of
+// Array.append(contentsOf:), so don't inline those either.
 
 // CHECK-LABEL: sil @{{.*}}testInt
 // CHECK-NOT: apply
@@ -22,14 +31,13 @@ public func testInt(_ a: inout [Int]) {
 // CHECK-DAG:    apply [[F]]
 // CHECK-DAG:    apply [[F]]
 // CHECK:      } // end sil function '{{.*}}testThreeInts{{.*}}'
-
 public func testThreeInts(_ a: inout [Int]) {
   a += [1, 2, 3]
 }
 
 // CHECK-LABEL: sil @{{.*}}testTooManyInts
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref  @$sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lFSi_SaySiGTg5Tf4gn_n
+// CHECK:        [[F:%[0-9]+]] = function_ref  @$sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lFSi_SaySiGTg5
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NOT: apply

--- a/test/SILOptimizer/array_semantics_nested.swift
+++ b/test/SILOptimizer/array_semantics_nested.swift
@@ -1,0 +1,148 @@
+// RUN: %target-swift-frontend -O -emit-sil %s -Xllvm -debug-only=sil-inliner -Xllvm -debug-only=array-element-propagation -Xllvm -debug-only=cowarray-opts 2>&1 | %FileCheck %s
+
+// Test nested array semantic calls.
+//
+// The relevant sequence of passes is:
+//
+// - Early inlining does *not* inline Array.append(contentsOf:).
+//
+// - Early inlining inlines testInlineElts -> testInlineAppend.
+//
+// - ArrayElementPropagation of literal '[1, 2]' replaces
+// append(contentsOf:) with two calls to Array.append and removes the
+// temporary array literal.
+//
+// - Performance inlining does *not* initially inline any nested Array semantic
+// calls, like "_makeUniqueAndReserveCapacityIfNotUnique".
+//
+// - Performance inlining inlines Array.append(contentsOf:) and resets
+// the function pipeline.
+//
+// - COWArrayOpts hoists the call to _makeUniqueAndReserveCapacityIfNotUnique".
+
+// Here is the same sequence with interleaved CHECKs:
+
+// - Performance inlining does not initially inline any nested Array semantic
+// CHECK-NOT: inline [{{.*}}]] $sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lF
+// CHECK-NOT: inline [{{.*}}] $sSa034_makeUniqueAndReserveCapacityIfNotB0yyFSi_Tg5
+
+// - Early inlining inlines testInlineElts -> testInlineAppend.
+// CHECK-LABEL: Inline into caller: $s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF
+// CHECK:       inline [{{.*}}] $s22array_semantics_nested14testInlineElts_4eltsySaySiGz_ADtF
+
+// CHECK-NOT: inline [{{.*}}]] $sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lF
+// CHECK-NOT: inline [{{.*}}] $sSa034_makeUniqueAndReserveCapacityIfNotB0yyFSi_Tg5
+
+// - ArrayElementPropagation of literal '[1, 2]' replaces
+// append(contentsOf:) with two calls to Array.append and removes the
+// temporary array literal.
+// CHECK: Array append contentsOf calls replaced in $s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF
+
+// - Performance inlining does *not* initially inline any nested Array semantic
+// calls, like "_makeUniqueAndReserveCapacityIfNotUnique".
+
+// CHECK-NOT: inline [{{.*}}]] $sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lF
+// CHECK-NOT: inline [{{.*}}] $sSa034_makeUniqueAndReserveCapacityIfNotB0yyFSi_Tg5
+
+// - Performance inlining inlines Array.append(Element) and resets
+// the function pipeline.
+
+// CHECK: Inline into caller: $s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF
+// CHECK: inline [{{.*}}] $sSa6appendyyxnFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa6appendyyxnFSi_Tg5
+
+// CHECK: COW Array Opts in Func $s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF
+// CHECK:   Array Opts in Loop Loop at depth 1 containing:
+// CHECK:     Checking mutable array:   %{{.*}} = alloc_stack $Array<Int>, var, name "result"
+// CHECK: Hoisting make_mutable:
+// CHECK: Removing make_mutable call:
+
+// CHECK-NOT: Inline into caller
+
+// - The next round of inlinling in the same function pipeline.
+// CHECK: Inline into caller: $s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF
+// CHECK: inline [{{.*}}] $sSa034_makeUniqueAndReserveCapacityIfNotB0yyFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa9_getCountSiyFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa12_getCapacitySiyFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa15reserveCapacityyySiFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa9_getCountSiyFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa36_reserveCapacityAssumingUniqueBuffer8oldCountySi_tFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa37_appendElementAssumeUniqueAndCapacity_03newB0ySi_xntFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa9_getCountSiyFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa36_reserveCapacityAssumingUniqueBuffer8oldCountySi_tFSi_Tg5
+// CHECK: inline [{{.*}}] $sSa37_appendElementAssumeUniqueAndCapacity_03newB0ySi_xntFSi_Tg5
+
+// This helper ensures that at least one round of inlining is needed
+// *before* inlining Array.append.
+func testInlineElts(_ a: inout [Int], elts: [Int]) -> () {
+  a.append(contentsOf: elts)
+}
+
+// CHECK-LABEL: sil @$s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF : $@convention(thin) (Int) -> @owned Array<Int> {
+// CHECK: bb0(%0 : $Int):
+// Initialize the array...
+// CHECK:   [[RESULTARRAY:%[0-9]+]] = alloc_stack $Array<Int>, var, name "result"
+// CHECK:   store %{{.*}} to [[RESULTARRAY]] : $*Array<Int>
+
+// Perform the uniqueness check... (FIXME: should be able to optimize this away since it hasn't been escaped)
+// CHECK:   [[BUFADR:%[0-9]+]] = struct_element_addr [[RESULTARRAY]] : $*Array<Int>, #Array._buffer
+// CHECK:   [[STORADR:%[0-9]+]] = struct_element_addr [[BUFADR]] : $*_ArrayBuffer<Int>, #_ArrayBuffer._storage
+// CHECK:   [[BRIDGE:%[0-9]+]] = struct_element_addr [[STORADR]] : $*_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
+// CHECK:   [[NATIVE:%[0-9]+]] = unchecked_addr_cast [[BRIDGE]] : $*Builtin.BridgeObject to $*Builtin.NativeObject
+// CHECK:   [[UNIQ:%[0-9]+]] = is_unique [[NATIVE]] : $*Builtin.NativeObject
+// CHECK:   [[EXPECT:%[0-9]+]] = builtin "int_expect_Int1"([[UNIQ]] : $Builtin.Int1
+// CHECK:   cond_br [[EXPECT]]
+
+// Enter the loop...
+// CHECK: [[LOOPBB:bb[0-9]+]](%{{.*}} : $Builtin.Int64): // Preds: [[TAILBB:bb[0-9]+]] bb
+
+// CHECK-NOT: apply
+
+// Reserve capacity...
+//
+// FIXME: There is still an is_uniq inside the loop because of reserveCapacity.
+// Either reserveCapacity should be split into a hoistable uniqueness check,
+// or we should be able to prove that the uniqueness check is dominated with no escape.
+// CHECK:   [[BRIDGEOBJ:%.*]] = load [[BRIDGE]] : $*Builtin.BridgeObject
+// CHECK:   struct_element_addr %{{.*}} : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+// CHECK:   load %{{.*}} : $*Builtin.Int64
+// CHECK:   struct_element_addr %{{.*}} : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage._capacityAndFlags
+// CHECK:   load %{{.*}} : $*Builtin.Int64
+// CHECK:   cond_br %{{.*}}, bb8, bb9
+// CHECK-NOT: apply
+// CHECK: bb
+// CHECK:   is_unique %{{.*}} : $*Builtin.NativeObject
+// CHECK:   cond_br
+
+// CHECK-NOT: apply
+
+// CHECK:   [[SZF:%[0-9]+]] = function_ref @_swift_stdlib_malloc_size : $@convention(c) (UnsafeRawPointer) -> Int
+// CHECK:   apply [[SZF]](%{{.*}}) : $@convention(c) (UnsafeRawPointer) -> Int
+
+// CHECK-NOT: apply
+
+// CHECK: builtin "copyArray"<Int>
+// CHECK: store %{{.*}} to [[RESULTARRAY]] : $*Array<Int>
+
+// CHECK-NOT: apply
+
+// CHECK:   [[CPF1:%.*]] = function_ref @$sSa16_copyToNewBuffer8oldCountySi_tFSi_Tg5 : $@convention(method) (Int, @inout Array<Int>) -> ()
+// CHECK:   apply [[CPF1]](%{{.*}}, [[RESULTARRAY]]) : $@convention(method) (Int, @inout Array<Int>) -> ()
+
+// CHECK-NOT: apply
+
+// CHECK:   [[CPF2:%.*]] = function_ref @$sSa16_copyToNewBuffer8oldCountySi_tFSi_Tg5 : $@convention(method) (Int, @inout Array<Int>) -> ()
+// CHECK:   apply [[CPF2]](%{{.*}}, [[RESULTARRAY]]) : $@convention(method) (Int, @inout Array<Int>) -> ()
+
+// CHECK-NOT: apply
+
+// CHECK: br [[LOOPBB]](%{{.*}} : $Builtin.Int64)
+// CHECK-LABEL: } // end sil function '$s22array_semantics_nested16testInlineAppend5countSaySiGSi_tF'
+
+public func testInlineAppend(count: Int) -> [Int] {
+  var result = Array<Int>()
+  for _ in 0..<count {
+    testInlineElts(&result, elts: [1, 2])
+  }
+  return result
+}

--- a/test/SILOptimizer/generic_specialization_loops_detection_with_loops.swift
+++ b/test/SILOptimizer/generic_specialization_loops_detection_with_loops.swift
@@ -21,7 +21,10 @@
 
 // Check that the compiler has produced a specialization information for a call-site that
 // was inlined from a specialized generic function.
-// CHECK-LABEL: // Generic specialization information for call-site $s044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSaySays5UInt8VGG_SaySaySiGGTg5:
+//
+// Currently, bar4<Int, Double> is inlined into foo4<Int, Double>.
+// CHECK-LABEL: sil shared [noinline] @$s044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSi_SdTg5 : $@convention(thin) (Int, Double) -> () {
+// CHECK:       // Generic specialization information for call-site $s044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSaySays5UInt8VGG_SaySaySiGGTg5:
 // CHECK-NEXT:  // Caller: $s044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSi_SdTg5
 // CHECK-NEXT:  // Parent: $s044generic_specialization_loops_detection_with_C04bar4yyx_q_tr0_lF
 // CHECK-NEXT:  // Substitutions: <Array<UInt8>, Array<Int>>
@@ -31,6 +34,7 @@
 // CHECK-NEXT:  // Substitutions: <Int, Double>
 // CHECK-NEXT:  //
 // CHECK-NEXT: apply %{{.*}}Array<Array<UInt8>>
+// CHECK-LABEL: } // end sil function '$s044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSi_SdTg5'
 
 // Check specializations of mutually recursive functions which
 // may result in an infinite specialization loop.
@@ -52,6 +56,11 @@ public func testFooBar3() {
 // Check specializations of mutually recursive functions which
 // may result in an infinite specialization loop.
 public var g = 0
+
+// Don't inline foo4 just so we can reliably check for specialization
+// information both at the function and call-site level.
+// bar4 is still inlined so we can test for inlined specialization info.
+@inline(never)
 func foo4<T, S>(_ t: T, _ s: S) {
   // Here we have multiple call-sites of the same generic
   // functions inside the same caller.

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -304,18 +304,22 @@ public final class StreamClass {
         self.buffer = []
     }
 
+    @inline(__always)
     public func write(_ byte: UInt8) {
         buffer.append(byte)
     }
 
+    @inline(__always)
     public func write(_ value: WriteProt) {
         value.writeTo(self)
     }
 
+    @inline(__always)
     public func writeEscaped(_ string: String) {
         writeEscaped(string: string.utf8)
     }
     
+    @inline(__always)
     public func writeEscaped<T: Collection>(
         string sequence: T
     ) where T.Iterator.Element == UInt8 {
@@ -326,12 +330,14 @@ public final class StreamClass {
     }
 }
 
+@inline(__always)
 public func toStream(_ stream: StreamClass, _ value: WriteProt) -> StreamClass {
     stream.write(value)
     return stream
 }
 
 extension UInt8: WriteProt {
+    @inline(__always)
     public func writeTo(_ stream: StreamClass) {
         stream.write(self)
     }
@@ -344,6 +350,7 @@ public func asWriteProt(_ string: String) -> WriteProt {
 private struct EscapedString: WriteProt {
     let value: String
         
+    @inline(__always)
     func writeTo(_ stream: StreamClass) {
         _ = toStream(stream, UInt8(ascii: "a"))
         stream.writeEscaped(value)
@@ -359,6 +366,7 @@ private struct EscapedTransforme<T>: WriteProt {
     let items: [T]
     let transform: (T) -> String
 
+    @inline(__always)
     func writeTo(_ stream: StreamClass) {
         for (i, item) in items.enumerated() {
             if i != 0 { _ = toStream(stream, asWriteProt(transform(item))) }
@@ -388,6 +396,6 @@ public func run_MergeTest9(_ N: Int) {
   let listOfThings: [Thing] = listOfStrings.map(Thing.init)
   for _ in 1...N {
     let stream = StreamClass()
-      _ = toStream(stream, asWriteProt(listOfThings, transform: { $0.value }))
+    _ = toStream(stream, asWriteProt(listOfThings, transform: { $0.value }))
   }
 }

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -68,6 +68,7 @@ _swift_complete()
       -sil-verify-without-invalidation \
       -sil-inline-test-threshold \
       -sil-inline-test \
+      -sil-inline-never-functions \
       -sroa-args-remove-dead-args-after \
       -ml \
       -sil-print-escapes \


### PR DESCRIPTION
This is a small series of commits that together fixes issues in the pass pipeline that are causing severe instability in benchmark performance and blocking other bug fixes.

We have heroic optimizations for array access, but whether those actually kick in was essentially random. Now, those optimizations always have a chance to run and the pass pipeline consistently reruns when necessary as it was designed to do.

The two main bug fixes are
- Don't inline array semantic calls before the mid-level pipeline
- Fix the mid-level pipeline restart mechanism