### PR TITLE
[test] Test fix for platforms like s390x

### DIFF
--- a/test/IRGen/clang_inline_opt.swift
+++ b/test/IRGen/clang_inline_opt.swift
@@ -7,7 +7,7 @@ func return10() -> UInt32 {
 // Sanity check that we tell Clang to generate optimizable code when
 // we're optimizing.
 
-// CHECK: define internal i32 @return7() [[CLANG_ATTRS:#[0-9]+]] {
+// CHECK: define internal{{( zeroext)?}} i32 @return7() [[CLANG_ATTRS:#[0-9]+]] {
 
 // CHECK: attributes [[CLANG_ATTRS]] = {
 // CHECK-NOT: noinline


### PR DESCRIPTION
This fix has already been merged in master (https://github.com/apple/swift/blob/master/test/IRGen/clang_inline_opt.swift) from commit https://github.com/apple/swift/commit/56318f3e1f6b73d5217de8ee28a2bcf19517bcfa#diff-55b9807777157809ac141c08ac044ac7. It adds supports for s390x and powerPC. I am now pushing it to branch 5.0. 