### PR TITLE
SILGen: Fix the logic of dynamic replacements for class constructors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3925,6 +3925,10 @@ ERROR(dynamic_replacement_replaced_not_objc_dynamic, none,
       "%0 is not marked @objc dynamic", (DeclName))
 ERROR(dynamic_replacement_replacement_not_objc_dynamic, none,
       "%0 is marked @objc dynamic", (DeclName))
+ERROR(dynamic_replacement_replaced_constructor_is_convenience, none,
+      "replaced constructor %0 is marked as convenience", (DeclName))
+ERROR(dynamic_replacement_replaced_constructor_is_not_convenience, none,
+      "replaced constructor %0 is not marked as convenience", (DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: @available

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -896,9 +896,11 @@ public:
   }
 
   static LinkEntity
-  forDynamicallyReplaceableFunctionVariable(AbstractFunctionDecl *decl) {
+  forDynamicallyReplaceableFunctionVariable(AbstractFunctionDecl *decl,
+                                            bool isAllocator) {
     LinkEntity entity;
     entity.setForDecl(Kind::DynamicallyReplaceableFunctionVariableAST, decl);
+    entity.SecondaryPointer = isAllocator ? decl : nullptr;
     return entity;
   }
 
@@ -912,16 +914,20 @@ public:
   }
 
   static LinkEntity
-  forDynamicallyReplaceableFunctionKey(AbstractFunctionDecl *decl) {
+  forDynamicallyReplaceableFunctionKey(AbstractFunctionDecl *decl,
+                                       bool isAllocator) {
     LinkEntity entity;
     entity.setForDecl(Kind::DynamicallyReplaceableFunctionKeyAST, decl);
+    entity.SecondaryPointer = isAllocator ? decl : nullptr;
     return entity;
   }
 
   static LinkEntity
-  forDynamicallyReplaceableFunctionImpl(AbstractFunctionDecl *decl) {
+  forDynamicallyReplaceableFunctionImpl(AbstractFunctionDecl *decl,
+                                        bool isAllocator) {
     LinkEntity entity;
     entity.setForDecl(Kind::DynamicallyReplaceableFunctionImpl, decl);
+    entity.SecondaryPointer = isAllocator ? decl : nullptr;
     return entity;
   }
 
@@ -998,6 +1004,12 @@ public:
   bool isDynamicallyReplaceable() const {
     assert(getKind() == Kind::SILFunction);
     return LINKENTITY_GET_FIELD(Data, IsDynamicallyReplaceableImpl);
+  }
+  bool isAllocator() const {
+    assert(getKind() == Kind::DynamicallyReplaceableFunctionImpl ||
+           getKind() == Kind::DynamicallyReplaceableFunctionKeyAST ||
+           getKind() == Kind::DynamicallyReplaceableFunctionVariableAST);
+    return SecondaryPointer != nullptr;
   }
   bool isValueWitness() const { return getKind() == Kind::ValueWitness; }
   CanType getType() const {

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -392,6 +392,8 @@ struct SILDeclRef {
 
   bool isDynamicallyReplaceable() const;
 
+  bool canBeDynamicReplacement() const;
+
 private:
   friend struct llvm::DenseMapInfo<swift::SILDeclRef>;
   /// Produces a SILDeclRef from an opaque value.

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -318,7 +318,7 @@ std::string LinkEntity::mangleAsString() const {
     assert(isa<AbstractFunctionDecl>(getDecl()));
     std::string Result;
     if (auto *Constructor = dyn_cast<ConstructorDecl>(getDecl())) {
-      Result = mangler.mangleConstructorEntity(Constructor, true,
+      Result = mangler.mangleConstructorEntity(Constructor, isAllocator(),
                                                /*isCurried=*/false);
     } else  {
       Result = mangler.mangleEntity(getDecl(), /*isCurried=*/false);
@@ -344,8 +344,9 @@ std::string LinkEntity::mangleAsString() const {
     assert(isa<AbstractFunctionDecl>(getDecl()));
     std::string Result;
     if (auto *Constructor = dyn_cast<ConstructorDecl>(getDecl())) {
-      Result = mangler.mangleConstructorEntity(Constructor, true,
-                                               /*isCurried=*/false);
+      Result =
+          mangler.mangleConstructorEntity(Constructor, isAllocator(),
+                                          /*isCurried=*/false);
     } else  {
       Result = mangler.mangleEntity(getDecl(), /*isCurried=*/false);
     }
@@ -357,8 +358,9 @@ std::string LinkEntity::mangleAsString() const {
     assert(isa<AbstractFunctionDecl>(getDecl()));
     std::string Result;
     if (auto *Constructor = dyn_cast<ConstructorDecl>(getDecl())) {
-      Result = mangler.mangleConstructorEntity(Constructor, true,
-                                               /*isCurried=*/false);
+      Result =
+          mangler.mangleConstructorEntity(Constructor, isAllocator(),
+                                          /*isCurried=*/false);
     } else  {
       Result = mangler.mangleEntity(getDecl(), /*isCurried=*/false);
     }

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -1019,12 +1019,35 @@ unsigned SILDeclRef::getParameterListCount() const {
   }
 }
 
+static bool isDesignatedConstructorForClass(ValueDecl *decl) {
+  if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(decl))
+    if (ctor->getDeclContext()->getSelfClassDecl())
+      return ctor->isDesignatedInit();
+  return false;
+}
+
+bool SILDeclRef::canBeDynamicReplacement() const {
+  if (kind == SILDeclRef::Kind::Destroyer)
+    return false;
+  if (kind == SILDeclRef::Kind::Initializer)
+    return isDesignatedConstructorForClass(getDecl());
+  if (kind == SILDeclRef::Kind::Allocator)
+    return !isDesignatedConstructorForClass(getDecl());
+  return true;
+}
+
 bool SILDeclRef::isDynamicallyReplaceable() const {
   if (isStoredPropertyInitializer())
     return false;
 
+  // Class allocators are not dynamic replaceable.
+  if (kind == SILDeclRef::Kind::Allocator &&
+      isDesignatedConstructorForClass(getDecl()))
+    return false;
+
   if (kind == SILDeclRef::Kind::Destroyer ||
-      kind == SILDeclRef::Kind::Initializer ||
+      (kind == SILDeclRef::Kind::Initializer &&
+       !isDesignatedConstructorForClass(getDecl())) ||
       kind == SILDeclRef::Kind::GlobalAccessor) {
     return false;
   }

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -86,7 +86,7 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
     return;
   }
 
-  if (constant.isInitializerOrDestroyer())
+  if (!constant.canBeDynamicReplacement())
     return;
 
   SILDeclRef declRef(replacedDecl, constant.kind, false);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2253,6 +2253,22 @@ void TypeChecker::checkDynamicReplacementAttribute(ValueDecl *D) {
     DeclAttributes &attrs = replacements[index]->getAttrs();
     attrs.add(newAttr);
   }
+  if (auto *CD = dyn_cast<ConstructorDecl>(D)) {
+    auto *attr = CD->getAttrs().getAttribute<DynamicReplacementAttr>();
+    auto replacedIsConvenienceInit =
+        cast<ConstructorDecl>(attr->getReplacedFunction())->isConvenienceInit();
+    if (replacedIsConvenienceInit &&!CD->isConvenienceInit()) {
+      diagnose(attr->getLocation(),
+               diag::dynamic_replacement_replaced_constructor_is_convenience,
+               attr->getReplacedFunctionName());
+    } else if (!replacedIsConvenienceInit && CD->isConvenienceInit()) {
+      diagnose(
+          attr->getLocation(),
+          diag::dynamic_replacement_replaced_constructor_is_not_convenience,
+          attr->getReplacedFunctionName());
+    }
+  }
+
 
   // Remove the attribute on the abstract storage (we have moved it to the
   // accessor decl).

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -166,6 +166,21 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
   }
 }
 
+/// Determine whether dynamic replacement should be emitted for the allocator or
+/// the initializer given a decl.
+/// The rule is that structs and convenience init of classes emit a
+/// dynamic replacement for the allocator.
+/// Designated init of classes emit a dynamic replacement for the intializer.
+/// This is because the super class init call is emitted to the initializer and
+/// needs to be dynamic.
+static bool shouldUseAllocatorMangling(const AbstractFunctionDecl *afd) {
+  auto constructor = dyn_cast<ConstructorDecl>(afd);
+  if (!constructor)
+    return false;
+  return constructor->getParent()->getSelfClassDecl() == nullptr ||
+         constructor->isConvenienceInit();
+}
+
 void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   // A @_silgen_name("...") function without a body only exists
   // to forward-declare a symbol from another library.
@@ -177,13 +192,20 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
 
   // Add the global function pointer for a dynamically replaceable function.
   if (AFD->isNativeDynamic()) {
-    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(AFD));
-    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionImpl(AFD));
-    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionKey(AFD));
+    bool useAllocator = shouldUseAllocatorMangling(AFD);
+    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(
+        AFD, useAllocator));
+    addSymbol(
+        LinkEntity::forDynamicallyReplaceableFunctionImpl(AFD, useAllocator));
+    addSymbol(
+        LinkEntity::forDynamicallyReplaceableFunctionKey(AFD, useAllocator));
   }
   if (AFD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
-    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(AFD));
-    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionImpl(AFD));
+    bool useAllocator = shouldUseAllocatorMangling(AFD);
+    addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(
+        AFD, useAllocator));
+    addSymbol(
+        LinkEntity::forDynamicallyReplaceableFunctionImpl(AFD, useAllocator));
   }
 
   if (AFD->getAttrs().hasAttribute<CDeclAttr>()) {

--- a/test/Interpreter/Inputs/dynamic_replacement_module.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_module.swift
@@ -155,8 +155,7 @@ public func replacement_for_public_global_generic_func<T>(_ t: T.Type) -> String
 
 extension PublicClass {
   @_dynamicReplacement(for: init(x:))
-  convenience public init(y: Int) {
-    self.init(x: y)
+  public init(y: Int) {
     str = "replacement of public_class_init"
   }
 

--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -38,7 +38,7 @@ struct Strukt {
     }
   }
 }
-// CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable5KlassC1xACSi_tcfC : $@convention(method) (Int, @thick Klass.Type) -> @owned Klass
+// CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable5KlassC1xACSi_tcfc : $@convention(method) (Int, @owned Klass) -> @owned Klass
 // CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable5KlassC08dynamic_B0yyF : $@convention(method) (@guaranteed Klass) -> () {
 // CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable5KlassC08dynamic_B4_varSivg
 // CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable5KlassC08dynamic_B4_varSivs
@@ -46,6 +46,13 @@ struct Strukt {
 // CHECK_LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable5KlassCyS2icis : $@convention(method) (Int, Int, @guaranteed Klass) -> ()
 class Klass {
   dynamic init(x: Int) {
+  }
+
+  dynamic convenience init(c: Int) {
+    self.init(x: c)
+  }
+
+  dynamic convenience init(a: Int, b: Int) {
   }
   dynamic func dynamic_replaceable() {
   }
@@ -67,6 +74,15 @@ class Klass {
   }
 }
 
+class SubKlass : Klass {
+  // CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable8SubKlassC1xACSi_tcfc
+  // CHECK: // dynamic_function_ref Klass.init(x:)
+  // CHECK: [[FUN:%.*]] = dynamic_function_ref @$s23dynamically_replaceable5KlassC1xACSi_tcfc
+  // CHECK: apply [[FUN]]
+  dynamic override init(x: Int) {
+    super.init(x: x)
+  }
+}
 // CHECK-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable6globalSivg : $@convention(thin) () -> Int {
 dynamic var global : Int {
   return 1
@@ -93,12 +109,25 @@ extension Klass {
     dynamic_replaceable2()
   }
 
-  // CHECK-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC1xACSi_tcfC"] [ossa] @$s23dynamically_replaceable5KlassC1yACSi_tcfC : $@convention(method) (Int, @thick Klass.Type) -> @owned Klass {
-  // CHECK:  [[FUN:%.*]] = prev_dynamic_function_ref @$s23dynamically_replaceable5KlassC1yACSi_tcfC
+  // CHECK-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC1cACSi_tcfC"] [ossa] @$s23dynamically_replaceable5KlassC2crACSi_tcfC : $@convention(method) (Int, @thick Klass.Type) -> @owned Klass {
+  // CHECK:  [[FUN:%.*]] = prev_dynamic_function_ref @$s23dynamically_replaceable5KlassC2crACSi_tcfC
   // CHECK:  apply [[FUN]]({{.*}}, %1)
+  @_dynamicReplacement(for: init(c:))
+  convenience init(cr: Int) {
+    self.init(c: cr + 1)
+  }
+
+  // CHECK-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC1a1bACSi_SitcfC"] [ossa] @$s23dynamically_replaceable5KlassC2ar2brACSi_SitcfC
+  // CHECK: // dynamic_function_ref Klass.__allocating_init(c:)
+  // CHECK: [[FUN:%.*]] = dynamic_function_ref @$s23dynamically_replaceable5KlassC1cACSi_tcfC
+  // CHECK: apply [[FUN]]({{.*}}, %2)
+  @_dynamicReplacement(for: init(a: b:))
+  convenience init(ar: Int, br: Int) {
+    self.init(c: ar + br)
+  }
+
   @_dynamicReplacement(for: init(x:))
-  convenience init(y: Int) {
-    self.init(x: y + 1)
+    init(xr: Int) {
   }
 
 // CHECK-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC08dynamic_B4_varSivg"] [ossa] @$s23dynamically_replaceable5KlassC1rSivg : $@convention(method) (@guaranteed Klass) -> Int {

--- a/test/attr/Inputs/dynamicReplacementC.swift
+++ b/test/attr/Inputs/dynamicReplacementC.swift
@@ -7,3 +7,8 @@ public extension TheReplaceables {
   dynamic subscript (i: Int) -> Int { return 0 }
   dynamic subscript (s: String) -> String { return "" }
 }
+
+public class K {
+  public init(i: Int) {}
+  public convenience init(c : Int) { self.init(i : c) }
+}

--- a/test/attr/dynamicReplacement.swift
+++ b/test/attr/dynamicReplacement.swift
@@ -38,3 +38,11 @@ extension TheReplaceables {
   @_dynamicReplacement(for: subscript(_:))
   subscript (string_string i: String) -> String { return "" }
 }
+
+extension K {
+  @_dynamicReplacement(for: init(i:)) // expected-error{{replaced constructor 'init(i:)' is not marked as convenience}}
+  convenience init(ri: Int) { }
+
+  @_dynamicReplacement(for: init(c:)) // expected-error{{replaced constructor 'init(c:)' is marked as convenience}})
+  init(rc: Int) { }
+}


### PR DESCRIPTION
To correctly call designated super class initializers the designated
intializer (and not the allocator) is dynamically replaceable.
Convenience allocators are dynamically replaceable as before.

