### PR TITLE
build-script: install swiftsyntax parser into the toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1900,12 +1900,11 @@ swift-include-tests=0
 darwin-deployment-version-ios=10.0
 darwin-crash-reporter-client=1
 
-[preset: build_swiftsyntax_release]
+[preset: install_swiftsyntax_parser]
 release
 lto
 no-assertions
 build-libparser-only
-swiftsyntax
 verbose-build
-skip-swiftsyntax-swiftside
 darwin-install-extract-symbols
+install-swift

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3502,6 +3502,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_SWIFT}" ]] ; then
                     continue
                 fi
+                # Swift syntax parser is currently a sub-product of Swift;
+                # We need to specify the install target separately here.
+                if [ "${BUILD_LIBPARSER_ONLY}" ]; then
+                    INSTALL_TARGETS=tools/libSwiftSyntaxParser/install
+                fi
                 ;;
             llbuild)
                 if [[ -z "${INSTALL_LLBUILD}" ]] ; then
@@ -3807,15 +3812,9 @@ for host in "${ALL_HOSTS[@]}"; do
             call darwin_install_extract_symbols
         else
             set -x
-            if [ "${BUILD_LIBPARSER_ONLY}" ]; then
-                # We don't have a toolchain so we should install to the specified dir
-                CURRENT_INSTALL_DIR="${INSTALL_DESTDIR}"
-                CURRENT_PREFIX="/."
-            else
-                # If we have a toolchain, use the toolchain install dir.
-                CURRENT_INSTALL_DIR=${host_install_destdir}
-                CURRENT_PREFIX="${TOOLCHAIN_PREFIX}"
-            fi
+
+            CURRENT_INSTALL_DIR=${host_install_destdir}
+            CURRENT_PREFIX="${TOOLCHAIN_PREFIX}"
 
             # Copy executables and shared libraries from the `host_install_destdir` to
             # INSTALL_SYMROOT and run dsymutil on them.


### PR DESCRIPTION
This patch teaches build-script to combine both --build-libparser-only and
--install-swift. When using preset `install_swiftsyntax_parser`, we'll build swift-syntax parser and install it to the correct place in the toolchain.
