### PR TITLE
invalid unary ops crash repl completer

### DIFF
--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -286,6 +286,10 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
 /// When we see an expression in a TopLevelCodeDecl in the REPL, process it,
 /// adding the proper decls back to the top level of the file.
 void REPLChecker::processREPLTopLevelExpr(Expr *E) {
+  // Don't try to print expressions without types.
+  if (!E->getType())
+    return;
+
   CanType T = E->getType()->getCanonicalType();
 
   // Don't try to print invalid expressions, module exprs, or void expressions.

--- a/test/IDE/complete_tf_194.swift
+++ b/test/IDE/complete_tf_194.swift
@@ -1,0 +1,7 @@
+// https://bugs.swift.org/browse/TF-194: invalid unary ops crash repl completer
+
+// The ASTVerifier doesn't like this AST.
+// XFAIL: swift_ast_verifier
+
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename=%s
+%invalidunary le


### PR DESCRIPTION
Fixes a crash in the REPL completer. (Affects both the integrated REPL and the LLDB REPL).

The testcase that I included won't work until https://github.com/apple/swift/pull/22440 merges.