### PR TITLE
test: do not link against `libcmt` on Win32

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -804,12 +804,10 @@ elif run_os in ['windows-msvc']:
     config.target_runtime = 'native'
 
     config.target_build_swift =                                                  \
-            ('%r -target %s %s %s %s %s' % (config.swiftc,                       \
-                                            config.variant_triple,               \
-                                            resource_dir_opt,                    \
-                                            config.swift_test_options,           \
-                                            config.swift_driver_test_options,    \
-                                            swift_execution_tests_extra_flags))
+            ('%r -target %s %s %s %s %s -Xlinker -nodefaultlib:libcmt' %         \
+                    (config.swiftc, config.variant_triple, resource_dir_opt,     \
+                     config.swift_test_options, config.swift_driver_test_options,\
+                     swift_execution_tests_extra_flags))
 
     config.target_run = ''
 


### PR DESCRIPTION
Since we do not support building in `/MT` or `/MTd` mode currently,
ensure that we link against the dynamic runtime.  This allows us to
properly run tests without getting lucky in the internal structures
of libc aligning up across the variants.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
