### PR TITLE
Add ASTNode.dump() methods

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -20,6 +20,10 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "swift/AST/TypeAlignments.h"
 
+namespace llvm {
+  class raw_ostream;
+}
+
 namespace swift {
   class Expr;
   class Stmt;
@@ -57,6 +61,11 @@ namespace swift {
     FUNC(Expr)
     FUNC(Decl)
 #undef FUNC
+    
+    LLVM_ATTRIBUTE_DEPRECATED(
+        void dump() const LLVM_ATTRIBUTE_USED,
+        "only for use within the debugger");
+    void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
 
     /// Whether the AST node is implicit.
     bool isImplicit() const;

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -77,6 +77,21 @@ void ASTNode::walk(ASTWalker &Walker) {
     llvm_unreachable("unsupported AST node");
 }
 
+void ASTNode::dump(raw_ostream &OS, unsigned Indent) const {
+  if (auto S = dyn_cast<Stmt*>())
+    S->dump(OS, /*context=*/nullptr, Indent);
+  else if (auto E = dyn_cast<Expr*>())
+    E->dump(OS, Indent);
+  else if (auto D = dyn_cast<Decl*>())
+    D->dump(OS, Indent);
+  else
+    OS << "<null>";
+}
+
+void ASTNode::dump() const {
+  dump(llvm::errs());
+}
+
 #define FUNC(T)                                                               \
 bool ASTNode::is##T(T##Kind Kind) const {                                     \
   if (!is<T*>())                                                              \


### PR DESCRIPTION
Mainly for debugging, since their internal structure is impenetrable to lldb. They just forward to the underlying node's `dump()` method.