### PR TITLE
[NFC] Move selector family logic to ObjCSelector

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -592,6 +592,21 @@ public:
                             "only for use within the debugger");
 };
 
+/// Apply a macro FAMILY(Name, Prefix) to all ObjC selector families.
+#define FOREACH_OBJC_SELECTOR_FAMILY(FAMILY)       \
+  FAMILY(Alloc, "alloc")                           \
+  FAMILY(Copy, "copy")                             \
+  FAMILY(Init, "init")                             \
+  FAMILY(MutableCopy, "mutableCopy")               \
+  FAMILY(New, "new")
+
+enum class ObjCSelectorFamily : unsigned {
+  None,
+#define GET_LABEL(LABEL, PREFIX) LABEL,
+FOREACH_OBJC_SELECTOR_FAMILY(GET_LABEL)
+#undef GET_LABEL
+};
+
 /// Represents an Objective-C selector.
 class ObjCSelector {
   /// The storage for an Objective-C selector.
@@ -655,6 +670,8 @@ public:
   ///
   /// \param scratch Scratch space to use.
   StringRef getString(llvm::SmallVectorImpl<char> &scratch) const;
+
+  ObjCSelectorFamily getSelectorFamily() const;
 
   void *getOpaqueValue() const { return Storage.getOpaqueValue(); }
   static ObjCSelector getFromOpaqueValue(void *p) {

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -592,19 +592,10 @@ public:
                             "only for use within the debugger");
 };
 
-/// Apply a macro FAMILY(Name, Prefix) to all ObjC selector families.
-#define FOREACH_OBJC_SELECTOR_FAMILY(FAMILY)       \
-  FAMILY(Alloc, "alloc")                           \
-  FAMILY(Copy, "copy")                             \
-  FAMILY(Init, "init")                             \
-  FAMILY(MutableCopy, "mutableCopy")               \
-  FAMILY(New, "new")
-
 enum class ObjCSelectorFamily : unsigned {
   None,
-#define GET_LABEL(LABEL, PREFIX) LABEL,
-FOREACH_OBJC_SELECTOR_FAMILY(GET_LABEL)
-#undef GET_LABEL
+#define OBJC_SELECTOR_FAMILY(LABEL, PREFIX) LABEL,
+#include "swift/AST/ObjCSelectorFamily.def"
 };
 
 /// Represents an Objective-C selector.

--- a/include/swift/AST/ObjCSelectorFamily.def
+++ b/include/swift/AST/ObjCSelectorFamily.def
@@ -1,0 +1,29 @@
+//===--- ObjCSelectorFamily.def - Objective-C Selector Families - C++ ---*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with Objective-C
+// selector families, categories of Objective-C methods with special ARC
+// semantics.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OBJC_SELECTOR_FAMILY
+#define OBJC_SELECTOR_FAMILY(LABEL, PREFIX)
+#endif
+
+OBJC_SELECTOR_FAMILY(Alloc, "alloc")
+OBJC_SELECTOR_FAMILY(Copy, "copy")
+OBJC_SELECTOR_FAMILY(Init, "init")
+OBJC_SELECTOR_FAMILY(MutableCopy, "mutableCopy")
+OBJC_SELECTOR_FAMILY(New, "new")
+
+#undef OBJC_SELECTOR_FAMILY

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -218,10 +218,9 @@ ObjCSelectorFamily ObjCSelector::getSelectorFamily() const {
   };
 
   if (false) /*for #define purposes*/;
