### PR TITLE
[stdlib] Make some trivial Substring methods inlinable

### DIFF
--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -199,8 +199,9 @@ extension Substring: StringProtocol {
     return _slice.distance(from: start, to: end)
   }
 
+  @inlinable
   public subscript(i: Index) -> Character {
-    return _slice[i]
+    @inline(__always) get { return _slice[i] }
   }
 
   public mutating func replaceSubrange<C>(
@@ -402,12 +403,15 @@ extension Substring.UTF8View : BidirectionalCollection {
     _slice._failEarlyRangeCheck(range, bounds: bounds)
   }
 
+  @inlinable
   public func index(before i: Index) -> Index { return _slice.index(before: i) }
 
+  @inlinable
   public func formIndex(before i: inout Index) {
     _slice.formIndex(before: &i)
   }
 
+  @inlinable
   public subscript(r: Range<Index>) -> Substring.UTF8View {
     // FIXME(strings): tests.
     _precondition(r.lowerBound >= startIndex && r.upperBound <= endIndex,
@@ -804,5 +808,3 @@ extension Substring {
     return Substring(_slice[r])
   }
 }
-
-


### PR DESCRIPTION
These look like simple oversights.

CC @milseman 