### PR TITLE
[AutoDiff] Fix memory leak on adjoint accumulation.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4809,10 +4809,10 @@ AdjointEmitter::accumulateAdjointsDirect(AdjointValue &&lhs,
     // x + y
     case AdjointValueKind::Concrete: {
       auto rhsVal = rhs.getConcreteValue();
+      auto sum = accumulateDirect(lhsVal, rhsVal);
       return makeConcreteAdjointValue(ValueWithCleanup(
-          accumulateDirect(lhsVal, rhsVal),
-              makeCleanupFromChildren({lhsVal.getCleanup(),
-                                       rhsVal.getCleanup()})));
+          sum, makeCleanup(sum, emitCleanup, {lhsVal.getCleanup(),
+                                              rhsVal.getCleanup()})));
     }
     // x + 0 => x
     case AdjointValueKind::Zero:


### PR DESCRIPTION
Direct adjoint accumulation produces a new value, but we didn't create a cleanup for this new value, which caused a memory leak whenever there's a fanout in the original program. This PR fixes that.

We should add reference counting codegen tests systematically. This is fixing a P0, so I'm deferring that.
