### PR TITLE
[benchmark] Finish Naming Convention Support

### DIFF
--- a/benchmark/Naming.md
+++ b/benchmark/Naming.md
@@ -28,8 +28,8 @@ benchmark is testing individual method on a concrete type.
 ````
 ⛔️ Dictionary2
 ✅ AngryPhonebook
-✅ Dictionary.AnyHashable.String.update
 ✅ Array.append.Array.Int
+✅ Dictionary.AnyHashable.String.update
 ````
 
 Benchmark names are used to run individual tests when passed as command line
@@ -42,8 +42,8 @@ optional chaining etc.
 
 ````
 ✅ Array.append.Array.Int?
-✅ Flatten.Array.Tuple4.for-in.reserved
 ✅ Bridging.NSArray.as!.Array.NSString
+✅ Flatten.Array.Tuple4.for-in.Reserve
 ````
 
 Note: Special characters that could be interpreted by the shell require escaping

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -200,7 +200,7 @@ class BenchmarkDriver(object):
         with open(log_file, 'w') as f:
             f.write(output)
 
-    RESULT = '{:>3} {:<25} {:>7} {:>7} {:>6} {:>10} {:>6} {:>7} {:>10}'
+    RESULT = '{:>3} {:<40} {:>7} {:>7} {:>6} {:>10} {:>6} {:>7} {:>10}'
 
     def run_and_log(self, csv_console=True):
         """Run benchmarks and continuously log results to the console.

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -363,9 +363,9 @@ class LogParser(object):
     # Parse lines like this
     # #,TEST,SAMPLES,MIN(μs),MAX(μs),MEAN(μs),SD(μs),MEDIAN(μs)
     results_re = re.compile(
-        r'( *\d+[, \t]+[\w.]+[, \t]+' +  # #,TEST
-        r'[, \t]+'.join([r'\d+'] * 2) +  # at least 2...
-        r'(?:[, \t]+\d*)*)')             # ...or more numeric columns
+        r'( *\d+[, \t]+[\w.\-\?!]+[, \t]+' +  # #,TEST
+        r'[, \t]+'.join([r'\d+'] * 2) +       # at least 2...
+        r'(?:[, \t]+\d*)*)')                  # ...or more numeric columns
 
     def _append_result(self, result):
         columns = result.split(',') if ',' in result else result.split()

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -366,10 +366,10 @@ class TestBenchmarkDriverRunningTests(unittest.TestCase):
         self.assertEqual(log, header + csv_log)
         self.assertEqual(
             out.getvalue(),
-            '  # TEST                      SAMPLES MIN(μs) Q1(μs)' +
-            ' MEDIAN(μs) Q3(μs) MAX(μs) MAX_RSS(B)\n' +
-            '  3 b1                              5     101    102' +
-            '        103    104     105        888\n' +
+            '  # TEST                                     SAMPLES MIN(μs)' +
+            ' Q1(μs) MEDIAN(μs) Q3(μs) MAX(μs) MAX_RSS(B)\n' +
+            '  3 b1                                             5     101' +
+            '    102        103    104     105        888\n' +
             '\n' +
             'Total performance tests executed: 1\n')
 

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -445,14 +445,20 @@ class TestLogParser(unittest.TestCase):
     def test_parse_results_csv(self):
         """Ignores uknown lines, extracts data from supported formats."""
         log = """#,TEST,SAMPLES,MIN(us),MAX(us),MEAN(us),SD(us),MEDIAN(us)
-34,BitCount,20,3,4,4,0,4
+7,Array.append.Array.Int?,20,10,10,10,0,10
+21,Bridging.NSArray.as!.Array.NSString,20,11,11,11,0,11
+42,Flatten.Array.Tuple4.lazy.for-in.Reserve,20,3,4,4,0,4
 
 Total performance tests executed: 1
 """
         parser = LogParser()
         results = parser.parse_results(log.splitlines())
         self.assertTrue(isinstance(results[0], PerformanceTestResult))
-        self.assertEqual(results[0].name, 'BitCount')
+        self.assertEquals(results[0].name, 'Array.append.Array.Int?')
+        self.assertEquals(results[1].name,
+                          'Bridging.NSArray.as!.Array.NSString')
+        self.assertEquals(results[2].name,
+                          'Flatten.Array.Tuple4.lazy.for-in.Reserve')
 
     def test_parse_results_tab_delimited(self):
         log = '34\tBitCount\t20\t3\t4\t4\t0\t4'


### PR DESCRIPTION
These are few commits extracted from #20552, which has been stuck in limbo for a while, to fix the `LogParser` support for the new Benchmark Naming Convention from #20334 and use the 40 character limit to better align columns in `Benchmark_Driver`'s console output (in `-output-dir` mode). 