### PR TITLE
[AutoDiff] TF-235: Fix/simplify AdjointGen substitution map remapping.

### DIFF
--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -19,8 +19,7 @@ var TensorADTests = TestSuite("TensorIndirectAD")
 TensorADTests.testAllBackends("Generic") {
   // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
   func indirect<Scalar : Differentiable & FloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar>
-    where Scalar.TangentVector : AdditiveArithmetic, Scalar.CotangentVector : AdditiveArithmetic,
-          Scalar == Scalar.CotangentVector
+    where Scalar == Scalar.CotangentVector
   {
     return (x + 3) * (x + 3)
   }
@@ -78,6 +77,7 @@ TensorADTests.testAllBackends("ResultSelection") {
 }
 
 TensorADTests.testAllBackends("GenericLayerMember") {
+  // Tests TF-203.
   // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
   struct GenericLayerWrapper<T: Layer> : Layer
     where T.TangentVector : AdditiveArithmetic, T.CotangentVector : AdditiveArithmetic,
@@ -90,6 +90,99 @@ TensorADTests.testAllBackends("GenericLayerMember") {
       return layer.applied(to: input)
     }
   }
+}
+
+TensorADTests.testAllBackends("GenericLayerMembers") {
+  // Tests TF-235.
+  // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
+  struct Sequential<LHS: Layer, RHS: Layer>: Layer
+    where LHS.Output == RHS.Input,
+          LHS.TangentVector: AdditiveArithmetic,
+          RHS.TangentVector: AdditiveArithmetic,
+          LHS.CotangentVector: AdditiveArithmetic,
+          RHS.CotangentVector: AdditiveArithmetic,
+          LHS.Input.CotangentVector: AdditiveArithmetic,
+          LHS.Output.CotangentVector: AdditiveArithmetic,
+          RHS.Output.CotangentVector: AdditiveArithmetic,
+          RHS.Output.TangentVector: AdditiveArithmetic {
+    let lhs: LHS
+    let rhs: RHS
+
+    init(_ lhs: LHS, _ rhs: RHS) {
+      self.lhs = lhs
+      self.rhs = rhs
+    }
+
+    @differentiable(wrt: (self, input))
+    func applied(to input: LHS.Input) -> RHS.Output {
+      let intermediateValue = lhs.applied(to: input)
+      return rhs.applied(to: intermediateValue)
+    }
+  }
+
+  // TODO(TF-213): Remove unnecessary conformances after generic signature minimization bug fix.
+  struct LayerTriple<T: Layer, U: Layer, V : Layer>: Layer
+    where T.Output == U.Input, U.Output == V.Input,
+          T.TangentVector: AdditiveArithmetic,
+          U.TangentVector: AdditiveArithmetic,
+          V.TangentVector: AdditiveArithmetic,
+          T.CotangentVector: AdditiveArithmetic,
+          U.CotangentVector: AdditiveArithmetic,
+          V.CotangentVector: AdditiveArithmetic,
+          T.Input.CotangentVector: AdditiveArithmetic,
+          T.Output.CotangentVector: AdditiveArithmetic,
+          U.Output.CotangentVector: AdditiveArithmetic,
+          U.Output.TangentVector: AdditiveArithmetic {
+    let first: T
+    let second: U
+    let third: V
+
+    init(_ first: T, _ second: U, _ third: V) {
+      self.first = first
+      self.second = second
+      self.third = third
+    }
+
+    @differentiable(wrt: (self, input))
+    func applied(to input: T.Input) -> V.Output {
+      let intermediate1 = first.applied(to: input)
+      let intermediate2 = second.applied(to: intermediate1)
+      return third.applied(to: intermediate2)
+    }
+  }
+
+  // FIXME(TF-242): Pullback indirect results should not be released.
+  // Otherwise, pullback calls segfault.
+  /*
+  func testFixedInput() {
+    let lhs = Dense<Float>(inputSize: 3, outputSize: 4, activation: relu)
+    let rhs = Dense<Float>(inputSize: 4, outputSize: 5, activation: sigmoid)
+    let combined = Sequential(lhs, rhs)
+
+    let input = Tensor<Float>(ones: [2, 3])
+    let seed = Tensor<Float>(ones: [input.shape[0], rhs.weight.shape[1]])
+    let (𝛁lhs, 𝛁rhs) = pullback(at: lhs, rhs) { lhs, rhs in
+      rhs.applied(to: lhs.applied(to: input))
+    }(seed)
+    let 𝛁combined = pullback(at: combined) { $0.applied(to: input) }(seed + 1)
+    expectEqual(Sequential.CotangentVector(lhs: 𝛁lhs, rhs: 𝛁rhs), 𝛁combined)
+  }
+  testFixedInput()
+
+  func testWrtInput(_ input: Tensor<Float>) {
+    let lhs = Dense<Float>(inputSize: 3, outputSize: 4, activation: relu)
+    let rhs = Dense<Float>(inputSize: 4, outputSize: 5, activation: sigmoid)
+    let combined = Sequential(lhs, rhs)
+
+    let seed = Tensor<Float>(ones: [input.shape[0], rhs.weight.shape[1]])
+    let (𝛁lhs, 𝛁rhs) = pullback(at: lhs, rhs) { lhs, rhs in
+      rhs.applied(to: lhs.applied(to: input))
+    }(seed)
+    let 𝛁combined = pullback(at: combined) { $0.applied(to: input) }(seed)
+    expectEqual(Sequential.CotangentVector(lhs: 𝛁lhs, rhs: 𝛁rhs), 𝛁combined)
+  }
+  testWrtInput(Tensor(randomUniform: [2, 3]))
+  */
 }
 
 runAllTests()


### PR DESCRIPTION
The old substitution map remapping logic was incorrect and needlessly complex.
The new logic is correct and simpler.
There is certainly more room for simplification: to be explored.

Enables (partially correct) differentiation of `applied(to:)` for
generic layer combinators.

Partially resolves [TF-235](https://bugs.swift.org/browse/TF-235).
[TF-242](https://bugs.swift.org/browse/TF-242) will soon be resolved to fix `applied(to:)` adjoint segfault.