### PR TITLE
runtime: correct signature for `swift_swiftValueConformsTo`

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -677,7 +677,7 @@ static bool _dynamicCastFromAnyHashable(OpaqueValue *destination,
 
 #if !SWIFT_OBJC_INTEROP // __SwiftValue is a native class
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-bool swift_swiftValueConformsTo(const Metadata *destinationType);
+bool swift_swiftValueConformsTo(const Metadata *, const Metadata *);
 
 #define _bridgeAnythingToObjectiveC                                 \
   MANGLE_SYM(s27_bridgeAnythingToObjectiveCyyXlxlF)
@@ -780,14 +780,16 @@ static bool _dynamicCastToExistential(OpaqueValue *dest,
         return true;
       }
 #else // !SWIFT_OBJC_INTEROP -- __SwiftValue is a native class
-	  bool isMetatype = kind == MetadataKind::ExistentialMetatype || kind == MetadataKind::Metatype;
-	  if (!isMetatype && (isTargetTypeAnyObject || swift_swiftValueConformsTo(targetType))) {
-		  auto object = _bridgeAnythingToObjectiveC(src, srcType);
-		  swift_retain(object);
-		  destExistential->Value = object;
-		  maybeDeallocateSource(true);
-		  return true;
-	  }
+      bool isMetatype = kind == MetadataKind::ExistentialMetatype ||
+                        kind == MetadataKind::Metatype;
+      if (!isMetatype && (isTargetTypeAnyObject ||
+                          swift_swiftValueConformsTo(targetType, targetType))) {
+        auto object = _bridgeAnythingToObjectiveC(src, srcType);
+        swift_retain(object);
+        destExistential->Value = object;
+        maybeDeallocateSource(true);
+        return true;
+      }
 #endif
 
       return _fail(src, srcType, targetType, flags);


### PR DESCRIPTION
The swift side signature for `swift_swiftValueConformsTo` is:
`func swift_swiftValueConformsTo<T>(_: T.self) -> Bool`

This translates to:
`bool swift_swiftValueConformsTo(const Metadata *, const Metadata *)`

The elided parameter would be passed invalid values..  Running this on
Windows with optimizations triggered an optimization where the parameter
happened to be null as `rdx` is the second parameter rather than the 4th
parameter.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
