### PR TITLE
[AutoDiff] TF-21: Start support for `struct` differentiation.

### DIFF
--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -143,4 +143,32 @@ SimpleMathTests.test("TupleSideEffects") {
   */
 }
 
+// Tests TF-21.
+SimpleMathTests.test("StructMemberwiseInitializer") {
+  struct Foo : AdditiveArithmetic, Differentiable {
+    var stored: Float
+    var computed: Float {
+      return stored * stored
+    }
+  }
+
+  let 𝛁foo = pullback(at: Float(4), in: { input -> Foo in
+    let foo = Foo(stored: input)
+    return foo + foo
+  })(Foo.CotangentVector(stored: 1))
+  expectEqual(2, 𝛁foo)
+
+  let 𝛁computed = gradient(at: Float(4)) { input -> Float in
+    let foo = Foo(stored: input)
+    return foo.computed
+  }
+  expectEqual(8, 𝛁computed)
+
+  let 𝛁product = gradient(at: Float(4)) { input -> Float in
+    let foo = Foo(stored: input)
+    return foo.computed * foo.stored
+  }
+  expectEqual(16, 𝛁product)
+}
+
 runAllTests()


### PR DESCRIPTION
Support differentiation of the `struct` instruction for fieldwise
product space structs. This enables differentiation of functions that
construct/use structs in their body.

Partially resolves [TF-21](https://bugs.swift.org/browse/TF-21).
Next steps:
- Enable `@differentiable` to be declared on initializers.
- Synthesize `@differentiable` attribute for struct memberwise
  initializers during `Differentiable` derived conformances.
- Support/test differentiation of `struct` instruction via
  memberwise initializer VJP calls.