### PR TITLE
Add support to extract a TF_Function in tracing.

### DIFF
--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -161,6 +161,10 @@ namespace tf {
     static constexpr char tfDataTypeSupportedTypesDesc[] =
         "TensorDataType or [TensorDataType]";
 
+    /// An English list of all the types that TFFunctionAttribute supports, for
+    /// use in diagnostics.
+    static constexpr char tfFunctionSupportedTypesDesc[] = "String";
+
     /// Classify `type` for use as a NormalAttribute.
     Normal classifyNormalAttribute(Type type);
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1538,6 +1538,14 @@ FUNCTION(TFC_OpSetAttrString, _swift_tfc_OpSetAttrString, C_CC,
          ARGS(Int8PtrTy, Int8PtrTy, Int64Ty, BridgeObjectPtrTy),
          ATTRS(NoUnwind))
 
+// The swift function signature is (CTFEOp, UnsafePointer<Int8>, String) -> ().
+// In LLVM IR, the String gets exploded to (BridgeObjectPtrTy, Int64Ty), so
+// IRGen passes those two values in place of the Swift String.
+FUNCTION(TFC_OpSetAttrFunctionName, _swift_tfc_OpSetAttrFunctionName, C_CC,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy, Int8PtrTy, Int64Ty, BridgeObjectPtrTy),
+         ATTRS(NoUnwind))
+
 FUNCTION(TFC_OpSetAttrStringArray, _swift_tfc_OpSetAttrStringArray,
          C_CC, RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -86,6 +86,12 @@ public:
     /// Written as named argument with "$dtype" suffix.
     TFDataTypeAttribute,
 
+    /// A string representing the TFFunction name to be passed to a function
+    /// attribute of a tfop.
+    ///
+    /// Written as named argument with "$func" suffix.
+    TFFunctionAttribute,
+
     /// An argument specifying the address where an indirect output should be
     /// stored. This occurs when the graph_op exists in a context where its
     /// output is address-only.

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -110,6 +110,8 @@ GraphOperationInfo::getArgumentLoweringSuffix(ArgumentLowering lowering) {
     return "$shape";
   case ArgumentLowering::TFDataTypeAttribute:
     return "$dtype";
+  case ArgumentLowering::TFFunctionAttribute:
+    return "$func";
   case ArgumentLowering::Out:
     return "$out";
   }
@@ -137,6 +139,7 @@ GraphOperationInfo::decodeArgumentName(StringRef Name) {
           .Case("tensor", ArgumentLowering::TensorAttribute)
           .Case("shape", ArgumentLowering::ShapeAttribute)
           .Case("dtype", ArgumentLowering::TFDataTypeAttribute)
+          .Case("func", ArgumentLowering::TFFunctionAttribute)
           .Case("out", ArgumentLowering::Out)
           .Default(None);
     if (!loweringOpt)

--- a/lib/AST/TensorFlow.cpp
+++ b/lib/AST/TensorFlow.cpp
@@ -322,6 +322,7 @@ static Type getArrayType(const ASTContext &ctx, Type element) {
 constexpr char AttributeTypeClassifier::normalSupportedTypesDesc[];
 constexpr char AttributeTypeClassifier::shapeSupportedTypesDesc[];
 constexpr char AttributeTypeClassifier::tfDataTypeSupportedTypesDesc[];
+constexpr char AttributeTypeClassifier::tfFunctionSupportedTypesDesc[];
 
 AttributeTypeClassifier::Normal
 AttributeTypeClassifier::classifyNormalAttribute(Type type) {

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1610,6 +1610,12 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         llvm_unreachable(
             "only integers and arrays are possible for TF_DataType attrs");
       }
+      break;
+    case GraphOperationInfo::ArgumentLowering::TFFunctionAttribute:
+      assert(attrValue.getKind() == SymbolicValue::String);
+      auto fname = attrValue.getStringValue();
+      TF_SetAttrFuncName(op, name.c_str(), fname.data(), fname.size());
+      break;
     }
   }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2398,6 +2398,17 @@ namespace {
               return nullptr;
             }
             break;
+          case tf::GraphOperationInfo::ArgumentLowering::TFFunctionAttribute:
+            if (atc.classifyNormalAttribute(argType) !=
+                tf::AttributeTypeClassifier::Normal::String) {
+              diagnose(
+                  argLoc,
+                  StringRef("$func attribute requires ") +
+                      tf::AttributeTypeClassifier::tfFunctionSupportedTypesDesc +
+                      ", but got type '" + argType->getString() + "'");
+              return nullptr;
+            }
+            break;
           case tf::GraphOperationInfo::ArgumentLowering::Out:
             // SILGen generates $out attributes. It does not make sense to
             // specify them in code.

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -318,6 +318,108 @@ private class TraceContext {
     internalConsistencyCheck(returnValueIdx == outputReturnValueCount)
     return traceGraphOutputs
   }
+
+  /// Bind data to the inputs of the graph and return the specialized graph.
+  func specializedTFFunc(data: TensorGroup) -> String {
+    // TODO(bgogul): When we have additional inputs, we will have do a bit more.
+    // We will simply cause such cases to fail temporarily.
+    internalConsistencyCheck(additionalInputTensorCount == 0)
+
+    let specializedGraph = TF_NewGraph()!
+
+    TF_GraphCopyFunction(
+      specializedGraph, traceGraphFn, /*gradient*/ nil, status)
+    checkOk(status)
+
+    let tracedFunctionName = TF_FunctionName(traceGraphFn)
+    internalConsistencyCheck(tracedFunctionName != nil)
+    let tracedOpDesc = TF_NewOperation(
+                         specializedGraph, tracedFunctionName, "tracedFn")
+
+    // Create and append the inputs to the graph function.
+    let traceeInputs = symbolicInputs.dropLast(
+      Int(data._tensorHandleCount + additionalInputTensorCount))
+    var inputs:[TF_Output] = []
+    for (i, traceeInput) in traceeInputs.enumerated() {
+      let desc = TF_NewOperation(specializedGraph, "Placeholder", "input_\(i)")
+      TF_SetAttrType(desc, "dtype", TF_OperationOutputType(traceeInput))
+      let result = TF_FinishOperation(desc, status)
+      checkOk(status)
+      let input = TF_Output(oper: result, index: 0)
+      TF_AddInput(tracedOpDesc, input)
+      inputs.append(input)
+    }
+
+    // Wire the data to the corresponding inputs of the tracedOp.
+    for (i, cTensorHandle) in data.cTensorHandles.enumerated() {
+      let cTensor = TFE_TensorHandleResolve(cTensorHandle, status)
+      checkOk(status)
+      let desc = TF_NewOperation(specializedGraph, "Const", "input_const_\(i)")
+      TF_SetAttrType(desc, "dtype", TFE_TensorHandleDataType(cTensorHandle))
+      TF_SetAttrTensor(desc, "value", cTensor, status)
+      checkOk(status)
+      let result = TF_FinishOperation(desc, status)
+      checkOk(status)
+      TF_AddInput(tracedOpDesc, TF_Output(oper: result, index: 0))
+    }
+
+    // TODO(bgogul): additional input tensors.
+
+    let tracedOp = TF_FinishOperation(tracedOpDesc, status)
+    checkOk(status)
+
+    // Set up outputs
+    var outputIndex:Int32 = 0
+    var outputs: [TF_Output] = []
+    // Get the symbolic outputs from the output.
+    for output in tracedOutputs
+      where TFE_TensorHandleIsConcrete(output) == 0 {
+      outputs.append(TF_Output(oper: tracedOp, index: outputIndex))
+      outputIndex += 1
+    }
+    // Create constants for the concrete outputs.
+    for output in tracedOutputs
+      where TFE_TensorHandleIsConcrete(output) != 0 {
+      let cTensor = TFE_TensorHandleResolve(output, status)
+      checkOk(status)
+      let desc = TF_NewOperation(
+        specializedGraph, "Const", "output_const_\(outputIndex)")
+      TF_SetAttrType(desc, "dtype", TFE_TensorHandleDataType(output))
+      TF_SetAttrTensor(desc, "value", cTensor, status);
+      checkOk(status)
+      let result = TF_FinishOperation(desc, status)
+      checkOk(status)
+      outputs.append(TF_Output(oper: result, index: outputIndex))
+      outputIndex += 1
+    }
+    let specializedTFFuncName : String =
+      "specialized_tffunc_\(_RuntimeConfig.traceGraphFunctionCounter)"
+    _RuntimeConfig.traceGraphFunctionCounter += 1
+
+    let tffunc =
+      TF_GraphToFunction(specializedGraph, specializedTFFuncName,
+                         /*append_hash_to_fn_name*/ 0,
+                         /*num_opers*/ -1,
+                         /*opers*/ nil,
+                         /*numinputs*/ Int32(inputs.count),
+                         /*inputs*/ inputs,
+                         /*noutputs*/ Int32(outputs.count),
+                         /*outputs*/ outputs,
+                         /*outputnames*/ nil,
+                         /*functionoptions*/ nil, "", status)
+    checkOk(status)
+
+    if _RuntimeConfig.printsDebugLog {
+      var len: Int = 0
+      let funcDebugStr = TF_FunctionDebugString(tffunc, &len)!
+      debugLog("Specialied TF_Function is:\n\(String(cString: funcDebugStr))")
+      free(funcDebugStr)
+    }
+    let eagerContext = _TFCGetGlobalEagerContext()
+    TFE_ContextAddFunction(eagerContext, tffunc, status)
+    checkOk(status)
+    return specializedTFFuncName
+  }
 }
 
 // This enum keeps track of whether we are building or executing a trace.
