### PR TITLE
[5.0][CSBindings] Preserve l-valueness of optional object type

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -350,6 +350,14 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
          "not a representative");
   assert(!typeVar->getImpl().getFixedType(nullptr) && "has a fixed type");
 
+  // Determines whether this type variable represents an object
+  // of the optional type extracted by force unwrap.
+  bool isOptionalObject = false;
+  if (auto *locator = typeVar->getImpl().getLocator()) {
+    auto *anchor = locator->getAnchor();
+    isOptionalObject = anchor && isa<ForceValueExpr>(anchor);
+  }
+
   // Gather the constraints associated with this type variable.
   llvm::SetVector<Constraint *> constraints;
   getConstraintGraph().gatherConstraints(
@@ -400,6 +408,18 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       auto type = binding->BindingType;
       if (exactTypes.insert(type->getCanonicalType()).second) {
         result.addPotentialBinding(*binding);
+
+        // Result of force unwrap is always connected to its base
+        // optional type via `OptionalObject` constraint which
+        // preserves l-valueness, so in case where object type got
+        // inferred before optional type (because it got the
+        // type from context e.g. parameter type of a function call),
+        // we need to test type with and without l-value after
+        // delaying bindings for as long as possible.
+        if (isOptionalObject && !type->is<LValueType>()) {
+          result.FullyBound = true;
+          result.PotentiallyIncomplete = true;
+        }
 
         if (auto *locator = typeVar->getImpl().getLocator()) {
           auto path = locator->getPath();


### PR DESCRIPTION
- **Explanation**:  Result of force unwrap is always connected to its base
optional type via `OptionalObject` constraint which
preserves l-valueness, so in case where object type got
inferred before optional type (because it got the
type from context e.g. parameter type of a function call),
we need to test type with and without l-value after
delaying bindings for as long as possible.

- **Issue**: rdar://problem/47967277

- **Scope**: Affects only situations when bindings are inferred for the optional object type before its base type

- **Risk**: Low

- **Testing**:  Added compiler regression tests.

- **Reviewed by**: @DougGregor 

Resolves: rdar://problem/47967277
(cherry picked from commit 8f884c45c41e8591e8ea5a1660264ddb4e8b0daa)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
