### PR TITLE
[test] Require optimized stdlib for CollectionOfRef validation tests

### DIFF
--- a/validation-test/stdlib/Collection/DefaultedBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -127,6 +127,10 @@ runAllTests()
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
This is a followup to #22320, which accidentally left collection-of-reference tests enabled. (Sigh.)

I expect this will unblock DebInfo+Assert builds on CI, which are currently failing due to test timeouts.