### PR TITLE
[Typechecker] Fix an issue with @discardableResult error not being emitted

### DIFF
--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -211,3 +211,14 @@ class Foo {
     myOptionalFooProtocol?.returnSomething() // okay
   }
 }
+
+class Discard {
+  @discardableResult func bar() -> Int {
+    return 0
+  }
+
+  func baz() {
+    self.bar // expected-error {{expression resolves to an unused function}}
+    bar // expected-error {{expression resolves to an unused function}}
+  }
+}


### PR DESCRIPTION
This PR resolves an issue where the `Expression resolves to an unused function` error diagnostic was not being emitted for the example below.

```swift
class Foo {
  @discardableResult func bar() -> Int {
    return 0
  }

  func test() {
    // expected: 'Expression resolves to an unused function' error
    // actual: No error
    self.bar
    bar // Same here as well
  }
}
```