### PR TITLE
[5.0][stdlib] Two String bug fixes

### DIFF
--- a/stdlib/public/core/ContiguouslyStored.swift
+++ b/stdlib/public/core/ContiguouslyStored.swift
@@ -42,7 +42,7 @@ extension UnsafeBufferPointer: _HasContiguousBytes {
   func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    let ptr = UnsafeRawPointer(self.baseAddress._unsafelyUnwrappedUnchecked)
+    let ptr = UnsafeRawPointer(self.baseAddress)
     let len = self.count &* MemoryLayout<Element>.stride
     return try body(UnsafeRawBufferPointer(start: ptr, count: len))
   }
@@ -52,7 +52,7 @@ extension UnsafeMutableBufferPointer: _HasContiguousBytes {
   func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    let ptr = UnsafeRawPointer(self.baseAddress._unsafelyUnwrappedUnchecked)
+    let ptr = UnsafeRawPointer(self.baseAddress)
     let len = self.count &* MemoryLayout<Element>.stride
     return try body(UnsafeRawBufferPointer(start: ptr, count: len))
   }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -242,6 +242,11 @@ extension _SmallString {
   // Direct from UTF-8
   @inlinable @inline(__always)
   internal init?(_ input: UnsafeBufferPointer<UInt8>) {
+    if input.isEmpty {
+      self.init()
+      return
+    }
+
     let count = input.count
     guard count <= _SmallString.capacity else { return nil }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -405,10 +405,9 @@ extension String {
        contigBytes._providesContiguousBytesNoCopy
     {
       self = contigBytes.withUnsafeBytes { rawBufPtr in
-        let ptr = rawBufPtr.baseAddress._unsafelyUnwrappedUnchecked
         return String._fromUTF8Repairing(
           UnsafeBufferPointer(
-            start: ptr.assumingMemoryBound(to: UInt8.self),
+            start: rawBufPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
             count: rawBufPtr.count)).0
       }
       return
@@ -836,7 +835,7 @@ extension String {
     }
     return codeUnits
   }
-  
+
   public // @testable
   func _withNFCCodeUnits(_ f: (UInt8) throws -> Void) rethrows {
     try _gutsSlice._withNFCCodeUnits(f)

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 internal func _allASCII(_ input: UnsafeBufferPointer<UInt8>) -> Bool {
+  if input.isEmpty { return true }
+
   // NOTE: Avoiding for-in syntax to avoid bounds checks
   //
   // TODO(String performance): SIMD-ize
@@ -146,9 +148,8 @@ extension String {
     _ body: (UnsafeBufferPointer<UTF8.CodeUnit>) throws -> R
   ) rethrows -> R {
     return try self.withUnsafeBytes { rawBufPtr in
-      let rawPtr = rawBufPtr.baseAddress._unsafelyUnwrappedUnchecked
       return try body(UnsafeBufferPointer(
-        start: rawPtr.assumingMemoryBound(to: UInt8.self),
+        start: rawBufPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
         count: rawBufPtr.count))
     }
   }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -241,11 +241,7 @@ extension String {
   @inlinable
   public var utf8: UTF8View {
     @inline(__always) get { return UTF8View(self._guts) }
-    set {
-      // TODO(String testing): test suite doesn't currenlty exercise this code at
-      // all, test it.
-      self = String(utf8._guts)
-    }
+    set { self = String(newValue._guts) }
   }
 
   /// A contiguously stored null-terminated UTF-8 representation of the string.

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+defer { runAllTests() }
+
+var StringCreateTests = TestSuite("StringCreateTests")
+
+enum SimpleString: String {
+  case smallASCII = "abcdefg"
+  case smallUnicode = "abéÏ𓀀"
+  case largeASCII = "012345678901234567890"
+  case largeUnicode = "abéÏ012345678901234567890𓀀"
+  case emoji = "😀😃🤢🤮👩🏿‍🎤🧛🏻‍♂️🧛🏻‍♂️👩‍👩‍👦‍👦"
+}
+
+let simpleStrings: [String] = [
+    SimpleString.smallASCII.rawValue,
+    SimpleString.smallUnicode.rawValue,
+    SimpleString.largeASCII.rawValue,
+    SimpleString.largeUnicode.rawValue,
+    SimpleString.emoji.rawValue,
+    "",
+]
+
+extension String {
+  var utf32: [UInt32] { return unicodeScalars.map { $0.value } }
+}
+
+StringCreateTests.test("String(decoding:as)") {
+  func validateDecodingAs(_ str: String) {
+    // Non-contiguous (maybe) storage
+    expectEqual(str, String(decoding: str.utf8, as: UTF8.self))
+    expectEqual(str, String(decoding: str.utf16, as: UTF16.self))
+    expectEqual(str, String(decoding: str.utf32, as: UTF32.self))
+
+    // Contiguous storage
+    expectEqual(str, String(decoding: Array(str.utf8), as: UTF8.self))
+    expectEqual(str, String(decoding: Array(str.utf16), as: UTF16.self))
+    expectEqual(str, String(decoding: Array(str.utf32), as: UTF32.self))
+
+  }
+
+  for str in simpleStrings {
+    validateDecodingAs(str)
+  }
+
+  // Corner-case: UBP with null pointer (https://bugs.swift.org/browse/SR-9869)
+  expectEqual(
+    "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF8.self))
+  expectEqual(
+    "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF16.self))
+  expectEqual(
+    "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF32.self))
+}
+

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -796,4 +796,28 @@ tests.test("String.UTF32View/BidirectionalCollection")
     test.unicodeScalars, test.string.unicodeScalars) { $0 == $1 }
 }
 
+tests.test("String View Setters") {
+  var string = "abcd🤠👨‍👨‍👦‍👦efg"
+
+  string.utf8 = winter.utf8
+  expectEqual(winter, string)
+  string.utf8 = summer.utf8
+  expectEqual(summer, string)
+
+  string.utf16 = winter.utf16
+  expectEqual(winter, string)
+  string.utf16 = summer.utf16
+  expectEqual(summer, string)
+
+  string.unicodeScalars = winter.unicodeScalars
+  expectEqual(winter, string)
+  string.unicodeScalars = summer.unicodeScalars
+  expectEqual(summer, string)
+
+  string = winter
+  expectEqual(winter, string)
+  string = summer
+  expectEqual(summer, string)
+}
+
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->

This cherry picks two bug fixes: 

https://github.com/apple/swift/pull/22417
https://github.com/apple/swift/pull/22430

- **Explanation**: This fixes two important bugs
  * `String.utf8`'s setter was dropping the new value, effectively making it a no-op. In addition to making it unusable, this is a dangerous bug as it violates programmer reasoning about bounds. This was somehow untested anywhere in our testing, SPM, or otherwise. This PR adds extensive tests.
  * `String.init(describing:as:)` **crashes** if given a null `UnsafeBufferPointer<UInt8>`. This is a serious bug because we expect more and more developers to exercise this code path going forwards. This PR adds extensive tests.

- **Scope**: Limited to the situation described above.

- **Issue**: rdar://problem/47864610 and rdar://problem/47864538

- **Risk**: Low. The change is small, and every part of it makes code more robust.

- **Testing**: Added regression tests, passed testing

- **Reviewed by**: @jrose-apple 

