### PR TITLE
[TF] Add aliases for TensorFlow-compatible scalar protocols.

### DIFF
--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -70,6 +70,12 @@ public protocol _TensorFlowDataTypeCompatible {
 // This includes all `_TensorFlowDataTypeCompatible` types except `String`.
 public protocol TensorFlowScalar : _TensorFlowDataTypeCompatible {}
 
+public typealias TensorFlowNumeric = TensorFlowScalar & Numeric
+public typealias TensorFlowSignedNumeric = TensorFlowScalar & SignedNumeric
+public typealias TensorFlowInteger = TensorFlowScalar & BinaryInteger
+public typealias TensorFlowFloatingPoint
+  = TensorFlowScalar & FloatingPoint & Differentiable
+
 // This is the implementation of the _getScalarOrDie requirement for each
 // concrete type below.  We use this round-about approach to implement the
 // global _TFGetScalarOrDie function in order to ensure that the noinline

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -74,7 +74,7 @@ public typealias TensorFlowNumeric = TensorFlowScalar & Numeric
 public typealias TensorFlowSignedNumeric = TensorFlowScalar & SignedNumeric
 public typealias TensorFlowInteger = TensorFlowScalar & BinaryInteger
 public typealias TensorFlowFloatingPoint
-  = TensorFlowScalar & FloatingPoint & Differentiable
+  = TensorFlowScalar & BinaryFloatingPoint & Differentiable
 
 // This is the implementation of the _getScalarOrDie requirement for each
 // concrete type below.  We use this round-about approach to implement the


### PR DESCRIPTION
Add aliases for TensorFlow-compatible scalar protocols for easier composition of generic constraints in deep learning library code and user code.