### PR TITLE
[5.0] Fix crashes in Unsafe[Raw]BufferPointer with nil baseAddress.

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -495,8 +495,8 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Parameter slice: The buffer slice to rebase.
   @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeBufferPointer<Element>>) {
-    self.init(start: slice.base.baseAddress! + slice.startIndex,
-      count: slice.count)
+    let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
+    self.init(start: base, count: slice.count)
   }
 
 %  end
@@ -522,9 +522,8 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Parameter slice: The buffer slice to rebase.
   @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeMutableBufferPointer<Element>>) {
-    self.init(
-      start: slice.base.baseAddress! + slice.startIndex,
-      count: slice.count)
+    let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
+    self.init(start: base, count: slice.count)
   }
 
   /// Deallocates the memory block previously allocated at this buffer pointer’s 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -467,7 +467,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   buffer's type `T` must be a trivial type.
   @inlinable
   public init<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
-    self.init(start: buffer.baseAddress!,
+    self.init(start: buffer.baseAddress,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 
@@ -478,7 +478,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   buffer's type `T` must be a trivial type.
   @inlinable
   public init<T>(_ buffer: UnsafeBufferPointer<T>) {
-    self.init(start: buffer.baseAddress!,
+    self.init(start: buffer.baseAddress,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 %  end # !mutable
@@ -506,8 +506,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter slice: The raw buffer slice to rebase.
   @inlinable
   public init(rebasing slice: Slice<UnsafeRawBufferPointer>) {
-    self.init(start: slice.base.baseAddress! + slice.startIndex,
-      count: slice.count)
+    let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
+    self.init(start: base, count: slice.count)
   }
 %  end # !mutable
 
@@ -533,8 +533,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter slice: The raw buffer slice to rebase.
   @inlinable
   public init(rebasing slice: Slice<UnsafeMutableRawBufferPointer>) {
-    self.init(start: slice.base.baseAddress! + slice.startIndex,
-      count: slice.count)
+    let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
+    self.init(start: base, count: slice.count)
   }
 
   /// A pointer to the first byte of the buffer.

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -39,6 +39,38 @@ UnsafeRawBufferPointerTestSuite.test("initFromValue") {
   expectEqual(value2, value1)
 }
 
+UnsafeRawBufferPointerTestSuite.test("initFromNilBuffer") {
+  let urbp1 =
+    UnsafeRawBufferPointer(UnsafeBufferPointer<Int>(start: nil, count: 0))
+  expectEqual(urbp1.baseAddress, nil)
+
+  let urbp2 =
+    UnsafeRawBufferPointer(UnsafeMutableBufferPointer<Int>(start: nil, count: 0))
+  expectEqual(urbp2.baseAddress, nil)
+
+  let umrbp =
+    UnsafeMutableRawBufferPointer(
+      UnsafeMutableBufferPointer<Int>(start: nil, count: 0))
+  expectEqual(umrbp.baseAddress, nil)
+}
+
+UnsafeRawBufferPointerTestSuite.test("initFromNilSlice") {
+  let urbp1 =
+    UnsafeRawBufferPointer(
+      rebasing: UnsafeRawBufferPointer(start: nil, count: 0)[...])
+  expectEqual(urbp1.baseAddress, nil)
+
+  let urbp2 =
+    UnsafeRawBufferPointer(
+      rebasing: UnsafeMutableRawBufferPointer(start: nil, count: 0)[...])
+  expectEqual(urbp2.baseAddress, nil)
+
+  let umrbp =
+    UnsafeMutableRawBufferPointer(
+      rebasing: UnsafeMutableRawBufferPointer(start: nil, count: 0)[...])
+  expectEqual(umrbp.baseAddress, nil)
+}
+
 // Test mutability and subscript getter/setters.
 UnsafeRawBufferPointerTestSuite.test("nonmutating_subscript_setter") {
   var value1: Int32 = -1

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -104,6 +104,19 @@ ${SelfName}TestSuite.test("rebasing") {
       expectEqual(rebased2[0], slice[i + 1])
     }
   }
+
+  let rebased3 = ${SelfType}(rebasing: ${SelfType}(start: nil, count: 0)[...])
+  expectEqual(rebased3.baseAddress, nil)
+
+%   if not IsMutable:
+%   if IsRaw:
+  let rebased4 = ${SelfType}(rebasing: UnsafeMutableRawBufferPointer(start: nil, count: 0)[...])
+  expectEqual(rebased4.baseAddress, nil)
+%   else:
+  let rebased4 = ${SelfType}(rebasing: UnsafeMutableBufferPointer<Float>(start: nil, count: 0)[...])
+  expectEqual(rebased4.baseAddress, nil)
+%   end # !Raw
+%   end # Mutable
 }
 
 // Allocate two buffers. Initialize one and copy it into the other. Pass those


### PR DESCRIPTION
This fix updates various initializers to handle incoming empty buffers
that happen to have a nil base. They should simply create another
buffer with nil base rather than crashing!

It is valid for an Unsafe[Raw]BufferPointer can have a nil base
address. This allows round-tripping with C code that takes a
pointer/length pair and uses `0` as the pointer value.

The original design wrongly assumed that we would use a sentinel value
for empty buffers and was never updated for or tested with the current
design.

Fixes <rdar://problem/47946984> Regression in Foundation.Data's
UnsafeBufferPointer constructor.

(cherry picked from commit 28a529ceedd31fcd3fc0849d36a6fc5623d9e1fe)
