### PR TITLE
[CSDiagnostics] Imporove requirement diagnostics originating in conte…

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -236,6 +236,10 @@ protected:
   /// Determine whether this is a conditional requirement failure.
   bool isConditional() const { return bool(Conformance); }
 
+  /// Check whether this requirement comes from the contextual type
+  /// that root expression is coerced/converted into.
+  bool isFromContextualType() const;
+
   /// Retrieve declaration contextual where current
   /// requirement has been introduced.
   const DeclContext *getRequirementDC() const;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2466,7 +2466,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       assert(!expr->isSemanticallyInOutExpr());
 
       // Save the locator we're using for the expression.
-      Locator = cs.getConstraintLocator(expr);
+      Locator =
+          cs.getConstraintLocator(expr, ConstraintLocator::ContextualType);
 
       // Collect constraints from the pattern.
       initType = cs.generateConstraints(pattern, Locator);

--- a/test/Constraints/requirement_failures_in_contextual_type.swift
+++ b/test/Constraints/requirement_failures_in_contextual_type.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+
+struct A<T> {}
+
+extension A where T == Int32 { // expected-note 2 {{where 'T' = 'Int'}}
+  struct B : ExpressibleByIntegerLiteral { // expected-note {{where 'T' = 'Int'}}
+    typealias E = Int
+    typealias IntegerLiteralType = Int
+
+    init(integerLiteral: IntegerLiteralType) {}
+  }
+
+  typealias C = Int
+}
+
+let _: A<Int>.B = 0
+// expected-error@-1 {{referencing struct 'B' on 'A' requires the types 'Int' and 'Int32' be equivalent}}
+let _: A<Int>.C = 0
+// expected-error@-1 {{referencing type alias 'C' on 'A' requires the types 'Int' and 'Int32' be equivalent}}
+let _: A<Int>.B.E = 0
+// expected-error@-1 {{referencing type alias 'E' on 'A.B' requires the types 'Int' and 'Int32' be equivalent}}

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -30,11 +30,11 @@ func arraySameType() {
 
     let _: SameType = arrayWorks
     let _: SameType = arrayFails
-    // expected-error@-1 {{let 'arrayFails' requires the types 'Fails' and 'Works' be equivalent}}
+    // expected-error@-1 {{protocol 'SameType' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [works] as [Works]
     let _: SameType = [fails] as [Fails]
-    // expected-error@-1 {{generic struct 'Array' requires the types 'Fails' and 'Works' be equivalent}}
+    // expected-error@-1 {{protocol 'SameType' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [works] as SameType
     let _: SameType = [fails] as SameType
@@ -55,11 +55,11 @@ func dictionarySameType() {
 
     let _: SameType = dictWorks
     let _: SameType = dictFails
-    // expected-error@-1 {{let 'dictFails' requires the types 'Fails' and 'Works' be equivalent}}
+    // expected-error@-1 {{protocol 'SameType' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [0 : works] as [Int : Works]
     let _: SameType = [0 : fails] as [Int : Fails]
-    // expected-error@-1 {{generic struct 'Dictionary' requires the types 'Fails' and 'Works' be equivalent}}
+    // expected-error@-1 {{protocol 'SameType' requires the types 'Fails' and 'Works' be equivalent}}
 
     let _: SameType = [0 : works] as SameType
     let _: SameType = [0 : fails] as SameType
@@ -76,15 +76,15 @@ func arrayConforms() {
 
     let _: Conforms = [works]
     let _: Conforms = [fails]
-    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = arrayWorks
     let _: Conforms = arrayFails
-    // expected-error@-1 {{let 'arrayFails' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [works] as [Works]
     let _: Conforms = [fails] as [Fails]
-    // expected-error@-1 {{eneric struct 'Array' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [works] as Conforms
     let _: Conforms = [fails] as Conforms
@@ -101,15 +101,15 @@ func dictionaryConforms() {
 
     let _: Conforms = [0 : works]
     let _: Conforms = [0 : fails]
-    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = dictWorks
     let _: Conforms = dictFails
-    // expected-error@-1 {{let 'dictFails' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [0 : works] as [Int : Works]
     let _: Conforms = [0 : fails] as [Int : Fails]
-    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = [0 : works] as Conforms
     let _: Conforms = [0 : fails] as Conforms
@@ -123,7 +123,7 @@ func dictionaryConforms() {
 func combined() {
     let _: Conforms = [[0: [1 : [works]]]]
     let _: Conforms = [[0: [1 : [fails]]]]
-    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
 
     // Needs self conforming protocols:
     let _: Conforms = [[0: [1 : [works]] as Conforms]]


### PR DESCRIPTION
…xtual type

Detect that failed requirement comes from contextual type and use
that information to determine affected declaration.

Resolves: rdar://problem/47980354

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
