### PR TITLE
tests: adjustments for Windows

### DIFF
--- a/test/ClangImporter/Inputs/non-modular/Foo.framework/Headers/Foo.h
+++ b/test/ClangImporter/Inputs/non-modular/Foo.framework/Headers/Foo.h
@@ -1,3 +1,3 @@
-#import <NonModular.h>
+#include <NonModular.h>
 
 extern int x;

--- a/test/ClangImporter/MixedSource/autolinking.swift
+++ b/test/ClangImporter/MixedSource/autolinking.swift
@@ -12,5 +12,5 @@ public let y = Test()
 
 // CHECK: !llvm.linker.options
 // CHECK-NOT: !{!"-framework", !"AutolinkingTest"}
-// CHECK: !{!"-lswiftCore"}
+// CHECK: !{!{{"-lswiftCore"|"/DEFAULTLIB:swiftCore.lib"}}}
 // CHECK-NOT: !{!"-framework", !"AutolinkingTest"}

--- a/test/ClangImporter/MixedSource/broken-modules.swift
+++ b/test/ClangImporter/MixedSource/broken-modules.swift
@@ -1,4 +1,5 @@
 // RUN: %empty-directory(%t)
+
 // RUN: not %target-swift-frontend -enable-objc-interop -typecheck %/s -I %S/Inputs/broken-modules/ -enable-source-import -show-diagnostics-after-fatal -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CLANG-CHECK %s
 
 // RUN: not %target-swift-frontend -typecheck %/s -enable-objc-interop -import-objc-header %S/Inputs/broken-modules/BrokenClangModule.h -enable-source-import -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK-BRIDGING-HEADER -check-prefix CLANG-CHECK %s
@@ -22,13 +23,13 @@ import MissingDependencyFromClang
 // CHECK: error: no such module 'MissingDependencyFromClang'
 
 import BrokenClangModule
-// CLANG-CHECK: {{.+}}/Inputs/broken-modules/BrokenClangModule.h:2:13: error: redefinition of 'conflict' as different kind of symbol
-// CLANG-CHECK: {{.+}}/Inputs/broken-modules/BrokenClangModule.h:1:5: note: previous definition is here
+// CLANG-CHECK: {{.+}}{{/|\\}}Inputs{{/|\\}}broken-modules{{/|\\}}BrokenClangModule.h:2:13: error: redefinition of 'conflict' as different kind of symbol
+// CLANG-CHECK: {{.+}}{{/|\\}}Inputs{{/|\\}}broken-modules{{/|\\}}BrokenClangModule.h:1:5: note: previous definition is here
 // CLANG-CHECK: a-fake-file.h:43:13: error: redefinition of 'conflict2' as different kind of symbol
 // CLANG-CHECK: a-fake-file.h:42:5: note: previous definition is here
 // CLANG-CHECK: a-fake-file.h:46:5: error: expected identifier or '('
 // CLANG-CHECK: a-fake-file.h:45:11: note: expanded from macro 'I'
-// CLANG-CHECK: {{.+}}/Inputs/broken-modules/BrokenClangModule.h:11:35: error: expected ';' after top level declarator
+// CLANG-CHECK: {{.+}}{{/|\\}}Inputs{{/|\\}}broken-modules{{/|\\}}BrokenClangModule.h:11:35: error: expected ';' after top level declarator
 
 // CHECK: broken-modules.swift:[[@LINE-9]]:8: error: could not build Objective-C module 'BrokenClangModule'
 // CHECK: error: no such module 'BrokenClangModule'

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -12,7 +12,7 @@
 // RUN: rm -rf %t/mixed-target/
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
 
-// XFAIL: linux
+// REQUIRES: SR7768
 
 import MixedWithHeader
 

