### PR TITLE
[Sema] TF-198: Fix `@dynamicCallable` code completion crasher.

### DIFF
--- a/test/IDE/complete_tf_198.swift
+++ b/test/IDE/complete_tf_198.swift
@@ -1,0 +1,7 @@
+// https://bugs.swift.org/browse/TF-198: `@dynamicCallable` REPL completer crash.
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename=%s
+
+// TODO(TF-214): Require `python` lit feature, after it is created.
+
+import Python
+Python.str("name").strip(


### PR DESCRIPTION
Previously, `finishApplyDynamicCallable` in `CSApply.cpp` created new implicit array/dictionary argument expressions without propagating source location information.

This led to the crash in [TF-198](https://bugs.swift.org/browse/TF-198) because a `@dynamicCallable` `CallExpr` had an invalid source range:
* The start location was invalid (it came from another `@dynamicCallable` expression, whose start location was erased in `finishApplyDynamicCallable`).
* But the end location was valid (it came from a `@dynamicMemberLookup` subscript expression, which had propagated source loc info).

Now, `finishApplyDynamicCallable` propagates source location info to synthesized argument expressions.

Minor cleanup/gardening.

Resolves [TF-198](https://bugs.swift.org/browse/TF-198).