### PR TITLE
[update-checkout] Add new branch configs for Swift 5.1

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -243,6 +243,58 @@
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master"
             }
+        },
+        "swift-5.1-old-llvm-branch" : {
+            "aliases": ["swift-5.1-old-llvm-branch"],
+            "repos": {
+                "llvm": "swift-5.0-branch",
+                "clang": "swift-5.0-branch",
+                "compiler-rt": "swift-5.0-branch",
+                "swift": "swift-5.1-old-llvm-branch",
+                "lldb": "stable",
+                "cmark": "master",
+                "llbuild": "master",
+                "swiftpm": "master",
+                "swift-syntax": "master",
+                "swift-stress-tester": "master",
+                "swift-corelibs-xctest": "master",
+                "swift-corelibs-foundation": "master",
+                "swift-corelibs-libdispatch": "master",
+                "swift-integration-tests": "master",
+                "swift-xcode-playground-support": "master",
+                "ninja": "release",
+                "icu": "release-61-1",
+                "clang-tools-extra": "swift-5.0-branch",
+                "libcxx": "swift-5.0-branch",
+                "indexstore-db": "master",
+                "sourcekit-lsp": "master"
+            }
+        },
+        "swift-5.1-branch" : {
+            "aliases": ["swift-5.1-branch"],
+            "repos": {
+                "llvm": "swift-5.1-branch",
+                "clang": "swift-5.1-branch",
+                "compiler-rt": "swift-5.1-branch",
+                "swift": "swift-5.1-branch",
+                "lldb": "stable",
+                "cmark": "master",
+                "llbuild": "master",
+                "swiftpm": "master",
+                "swift-syntax": "master",
+                "swift-stress-tester": "master",
+                "swift-corelibs-xctest": "master",
+                "swift-corelibs-foundation": "master",
+                "swift-corelibs-libdispatch": "master",
+                "swift-integration-tests": "master",
+                "swift-xcode-playground-support": "master",
+                "ninja": "release",
+                "icu": "release-61-1",
+                "clang-tools-extra": "swift-5.1-branch",
+                "libcxx": "swift-5.1-branch",
+                "indexstore-db": "master",
+                "sourcekit-lsp": "master"
+            }
         }
     }
 }


### PR DESCRIPTION
Add a tentative branch config for "swift-5.1-branch". Not all of the repos
are branched yet. I went ahead and added a reference to swift-5.1-branch for
the Swift repo, so that I can use this to start pulling together something
with cherry-picks from master-next. (The current master-next branch has
moved past the point where we branched the LLVM repos for swift-5.1-branch,
so we can't just grab a copy of master-next.) I also added a separate config
for "swift-5.1-old-llvm-branch", which will be used temporarily to track the
same Swift content as swift-5.1-branch but still building with the version
of LLVM in swift-5.0-branch.