### PR TITLE
[5.0] `@objc extension` makes even 'private' members '@objc'

### DIFF
--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2326,4 +2326,18 @@ extension MyObjCClass {
         }
         set {}
     }
+
+    // CHECK: {{^}} @objc private dynamic func stillExposedToObjCDespiteBeingPrivate()
+    private func stillExposedToObjCDespiteBeingPrivate() {}
 }
+
+@objc private extension MyObjCClass {
+  // CHECK: {{^}} @objc dynamic func alsoExposedToObjCDespiteBeingPrivate()
+  func alsoExposedToObjCDespiteBeingPrivate() {}
+}
+
+@objcMembers class VeryObjCClass: NSObject {
+  // CHECK: {{^}} private func notExposedToObjC()
+  private func notExposedToObjC() {}
+}
+


### PR DESCRIPTION
- **Explanation**: `@objc` on an extension is supposed to be the same as implicitly writing `@objc` on all members of the extension except for declarations where that wouldn't make sense (mostly types and various accessors). A fix for another issue (mistakenly implicitly adding `@objc` to `read` and `modify` accessors) accidentally started filtering this by access control, similar to the behavior of Swift-3-style `@objc` inference. This patch distinguishes those two cases of "implicitly add `@objc`" to restore source compatibility with Swift 4.2.

- **Scope**: Affects private and fileprivate members of extensions marked `@objc`.

- **Issue**: rdar://problem/47869562

- **Risk**: Low. This is getting us closer to what we had in Swift 4.2, and the change is very small.

- **Testing**: Added compiler regression tests, passed source compatibility suite.

- **Reviewed by**: @rjmccall, @DougGregor    