### PR TITLE
WinSDK: improve module map further

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -112,6 +112,16 @@ module WinSDK [system] [extern_c] {
     export *
   }
 
+  module ShellAPI {
+    header "Shlwapi.h"
+    export *
+  }
+
+  module User {
+    header "WinUser.h"
+    export *
+  }
+
   module WinCrypt {
     header "wincrypt.h"
     export *


### PR DESCRIPTION
Split out the User32 interfaces from the previously owning module
(WinSock2).  This improves the debugging experience and more accurately
reflects the module structure but should not impact the ability to build
the swift runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
