### PR TITLE
[AutoDiff] TF-247: Handle `tuple_element_addr` in AdjointGen.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1411,7 +1411,7 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
         // Handle `copy_addr`.
         else if (auto *cai = dyn_cast<CopyAddrInst>(&inst)) {
           if (isUseful(cai->getDest(), i))
-            setUsefulIfDifferentiable(cai->getSrc(), i);
+            propagateUsefulThroughBuffer(cai->getSrc(), i);
         }
         // Handle reads.
         else if (inst.mayReadFromMemory()) {
@@ -2252,8 +2252,8 @@ static SILFunction *getOrCreateReabstractionThunk(SILOptFunctionBuilder &fb,
   builder.createReturn(loc, retVal);
 
   LLVM_DEBUG(auto &s = getADDebugStream() << "Created reabstraction thunk.\n";
-             s << "From type: " << fromType << '\n';
-             s << "To type: " << toType << '\n';
+             s << "  From type: " << fromType << '\n';
+             s << "  To type: " << toType << '\n';
              s << '\n' << *thunk);
 
   return thunk;
@@ -2549,7 +2549,6 @@ public:
                 << getPrimalInfo().getPrimalValueStruct()->getName() << ":\n";
       for (auto *var : getPrimalInfo().getPrimalValueStruct()->getMembers()) {
         var->dump(s);
-        s << '\n';
       }
     });
     LLVM_DEBUG(getADDebugStream() << "Finished PrimalGen for function "
@@ -4281,7 +4280,7 @@ public:
 
   /// Handle `tuple` instruction.
   ///   y = tuple (x0, x1, x2, ...)
-  ///   adj[x0] += tuple_extract 0, adj[y]
+  ///   adj[x0] += tuple_extract adj[y], 0
   ///   ...
   void visitTupleInst(TupleInst *ti) {
     auto av = takeAdjointValue(ti);
@@ -4308,8 +4307,8 @@ public:
   }
 
   /// Handle `tuple_extract` instruction.
-  ///   y = tuple_extract <n>, x
-  ///                      |--- n-th element
+  ///   y = tuple_extract x, <n>
+  ///                         |--- n-th element
   ///   adj[x] += tuple (0, 0, ..., adj[y], ..., 0, 0)
   void visitTupleExtractInst(TupleExtractInst *tei) {
     auto *tupleTy = tei->getTupleType();
@@ -4337,6 +4336,30 @@ public:
       break;
     }
     }
