### PR TITLE
swift-5.1: temporarily disable the IRGen/newtype.swift test

### DIFF
--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -6,6 +6,7 @@ import CoreFoundation
 import Foundation
 import Newtype
 
+// REQUIRES: rdar48056043
 // REQUIRES: objc_interop
 
 // Conformance descriptor for synthesized ClosedEnums : _ObjectiveCBridgeable.


### PR DESCRIPTION
The expected output needs to be adjusted for differing optimizer behavior.
Tracked by rdar://problem/48056043