--- a/test/ClangImporter/autolinking.swift
+++ b/test/ClangImporter/autolinking.swift
@@ -1,13 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -o - | %FileCheck %s
+
+// RUN: %target-swift-frontend %s -sdk %S/Inputs -Fsystem %S/Inputs/System/Library/Frameworks -enable-objc-interop -I %S/Inputs/custom-modules -emit-ir -o - | %FileCheck %s
 
 // RUN: %target-swift-frontend -emit-module %S/Inputs/adapter.swift -sdk %S/Inputs -module-link-name SwiftAdapter -module-name ClangModuleWithAdapter -I %S/Inputs/custom-modules -o %t
 
-// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -I %t -emit-ir -o %t/with-adapter.ll
+// RUN: %target-swift-frontend %s -sdk %S/Inputs -Fsystem %S/Inputs/System/Library/Frameworks -enable-objc-interop -I %S/Inputs/custom-modules -I %t -emit-ir -o %t/with-adapter.ll
 // RUN: %FileCheck %s < %t/with-adapter.ll
 // RUN: %FileCheck -check-prefix CHECK-WITH-SWIFT %s < %t/with-adapter.ll
 
-// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -disable-autolink-framework LinkFramework -o - > %t/with-disabled.ll
+// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -Fsystem %S/Inputs/System/Library/Frameworks -enable-objc-interop -emit-ir -disable-autolink-framework LinkFramework -o - > %t/with-disabled.ll
 // RUN: %FileCheck -check-prefix CHECK-WITH-DISABLED %s < %t/with-disabled.ll
 // RUN: %FileCheck -check-prefix NEGATIVE-WITH-DISABLED %s < %t/with-disabled.ll
 
@@ -29,15 +30,15 @@ UsesSubmodule.useSomethingFromSubmodule()
 
 // CHECK: !llvm.linker.options = !{
 
-// CHECK-DAG: !{{[0-9]+}} = !{!"-lLock"}
-// CHECK-DAG: !{{[0-9]+}} = !{!"-lStock"}
+// CHECK-DAG: !{{[0-9]+}} = !{!{{"-lLock"|"/DEFAULTLIB:Lock.lib"}}}
+// CHECK-DAG: !{{[0-9]+}} = !{!{{"-lStock"|"/DEFAULTLIB:Stock.lib"}}}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-framework", !"Barrel"}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-framework", !"LinkFramework"}
-// CHECK-DAG: !{{[0-9]+}} = !{!"-lUnderlyingClangLibrary"}
+// CHECK-DAG: !{{[0-9]+}} = !{!{{"-lUnderlyingClangLibrary"|"/DEFAULTLIB:UnderlyingClangLibrary.lib"}}}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-framework", !"Indirect"}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-framework", !"HasSubmodule"}
 
-// CHECK-WITH-SWIFT: !{{[0-9]+}} = !{!"-lSwiftAdapter"}
+// CHECK-WITH-SWIFT: !{{[0-9]+}} = !{!{{"-lSwiftAdapter"|"/DEFAULTLIB:SwiftAdapter.lib"}}}
 
 // CHECK-WITH-DISABLED-DAG: !{!"-framework", !"Barrel"}
 // CHECK-WITH-DISABLED-DAG: !{!"-framework", !"Indirect"}

--- a/test/ClangImporter/broken-modules.swift
+++ b/test/ClangImporter/broken-modules.swift
@@ -6,7 +6,7 @@
 
 #if MISSING_FROM_MODULE
 import MissingHeader
-// CHECK-MODULE-MAP: {{.*}}/Inputs/custom-modules/module.map:{{[0-9]+:[0-9]+}}: error: header 'this-header-does-not-exist.h' not found
+// CHECK-MODULE-MAP: {{.*}}{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}module.map:{{[0-9]+:[0-9]+}}: error: header 'this-header-does-not-exist.h' not found
 // CHECK-MODULE-MAP: broken-modules.swift:[[@LINE-2]]:8: error: could not build Objective-C module 'MissingHeader'
 
 #else
@@ -17,7 +17,7 @@ import ImportsMissingHeaderIndirect
 import ImportsMissingHeader
 #endif
 