-#define CHECK_PREFIX(LABEL, PREFIX) \
-else if (hasPrefix(text, PREFIX)) return ObjCSelectorFamily::LABEL;
-  FOREACH_OBJC_SELECTOR_FAMILY(CHECK_PREFIX)
-#undef CHECK_PREFIX
+#define OBJC_SELECTOR_FAMILY(LABEL, PREFIX) \
+  else if (hasPrefix(text, PREFIX)) return ObjCSelectorFamily::LABEL;
+#include "swift/AST/ObjCSelectorFamily.def"
   else return ObjCSelectorFamily::None;
 }
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -29,7 +29,6 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Analysis/DomainSpecific/CocoaConventions.h"
-#include "clang/Basic/CharInfo.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
@@ -1710,64 +1709,27 @@ static const clang::Decl *findClangMethod(ValueDecl *method) {
 //                      Selector Family SILFunctionTypes
 //===----------------------------------------------------------------------===//
 
-/// Apply a macro FAMILY(Name, Prefix) to all ObjC selector families.
-#define FOREACH_FAMILY(FAMILY)       \
-  FAMILY(Alloc, "alloc")             \
-  FAMILY(Copy, "copy")               \
-  FAMILY(Init, "init")               \
-  FAMILY(MutableCopy, "mutableCopy") \
-  FAMILY(New, "new")
-
-namespace {
-  enum class SelectorFamily : unsigned {
-    None,
-#define GET_LABEL(LABEL, PREFIX) LABEL,
-FOREACH_FAMILY(GET_LABEL)
-#undef GET_LABEL
-  };
-} // end anonymous namespace
-
 /// Derive the ObjC selector family from an identifier.
 ///
 /// Note that this will never derive the Init family, which is too dangerous
 /// to leave to chance. Swift functions starting with "init" are always
 /// emitted as if they are part of the "none" family.
-static SelectorFamily getSelectorFamily(Identifier name) {
-  StringRef text = name.get();
-  while (!text.empty() && text[0] == '_') text = text.substr(1);
+static ObjCSelectorFamily getSelectorFamily(ObjCSelector name) {
+  auto result = name.getSelectorFamily();
 
-  // Does the given selector start with the given string as a prefix, in the
-  // sense of the selector naming conventions?
-  // This implementation matches the one used by
-  // clang::Selector::getMethodFamily, to make sure we behave the same as Clang
-  // ARC. We're not just calling that method here because it means allocating a
-  // clang::IdentifierInfo, which requires a Clang ASTContext.
-  auto hasPrefix = [](StringRef text, StringRef prefix) {
-    if (!text.startswith(prefix)) return false;
-    if (text.size() == prefix.size()) return true;
-    assert(text.size() > prefix.size());
-    return !clang::isLowercase(text[prefix.size()]);
-  };
+  if (result == ObjCSelectorFamily::Init)
+    return ObjCSelectorFamily::None;
 
-  auto result = SelectorFamily::None;
-  if (false) /*for #define purposes*/;
-#define CHECK_PREFIX(LABEL, PREFIX) \
-  else if (hasPrefix(text, PREFIX)) result = SelectorFamily::LABEL;
-  FOREACH_FAMILY(CHECK_PREFIX)
-#undef CHECK_PREFIX
-
-  if (result == SelectorFamily::Init)
-    return SelectorFamily::None;
   return result;
 }
 
 /// Get the ObjC selector family a foreign SILDeclRef belongs to.
-static SelectorFamily getSelectorFamily(SILDeclRef c) {
+static ObjCSelectorFamily getSelectorFamily(SILDeclRef c) {
   assert(c.isForeign);
   switch (c.kind) {
   case SILDeclRef::Kind::Func: {
     if (!c.hasDecl())
-      return SelectorFamily::None;
+      return ObjCSelectorFamily::None;
       
     auto *FD = cast<FuncDecl>(c.getDecl());
     if (auto accessor = dyn_cast<AccessorDecl>(FD)) {
@@ -1783,11 +1745,11 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
       }
     }
 
-    return getSelectorFamily(FD->getObjCSelector().getSelectorPieces().front());
+    return getSelectorFamily(FD->getObjCSelector());
   }
   case SILDeclRef::Kind::Initializer:
   case SILDeclRef::Kind::IVarInitializer:
-    return SelectorFamily::Init;
+    return ObjCSelectorFamily::Init;
 
   /// Currently IRGen wraps alloc/init methods into Swift constructors
   /// with Swift conventions.
@@ -1796,7 +1758,7 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
   case SILDeclRef::Kind::Destroyer:
   case SILDeclRef::Kind::Deallocator:
   case SILDeclRef::Kind::IVarDestroyer:
-    return SelectorFamily::None;
+    return ObjCSelectorFamily::None;
 
   case SILDeclRef::Kind::EnumElement:
   case SILDeclRef::Kind::GlobalAccessor:
@@ -1811,10 +1773,10 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
 namespace {
 
 class SelectorFamilyConventions : public Conventions {
-  SelectorFamily Family;
+  ObjCSelectorFamily Family;
 
 public:
-  SelectorFamilyConventions(SelectorFamily family)
+  SelectorFamilyConventions(ObjCSelectorFamily family)
     : Conventions(ConventionsKind::SelectorFamily), Family(family) {}
 
   ParameterConvention getIndirectParameter(unsigned index,
@@ -1836,14 +1798,14 @@ public:
 
   ResultConvention getResult(const TypeLowering &tl) const override {
     switch (Family) {
-    case SelectorFamily::Alloc:
-    case SelectorFamily::Copy:
-    case SelectorFamily::Init:
-    case SelectorFamily::MutableCopy:
-    case SelectorFamily::New:
+    case ObjCSelectorFamily::Alloc:
+    case ObjCSelectorFamily::Copy:
+    case ObjCSelectorFamily::Init:
+    case ObjCSelectorFamily::MutableCopy:
+    case ObjCSelectorFamily::New:
       return ResultConvention::Owned;
 
-    case SelectorFamily::None:
+    case ObjCSelectorFamily::None:
       // Defaults below.
       break;
     }
@@ -1860,7 +1822,7 @@ public:
 
   ParameterConvention
   getDirectSelfParameter(const AbstractionPattern &type) const override {
-    if (Family == SelectorFamily::Init)
+    if (Family == ObjCSelectorFamily::Init)
       return ParameterConvention::Direct_Owned;
     return ObjCSelfConvention;
   }
@@ -1879,7 +1841,7 @@ public:
 } // end anonymous namespace
 
 static CanSILFunctionType
-getSILFunctionTypeForSelectorFamily(SILModule &M, SelectorFamily family,
+getSILFunctionTypeForSelectorFamily(SILModule &M, ObjCSelectorFamily family,
                                     CanAnyFunctionType origType,
                                     CanAnyFunctionType substInterfaceType,
                                     AnyFunctionType::ExtInfo extInfo,


### PR DESCRIPTION
SILFunctionType has some logic which examines a selector and decides if it belongs to one of Objective-C’s special “method families”, like `-alloc*` and `-copy*`, which need to return a retained object instead of an autoreleased one. This change extracts most of that logic into SwiftAST as `ObjCSelector::getSelectorFamily()`, while leaving details specific to SIL’s use of it behind.