### PR TITLE
Small RemoteAST fixes

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -502,14 +502,14 @@ public:
         if (!readObjCClassName(MetadataAddress, className))
           return BuiltType();
 
-        auto BuiltObjCClass = Builder.createObjCClassType(std::move(className));
+        BuiltType BuiltObjCClass = Builder.createObjCClassType(std::move(className));
         if (!BuiltObjCClass) {
           // Try the superclass.
           if (!classMeta->Superclass)
             return BuiltType();
 
-          return readTypeFromMetadata(classMeta->Superclass,
-                                      skipArtificialSubclasses);
+          BuiltObjCClass = readTypeFromMetadata(classMeta->Superclass,
+                                                skipArtificialSubclasses);
         }
 
         TypeCache[MetadataAddress] = BuiltObjCClass;

--- a/test/RemoteAST/existentials_objc.swift
+++ b/test/RemoteAST/existentials_objc.swift
@@ -12,5 +12,22 @@ func printDynamicTypeAndAddressForExistential<T>(_: T)
 // CHECK: NSObject
 printDynamicTypeAndAddressForExistential(NSObject() as AnyObject)
 
+// Print tagged pointer types three times to ensure the caching works.
+
 // CHECK: NSNumber
 printDynamicTypeAndAddressForExistential(NSNumber(123) as AnyObject)
+
+// CHECK: NSNumber
+printDynamicTypeAndAddressForExistential(NSNumber(123) as AnyObject)
+
+// CHECK: NSNumber
+printDynamicTypeAndAddressForExistential(NSNumber(123) as AnyObject)
+
+// CHECK: NSString
+printDynamicTypeAndAddressForExistential(NSString("hello") as AnyObject)
+
+// CHECK: NSString
+printDynamicTypeAndAddressForExistential(NSString("hello") as AnyObject)
+
+// CHECK: NSString
+printDynamicTypeAndAddressForExistential(NSString("hello") as AnyObject)

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -40,15 +40,24 @@ using namespace swift::remoteAST;
 /// The context for the code we're running.  Set by the observer.
 static ASTContext *Context = nullptr;
 
+/// The RemoteAST for the code we're running.
+std::shared_ptr<MemoryReader> reader;
+std::unique_ptr<RemoteASTContext> remoteContext;
+
+static RemoteASTContext &getRemoteASTContext() {
+  if (remoteContext)
+    return *remoteContext;
+
+  std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
+  remoteContext.reset(new RemoteASTContext(*Context, std::move(reader)));
+  return *remoteContext;
+}
+
 // FIXME: swiftcall
 /// func printType(forMetadata: Any.Type)
 LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
 printMetadataType(const Metadata *typeMetadata) {
-  assert(Context && "context was not set");
-
-  std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
-  RemoteASTContext remoteAST(*Context, std::move(reader));
-
+  auto &remoteAST = getRemoteASTContext();
   auto &out = llvm::outs();
 
   auto result =
@@ -66,11 +75,7 @@ printMetadataType(const Metadata *typeMetadata) {
 /// func printDynamicType(_: AnyObject)
 LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
 printHeapMetadataType(void *object) {
-  assert(Context && "context was not set");
-
-  std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
-  RemoteASTContext remoteAST(*Context, std::move(reader));
-
+  auto &remoteAST = getRemoteASTContext();
   auto &out = llvm::outs();
 
   auto metadataResult =
@@ -94,11 +99,7 @@ printHeapMetadataType(void *object) {
 
 static void printMemberOffset(const Metadata *typeMetadata,
                               StringRef memberName, bool passMetadata) {
-  assert(Context && "context was not set");
-
-  std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
-  RemoteASTContext remoteAST(*Context, std::move(reader));
-
+  auto &remoteAST = getRemoteASTContext();
   auto &out = llvm::outs();
 
   // The first thing we have to do is get the type.
@@ -147,10 +148,7 @@ printTypeMetadataMemberOffset(const Metadata *typeMetadata,
 LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
 printDynamicTypeAndAddressForExistential(void *object,
                                          const Metadata *typeMetadata) {
-  assert(Context && "context was not set");
-  std::shared_ptr<MemoryReader> reader(new InProcessMemoryReader());
-  RemoteASTContext remoteAST(*Context, std::move(reader));
-
+  auto &remoteAST = getRemoteASTContext();
   auto &out = llvm::outs();
 
   // First, retrieve the static type of the existential, so we can understand


### PR DESCRIPTION
My earlier changes in #22498 had a bug; I neglected to handle 'obfuscated' tagged pointers.