### PR TITLE
Changes for test failures on PowerPC64LE when running as non-root user

### DIFF
--- a/test/Index/Store/output-failure.swift
+++ b/test/Index/Store/output-failure.swift
@@ -1,4 +1,3 @@
-// XFAIL: CPU=powerpc64le
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/idx
 

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
@@ -1,5 +1,4 @@
 // RUN: %empty-directory(%t)
-// XFAIL: CPU=powerpc64le
 
 // 1. Not finding things is okay.
 // RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
@@ -1,5 +1,4 @@
 // RUN: %empty-directory(%t)
-// XFAIL: CPU=powerpc64le
 
 // 1. Not finding things is okay.
 // RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode.swift
@@ -1,5 +1,4 @@
 // RUN: %empty-directory(%t)
-// XFAIL: CPU=powerpc64le
 
 // 1. Not finding things is okay.
 // RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s

--- a/test/SIL/Serialization/opaque_values_serialize.sil
+++ b/test/SIL/Serialization/opaque_values_serialize.sil
@@ -1,4 +1,3 @@
-// XFAIL: CPU=powerpc64le
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: %empty-directory(%t)
 // FIXME: <rdar://problem/29281364> sil-opt -verify is broken

--- a/test/remote-run/upload-stderr.test-sh
+++ b/test/remote-run/upload-stderr.test-sh
@@ -1,5 +1,4 @@
 REQUIRES: sftp_server
-// XFAIL: CPU=powerpc64le
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/REMOTE/input)


### PR DESCRIPTION
These 6 test cases were earlier marked as XFAIL since they were failing when run as root users( #21541 ). However, these 6 test cases now pass successfully when run as non-root(normal) user. Submitting this changeset/pull request since the test suite proceeds ahead to other test suites like those for TestFoundation, etc as non-root(normal) user successfully. Please review and approve.