### PR TITLE
Add unit tests covering Data.init<T>(buffer: Unsafe{Mutable}BufferPointer<T>)

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -238,6 +238,68 @@ class TestData : TestDataSuper {
         let data3 = Data(bytes: [1, 2, 3, 4, 5][1..<3])
         expectEqual(2, data3.count)
     }
+
+    func testInitializationWithBufferPointer() {
+        let nilBuffer = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
+        let data = Data(buffer: nilBuffer)
+        expectEqual(data, Data())
+
+        let validPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 2)
+        validPointer[0] = 0xCA
+        validPointer[1] = 0xFE
+        defer { validPointer.deallocate() }
+
+        let emptyBuffer = UnsafeBufferPointer<UInt8>(start: validPointer, count: 0)
+        let data2 = Data(buffer: emptyBuffer)
+        expectEqual(data2, Data())
+
+        let shortBuffer = UnsafeBufferPointer<UInt8>(start: validPointer, count: 1)
+        let data3 = Data(buffer: shortBuffer)
+        expectEqual(data3, Data([0xCA]))
+
+        let fullBuffer = UnsafeBufferPointer<UInt8>(start: validPointer, count: 2)
+        let data4 = Data(buffer: fullBuffer)
+        expectEqual(data4, Data([0xCA, 0xFE]))
+
+        let tuple: (UInt16, UInt16, UInt16, UInt16) = (0xFF, 0xFE, 0xFD, 0xFC)
+        withUnsafeBytes(of: tuple) {
+            // If necessary, port this to big-endian.
+            let tupleBuffer: UnsafeBufferPointer<UInt8> = $0.bindMemory(to: UInt8.self)
+            let data5 = Data(buffer: tupleBuffer)
+            expectEqual(data5, Data([0xFF, 0x00, 0xFE, 0x00, 0xFD, 0x00, 0xFC, 0x00]))
+        }
+    }
+
+    func testInitializationWithMutableBufferPointer() {
+        let nilBuffer = UnsafeMutableBufferPointer<UInt8>(start: nil, count: 0)
+        let data = Data(buffer: nilBuffer)
+        expectEqual(data, Data())
+
+        let validPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 2)
+        validPointer[0] = 0xCA
+        validPointer[1] = 0xFE
+        defer { validPointer.deallocate() }
+
+        let emptyBuffer = UnsafeMutableBufferPointer<UInt8>(start: validPointer, count: 0)
+        let data2 = Data(buffer: emptyBuffer)
+        expectEqual(data2, Data())
+
+        let shortBuffer = UnsafeMutableBufferPointer<UInt8>(start: validPointer, count: 1)
+        let data3 = Data(buffer: shortBuffer)
+        expectEqual(data3, Data([0xCA]))
+
+        let fullBuffer = UnsafeMutableBufferPointer<UInt8>(start: validPointer, count: 2)
+        let data4 = Data(buffer: fullBuffer)
+        expectEqual(data4, Data([0xCA, 0xFE]))
+
+        var tuple: (UInt16, UInt16, UInt16, UInt16) = (0xFF, 0xFE, 0xFD, 0xFC)
+        withUnsafeMutableBytes(of: &tuple) {
+            // If necessary, port this to big-endian.
+            let tupleBuffer: UnsafeMutableBufferPointer<UInt8> = $0.bindMemory(to: UInt8.self)
+            let data5 = Data(buffer: tupleBuffer)
+            expectEqual(data5, Data([0xFF, 0x00, 0xFE, 0x00, 0xFD, 0x00, 0xFC, 0x00]))
+        }
+    }
     
     func testMutableData() {
         let hello = dataFrom("hello")
@@ -3742,6 +3804,8 @@ class TestData : TestDataSuper {
 var DataTests = TestSuite("TestData")
 DataTests.test("testBasicConstruction") { TestData().testBasicConstruction() }
 DataTests.test("testInitializationWithArray") { TestData().testInitializationWithArray() }
+DataTests.test("testInitializationWithBufferPointer") { TestData().testInitializationWithBufferPointer() }
+DataTests.test("testInitializationWithMutableBufferPointer") { TestData().testInitializationWithMutableBufferPointer() }
 DataTests.test("testMutableData") { TestData().testMutableData() }
 DataTests.test("testCustomData") { TestData().testCustomData() }
 DataTests.test("testBridgingDefault") { TestData().testBridgingDefault() }


### PR DESCRIPTION
**What's in this pull request?**
Adds unit tests which exercise the changes in #22521.
(Addresses rdar://problem/47978737)