### PR TITLE
[benchmark] Janitor Duty: Troublemaker Legacy

### DIFF
--- a/benchmark/single-source/Fibonacci.swift
+++ b/benchmark/single-source/Fibonacci.swift
@@ -15,10 +15,10 @@ import TestsUtils
 public let Fibonacci = BenchmarkInfo(
   name: "Fibonacci",
   runFunction: run_Fibonacci,
-  tags: [.unstable, .algorithm])
+  tags: [.algorithm])
 
 func fibonacci(_ n: Int) -> Int {
-  if (n < 2) { return 1 }
+  if (n <= 2) { return 1 }
   return fibonacci(n - 2) + fibonacci(n - 1)
 }
 
@@ -28,14 +28,14 @@ func Fibonacci(_ n: Int) -> Int {
   // at compile time.
   if False() { return 0 }
 
-  if (n < 2) { return 1 }
+  if (n <= 2) { return 1 }
   return fibonacci(n - 2) + fibonacci(n - 1)
 }
 
 @inline(never)
 public func run_Fibonacci(_ N: Int) {
-  let n = 32
-  let ref_result = 3524578
+  let n = 24
+  let ref_result = 46368
   var result = 0
   for _ in 1...N {
     result = Fibonacci(n)

--- a/benchmark/single-source/FloatingPointPrinting.swift
+++ b/benchmark/single-source/FloatingPointPrinting.swift
@@ -19,47 +19,56 @@ public let FloatingPointPrinting = [
   BenchmarkInfo(
     name: "FloatingPointPrinting_Float_description_small",
     runFunction: run_FloatingPointPrinting_Float_description_small,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 108),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Double_description_small",
     runFunction: run_FloatingPointPrinting_Double_description_small,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 100),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Float80_description_small",
     runFunction: run_FloatingPointPrinting_Float80_description_small,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 108),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Float_description_uniform",
     runFunction: run_FloatingPointPrinting_Float_description_uniform,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 100),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Double_description_uniform",
     runFunction: run_FloatingPointPrinting_Double_description_uniform,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 100),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Float80_description_uniform",
     runFunction: run_FloatingPointPrinting_Float80_description_uniform,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 100),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Float_interpolated",
     runFunction: run_FloatingPointPrinting_Float_interpolated,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 200),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Double_interpolated",
     runFunction: run_FloatingPointPrinting_Double_interpolated,
-    tags: [.validation, .api, .runtime, .String]),
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 200),
 
   BenchmarkInfo(
     name: "FloatingPointPrinting_Float80_interpolated",
     runFunction: run_FloatingPointPrinting_Float80_interpolated,
-    tags: [.validation, .api, .runtime, .String])
+    tags: [.validation, .api, .runtime, .String],
+    legacyFactor: 200)
 ]
 
 // Generate descriptions for 100,000 values around 1.0.
