### PR TITLE
Fix PlaygroundTransform/placeholder.swift for windows

### DIFF
--- a/test/PlaygroundTransform/placeholder.swift
+++ b/test/PlaygroundTransform/placeholder.swift
@@ -3,19 +3,13 @@
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -o %t/main %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: ! %target-run %t/main --crash 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
+// RUN: not --crash %target-run %t/main --crash 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
 // REQUIRES: executable_test
-
-// NOTE: "!" is used above instead of "not --crash" because simctl's exit
-// status doesn't reflect whether its child process crashed or not. So "not
-// --crash %target-run ..." always fails when testing for the iOS Simulator.
-// The more precise solution would be to use a version of 'not' cross-compiled
-// for the simulator.
 
 func f(crash crash: Bool) -> Int {
   if crash {
     return <#T#>
-    // CRASH-CHECK: fatal error: attempt to evaluate editor placeholder: file {{.*}}/main.swift, line [[@LINE-1]]
+    // CRASH-CHECK: {{[Ff]}}atal error: attempt to evaluate editor placeholder: file {{.*}}/main.swift, line [[@LINE-1]]
   } else {
     return 42
   }


### PR DESCRIPTION
This test fails on windows because of the use of `!` and switching it to `not --crash` fixes it.

I noticed from the comments that this test was changed in late 2015 because of a limitation of simctl. I don't know if the situation on that has changed at all, but I'm hoping that if it hasn't, then it will be caught in CI. If it still fails there, we should think up a solution that works for all platforms. :)

cc @compnerd 