### PR TITLE
Speed up roundtrip syntax tests

### DIFF
--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -76,9 +76,12 @@ class RoundTripTask(object):
 
         contents = ''.join(map(lambda l: l.decode('utf-8', errors='replace'),
                                open(self.input_filename).readlines()))
-        lines = difflib.unified_diff(contents,
-                                     self.stdout.decode('utf-8',
-                                                        errors='replace'),
+        stdout_contents = self.stdout.decode('utf-8', errors='replace')
+
+        if contents == stdout_contents:
+          return None
+
+        lines = difflib.unified_diff(contents, stdout_contents,
                                      fromfile=self.input_filename,
                                      tofile='-')
         diff = '\n'.join(line for line in lines)

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -79,7 +79,7 @@ class RoundTripTask(object):
         stdout_contents = self.stdout.decode('utf-8', errors='replace')
 
         if contents == stdout_contents:
-          return None
+            return None
 
         lines = difflib.unified_diff(contents, stdout_contents,
                                      fromfile=self.input_filename,


### PR DESCRIPTION
Running the unified diff is really slow, so first check if the strings are identical. Speeds up the roundtrip stdlib test by 8x on my machine.