### PR TITLE
[5.0] [ABI] [GSB] Consistently use nested type name match constraints.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2100,7 +2100,9 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   // Infer same-type constraints among same-named associated type anchors.
   if (assocTypeAnchors.size() > 1) {
     auto anchorType = getAnchor(builder, builder.getGenericParams());
-    auto inferredSource = FloatingRequirementSource::forInferred(nullptr);
+    auto inferredSource =
+      FloatingRequirementSource::forNestedTypeNameMatch(
+        assocTypeAnchors.front()->getName());
     for (auto assocType : assocTypeAnchors) {
       if (assocType == bestAssocType) continue;
 
@@ -4732,7 +4734,8 @@ void GenericSignatureBuilder::addedNestedType(PotentialArchetype *nestedPA) {
   if (allNested.size() > 1) {
     auto firstPA = allNested.front();
     auto inferredSource =
-      FloatingRequirementSource::forInferred(nullptr);
+      FloatingRequirementSource::forNestedTypeNameMatch(
+        nestedPA->getNestedName());
 
     addSameTypeRequirement(firstPA, nestedPA, inferredSource,
                            UnresolvedHandlingKind::GenerateConstraints);

--- a/test/Generics/Inputs/rdar48049725_other.swift
+++ b/test/Generics/Inputs/rdar48049725_other.swift
@@ -1,0 +1,17 @@
+public protocol P1 {
+  associatedtype A1: SomeClass
+}
+
+public protocol P4: P2 where A2: P1 {}
+
+
+public class SomeClass { }
+
+protocol P5 {
+  associatedtype A3: P4
+}
+
+struct Foo {
+  static func f<T: P5>(_: T) {
+  }
+}

--- a/test/Generics/rdar48049725.swift
+++ b/test/Generics/rdar48049725.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir %S/Inputs/rdar48049725_other.swift | %FileCheck %s
+public protocol P3 {
+  associatedtype A1: SomeClass
+}
+
+
+public protocol P2 {
+  associatedtype A2: P3
+}
+
+
+func test<T: P5>(value: T) {
+  // Ensure that we get the right generic signature for Foo.f
+  // CHECK: call swiftcc void @"$s12rdar480497253FooV1fyyxAA2P5RzlFZ"
+  Foo.f(value)
+}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -154,12 +154,11 @@ protocol P10 {
 }
 
 // CHECK-LABEL: sameTypeConcrete1@
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.A == X3, τ_0_0.A == X3, τ_0_0.B == Int, τ_0_0.C == Int>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.A == X3, τ_0_0.B == Int, τ_0_0.C == Int>
 func sameTypeConcrete1<T : P9 & P10>(_: T) where T.A == X3, T.C == T.B, T.C == Int { }
 
 // CHECK-LABEL: sameTypeConcrete2@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.B == X3, τ_0_0.C == X3>
-// FIXME: Should have τ_0_0.A == τ_0_0.A
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
 // expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
 // expected-note@-2{{same-type constraint 'T.C' == 'X3' written here}}
@@ -402,7 +401,7 @@ protocol P30 {
 protocol P31 { }
 
 // CHECK-LABEL: .sameTypeNameMatch1@
-// CHECK: Generic signature: <T where T : P29, T : P30, T.X : P31, T.X == T.X>
+// CHECK: Generic signature: <T where T : P29, T : P30, T.X : P31>
 func sameTypeNameMatch1<T: P29 & P30>(_: T) where T.X: P31 { }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We generated a mix of "inferred" and "nested type name match"
constraints for the case where we had two nested types with the same
name and inferred that they are equal. Make them consistent by always
using nested type name match constraints. This fixes a bug where we
would get different canonical generic signatures in different source
files because we inferred the same-type constraint with different
requirement sources.

Fixes rdar://problem/48049725.

**ABI Note** This pull request *does* change the ABI by fixing a bug in 
the minimization algorithm used by the generic signature builder, in a
particular corner case. Neither the standard library nor the overlays
contain any cases where the bug manifest, so it is not ABI breaking
for those.