### PR TITLE
RemoteAST fixes

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -520,15 +520,14 @@ public:
           readMetadataAndValueOpaqueExistential(ExistentialAddress);
       if (!OptMetaAndValue)
         return false;
-      RemoteAddress MetadataAddress = OptMetaAndValue->first;
-      RemoteAddress ValueAddress = OptMetaAndValue->second;
 
-      auto InstanceTR = readTypeFromMetadata(MetadataAddress.getAddressData());
+      auto InstanceTR = readTypeFromMetadata(
+          OptMetaAndValue->MetadataAddress.getAddressData());
       if (!InstanceTR)
         return false;
 
       *OutInstanceTR = InstanceTR;
-      *OutInstanceAddress = ValueAddress;
+      *OutInstanceAddress = OptMetaAndValue->PayloadAddress;
       return true;
     }
     case RecordKind::ErrorExistential: {
@@ -537,17 +536,15 @@ public:
       if (!OptMetaAndValue)
         return false;
 
-      RemoteAddress InstanceMetadataAddress = std::get<0>(*OptMetaAndValue);
-      RemoteAddress InstanceAddress = std::get<1>(*OptMetaAndValue);
-      // FIXME: Check third value, 'isBridged'
+      // FIXME: Check third value, 'IsBridgedError'
 
-      auto InstanceTR =
-          readTypeFromMetadata(InstanceMetadataAddress.getAddressData());
+      auto InstanceTR = readTypeFromMetadata(
+          OptMetaAndValue->MetadataAddress.getAddressData());
       if (!InstanceTR)
         return false;
 
       *OutInstanceTR = InstanceTR;
-      *OutInstanceAddress = RemoteAddress(InstanceAddress);
+      *OutInstanceAddress = OptMetaAndValue->PayloadAddress;
       return true;
     }
     default:

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -537,8 +537,9 @@ public:
       if (!OptMetaAndValue)
         return false;
 
-      RemoteAddress InstanceMetadataAddress = OptMetaAndValue->first;
-      RemoteAddress InstanceAddress = OptMetaAndValue->second;
+      RemoteAddress InstanceMetadataAddress = std::get<0>(*OptMetaAndValue);
+      RemoteAddress InstanceAddress = std::get<1>(*OptMetaAndValue);
+      // FIXME: Check third value, 'isBridged'
 
       auto InstanceTR =
           readTypeFromMetadata(InstanceMetadataAddress.getAddressData());

--- a/include/swift/RemoteAST/RemoteAST.h
+++ b/include/swift/RemoteAST/RemoteAST.h
@@ -136,6 +136,8 @@ public:
   }
 };
 
+using OpenedExistential = Result<std::pair<Type, remote::RemoteAddress>>;
+
 /// A context for performing an operation relating the remote process with
 /// the AST.  This may be discarded and recreated at any time without danger,
 /// but reusing a context across multiple calls may allow some redundant work
@@ -212,11 +214,17 @@ public:
   Result<remote::RemoteAddress>
   getHeapMetadataForObject(remote::RemoteAddress address);
 
+  /// Resolve the dynamic type and the value address of an error existential
+  /// object, Unlike getDynamicTypeAndAddressForExistential(), this function
+  /// takes the address of the instance and not the address of the reference.
+  OpenedExistential
+  getDynamicTypeAndAddressForError(remote::RemoteAddress object);
+
   /// Given an existential and its static type, resolve its dynamic
   /// type and address. A single step of unwrapping is performed, i.e. if the
   /// value stored inside the existential is itself an existential, the
   /// caller can decide whether to iterate itself.
-  Result<std::pair<Type, remote::RemoteAddress>>
+  OpenedExistential
   getDynamicTypeAndAddressForExistential(remote::RemoteAddress address,
                                          Type staticType);
 };

--- a/include/swift/RemoteAST/RemoteAST.h
+++ b/include/swift/RemoteAST/RemoteAST.h
@@ -23,6 +23,7 @@
 #include "swift/Remote/MemoryReader.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/Type.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -31,7 +32,6 @@
 namespace swift {
 class ASTContext;
 class NominalTypeDecl;
-class Type;
 
 namespace remoteAST {
 
@@ -136,7 +136,20 @@ public:
   }
 };
 