@@ -822,6 +924,7 @@ private func _graphInternal<State : _TensorArrayProtocolEnhanced,
   }
 }
 
+
 // TODO: rename this to `graph` when it's ready for end users.
 public func _graph<State : _TensorArrayProtocolEnhanced,
                    Data : TensorGroup,
@@ -853,6 +956,24 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
   return { (state: State, data: Data) in
     let result = graphFunction(state, data)
     return result.0
+  }
+}
+
+
+public func _TFFuncSpecializer<State : _TensorArrayProtocolEnhanced,
+                               Data : TensorGroup>(
+  with state: State,
+  in fn: @escaping (State, Data) -> (State)
+) -> (Data) -> (String) {
+  let wrappedFn = {
+    // The result argument needs to be a type that conforms to TensorGroup.
+    // We are arbitrarily picking Tensor<Float> here.
+    (s: State, d: Data) -> (State, Tensor<Float>?) in
+      (fn(s, d), nil)
+  }
+  let traceContext = _trace(with: state, in : wrappedFn)
+  return { (data: Data) -> String in
+    traceContext.specializedTFFunc(data: data)
   }
 }
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1771,6 +1771,20 @@ func _TFCOpSetAttrString(_ op: CTFEOp,
   }
 }
 
+/// Wrapper around TFE_OpSetAttrString that handles converting the Swift Stdlib
+/// String into a buffer that TFE_OpSetAttrString can read.
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrFunctionName")
+func _TFCOpSetAttrFunctionName(_ op: CTFEOp,
+                               _ attrName: UnsafePointer<Int8>,
+                               _ value: String) {
+  value.utf8CString.withUnsafeBufferPointer { buffer in
+    // utf8CString is null-terminated; TFE_OpSetAttrString wants
+    // non-null-terminated.
+    TFE_OpSetAttrFunctionName(op, attrName, buffer.baseAddress, buffer.count - 1)
+  }
+}
+
 /// Wrapper around TFE_OpSetAttrStringList that handles converting the Swift
 /// Strings into buffers that TFE_OpSetAttrStringList can read.
 @usableFromInline

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -368,8 +368,8 @@ private class TraceContext {
     let tracedOp = TF_FinishOperation(tracedOpDesc, status)
     checkOk(status)
 
-    // Set up outputs
-    var outputIndex:Int32 = 0
+    // Set up outputs.
+    var outputIndex: Int32 = 0
     var outputs: [TF_Output] = []
     // Get the symbolic outputs from the output.
     for output in tracedOutputs

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -960,8 +960,8 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
 }
 
 
