### PR TITLE
Fix an overspecific lit check: unsafebufferpointer.swift.

### DIFF
--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -56,10 +56,9 @@ public func testCount(_ x: UnsafeBufferPointer<UInt>) -> Int {
 //
 // CHECK: ; <label>:[[LOOP]]:
 // CHECK: phi float [ 0.000000e+00
-// CHECK: add nuw i64 %{{.*}}, 1
 // CHECK: load float, float*
 // CHECK: fadd float
-// CHECK: [[CMP:%[0-9]+]] = icmp eq i64 %{{.*}}, %{{.*}}
+// CHECK: [[CMP:%[0-9]+]] = icmp eq
 // CHECK: br i1 [[CMP]], label %.loopexit, label %[[LOOP]]
 public func testSubscript(_ ubp: UnsafeBufferPointer<Float>) -> Float {
   var sum: Float = 0
@@ -80,12 +79,10 @@ public func testSubscript(_ ubp: UnsafeBufferPointer<Float>) -> Float {
 //
 // CHECK: ; <label>:[[LOOP]]:
 // CHECK: phi i64 [ 0
-// CHECK: phi i64 [ 0
-// CHECK: add nuw i64 %{{.*}}, 1
 // CHECK: load i8, i8*
 // CHECK: zext i8 %{{.*}} to i64
 // CHECK: add i64
-// CHECK: [[CMP:%[0-9]+]] = icmp eq i64 %{{.*}}, %{{.*}}
+// CHECK: [[CMP:%[0-9]+]] = icmp eq
 // CHECK: br i1 [[CMP]], label %[[RET]], label %[[LOOP]]
 public func testSubscript(_ ubp: UnsafeRawBufferPointer) -> Int64 {
   var sum: Int64 = 0


### PR DESCRIPTION
<rdar://problem/48016982> TEST 'Swift(iphonesimulator-i386) :: SILOptimizer/unsafebufferpointer.swift' FAILED