### PR TITLE
test: adjustment for Windows

### DIFF
--- a/test/Parse/objc_enum.swift
+++ b/test/Parse/objc_enum.swift
@@ -1,10 +1,10 @@
 // RUN: %target-typecheck-verify-swift -enable-objc-interop
 
-@objc enum Foo: Int {
+@objc enum Foo: Int32 {
   case Zim, Zang, Zung
 }
 
-@objc enum Generic<T>: Int { // expected-error{{'@objc' enum cannot be generic}} {{1-7=}}
+@objc enum Generic<T>: Int32 { // expected-error{{'@objc' enum cannot be generic}} {{1-7=}}
   case Zim, Zang, Zung
 }
 
@@ -30,7 +30,7 @@ class Bar {
 }
 
 // <rdar://problem/23681566> @objc enums with payloads rejected with no source location info
-@objc enum r23681566 : Int {  // expected-error {{'r23681566' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int' here}}
+@objc enum r23681566 : Int32 {  // expected-error {{'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int32' here}}
   case Foo(progress: Int)     // expected-error {{enum with raw type cannot have cases with arguments}}
 }
 


### PR DESCRIPTION
Adjust the Parse/objc_enum test for Windows.  Windows x64 is a LLp64 target,
which imports `Int` differently.  Explicitly use `Int32` for the inheritance.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
