### PR TITLE
[AutoDiff] Diagnose duplicate @differentiable attributes with same parameters.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -107,6 +107,8 @@ namespace swift {
   // SWIFT_ENABLE_TENSORFLOW
   enum class AutoDiffAssociatedVectorSpaceKind : unsigned;
   class VectorSpace;
+  class AutoDiffParameterIndices;
+  class DifferentiableAttr;
 
   enum class KnownProtocolKind : uint8_t;
 
@@ -274,6 +276,12 @@ public:
   /// Cache of autodiff-associated vector spaces.
   llvm::DenseMap<std::pair<Type, unsigned>,
                  Optional<VectorSpace>> AutoDiffVectorSpaces;
+
+  /// Cache of `@differentiable` attributes keyed by parameter indices. This
+  /// helps us diagnose multiple `@differentiable`s that are with respect to the
+  /// same set of parameters.
+  llvm::DenseMap<std::pair<Decl *, AutoDiffParameterIndices *>,
+                 DifferentiableAttr *> DifferentiableAttrs;
 
 private:
   /// \brief The current generation number, which reflects the number of

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2706,6 +2706,8 @@ ERROR(differentiable_attr_wrt_self_instance_method_only,none,
 ERROR(differentiable_attr_cannot_diff_wrt_objects_or_existentials,none,
       "class objects and protocol existentials (%0) cannot be differentiated "
       "with respect to", (Type))
+ERROR(differentiable_attr_duplicate,none,
+      "duplicate '@differentiable' attribute", ())
 ERROR(differentiable_attr_function_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclName))
 ERROR(differentiable_attr_specified_not_function,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2659,6 +2659,14 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   }
 
   auto *checkedWrtParamIndices = autoDiffParameterIndicesBuilder.build(ctx);
+  auto insertion =
+      ctx.DifferentiableAttrs.try_emplace({D, checkedWrtParamIndices}, attr);
+  // Differentiable attributes are uniqued by their parameter indices. Reject
+  // duplicates.
+  if (!insertion.second) {
+    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_duplicate);
+    return;
+  }
 
   // This can happen when someone puts the attribute on an instance method with
   // no parameters (other than the self parameter), and does not specify a wrt

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -11,6 +11,16 @@ func no_jvp_or_vjp(_ x: Float) -> Float {
   return x * x
 }
 
+@differentiable // expected-error {{duplicate '@differentiable' attribute}}
+@differentiable
+func dupe_attributes(arg: Float) -> Float { return arg }
+
+@differentiable(wrt: arg1) // expected-error {{duplicate '@differentiable' attribute}}
+@differentiable(wrt: arg1)
+@differentiable(wrt: arg2) // expected-error {{duplicate '@differentiable' attribute}}
+@differentiable(wrt: arg2)
+func dupe_attributes(arg1: Float, arg2: Float) -> Float { return arg1 }
+
 // JVP
 
 @differentiable(jvp: jvpSimpleJVP)


### PR DESCRIPTION
`@differentiable` attributes are uniqued by their wrt-parameters. Reject duplicates.

Resolves [TF-163](https://bugs.swift.org/browse/TF-163).