### PR TITLE
[ConstraintSystem] Diagnose conditional requirement failures via fixes

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -24,6 +24,8 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Parse/Lexer.h"
@@ -88,19 +90,54 @@ Type RequirementFailure::getOwnerType() const {
 }
 
 const GenericContext *RequirementFailure::getGenericContext() const {
+  // For conditional requirements, this is easy because all
+  // required information is contained in the conformance
+  // reference.
+  if (isConditional()) {
+    auto *conformance = getConformanceRef().getConcrete();
+    auto *DC = conformance->getDeclContext();
+    return DC->getAsDecl()->getAsGenericContext();
+  }
+
   if (auto *genericCtx = AffectedDecl->getAsGenericContext())
     return genericCtx;
   return AffectedDecl->getDeclContext()->getAsDecl()->getAsGenericContext();
 }
 
 const Requirement &RequirementFailure::getRequirement() const {
+  // If this is a conditional requirement failure we need to
+  // fetch conformance from constraint system associated with
+  // type requirement this conditional conformance belongs to.
+  if (isConditional()) {
+    auto conformanceRef = getConformanceRef();
+    return conformanceRef.getConditionalRequirements()[getRequirementIndex()];
+  }
+
   return getGenericContext()->getGenericRequirements()[getRequirementIndex()];
+}
+
+ProtocolConformanceRef RequirementFailure::getConformanceRef() const {
+  assert(isConditional());
+
+  auto &cs = getConstraintSystem();
+  auto *locator = getLocator();
+
+  auto *typeReqLoc =
+      cs.getConstraintLocator(getRawAnchor(), locator->getPath().drop_back(),
+                              /*summaryFlags=*/0);
+
+  auto conformance = llvm::find_if(
+      cs.CheckedConformances,
+      [&](const std::pair<ConstraintLocator *, ProtocolConformanceRef>
+              &conformance) { return conformance.first == typeReqLoc; });
+  assert(conformance != cs.CheckedConformances.end());
+  return conformance->second;
 }
 
 ValueDecl *RequirementFailure::getDeclRef() const {
   auto &cs = getConstraintSystem();
 
-  auto *anchor = getAnchor();
+  auto *anchor = getRawAnchor();
   auto *locator = cs.getConstraintLocator(anchor);
   if (auto *AE = dyn_cast<CallExpr>(anchor)) {
     assert(isa<TypeExpr>(AE->getFn()));
@@ -142,6 +179,13 @@ ValueDecl *RequirementFailure::getDeclRef() const {
 }
 
 const DeclContext *RequirementFailure::getRequirementDC() const {
+  // In case of conditional requirement failure, we don't
+  // have to guess where the it comes from.
+  if (isConditional()) {
+    auto *conformance = getConformanceRef().getConcrete();
+    return conformance->getDeclContext();
+  }
+
   const auto &req = getRequirement();
   auto *DC = AffectedDecl->getDeclContext();
 
@@ -159,23 +203,26 @@ bool RequirementFailure::diagnoseAsError() {
   if (!canDiagnoseFailure())
     return false;
 
-  auto *anchor = getAnchor();
+  auto *anchor = getRawAnchor();
   const auto *reqDC = getRequirementDC();
   auto *genericCtx = getGenericContext();
+
+  auto lhs = resolveType(getLHS());
+  auto rhs = resolveType(getRHS());
 
   if (reqDC != genericCtx) {
     auto *NTD = reqDC->getSelfNominalTypeDecl();
     emitDiagnostic(anchor->getLoc(), getDiagnosticInRereference(),
                    AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), NTD->getDeclaredType(),
-                   getLHS(), getRHS());
+                   AffectedDecl->getFullName(), NTD->getDeclaredType(), lhs,
+                   rhs);
   } else {
     emitDiagnostic(anchor->getLoc(), getDiagnosticOnDecl(),
                    AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), getLHS(), getRHS());
+                   AffectedDecl->getFullName(), lhs, rhs);
   }
 
-  emitRequirementNote(reqDC->getAsDecl());
+  emitRequirementNote(reqDC->getAsDecl(), lhs, rhs);
   return true;
 }
 
@@ -188,23 +235,32 @@ bool RequirementFailure::diagnoseAsNote() {
   return true;
 }
 
