### PR TITLE
[docs][SR-9915] Compilation fix of docs snippet of type(of:)

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -753,8 +753,8 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 /// declared for the parameter) and a dynamic type of `Int`.
 ///
 ///     func printInfo(_ value: Any) {
-///         let type = type(of: value)
-///         print("'\(value)' of type '\(type)'")
+///         let t = type(of: value)
+///         print("'\(value)' of type '\(t)'")
 ///     }
 ///
 ///     let count: Int = 5
@@ -816,8 +816,8 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 /// of `String.self` (the dynamic type inside the parameter).
 ///
 ///     func printGenericInfo<T>(_ value: T) {
-///         let type = type(of: value)
-///         print("'\(value)' of type '\(type)'")
+///         let t = type(of: value)
+///         print("'\(value)' of type '\(t)'")
 ///     }
 ///
 ///     protocol P {}
@@ -835,8 +835,8 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 /// calling `type(of:)`.
 ///
 ///     func betterPrintGenericInfo<T>(_ value: T) {
-///         let type = type(of: value as Any)
-///         print("'\(value)' of type '\(type)'")
+///         let t = type(of: value as Any)
+///         print("'\(value)' of type '\(t)'")
 ///     }
 ///
 ///     betterPrintGenericInfo(stringAsP)


### PR DESCRIPTION
Compilation of code sample snippets was broken due to using the same
identifier as the `type` function itself to store its result resulting
in:

```swift
func printGenericInfo<T>(_ value: T) {
    let type = type(of: value)
    print("'\(value)' of type '\(type)'")
}

// error: repl.swift:2:16: error: variable used within its own initial
// value
//    let type = type(of: value)
//               ^
```

Result:

- Snippets are more copy&paste friendly.
- Resolves https://bugs.swift.org/browse/SR-9915

// My first PR to Swift, hello there 👋
