### PR TITLE
[AutoDiff] Fix wrong diagnostic for indirectness and diagnose unreachable.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -412,6 +412,8 @@ NOTE(autodiff_control_flow_not_supported,none,
      "differentiating control flow is not supported yet", ())
 NOTE(autodiff_nested_not_supported,none,
      "nested differentiation is not supported yet", ())
+NOTE(autodiff_missing_return,none,
+     "missing return for differentiation", ())
 
 ERROR(non_physical_addressof,none,
       "addressof only works with purely physical lvalues; "


### PR DESCRIPTION
- The [diagnostic emission method added for indirectness](https://github.com/apple/swift/pull/22496/files#diff-4ede198777b59748c377cdd17c444e83L1036) was implemented very wrong. It should use the recursive emission logic instead of forcing an error on the top-level invoker. This PR fixes that.

- Reject functions that need to be differentiated but do not have a return. Resolves [TF-7](https://bugs.swift.org/browse/TF-7).