### PR TITLE
[5.0][stdlib]Remove overly-permissive UnsafePointer init

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -93,34 +93,6 @@ extension _Pointer {
     guard let unwrapped = other else { return nil }
     self.init(unwrapped._rawValue)
   }
-
-  // all pointers are creatable from mutable pointers
-  
-  /// Creates a new pointer from the given mutable pointer.
-  ///
-  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
-  /// instance. This initializer creates a new pointer to the same address as
-  /// `other` and performs no allocation or copying.
-  ///
-  /// - Parameter other: The typed pointer to convert.
-  @_transparent
-  public init<T>(_ other: UnsafeMutablePointer<T>) {
-    self.init(other._rawValue)
-  }
-
-  /// Creates a new raw pointer from the given typed pointer.
-  ///
-  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
-  /// instance. This initializer creates a new pointer to the same address as
-  /// `other` and performs no allocation or copying.
-  ///
-  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
-  ///   result is `nil`.
-  @_transparent
-  public init?<T>(_ other: UnsafeMutablePointer<T>?) {
-    guard let unwrapped = other else { return nil }
-    self.init(unwrapped)
-  }
 }
 
 // well, this is pretty annoying

--- a/stdlib/public/core/StringBreadcrumbs.swift
+++ b/stdlib/public/core/StringBreadcrumbs.swift
@@ -126,7 +126,8 @@ extension _StringGuts {
     }
 
     _internalInvariant(mutPtr.pointee != nil)
-    return UnsafePointer(mutPtr)
+    // assuming optional class reference and class reference can alias
+    return UnsafeRawPointer(mutPtr).assumingMemoryBound(to: _StringBreadcrumbs.self)
   }
 
   @inline(never) // slow-path
@@ -137,6 +138,7 @@ extension _StringGuts {
     // Thread-safe compare-and-swap
     let crumbs = _StringBreadcrumbs(String(self))
     _stdlib_atomicInitializeARCRef(
-      object: UnsafeMutablePointer(mutPtr), desired: crumbs)
+      object: UnsafeMutableRawPointer(mutPtr).assumingMemoryBound(to: Optional<AnyObject>.self), 
+      desired: crumbs)
   }
 }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -149,4 +149,5 @@ Subscript Substring.subscript(_:) has been removed
 
 Func Collection.makeIterator() has self access kind changing from NonMutating to __Consuming
 
+Constructor _Pointer.init(_:) has been removed
 Func Sequence.count(where:) has been removed

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -85,6 +85,11 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}}
   _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'RawPointer'}}
   _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}}
+
+  _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'RawPointer'}}
+  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<_>'}}
+  _ = UnsafePointer<String>(upi) // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'RawPointer'}}
+  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<_>'}}
 }
 
 func unsafeRawBufferPointerConversions(
@@ -114,4 +119,14 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeRawBufferPointer(start: omrp, count: 1)
   _ = UnsafeMutableRawBufferPointer(start: orp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
   _ = UnsafeRawBufferPointer(start: orp, count: 1)
+}
+
+
+struct SR9800 {
+  func foo(_: UnsafePointer<CChar>) {}
+  func foo(_: UnsafePointer<UInt8>) {}
+
+  func ambiguityTest(buf: UnsafeMutablePointer<CChar>) {
+    _ = foo(UnsafePointer(buf)) // this call should be unambiguoius
+  }
 }

--- a/validation-test/compiler_crashers_2_fixed/0060-sr2702.swift
+++ b/validation-test/compiler_crashers_2_fixed/0060-sr2702.swift
@@ -46,7 +46,7 @@ public func XUAllSubclassesOfClass<T: AnyObject>(_ aClass: T.Type) -> [T.Type] {
 			free(memory)
 		}
 		
-		let classesPtr = memory.assumingMemoryBound(to: Optional<AnyClass>.self)
+		let classesPtr = memory.assumingMemoryBound(to: AnyClass.self)
 		let classes = AutoreleasingUnsafeMutablePointer<AnyClass>(classesPtr)
 		numClasses = objc_getClassList(classes, numClasses)
 


### PR DESCRIPTION
This is part 2 of https://github.com/apple/swift/pull/22315

* Explanation: This change removes the
UnsafePointer<T>.init(UnsafeMutablePointer<U>) initializer that was
added by mistake.
* Scope of Issue: Part 1 of this change added valid concrete versions of
this initializer, so this is not a breaking change, even for the code
that migh have used the initializer being removed in earlier beta.
* Reviewed By: Ben Cohen
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/47706090>