### PR TITLE
[remote-ast] Disable non-deterministic test failure.

### DIFF
--- a/test/RemoteAST/existentials_objc.swift
+++ b/test/RemoteAST/existentials_objc.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift-remoteast-test
 // REQUIRES: objc_interop
+// REQUIRES: SR9908
 
 import Foundation
 


### PR DESCRIPTION
This is failing for me ~10% of the time. It is resulting in spurious PR testing
failures.

SR-9908
