### PR TITLE
[master-next] Remove workaround for -Wobjc-property-assign-on-object-type

### DIFF
--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -5,7 +5,7 @@ config.substitutions.insert(0, ('%check-in-clang',
   '%%clang -fsyntax-only -x objective-c-header -fobjc-arc -fmodules '
   '-fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
-  '-Wno-auto-import -Wno-objc-property-assign-on-object-type '
+  '-Wno-auto-import '
   '-F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )


### PR DESCRIPTION
The issue was fixed in https://github.com/apple/swift/pull/19167 so we
no longer need to disable this warning.
rdar://problem/47777548