### PR TITLE
[TF-196] autocomplete crasher when satisfying diff protocol req

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1504,7 +1504,7 @@ public:
 
   bool parametersMatch(const DifferentiableAttr &other) const {
     assert(ParameterIndices);
-    assert(other.ParameterIndices);
+    assert(ParameterIndices && other.ParameterIndices);
     return ParameterIndices->parameters == other.ParameterIndices->parameters;
   }
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1503,7 +1503,6 @@ public:
   void setVJPFunction(FuncDecl *decl) { VJPFunction = decl; }
 
   bool parametersMatch(const DifferentiableAttr &other) const {
-    assert(ParameterIndices);
     assert(ParameterIndices && other.ParameterIndices);
     return ParameterIndices->parameters == other.ParameterIndices->parameters;
   }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1503,6 +1503,8 @@ public:
   void setVJPFunction(FuncDecl *decl) { VJPFunction = decl; }
 
   bool parametersMatch(const DifferentiableAttr &other) const {
+    assert(ParameterIndices);
+    assert(other.ParameterIndices);
     return ParameterIndices->parameters == other.ParameterIndices->parameters;
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -491,7 +491,9 @@ swift::matchWitness(
           witnessAttrs.getAttribute<DifferentiableAttr>(
               /*AllowInvalid*/ true);
       if (reqDifferentiationAttr &&
-          (!witnessDifferentiationAttr ||
+          (!reqDifferentiationAttr->getParameterIndices() ||
+           !witnessDifferentiationAttr ||
+           !witnessDifferentiationAttr->getParameterIndices() ||
            !witnessDifferentiationAttr->parametersMatch(
                *reqDifferentiationAttr)))
         return RequirementMatch(witness, MatchKind::DifferentiableConflict);

--- a/test/IDE/complete_autodiff.swift
+++ b/test/IDE/complete_autodiff.swift
@@ -1,0 +1,16 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE | %FileCheck %s
+
+protocol DifferentiableRequirements {
+  @differentiable
+  func f(_ x: Float) -> Float
+}
+
+struct Foo : DifferentiableRequirements {
+  @differentiable
+  func f#^COMPLETE^#
+}
+
+// CHECK-LABEL: Begin completions
+// CHECK: func f(_ x: Float) -> Float
+// CHECK: End completions


### PR DESCRIPTION
The autocompleter was running TypeCheckProtocol with NULL ParameterIndices.

Resolves https://bugs.swift.org/browse/TF-196.