### PR TITLE
[CSFix] NFC: Fixes should only be created via `create(...)`

### DIFF
--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -441,10 +441,10 @@ public:
 /// }
 /// ```
 class AutoClosureForwarding final : public ConstraintFix {
-public:
   AutoClosureForwarding(ConstraintSystem &cs, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AutoClosureForwarding, locator) {}
 
+public:
   std::string getName() const override { return "fix @autoclosure forwarding"; }
 
   bool diagnose(Expr *root, bool asNote = false) const override;
@@ -456,10 +456,10 @@ public:
 class RemoveUnwrap final : public ConstraintFix {
   Type BaseType;
 
-public:
   RemoveUnwrap(ConstraintSystem &cs, Type baseType, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::RemoveUnwrap, locator), BaseType(baseType) {}
 
+public:
   std::string getName() const override {
     return "remove unwrap operator `!` or `?`";
   }
@@ -471,10 +471,10 @@ public:
 };
 
 class InsertExplicitCall final : public ConstraintFix {
-public:
   InsertExplicitCall(ConstraintSystem &cs, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::InsertCall, locator) {}
 
+public:
   std::string getName() const override {
     return "insert explicit `()` to make a call";
   }
@@ -486,10 +486,10 @@ public:
 };
 
 class UseSubscriptOperator final : public ConstraintFix {
-public:
   UseSubscriptOperator(ConstraintSystem &cs, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::UseSubscriptOperator, locator) {}
 
+public:
   std::string getName() const override {
     return "replace '.subscript(...)' with subscript operator";
   }
@@ -504,12 +504,12 @@ class DefineMemberBasedOnUse final : public ConstraintFix {
   Type BaseType;
   DeclName Name;
 
-public:
   DefineMemberBasedOnUse(ConstraintSystem &cs, Type baseType, DeclName member,
                          ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::DefineMemberBasedOnUse, locator),
         BaseType(baseType), Name(member) {}
 
+public:
   std::string getName() const override {
     llvm::SmallVector<char, 16> scratch;
     auto memberName = Name.getString(scratch);
@@ -525,12 +525,12 @@ public:
 };
 
 class AllowInvalidPartialApplication final : public ConstraintFix {
-public:
   AllowInvalidPartialApplication(bool isWarning, ConstraintSystem &cs,
                                  ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AllowInvalidPartialApplication, locator,
                       isWarning) {}
 
+public:
   std::string getName() const override {
     return "allow partially applied 'mutating' method";
   }


### PR DESCRIPTION
This is a small access control cleanup where some of the
fixes had public constructors, which is not a preferred
way to create fixes, `create(...)` should be used instead.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
