### PR TITLE
Add test that catches (currently fixed) regression - SR-9837

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -27,7 +27,7 @@ We use multiple approaches to test the Swift toolchain.
 
 ### Testsuite subsets
 
-The testsuite is split into four subsets:
+The testsuite is split into five subsets:
 
 * Primary testsuite, located under ``swift/test``.
 * Validation testsuite, located under ``swift/validation-test``.
@@ -59,7 +59,7 @@ configured to use your local build directory. For example:
     % ${LLVM_SOURCE_ROOT}/utils/lit/lit.py -sv ${SWIFT_BUILD_DIR}/test-macosx-x86_64/Parse/
 ```
 
-This runs the tests in the 'test/Parse/' directory targeting 64-bit macOS. 
+This runs the tests in the 'test/Parse/' directory targeting 64-bit macOS.
 The ``-sv`` options give you a nice progress bar and only show you
 output from the tests that fail.
 

--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -43,7 +43,7 @@ CastsTests.test("No overrelease of existential boxes in failed casts") {
             }
         }
     }
-    
+
     let err: Error = ErrClass()
     bar(err)
 }
@@ -68,6 +68,16 @@ CastsTests.test("Multi-level optionals can be casted") {
   testFailure(42, from: Int?.self, to: String.self)
   testFailure(42, from: Int??.self, to: String.self)
   testFailure(42, from: Int???.self, to: String.self)
+}
+
+// Test for SR-9837: Optional<T>.none not casting to Optional<U>.none in generic context
+CastsTests.test("Optional<T>.none can be casted to Optional<U>.none in generic context") {
+  func test<T>(_ type: T.Type) -> T? {
+    return Any?.none as? T
+  }
+
+  expectEqual(type(of: test(Bool.self)), Bool?.self)
+  expectEqual(type(of: test(Bool?.self)), Bool??.self)
 }
 
 #if _runtime(_ObjC)


### PR DESCRIPTION
<!-- What's in this pull request? -->
I added a test that targets a regression I found in a Swift 5 nightly build a while ago. The regression has been fixed, but this test case would catch it in the future.

The regression, as explained in SR-9837, has to do with properly casting `Optional.none` in a generic context.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9837](https://bugs.swift.org/browse/SR-9837).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
