### PR TITLE
AST: TapExpr should return sub-expression's source locations if set.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -988,8 +988,11 @@ public:
   BraceStmt * getBody() const { return Body; }
   void setBody(BraceStmt * b) { Body = b; }
 
-  SourceLoc getLoc() const { return SourceLoc(); }
-  SourceRange getSourceRange() const { return SourceRange(); }
+  SourceLoc getLoc() const { return SubExpr ? SubExpr->getLoc() : SourceLoc(); }
+
+  SourceRange getSourceRange() const {
+    return SubExpr ? SubExpr->getSourceRange() : SourceRange();
+  }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Tap;

--- a/test/IDE/range_info_string_interpolation.swift
+++ b/test/IDE/range_info_string_interpolation.swift
@@ -1,0 +1,9 @@
+func test(x: Int, y: Int) {
+  let z = "x = \(x), y = \(y)"
+  print(z)
+}
+
+// RUN: %target-swift-ide-test -range -pos=2:1 -end-pos 4:1 -source-filename %s | %FileCheck %s -check-prefix=CHECK-PARAMS
+
+// CHECK-PARAMS: <Referenced>x</Referenced><Type>Int</Type>
+// CHECK-PARAMS: <Referenced>y</Referenced><Type>Int</Type>


### PR DESCRIPTION
Without source location, TapExpr could stop IDE from collecting parameters
while perform refactoring.

rdar://47835267