### PR TITLE
[ome] Eliminate inefficiencies in lowering of destructures to ensure -Onone output stays the same.

### DIFF
--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -299,3 +299,22 @@ bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2)
   %7 = tuple(%2 : $Builtin.NativeObject, %3 : $Builtin.Int32, %4 : $TestArrayStorage, %5 : $Builtin.Int32, %6 : $TestArrayStorage)
   return %7 : $(Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Builtin.Int32, TestArrayStorage)
 }
+
+// In the following test, the trivial parts do not have any actual uses... do
+// not emit any value projections for them!
+//
+// CHECK-LABEL: sil [canonical] @test_destructure_with_only_some_uses : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, TestArrayStorage, TestArrayStorage) {
+// CHECK:    bb0([[ARG0:%.*]] : $(Builtin.NativeObject, Builtin.Int32), [[ARG1:%.*]] : $TestArray2):
+// CHECK-NEXT:   [[ARG0_0:%.*]] = tuple_extract [[ARG0]]
+// CHECK-NEXT:   [[STORAGE:%.*]] = struct_extract [[ARG1]] : $TestArray2, #TestArray2.storage
+// CHECK-NEXT:   [[STORAGE2:%.*]] = struct_extract [[ARG1]] : $TestArray2, #TestArray2.storage2
+// CHECK-NEXT:   [[RESULT:%.*]] = tuple ([[ARG0_0]] : ${{.*}}, [[STORAGE]] : ${{.*}}, [[STORAGE2]] : ${{.*}})
+// CHECK-NEXT:   return [[RESULT]]
+// CHECK: } // end sil function 'test_destructure_with_only_some_uses'
+sil [canonical] [ossa] @test_destructure_with_only_some_uses : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, TestArrayStorage, TestArrayStorage) {
+bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2):
+  (%2, %3) = destructure_tuple %0 : $(Builtin.NativeObject, Builtin.Int32)
+  (%4, %5, %6) = destructure_struct %1 : $TestArray2
+  %7 = tuple (%2 : $Builtin.NativeObject, %4 : $TestArrayStorage, %6 : $TestArrayStorage)
+  return %7 : $(Builtin.NativeObject, TestArrayStorage, TestArrayStorage)
+}

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -318,3 +318,14 @@ bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2)
   %7 = tuple (%2 : $Builtin.NativeObject, %4 : $TestArrayStorage, %6 : $TestArrayStorage)
   return %7 : $(Builtin.NativeObject, TestArrayStorage, TestArrayStorage)
 }
+
+// CHECK-LABEL: sil [canonical] @test_simplify_instruction : $@convention(thin) (@owned Builtin.NativeObject, Builtin.Int32) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject,
+// CHECK-NEXT:   return [[ARG]]
+// CHECK: } // end sil function 'test_simplify_instruction'
+sil [canonical] [ossa] @test_simplify_instruction : $@convention(thin) (@owned Builtin.NativeObject, Builtin.Int32) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Builtin.NativeObject, %1 : $Builtin.Int32):
+  %2 = tuple(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32)
+  (%3, %4) = destructure_tuple %2 : $(Builtin.NativeObject, Builtin.Int32)
+  return %3 : $Builtin.NativeObject
+}

--- a/test/Serialization/transparent-std.swift
+++ b/test/Serialization/transparent-std.swift
@@ -16,13 +16,17 @@ func test_foo(x: Builtin.Int1, y: Builtin.Int1) -> Builtin.Int1 {
 }
 
 // SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$s19def_transparent_std12assign_tuple1x1yyBi64__Bot_BptF : $@convention(thin) (Builtin.Int64, @guaranteed Builtin.NativeObject, Builtin.RawPointer) -> () {
-// SIL: = tuple (%0 : $Builtin.Int64, %1 : $Builtin.NativeObject)
-// SIL: retain_value
-// SIL: = tuple_extract
-// SIL: = tuple_extract
-// SIL: = pointer_to_address
-// SIL: = tuple
-// SIL: = load
+// SIL: bb0([[ARG0:%.*]] : ${{.*}}, [[ARG1:%.*]] : ${{.*}}, [[ARG2:%.*]] :
+// SIL: [[TUP:%.*]] = tuple ([[ARG0]] : $Builtin.Int64, [[ARG1]] : $Builtin.NativeObject)
+// SIL: retain_value [[TUP]]
+// SIL: [[CASTED_PTR:%.*]] = pointer_to_address [[ARG2]]
+// SIL: [[CASTED_PTR_0:%.*]] = tuple_element_addr [[CASTED_PTR]] : $*(Builtin.Int64, Builtin.NativeObject), 0
+// SIL: store [[ARG0]] to [[CASTED_PTR_0]]
+// SIL: [[CASTED_PTR_1:%.*]] = tuple_element_addr [[CASTED_PTR]] : $*(Builtin.Int64, Builtin.NativeObject), 1
+// SIL: [[OLD_VALUE:%.*]] = load [[CASTED_PTR_1]]
+// SIL: store [[ARG1]] to [[CASTED_PTR_1]]
+// SIL: strong_release [[OLD_VALUE]]
+// SIL: } // end sil function '$s19def_transparent_std12assign_tuple1x1yyBi64__Bot_BptF' 
 func test_tuple(x: (Builtin.Int64, Builtin.NativeObject),
                 y: Builtin.RawPointer) {
   assign_tuple(x: x, y: y)


### PR DESCRIPTION
This is just fixing a few inefficiencies so that -Onone code output stays the same [and I can avoid needing to update certain tests ; )]. Specifically:

1. We only emit projections if a destructure's result is actually used. (Before we eagerly emitted).
2. If we do insert a projection, we try to simplify the projection. This is a quick, stateless check that seems to eliminate unnecessary aggregate formation in -Onone output.