-void RequirementFailure::emitRequirementNote(const Decl *anchor) const {
+void RequirementFailure::emitRequirementNote(const Decl *anchor, Type lhs,
+                                             Type rhs) const {
   auto &req = getRequirement();
 
-  if (getRHS()->isEqual(req.getSecondType())) {
-    emitDiagnostic(anchor, diag::where_requirement_failure_one_subst,
-                   req.getFirstType(), getLHS());
+  if (isConditional()) {
+    auto *conformance = getConformanceRef().getConcrete();
+    emitDiagnostic(anchor, diag::requirement_implied_by_conditional_conformance,
+                   resolveType(conformance->getType()),
+                   conformance->getProtocol()->getDeclaredInterfaceType());
     return;
   }
 
-  if (getLHS()->isEqual(req.getFirstType())) {
+  if (rhs->isEqual(req.getSecondType())) {
     emitDiagnostic(anchor, diag::where_requirement_failure_one_subst,
-                   req.getSecondType(), getRHS());
+                   req.getFirstType(), lhs);
+    return;
+  }
+
+  if (lhs->isEqual(req.getFirstType())) {
+    emitDiagnostic(anchor, diag::where_requirement_failure_one_subst,
+                   req.getSecondType(), rhs);
     return;
   }
 
   emitDiagnostic(anchor, diag::where_requirement_failure_both_subst,
-                 req.getFirstType(), getLHS(), req.getSecondType(), getRHS());
+                 req.getFirstType(), lhs, req.getSecondType(), rhs);
 }
 
 bool MissingConformanceFailure::diagnoseAsError() {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -186,11 +186,11 @@ public:
     assert(!path.empty());
 
     auto &last = path.back();
-    assert(last.getKind() == ConstraintLocator::TypeParameterRequirement ||
-           last.getKind() == ConstraintLocator::ConditionalRequirement);
+    assert(last.isTypeParameterRequirement() ||
+           last.isConditionalRequirement());
     assert(static_cast<RequirementKind>(last.getValue2()) == kind);
 
-    IsConditional = last.getKind() == ConstraintLocator::ConditionalRequirement;
+    IsConditional = last.isConditionalRequirement();
 
     // It's possible sometimes not to have no base expression.
     if (!expr)
@@ -205,10 +205,8 @@ public:
     assert(!path.empty());
 
     auto &requirementLoc = path.back();
-    assert(requirementLoc.getKind() ==
-               ConstraintLocator::TypeParameterRequirement ||
-           requirementLoc.getKind() ==
-               ConstraintLocator::ConditionalRequirement);
+    assert(requirementLoc.isTypeParameterRequirement() ||
+           requirementLoc.isConditionalRequirement());
     return requirementLoc.getValue();
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -269,6 +269,10 @@ private:
   ValueDecl *getDeclRef() const;
 
   void emitRequirementNote(const Decl *anchor, Type lhs, Type rhs) const;
+
+  /// Determine whether given declaration represents a static
+  /// or instance property/method, excluding operators.
+  static bool isStaticOrInstanceMember(const ValueDecl *decl);
 };
 
 /// Diagnostics for failed conformance checks originating from

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -172,6 +172,9 @@ protected:
   /// to diagnose failures related to arguments.
   const ApplyExpr *Apply = nullptr;
 
+  /// If this failure associated with one of the conditional requirements.
+  bool IsConditional = false;
+
 public:
   RequirementFailure(ConstraintSystem &cs, Expr *expr, RequirementKind kind,
                      ConstraintLocator *locator)
@@ -183,8 +186,11 @@ public:
     assert(!path.empty());
 
     auto &last = path.back();
-    assert(last.getKind() == ConstraintLocator::TypeParameterRequirement);
+    assert(last.getKind() == ConstraintLocator::TypeParameterRequirement ||
+           last.getKind() == ConstraintLocator::ConditionalRequirement);
     assert(static_cast<RequirementKind>(last.getValue2()) == kind);
+
+    IsConditional = last.getKind() == ConstraintLocator::ConditionalRequirement;
 
     // It's possible sometimes not to have no base expression.
     if (!expr)
@@ -199,7 +205,10 @@ public:
     assert(!path.empty());
 
     auto &requirementLoc = path.back();
-    assert(requirementLoc.getKind() == PathEltKind::TypeParameterRequirement);
+    assert(requirementLoc.getKind() ==
+               ConstraintLocator::TypeParameterRequirement ||
+           requirementLoc.getKind() ==
+               ConstraintLocator::ConditionalRequirement);
     return requirementLoc.getValue();
   }
 
@@ -219,6 +228,13 @@ public:
   bool diagnoseAsNote() override;
 
 protected:
+  /// Determine whether this is a conditional requirement failure.
+  bool isConditional() const { return IsConditional; }
+
+  /// If this is a failure in condition requirement, retrieve
+  /// conformance information.
+  ProtocolConformanceRef getConformanceRef() const;
+
   /// Retrieve declaration contextual where current
   /// requirement has been introduced.
   const DeclContext *getRequirementDC() const;
