### PR TITLE
Don't prompt for credentials in update_checkout

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -223,20 +223,24 @@ def obtain_additional_swift_sources(pool_args):
         print("Cloning '" + repo_name + "'")
 
         if skip_history:
-            shell.run(['git', 'clone', '--recursive', '--depth', '1',
-                       '--branch', repo_branch, remote, repo_name],
+            shell.run(['GIT_TERMINAL_PROMPT=0', 'git', 'clone', '--recursive',
+                       '--depth', '1', '--branch',
+                       repo_branch, remote, repo_name],
                       echo=True)
         else:
-            shell.run(['git', 'clone', '--recursive', remote,
-                       repo_name], echo=True)
+            shell.run(['GIT_TERMINAL_PROMPT=0', 'git', 'clone', '--recursive',
+                       remote, repo_name],
+                      echo=True)
         if scheme_name:
             src_path = os.path.join(SWIFT_SOURCE_ROOT, repo_name, ".git")
-            shell.run(['git', '--git-dir', src_path, '--work-tree',
+            shell.run(['GIT_TERMINAL_PROMPT=0', 'git', '--git-dir', src_path,
+                       '--work-tree',
                        os.path.join(SWIFT_SOURCE_ROOT, repo_name),
                        'checkout', repo_branch], echo=False)
     with shell.pushd(os.path.join(SWIFT_SOURCE_ROOT, repo_name),
                      dry_run=False, echo=False):
-        shell.run(["git", "submodule", "update", "--recursive"],
+        shell.run(['GIT_TERMINAL_PROMPT=0', "git", "submodule", "update",
+                   "--recursive"],
                   echo=False)
 
 

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -223,24 +223,24 @@ def obtain_additional_swift_sources(pool_args):
         print("Cloning '" + repo_name + "'")
 
         if skip_history:
-            shell.run(['GIT_TERMINAL_PROMPT=0', 'git', 'clone', '--recursive',
-                       '--depth', '1', '--branch',
+            shell.run(['env', 'GIT_TERMINAL_PROMPT=0', 'git', 'clone',
+                       '--recursive', '--depth', '1', '--branch',
                        repo_branch, remote, repo_name],
                       echo=True)
         else:
-            shell.run(['GIT_TERMINAL_PROMPT=0', 'git', 'clone', '--recursive',
-                       remote, repo_name],
+            shell.run(['env', 'GIT_TERMINAL_PROMPT=0', 'git', 'clone',
+                       '--recursive', remote, repo_name],
                       echo=True)
         if scheme_name:
             src_path = os.path.join(SWIFT_SOURCE_ROOT, repo_name, ".git")
-            shell.run(['GIT_TERMINAL_PROMPT=0', 'git', '--git-dir', src_path,
-                       '--work-tree',
+            shell.run(['env', 'GIT_TERMINAL_PROMPT=0', 'git', '--git-dir',
+                       src_path, '--work-tree',
                        os.path.join(SWIFT_SOURCE_ROOT, repo_name),
                        'checkout', repo_branch], echo=False)
     with shell.pushd(os.path.join(SWIFT_SOURCE_ROOT, repo_name),
                      dry_run=False, echo=False):
-        shell.run(['GIT_TERMINAL_PROMPT=0', "git", "submodule", "update",
-                   "--recursive"],
+        shell.run(['env', 'GIT_TERMINAL_PROMPT=0', "git", "submodule",
+                   "update", "--recursive"],
                   echo=False)
 
 


### PR DESCRIPTION
The script is not supposed to be interactive, so it's OK to just fail if
it's unable to authenticate the user.