### PR TITLE
[benchmark] Gather more independent samples for changes

### DIFF
--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -185,7 +185,7 @@ def test_performance(opt_level, old_dir, new_dir, threshold, num_samples,
     tests = TestComparator(results[0], results[1], threshold)
     changed = tests.decreased + tests.increased
 
-    while len(changed) > 0 and unchanged_length_count < 5:
+    while len(changed) > 0 and unchanged_length_count < 10:
         i += 1
         if VERBOSE:
             log('        test again: ' + str([test.name for test in changed]))


### PR DESCRIPTION
Multimodal benchmarks with significant delta between the modes can report false performance changes when we gather too few independent samples. This increases the minimal number of independent samples for potential performance changes from 5 to 10.

Resolves [SR-9907](https://bugs.swift.org/browse/SR-9907).