### PR TITLE
Assure DIFiles get the directory name during IRCodeGen

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -358,6 +358,18 @@ private:
 
 #endif
 
+  StringRef getCurrentDirname() {
+    if (!IGM.getOptions().DebugCompilationDir.empty())
+      return IGM.getOptions().DebugCompilationDir;
+
+    if (!CWDName.empty())
+      return CWDName;
+
+    SmallString<256> CWD;
+    llvm::sys::fs::current_path(CWD);
+    return CWDName = BumpAllocatedString(CWD);
+  }
+
   llvm::DIFile *getOrCreateFile(StringRef Filename) {
     if (Filename.empty())
       Filename = SILLocation::getCompilerGeneratedDebugLoc().Filename;
@@ -388,6 +400,8 @@ private:
     llvm::SmallString<512> Path(Filename);
     llvm::sys::path::remove_filename(Path);
     llvm::sys::path::remove_dots(Path);
+    if (Path.size() == 0)
+      Path = getCurrentDirname();
     llvm::DIFile *F = DBuilder.createFile(DebugPrefixMap.remapPath(File),
                                           DebugPrefixMap.remapPath(Path));
 


### PR DESCRIPTION
PDB generation assumes DIFiles have both a filename and a directory.
IRGenDebugInfoImpl currently checks if an absolute path is given for
the Filename and if not it just moves forward with only the filename
which causes PDB generation to be broken.

Clang handles a non absolute path for a file by by first querying the
DebugCompilationDir then the IGM.CWDName and lastly just getting
llvm::sys::fs::current_path. We should do the same here.
