### PR TITLE
[5.1] [CMake] StandaloneOverlay: set components before including apinotes/

### DIFF
--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -28,6 +28,10 @@ add_custom_target("copy_apinotes"
     COMMENT "Copying API notes to ${output_dir}"
     SOURCES "${sources}")
 
+# This is treated as an OPTIONAL target because if we don't build the SDK
+# overlay, the files will be missing anyway. It also allows us to build
+# single overlays without installing the API notes.
 swift_install_in_component(sdk-overlay
-    FILES ${sources}
-    DESTINATION "lib/swift/apinotes")
+    DIRECTORY "${output_dir}"
+    DESTINATION "lib/swift/"
+    OPTIONAL)

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -59,13 +59,13 @@ precondition(SWIFT_DEST_ROOT)
 precondition(SWIFT_HOST_VARIANT_SDK)
 precondition(TOOLCHAIN_DIR)
 
+# Without this line, installing components is broken. This needs refactoring.
+swift_configure_components()
+
 # Some overlays include the runtime's headers,
 # and some of those headers are generated at build time.
 add_subdirectory("${SWIFT_SOURCE_DIR}/include" "${SWIFT_SOURCE_DIR}/include")
 add_subdirectory("${SWIFT_SOURCE_DIR}/apinotes" "${SWIFT_SOURCE_DIR}/apinotes")
-
-# Without this line, installing components is broken. This needs refactoring.
-swift_configure_components()
 
 precondition(unknown_sdks NEGATE MESSAGE "Unknown SDKs: ${unknown_sdks}")
 precondition(SWIFT_CONFIGURED_SDKS MESSAGE "No SDKs selected.")


### PR DESCRIPTION
Cherry-pick of #22592 for the 5.1 branch that's currently being set up.