### PR TITLE
SwiftPrivateThreadExtras: address improvement suggestions

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -89,14 +89,14 @@ public func _stdlib_thread_create_block<Argument, Result>(
   let contextAsVoidPointer = Unmanaged.passRetained(context).toOpaque()
 
 #if os(Windows)
-  var threadID =
+  let threadID =
       _beginthreadex(nil, 0, { invokeBlockContext($0)!
                                   .assumingMemoryBound(to: UInt32.self).pointee },
                      contextAsVoidPointer, 0, nil)
   if threadID == 0 {
     return (errno, nil)
   } else {
-    return (0, unsafeBitCast(threadID, to: ThreadHandle.self))
+    return (0, ThreadHandle(bitPattern: threadID))
   }
 #else
   var threadID = _make_pthread_t()


### PR DESCRIPTION
Use `ThreadHandle(bitPattern:)` rather than `unsafeBitCast` for the
conversion of the `uintptr_t` to the `HANDLE`.  Convert a variable from
`var` to `let` binding.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
