### PR TITLE
repl completer crash while defining struct

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -508,7 +508,8 @@ public:
       Type contextType = yieldType;
       if (yieldResults[i].isInOut()) {
         contextTypePurpose = CTP_YieldByReference;
-        contextType = LValueType::get(contextType);
+        if (!contextType->hasError())
+          return nullptr;
 
         // Check that the yielded expression is a &.
         if ((inout = dyn_cast<InOutExpr>(exprToCheck))) {

--- a/test/IDE/complete_tf_195.swift
+++ b/test/IDE/complete_tf_195.swift
@@ -1,0 +1,8 @@
+// https://bugs.swift.org/browse/TF-195: repl completer crash while defining
+// struct
+
+// The ASTVerifier doesn't like this AST.
+// XFAIL: swift_ast_verifier
+
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename=%s
+struct Foo { var ba


### PR DESCRIPTION
Fixes a crash in the REPL completer. (Affects both the integrated REPL and the LLDB REPL).

It crashes because `LValueType::get` asserts that its argument is non-error. I'm not sure what the right thing to do here, but this fixes the crash that I'm getting.

The testcase that I included won't work until #22440 merges.