### PR TITLE
Update readme in TensorFlow branch to mention build-toolchain-tensorflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,31 +210,29 @@ then run the build product in Terminal.
 #### Building
 
 Swift toolchains are created using the script
-[build-toolchain](https://github.com/apple/swift/blob/master/utils/build-toolchain). This
-script is used by swift.org's CI to produce snapshots and can allow for one to
+[build-toolchain-tensorflow](https://github.com/apple/swift/blob/tensorflow/utils/build-toolchain-tensorflow).
+This script is used by swift.org's CI to produce snapshots and can allow for one to
 locally reproduce such builds for development or distribution purposes. E.x.:
 
 ```
-  $ ./utils/build-toolchain $BUNDLE_PREFIX
+  $ ./utils/build-toolchain-tensorflow $BUNDLE_PREFIX
 ```
 
-where ``$BUNDLE_PREFIX`` is a string that will be prepended to the build 
-date to give the bundle identifier of the toolchain's ``Info.plist``. For 
-instance, if ``$BUNDLE_PREFIX`` was ``com.example``, the toolchain 
-produced will have the bundle identifier ``com.example.YYYYMMDD``. It 
-will be created in the directory you run the script with a filename 
+where ``$BUNDLE_PREFIX`` is a string that will be prepended to the build
+date to give the bundle identifier of the toolchain's ``Info.plist``. For
+instance, if ``$BUNDLE_PREFIX`` was ``com.example``, the toolchain
+produced will have the bundle identifier ``com.example.YYYYMMDD``. It
+will be created in the directory you run the script with a filename
 of the form: ``swift-LOCAL-YYYY-MM-DD-a-osx.tar.gz``.
 
-Beyond building the toolchain, ``build-toolchain`` also supports the 
+Beyond building the toolchain, ``build-toolchain-tensorflow`` also supports the
 following (non-exhaustive) set of useful options::
 
 - ``--dry-run``: Perform a dry run build. This is off by default.
 - ``--test``: Test the toolchain after it has been compiled. This is off by default.
-- ``--distcc``: Use distcc to speed up the build by distributing the c++ part of
-  the swift build. This is off by default.
 
 More options may be added over time. Please pass ``--help`` to
-``build-toolchain`` to see the full set of options.
+``build-toolchain-tensorflow`` to see the full set of options.
 
 #### Installing into Xcode
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ date to give the bundle identifier of the toolchain's ``Info.plist``. For
 instance, if ``$BUNDLE_PREFIX`` was ``com.example``, the toolchain
 produced will have the bundle identifier ``com.example.YYYYMMDD``. It
 will be created in the directory you run the script with a filename
-of the form: ``swift-LOCAL-YYYY-MM-DD-a-osx.tar.gz``.
+ of the form: ``swift-tensorflow-LOCAL-YYYY-MM-DD-a-osx.tar.gz``.
 
 Beyond building the toolchain, ``build-toolchain-tensorflow`` also supports the
 following (non-exhaustive) set of useful options::


### PR DESCRIPTION
I figured it was worth updating the README to mention this new script.

I'm not actually sure if the part about Swift CI building using the new build script is correct. Is there an easy way to check?

@rxwei 