### PR TITLE
[TF-8] Fix autodiff witness generation when orig type is address-only and tangent type isn't

### DIFF
--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -155,3 +155,24 @@ enum T : P {
   a = a + x
   return a
 }
+
+//===----------------------------------------------------------------------===//
+// Crasher TF-8
+//===----------------------------------------------------------------------===//
+
+protocol TF8Proto : Differentiable {
+  associatedtype Scalar
+  @differentiable(wrt: (self, input))
+  func applied(to input: Float) -> Float
+}
+
+struct TF8Struct<Scalar> : TF8Proto where Scalar : FloatingPoint & Differentiable {
+  @noDerivative let bar: Scalar
+
+  @differentiable(wrt: (self, input))
+  // expected-note @+2 {{differentiating functions with parameters or result of unknown size is not supported yet}}
+  // expected-error @+1 {{function is not differentiable}}
+  func applied(to input: Float) -> Float {
+    return input
+  }
+}


### PR DESCRIPTION
The problem is that "lowering function type from AST to SIL" does not commute with "getting autodiff associated function type", and we have some places that do them in different orders and need to get the same results.

In particular, suppose that `Foo` is address-only but `Foo.CotangentVector` is not. Then:
```
lower(vjp( (Foo) -> Float ))
    = lower( (Foo) -> (Float, (Float) -> Foo.CotangentVector) )
    = (@in Foo) -> (Float, (Float) -> Foo.CotangentVector)

vjp(lower( (Foo) -> Float ))
    = vjp( (@in Foo) -> Float )
    = (@in Foo) -> (Float, (Float) -> @out Foo.CotangentVector)
```

This PR is a quite hacky fix that modifies one place to do it in the "right" order so that its results match with all the other results.

I think we should reconsider adding the associated function types to `SILFunctionType`! It would make it possible for "lowering" to commute with "getting autodiff associated function type", which would make this hack unnnecessary and would also prevent other bugs caused by noncommutativity that might be lurking in the code.