### PR TITLE
Add a tracing variant to traces functions of type (State, Data)->(State)

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -776,7 +776,7 @@ private func _graphInternal<State : _TensorArrayProtocolEnhanced,
 
   debugLog("Assembling output tensor handles.")
   let outputTensorHandles = 
-    (outputResult != nil)
+    outputResult != nil
       ? (outputState.cTensorHandles + outputResult!.cTensorHandles)
       : outputState.cTensorHandles
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -832,18 +832,18 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
 public func _graph<State : _TensorArrayProtocolEnhanced,
                    Data : TensorGroup>(
   with state: State,
-  in fn: @escaping (State, Data) -> (State)
-) -> (State, Data) -> (State) {
+  in fn: @escaping (State, Data) -> State
+) -> (State, Data) -> State {
   let wrappedFn = {
     // The result argument needs to a type that conforms to TensorGroup. 
     // We are arbitrarily picking Tensor<Float> here. 
     (s: State, d: Data) -> (State, Tensor<Float>?) in
-      (fn(s,d), nil)
+      (fn(s, d), nil)
   }
   let graphFunction = _graphInternal(with: state, in: wrappedFn)
   return { (state: State, data: Data) in
     let result = graphFunction(state, data)
-    return (result.0)
+    return result.0
   }
 }
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -738,12 +738,12 @@ extension _TensorArrayProtocolEnhanced {
 }
 
 // TODO: rename this to `graph` when it's ready for end users.
-public func _graph<State : _TensorArrayProtocolEnhanced,
-                   Data : TensorGroup,
-                   Result : TensorGroup>(
+private func _graphInternal<State : _TensorArrayProtocolEnhanced,
+                            Data : TensorGroup,
+                            Result : TensorGroup>(
   with state: State,
-  in fn: (State, Data) -> (State, Result)
-) -> (State, Data) -> (State, Result) {
+  in fn: (State, Data) -> (State, Result?)
+) -> (State, Data) -> (State, Result?) {
   debugLog("""
              Tracing over a function with \(state._tensorHandleCount) input \
              state tensors and \(Data._typeList.count) input data tensors.
@@ -775,8 +775,11 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
   let (outputState, outputResult) = fn(symbolicState, symbolicData)
 
   debugLog("Assembling output tensor handles.")
-  let outputTensorHandles = outputState.cTensorHandles
-    + outputResult.cTensorHandles
+  let outputTensorHandles = 
+    (outputResult != nil)
+      ? (outputState.cTensorHandles + outputResult!.cTensorHandles)
+      : outputState.cTensorHandles
+
 
   debugLog("Finalizing trace graph function.")
   // TAP means tensor array protocol.
@@ -786,7 +789,7 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
 
   // The result is a closure that captures and executes the trace graph
   // function in the trace context.
-  return { (oldState: State, data: Data) -> (State, Result) in
+  return { (oldState: State, data: Data) -> (State, Result?) in
     debugLog("Running trace function over state \(oldState) and data \(data).")
 
     debugLog("Getting input state tensor handles.")
@@ -805,11 +808,42 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
                                             outputs: outputTensorHandles)
 
     debugLog("Creating output model instance.")
-    let newState = state._makeInstance(owning: returnValues.dropLast(
-                                         Data._typeList.count))
-    let result = Result(
-      _copying: returnValues.dropFirst(Int(state._tensorHandleCount)))
+    let newState = state._makeInstance(owning: returnValues.prefix(
+                                         Int(state._tensorHandleCount)))
+    let resultValues = returnValues.dropFirst(Int(state._tensorHandleCount))
+    let result = resultValues.isEmpty ? nil : Result(_copying: resultValues)
     return (newState, result)
+  }
+}
+
+public func _graph<State : _TensorArrayProtocolEnhanced,
+                   Data : TensorGroup,
+                   Result : TensorGroup>(
+  with state: State,
+  in fn: @escaping (State, Data) -> (State, Result)
+) -> (State, Data) -> (State, Result) {
+  let graphFunction = _graphInternal(with: state, in: fn)
+  return { (state: State, data: Data) in
+    let result = graphFunction(state, data)
+    return (result.0, result.1!)
+  }
+}
+
+public func _graph<State : _TensorArrayProtocolEnhanced,
+                   Data : TensorGroup>(
+  with state: State,
+  in fn: @escaping (State, Data) -> (State)
+) -> (State, Data) -> (State) {
+  let wrappedFn = {
+    // The result argument needs to a type that conforms to TensorGroup. 
+    // We are arbitrarily picking Tensor<Float> here. 
+    (s: State, d: Data) -> (State, Tensor<Float>?) in
+      (fn(s,d), nil)
+  }
+  let graphFunction = _graphInternal(with: state, in: wrappedFn)
+  return { (state: State, data: Data) in
+    let result = graphFunction(state, data)
+    return (result.0)
   }
 }
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -825,6 +825,7 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
   let graphFunction = _graphInternal(with: state, in: fn)
   return { (state: State, data: Data) in
     let result = graphFunction(state, data)
+    internalConsistencyCheck(result.1 != nil)
     return (result.0, result.1!)
   }
 }

--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -118,6 +118,17 @@ TracerTests.testAllBackends("AllDtypeSupport") {
   expectFalse(bd.scalarized())
 }
 
+TracerTests.testAllBackends("TraceWithNoResult") {
+  func add(state: Tensor<Float>, data: Data) -> (Tensor<Float>) {
+    return state + data
+  }
+  let tracedAdd = _graph(with: Tensor<Float>(2.0), in: add)
+  let three = Tensor<Float>(3.0)
+  expectNearlyEqualWithScalarTensor(5.0, tracedAdd(Tensor<Float>(2.0), three))
+  expectNearlyEqualWithScalarTensor(6.0, tracedAdd(Tensor<Float>(3.0), three))
+  expectNearlyEqualWithScalarTensor(8.0, tracedAdd(Tensor<Float>(5.0), three))
+}
+
 TracerTests.testAllBackends("Basic_IntermediateTensors") {
   func tracee(state: Tensor<Float>, data: Data) -> (Tensor<Float>, Result) {
     // Create an intermediate tensor value, which the tracing infra needs to


### PR DESCRIPTION
This allows the tracer to handle functions where we don't need a result. 

We will need such a functionality to be able to support tracing in the Dataset pipeline.