### PR TITLE
Add a preliminary module map for the Swift include directory.

### DIFF
--- a/include/swift/AST/FileSystem.h
+++ b/include/swift/AST/FileSystem.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/FileSystem.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsCommon.h"
 
 namespace swift {
 

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -20,6 +20,7 @@
 namespace swift {
 
 class ModuleDecl;
+class CompilerInvocation;
 
 /// Options for controlling the generation of the .swiftinterface output.
 struct ParseableInterfaceOptions {

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -1,0 +1,157 @@
+// This is defined as one big module because there are cyclic dependencies
+// between the submodules all over the place. Breaking this up may actually
+// speed up compilation.
+
+module Swift {
+  // FIXME: Define submodules for all the other directories.
+
+  module Strings {
+    requires cplusplus
+    header "Strings.h"
+    export *
+  }
+
+  module ABI {
+    requires cplusplus
+    // No submodules, there are missing includes.
+    umbrella "ABI"
+   
+    // These headers introduce a cyclic dependency with Swift_Shims.
+    textual header "ABI/HeapObject.h"
+    textual header "ABI/KeyPath.h"
+    textual header "ABI/Metadata.h"
+    textual header "ABI/MetadataValues.h"
+    textual header "ABI/System.h"
+   
+    textual header "ABI/MetadataKind.def"
+    textual header "ABI/ValueWitness.def"
+  }
+
+  module AST {
+    requires cplusplus
+    umbrella "AST" //module * { export * }
+    textual header "AST/ReferenceStorage.def"
+    textual header "AST/StmtNodes.def"
+    textual header "AST/AccessTypeIDZone.def"
+    textual header "AST/TypeCheckerTypeIDZone.def"
+    textual header "AST/AccessorKinds.def"
+    textual header "AST/TypeNodes.def"
+    textual header "AST/Attr.def"
+    textual header "AST/TypeReprNodes.def"
+    textual header "AST/Builtins.def"
+    textual header "AST/DeclNodes.def"
+    textual header "AST/DiagnosticsAll.def"
+    textual header "AST/DiagnosticsClangImporter.def"
+    textual header "AST/DiagnosticsCommon.def"
+    textual header "AST/DiagnosticsDriver.def"
+    textual header "AST/DiagnosticsFrontend.def"
+    textual header "AST/DiagnosticsIRGen.def"
+    textual header "AST/DiagnosticsModuleDiffer.def"
+    textual header "AST/DiagnosticsParse.def"
+    textual header "AST/DiagnosticsRefactoring.def"
+    textual header "AST/DiagnosticsSIL.def"
+    textual header "AST/DiagnosticsSema.def"
+    textual header "AST/ExprNodes.def"
+    textual header "AST/KnownDecls.def"
+    textual header "AST/KnownFoundationEntities.def"
+    textual header "AST/KnownIdentifiers.def"
+    textual header "AST/KnownProtocols.def"
+    textual header "AST/KnownStdlibTypes.def"
+    textual header "AST/NameLookupTypeIDZone.def"
+    textual header "AST/PatternNodes.def"
+    textual header "AST/PlatformKinds.def"
+
+    // Missing include.
+    textual header "AST/DiagnosticsCommon.h"
+    textual header "AST/FileSystem.h"
+
+    // Included inside a namespace.
+    textual header "Basic/DefineTypeIDZone.h"
+    textual header "Basic/ImplementTypeIDZone.h"
+  }
+
+  module Basic {
+    requires cplusplus
+    umbrella "Basic" module * { export * }
+    textual header "Basic/CTypeIDZone.def"
+    textual header "Basic/FileTypes.def"
+    textual header "Basic/Statistics.def"
+
+    // This is included by Swift_Shims.
+    textual header "Basic/type_traits.h"
+    textual header "Basic/Compiler.h"
+  }
+
+  module Demangling {
+    requires cplusplus
+    umbrella "Demangling" module * { export * }
+    textual header "Demangling/DemangleNodes.def"
+    textual header "Demangling/StandardTypesMangling.def"
+    textual header "Demangling/ValueWitnessMangling.def"
+  }
+
+  module Frontend {
+    requires cplusplus
+    umbrella "Frontend" module * { export * }
+  }
+
+  module Parse {
+    requires cplusplus
+    umbrella "Parse" module * { export * }
+  }
+
+  module IDE {
+    requires cplusplus
+    umbrella "IDE" module * { export * }
+    textual header "IDE/DigesterEnums.def"
+    textual header "IDE/RefactoringKinds.def"
+  }    
+
+  module Reflection {
+    requires cplusplus
+    umbrella "Reflection" module * { export * }
+    textual header "Reflection/MetadataSources.def"
+    textual header "Reflection/TypeRefs.def"    
+  }
+
+  module Remote {
+    requires cplusplus
+    umbrella "Remote" module * { export * }
+    textual header "Remote/FailureKinds.def"
+  }
+
+  module RemoteAST {
+    requires cplusplus
+    umbrella "RemoteAST" module * { export * }
+  }
+
+  module Runtime {
+    requires cplusplus
+    umbrella "Runtime" module * { export * }
+   
+    // These two headers introduce a cyclic dependency with Swift_Shims.
+    textual header "Runtime/Config.h"
+    textual header "Runtime/HeapObject.h"
+   
+    textual header "Runtime/BuiltinTypes.def"
+
+    textual header "Runtime/Atomic.h"
+    textual header "Runtime/Debug.h"
+    textual header "Runtime/Unreachable.h"
+   
+    module MutexWin32 {
+      header "Runtime/MutexWin32.h"
+      requires windows
+    }
+  }
+
+  module SIL {
+    requires cplusplus
+    umbrella "SIL" module * { export * }
+    textual header "SIL/AccessedStorage.def"
+    textual header "SIL/BridgedTypes.def"
+    textual header "SIL/SILNodes.def"
+  }
+
+  extern module SwiftShims "../../stdlib/public/SwiftShims/module.modulemap"
+}

--- a/stdlib/public/SwiftShims/module.modulemap
+++ b/stdlib/public/SwiftShims/module.modulemap
@@ -3,11 +3,11 @@ module SwiftShims {
   header "CoreFoundationShims.h"
   header "FoundationShims.h"
   header "GlobalObjects.h"
-  header "HeapObject.h"
+  textual header "HeapObject.h"
   header "KeyPath.h"
   header "LibcShims.h"
   header "Random.h"
-  header "RefCount.h"
+  textual header "RefCount.h"
   header "RuntimeShims.h"
   header "RuntimeStubs.h"
   header "SwiftStdbool.h"
@@ -16,7 +16,7 @@ module SwiftShims {
   header "System.h"
   header "ThreadLocalStorage.h"
   header "UnicodeShims.h"
-  header "Visibility.h"
+  textual header "Visibility.h"
   export *
 }
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -667,6 +667,9 @@ function set_build_options_for_host() {
                 -DSANITIZER_MIN_OSX_VERSION="${cmake_osx_deployment_target}"
                 -DLLVM_ENABLE_MODULES:BOOL="$(true_false ${LLVM_ENABLE_MODULES})"
             )
+	    lldb_cmake_options=(
+                -DLLVM_ENABLE_MODULES:BOOL="$(true_false ${LLVM_ENABLE_MODULES})"
+	    )
             if [[ $(is_llvm_lto_enabled) == "TRUE" ]]; then
                 if [[ $(cmake_needs_to_specify_standard_computed_defaults) == "TRUE" ]]; then
                     llvm_cmake_options+=(
@@ -752,7 +755,6 @@ function set_build_options_for_host() {
         -DSWIFT_HOST_VARIANT_SDK="${SWIFT_HOST_VARIANT_SDK}"
         -DSWIFT_HOST_VARIANT_ARCH="${SWIFT_HOST_VARIANT_ARCH}"
     )
-
     if [[ "${LLVM_LIT_ARGS}" ]]; then
         llvm_cmake_options+=(
             -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS}"


### PR DESCRIPTION
This is a preliminary module map that is just barely good enough to compile LLDB. Getting this to work at all turned out to be quite difficult because there are many cyclic dependencies between the various directories as well as a bunch of missing includes. I have not tried building Swift with this modulemap yet.