### PR TITLE
[AutoDiff] Check `@differentiable` attribute JVP/VJP parameter variad…

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2796,8 +2796,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
       return false;
     for (auto paramPair : llvm::zip(candidateFnTy.getParams(),
                                     required.getParams()))
-      if (std::get<0>(paramPair).getParameterType() !=
-          std::get<1>(paramPair).getParameterType())
+      if (!std::get<0>(paramPair).getPlainType()->isEqual(
+          std::get<1>(paramPair).getPlainType()))
         return false;
 
     // If required result type is non-function, check that result types match

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -497,7 +497,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   func _vjpTransposed(
     withPermutations permutations: Tensor<Int32>
   ) -> (Tensor, (Tensor) -> Tensor) {
-    let value = transposed()
+    let value = transposed(withPermutations: permutations)
     return (value, { $0.transposed(withPermutations: permutations) })
   }
 
@@ -505,7 +505,15 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   func _vjpTransposed(
     withPermutations permutations: [Int32]
   ) -> (Tensor, (Tensor) -> Tensor) {
-    let value = transposed()
+    let value = transposed(withPermutations: permutations)
+    return (value, { $0.transposed(withPermutations: permutations) })
+  }
+
+  @inlinable
+  func _vjpTransposed(
+    withPermutations permutations: Int32...
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    let value = transposed(withPermutations: permutations)
     return (value, { $0.transposed(withPermutations: permutations) })
   }
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -448,6 +448,15 @@ extension MethodDiffReq where Self : Differentiable {
   }
 }
 
+// expected-error @+1 {{'vjpNonvariadic' does not have expected type '(Float, Int32...) -> (Float, (Float.CotangentVector) -> Float.CotangentVector)' (aka '(Float, Int32...) -> (Float, (Float) -> Float)')}}
+@differentiable(wrt: x, vjp: vjpNonvariadic)
+func variadic(_ x: Float, indices: Int32...) -> Float {
+  return x
+}
+func vjpNonvariadic(_ x: Float, indices: [Int32]) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+
 // expected-error @+2 {{type 'Scalar' constrained to non-protocol, non-class type 'Float'}}
 // expected-error @+1 {{can only differentiate with respect to parameters that conform to 'Differentiable', but 'Scalar' does not conform to 'Differentiable'}}
 @differentiable(where Scalar : Float)


### PR DESCRIPTION
…ic-ness.

- Check JVP/VJP parameter variadic-ness during `@differentiable` attribute type-checking.
  - Previously, variadic functions like `Tensor.transposed(withPermutations: Int32...)`
    could have non-variadic VJPs, which led to crashes.
  - Now, parameter variadic-ness must be consistent.
- Add variadic VJP for variadic `Tensor.transposed` function.
- Fix `Tensor.transposed` VJP definitions.

Resolves [TF-200](https://bugs.swift.org/browse/TF-200).