### PR TITLE
handle diags that happen during repl code completion

### DIFF
--- a/test/IDE/repl_complete_with_error.swift
+++ b/test/IDE/repl_complete_with_error.swift
@@ -1,0 +1,8 @@
+// While running completion on this, the typechecker produces a diagnostic and
+// an AST with an error type. If the ASTVerifier ran on the AST with the error
+// type, then it would fail. This test verifies that the ASTVerifier does not
+// run on ASTs with error types produced by completion requests.
+
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename=%s
+
+let bar: NotARealType = 0; ba


### PR DESCRIPTION
If a REPL completion request encounters an error during typechecking and produces an AST with an error type, then the ASTVerifier must not run, because the ASTVerifier is only supposed to run on ASTs without errors.

REPLCodeCompletion.cpp's previous strategy for suppressing diagnostics stopped the diagnostics from being added to the ASTContext, so ASTVerifier did not know that there were errors, so it tried to run.

This PR makes it use DiagnosticSuppression, which suppresses the diagnostic consumer that prints diagnostics, but which does not stop the diagnostics from being added to the ASTContext.

Related discussions in: #22580 and #22579