### PR TITLE
[5.0] [index] Add back override relation for associated type witnesses

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -129,7 +129,7 @@ public:
   }
 };
 
-struct ValueWitness {
+struct IndexedWitness {
   ValueDecl *Member;
   ValueDecl *Requirement;
 };
@@ -146,7 +146,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
     Decl *D;
     SymbolInfo SymInfo;
     SymbolRoleSet Roles;
-    SmallVector<ValueWitness, 6> ExplicitValueWitnesses;
+    SmallVector<IndexedWitness, 6> ExplicitWitnesses;
     SmallVector<SourceLoc, 6> RefsToSuppress;
   };
   SmallVector<Entity, 6> EntitiesStack;
@@ -462,8 +462,8 @@ private:
   bool reportExtension(ExtensionDecl *D);
   bool reportRef(ValueDecl *D, SourceLoc Loc, IndexSymbol &Info,
                  Optional<AccessKind> AccKind);
-  bool reportImplicitValueConformance(ValueDecl *witness, ValueDecl *requirement,
-                                      Decl *container);
+  bool reportImplicitConformance(ValueDecl *witness, ValueDecl *requirement,
+                                 Decl *container);
 
   bool startEntity(Decl *D, IndexSymbol &Info, bool IsRef);
   bool startEntityDecl(ValueDecl *D);
@@ -535,7 +535,7 @@ private:
   /// members.
   ///
   /// \returns false if AST visitation should stop.
-  bool handleValueWitnesses(Decl *D, SmallVectorImpl<ValueWitness> &explicitValueWitnesses);
+  bool handleWitnesses(Decl *D, SmallVectorImpl<IndexedWitness> &explicitWitnesses);
 
   void getModuleHash(SourceFileOrModule SFOrMod, llvm::raw_ostream &OS);
   llvm::hash_code hashModule(llvm::hash_code code, SourceFileOrModule SFOrMod);
@@ -695,7 +695,7 @@ bool IndexSwiftASTWalker::visitImports(
   return true;
 }
 
-bool IndexSwiftASTWalker::handleValueWitnesses(Decl *D, SmallVectorImpl<ValueWitness> &explicitValueWitnesses) {
+bool IndexSwiftASTWalker::handleWitnesses(Decl *D, SmallVectorImpl<IndexedWitness> &explicitWitnesses) {
   auto DC = dyn_cast<DeclContext>(D);
   if (!DC)
     return true;
@@ -719,11 +719,26 @@ bool IndexSwiftASTWalker::handleValueWitnesses(Decl *D, SmallVectorImpl<ValueWit
         return;
 
       if (decl->getDeclContext() == DC) {
-        explicitValueWitnesses.push_back(ValueWitness{decl, req});
+        explicitWitnesses.push_back({decl, req});
+      } else {
+        reportImplicitConformance(decl, req, D);
+      }
+    });
+
+    normal->forEachTypeWitness(nullptr,
+                 [&](AssociatedTypeDecl *assoc, Type type, TypeDecl *typeDecl) {
+      if (Cancelled)
+        return true;
+      if (typeDecl == nullptr)
+        return false;
+
+      if (typeDecl->getDeclContext() == DC) {
+        explicitWitnesses.push_back({typeDecl, assoc});
       } else {
         // Report the implicit conformance.
-        reportImplicitValueConformance(decl, req, D);
+        reportImplicitConformance(typeDecl, assoc, D);
       }
+      return false;
     });
   }
 
@@ -741,12 +756,12 @@ bool IndexSwiftASTWalker::startEntity(Decl *D, IndexSymbol &Info, bool IsRef) {
     case swift::index::IndexDataConsumer::Skip:
       return false;
     case swift::index::IndexDataConsumer::Continue: {
-      SmallVector<ValueWitness, 6> explicitValueWitnesses;
+      SmallVector<IndexedWitness, 6> explicitWitnesses;
       if (!IsRef) {
-        if (!handleValueWitnesses(D, explicitValueWitnesses))
+        if (!handleWitnesses(D, explicitWitnesses))
           return false;
       }
-      EntitiesStack.push_back({D, Info.symInfo, Info.roles, std::move(explicitValueWitnesses), {}});
+      EntitiesStack.push_back({D, Info.symInfo, Info.roles, std::move(explicitWitnesses), {}});
       return true;
     }
   }
