### PR TITLE
Move an ineffective variable initialization to a where is has an effect

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2527,10 +2527,6 @@ for host in "${ALL_HOSTS[@]}"; do
                       -DLLDB_BUILD_FRAMEWORK:BOOL=TRUE
                       -DLLDB_CODESIGN_IDENTITY=""
                     )
-                    if [[ "${ENABLE_ASAN}" ]] ; then
-                      # Limit the number of parallel tests
-                      LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --threads=$(sysctl hw.physicalcpu | awk '{ print $2 }')"
-                    fi
                   fi
                 fi
                 ;;
@@ -3134,9 +3130,15 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Prefer to use lldb-dotest, as building it guarantees that we build all
                 # test dependencies. Ultimately we want to delete as much lldb-specific logic
                 # from this file as possible and just have a single call to lldb-dotest.
+
+                if [[ "${ENABLE_ASAN}" ]] ; then
+                    # Limit the number of parallel tests
+                    LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --threads=$(sysctl hw.physicalcpu | awk '{ print $2 }')"
+                fi
+
                 if [[ "$using_xcodebuild" == "FALSE" ]] ; then
                     with_pushd ${lldb_build_dir} \
-                     call ${NINJA_BIN} unittests/LLDBUnitTests
+                          call ${NINJA_BIN} unittests/LLDBUnitTests
                     with_pushd ${results_dir} \
                           call "${llvm_build_dir}/bin/llvm-lit" \
                                "${lldb_build_dir}/lit" \


### PR DESCRIPTION
The original location was only invoked when build-script invked cmake
and on top of that it did not actually make it into the cmake command
line. Since build-script is running lit manually anyway, we can just
move it over there.
