### PR TITLE
Install signal handler to exit upon SIGINT.

### DIFF
--- a/stdlib/public/CTensorFlow/ctensorflow_init.cpp
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.cpp
@@ -6,14 +6,23 @@
 #include "tensorflow/core/platform/init_main.h"
 
 #include <assert.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
 
 extern "C" {
 
+void handle_sigint(int signal) {
+  printf("Caught interrupt signal, exiting...\n");
+  exit(1);
+}
+
 void InitTensorFlowRuntime(unsigned char enable_debug_logging,
                            int verbose_level) {
+  // Install a signal handler to ensure we exit when interrupted.
+  signal(SIGINT, handle_sigint);
+
   // Synthesize argc and argv
   char arg0[] = "dummyProgramName";
   std::vector<char*> my_argv;


### PR DESCRIPTION
Normally, signal handling gets confused when using TensorFlow. In order to
restore Ctrl-C (aka SIGINT) functionality, this commit installs a signal
handler upon initializing TensorFlow. This restores expected Ctrl-C
functionality.

See the following terminal output showing the correct signal handler being
invoked and the proper behavior (exiting) occurring:

```bash
saeta@saeta:~/src/tmp$ ../s4tf/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swiftc main.swift
saeta@saeta:~/src/tmp$ ./main
Hello world!
About to sleep...
^CCaught interrupt signal, exiting...
saeta@saeta:~/src/tmp$ cat main.swift
import TensorFlow

print("Hello world!")

let images = Tensor(ShapedArray(0))
let weirdo = images * images

print("About to sleep...")
sleep(100);
print("Done sleeping!")
saeta@saeta:~/src/tmp$
```

Resolves [TF-36](https://bugs.swift.org/browse/TF-36).
