### PR TITLE
Extend transitive availability checking to initial value expressions (better version)

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -540,10 +540,18 @@ public:
     void verifyParsed(Stmt *S) {}
     void verifyParsed(Pattern *P) {}
     void verifyParsed(Decl *D) {
+      PrettyStackTraceDecl debugStack("verifying ", D);
       if (!D->getDeclContext()) {
-        Out << "every Decl should have a DeclContext";
-        PrettyStackTraceDecl debugStack("verifying DeclContext", D);
+        Out << "every Decl should have a DeclContext\n";
         abort();
+      }
+      if (auto *DC = dyn_cast<DeclContext>(D)) {
+        if (D->getDeclContext() != DC->getParent()) {
+          Out << "Decl's DeclContext not in sync with DeclContext's parent\n";
+          D->getDeclContext()->dumpContext();
+          DC->getParent()->dumpContext();
+          abort();
+        }
       }
     }
     template<typename T>

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1110,35 +1110,17 @@ static void findAvailabilityFixItNodes(SourceRange ReferenceRange,
   FoundVersionCheckNode =
       findInnermostAncestor(ReferenceRange, SM, SearchRoot, IsGuardable);
 
-  // Find some Decl that contains the reference range. We use this declaration
-  // as a starting place to climb the DeclContext hierarchy to find
-  // places to suggest adding @available() annotations.
-  InnermostAncestorFinder::MatchPredicate IsDeclaration = [](
-      ASTNode Node, ASTWalker::ParentTy Parent) { return Node.is<Decl *>(); };
-
-  Optional<ASTNode> FoundDeclarationNode =
-      findInnermostAncestor(ReferenceRange, SM, SearchRoot, IsDeclaration);
-
-  const Decl *ContainingDecl = nullptr;
-  if (FoundDeclarationNode.hasValue()) {
-    ContainingDecl = FoundDeclarationNode.getValue().get<Decl *>();
-  }
-
-  if (!ContainingDecl) {
-    ContainingDecl = ReferenceDC->getInnermostMethodContext();
-  }
-
   // Try to find declarations on which @available attributes can be added.
   // The heuristics for finding these declarations are biased towards deeper
   // nodes in the AST to limit the scope of suggested availability regions
   // and provide a better IDE experience (it can get jumpy if Fix-It locations
   // are far away from the error needing the Fix-It).
-  if (ContainingDecl) {
+  if (DeclarationToSearch) {
     FoundMemberLevelDecl =
-        ancestorMemberLevelDeclForAvailabilityFixit(ContainingDecl);
+        ancestorMemberLevelDeclForAvailabilityFixit(DeclarationToSearch);
 
     FoundTypeLevelDecl =
-        ancestorTypeLevelDeclForAvailabilityFixit(ContainingDecl);
+        ancestorTypeLevelDeclForAvailabilityFixit(DeclarationToSearch);
   }
 }
 

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -1,13 +1,17 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -parse-as-library
 // REQUIRES: OS=macosx
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
 @available(OSX, unavailable)
-func osx() {} // expected-note 2{{'osx()' has been explicitly marked unavailable here}}
+@discardableResult
+func osx() -> Int { return 0 } // expected-note * {{'osx()' has been explicitly marked unavailable here}}
 
 @available(OSXApplicationExtension, unavailable)
 func osx_extension() {}
+
+@available(OSX, unavailable)
+func osx_pair() -> (Int, Int) { return (0, 0) } // expected-note * {{'osx_pair()' has been explicitly marked unavailable here}}
 
 func call_osx_extension() {
     osx_extension() // OK; osx_extension is only unavailable if -application-extension is passed.
@@ -34,4 +38,85 @@ func osx_extension_call_osx_extension() {
 @available(OSXApplicationExtension, unavailable)
 func osx_extension_call_osx() {
     osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+var osx_init_osx = osx() // OK
+
+@available(OSXApplicationExtension, unavailable)
+var osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
+
+@available(OSX, unavailable)
+var osx_inner_init_osx = { let inner_var = osx() } // OK
+
+// FIXME: I'm not sure why this produces two errors instead of just one.
+@available(OSXApplicationExtension, unavailable)
+var osx_extension_inner_init_osx = { let inner_var = osx() } // expected-error 2 {{'osx()' is unavailable}}
+
+struct Outer {
+  @available(OSX, unavailable)
+  var osx_init_osx = osx() // OK
+
+  @available(OSX, unavailable)
+  lazy var osx_lazy_osx = osx() // OK
+
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
+
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_lazy_osx = osx() // expected-error {{'osx()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var osx_init_multi1_osx = osx(), osx_init_multi2_osx = osx() // OK
+
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_init_multi1_osx = osx(), osx_extension_init_multi2_osx = osx() // expected-error 2 {{'osx()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var (osx_init_deconstruct1_osx, osx_init_deconstruct2_osx) = osx_pair() // OK
+
+  @available(OSXApplicationExtension, unavailable)
+  var (osx_extension_init_deconstruct1_osx, osx_extension_init_deconstruct2_osx) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var (_, osx_init_deconstruct2_only_osx) = osx_pair() // OK
+  
+  @available(OSXApplicationExtension, unavailable)
+  var (_, osx_extension_init_deconstruct2_only_osx) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var (osx_init_deconstruct1_only_osx, _) = osx_pair() // OK
+  
+  @available(OSXApplicationExtension, unavailable)
+  var (osx_extension_init_deconstruct1_only_osx, _) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var osx_inner_init_osx = { let inner_var = osx() } // OK
+  
+  // FIXME: I'm not sure why this produces two errors instead of just one.
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_inner_init_osx = { let inner_var = osx() } // expected-error 2 {{'osx()' is unavailable}}
+}
+
+extension Outer {
+  @available(OSX, unavailable)
+  static var also_osx_init_osx = osx() // OK
+  
+  @available(OSXApplicationExtension, unavailable)
+  static var also_osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+extension Outer {
+  static var outer_osx_init_osx = osx() // OK
+}
+
+@available(OSX, unavailable)
+struct NotOnOSX {
+  var osx_init_osx = osx() // OK
+  lazy var osx_lazy_osx = osx() // OK
+  var osx_init_multi1_osx = osx(), osx_init_multi2_osx = osx() // OK
+  var (osx_init_deconstruct1_osx, osx_init_deconstruct2_osx) = osx_pair() // OK
+  var (_, osx_init_deconstruct2_only_osx) = osx_pair() // OK
+  var (osx_init_deconstruct1_only_osx, _) = osx_pair() // OK
 }


### PR DESCRIPTION
Because initial value expressions aren't actually considered _within_ the VarDecl or PatternBindingDecl they're initializing, the existing logic to search for availability attributes wasn't kicking in, leading to errors when a conditionally-unavailable value was used in an initial value expression for a conditionally-unavailable binding. Fix this by walking the enclosing type or extension to find the appropriate PatternBindingDecl.

[SR-9867](https://bugs.swift.org/browse/SR-9867) / rdar://problem/47852718

* * *

@brentdax caught some missing cases in the previous version (#22438); this is better.