@@ -75,7 +84,7 @@ public let FloatingPointPrinting = [
 
 @inline(never)
 public func run_FloatingPointPrinting_Float_description_small(_ N: Int) {
-  let count = 100_000
+  let count = 1_000
   for _ in 0..<N {
     for i in 1...count {
       let f = Float(i) / 101.0
@@ -86,7 +95,7 @@ public func run_FloatingPointPrinting_Float_description_small(_ N: Int) {
 
 @inline(never)
 public func run_FloatingPointPrinting_Double_description_small(_ N: Int) {
-  let count = 100_000
+  let count = 1_000
   for _ in 0..<N {
     for i in 1...count {
       let f = Double(i) / 101.0
@@ -101,7 +110,7 @@ public func run_FloatingPointPrinting_Float80_description_small(_ N: Int) {
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 // On Linux, Float80 is at aleast available on x86.
 #if arch(x86_64) || arch(i386)
-  let count = 100_000
+  let count = 1_000
   for _ in 0..<N {
     for i in 1...count {
       let f = Float80(i) / 101.0
@@ -117,7 +126,7 @@ public func run_FloatingPointPrinting_Float80_description_small(_ N: Int) {
 
 @inline(never)
 public func run_FloatingPointPrinting_Float_description_uniform(_ N: Int) {
-  let count = 100_000
+  let count = 1_000
   let step = UInt32.max / UInt32(count)
   for _ in 0..<N {
     for i in 0..<count {
@@ -130,7 +139,7 @@ public func run_FloatingPointPrinting_Float_description_uniform(_ N: Int) {
 
 @inline(never)
 public func run_FloatingPointPrinting_Double_description_uniform(_ N: Int) {
-  let count = 100_000
+  let count = 1_000
   let step = UInt64.max / UInt64(count)
   for _ in 0..<N {
     for i in 0..<count {
@@ -147,7 +156,7 @@ public func run_FloatingPointPrinting_Float80_description_uniform(_ N: Int) {
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 // On Linux, Float80 is at aleast available on x86.
 #if arch(x86_64) || arch(i386)
-  let count = 100_000
+  let count = 1_000
   let step = UInt64.max / UInt64(count)
   for _ in 0..<N {
     for i in 0..<count {
@@ -167,7 +176,7 @@ public func run_FloatingPointPrinting_Float80_description_uniform(_ N: Int) {
 
 @inline(never)
 public func run_FloatingPointPrinting_Float_interpolated(_ N: Int) {
-  let count = 100_000
+  let count = 500
   let step = UInt32.max / UInt32(count)
   for _ in 0..<N {
     for i in 0..<count {
@@ -180,7 +189,7 @@ public func run_FloatingPointPrinting_Float_interpolated(_ N: Int) {
 
 @inline(never)
 public func run_FloatingPointPrinting_Double_interpolated(_ N: Int) {
-  let count = 100_000
+  let count = 500
   let step = UInt64.max / UInt64(count)
   for _ in 0..<N {
     for i in 0..<count {
@@ -197,7 +206,7 @@ public func run_FloatingPointPrinting_Float80_interpolated(_ N: Int) {
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 // On Linux, Float80 is at aleast available on x86.
 #if arch(x86_64) || arch(i386)
-  let count = 100_000
+  let count = 500
   let step = UInt64.max / UInt64(count)
   for _ in 0..<N {
     for i in 0..<count {
@@ -210,4 +219,3 @@ public func run_FloatingPointPrinting_Float80_interpolated(_ N: Int) {
 #endif // x86
 #endif // Darwin/Linux
 }
-

--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -13,26 +13,66 @@
 import TestsUtils
 import Foundation
 
+let t: [BenchmarkCategory] = [.validation, .bridging]
+let ts: [BenchmarkCategory] = [.validation, .bridging, .String]
+
 public let ObjectiveCBridging = [
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSString", runFunction: run_ObjectiveCBridgeFromNSString, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSStringForced", runFunction: run_ObjectiveCBridgeFromNSStringForced, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeToNSString", runFunction: run_ObjectiveCBridgeToNSString, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObject", runFunction: run_ObjectiveCBridgeFromNSArrayAnyObject, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectForced", runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectForced, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeToNSArray", runFunction: run_ObjectiveCBridgeToNSArray, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectToString, tags: [.validation, .bridging, .String]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectToStringForced, tags: [.validation, .bridging, .String]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObject", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObject, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectForced", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectForced, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeToNSDictionary", runFunction: run_ObjectiveCBridgeToNSDictionary, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToString, tags: [.validation, .bridging, .String, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced, tags: [.validation, .bridging, .String, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObject", runFunction: run_ObjectiveCBridgeFromNSSetAnyObject, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectForced", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectForced, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeToNSSet", runFunction: run_ObjectiveCBridgeToNSSet, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToString, tags: [.validation, .bridging, .String]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced, tags: [.validation, .bridging, .String, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDateComponents", runFunction: run_ObjectiveCBridgeFromNSDateComponents, tags: [.validation, .bridging], setUpFunction: setup_dateComponents)
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSString",
+    runFunction: run_ObjectiveCBridgeFromNSString, tags: t,
+    legacyFactor: 5),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSStringForced",
+    runFunction: run_ObjectiveCBridgeFromNSStringForced, tags: t,
+    legacyFactor: 5),
+  BenchmarkInfo(name: "ObjectiveCBridgeToNSString",
+    runFunction: run_ObjectiveCBridgeToNSString, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObject",
+    runFunction: run_ObjectiveCBridgeFromNSArrayAnyObject, tags: t,
+    legacyFactor: 100),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectForced",
+    runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectForced, tags: t,
+    legacyFactor: 20),
+  BenchmarkInfo(name: "ObjectiveCBridgeToNSArray",
+    runFunction: run_ObjectiveCBridgeToNSArray, tags: t,
+    legacyFactor: 50),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectToString",
+    runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectToString, tags: ts,
+    legacyFactor: 100),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectToStringForced",
+    runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectToStringForced,
+    tags: ts, legacyFactor: 200),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObject",
+    runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObject, tags: t,
+    legacyFactor: 100),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectForced",
+    runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectForced, tags: t,
+    legacyFactor: 50),
+  BenchmarkInfo(name: "ObjectiveCBridgeToNSDictionary",
+    runFunction: run_ObjectiveCBridgeToNSDictionary, tags: t,
+    legacyFactor: 50),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToString",
+    runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToString,
+    tags: ts, legacyFactor: 500),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced",
+    runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced,
+    tags: ts, legacyFactor: 500),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObject",
+    runFunction: run_ObjectiveCBridgeFromNSSetAnyObject, tags: t,
+    legacyFactor: 200),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectForced",
+    runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectForced, tags: t,
+    legacyFactor: 20),
+  BenchmarkInfo(name: "ObjectiveCBridgeToNSSet",
+    runFunction: run_ObjectiveCBridgeToNSSet, tags: t,
+    legacyFactor: 50),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToString",
+    runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToString, tags: ts,
+    legacyFactor: 500),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToStringForced",
+    runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced, tags: ts,
+    legacyFactor: 500),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDateComponents",
+    runFunction: run_ObjectiveCBridgeFromNSDateComponents, tags: t,
+    setUpFunction: setup_dateComponents),
 ]
 
 #if _runtime(_ObjC)
@@ -60,7 +100,7 @@ func testObjectiveCBridgeFromNSString() {
   let nsString = createNSString()
 
   var s: String?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 2_000 {
     // Call _conditionallyBridgeFromObjectiveC.
     let n : String? = conditionalCast(nsString)
     if n != nil {
@@ -88,7 +128,7 @@ func testObjectiveCBridgeFromNSStringForced() {
   let nsString = createNSString()
 
   var s: String?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 2_000 {
     // Call _forceBridgeFromObjectiveC
     s = forcedCast(nsString)
   }
@@ -157,7 +197,7 @@ func testObjectiveCBridgeFromNSArrayAnyObject() {
   let nsArray = createNSArray()
 
   var nativeString : String?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 100 {
     if let nativeArray : [NSString] = conditionalCast(nsArray) {
        nativeString = forcedCast(nativeArray[0])
     }
@@ -183,7 +223,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectForced() {
   let nsArray = createNSArray()
 
   var nativeString : String?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 500 {
     let nativeArray : [NSString] = forcedCast(nsArray)
     nativeString = forcedCast(nativeArray[0])
   }
@@ -209,7 +249,7 @@ func testObjectiveCBridgeToNSArray() {
     "abcde", "abcde", "abcde", "abcde", "abcde"]
 
   var nsString : Any?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 200 {
     let nsArray = nativeArray as NSArray
     nsString = nsArray.object(at: 0)
   }
@@ -234,7 +274,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectToString() {
   let nsArray = createNSArray()
 
   var nativeString : String?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 100 {
     if let nativeArray : [String] = conditionalCast(nsArray) {
       nativeString = nativeArray[0]
     }
@@ -260,7 +300,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectToStringForced() {
   let nsArray = createNSArray()
 
   var nativeString : String?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 50 {
     let nativeArray : [String] = forcedCast(nsArray)
     nativeString = nativeArray[0]
   }
@@ -314,7 +354,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObject() {
   let nsString = NSString(cString: "NSString that does not fit in tagged pointer", encoding: String.Encoding.utf8.rawValue)!
 
   var nativeInt : Int?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 100 {
     if let nativeDictionary : [NSString : NSNumber] = conditionalCast(nsDictionary) {
        nativeInt = forcedCast(nativeDictionary[nsString])
     }
@@ -341,7 +381,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObjectForced() {
   let nsString = NSString(cString: "NSString that does not fit in tagged pointer", encoding: String.Encoding.utf8.rawValue)!
 
   var nativeInt : Int?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 200 {
     if let nativeDictionary : [NSString : NSNumber] = forcedCast(nsDictionary) {
        nativeInt = forcedCast(nativeDictionary[nsString])
     }
@@ -370,7 +410,7 @@ func testObjectiveCBridgeToNSDictionary() {
   let key = "abcde1" as NSString
 
   var nsNumber : Any?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 200 {
     let nsDict = nativeDictionary as NSDictionary
     nsNumber = nsDict.object(forKey: key)
   }
@@ -397,7 +437,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObjectToString() {
   let nativeString = nsString as String
 
   var nativeInt : Int?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 20 {
     if let nativeDictionary : [String : Int] = conditionalCast(nsDictionary) {
        nativeInt = nativeDictionary[nativeString]
     }
@@ -425,7 +465,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced() {
   let nativeString = nsString as String
 
   var nativeInt : Int?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 20 {
     if let nativeDictionary : [String : Int] = forcedCast(nsDictionary) {
        nativeInt = nativeDictionary[nativeString]
     }
@@ -481,7 +521,7 @@ func testObjectiveCBridgeFromNSSetAnyObject() {
   let nsString = NSString(cString: "NSString that does not fit in tagged pointer", encoding: String.Encoding.utf8.rawValue)!
 
   var result : Bool?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 50 {
     if let nativeSet : Set<NSString> = conditionalCast(nsSet) {
        result = nativeSet.contains(nsString)
     }
@@ -508,7 +548,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectForced() {
   let nsString = NSString(cString: "NSString that does not fit in tagged pointer", encoding: String.Encoding.utf8.rawValue)!
 
   var result : Bool?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 500 {
     if let nativeSet : Set<NSString> = forcedCast(nsSet) {
        result = nativeSet.contains(nsString)
     }
@@ -536,7 +576,7 @@ func testObjectiveCBridgeToNSSet() {
   let key = "abcde1" as NSString
 
   var nsString : Any?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 200 {
     let nsDict = nativeSet as NSSet
     nsString = nsDict.member(key)
   }
@@ -563,7 +603,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToString() {
   let nsSet = createNSSet()
 
   var result : Bool?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 20 {
     if let nativeSet : Set<String> = conditionalCast(nsSet) {
        result = nativeSet.contains(nativeString)
     }
@@ -591,7 +631,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToStringForced() {
   let nativeString = nsString as String
 
   var result : Bool?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 20 {
     if let nativeSet : Set<String> = forcedCast(nsSet) {
        result = nativeSet.contains(nativeString)
     }
@@ -616,7 +656,7 @@ public func run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced(_ N: Int) {
 //translated directly from an objc part of the original testcase
 @objc class DictionaryContainer : NSObject {
   @objc var _dictionary:NSDictionary
-  
+
   //simulate an objc property being imported via bridging
   @objc var dictionary:Dictionary<DateComponents, String> {
     @inline(never)
@@ -624,7 +664,7 @@ public func run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced(_ N: Int) {
       return _dictionary as! Dictionary<DateComponents, String>
     }
   }
-  
+
   override init() {
     _dictionary = NSDictionary()
     super.init()
@@ -653,7 +693,7 @@ public func setup_dateComponents() {
     guard let date = calendar.date(byAdding: .day, value: -day, to: now) else {
       return nil
     }
-    
+
     return calendar.dateComponents([.year, .month, .day], from: date)
   }
   #endif

--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -16,28 +16,70 @@ import Foundation
 import ObjectiveCTests
 #endif
 
+let t: [BenchmarkCategory] = [.validation, .bridging]
+let ts: [BenchmarkCategory] = [.validation, .String, .bridging]
+
 public let ObjectiveCBridgingStubs = [
-  BenchmarkInfo(name: "ObjectiveCBridgeStubDataAppend", runFunction: run_ObjectiveCBridgeStubDataAppend, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubDateAccess", runFunction: run_ObjectiveCBridgeStubDateAccess, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubDateMutation", runFunction: run_ObjectiveCBridgeStubDateMutation, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubFromArrayOfNSString2", runFunction: run_ObjectiveCBridgeStubFromArrayOfNSString, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDate", runFunction: run_ObjectiveCBridgeStubFromNSDate, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSString", runFunction: run_ObjectiveCBridgeStubFromNSString, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubToArrayOfNSString2", runFunction: run_ObjectiveCBridgeStubToArrayOfNSString, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSDate2", runFunction: run_ObjectiveCBridgeStubToNSDate, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSString", runFunction: run_ObjectiveCBridgeStubToNSString, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubURLAppendPath2", runFunction: run_ObjectiveCBridgeStubURLAppendPath, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqual", runFunction: run_ObjectiveCBridgeStringIsEqual, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqual2", runFunction: run_ObjectiveCBridgeStringIsEqual2, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqualAllSwift", runFunction: run_ObjectiveCBridgeStringIsEqualAllSwift, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringCompare", runFunction: run_ObjectiveCBridgeStringCompare, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringCompare2", runFunction: run_ObjectiveCBridgeStringCompare2, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringGetASCIIContents", runFunction: run_ObjectiveCBridgeStringGetASCIIContents, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringGetUTF8Contents", runFunction: run_ObjectiveCBridgeStringGetUTF8Contents, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringRangeOfString", runFunction: run_ObjectiveCBridgeStringRangeOfString, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringHash", runFunction: run_ObjectiveCBridgeStringHash, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringUTF8String", runFunction: run_ObjectiveCBridgeStringUTF8String, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
-  BenchmarkInfo(name: "ObjectiveCBridgeStringCStringUsingEncoding", runFunction: run_ObjectiveCBridgeStringCStringUsingEncoding, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubDataAppend",
+    runFunction: run_ObjectiveCBridgeStubDataAppend, tags: t,
+    legacyFactor: 20),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubDateAccess",
+    runFunction: run_ObjectiveCBridgeStubDateAccess, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubDateMutation",
+    runFunction: run_ObjectiveCBridgeStubDateMutation, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubFromArrayOfNSString2",
+    runFunction: run_ObjectiveCBridgeStubFromArrayOfNSString, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDate",
+    runFunction: run_ObjectiveCBridgeStubFromNSDate, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSString",
+    runFunction: run_ObjectiveCBridgeStubFromNSString, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubToArrayOfNSString2",
+    runFunction: run_ObjectiveCBridgeStubToArrayOfNSString, tags: t,
+    legacyFactor: 20),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSDate2",
+    runFunction: run_ObjectiveCBridgeStubToNSDate, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSString",
+    runFunction: run_ObjectiveCBridgeStubToNSString, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubURLAppendPath2",
+    runFunction: run_ObjectiveCBridgeStubURLAppendPath, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqual",
+    runFunction: run_ObjectiveCBridgeStringIsEqual, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqual2",
+    runFunction: run_ObjectiveCBridgeStringIsEqual2, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqualAllSwift",
+    runFunction: run_ObjectiveCBridgeStringIsEqualAllSwift, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringCompare",
+    runFunction: run_ObjectiveCBridgeStringCompare, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringCompare2",
+    runFunction: run_ObjectiveCBridgeStringCompare2, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringGetASCIIContents",
+    runFunction: run_ObjectiveCBridgeStringGetASCIIContents, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringGetUTF8Contents",
+    runFunction: run_ObjectiveCBridgeStringGetUTF8Contents, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringRangeOfString",
+    runFunction: run_ObjectiveCBridgeStringRangeOfString, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringHash",
+    runFunction: run_ObjectiveCBridgeStringHash, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringUTF8String",
+    runFunction: run_ObjectiveCBridgeStringUTF8String, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringCStringUsingEncoding",
+    runFunction: run_ObjectiveCBridgeStringCStringUsingEncoding, tags: ts,
+    setUpFunction: setup_StringBridgeBenchmark),
 ]
 
 var b:BridgeTester! = nil
@@ -71,7 +113,7 @@ public func run_ObjectiveCBridgeStubFromNSString(_ N: Int) {
 func testObjectiveCBridgeStubToNSString() {
    let b = BridgeTester()
    let str = "hello world"
-   for _ in 0 ..< 10_000 {
+   for _ in 0 ..< 1_000 {
      b.test(from: str)
    }
 }
@@ -93,7 +135,7 @@ func testObjectiveCBridgeStubFromArrayOfNSString() {
    let b = BridgeTester()
    var arr : [String] = []
    var str = ""
-   for _ in 0 ..< 1_000 {
+   for _ in 0 ..< 100 {
      arr = b.testToArrayOfStrings()
      str = arr[0]
    }
@@ -117,7 +159,7 @@ func testObjectiveCBridgeStubToArrayOfNSString() {
    let b = BridgeTester()
    let str = "hello world"
    let arr = [str, str, str, str, str, str, str, str, str, str]
-   for _ in 0 ..< 1_000 {
+   for _ in 0 ..< 50 {
      b.test(fromArrayOf: arr)
    }
 }
@@ -139,7 +181,7 @@ public func run_ObjectiveCBridgeStubToArrayOfNSString(_ N: Int) {
 func testObjectiveCBridgeStubFromNSDate() {
   let b = BridgeTester()
 
-  for _ in 0 ..< 100_000 {
+  for _ in 0 ..< 10_000 {
     let bridgedBegin = b.beginDate()
     let bridgedEnd = b.endDate()
     let _ = bridgedEnd.timeIntervalSince(bridgedBegin)
@@ -172,7 +214,7 @@ public func testObjectiveCBridgeStubToNSDate() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToNSDate(N: Int) {
 #if _runtime(_ObjC)
-  for _ in 0 ..< 10 * N {
+  for _ in 0 ..< N {
     autoreleasepool {
       testObjectiveCBridgeStubToNSDate()
     }
@@ -227,7 +269,7 @@ public func run_ObjectiveCBridgeStubDateMutation(N: Int) {
 @inline(never)
 func testObjectiveCBridgeStubURLAppendPath() {
   let startUrl = URL(string: "/")!
-  for _ in 0 ..< 100 {
+  for _ in 0 ..< 10 {
     var url = startUrl
     for _ in 0 ..< 10 {
       url.appendPathComponent("foo")
@@ -252,7 +294,7 @@ public func run_ObjectiveCBridgeStubURLAppendPath(N: Int) {
 func testObjectiveCBridgeStubDataAppend() {
   let proto = Data()
   var value: UInt8 = 1
-  for _ in 0 ..< 1_000 {
+  for _ in 0 ..< 50 {
     var d = proto
     for _ in 0 ..< 100 {
        d.append(&value, count: 1)

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -21,15 +21,30 @@ import Foundation
 import ObjectiveCTests
 #endif
 
+let t: [BenchmarkCategory] = [.validation, .bridging]
+
 public let ObjectiveCNoBridgingStubs = [
-  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSStringRef", runFunction: run_ObjectiveCBridgeStubToNSStringRef, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSDateRef", runFunction: run_ObjectiveCBridgeStubToNSDateRef, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateRefAccess", runFunction: run_ObjectiveCBridgeStubNSDateRefAccess, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateMutationRef", runFunction: run_ObjectiveCBridgeStubNSDateMutationRef, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDataAppend", runFunction: run_ObjectiveCBridgeStubNSDataAppend, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSStringRef", runFunction: run_ObjectiveCBridgeStubFromNSStringRef, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDateRef", runFunction: run_ObjectiveCBridgeStubFromNSDateRef, tags: [.validation, .bridging, .unstable]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubURLAppendPathRef2", runFunction: run_ObjectiveCBridgeStubURLAppendPathRef, tags: [.validation, .bridging]),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSStringRef",
+    runFunction: run_ObjectiveCBridgeStubToNSStringRef, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubToNSDateRef",
+    runFunction: run_ObjectiveCBridgeStubToNSDateRef, tags: t,
+    legacyFactor: 20),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateRefAccess",
+    runFunction: run_ObjectiveCBridgeStubNSDateRefAccess, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateMutationRef",
+    runFunction: run_ObjectiveCBridgeStubNSDateMutationRef, tags: t,
+    legacyFactor: 4),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDataAppend",
+    runFunction: run_ObjectiveCBridgeStubNSDataAppend, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSStringRef",
+    runFunction: run_ObjectiveCBridgeStubFromNSStringRef, tags: t),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDateRef",
+    runFunction: run_ObjectiveCBridgeStubFromNSDateRef, tags: t,
+    legacyFactor: 10),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubURLAppendPathRef2",
+    runFunction: run_ObjectiveCBridgeStubURLAppendPathRef, tags: t,
+    legacyFactor: 10),
 ]
 
 #if _runtime(_ObjC)
@@ -80,7 +95,7 @@ public func run_ObjectiveCBridgeStubToNSStringRef(N: Int) {
 @inline(never)
 func testObjectiveCBridgeStubFromNSDateRef() {
   let b = BridgeTester()
-  for _ in 0 ..< 100_000 {
+  for _ in 0 ..< 10_000 {
     let bridgedBegin = b.beginDate()
     let bridgedEnd = b.endDate()
     let _ = bridgedEnd.timeIntervalSince(bridgedBegin)
@@ -113,7 +128,7 @@ public func testObjectiveCBridgeStubToNSDateRef() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToNSDateRef(N: Int) {
 #if _runtime(_ObjC)
-  for _ in 0 ..< 100 * N {
+  for _ in 0 ..< 5 * N {
     autoreleasepool {
       testObjectiveCBridgeStubToNSDateRef()
     }
@@ -148,7 +163,7 @@ public func run_ObjectiveCBridgeStubNSDateRefAccess(N: Int) {
 @inline(never)
 func testObjectiveCBridgeStubNSDateMutationRef() {
   var d = NSDate()
-  for _ in 0 ..< 100 {
+  for _ in 0 ..< 25 {
       d = d.addingTimeInterval(1)
   }
 }
@@ -169,7 +184,7 @@ public func run_ObjectiveCBridgeStubNSDateMutationRef(N: Int) {
 @inline(never)
 func testObjectiveCBridgeStubURLAppendPathRef() {
   let startUrl = URL(string: "/")!
-  for _ in 0 ..< 100 {
+  for _ in 0 ..< 10 {
     var url = startUrl
     for _ in 0 ..< 10 {
       url = url.appendingPathComponent("foo")
@@ -194,7 +209,7 @@ public func run_ObjectiveCBridgeStubURLAppendPathRef(N: Int) {
 func testObjectiveCBridgeStubNSDataAppend() {
   let proto = NSMutableData()
   var value: UInt8 = 1
-  for _ in 0 ..< 1_000 {
+  for _ in 0 ..< 100 {
     let d = proto.mutableCopy() as! NSMutableData
     for _ in 0 ..< 100 {
        d.append(&value, length: 1)

--- a/benchmark/single-source/ProtocolDispatch.swift
+++ b/benchmark/single-source/ProtocolDispatch.swift
@@ -15,15 +15,14 @@ import TestsUtils
 public let ProtocolDispatch = BenchmarkInfo(
   name: "ProtocolDispatch",
   runFunction: run_ProtocolDispatch,
-  tags: [.validation, .abstraction, .unstable])
+  tags: [.validation, .abstraction])
 
 @inline(never)
 public func run_ProtocolDispatch(_ N: Int) {
 
   let x = someProtocolFactory()
 
-  for _ in 0...1000000 * N {
+  for _ in 0...100_000 * N {
     _ = x.getValue()
   }
 }
-

--- a/benchmark/single-source/ProtocolDispatch2.swift
+++ b/benchmark/single-source/ProtocolDispatch2.swift
@@ -20,7 +20,7 @@ import Foundation
 public let ProtocolDispatch2 = BenchmarkInfo(
   name: "ProtocolDispatch2",
   runFunction: run_ProtocolDispatch2,
-  tags: [.validation, .abstraction, .unstable])
+  tags: [.validation, .abstraction])
 
 protocol Pingable { func ping() -> Int;  func pong() -> Int}
 
@@ -58,7 +58,7 @@ public func run_ProtocolDispatch2(_ N: Int) {
   var c = 0
   let g1 = Game()
   let g2 = Game()
-  for _ in 1...N {
+  for _ in 1...10*N {
     c = 0
     for i in 1...5000 {
       c += wrapper(i, g1, g2)
@@ -66,4 +66,3 @@ public func run_ProtocolDispatch2(_ N: Int) {
   }
   CheckResults(c == 75000)
 }
-

--- a/benchmark/single-source/Radix2CooleyTukey.swift
+++ b/benchmark/single-source/Radix2CooleyTukey.swift
@@ -11,13 +11,15 @@ public var Radix2CooleyTukey = [
     runFunction: run_Radix2CooleyTukey,
     tags: [.validation, .algorithm],
     setUpFunction: setUpRadix2CooleyTukey,
-    tearDownFunction: tearDownRadix2CooleyTukey),
+    tearDownFunction: tearDownRadix2CooleyTukey,
+    legacyFactor: 48),
   BenchmarkInfo(
     name: "Radix2CooleyTukeyf",
     runFunction: run_Radix2CooleyTukeyf,
     tags: [.validation, .algorithm],
     setUpFunction: setUpRadix2CooleyTukeyf,
-    tearDownFunction: tearDownRadix2CooleyTukeyf),
+    tearDownFunction: tearDownRadix2CooleyTukeyf,
+  legacyFactor: 48),
 ]
 
 //===----------------------------------------------------------------------===//
@@ -31,7 +33,7 @@ var double_output_imag: UnsafeMutablePointer<Double>?
 var double_temp_real: UnsafeMutablePointer<Double>?
 var double_temp_imag: UnsafeMutablePointer<Double>?
 
-let doubleN = 65_536
+let doubleN = 2_048
 let doubleSize = { MemoryLayout<Double>.size * doubleN }()
 
 func setUpRadix2CooleyTukey() {
@@ -143,7 +145,7 @@ public func run_Radix2CooleyTukey(_ N: Int) {
 // Float Benchmark
 //===----------------------------------------------------------------------===//
 
-let floatN = 65_536
+let floatN = 2_048
 let floatSize = { MemoryLayout<Float>.size * floatN }()
 
 var float_input_real: UnsafeMutablePointer<Float>?


### PR DESCRIPTION
This PR follows-up  #20861, #21413, #21516, #21794, #22026 and #22296 in clean-up efforts to enable [robust performance measurements](https://forums.swift.org/t/towards-robust-performance-measurement/11490) by adjusting workloads to run in reasonable time (< 1000 μs), minimizing the accumulated error. To maintain long-term performance tracking, it applies [legacy factor](https://github.com/apple/swift/pull/20212) where necessary.

This one picks up on troublemakers skipped from #22026 and re-adds a few previously disabled benchmarks. Remember, there never were truly unstable benchmarks, it was our measurement methodology that was flawed before.