### PR TITLE
SwiftPrivateThreadExtras: fix casting due to API changes

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -96,7 +96,7 @@ public func _stdlib_thread_create_block<Argument, Result>(
   if threadID == 0 {
     return (errno, nil)
   } else {
-    return (0, UnsafeMutablePointer<ThreadHandle>(&threadID).pointee)
+    return (0, unsafeBitCast(threadID, to: ThreadHandle.self))
   }
 #else
   var threadID = _make_pthread_t()


### PR DESCRIPTION
The recent changes to the UnsafemutablePointer prevented the "abuse" of
the type for casting.  Switch to `unsafeBitCast`.  This should repair
the Windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
