### PR TITLE
Fix sourcekitd interface generation crashing for modules that only have a .swiftinterface file

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -24,3 +24,11 @@ func f(s : inout [Int]) {
 // RUN: %sourcekitd-test -req=interface-gen-open -module Swift \
 // RUN: 	== -req=find-usr -usr "s:SMsSkRzSL7ElementSTRpzrlE4sortyyF::SYNTHESIZED::s:Sa::SYNTHESIZED::USRDOESNOTEXIST" | %FileCheck -check-prefix=SYNTHESIZED-USR3 %s
 // SYNTHESIZED-USR3-NOT: USR NOT FOUND
+
+
+// Test we can generate the interface of a module loaded via a .swiftinterface file correctly
+
+// RUN: %empty-directory(%t.mod)
+// RUN: %swift -emit-module -o /dev/null -emit-parseable-module-interface-path %t.mod/swift_mod.swiftinterface %S/Inputs/swift_mod.swift -parse-as-library
+// RUN: %sourcekitd-test -req=interface-gen -module swift_mod -- -I %t.mod -enable-parseable-module-interface -module-cache-path %t/mcp > %t.response
+// RUN: diff -u %s.from_swiftinterface.response %t.response

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
@@ -1,0 +1,112 @@
+
+public class MyClass {
+
+    public func pub_method()
+}
+
+public func pub_function()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 8,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 14,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 29,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 36,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 41,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 57,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 64,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 69,
+    key.length: 12
+  }
+]
+<<NULL>>
+[
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "MyClass",
+    key.offset: 8,
+    key.length: 47,
+    key.runtime_name: "_TtC4main7MyClass",
+    key.nameoffset: 14,
+    key.namelength: 7,
+    key.bodyoffset: 23,
+    key.bodylength: 31,
+    key.attributes: [
+      {
+        key.offset: 1,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "pub_method()",
+        key.offset: 36,
+        key.length: 17,
+        key.nameoffset: 41,
+        key.namelength: 12,
+        key.attributes: [
+          {
+            key.offset: 29,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "pub_function()",
+    key.offset: 64,
+    key.length: 19,
+    key.nameoffset: 69,
+    key.namelength: 14,
+    key.attributes: [
+      {
+        key.offset: 57,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  }
+]

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -708,6 +708,7 @@ void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
   }
 
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
+  Invocation.getFrontendOptions().EnableParseableModuleInterface = true;
 
   std::string ErrMsg;
   auto IFaceGenRef = SwiftInterfaceGenContext::create(Name,


### PR DESCRIPTION
[ParseableInterface][sourcekitd] Set the DetailPreprocessor ClangImporter option on the sub invocation if it's set on the parent

In addition to capturing more detailed preprocessor info, the DetailedPreprocessorRecord option sets the clang module format to 'raw' rather than the default 'object'. Sourcekitd doesn't link the code generation libs, which it looks like the default 'object' format requires, so it sets this option to true. The subinvocation generated when loading a module from a .swiftinterface file still used the default prior to this change though, so it would end up crashing sourcekitd.

This change sets the DetailedProccessorRecord option if the DetailedRecord option is set on the preprocessor options of parent context's clang module loader. This fixes interface generation crashing for modules that only have a .swiftinterface file.