### PR TITLE
Added Windows support for Python module

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -124,12 +124,14 @@ extension PythonObject : CustomStringConvertible {
   }
 }
 
+#if !swift(>=5)
 // Make `PythonObject` show up nicely in the Xcode Playground results sidebar.
 extension PythonObject : CustomPlaygroundQuickLookable {
   public var customPlaygroundQuickLook: PlaygroundQuickLook {
     return .text(description)
   }
 }
+#endif
 
 // Mirror representation, used by debugger/REPL.
 extension PythonObject : CustomReflectable {

--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -55,7 +55,7 @@ public struct PythonLibrary {
 
   static func loadSymbol(
     _ libraryHandle: UnsafeMutableRawPointer, _ name: String
-    ) -> UnsafeMutableRawPointer? {
+  ) -> UnsafeMutableRawPointer? {
     #if canImport(Darwin) || canImport(Glibc)
     return dlsym(libraryHandle, name)
     #elseif os(Windows)
@@ -68,7 +68,7 @@ public struct PythonLibrary {
 
   static func loadSymbol<T>(
     name: String, legacyName: String? = nil, type: T.Type = T.self
-    ) -> T {
+  ) -> T {
     var name = name
     if let legacyName = legacyName, PythonLibrary.shared.isLegacyPython {
       name = legacyName
@@ -202,7 +202,7 @@ private extension PythonLibrary {
 
   static func loadPythonLibrary(
     at path: String, version: PythonVersion
-    ) -> UnsafeMutableRawPointer? {
+  ) -> UnsafeMutableRawPointer? {
     let versionString = version.versionString
 
     if let requiredPythonVersion = Environment.version.value {


### PR DESCRIPTION
- Adds support for loading Python dynamically on Windows.
- Disable `PythonObject`'s `CustomPlaygroundQuickLookable` conformance which is not supported on Swift 5+.

(Mainly to keep PythonKit and Swift for TensorFlow Python module in sync. Also, I hope to see Swift for TensorFlow on Windows eventually 🙂)