### PR TITLE
[CodeCompletion] Analyze the parent of initializer

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
@@ -691,7 +692,11 @@ public:
       } else
         return false;
     });
-    DC->walkContext(Finder);
+
+    // For 'Initializer' context, we need to look into its parent because it
+    // might constrain the initializer's type.
+    auto analyzeDC = isa<Initializer>(DC) ? DC->getParent() : DC;
+    analyzeDC->walkContext(Finder);
 
     if (Finder.Ancestors.empty())
       return;

--- a/test/IDE/complete_in_accessors.swift
+++ b/test/IDE/complete_in_accessors.swift
@@ -150,7 +150,7 @@ func returnsInt() -> Int {}
 
 // WITH_MEMBER_DECLS_INIT: Begin completions
 // WITH_MEMBER_DECLS_INIT-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_MEMBER_DECLS_INIT-DAG: Decl[FreeFunction]/CurrModule:    returnsInt()[#Int#]{{; name=.+$}}
+// WITH_MEMBER_DECLS_INIT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: returnsInt()[#Int#]{{; name=.+$}}
 // WITH_MEMBER_DECLS_INIT-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc({#self: MemberAccessors#})[#(Int) -> Float#]{{; name=.+$}}
 // WITH_MEMBER_DECLS_INIT: End completions
 

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -100,6 +100,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERICPARAM_20 | %FileCheck %s -check-prefix=GENERICPARAM_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERICPARAM_21 | %FileCheck %s -check-prefix=GENERICPARAM_1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DECL_MEMBER_INIT_1 | %FileCheck %s -check-prefix=UNRESOLVED_3
+
 enum SomeEnum1 {
   case South
   case North
@@ -644,4 +646,8 @@ func testingGenericParam2<X>(obj: C<X>) {
   // Same as GENERICPARAM_1.
   obj.t = .#^GENERICPARAM_21^#
   // Same as GENERICPARAM_1.
+}
+
+struct TestingStruct {
+  var value: SomeEnum1 = .#^DECL_MEMBER_INIT_1^#
 }


### PR DESCRIPTION
For `Initializer` decl context, type context analyzer should look into its parent context because that might constrain initializer's type.

rdar://problem/48208253
