### PR TITLE
[diagnose-unreachable] Emit a diagnostic if a Never field of a destru…

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -438,6 +438,17 @@ static SILInstruction *getAsCallToNoReturn(SILInstruction *I) {
       return SEAI;
   }
 
+  // If we have a destructure_struct and we have a result of uninhabited type
+  // that has a use, return the destructure_struct.
+  if (auto *DSI = dyn_cast<DestructureStructInst>(I)) {
+    if (llvm::any_of(DSI->getResults(), [](SILValue result) {
+          return !result->use_empty() &&
+                 result->getType().getASTType()->isUninhabited();
+        })) {
+      return DSI;
+    }
+  }
+
   return nullptr;
 }
 

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -448,3 +448,28 @@ bb2(%3 : $Never):
 bb3(%4 : $Error):
   throw %4 : $Error
 }
+
+struct Pair<L, R> {
+  var left: L
+  var right: R
+}
+
+// CHECK-LABEL: sil [ossa] @destructure_struct_never_positive : $@convention(thin) (@owned Pair<Builtin.NativeObject, Never>) -> @owned Builtin.NativeObject {
+// CHECK-NOT: {{ unreachable }}
+// CHECK: } // end sil function 'destructure_struct_never_positive'
+sil [ossa] @destructure_struct_never_positive : $@convention(thin) (@owned Pair<Builtin.NativeObject, Never>) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Pair<Builtin.NativeObject, Never>):
+  (%1, %2) = destructure_struct %0 : $Pair<Builtin.NativeObject, Never>
+  return %1 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @destructure_struct_never_negative : $@convention(thin) (@owned Pair<Builtin.NativeObject, Never>) -> Never {
+// CHECK: bb0(
+// CHECK-NEXT: {{ unreachable }}
+// CHECK: } // end sil function 'destructure_struct_never_negative'
+sil [ossa] @destructure_struct_never_negative : $@convention(thin) (@owned Pair<Builtin.NativeObject, Never>) -> Never {
+bb0(%0 : @owned $Pair<Builtin.NativeObject, Never>):
+  (%1, %2) = destructure_struct %0 : $Pair<Builtin.NativeObject, Never>
+  destroy_value %1 : $Builtin.NativeObject
+  return %2 : $Never
+}


### PR DESCRIPTION
…ctured struct is used.

Sometimes SILGen will emit a destructure_struct instead of struct_extract. So I
am broadening this check to handle destructure_struct to ensure that in those
cases, we still get an unreachable code diagnostic. The key thing here is that
we only emit the error if the Never field is actually used. This replicates the
behavior of the struct_extract since we can not destructure individual fields,
only the whole value.
