### PR TITLE
[TypeChecker] Disable perf test-case for rdar://problem/21398466

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+// REQUIRES: rdar48061151
 
 // This problem is related to renaming,
 // as soon as `init(truncatingBitPattern:)` is changed


### PR DESCRIPTION
Looks like obsoleted initializer has been removed,
and there are no solutions available for 'init(truncatingBitPattern:)'
which leads to performance regression with designated types enabled.

Resolves: rdar://problem/48061151

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
