### PR TITLE
[AutoDiff] TF-216: Fix adjoint buffer allocation logic.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3524,11 +3524,11 @@ private:
     if (!insertion.second) // not inserted
       return insertion.first->getSecond();
     // Set insertion point for local allocation builder: before the last local
-    // allocation, or at the end of the adjoint entry BB if no local allocations
-    // exist.
+    // allocation, or at the start of the adjoint entry BB if no local
+    // allocations exist yet.
     if (localAllocations.empty())
       localAllocBuilder.setInsertionPoint(
-          getAdjoint().getEntryBlock()->begin());
+          getAdjoint().getEntryBlock(), getAdjoint().getEntryBlock()->begin());
     else
       localAllocBuilder.setInsertionPoint(
           localAllocations.back().getValue()->getDefiningInstruction());

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3551,8 +3551,7 @@ private:
       else
         b.createDestroyAddr(loc, v);
     };
-    auto bufWithCleanup =
-        ValueWithCleanup(newBuf, makeCleanup(newBuf, cleanupFn));
+    ValueWithCleanup bufWithCleanup(newBuf, makeCleanup(newBuf, cleanupFn));
     localAllocations.push_back(bufWithCleanup);
     return (insertion.first->getSecond() = bufWithCleanup);
   }


### PR DESCRIPTION
Previously, `AdjointEmitter::getAdjointBuffer` allocated adjoint buffers at the current
SILBuilder position. Those adjoint buffers were freed at the end of the adjoint function.

However, this breaks modular allocation/deallocation in AdjointGen for instructions like
`alloc_stack` and `dealloc_stack`.

Now, adjoint local buffer allocation is modular:
- Local buffers are allocated at the beginning of the adjoint entry BB
  (done in `AdjointEmitter::getAdjointBuffer`).
- Those buffers are deallocated at the end of the adjoint exit BB
  (done in `AdjointEmitter::run`).

Remove old code for setting original indirect parameter adjoint buffers.
Minor gardening.

Resolves [TF-216](https://bugs.swift.org/browse/TF-216).