### PR TITLE
[TF] Update update-checkout to use tensorflow/swift-apis.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -39,7 +39,7 @@
         "tensorflow-swift-bindings": {
             "remote": { "id": "tensorflow/swift-bindings" } },
         "tensorflow-swift-apis": {
-            "remote": { "id": "rxwei/DeepLearning" } },
+            "remote": { "id": "tensorflow/swift-apis" } },
         "icu": {
             "remote": { "id": "unicode-org/icu" },
             "platforms": [ "Linux" ]
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "95f8fd4f30b1e59ea3cb64fbf0036bd7474842cc",
                 "tensorflow-swift-bindings": "10e591340134c37a6c3a1df735a7334a77d5cbc7",
-                "tensorflow-swift-apis": "4c00ada7e6d585a98a8658860c9d298efc4a4b46"
+                "tensorflow-swift-apis": "93d8ea5568d9f5eeb2d1e74ebf04c41eb27637b0"
             }
         }
     }


### PR DESCRIPTION
https://github.com/tensorflow/swift-apis is online. Switch the deep learning library over to treat that as the source of truth.