### PR TITLE
[Serialization] Clean up type deserialization in the same way as decl deserialization

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -49,6 +49,7 @@ class ModuleFile
     public LazyConformanceLoader {
   friend class SerializedASTFile;
   friend class DeclDeserializer;
+  friend class TypeDeserializer;
   friend class SILDeserializer;
   using Status = serialization::Status;
   using TypeID = serialization::TypeID;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4802,7 +4802,7 @@ public:
     decls_block::SILBoxTypeLayout::readRecord(scratch, layoutID, subMapID);
 
     // Get the layout.
-    auto getLayout = [&]() -> SILLayout * {
+    auto getLayout = [this](SILLayoutID layoutID) -> SILLayout * {
       assert(layoutID > 0 && layoutID <= MF.SILLayouts.size()
              && "invalid layout ID");
 
@@ -4822,7 +4822,7 @@ public:
       return layout;
     };
 
-    auto layout = getLayout();
+    auto layout = getLayout(layoutID);
     if (!layout)
       return nullptr;
 


### PR DESCRIPTION
…by using a helper class. Type equivalent of #22610. Not quite as much of a cleanup as the decl one, but still good, and still possibly going to improve backtraces.

No functionality change. I suggest reviewing commit by commit.