### PR TITLE
Runtime: Replace some dlsym() calls with direct (weak) references

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -43,7 +43,6 @@
 #else
 #include <sys/mman.h>
 #include <unistd.h>
-#include <dlfcn.h>
 #endif
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
@@ -2721,13 +2720,6 @@ _swift_updateClassMetadataImpl(ClassMetadata *self,
                                const TypeLayout * const *fieldTypes,
                                size_t *fieldOffsets,
                                bool allowDependency) {
-#ifndef OBJC_REALIZECLASSFROMSWIFT_DEFINED
-  // Temporary workaround until _objc_realizeClassFromSwift is in the SDK.
-  static auto _objc_realizeClassFromSwift =
-    (Class (*)(Class _Nullable, void* _Nullable))
-    dlsym(RTLD_NEXT, "_objc_realizeClassFromSwift");
-#endif
-
   bool requiresUpdate = (_objc_realizeClassFromSwift != nullptr);
 
   // If we're on a newer runtime, we're going to be initializing the

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -47,7 +47,6 @@ using namespace reflection;
 #include <objc/runtime.h>
 #include <objc/message.h>
 #include <objc/objc.h>
-#include <dlfcn.h>
 #endif
 
 /// Produce a Demangler value suitable for resolving runtime type metadata
@@ -1387,12 +1386,6 @@ swift_stdlib_getTypeByMangledNameUntrusted(const char *typeNameStart,
 // Return the ObjC class for the given type name.
 // This gets installed as a callback from libobjc.
 
-// FIXME: delete this #if and dlsym once we don't
-// need to build with older libobjc headers
-#if !OBJC_GETCLASSHOOK_DEFINED
-using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
-                                    Class _Nullable * _Nonnull outClass);
-#endif
 static objc_hook_getClass OldGetClassHook;
 
 static BOOL
@@ -1418,17 +1411,6 @@ getObjCClassByMangledName(const char * _Nonnull typeName,
 
 __attribute__((constructor))
 static void installGetClassHook() {
-  // FIXME: delete this #if and dlsym once we don't
-  // need to build with older libobjc headers
-#if !OBJC_GETCLASSHOOK_DEFINED
-  using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
-                                      Class _Nullable * _Nonnull outClass);
-  auto objc_setHook_getClass =
-    (void(*)(objc_hook_getClass _Nonnull,
-             objc_hook_getClass _Nullable * _Nonnull))
-    dlsym(RTLD_DEFAULT, "objc_setHook_getClass");
-#endif
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
   if (objc_setHook_getClass) {


### PR DESCRIPTION
Xcode 10.2 ships new SDKs that declare these symbols so we don't need to use
dlsym() to look them up anymore.