### PR TITLE
Eliminate "sorting" of DeclContext-local protocols / conformances.

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -541,17 +541,13 @@ public:
   ///
   /// \param diagnostics If non-null, will be populated with the set of
   /// diagnostics that should be emitted for this declaration context.
-  ///
-  /// \param sorted Whether to sort the results in a canonical order.
-  ///
   /// FIXME: This likely makes more sense on IterableDeclContext or
   /// something similar.
   SmallVector<ProtocolDecl *, 2>
   getLocalProtocols(ConformanceLookupKind lookupKind
                       = ConformanceLookupKind::All,
                     SmallVectorImpl<ConformanceDiagnostic> *diagnostics
-                      = nullptr,
-                    bool sorted = false) const;
+                      = nullptr) const;
 
   /// Retrieve the set of protocol conformances associated with this
   /// declaration context.
@@ -561,16 +557,13 @@ public:
   /// \param diagnostics If non-null, will be populated with the set of
   /// diagnostics that should be emitted for this declaration context.
   ///
-  /// \param sorted Whether to sort the results in a canonical order.
-  ///
   /// FIXME: This likely makes more sense on IterableDeclContext or
   /// something similar.
   SmallVector<ProtocolConformance *, 2>
   getLocalConformances(ConformanceLookupKind lookupKind
                          = ConformanceLookupKind::All,
                        SmallVectorImpl<ConformanceDiagnostic> *diagnostics
-                         = nullptr,
-                       bool sorted = false) const;
+                         = nullptr) const;
 
   /// Retrieve the syntactic depth of this declaration context, i.e.,
   /// the number of non-module-scoped contexts.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1381,8 +1381,7 @@ NominalTypeDecl::getSatisfiedProtocolRequirementsForMember(
 SmallVector<ProtocolDecl *, 2>
 DeclContext::getLocalProtocols(
   ConformanceLookupKind lookupKind,
-  SmallVectorImpl<ConformanceDiagnostic> *diagnostics,
-  bool sorted) const
+  SmallVectorImpl<ConformanceDiagnostic> *diagnostics) const
 {
   SmallVector<ProtocolDecl *, 2> result;
 
@@ -1401,19 +1400,13 @@ DeclContext::getLocalProtocols(
     nullptr,
     diagnostics);
 
-  // Sort if required.
-  if (sorted) {
-    llvm::array_pod_sort(result.begin(), result.end(), TypeDecl::compare);
-  }
-
   return result;
 }
 
 SmallVector<ProtocolConformance *, 2>
 DeclContext::getLocalConformances(
   ConformanceLookupKind lookupKind,
-  SmallVectorImpl<ConformanceDiagnostic> *diagnostics,
-  bool sorted) const
+  SmallVectorImpl<ConformanceDiagnostic> *diagnostics) const
 {
   SmallVector<ProtocolConformance *, 2> result;
 
@@ -1438,12 +1431,6 @@ DeclContext::getLocalConformances(
     nullptr,
     &result,
     diagnostics);
-
-  // If requested, sort the results.
-  if (sorted) {
-    llvm::array_pod_sort(result.begin(), result.end(),
-                         &ConformanceLookupTable::compareProtocolConformances);
-  }
 
   return result;
 }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1174,7 +1174,7 @@ namespace {
       llvm::SmallSetVector<ProtocolDecl *, 2> protocols;
       for (auto conformance : dc->getLocalConformances(
                                 ConformanceLookupKind::OnlyExplicit,
-                                nullptr, /*sorted=*/true)) {
+                                nullptr)) {
         ProtocolDecl *proto = conformance->getProtocol();
         getObjCProtocols(proto, protocols);
       }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -880,8 +880,7 @@ IRGenModule::getConstantReferenceForProtocolDescriptor(ProtocolDecl *proto) {
 
 void IRGenModule::addLazyConformances(DeclContext *dc) {
   for (const ProtocolConformance *conf :
-         dc->getLocalConformances(ConformanceLookupKind::All,
-                                  nullptr, /*sorted=*/true)) {
+         dc->getLocalConformances(ConformanceLookupKind::All, nullptr)) {
     IRGen.addLazyWitnessTable(conf);
   }
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1438,7 +1438,7 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
     // Emit witness tables.
     auto nom = cast<NominalTypeDecl>(d);
     for (auto c : nom->getLocalConformances(ConformanceLookupKind::All,
-                                            nullptr, /*sorted=*/true)) {
+                                            nullptr)) {
       auto *proto = c->getProtocol();
       if (Lowering::TypeConverter::protocolRequiresWitnessTable(proto) &&
           isa<NormalProtocolConformance>(c) &&

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -968,8 +968,7 @@ public:
     // Emit witness tables for conformances of concrete types. Protocol types
     // are existential and do not have witness tables.
     for (auto *conformance : theType->getLocalConformances(
-                               ConformanceLookupKind::All,
-                               nullptr, /*sorted=*/true)) {
+                               ConformanceLookupKind::All, nullptr)) {
       if (conformance->isComplete() &&
           isa<NormalProtocolConformance>(conformance))
         SGM.getWitnessTable(conformance);
@@ -1070,7 +1069,7 @@ public:
       // extension.
       for (auto *conformance : e->getLocalConformances(
                                  ConformanceLookupKind::All,
-                                 nullptr, /*sorted=*/true)) {
+                                 nullptr)) {
         if (conformance->isComplete() &&
             isa<NormalProtocolConformance>(conformance))
           SGM.getWitnessTable(conformance);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5020,8 +5020,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   // Check each of the conformances associated with this context.
   SmallVector<ConformanceDiagnostic, 4> diagnostics;
   auto conformances = dc->getLocalConformances(ConformanceLookupKind::All,
-                                               &diagnostics,
-                                               /*sorted=*/true);
+                                               &diagnostics);
 
   // The conformance checker bundle that checks all conformances in the context.
   MultiConformanceChecker groupChecker(*this);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2771,8 +2771,7 @@ void Serializer::writeDecl(const Decl *D) {
     (void)addDeclRef(baseNominal);
 
     auto conformances = extension->getLocalConformances(
-                          ConformanceLookupKind::All,
-                          nullptr, /*sorted=*/true);
+                          ConformanceLookupKind::All, nullptr);
 
     SmallVector<TypeID, 8> inheritedAndDependencyTypes;
     for (auto inherited : extension->getInherited()) {
@@ -3027,8 +3026,7 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(theStruct->getDeclContext());
 
     auto conformances = theStruct->getLocalConformances(
-                          ConformanceLookupKind::All,
-                          nullptr, /*sorted=*/true);
+                          ConformanceLookupKind::All, nullptr);
 
     SmallVector<TypeID, 4> inheritedTypes;
     for (auto inherited : theStruct->getInherited()) {
@@ -3065,8 +3063,7 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(theEnum->getDeclContext());
 
     auto conformances = theEnum->getLocalConformances(
-                          ConformanceLookupKind::All,
-                          nullptr, /*sorted=*/true);
+                          ConformanceLookupKind::All, nullptr);
 
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
     for (auto inherited : theEnum->getInherited()) {
@@ -3120,8 +3117,7 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(theClass->getDeclContext());
 
     auto conformances = theClass->getLocalConformances(
-                          ConformanceLookupKind::All,
-                          nullptr, /*sorted=*/true);
+                          ConformanceLookupKind::All, nullptr);
 
     SmallVector<TypeID, 4> inheritedTypes;
     for (auto inherited : theClass->getInherited()) {

--- a/test/IRGen/deserialize-clang-importer-witness-tables.swift
+++ b/test/IRGen/deserialize-clang-importer-witness-tables.swift
@@ -9,8 +9,8 @@ public func foo(line: String) {
   // from the default argument expression passed to `RegEx(pattern:options:)`
   // below. Ensure that a local copy of the definition was deserialized
   // and lowered to IR.
-  // CHECK-LABEL: define {{.*}} i8** @"$sSo26NSRegularExpressionOptionsVABSQSCWl"()
   // CHECK-LABEL: define {{.*}} void @"$sSo26NSRegularExpressionOptionsVs10SetAlgebraSCsACPxycfCTW"
+  // CHECK-LABEL: define {{.*}} i8** @"$sSo26NSRegularExpressionOptionsVABSQSCWl"()
   let versionRegex = try! RegEx(pattern: "Apple")
   _ = versionRegex.firstMatch(in: line)  
 }

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -10,13 +10,13 @@ final class Final<T> {
 // CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
+// CHECK:     var hashValue: Int { get }
+// CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:     var stringValue: String { get }
 // CHECK:     init?(stringValue: String)
 // CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
-// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
-// CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:   }
 // CHECK: }
 
@@ -30,13 +30,13 @@ class Nonfinal<T> {
 // CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
+// CHECK:     var hashValue: Int { get }
+// CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:     var stringValue: String { get }
 // CHECK:     init?(stringValue: String)
 // CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
-// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
-// CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:   }
 // CHECK: }
 

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -10,14 +10,14 @@ struct Struct<T> {
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
-// CHECK:     var stringValue: String { get }
-// CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
-// CHECK:     init?(intValue: Int)
 // CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Struct<T>.CodingKeys, _ b: Struct<T>.CodingKeys) -> Bool
 // CHECK-RESILIENT: static func == (a: Struct<T>.CodingKeys, b: Struct<T>.CodingKeys) -> Bool
 // CHECK:     var hashValue: Int { get }
 // CHECK:     func hash(into hasher: inout Hasher)
+// CHECK:     var stringValue: String { get }
+// CHECK:     init?(stringValue: String)
+// CHECK:     var intValue: Int? { get }
+// CHECK:     init?(intValue: Int)
 // CHECK:   }
 // CHECK: }
 // CHECK-LABEL: extension Struct : Equatable where T : Equatable {

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1203,8 +1203,8 @@
       "conformances": [
         {
           "kind": "Conformance",
-          "name": "Comparable",
-          "printedName": "Comparable"
+          "name": "FixedWidthInteger",
+          "printedName": "FixedWidthInteger"
         },
         {
           "kind": "Conformance",
@@ -1318,8 +1318,8 @@
         },
         {
           "kind": "Conformance",
-          "name": "FixedWidthInteger",
-          "printedName": "FixedWidthInteger"
+          "name": "Comparable",
+          "printedName": "Comparable"
         },
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1092,8 +1092,8 @@
       "conformances": [
         {
           "kind": "Conformance",
-          "name": "Comparable",
-          "printedName": "Comparable"
+          "name": "FixedWidthInteger",
+          "printedName": "FixedWidthInteger"
         },
         {
           "kind": "Conformance",
@@ -1216,8 +1216,8 @@
         },
         {
           "kind": "Conformance",
-          "name": "FixedWidthInteger",
-          "printedName": "FixedWidthInteger"
+          "name": "Comparable",
+          "printedName": "Comparable"
         },
         {
           "kind": "Conformance",


### PR DESCRIPTION
Sorting of DeclContext-local protocols and conformances shouldn't ever
be necessary, because the underlying data structures that produce
these lists should be deterministic. Sorting can hide any
nondeterminism, so stop doing it and we can address the underlying
nondeterminism.
