### PR TITLE
SILFunction::removeDifferentiableAttr does not remove attributes.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -719,7 +719,8 @@ public:
   void addDifferentiableAttr(SILDifferentiableAttr *attr);
 
   void removeDifferentiableAttr(SILDifferentiableAttr *attr) {
-    std::remove(DifferentiableAttrs.begin(), DifferentiableAttrs.end(), attr);
+    DifferentiableAttrs.erase(std::remove(DifferentiableAttrs.begin(),
+                                          DifferentiableAttrs.end(), attr));
   }
 
   /// Get this function's optimization mode or OptimizationMode::NotSet if it is


### PR DESCRIPTION
The current implementation only moves the matching entries to the end of the attributes vector. DifferentiableAttrs.erase(std::remove(...)) deletes the attributes for real. e.g., https://en.cppreference.com/w/cpp/algorithm/remove