### PR TITLE
[benchmark] Move fake autoreleasepool to TestUtils

### DIFF
--- a/benchmark/single-source/Codable.swift
+++ b/benchmark/single-source/Codable.swift
@@ -107,18 +107,6 @@ public func setup_json() {
   JSONTester = CodablePerfTester(encoder: JSONEncoder(), decoder: JSONDecoder())
 }
 
-#if !_runtime(_ObjC)
-// If we do not have an objc-runtime, then we do not have a definition for
-// autoreleasepool. Add in our own fake autoclosure for it that is inline
-// always. That should be able to be eaten through by the optimizer no problem.
-@inline(__always)
-public func autoreleasepool<Result>(
-  invoking body: () throws -> Result
-) rethrows -> Result {
-  return try body()
-}
-#endif
-
 @inline(never)
 public func run_JSONPerfEncode(_ N: Int) {
   autoreleasepool {

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -235,6 +235,19 @@ public func CheckResults(
     }
 }
 
+#if !_runtime(_ObjC)
+// If we do not have an objc-runtime, then we do not have a definition for
+// autoreleasepool. Add in our own fake autoclosure for it that is inline
+// always. That should be able to be eaten through by the optimizer no problem.
+@inlinable // FIXME(inline-always)
+@inline(__always)
+public func autoreleasepool<Result>(
+  invoking body: () throws -> Result
+) rethrows -> Result {
+  return try body()
+}
+#endif
+
 public func False() -> Bool { return false }
 
 /// This is a dummy protocol to test the speed of our protocol dispatch.


### PR DESCRIPTION
This workaround for writing cross platform benchmarks originally introduced by @gottesmm in #21905 is required in multiple performance tests.

Undeclared `autoreleasepool` was the reason for failing linux smoke test on #22648 during `swiftpm` compilation of benchmarks. This should fix it.