-public func _TFFuncSpecializer<State : _TensorArrayProtocolEnhanced,
-                               Data : TensorGroup>(
+public func _tffunc<State : _TensorArrayProtocolEnhanced,
+                    Data : TensorGroup>(
   with state: State,
   in fn: @escaping (State, Data) -> (State)
 ) -> (Data) -> (String) {

--- a/test/TensorFlowRuntime/tracer_tffunc.swift
+++ b/test/TensorFlowRuntime/tracer_tffunc.swift
@@ -35,7 +35,7 @@ TracerTests.testAllBackends("SimpleTFFunction") {
   let tffunc = _tffunc(with: Tensor<Int32>(0), in: cond)
 
   func runWhile(_ n: Int32) -> Tensor<Int32> {
-    return  #tfop(
+    return #tfop(
       "StatelessWhile",
       Tensor<Int32>(0),
       T$dtype: [Int32.tensorFlowDataType],

--- a/test/TensorFlowRuntime/tracer_tffunc.swift
+++ b/test/TensorFlowRuntime/tracer_tffunc.swift
@@ -32,18 +32,17 @@ TracerTests.testAllBackends("SimpleTFFunction") {
     return i + 1
   }
 
-  let specializer = _TFFuncSpecializer(with: Tensor<Int32>(0), in: cond)
+  let tffunc = _tffunc(with: Tensor<Int32>(0), in: cond)
 
   func runWhile(_ n: Int32) -> Tensor<Int32> {
     return  #tfop(
       "StatelessWhile",
       Tensor<Int32>(0),
       T$dtype: [Int32.tensorFlowDataType],
-      cond$func: specializer(Tensor<Int32>(n)),
+      cond$func: tffunc(Tensor<Int32>(n)),
       body: body)
   }
 
-  let result = runWhile(130)
   expectEqualWithScalarTensor(10, runWhile(10))
   expectEqualWithScalarTensor(300, runWhile(300))
 }

--- a/test/TensorFlowRuntime/tracer_tffunc.swift
+++ b/test/TensorFlowRuntime/tracer_tffunc.swift
@@ -1,0 +1,51 @@
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Tracer tests.
+
+import TensorFlow
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var TracerTests = TestSuite("TracerTFFunction")
+
+extension Tensor : _TensorArrayProtocolEnhanced {
+  public func _makeInstance<C: Collection>(owning inputs: C) -> Tensor
+    where C.Element == CTensorHandle {
+    assert(inputs.count == 1)
+    return Tensor(handle: TensorHandle<Scalar>(_owning: inputs.first!))
+  }
+}
+
+TracerTests.testAllBackends("SimpleTFFunction") {
+  func cond(i: Tensor<Int32>, n: Tensor<Int32>) -> (Tensor<Int32>) {
+    return (Tensor<Int32>(i .< n))
+  }
+
+  @TensorFlowGraph
+  func body(i: Tensor<Int32>) -> Tensor<Int32> {
+    return i + 1
+  }
+
+  let specializer = _TFFuncSpecializer(with: Tensor<Int32>(0), in: cond)
+
+  func runWhile(_ n: Int32) -> Tensor<Int32> {
+    return  #tfop(
+      "StatelessWhile",
+      Tensor<Int32>(0),
+      T$dtype: [Int32.tensorFlowDataType],
+      cond$func: specializer(Tensor<Int32>(n)),
+      body: body)
+  }
+
+  let result = runWhile(130)
+  expectEqualWithScalarTensor(10, runWhile(10))
+  expectEqualWithScalarTensor(300, runWhile(300))
+}
+
+runAllTests()


### PR DESCRIPTION
This makes changes in three places: 

1. Adds a '$func' keyword for specifying which can be used to specify a function name for attributes of tensorflow ops that require a function (e.g., "If", "While", etc.)
2. Changes the IRGenSIL to generate appropriate tensorflow runtime calls for "$func" keyword.
3. Adds a _tffunc method to the compiler runtime to construct a TF_Function and return its name.

(Unfortunately, I could not split this up into smaller PRs with tests.)