@@ -230,6 +246,13 @@ protected:
   /// Determine whether it would be possible to diagnose
   /// current requirement failure.
   bool canDiagnoseFailure() const {
+    // If this is a conditional requirement failure,
+    // we have a lot more information compared to
+    // type requirement case, because we know that
+    // underlying conformance requirement matched.
+    if (isConditional())
+      return true;
+
     // For static/initializer calls there is going to be
     // a separate fix, attached to the argument, which is
     // much easier to diagnose.
@@ -247,7 +270,7 @@ private:
   /// Retrieve declaration associated with failing generic requirement.
   ValueDecl *getDeclRef() const;
 
-  void emitRequirementNote(const Decl *anchor) const;
+  void emitRequirementNote(const Decl *anchor, Type lhs, Type rhs) const;
 };
 
 /// Diagnostics for failed conformance checks originating from

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2691,10 +2691,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (conformance.isConcrete()) {
       unsigned index = 0;
       for (const auto &req : conformance.getConditionalRequirements()) {
-        addConstraint(
-          req,
-          locator.withPathElement(
-            LocatorPathElt::getConditionalRequirementComponent(index++)));
+        addConstraint(req,
+                      locator.withPathElement(
+                          LocatorPathElt::getConditionalRequirementComponent(
+                              index++, req.getKind())));
       }
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1615,7 +1615,7 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   auto req = path.back();
 
   ConstraintLocator *reqLoc = nullptr;
-  if (req.getKind() == ConstraintLocator::ConditionalRequirement) {
+  if (req.isConditionalRequirement()) {
     // If underlaying conformance requirement has been fixed as
     // we there is no reason to fix up conditional requirements.
     if (cs.hasFixFor(cs.getConstraintLocator(anchor, req)))
@@ -2777,11 +2777,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     SmallVector<LocatorPathElt, 4> path;
     auto *anchor = locator.getLocatorParts(path);
 
-    if (!path.empty() &&
-        (path.back().getKind() == ConstraintLocator::TypeParameterRequirement ||
-         path.back().getKind() == ConstraintLocator::ConditionalRequirement)) {
+    if (path.empty())
+      return SolutionKind::Error;
+
+    if (path.back().isTypeParameterRequirement() ||
+        path.back().isConditionalRequirement()) {
       ConstraintLocator *reqLoc = nullptr;
-      if (path.back().getKind() == ConstraintLocator::ConditionalRequirement) {
+      if (path.back().isConditionalRequirement()) {
         // Underlying conformance requirement is itself fixed,
         // this wouldn't lead to right solution.
         if (hasFixFor(getConstraintLocator(anchor, path.back())))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1602,7 +1602,7 @@ ConstraintSystem::matchTypesBindTypeVar(
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
                                             Type type2, Expr *anchor,
-                                            LocatorPathElt &req) {
+                                            ArrayRef<LocatorPathElt> path) {
   // Can't fix not yet properly resolved types.
   if (type1->hasTypeVariable() || type2->hasTypeVariable())
     return nullptr;
@@ -1612,9 +1612,21 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   if (type1->hasDependentMember() || type2->hasDependentMember())
     return nullptr;
 
-  // Build simplified locator which only contains anchor and requirement info.
-  ConstraintLocatorBuilder requirement(cs.getConstraintLocator(anchor));
-  auto *reqLoc = cs.getConstraintLocator(requirement.withPathElement(req));
+  auto req = path.back();
+
+  ConstraintLocator *reqLoc = nullptr;
+  if (req.getKind() == ConstraintLocator::ConditionalRequirement) {
+    // If underlaying conformance requirement has been fixed as
+    // we there is no reason to fix up conditional requirements.
+    if (cs.hasFixFor(cs.getConstraintLocator(anchor, req)))
+      return nullptr;
+
+    // For conditional requirements we need a full path.
+    reqLoc = cs.getConstraintLocator(anchor, path, /*summaryFlags=*/0);
+  } else {
+    // Build simplified locator which only contains anchor and requirement info.
+    reqLoc = cs.getConstraintLocator(anchor, req);
+  }
 
   auto reqKind = static_cast<RequirementKind>(req.getValue2());
   switch (reqKind) {
@@ -1644,8 +1656,9 @@ repairFailures(ConstraintSystem &cs, Type lhs, Type rhs,
 
   auto &elt = path.back();
   switch (elt.getKind()) {
-  case ConstraintLocator::TypeParameterRequirement: {
-    if (auto *fix = fixRequirementFailure(cs, lhs, rhs, anchor, elt))
+  case ConstraintLocator::TypeParameterRequirement:
+  case ConstraintLocator::ConditionalRequirement: {
+    if (auto *fix = fixRequirementFailure(cs, lhs, rhs, anchor, path))
       conversionsOrFixes.push_back(fix);
     break;
   }
@@ -2764,15 +2777,25 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     SmallVector<LocatorPathElt, 4> path;
     auto *anchor = locator.getLocatorParts(path);
 
-    if (!path.empty() && path.back().getKind() ==
-        ConstraintLocator::PathElementKind::TypeParameterRequirement) {
-      auto typeRequirement = path.back();
-      // Let's strip all of the unnecessary information from locator,
-      // diagnostics only care about anchor - to lookup type,
-      // and what was the requirement# which is not satisfied.
-      ConstraintLocatorBuilder requirement(getConstraintLocator(anchor));
-      auto *reqLoc =
-          getConstraintLocator(requirement.withPathElement(typeRequirement));
+    if (!path.empty() &&
+        (path.back().getKind() == ConstraintLocator::TypeParameterRequirement ||
+         path.back().getKind() == ConstraintLocator::ConditionalRequirement)) {
+      ConstraintLocator *reqLoc = nullptr;
+      if (path.back().getKind() == ConstraintLocator::ConditionalRequirement) {
+        // Underlying conformance requirement is itself fixed,
+        // this wouldn't lead to right solution.
+        if (hasFixFor(getConstraintLocator(anchor, path.back())))
+          return SolutionKind::Error;
+
+        // For conditional requirements we need complete path, which includes
+        // type requirement position, to be able to fetch conformance later.
+        reqLoc = getConstraintLocator(locator);
+      } else {
+        // Let's strip all of the unnecessary information from locator,
+        // diagnostics only care about anchor - to lookup type,
+        // and what was the requirement# which is not satisfied.
+        reqLoc = getConstraintLocator(anchor, path.back());
+      }
 
       auto *fix = MissingConformance::create(*this, type, protocol, reqLoc);
       if (!recordFix(fix))
@@ -5417,12 +5440,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix) {
     // Always useful, unless duplicate of exactly the same fix and location.
     // This situation might happen when the same fix kind is applicable to
     // different overload choices.
-    auto *loc = fix->getLocator();
-    auto existingFix = llvm::find_if(Fixes, [&](const ConstraintFix *e) {
-      // If we already have a fix like this recorded, let's not do it again,
-      return e->getKind() == fix->getKind() && e->getLocator() == loc;
-    });
-    if (existingFix == Fixes.end())
+    if (!hasFixFor(fix->getLocator()))
       Fixes.push_back(fix);
   } else {
     // Only useful to record if no pre-existing fix in the subexpr tree.

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -106,6 +106,25 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
     }
   }
 
+  auto dumpReqKind = [&out](RequirementKind kind) {
+    out << " (";
+    switch (kind) {
+    case RequirementKind::Conformance:
+      out << "conformance";
+      break;
+    case RequirementKind::Superclass:
+      out << "superclass";
+      break;
+    case RequirementKind::SameType:
+      out << "same-type";
+      break;
+    case RequirementKind::Layout:
+      out << "layout";
+      break;
+    }
+    out << ")";
+  };
+
   for (auto elt : getPath()) {
     out << " -> ";
     switch (elt.getKind()) {
@@ -222,26 +241,12 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case ConditionalRequirement:
       out << "conditional requirement #" << llvm::utostr(elt.getValue());
+      dumpReqKind(static_cast<RequirementKind>(elt.getValue2()));
       break;
 
     case TypeParameterRequirement: {
-      out << "type parameter requirement #" << llvm::utostr(elt.getValue())
-          << " (";
-      switch (static_cast<RequirementKind>(elt.getValue2())) {
-      case RequirementKind::Conformance:
-        out << "conformance";
-        break;
-      case RequirementKind::Superclass:
-        out << "superclass";
-        break;
-      case RequirementKind::SameType:
-        out << "same-type";
-        break;
-      case RequirementKind::Layout:
-        out << "layout";
-        break;
-      }
-      out << ")";
+      out << "type parameter requirement #" << llvm::utostr(elt.getValue());
+      dumpReqKind(static_cast<RequirementKind>(elt.getValue2()));
       break;
     }
 

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -421,6 +421,14 @@ public:
     unsigned getNewSummaryFlags() const {
       return getSummaryFlagsForPathElement(getKind());
     }
+
+    bool isTypeParameterRequirement() const {
+      return getKind() == PathElementKind::TypeParameterRequirement;
+    }
+
+    bool isConditionalRequirement() const {
+      return getKind() == PathElementKind::ConditionalRequirement;
+    }
   };
 
   /// Return the summary flags for an entire path.

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -162,10 +162,10 @@ public:
     case NamedTupleElement:
     case TupleElement:
     case KeyPathComponent:
-    case ConditionalRequirement:
       return 1;
 
     case TypeParameterRequirement:
+    case ConditionalRequirement:
     case ApplyArgToParam:
       return 2;
     }
@@ -340,8 +340,10 @@ public:
     }
 
     /// Get a path element for a conditional requirement.
-    static PathElement getConditionalRequirementComponent(unsigned index) {
-      return PathElement(ConditionalRequirement, index);
+    static PathElement
+    getConditionalRequirementComponent(unsigned index, RequirementKind kind) {
+      return PathElement(ConditionalRequirement, index,
+                         static_cast<unsigned>(kind));
     }
 
     static PathElement getTypeRequirementComponent(unsigned index,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -944,6 +944,7 @@ public:
   friend class SplitterStep;
   friend class ComponentStep;
   friend class TypeVariableStep;
+  friend class RequirementFailure;
   friend class MissingMemberFailure;
 
   class SolverScope;
@@ -1810,6 +1811,14 @@ public:
   /// Log and record the application of the fix. Return true iff any
   /// subsequent solution would be worse than the best known solution.
   bool recordFix(ConstraintFix *fix);
+
+  /// Determine whether constraint system already has a fix recorded
+  /// for a particular location.
+  bool hasFixFor(ConstraintLocator *locator) const {
+    return llvm::any_of(Fixes, [&locator](const ConstraintFix *fix) {
+      return fix->getLocator() == locator;
+    });
+  }
 
   /// If an UnresolvedDotExpr, SubscriptMember, etc has been resolved by the
   /// constraint system, return the decl that it references.

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -329,6 +329,7 @@ protocol P { }
 struct PArray<T> { }
 
 extension PArray : ExpressibleByArrayLiteral where T: P {
+  // expected-note@-1 {{requirement from conditional conformance of 'PArray<String>' to 'ExpressibleByArrayLiteral'}}
   typealias ArrayLiteralElement = T
 
   init(arrayLiteral elements: T...) { }
@@ -338,7 +339,7 @@ extension Int: P { }
 
 func testConditional(i: Int, s: String) {
   let _: PArray<Int> = [i, i, i]
-  let _: PArray<String> = [s, s, s] // expected-error{{cannot convert value of type '[String]' to specified type 'PArray<String>'}}
+  let _: PArray<String> = [s, s, s] // expected-error{{generic struct 'PArray' requires that 'String' conform to 'P'}}
 }
 
 

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -399,6 +399,6 @@ extension BinaryInteger {
     return self <= 1
             ? 1
             : (2...self).reduce(1, *)
-            // expected-error@-1 {{instance method 'reduce' requires that 'Self.Stride' conform to 'SignedInteger'}}
+            // expected-error@-1 {{referencing instance method 'reduce' on 'ClosedRange' requires that 'Self.Stride' conform to 'SignedInteger'}}
   }
 }

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -12,55 +12,36 @@ protocol P6: P2 {}
 protocol Assoc { associatedtype AT }
 
 func takes_P2<X: P2>(_: X) {}
-// FIXME: "requirement specified as..." isn't accurate below
-// expected-note@-2{{candidate requires that the types 'U' and 'V' be equivalent (requirement specified as 'U' == 'V')}}
-// expected-note@-3{{requirement from conditional conformance of 'SameTypeGeneric<U, V>' to 'P2'}}
-// expected-note@-4{{candidate requires that the types 'U' and 'Int' be equivalent (requirement specified as 'U' == 'Int')}}
-// expected-note@-5{{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
-// expected-note@-6{{candidate requires that the types 'Int' and 'Float' be equivalent (requirement specified as 'Int' == 'Float')}}
-// expected-note@-7{{requirement from conditional conformance of 'SameTypeGeneric<Int, Float>' to 'P2'}}
-// expected-note@-8{{candidate requires that 'C1' inherit from 'U' (requirement specified as 'U' : 'C1')}}
-// expected-note@-9{{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
-// expected-note@-10{{candidate requires that 'C3' inherit from 'U' (requirement specified as 'U' : 'C3')}}
-// expected-note@-11{{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
-// expected-note@-12{{candidate requires that 'C1' inherit from 'Int' (requirement specified as 'Int' : 'C1')}}
-// expected-note@-13{{requirement from conditional conformance of 'SubclassBad' to 'P2'}}
-// expected-note@-14{{candidate requires that the types 'Float' and 'Int' be equivalent (requirement specified as 'Float' == 'Int')}}
-// expected-note@-15{{requirement from conditional conformance of 'Infer<Constrained<U>, V>' to 'P2'}}
-// expected-note@-16{{candidate requires that the types 'Constrained<U>' and 'Constrained<V>' be equivalent (requirement specified as 'Constrained<U>' == 'Constrained<V>')}}
-// expected-note@-17{{candidate requires that the types 'U' and 'Int' be equivalent (requirement specified as 'U' == 'Int')}}
-// expected-note@-18{{requirement from conditional conformance of 'SameType<Float>' to 'P2'}}
-// expected-note@-19{{requirement from conditional conformance of 'SameType<U>' to 'P2'}}
+// expected-note@-1 {{candidate requires that the types 'U' and 'V' be equivalent (requirement specified as 'U' == 'V')}}
+// expected-note@-2 {{requirement from conditional conformance of 'SameTypeGeneric<U, V>' to 'P2'}}
+// expected-note@-3 {{requirement from conditional conformance of 'SubclassBad' to 'P2'}}
+// expected-note@-4 {{candidate requires that 'C1' inherit from 'U' (requirement specified as 'U' : 'C1')}}
+// expected-note@-5 {{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
+// expected-note@-6 {{candidate requires that 'C1' inherit from 'Int' (requirement specified as 'Int' : 'C1')}}
 func takes_P5<X: P5>(_: X) {}
 
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free<T>
 // CHECK-NEXT: (normal_conformance type=Free<T> protocol=P2
 // CHECK-NEXT:   conforms_to: T P1)
-extension Free: P2 where T: P1 {}
+extension Free: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'Free<U>' to 'P2'}}
 func free_good<U: P1>(_: U) {
     takes_P2(Free<U>())
 }
 func free_bad<U>(_: U) {
-    takes_P2(Free<U>()) // expected-error{{type 'U' does not conform to protocol 'P1'}}}}
-    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P1'}}
-    // expected-note@-2{{requirement specified as 'U' : 'P1'}}
-    // expected-note@-3{{requirement from conditional conformance of 'Free<U>' to 'P2'}}
+    takes_P2(Free<U>()) // expected-error{{global function 'takes_P2' requires that 'U' conform to 'P1'}}
 }
 
 struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained<T>
 // CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
 // CHECK-NEXT:   conforms_to: T P3)
-extension Constrained: P2 where T: P3 {}
+extension Constrained: P2 where T: P3 {} // expected-note {{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
 func constrained_good<U: P1 & P3>(_: U) {
     takes_P2(Constrained<U>())
 }
 func constrained_bad<U: P1>(_: U) {
-    takes_P2(Constrained<U>()) // expected-error{{type 'U' does not conform to protocol 'P3'}}
-    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P3'}}
-    // expected-note@-2{{requirement specified as 'U' : 'P3'}}
-    // expected-note@-3{{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
+  takes_P2(Constrained<U>()) // expected-error{{global function 'takes_P2' requires that 'U' conform to 'P3'}}
 }
 
 struct RedundantSame<T: P1> {}
@@ -77,15 +58,12 @@ struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub<T>
 // CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
 // CHECK-NEXT:   conforms_to: T P4)
-extension OverlappingSub: P2 where T: P4 {}
+extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
 func overlapping_sub_good<U: P4>(_: U) {
     takes_P2(OverlappingSub<U>())
 }
 func overlapping_sub_bad<U: P1>(_: U) {
-    takes_P2(OverlappingSub<U>()) // expected-error{{type 'U' does not conform to protocol 'P4'}}
-    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P4'}}
-    // expected-note@-2{{requirement specified as 'U' : 'P4'}}
-    // expected-note@-3{{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
+  takes_P2(OverlappingSub<U>()) // expected-error{{global function 'takes_P2' requires that 'U' conform to 'P4'}}
 }
 
 
@@ -94,12 +72,14 @@ struct SameType<T> {}
 // CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
 // CHECK-NEXT:   same_type: T Int)
 extension SameType: P2 where T == Int {}
+// expected-note@-1 {{requirement from conditional conformance of 'SameType<U>' to 'P2'}}
+// expected-note@-2 {{requirement from conditional conformance of 'SameType<Float>' to 'P2'}}
 func same_type_good() {
     takes_P2(SameType<Int>())
 }
 func same_type_bad<U>(_: U) {
-    takes_P2(SameType<U>()) // expected-error{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameType<U>)'}}
-    takes_P2(SameType<Float>()) // expected-error{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameType<Float>)'}}
+  takes_P2(SameType<U>()) // expected-error{{global function 'takes_P2' requires the types 'U' and 'Int' be equivalent}}
+  takes_P2(SameType<Float>()) // expected-error{{global function 'takes_P2' requires the types 'Float' and 'Int' be equivalent}}
 }
 
 
@@ -108,6 +88,8 @@ struct SameTypeGeneric<T, U> {}
 // CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T U)
 extension SameTypeGeneric: P2 where T == U {}
+// expected-note@-1 {{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
+// expected-note@-2 {{requirement from conditional conformance of 'SameTypeGeneric<Int, Float>' to 'P2'}}
 func same_type_generic_good<U, V>(_: U, _: V)
   where U: Assoc, V: Assoc, U.AT == V.AT
 {
@@ -116,12 +98,12 @@ func same_type_generic_good<U, V>(_: U, _: V)
     takes_P2(SameTypeGeneric<U.AT, V.AT>())
 }
 func same_type_bad<U, V>(_: U, _: V) {
-    takes_P2(SameTypeGeneric<U, V>())
-    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<U, V>)'}}
-    takes_P2(SameTypeGeneric<U, Int>())
-    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<U, Int>)'}}
-    takes_P2(SameTypeGeneric<Int, Float>())
-    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<Int, Float>)'}}
+  takes_P2(SameTypeGeneric<U, V>())
+  // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<U, V>)'}}
+  takes_P2(SameTypeGeneric<U, Int>())
+  // expected-error@-1{{global function 'takes_P2' requires the types 'U' and 'Int' be equivalent}}
+  takes_P2(SameTypeGeneric<Int, Float>())
+  // expected-error@-1{{global function 'takes_P2' requires the types 'Int' and 'Float' be equivalent}}
 }
 
 
@@ -131,14 +113,16 @@ struct Infer<T, U> {}
 // CHECK-NEXT:   same_type: T Constrained<U>
 // CHECK-NEXT:   conforms_to:  U P1)
 extension Infer: P2 where T == Constrained<U> {}
+// expected-note@-1 2 {{requirement from conditional conformance of 'Infer<Constrained<U>, V>' to 'P2'}}
 func infer_good<U: P1>(_: U) {
     takes_P2(Infer<Constrained<U>, U>())
 }
 func infer_bad<U: P1, V>(_: U, _: V) {
-    takes_P2(Infer<Constrained<U>, V>())
-    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(Infer<Constrained<U>, V>)'}}
-    takes_P2(Infer<Constrained<V>, V>())
-    // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
+  takes_P2(Infer<Constrained<U>, V>())
+  // expected-error@-1{{global function 'takes_P2' requires the types 'Constrained<U>' and 'Constrained<V>' be equivalent}}
+  // expected-error@-2{{global function 'takes_P2' requires that 'V' conform to 'P1'}}
+  takes_P2(Infer<Constrained<V>, V>())
+  // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
 }
 
 struct InferRedundant<T, U: P1> {}
@@ -178,13 +162,13 @@ struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific<T>
 // CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
 // CHECK-NEXT:   superclass: T C3)
-extension ClassMoreSpecific: P2 where T: C3 {}
+extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
 func class_more_specific_good<U: C3>(_: U) {
     takes_P2(ClassMoreSpecific<U>())
 }
 func class_more_specific_bad<U: C1>(_: U) {
-    takes_P2(ClassMoreSpecific<U>())
-    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(ClassMoreSpecific<U>)'}}
+  takes_P2(ClassMoreSpecific<U>())
+  // expected-error@-1{{global function 'takes_P2' requires that 'U' inherit from 'C3'}}
 }
 
 
@@ -214,26 +198,20 @@ struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual<T>
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P2
 // CHECK-NEXT:    conforms_to: T P1)
-extension InheritEqual: P2 where T: P1 {}
+extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual<T>
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P5
 // CHECK-NEXT:    (normal_conformance type=InheritEqual<T> protocol=P2
 // CHECK-NEXT:      conforms_to: T P1)
 // CHECK-NEXT:    conforms_to: T P1)
-extension InheritEqual: P5 where T: P1 {}
+extension InheritEqual: P5 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
 func inheritequal_good<U: P1>(_: U) {
   takes_P2(InheritEqual<U>())
   takes_P5(InheritEqual<U>())
 }
 func inheritequal_bad<U>(_: U) {
-  takes_P2(InheritEqual<U>()) // expected-error{{type 'U' does not conform to protocol 'P1'}}
-  // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P1'}}
-  // expected-note@-2{{requirement specified as 'U' : 'P1'}}
-  // expected-note@-3{{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
-  takes_P5(InheritEqual<U>()) // expected-error{{type 'U' does not conform to protocol 'P1'}}
-  // expected-error@-1{{'<X where X : P5> (X) -> ()' requires that 'U' conform to 'P1'}}
-  // expected-note@-2{{requirement specified as 'U' : 'P1'}}
-  // expected-note@-3{{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
+  takes_P2(InheritEqual<U>()) // expected-error{{global function 'takes_P2' requires that 'U' conform to 'P1'}}
+  takes_P5(InheritEqual<U>()) // expected-error{{global function 'takes_P5' requires that 'U' conform to 'P1'}}
 }
 
 struct InheritLess<T> {}
@@ -248,33 +226,24 @@ struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore<T>
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P2
 // CHECK-NEXT:    conforms_to: T P1)
-extension InheritMore: P2 where T: P1 {}
+extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore<T>
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P5
 // CHECK-NEXT:    (normal_conformance type=InheritMore<T> protocol=P2
 // CHECK-NEXT:      conforms_to: T P1)
 // CHECK-NEXT:    conforms_to: T P4)
-extension InheritMore: P5 where T: P4 {}
+extension InheritMore: P5 where T: P4 {} // expected-note 2 {{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
 func inheritequal_good_good<U: P4>(_: U) {
   takes_P2(InheritMore<U>())
   takes_P5(InheritMore<U>())
 }
 func inheritequal_good_bad<U: P1>(_: U) {
   takes_P2(InheritMore<U>())
-  takes_P5(InheritMore<U>()) // expected-error{{type 'U' does not conform to protocol 'P4'}}
-  // expected-error@-1{{'<X where X : P5> (X) -> ()' requires that 'U' conform to 'P4'}}
-  // expected-note@-2{{requirement specified as 'U' : 'P4'}}
-  // expected-note@-3{{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
+  takes_P5(InheritMore<U>()) // expected-error{{global function 'takes_P5' requires that 'U' conform to 'P4'}}
 }
 func inheritequal_bad_bad<U>(_: U) {
-  takes_P2(InheritMore<U>()) // expected-error{{type 'U' does not conform to protocol 'P1'}}
-  // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P1'}}
-  // expected-note@-2{{requirement specified as 'U' : 'P1'}}
-  // expected-note@-3{{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
-  takes_P5(InheritMore<U>()) // expected-error{{type 'U' does not conform to protocol 'P4'}}
-  // expected-error@-1{{'<X where X : P5> (X) -> ()' requires that 'U' conform to 'P4'}}
-  // expected-note@-2{{requirement specified as 'U' : 'P4'}}
-  // expected-note@-3{{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
+  takes_P2(InheritMore<U>()) // expected-error{{global function 'takes_P2' requires that 'U' conform to 'P1'}}
+  takes_P5(InheritMore<U>()) // expected-error{{global function 'takes_P5' requires that 'U' conform to 'P4'}}
 }
 
 struct InheritImplicitOne<T> {}
@@ -379,14 +348,11 @@ extension X1: P8 {
 
 struct X2<T> { }
 
-extension X2: P7 where T: P8, T.A: P7 { }
+extension X2: P7 where T: P8, T.A: P7 { } // expected-note {{requirement from conditional conformance of 'X2<X1>' to 'P7'}}
 
 func takesF7<T: P7>(_: T) { }
 func passesConditionallyNotF7(x21: X2<X1>) {
-  takesF7(x21) // expected-error{{type 'X1.A' (aka 'X0') does not conform to protocol 'P7'}}
-  // expected-error@-1{{'<T where T : P7> (T) -> ()' requires that 'X1.A' (aka 'X0') conform to 'P7'}}
-  // expected-note@-2{{requirement specified as 'X1.A' (aka 'X0') : 'P7'}}
-  // expected-note@-3{{requirement from conditional conformance of 'X2<X1>' to 'P7'}}
+  takesF7(x21) // expected-error{{global function 'takesF7' requires that 'X1.A' (aka 'X0') conform to 'P7'}}
 }
 
 
@@ -424,4 +390,15 @@ protocol P {
 
 extension Foo: P where Bar: P {
   var foo: Foo { return self }
+}
+
+// rdar://problem/47871590
+
+extension BinaryInteger {
+  var foo: Self {
+    return self <= 1
+            ? 1
+            : (2...self).reduce(1, *)
+            // expected-error@-1 {{instance method 'reduce' requires that 'Self.Stride' conform to 'SignedInteger'}}
+  }
 }

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -9,9 +9,13 @@ struct Works: Hashable, Conforms {}
 struct Fails: Hashable {}
 
 extension Array: SameType where Element == Works {}
+// expected-note@-1 2 {{requirement from conditional conformance of '[Fails]' to 'SameType'}}
 extension Dictionary: SameType where Value == Works {}
+// expected-note@-1 2 {{requirement from conditional conformance of '[Int : Fails]' to 'SameType'}}
 extension Array: Conforms where Element: Conforms {}
+// expected-note@-1 5 {{requirement from conditional conformance of '[Fails]' to 'Conforms'}}
 extension Dictionary: Conforms where Value: Conforms {}
+// expected-note@-1 3 {{requirement from conditional conformance of '[Int : Fails]' to 'Conforms'}}
 
 let works = Works()
 let fails = Fails()
@@ -26,11 +30,11 @@ func arraySameType() {
 
     let _: SameType = arrayWorks
     let _: SameType = arrayFails
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'SameType'}}
+    // expected-error@-1 {{let 'arrayFails' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [works] as [Works]
     let _: SameType = [fails] as [Fails]
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'SameType'}}
+    // expected-error@-1 {{generic struct 'Array' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [works] as SameType
     let _: SameType = [fails] as SameType
@@ -51,11 +55,11 @@ func dictionarySameType() {
 
     let _: SameType = dictWorks
     let _: SameType = dictFails
-    // expected-error@-1 {{value of type '[Int : Fails]' does not conform to specified type 'SameType'}}
+    // expected-error@-1 {{let 'dictFails' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [0 : works] as [Int : Works]
     let _: SameType = [0 : fails] as [Int : Fails]
-    // expected-error@-1 {{value of type '[Int : Fails]' does not conform to specified type 'SameType'}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [0 : works] as SameType
     let _: SameType = [0 : fails] as SameType
@@ -72,15 +76,15 @@ func arrayConforms() {
 
     let _: Conforms = [works]
     let _: Conforms = [fails]
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = arrayWorks
     let _: Conforms = arrayFails
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{let 'arrayFails' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [works] as [Works]
     let _: Conforms = [fails] as [Fails]
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{eneric struct 'Array' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [works] as Conforms
     let _: Conforms = [fails] as Conforms
@@ -97,15 +101,15 @@ func dictionaryConforms() {
 
     let _: Conforms = [0 : works]
     let _: Conforms = [0 : fails]
-    // expected-error@-1 {{contextual type 'Conforms' cannot be used with dictionary literal}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = dictWorks
     let _: Conforms = dictFails
-    // expected-error@-1 {{value of type '[Int : Fails]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{let 'dictFails' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [0 : works] as [Int : Works]
     let _: Conforms = [0 : fails] as [Int : Fails]
-    // expected-error@-1 {{value of type '[Int : Fails]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [0 : works] as Conforms
     let _: Conforms = [0 : fails] as Conforms
@@ -119,12 +123,13 @@ func dictionaryConforms() {
 func combined() {
     let _: Conforms = [[0: [1 : [works]]]]
     let _: Conforms = [[0: [1 : [fails]]]]
-    // expected-error@-1 {{value of type '[[Int : [Int : [Fails]]]]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
 
     // Needs self conforming protocols:
     let _: Conforms = [[0: [1 : [works]] as Conforms]]
-    // expected-error@-1 {{value of type '[[Int : Conforms]]' does not conform to specified type 'Conforms'}}
+    // expected-error@-1 {{protocol type 'Conforms' cannot conform to 'Conforms' because only concrete types can conform to protocols}}
 
     let _: Conforms = [[0: [1 : [fails]] as Conforms]]
-    // expected-error@-1 {{'[Int : [Fails]]' is not convertible to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-2 {{protocol type 'Conforms' cannot conform to 'Conforms' because only concrete types can conform to protocols}}
 }

--- a/test/NameBinding/name_lookup_min_max_conditional_conformance.swift
+++ b/test/NameBinding/name_lookup_min_max_conditional_conformance.swift
@@ -42,7 +42,7 @@ extension NonConditional {
 
 struct Conditional<T> {}
 extension Conditional: ContainsMinMax where T: ContainsMinMax {}
-extension Conditional: ContainsFoo where T: ContainsFoo {}
+extension Conditional: ContainsFoo where T: ContainsFoo {} // expected-note {{requirement from conditional conformance of 'Conditional<T>' to 'ContainsFoo'}}
 
 extension Conditional {
     func f() {
@@ -53,6 +53,6 @@ extension Conditional {
         // expected-warning@-1{{use of 'min' as reference to global function in module 'Swift' will change in future versions of Swift to reference instance method in generic struct 'Conditional' which comes via a conditional conformance}}
         // expected-note@-2{{use 'Swift.' to continue to reference the global function}}
         _ = foo(5, 6)
-        // expected-error@-1{{type 'T' does not conform to protocol 'ContainsFoo'}}
+        // expected-error@-1{{instance method 'foo()' requires that 'T' conform to 'ContainsFoo'}}
     }
 }

--- a/test/NameBinding/name_lookup_min_max_conditional_conformance.swift
+++ b/test/NameBinding/name_lookup_min_max_conditional_conformance.swift
@@ -53,6 +53,6 @@ extension Conditional {
         // expected-warning@-1{{use of 'min' as reference to global function in module 'Swift' will change in future versions of Swift to reference instance method in generic struct 'Conditional' which comes via a conditional conformance}}
         // expected-note@-2{{use 'Swift.' to continue to reference the global function}}
         _ = foo(5, 6)
-        // expected-error@-1{{instance method 'foo()' requires that 'T' conform to 'ContainsFoo'}}
+        // expected-error@-1{{referencing instance method 'foo()' on 'Conditional' requires that 'T' conform to 'ContainsFoo'}}
     }
 }

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -51,9 +51,8 @@ protocol Bindable: class { }
 
 extension Bindable {
   func test<Value>(to targetKeyPath: ReferenceWritableKeyPath<Self, Value>, change: Value?) {
-    if self[keyPath:targetKeyPath] != change {  // expected-error{{}} 
-      // expected-note@-1{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
-      // expected-note@-2{{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    if self[keyPath:targetKeyPath] != change {
+      // expected-error@-1 {{operator function '!=' requires that 'Value' conform to 'Equatable'}}
       self[keyPath: targetKeyPath] = change!
     }
   }


### PR DESCRIPTION
Extend existing `RequirementFailure` functionality to support
conditional requirement failures. Such fixes are introduced
only if the parent type requirement has been matched successfully.

Resolves: rdar://problem/47871590

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
