### PR TITLE
[5.0][String] Naturalize Character

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -617,9 +617,10 @@ extension _StringObject {
  isNativelyStored: set for native stored strings
    - `largeAddressBits` holds an instance of `_StringStorage`.
    - I.e. the start of the code units is at the stored address + `nativeBias`
- isTailAllocated: start of the code units is at the stored address + `nativeBias`
+ isTailAllocated: contiguous UTF-8 code units starts at address + `nativeBias`
    - `isNativelyStored` always implies `isTailAllocated`, but not vice versa
       (e.g. literals)
+   - `isTailAllocated` always implies `isFastUTF8`
  TBD: Reserved for future usage
    - Setting a TBD bit to 1 must be semantically equivalent to 0
    - I.e. it can only be used to "cache" fast-path information in the future
@@ -1073,6 +1074,9 @@ extension _StringObject {
     } else {
       _internalInvariant(isLarge)
       _internalInvariant(largeCount == count)
+      if _countAndFlags.isTailAllocated {
+        _internalInvariant(providesFastUTF8)
+      }
       if providesFastUTF8 && largeFastIsTailAllocated {
         _internalInvariant(!isSmall)
         _internalInvariant(!largeIsCocoa)

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -75,5 +75,29 @@ StringBridgeTests.test("Tagged NSString") {
 #endif // not 32bit
 }
 
+func returnOne<T>(_ t: T) -> Int { return 1 }
+StringBridgeTests.test("Character from NSString") {
+  // NOTE: Using hard-coded literals to directly construct NSStrings
+  let ns1 = "A" as NSString
+  let ns2 = "A\u{301}" as NSString
+  let ns3 = "𓁹͇͈͉͍͎͊͋͌ͧͨͩͪͫͬͭͮ͏̛͓͔͕͖͙͚̗̘̙̜̹̺̻̼͐͑͒͗͛ͣͤͥͦ̽̾̿̀́͂̓̈́͆ͧͨͩͪͫͬͭͮ͘̚͜͟͢͝͞͠͡ͅ" as NSString
+
+  let c1 = Character(ns1 as String)
+  let c2 = Character(ns2 as String)
+  let c3 = Character(ns3 as String)
+
+  expectEqual("A", String(c1))
+  expectNotNil(String(c1).utf8.withContiguousStorageIfAvailable(returnOne))
+
+  expectEqual("A\u{301}", String(c2))
+  expectNotNil(String(c2).utf8.withContiguousStorageIfAvailable(returnOne))
+  expectNil((ns2 as String).utf8.withContiguousStorageIfAvailable(returnOne))
+
+  expectEqual("𓁹͇͈͉͍͎͊͋͌ͧͨͩͪͫͬͭͮ͏̛͓͔͕͖͙͚̗̘̙̜̹̺̻̼͐͑͒͗͛ͣͤͥͦ̽̾̿̀́͂̓̈́͆ͧͨͩͪͫͬͭͮ͘̚͜͟͢͝͞͠͡ͅ", String(c3))
+  expectNotNil(String(c3).utf8.withContiguousStorageIfAvailable(returnOne))
+  expectNil((ns3 as String).utf8.withContiguousStorageIfAvailable(returnOne))
+}
+
+
 runAllTests()
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/22663

* **Explanation**:  This change establishes an invariant (useful for later) that Characters are never backed by lazily-bridged NSStrings or other shared strings. They're either small or in native form.
* **Issue**: rdar://problem/48212434 https://bugs.swift.org/browse/SR-9935
* **Scope**: Affects the behavior of the inline_always initializer on Character taking a String if passed a non-native String. This is a very rare, but possible, scenario.
* **Risk**: Low
* **Testing**:  Added stdlib regression tests
* **Reviewed by**: @lorentey 