### PR TITLE
[NFC] Add TODO comments regarding TF-213.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2442,6 +2442,7 @@ ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
+// TODO(TF-213): Remove after generic signature minimization bug fix.
 ERROR(differentiable_need_explicit_addarith_conformance,none,
       "synthesizing a conformance to 'Differentiable' requires an explicit "
       "'%0' conformance constraint", (StringRef))

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -686,8 +686,8 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   // If the associated type is `TangentVector` or `CotangentVector`, make it
   // also conform to `AdditiveArithmetic`.
   if (id == C.Id_TangentVector || id == C.Id_CotangentVector) {
-    // FIXME: conforming to `AdditiveArithmetic` should always be possible.
-    // Otherwise, SR-9595 is triggered; diagnose and return `nullptr`.
+    // Diagnose missing `AdditiveArithmetic` conformance and return `nullptr`.
+    // TODO(TF-213): Remove logic after generic signature minimization bug fix.
     if (canDeriveAdditiveArithmetic) {
       inherited.push_back(addArithType);
     } else {

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -16,6 +16,7 @@ func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
 _ = gradient(at: 1.0, in: generic) // expected-error {{function is not differentiable}}
 
 // FIXME(TF-202): Diagnose "no conformance to `AdditiveArithmetic`" in differentiation pass.
+// TODO(TF-213): Remove this test after generic signature minimization bug fix.
 /*
 @differentiable
 func directMissingConformance<T : Differentiable>(_ x: T) -> T {
@@ -24,6 +25,7 @@ func directMissingConformance<T : Differentiable>(_ x: T) -> T {
 */
 
 @differentiable
+// TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
 func direct<T : Differentiable>(_ x: T) -> T where T.TangentVector : AdditiveArithmetic, T.CotangentVector : AdditiveArithmetic {
   return x
 }

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -185,8 +185,7 @@ struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differen
 }
 
 // Test type with generic members that conform to `Differentiable`.
-// FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
-// due to `Differentiable` protocol generic signature minimization bug.
+// TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
 // expected-error @+1 {{type 'GenericSynthesizeAllStructs<T>' does not conform to protocol 'Differentiable'}}
 struct GenericSynthesizeAllStructs<T> : Differentiable
   where T : Differentiable
@@ -197,8 +196,7 @@ struct GenericSynthesizeAllStructs<T> : Differentiable
 }
 
 // Test generic type with vector space types to `Self`.
-// FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
-// due to `Differentiable` protocol generic signature minimization bug.
+// TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
 // expected-error @+1 {{type 'GenericNotAdditiveArithmetic<T>' does not conform to protocol 'Differentiable'}}
 struct GenericNotAdditiveArithmetic<T> : Differentiable
   where T : Differentiable, T == T.TangentVector, T == T.CotangentVector
@@ -209,8 +207,7 @@ struct GenericNotAdditiveArithmetic<T> : Differentiable
 }
 
 // Test type in generic context.
-// FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
-// due to `Differentiable` protocol generic signature minimization bug.
+// TODO(TF-213): Update after generic signature minimization bug fix.
 struct A<T : Differentiable> {
   struct B<U : Differentiable, V> : Differentiable {
     // expected-error @+1 {{type 'A<T>.B<U, V>.InGenericContext' does not conform to protocol 'Differentiable'}}
@@ -232,8 +229,7 @@ struct Extended {
 extension Extended : Differentiable {}
 
 // Test extension of generic type.
-// FIXME: Blocked by SR-9595: type checker cannot infer `T.TangentVector : AdditiveArithmetic`
-// due to `Differentiable` protocol generic signature minimization bug.
+// TODO(TF-213): Update after generic signature minimization bug fix.
 struct GenericExtended<T> {
   // expected-error @+1 {{synthesizing a conformance to 'Differentiable' requires an explicit 'T.TangentVector : AdditiveArithmetic' conformance constraint}}
   var x: T
@@ -241,7 +237,8 @@ struct GenericExtended<T> {
 // expected-error @+1 {{type 'GenericExtended<T>' does not conform to protocol 'Differentiable'}}
 extension GenericExtended : Differentiable where T : Differentiable {}
 
-// Test constrained extension of generic type (workaround for SR-9595).
+// Test constrained extension of generic type.
+// TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
 struct GenericConstrained<T> {
   var x: T
 }

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -17,6 +17,7 @@ import TensorFlowUnittest
 var TensorADTests = TestSuite("TensorIndirectAD")
 
 TensorADTests.testAllBackends("Generic") {
+  // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
   func indirect<Scalar : Differentiable & FloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar>
     where Scalar.TangentVector : AdditiveArithmetic, Scalar.CotangentVector : AdditiveArithmetic,
           Scalar == Scalar.CotangentVector
@@ -36,6 +37,7 @@ TensorADTests.testAllBackends("Concrete") {
   expectEqual(Tensor(18), pullback(at: Tensor<Float>(3), in: indirect)(Tensor(3)))
 }
 
+// TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
 extension Tensor where Scalar : Differentiable & FloatingPoint,
                        Scalar.TangentVector : AdditiveArithmetic,
                        Scalar.CotangentVector : AdditiveArithmetic {
@@ -65,6 +67,7 @@ extension Double : Addable {
   }
 }
 TensorADTests.testAllBackends("ResultSelection") {
+  // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
   func indirect<T : Addable>(_ x: T, _ y: T) -> (T, T) where T.TangentVector : AdditiveArithmetic,
                                                              T.CotangentVector : AdditiveArithmetic {
     let first = T.add(x, x)


### PR DESCRIPTION
Mark code to-be-updated after [TF-213](https://bugs.swift.org/browse/TF-213) (generic signature minimization bug) is fixed, for easy grepping.