+  }
+
+  /// Handle `tuple_element_addr` instruction.
+  ///   y = tuple_element_addr x, <n>
+  ///                              |--- n-th element
+  ///   adj[x]#n = tuple_element_addr adj[y], <n>
+  ///   adj[x]#n += adj[y]
+  void visitTupleElementAddrInst(TupleElementAddrInst *teai) {
+    auto loc = teai->getLoc();
+    auto adjElt = getAdjointBuffer(teai);
+    auto adjTupleElt = builder.createTupleElementAddr(
+        loc, getAdjointBuffer(teai->getOperand()), teai->getFieldNo());
+    // Accumulate element address's adjoint buffer into the corresponding
+    // element address of `tuple_element_addr` operand's adjoint buffer:
+    // `adj[x]#n += adj[y]`.
+    auto *destAccess = builder.createBeginAccess(
+        loc, adjTupleElt, SILAccessKind::Modify, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    auto *readAccess = builder.createBeginAccess(
+        loc, adjElt, SILAccessKind::Read, SILAccessEnforcement::Static,
+        /*noNestedConflict*/ true, /*fromBuiltin*/ false);
+    accumulateIndirect(destAccess, readAccess);
+    builder.createEndAccess(loc, readAccess, /*aborted*/ false);
+    builder.createEndAccess(loc, destAccess, /*aborted*/ false);
   }
 
   // Handle `alloc_stack` instruction.
@@ -4651,16 +4674,7 @@ void AdjointEmitter::materializeAdjointIndirectHelper(
   /// since we need indirect passing for aggregate instruction, we just use
   /// `tuple_element_addr` to get element buffers and write elements to them.
   case AdjointValueKind::Zero:
-    if (auto tupleTy = val.getType().getAs<TupleType>()) {
-      SmallVector<SILValue, 8> eltVals;
-      for (unsigned i : range(tupleTy->getNumElements())) {
-        auto eltAddr = builder.createTupleElementAddr(loc, destBufferAccess, i);
-        emitZeroIndirect(tupleTy->getElementType(i)->getCanonicalType(),
-                         eltAddr, loc);
-      }
-    } else {
-      emitZeroIndirect(val.getSwiftType(), destBufferAccess, loc);
-    }
+    emitZeroIndirect(val.getSwiftType(), destBufferAccess, loc);
     break;
   /// Given a `%buf : *(T0, T1, T2, ...)` or `%buf : *Struct` recursively emit
   /// instructions to materialize the symbolic tuple or struct, filling the
@@ -4722,18 +4736,42 @@ void AdjointEmitter::emitZeroIndirect(CanType type, SILValue bufferAccess,
   auto confRef = swiftMod->lookupConformance(type, additiveArithmeticProto);
   // TODO(TF-202): Diagnose no `AdditiveArithmetic` due to generic signature
   // minimization bug.
-  assert(confRef.hasValue() && "Missing conformance to `AdditiveArithmetic`");
-  // %wm = witness_method ...
-  auto *getter = builder.createWitnessMethod(loc, type, *confRef,
-                                             accessorDeclRef, methodType);
-  // %metatype = metatype $T
-  auto metatypeType = CanMetatypeType::get(type, MetatypeRepresentation::Thick);
-  auto metatype = builder.createMetatype(
-      loc, SILType::getPrimitiveObjectType(metatypeType));
-  auto subMap = SubstitutionMap::getProtocolSubstitutions(
-      additiveArithmeticProto, type, *confRef);
-  builder.createApply(loc, getter, subMap, {bufferAccess, metatype},
-                      /*isNonThrowing*/ false);
+  auto cotangentSpace = type->getAutoDiffAssociatedVectorSpace(
+      AutoDiffAssociatedVectorSpaceKind::Cotangent,
+      LookUpConformanceInModule(swiftMod));
+  assert(cotangentSpace && "No tangent space for this type");
+  switch (cotangentSpace->getKind()) {
+  case VectorSpace::Kind::Vector: {
+    assert(confRef.hasValue() && "Missing conformance to `AdditiveArithmetic`");
+    // %wm = witness_method ...
+    auto *getter = builder.createWitnessMethod(
+        loc, type, *confRef, accessorDeclRef, methodType);
+    // %metatype = metatype $T
+    auto metatypeType = CanMetatypeType::get(
+        type, MetatypeRepresentation::Thick);
+    auto metatype = builder.createMetatype(
+        loc, SILType::getPrimitiveObjectType(metatypeType));
+    auto subMap = SubstitutionMap::getProtocolSubstitutions(
+        additiveArithmeticProto, type, *confRef);
+    builder.createApply(loc, getter, subMap, {bufferAccess, metatype},
+                        /*isNonThrowing*/ false);
+    return;
+  }
+  case VectorSpace::Kind::Tuple: {
+    auto tupleType = cotangentSpace->getTuple();
+    SmallVector<SILValue, 8> zeroElements;
+    for (unsigned i : range(tupleType->getNumElements())) {
+      auto eltAddr = builder.createTupleElementAddr(loc, bufferAccess, i);
+      emitZeroIndirect(tupleType->getElementType(i)->getCanonicalType(),
+                       eltAddr, loc);
+    }
+    return;
+  }
+  case VectorSpace::Kind::Function: {
+    llvm_unreachable(
+      "Unimplemented: Emit thunks for abstracting zero initialization");
+  }
+  }
 }
 
 SILValue AdjointEmitter::emitZeroDirect(CanType type, SILLocation loc) {

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -71,6 +71,7 @@ _ = pullback(at: Vector.zero, in: side_effect_release_zero)
 // CHECK:  [[ZERO_GETTER:%.*]] = function_ref @$s11refcounting6VectorV4zeroACvgZ
 // CHECK:  [[ZERO:%.*]] = apply [[ZERO_GETTER]]({{%.*}}) : $@convention(method) (@thin Vector.Type) -> @owned Vector
 // CHECK:  store [[ZERO]] to [[BUF_ACCESS]] : $*Vector
+// CHECK:  destroy_addr [[BUF]] : $*Vector
 // CHECK:  dealloc_stack [[BUF]] : $*Vector
 // CHECK:  release_value [[SEED:%.*]] : $Vector
 // CHECK: }

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -102,4 +102,45 @@ SimpleMathTests.test("SideEffects") {
   expectEqual(108, gradient(at: 3, in: foo))
 }
 
+SimpleMathTests.test("TupleSideEffects") {
+  func foo(_ x: Float) -> Float {
+    var tuple = (x, x)
+    tuple.0 = tuple.0 * x
+    tuple.0 = tuple.0 * x
+    return x * tuple.0
+  }
+  expectEqual(27, gradient(at: 3, in: foo))
+
+  func fooInout(_ x: Float) -> Float {
+    var tuple = (x, x)
+    tuple.0 *= x
+    tuple.0 *= x
+    return tuple.0 * tuple.0
+  }
+  // FIXME(TF-159): Update after activity analysis handles inout parameters.
+  // expectEqual(27, gradient(at: 3, in: fooInout))
+  expectEqual(0, gradient(at: 3, in: fooInout))
+
+  func bar(_ x: Float) -> Float {
+    var tuple = (x, x)
+    tuple.0 = tuple.0 * x
+    tuple.1 = tuple.0 * x
+    return tuple.0 * tuple.1
+  }
+  // FIXME(TF-246): Update after zero gradient bug is fixed.
+  // expectEqual(81, gradient(at: 3, in: bar))
+  expectEqual(0, gradient(at: 3, in: bar))
+
+  // FIXME(TF-201): Update after reabstraction thunks can be directly differentiated.
+  /*
+  func generic<T : Differentiable & AdditiveArithmetic>(_ x: T) -> T {
+    var tuple = (x, x)
+    tuple.0 += x
+    tuple.1 += x
+    return tuple.0 + tuple.0
+  }
+  expectEqual(1, gradient(at: 3.0, in: generic))
+  */
+}
+
 runAllTests()


### PR DESCRIPTION
Handle `tuple_element_addr` in AdjointGen to enable differentiation
of tuple variables, among other use cases.

- Add/update adjoint transformation rules.
- Change `emitZeroIndirect` to use `getAutoDiffAssociatedVectorSpace`,
  in order to handle tuple pointer types.
  - The old logic checked tuple pointer types for a conformance to
    `AdditiveArithmetic`, which crashed.
  - Update old caller, which manually checked for tuple types.
- Gardening.
  - Update AD debug printing.
- Add tests, including negative tests for known issues.

Resolves [TF-247](https://bugs.swift.org/browse/TF-247).