### PR TITLE
[TF-194] [TF-195] cherry-pick some autocomplete crasher fixes into tensorflow

### DIFF
--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -286,6 +286,10 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
 /// When we see an expression in a TopLevelCodeDecl in the REPL, process it,
 /// adding the proper decls back to the top level of the file.
 void REPLChecker::processREPLTopLevelExpr(Expr *E) {
+  // Don't try to print expressions without types.
+  if (!E->getType())
+    return;
+
   CanType T = E->getType()->getCanonicalType();
 
   // Don't try to print invalid expressions, module exprs, or void expressions.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -505,7 +505,8 @@ public:
       Type contextType = yieldType;
       if (yieldResults[i].isInOut()) {
         contextTypePurpose = CTP_YieldByReference;
-        contextType = LValueType::get(contextType);
+        if (!contextType->hasError())
+          contextType = LValueType::get(contextType);
 
         // Check that the yielded expression is a &.
         if ((inout = dyn_cast<InOutExpr>(exprToCheck))) {

--- a/test/IDE/complete_tf_194.swift
+++ b/test/IDE/complete_tf_194.swift
@@ -1,0 +1,7 @@
+// https://bugs.swift.org/browse/TF-194: invalid unary ops crash repl completer
+
+// The ASTVerifier doesn't like this AST.
+// XFAIL: swift_ast_verifier
+
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename=%s
+%invalidunary le

--- a/test/IDE/complete_tf_195.swift
+++ b/test/IDE/complete_tf_195.swift
@@ -1,0 +1,8 @@
+// https://bugs.swift.org/browse/TF-195: repl completer crash while defining
+// struct
+
+// The ASTVerifier doesn't like this AST.
+// XFAIL: swift_ast_verifier
+
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename=%s
+struct Foo { var ba


### PR DESCRIPTION
I'm working on getting these into `master` (https://github.com/apple/swift/pull/22580 and https://github.com/apple/swift/pull/22579) but I'd really like to have them in `tensorflow` ASAP because they make the colab autocomplete very crashy.