### PR TITLE
SyntaxNodes: implement the hash function for syntax nodes.

### DIFF
--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -247,3 +247,7 @@ def verify_syntax_node_serialization_codes(nodes, serialization_codes):
         if serialization_code in used_codes:
             error("Serialization code %d used twice" % serialization_code)
         used_codes.add(serialization_code)
+
+
+def get_serialization_code(syntax_kind):
+    return SYNTAX_NODE_SERIALIZATION_CODES[syntax_kind]

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -7,7 +7,9 @@ from DeclNodes import DECL_NODES  # noqa: I201
 from ExprNodes import EXPR_NODES  # noqa: I201
 from GenericNodes import GENERIC_NODES  # noqa: I201
 from NodeSerializationCodes import SYNTAX_NODE_SERIALIZATION_CODES, \
+    get_serialization_code, \
     verify_syntax_node_serialization_codes
+
 from PatternNodes import PATTERN_NODES  # noqa: I201
 from StmtNodes import STMT_NODES  # noqa: I201
 import Token
@@ -141,5 +143,28 @@ def dedented_lines(description):
     return textwrap.dedent(description).split('\n')
 
 
+def hash_syntax_node(node):
+    # Hash into the syntax name and serialization code
+    result = hash((node.name, str(get_serialization_code(node.syntax_kind))))
+    for child in node.children:
+        # Hash into the expected child syntax
+        result = hash((result, child.syntax_kind))
+        # Hash into the child name
+        result = hash((result, child.name))
+        # Hash into whether the child is optional
+        result = hash((result, str(child.is_optional)))
+    return result
+
+
+def hash_token_syntax(token):
+    # Hash into the token name and serialization code
+    return hash((token.name, str(token.serialization_code)))
+
+
 def calculate_node_hash():
-    return "abc"
+    result = 0
+    for node in SYNTAX_NODES:
+        result = hash((result, hash_syntax_node(node=node)))
+    for token in SYNTAX_TOKENS:
+        result = hash((result, hash_token_syntax(token=token)))
+    return result


### PR DESCRIPTION
This hash function will concatenate all interesting pieces of information
of node definitions in a single string and call hash() on this string.