-// CHECK-INDIRECT: {{.*}}/Inputs/custom-modules/more-custom-modules/ImportsMissingHeaderIndirect.h:1:9: note: while building module 'ImportsMissingHeader' imported from {{.*}}/Inputs/custom-modules/more-custom-modules/ImportsMissingHeaderIndirect.h:1:
+// CHECK-INDIRECT: {{.*}}{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}more-custom-modules{{/|\\}}ImportsMissingHeaderIndirect.h:1:9: note: while building module 'ImportsMissingHeader' imported from {{.*}}{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}more-custom-modules{{/|\\}}ImportsMissingHeaderIndirect.h:1:
 // CHECK-INDIRECT-NEXT: @import ImportsMissingHeader;
 
 // CHECK: <module-includes>:1:9: note: in file included from <module-includes>:1:
@@ -28,7 +28,7 @@ import ImportsMissingHeader
 // CHECK-INDIRECT: <module-includes>:1:9: note: in file included from <module-includes>:1:
 // CHECK-INDIRECT-NEXT: #import "{{.*}}ImportsMissingHeaderIndirect.h"
 
-// CHECK-INDIRECT: {{.*}}/Inputs/custom-modules/more-custom-modules/ImportsMissingHeaderIndirect.h:1:9: error: could not build module 'ImportsMissingHeader'
+// CHECK-INDIRECT: {{.*}}{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}more-custom-modules{{/|\\}}ImportsMissingHeaderIndirect.h:1:9: error: could not build module 'ImportsMissingHeader'
 // CHECK-INDIRECT-NEXT: @import ImportsMissingHeader;
 
 

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -2,7 +2,7 @@
 // RUN: not %target-swift-frontend -enable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-objc %s
 // RUN: not %target-swift-frontend -disable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-native %s
 
-// CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'
+// CHECK: {{.+}}/non-modular{{/|\\}}Foo.framework/Headers{{/|\\}}Foo.h:1:10: error: include of non-modular header inside framework module 'Foo'
 // CHECK-objc: error: could not build Objective-C module 'Foo'
 // CHECK-native: error: could not build C module 'Foo'
 // CHECK-NOT: error

--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -3,23 +3,23 @@
 // Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps
 // mention the .h the PCH was generated from, and any .h files included in it.
 //
-// RUN: %target-swift-frontend -emit-pch -o %t.pch %S/Inputs/chained-unit-test-bridging-header-to-pch.h
+// RUN: %target-swift-frontend -emit-pch -o %t.pch %/S/Inputs/chained-unit-test-bridging-header-to-pch.h
 // RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s -import-objc-header %t.pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
+// RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %/S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.persistent.d
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.persistent.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.persistent.swiftdeps
 
 print(app_function(1))
 
-// CHECK-DEPS: pch-bridging-header-deps.o : {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
+// CHECK-DEPS: pch-bridging-header-deps.o : {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}app-bridging-header-to-pch.h {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}chained-unit-test-bridging-header-to-pch.h
 
 // CHECK-SWIFTDEPS: depends-external:
-// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h"
-// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h"
+// CHECK-SWIFTDEPS: - "SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}app-bridging-header-to-pch.h"
+// CHECK-SWIFTDEPS: - "SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}chained-unit-test-bridging-header-to-pch.h"
 
 // CHECK-SWIFTDEPS2-NOT: {{.*}}.pch

--- a/test/ClangImporter/sdk.swift
+++ b/test/ClangImporter/sdk.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/Inputs/clang-importer-sdk/usr/include/MacTypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/MacTypes.h
@@ -14,7 +14,9 @@ STDLIB_TYPEDEF(__UINT8_TYPE__, UInt8);
 STDLIB_TYPEDEF(__UINT16_TYPE__, UInt16);
 STDLIB_TYPEDEF(__UINT32_TYPE__, UInt32);
 
+#if !defined(_WIN32)
 #include <stdint.h>
+#endif
 
 typedef SInt32                          Fixed;
 typedef Fixed *                         FixedPtr;


### PR DESCRIPTION
Alter the path separators for Windows paths.  This makes 66% of the
remaining tests pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
