### PR TITLE
[AutoDiff] TF-153: Reject differentiation of class methods until they become supported.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -410,6 +410,8 @@ NOTE(autodiff_nested_function_call_multiple_return_active,none,
      "function call is being differentiated from multiple return values", ())
 NOTE(autodiff_control_flow_not_supported,none,
      "differentiating control flow is not supported yet", ())
+NOTE(autodiff_class_member_not_supported,none,
+     "differentiating class members is not supported yet", ())
 NOTE(autodiff_nested_not_supported,none,
      "nested differentiation is not supported yet", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2726,6 +2726,8 @@ ERROR(differentiable_attr_nongeneric_trailing_where,none,
       "trailing 'where' clause in '@differentiable' attribute of non-generic function %0", (DeclName))
 ERROR(differentiable_attr_unsupported_req_kind,none,
       "layout requirement are not supported by '@differentiable' attribute", ())
+ERROR(differentiable_attr_class_unsupported,none,
+      "class members cannot be marked with '@differentiable'", ())
 
 // @differentiang
 ERROR(differentiating_attr_expected_result_tuple,none,

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1917,6 +1917,14 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
     return std::make_pair(convertedRef, requirementIndices);
   }
 
+  // Reject class methods.
+  if (auto *classMethod =
+          peerThroughFunctionConversions<ClassMethodInst>(original)) {
+    context.emitNondifferentiabilityError(original, parentTask,
+        diag::autodiff_class_member_not_supported);
+    return None;
+  }
+
   // Emit the general opaque function error.
   context.emitNondifferentiabilityError(original, parentTask,
       diag::autodiff_opaque_function_not_differentiable);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2476,11 +2476,18 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         original = nullptr;
     }
   }
-  
+
+  // Global immutable vars, for example, have no getter, and therefore trigger
+  // this.
   if (!original) {
-    // Global immutable vars, for example, have no getter, and therefore trigger
-    // this.
     diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute, attr);
+    return;
+  }
+
+  // Class members are not supported by differentiation yet.
+  if (original->getInnermostTypeContext() &&
+      isa<ClassDecl>(original->getInnermostTypeContext())) {
+    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_class_unsupported);
     return;
   }
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -97,6 +97,16 @@ func jvpAmbiguousVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { $0 })
 }
 
+// TF-153: Class methods are not supported yet.
+class Foo {
+  // Direct differentiation case.
+  // expected-error @+1 {{class members cannot be marked with '@differentiable'}}
+  @differentiable
+  func foo(_ x: Float) -> Float {
+    return x
+  }
+}
+
 struct JVPStruct {
   let p: Float
 


### PR DESCRIPTION
Resolves [TF-153](https://bugs.swift.org/browse/TF-153).