### PR TITLE
[5.0] Extend transitive availability checking to initial value expressions

### DIFF
--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -1,13 +1,17 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -parse-as-library
 // REQUIRES: OS=macosx
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
 @available(OSX, unavailable)
-func osx() {} // expected-note 2{{'osx()' has been explicitly marked unavailable here}}
+@discardableResult
+func osx() -> Int { return 0 } // expected-note * {{'osx()' has been explicitly marked unavailable here}}
 
 @available(OSXApplicationExtension, unavailable)
 func osx_extension() {}
+
+@available(OSX, unavailable)
+func osx_pair() -> (Int, Int) { return (0, 0) } // expected-note * {{'osx_pair()' has been explicitly marked unavailable here}}
 
 func call_osx_extension() {
     osx_extension() // OK; osx_extension is only unavailable if -application-extension is passed.
@@ -34,4 +38,85 @@ func osx_extension_call_osx_extension() {
 @available(OSXApplicationExtension, unavailable)
 func osx_extension_call_osx() {
     osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+var osx_init_osx = osx() // OK
+
+@available(OSXApplicationExtension, unavailable)
+var osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
+
+@available(OSX, unavailable)
+var osx_inner_init_osx = { let inner_var = osx() } // OK
+
+// FIXME: I'm not sure why this produces two errors instead of just one.
+@available(OSXApplicationExtension, unavailable)
+var osx_extension_inner_init_osx = { let inner_var = osx() } // expected-error 2 {{'osx()' is unavailable}}
+
+struct Outer {
+  @available(OSX, unavailable)
+  var osx_init_osx = osx() // OK
+
+  @available(OSX, unavailable)
+  lazy var osx_lazy_osx = osx() // OK
+
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
+
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_lazy_osx = osx() // expected-error {{'osx()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var osx_init_multi1_osx = osx(), osx_init_multi2_osx = osx() // OK
+
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_init_multi1_osx = osx(), osx_extension_init_multi2_osx = osx() // expected-error 2 {{'osx()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var (osx_init_deconstruct1_osx, osx_init_deconstruct2_osx) = osx_pair() // OK
+
+  @available(OSXApplicationExtension, unavailable)
+  var (osx_extension_init_deconstruct1_osx, osx_extension_init_deconstruct2_osx) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var (_, osx_init_deconstruct2_only_osx) = osx_pair() // OK
+  
+  @available(OSXApplicationExtension, unavailable)
+  var (_, osx_extension_init_deconstruct2_only_osx) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var (osx_init_deconstruct1_only_osx, _) = osx_pair() // OK
+  
+  @available(OSXApplicationExtension, unavailable)
+  var (osx_extension_init_deconstruct1_only_osx, _) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
+
+  @available(OSX, unavailable)
+  var osx_inner_init_osx = { let inner_var = osx() } // OK
+  
+  // FIXME: I'm not sure why this produces two errors instead of just one.
+  @available(OSXApplicationExtension, unavailable)
+  var osx_extension_inner_init_osx = { let inner_var = osx() } // expected-error 2 {{'osx()' is unavailable}}
+}
+
+extension Outer {
+  @available(OSX, unavailable)
+  static var also_osx_init_osx = osx() // OK
+  
+  @available(OSXApplicationExtension, unavailable)
+  static var also_osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+extension Outer {
+  static var outer_osx_init_osx = osx() // OK
+}
+
+@available(OSX, unavailable)
+struct NotOnOSX {
+  var osx_init_osx = osx() // OK
+  lazy var osx_lazy_osx = osx() // OK
+  var osx_init_multi1_osx = osx(), osx_init_multi2_osx = osx() // OK
+  var (osx_init_deconstruct1_osx, osx_init_deconstruct2_osx) = osx_pair() // OK
+  var (_, osx_init_deconstruct2_only_osx) = osx_pair() // OK
+  var (osx_init_deconstruct1_only_osx, _) = osx_pair() // OK
 }


### PR DESCRIPTION
- **Explanation**: A declaration marked unavailable on one platform is allowed to use other declarations marked unavailable on the same platform in its definition. This is especially important for the "application extension" platforms, which expose a subset of the API available on the base platform. However, changes to property initial value type-checking in Swift 5 made them fall outside of this rule. This commit (the important, non-refactoring part of #22460) changes the availability checking logic to look for the associated property decl in an enclosing scope, which makes the code in [SR-9867](https://bugs.swift.org/browse/SR-9867) work again.

- **Scope**: Affects properties marked with `@available` that use other declarations marked with `@available`.

- **Issue**: [SR-9867](https://bugs.swift.org/browse/SR-9867) / rdar://problem/47852718

- **Risk**: Low. This relaxes restrictions rather than adding them. It does search more of the AST, but only in a simple way based on source ranges.

- **Testing**: Added compiler regression tests, passed source compatibility suite.

- **Reviewed by**: @brentdax, @slavapestov