@@ -781,7 +796,7 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
   }
 
   if (auto Parent = getParentDecl()) {
-    for (const ValueWitness &witness : EntitiesStack.back().ExplicitValueWitnesses) {
+    for (const IndexedWitness &witness : EntitiesStack.back().ExplicitWitnesses) {
       if (witness.Member == D)
         addRelation(Info, (SymbolRoleSet) SymbolRole::RelationOverrideOf, witness.Requirement);
     }
@@ -1104,8 +1119,8 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
   return finishCurrentEntity();
 }
 
-bool IndexSwiftASTWalker::reportImplicitValueConformance(ValueDecl *witness, ValueDecl *requirement,
-                                                         Decl *container) {
+bool IndexSwiftASTWalker::reportImplicitConformance(ValueDecl *witness, ValueDecl *requirement,
+                                                    Decl *container) {
   if (!shouldIndex(witness, /*IsRef=*/true))
     return true; // keep walking
 

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -98,3 +98,29 @@ extension InheritingP { // CHECK: [[@LINE]]:11 | extension/ext-protocol/Swift | 
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[InheritingP_foo_USR]]
     // CHECK-NEXT: RelChild | extension/ext-protocol/Swift | InheritingP | [[InheritingP_USR]]
 }
+
+protocol WithAssocType {
+  associatedtype T // CHECK: [[@LINE]]:18 | type-alias/associated-type/Swift | T | [[WithAssocT_USR:.*]] | Def
+  func foo() -> T // CHECK: [[@LINE]]:17 | type-alias/associated-type/Swift | T | [[WithAssocT_USR]] | Ref
+}
+
+struct SAssocTypeAlias: WithAssocType {
+  typealias T = Int // CHECK: [[@LINE]]:13 | type-alias/Swift | T | [[SAssocT:.*]] | Def,RelChild,RelOver | rel: 2
+    // CHECK-NEXT: RelOver | type-alias/associated-type/Swift | T | [[WithAssocT_USR]]
+    // CHECK-NEXT: RelChild | struct/Swift | SAssocTypeAlias
+  func foo() -> T { return 0 } // CHECK: [[@LINE]]:17 | type-alias/Swift | T | [[SAssocT:.*]] | Ref
+}
+
+struct SAssocTypeInferred: WithAssocType {
+  func foo() -> Int { return 1 }
+  func bar() -> T { return 2 } // CHECK: [[@LINE]]:17 |  type-alias/associated-type/Swift | T | [[WithAssocT_USR]] | Ref
+}
+
+struct AssocViaExtension {
+  struct T {} // CHECK: [[@LINE]]:10 | struct/Swift | T | [[AssocViaExtensionT_USR:.*]] | Def
+  func foo() -> T { return T() }
+}
+
+extension AssocViaExtension: WithAssocType {} // CHECK: [[@LINE]]:11 | struct/Swift | T | [[AssocViaExtensionT_USR]] | Impl,RelOver,RelCont | rel: 2
+  // CHECK-NEXT: RelOver | type-alias/associated-type/Swift | T | [[WithAssocT_USR]]
+  // CHECK-NEXT: RelCont | extension/ext-struct/Swift | AssocViaExtension


### PR DESCRIPTION
When conforming to a protocol, the index should have a "override"
relation for each witness, including type witnesses.  This was
accidentally broken in 3bd80e5e31f when we stopped using the
type-checker to find all protocol conformances.

rdar://47833618

(cherry-pick 981167d3d533a)