### PR TITLE
[Sema] Fix derived conformances crashers.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3264,8 +3264,10 @@ public:
   Optional<KeyPathTypeKind> getKeyPathTypeKind() const;
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Get the memberwise initializer of the nominal type, if it exists.
-  ConstructorDecl *getMemberwiseInitializer();
+  /// Get effective memberwise initializer for the given nominal type, if it
+  /// exists: either a synthesized memberwise initializer or a user-defined
+  /// initializer with the same signature.
+  ConstructorDecl *getEffectiveMemberwiseInitializer();
 
   // SWIFT_ENABLE_TENSORFLOW
   /// Add `@_fixed_layout` attribute to the nominal type, if possible.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2447,8 +2447,9 @@ ERROR(differentiable_need_explicit_addarith_conformance,none,
       "synthesizing a conformance to 'Differentiable' requires an explicit "
       "'%0' conformance constraint", (StringRef))
 WARNING(differentiable_implicit_noderivative_fixit,none,
-      "stored property has no derivative because it does not conform to "
-      "'Differentiable'; add '@noDerivative' to make it explicit", ())
+      "stored property %0 has no derivative because it does not conform to "
+      "'Differentiable'; add '@noDerivative' to make it explicit",
+      (Identifier))
 NOTE(protocol_witness_missing_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3092,10 +3092,11 @@ ConstructorDecl *NominalTypeDecl::getEffectiveMemberwiseInitializer() {
                       getStoredProperties().end());
     auto ctorType =
         ctorDecl->getMethodInterfaceType()->castTo<AnyFunctionType>();
-    // Return false if parameter count/stored property count do not match.
+    // Return false if stored property/initializer parameter count do not match.
     if (numStoredProperties != ctorType->getNumParams())
       return false;
-    // Return true if stored property types/names match parameter types/labels.
+    // Return true if all stored property types/names match initializer
+    // parameter types/labels.
     return llvm::all_of(
         llvm::zip(getStoredProperties(), ctorType->getParams()),
         [&](std::tuple<VarDecl *, AnyFunctionType::Param> pair) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3095,13 +3095,15 @@ ConstructorDecl *NominalTypeDecl::getEffectiveMemberwiseInitializer() {
     // Return false if parameter count/stored property count do not match.
     if (numStoredProperties != ctorType->getNumParams())
       return false;
-    // Return true if stored property types match parameter types.
+    // Return true if stored property types/names match parameter types/labels.
     return llvm::all_of(
         llvm::zip(getStoredProperties(), ctorType->getParams()),
         [&](std::tuple<VarDecl *, AnyFunctionType::Param> pair) {
           auto *storedProp = std::get<0>(pair);
           auto param = std::get<1>(pair);
-          return storedProp->getInterfaceType()->isEqual(param.getPlainType());
+          return storedProp->getInterfaceType()->isEqual(
+                     param.getPlainType()) &&
+                 storedProp->getName() == param.getLabel();
         });
   };
 

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -104,7 +104,7 @@ bool checkOverrides(ValueDecl *decl);
 // These are implemented in CodeSynthesis.cpp.
 
 // SWIFT_ENABLE_TENSORFLOW
-// Made public so that DerivedConformanceParameterized can call it.
+// Made public for use in DerivedConformanceDifferentiable.cpp.
 void addExpectedOpaqueAccessorsToStorage(TypeChecker &TC,
                                          AbstractStorageDecl *storage);
 

--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -182,7 +182,8 @@ static void deriveBodyMathOperator(AbstractFunctionDecl *funcDecl,
   auto &C = nominal->getASTContext();
 
   // Create memberwise initializer: `Nominal.init(...)`.
-  auto *memberwiseInitDecl = nominal->getMemberwiseInitializer();
+  auto *memberwiseInitDecl = nominal->getEffectiveMemberwiseInitializer();
+  assert(memberwiseInitDecl && "Memberwise initializer must exist");
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
   initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
@@ -359,7 +360,8 @@ static void deriveBodyAdditiveArithmetic_zero(AbstractFunctionDecl *funcDecl) {
   auto *nominal = parentDC->getSelfNominalTypeDecl();
   auto &C = nominal->getASTContext();
 
-  auto *memberwiseInitDecl = nominal->getMemberwiseInitializer();
+  auto *memberwiseInitDecl = nominal->getEffectiveMemberwiseInitializer();
+  assert(memberwiseInitDecl && "Memberwise initializer must exist");
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
   initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
@@ -417,10 +419,10 @@ static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
   // The implicit memberwise constructor must be explicitly created so that it
   // can called when synthesizing the `zero` property getter. Normally, the
   // memberwise constructor is synthesized during SILGen, which is too late.
-  if (!nominal->getMemberwiseInitializer()) {
+  if (!nominal->getEffectiveMemberwiseInitializer()) {
     auto *initDecl = createImplicitConstructor(
         TC, nominal, ImplicitConstructorKind::Memberwise);
-    nominal->addMember(initDecl);
+    derived.addMembersToConformanceContext(initDecl);
     C.addSynthesizedDecl(initDecl);
   }
 

--- a/test/Sema/struct_additive_arithmetic.swift
+++ b/test/Sema/struct_additive_arithmetic.swift
@@ -75,3 +75,9 @@ struct GenericExtended<T> {
   var x: T
 }
 extension GenericExtended : Equatable, AdditiveArithmetic where T : AdditiveArithmetic {}
+
+// Test initializer that is not a memberwise initializer because of stored property name vs parameter label mismatch.
+struct HasCustomNonMemberwiseInitializer<T : AdditiveArithmetic>: AdditiveArithmetic {
+  var value: T
+  init(randomLabel value: T) { self.value = value }
+}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -186,6 +186,7 @@ struct TF_25: Differentiable {
     self.bar = bar
   }
 }
+// Test user-defined memberwise initializer.
 // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
 struct TF_25_Generic<T : Differentiable>: Differentiable
   where T.TangentVector : AdditiveArithmetic, T.CotangentVector : AdditiveArithmetic
@@ -194,6 +195,14 @@ struct TF_25_Generic<T : Differentiable>: Differentiable
   public init(bar: T) {
     self.bar = bar
   }
+}
+
+// Test initializer that is not a memberwise initializer because of stored property name vs parameter label mismatch.
+struct HasCustomNonMemberwiseInitializer<T : Differentiable>: Differentiable
+  where T.TangentVector : AdditiveArithmetic, T.CotangentVector : AdditiveArithmetic
+{
+  var value: T
+  init(randomLabel value: T) { self.value = value }
 }
 
 // Test type with generic environment.

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -1,5 +1,5 @@
 // SWIFT_ENABLE_TENSORFLOW
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
 // Verify that a `Differentiable` type upholds `AllDifferentiableVariables == CotangentVector`.
 func assertAllDifferentiableVariablesEqualsCotangentVector<T>(_: T.Type)
@@ -179,6 +179,23 @@ func testKeyPathIterable(x: TestKeyPathIterable) {
   _ = x.allDifferentiableVariables.allKeyPaths
 }
 
+// Test type with user-defined memberwise initializer.
+struct TF_25: Differentiable {
+  public let bar: Float
+  public init(bar: Float) {
+    self.bar = bar
+  }
+}
+// TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
+struct TF_25_Generic<T : Differentiable>: Differentiable
+  where T.TangentVector : AdditiveArithmetic, T.CotangentVector : AdditiveArithmetic
+{
+  public let bar: T
+  public init(bar: T) {
+    self.bar = bar
+  }
+}
+
 // Test type with generic environment.
 struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differentiable {
   var x: Float
@@ -247,6 +264,10 @@ extension GenericConstrained : Differentiable
         T.TangentVector : AdditiveArithmetic,
         T.CotangentVector : AdditiveArithmetic {}
 
+// TF-161: Test conditional conformance of `Array`.
+// expected-warning @+1 {{stored property '_buffer' has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
+extension Array : Differentiable where Element : Differentiable {}
+
 // Test errors.
 
 // Test manually customizing vector space types.
@@ -279,10 +300,10 @@ struct StaticMembersShouldNotAffectAnything : AdditiveArithmetic, Differentiable
 
 struct ImplicitNoDerivative : Differentiable {
   var a: Float
-  var b: Bool // expected-warning {{stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
+  var b: Bool // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
 }
 
 struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
   var x: DifferentiableSubset
-  var b: Bool // expected-warning {{stored property has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  var b: Bool // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }

--- a/test/Sema/struct_vector_numeric.swift
+++ b/test/Sema/struct_vector_numeric.swift
@@ -87,3 +87,9 @@ struct InvalidMixedScalar: VectorNumeric { // expected-error {{type 'InvalidMixe
   var float: Float
   var double: Double
 }
+
+// Test initializer that is not a memberwise initializer because of stored property name vs parameter label mismatch.
+struct HasCustomNonMemberwiseInitializer<T : VectorNumeric>: VectorNumeric {
+  var value: T
+  init(randomLabel value: T) { self.value = value }
+}


### PR DESCRIPTION
- Treat user-defined initializers with appropriate signatures as "effective
  memberwise initializers" to prevent duplicate memberwise initializer errors.
  - Resolves [TF-25](https://bugs.swift.org/projects/TF/issues/TF-25).
- Add synthesized memberwise initializers to the conformance context.
  - Resolves [TF-161](https://bugs.swift.org/projects/TF/issues/TF-161).
- Update "implicit `@noDerivative` stored property" warning.
  - Ensure that diagnostic displays a valid source location (preferably the
    stored property location, or the conformance context location as a backup).
  - Show stored property name in the diagnostic. This is important when
    conformance context location is shown.
  - Remove `-verify-ignore-unknown` from `test/Sema/struct_differentiable.swift`.
- Gardening.