### PR TITLE
IRGen: make Windows use resilient conformances

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -174,6 +174,7 @@ public:
   /// Force lazy initialization of class metadata
   /// Used on Windows to avoid cross-module references.
   unsigned LazyInitializeClassMetadata : 1;
+  unsigned LazyInitializeProtocolConformances : 1;
 
   /// Normally if the -read-legacy-type-info flag is not specified, we look for
   /// a file named "legacy-<arch>.yaml" in SearchPathOpts.RuntimeLibraryPath.
@@ -234,7 +235,7 @@ public:
         ValueNames(false), EnableReflectionMetadata(true),
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
         EnableResilienceBypass(false), LazyInitializeClassMetadata(false),
-        DisableLegacyTypeInfo(false),
+        LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),
         UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1080,6 +1080,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // (e.g. NativeObject).  Force the lazy initialization of the VWT always.
   Opts.LazyInitializeClassMetadata = Triple.isOSBinFormatCOFF();
 
+  // PE/COFF cannot deal with cross-module reference to the protocol conformance
+  // witness.  Use a runtime initialized value for the protocol conformance
+  // witness.
+  Opts.LazyInitializeProtocolConformances = Triple.isOSBinFormatCOFF();
+
   if (Args.hasArg(OPT_disable_legacy_type_info)) {
     Opts.DisableLegacyTypeInfo = true;
   }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1075,6 +1075,9 @@ public:
 
   llvm::Constant *tryGetConstantTable(IRGenModule &IGM,
                                       CanType conformingType) const override {
+    if (IGM.getOptions().LazyInitializeProtocolConformances &&
+        RootConformance->getDeclContext()->getParentModule() != IGM.getSwiftModule())
+      return nullptr;
     return IGM.getAddrOfWitnessTable(RootConformance);
   }
 };

--- a/test/IRGen/lazy-root-conformance.swift
+++ b/test/IRGen/lazy-root-conformance.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -DA -parse-as-library -parse-stdlib -module-name A %s -o %t/A.swiftmodule
+// RUN: %target-swift-frontend -emit-ir -DB -I %t -parse-as-library -parse-stdlib -module-name B -o - %s | %FileCheck %s -check-prefix CHECK-%target-import-type
+
+#if A
+public protocol P {
+}
+
+public enum E : P {
+}
+#endif
+
+#if B
+import A
+
+public protocol Q : P {
+}
+
+extension E : Q {
+}
+#endif
+
+// CHECK-DIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s1A1EO1B1QADMc" to i8*), i8* bitcast (i8** @"$s1A1EOAA1PAAWP" to i8*)]
+// CHECK-INDIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s1A1EO1B1QADMc" to i8*), i8* null]
+


### PR DESCRIPTION
Use the resilient conformance code path for PE/COFF as that forces the witnesses
to be generated at runtime avoiding the cross-module initialised static data.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
