### PR TITLE
Generate CodeView by deafult for Windows

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -918,8 +918,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
   } else if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::None) {
-    // If -g was specified but not -debug-info-format, DWARF is assumed.
-    Opts.DebugInfoFormat = IRGenDebugInfoFormat::DWARF;
+    if (Triple.isWindowsMSVCEnvironment()) {
+      Opts.DebugInfoFormat = IRGenDebugInfoFormat::CodeView;
+    } else {
+      Opts.DebugInfoFormat = IRGenDebugInfoFormat::DWARF;
+    }
   }
   if (Args.hasArg(options::OPT_debug_info_format) &&
       !Args.hasArg(options::OPT_g_Group)) {

--- a/test/DebugInfo/windows-debug-info-format.swift
+++ b/test/DebugInfo/windows-debug-info-format.swift
@@ -1,0 +1,6 @@
+// RUN: %swift-frontend -target x86_64-unknown-windows-msvc -g -emit-ir %s \
+// RUN:   | %FileCheck %s
+// CHECK: i32 2, !"CodeView", i32 1}
+
+// REQUIRES: OS=windows
+


### PR DESCRIPTION
llvm, lldb and swift combine to offer better support for PDBs on
Windows than it does DWARF. Default to generating PDBs on Windows.