### PR TITLE
IRGen: be more lenient in casting (followup for SVN r352827)

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4073,8 +4073,10 @@ IRGenModule::getOrCreateHelperFunction(StringRef fnName, llvm::Type *resultTy,
   llvm::FunctionType *fnTy =
     llvm::FunctionType::get(resultTy, paramTys, false);
 
-  llvm::Constant *fn = cast<llvm::Function>(
-      Module.getOrInsertFunction(fnName, fnTy).getCallee());
+  llvm::Constant *fn =
+      cast<llvm::Function>(Module.getOrInsertFunction(fnName, fnTy)
+                               .getCallee()
+                               ->stripPointerCasts());
 
   if (llvm::Function *def = shouldDefineHelper(*this, fn, setIsNoInline)) {
     IRGenFunction IGF(*this, def);

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -903,7 +903,10 @@ public:
     // Use copy-on-write existentials?
     auto fn = getDestroyBoxedOpaqueExistentialBufferFunction(
         IGF.IGM, getLayout(), addr.getAddress()->getType());
-    auto call = IGF.Builder.CreateCall(fn, {addr.getAddress()});
+    auto call = IGF.Builder.CreateCall(
+        fn, {IGF.Builder.CreateBitCast(
+                addr.getAddress(),
+                cast<llvm::Function>(fn)->arg_begin()->getType())});
     call->setCallingConv(IGF.IGM.DefaultCC);
     call->setDoesNotThrow();
     return;
@@ -2045,8 +2048,11 @@ Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
   /// Call a function to handle the non-fixed case.
   auto *allocateFun = getAllocateBoxedOpaqueExistentialBufferFunction(
       IGF.IGM, existLayout, existentialContainer.getAddress()->getType());
-  auto *call =
-      IGF.Builder.CreateCall(allocateFun, {existentialContainer.getAddress()});
+  auto *call = IGF.Builder.CreateCall(
+      allocateFun,
+      {IGF.Builder.CreateBitCast(
+          existentialContainer.getAddress(),
+          cast<llvm::Function>(allocateFun)->arg_begin()->getType())});
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
   auto addressOfValue = IGF.Builder.CreateBitCast(call, valuePointerType);


### PR DESCRIPTION
This adjusts the previous change for the IRGen API changes in SVN r352827.  We
sometimes may get back a BitCastInst for the function type coercion.  Ensure
that we strip the pointer casts before performing the cast which may otherwise
fail with an assertions build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
