### PR TITLE
[AutoDiff] TF-160: Add diagnostics tests for unsupported indirect passing.

### DIFF
--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -44,6 +44,17 @@ extension Tensor where Scalar : BinaryFloatingPoint {
   }
 }
 
+// expected-error @+2 {{function is not differentiable}}
+// expected-note @+1 {{differentiating functions with parameters or result of unknown size is not supported yet}}
+_ = gradient(at: 1.0, in: { x in x.squareRoot() })
+
+// FIXME(TF-159): Diagnose functions with inout parameters.
+// _ = Float(5).gradient { x -> Float in
+//   var a = x
+//   a += x
+//   return a
+// }
+
 //===----------------------------------------------------------------------===//
 // Non-differentiable stored properties
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The miscompilation in [TF-160](https://bugs.swift.org/browse/TF-160) is no longer reproducible because [#22472](https://github.com/apple/swift/pull/22472) fixed activity checking for indirect results. Now this is just an error.

Also add a commented-out reproducer as TODO for [TF-159](https://bugs.swift.org/browse/TF-159).