### PR TITLE
Disable sourcekit-lsp on Linux asan preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1026,6 +1026,9 @@ mixin-preset=buildbot_incremental_linux
 build-subdir=buildbot_incremental_asan
 
 enable-asan
+indexstore-db=0
+sourcekit-lsp=0
+
 
 # This does not currently pass due to leakers in the optimizer.
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=RDA,test=no]


### PR DESCRIPTION
This was an oversight and should not have been enabled (yet). When we're
ready we should enabled asan testing on macOS as well.

rdar://47973246