-using OpenedExistential = Result<std::pair<Type, remote::RemoteAddress>>;
+/// A structure representing an opened existential value.
+struct OpenedExistential {
+  /// The concrete type of the value inside the existential.
+  Type InstanceType;
+
+  /// The address of the payload.
+  ///
+  /// Note: If the concrete type is a class type, this is the address of the
+  /// instance and not the address of the reference to the instance.
+  remote::RemoteAddress PayloadAddress;
+
+  OpenedExistential(Type InstanceType, remote::RemoteAddress PayloadAddress)
+      : InstanceType(InstanceType), PayloadAddress(PayloadAddress) {}
+};
 
 /// A context for performing an operation relating the remote process with
 /// the AST.  This may be discarded and recreated at any time without danger,
@@ -217,14 +230,14 @@ public:
   /// Resolve the dynamic type and the value address of an error existential
   /// object, Unlike getDynamicTypeAndAddressForExistential(), this function
   /// takes the address of the instance and not the address of the reference.
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressForError(remote::RemoteAddress object);
 
   /// Given an existential and its static type, resolve its dynamic
   /// type and address. A single step of unwrapping is performed, i.e. if the
   /// value stored inside the existential is itself an existential, the
   /// caller can decide whether to iterate itself.
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressForExistential(remote::RemoteAddress address,
                                          Type staticType);
 };

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -509,6 +509,18 @@ public:
         Reader.readTypeFromMetadata(metadataAddress.getAddressData());
     if (!typeResult)
       return getFailure<std::pair<Type, RemoteAddress>>();
+
+    // When the existential wraps a class type, LLDB expects that the
+    // address returned is the class instance itself and not the address
+    // of the reference.
+    if (!isBridged && typeResult->getClassOrBoundGenericClass()) {
+      auto pointerval = Reader.readPointerValue(valueAddress.getAddressData());
+      if (!pointerval)
+        return getFailure<std::pair<Type, RemoteAddress>>();
+
+      valueAddress = RemoteAddress(*pointerval);
+    }
+
     return std::make_pair<Type, RemoteAddress>(std::move(typeResult),
                                                std::move(valueAddress));
   }
@@ -525,6 +537,18 @@ public:
         Reader.readTypeFromMetadata(metadataAddress.getAddressData());
     if (!typeResult)
       return getFailure<std::pair<Type, RemoteAddress>>();
+
+    // When the existential wraps a class type, LLDB expects that the
+    // address returned is the class instance itself and not the address
+    // of the reference.
+    if (typeResult->getClassOrBoundGenericClass()) {
+      auto pointerval = Reader.readPointerValue(valueAddress.getAddressData());
+      if (!pointerval)
+        return getFailure<std::pair<Type, RemoteAddress>>();
+
+      valueAddress = RemoteAddress(*pointerval);
+    }
+
     return std::make_pair<Type, RemoteAddress>(std::move(typeResult),
                                                std::move(valueAddress));
   }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -104,9 +104,9 @@ public:
   getDeclForRemoteNominalTypeDescriptor(RemoteAddress descriptor) = 0;
   virtual Result<RemoteAddress>
   getHeapMetadataForObject(RemoteAddress object) = 0;
-  virtual OpenedExistential
+  virtual Result<OpenedExistential>
   getDynamicTypeAndAddressForError(RemoteAddress object) = 0;
-  virtual OpenedExistential
+  virtual Result<OpenedExistential>
   getDynamicTypeAndAddressForExistential(RemoteAddress object,
                                          Type staticType) = 0;
 
