### PR TITLE
[basic] Add comparison operators to NullablePtr<T> against T* and oth…

### DIFF
--- a/include/swift/Basic/NullablePtr.h
+++ b/include/swift/Basic/NullablePtr.h
@@ -60,6 +60,14 @@ public:
   const T *getPtrOrNull() const { return Ptr; }
 
   explicit operator bool() const { return Ptr; }
+
+  bool operator==(NullablePtr<T> &&other) const { return other.Ptr == Ptr; }
+
+  bool operator!=(NullablePtr<T> &&other) const { return !(*this == other); }
+
+  bool operator==(const T *other) const { return other == Ptr; }
+
+  bool operator!=(const T *other) const { return !(*this == other); }
 };
   
 } // end namespace swift


### PR DESCRIPTION
…er NullablePtr<T>.

It is always safe to compare a nullptr with a non-null pointer.
