### PR TITLE
[5.0][DebuggerSupport] Unbreak closures in the expression parser.

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -953,8 +953,6 @@ void Lexer::lexDollarIdent() {
     // independent of language mode.
     return formToken(tok::identifier, tokStart);
   } else {
-    if (LangOpts.EnableDollarIdentifiers && !LangOpts.Playground)
-      return formToken(tok::identifier, tokStart);
     return formToken(tok::dollarident, tokStart);
   }
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2915,6 +2915,12 @@ Expr *Parser::parseExprAnonClosureArg() {
   auto closure = dyn_cast_or_null<ClosureExpr>(
       dyn_cast<AbstractClosureExpr>(CurDeclContext));
   if (!closure) {
+    if (Context.LangOpts.DebuggerSupport) {
+      auto refKind = DeclRefKind::Ordinary;
+      auto identifier = Context.getIdentifier(Name);
+      return new (Context) UnresolvedDeclRefExpr(DeclName(identifier), refKind,
+                                                 DeclNameLoc(Loc));
+    }
     diagnose(Loc, diag::anon_closure_arg_not_in_closure);
     return new (Context) ErrorExpr(Loc);
   }

--- a/test/Parse/closure-debugger.swift
+++ b/test/Parse/closure-debugger.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend %s -typecheck -debugger-support 2>&1 | %FileCheck %s --check-prefix=DEBUG
+// RUN: not %target-swift-frontend %s -typecheck 2>&1 | %FileCheck %s --check-prefix=NODEBUG
+
+// DEBUG: error: use of unresolved identifier '$0'
+// NODEBUG: error: anonymous closure argument not contained in a closure
+$0


### PR DESCRIPTION
* **Explanation**:  A previous commit regressed closures in the debugger, we now leave an unresolved identifier for the debugger to fill in.
* **Issue**: rdar://problem/47982630
* **Scope**: Affects only debugger support, despite being a change in parsing, so only lldb will be affected.
* **Risk**: Low
* **Testing**:  Added compiler regression tests
* **Reviewed by**: @jrose-apple 