@@ -478,89 +478,89 @@ public:
     return getFailure<RemoteAddress>();
   }
 
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressClassExistential(RemoteAddress object) {
     auto pointerval = Reader.readPointerValue(object.getAddressData());
     if (!pointerval)
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
     auto result = Reader.readMetadataFromInstance(*pointerval);
     if (!result)
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
     auto typeResult = Reader.readTypeFromMetadata(result.getValue());
     if (!typeResult)
-      return getFailure<std::pair<Type, RemoteAddress>>();
-    return std::make_pair<Type, RemoteAddress>(std::move(typeResult),
-                                               RemoteAddress(*pointerval));
+      return getFailure<OpenedExistential>();
+    return OpenedExistential(std::move(typeResult),
+                             RemoteAddress(*pointerval));
   }
 
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressErrorExistential(RemoteAddress object,
                                            bool dereference=true) {
     if (dereference) {
       auto pointerval = Reader.readPointerValue(object.getAddressData());
       if (!pointerval)
-        return getFailure<std::pair<Type, RemoteAddress>>();
+        return getFailure<OpenedExistential>();
       object = RemoteAddress(*pointerval);
     }
 
     auto result =
         Reader.readMetadataAndValueErrorExistential(object);
     if (!result)
-      return getFailure<std::pair<Type, RemoteAddress>>();
-
-    RemoteAddress metadataAddress = std::get<0>(*result);
-    RemoteAddress valueAddress = std::get<1>(*result);
-    bool isBridged = std::get<2>(*result);
+      return getFailure<OpenedExistential>();
 
     auto typeResult =
-        Reader.readTypeFromMetadata(metadataAddress.getAddressData());
+        Reader.readTypeFromMetadata(result->MetadataAddress.getAddressData());
     if (!typeResult)
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
+
 
     // When the existential wraps a class type, LLDB expects that the
     // address returned is the class instance itself and not the address
     // of the reference.
-    if (!isBridged && typeResult->getClassOrBoundGenericClass()) {
-      auto pointerval = Reader.readPointerValue(valueAddress.getAddressData());
+    auto payloadAddress = result->PayloadAddress;
+    if (!result->IsBridgedError &&
+        typeResult->getClassOrBoundGenericClass()) {
+      auto pointerval = Reader.readPointerValue(
+          payloadAddress.getAddressData());
       if (!pointerval)
-        return getFailure<std::pair<Type, RemoteAddress>>();
+        return getFailure<OpenedExistential>();
 
-      valueAddress = RemoteAddress(*pointerval);
+      payloadAddress = RemoteAddress(*pointerval);
     }
 
-    return std::make_pair<Type, RemoteAddress>(std::move(typeResult),
-                                               std::move(valueAddress));
+    return OpenedExistential(std::move(typeResult),
+                             std::move(payloadAddress));
   }
 
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressOpaqueExistential(RemoteAddress object) {
     auto result = Reader.readMetadataAndValueOpaqueExistential(object);
     if (!result)
-      return getFailure<std::pair<Type, RemoteAddress>>();
-    RemoteAddress metadataAddress = result->first;
-    RemoteAddress valueAddress = result->second;
+      return getFailure<OpenedExistential>();
 
     auto typeResult =
-        Reader.readTypeFromMetadata(metadataAddress.getAddressData());
+        Reader.readTypeFromMetadata(result->MetadataAddress.getAddressData());
     if (!typeResult)
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
 
     // When the existential wraps a class type, LLDB expects that the
     // address returned is the class instance itself and not the address
     // of the reference.
+    auto payloadAddress = result->PayloadAddress;
     if (typeResult->getClassOrBoundGenericClass()) {
-      auto pointerval = Reader.readPointerValue(valueAddress.getAddressData());
+      auto pointerval = Reader.readPointerValue(
+          payloadAddress.getAddressData());
       if (!pointerval)
-        return getFailure<std::pair<Type, RemoteAddress>>();
+        return getFailure<OpenedExistential>();
 
-      valueAddress = RemoteAddress(*pointerval);
+      payloadAddress = RemoteAddress(*pointerval);
     }
 
-    return std::make_pair<Type, RemoteAddress>(std::move(typeResult),
-                                               std::move(valueAddress));
+    return OpenedExistential(std::move(typeResult),
+                             std::move(payloadAddress));
   }
 
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressExistentialMetatype(RemoteAddress object) {
     // The value of the address is just the input address.
     // The type is obtained through the following sequence of steps:
@@ -569,21 +569,21 @@ public:
     // 3) Wrapping the resolved type in an existential metatype.
     auto pointerval = Reader.readPointerValue(object.getAddressData());
     if (!pointerval)
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
     auto typeResult = Reader.readTypeFromMetadata(*pointerval);
     if (!typeResult)
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
     auto wrappedType = ExistentialMetatypeType::get(typeResult);
     if (!wrappedType)
-      return getFailure<std::pair<Type, RemoteAddress>>();
-    return std::make_pair<Type, RemoteAddress>(std::move(wrappedType),
-                                               std::move(object));
+      return getFailure<OpenedExistential>();
+    return OpenedExistential(std::move(wrappedType),
+                             std::move(object));
   }
 
   /// Resolve the dynamic type and the value address of an error existential
   /// object, Unlike getDynamicTypeAndAddressForExistential(), this function
   /// takes the address of the instance and not the address of the reference.
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressForError(RemoteAddress object) override {
     return getDynamicTypeAndAddressErrorExistential(object,
                                                     /*dereference=*/false);
@@ -593,12 +593,12 @@ public:
   /// given its address and its static type. For class and error existentials,
   /// this API takes a pointer to the instance reference rather than the
   /// instance reference itself.
-  OpenedExistential
+  Result<OpenedExistential>
   getDynamicTypeAndAddressForExistential(RemoteAddress object,
                                          Type staticType) override {
     // If this is not an existential, give up.
     if (!staticType->isAnyExistentialType())
-      return getFailure<std::pair<Type, RemoteAddress>>();
+      return getFailure<OpenedExistential>();
 
     // Handle the case where this is an ExistentialMetatype.
     if (!staticType->isExistentialType())
@@ -674,13 +674,13 @@ RemoteASTContext::getHeapMetadataForObject(remote::RemoteAddress address) {
   return asImpl(Impl)->getHeapMetadataForObject(address);
 }
 
-OpenedExistential
+Result<OpenedExistential>
 RemoteASTContext::getDynamicTypeAndAddressForError(
     remote::RemoteAddress address) {
   return asImpl(Impl)->getDynamicTypeAndAddressForError(address);
 }
 
-OpenedExistential
+Result<OpenedExistential>
 RemoteASTContext::getDynamicTypeAndAddressForExistential(
     remote::RemoteAddress address, Type staticType) {
   return asImpl(Impl)->getDynamicTypeAndAddressForExistential(address,

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -500,8 +500,10 @@ public:
         Reader.readMetadataAndValueErrorExistential(RemoteAddress(*pointerval));
     if (!result)
       return getFailure<std::pair<Type, RemoteAddress>>();
-    RemoteAddress metadataAddress = result->first;
-    RemoteAddress valueAddress = result->second;
+
+    RemoteAddress metadataAddress = std::get<0>(*result);
+    RemoteAddress valueAddress = std::get<1>(*result);
+    bool isBridged = std::get<2>(*result);
 
     auto typeResult =
         Reader.readTypeFromMetadata(metadataAddress.getAddressData());

--- a/test/RemoteAST/existentials_objc.swift
+++ b/test/RemoteAST/existentials_objc.swift
@@ -31,3 +31,14 @@ printDynamicTypeAndAddressForExistential(NSString("hello") as AnyObject)
 
 // CHECK: NSString
 printDynamicTypeAndAddressForExistential(NSString("hello") as AnyObject)
+
+// Bridged NSError.
+class ClassError : NSError {
+  required init(coder: NSCoder) { fatalError() }
+  init() {
+    super.init(domain: "ClassError", code: 10, userInfo: [:])
+  }
+}
+
+// CHECK: ClassError
+printDynamicTypeAndAddressForExistential(ClassError() as Error)

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -15,6 +15,7 @@
 
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/Remote/InProcessMemoryReader.h"
+#include "swift/Remote/MetadataReader.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/FrontendTool/FrontendTool.h"
@@ -38,7 +39,7 @@ using namespace swift::remote;
 using namespace swift::remoteAST;
 
 /// The context for the code we're running.  Set by the observer.
-static ASTContext *Context = nullptr;
+static ASTContext *context = nullptr;
 
 /// The RemoteAST for the code we're running.
 std::shared_ptr<MemoryReader> reader;
@@ -49,7 +50,7 @@ static RemoteASTContext &getRemoteASTContext() {
     return *remoteContext;
 
   std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
-  remoteContext.reset(new RemoteASTContext(*Context, std::move(reader)));
+  remoteContext.reset(new RemoteASTContext(*context, std::move(reader)));
   return *remoteContext;
 }
 
@@ -166,7 +167,7 @@ printDynamicTypeAndAddressForExistential(void *object,
       RemoteAddress(object), staticTypeResult.getValue());
   if (result) {
     out << "found type: ";
-    result.getValue().first.print(out);
+    result.getValue().InstanceType.print(out);
     out << "\n";
   } else {
     out << result.getFailure().render() << '\n';
@@ -177,7 +178,7 @@ namespace {
 
 struct Observer : public FrontendObserver {
   void configuredCompiler(CompilerInstance &instance) override {
-    Context = &instance.getASTContext();
+    context = &instance.getASTContext();
   }
 };
 


### PR DESCRIPTION
In the service of https://github.com/apple/swift-lldb/pull/1286/. Replacing lldb's existing existential projection code path with RemoteAST exposed some limitations in the latter.