### PR TITLE
[ParseableInterface] Distinguish SDK and non-SDK dependencies

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 475; // Last change: Generalize nested archetype serialization
+const uint16_t SWIFTMODULE_VERSION_MINOR = 476; // Last change: SDK-relative dependencies flag
 
 using DeclIDField = BCFixed<31>;
 
@@ -673,6 +673,7 @@ namespace input_block {
     FILE_DEPENDENCY,
     FileSizeField,    // file size (for validation)
     FileModTimeField, // file mtime (for validation)
+    BCFixed<1>,       // SDK-relative?
     BCBlob            // path
   >;
 }

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -39,6 +39,7 @@ namespace swift {
       uint64_t Size;
       uint64_t ModificationTime;
       std::string Path;
+      bool SDKRelative;
     };
     ArrayRef<FileDependency> Dependencies;
 

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -34,9 +34,7 @@ void
 DependencyTracker::addDependency(StringRef File, bool IsSystem) {
   // DependencyTracker exposes an interface that (intentionally) does not talk
   // about clang at all, nor about missing deps. It does expose an IsSystem
-  // dimension, though it is presently always false, we accept it and pass it
-  // along to the clang DependencyCollector in case Swift callers start setting
-  // it to true someday.
+  // dimension, which we accept and pass along to the clang DependencyCollector.
   clangCollector->maybeAddDependency(File, /*FromModule=*/false,
                                      IsSystem, /*IsModuleFile=*/false,
                                      /*IsMissing=*/false);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -252,10 +252,14 @@ static bool validateInputBlock(
     StringRef blobData;
     unsigned kind = cursor.readRecord(entry.ID, scratch, &blobData);
     switch (kind) {
-    case input_block::FILE_DEPENDENCY:
+    case input_block::FILE_DEPENDENCY: {
+      bool isSDKRelative = false;
+      if (scratch.size() >= 2)
+        isSDKRelative = scratch[2];
       dependencies.push_back(SerializationOptions::FileDependency{
-          scratch[0], scratch[1], blobData});
+          scratch[0], scratch[1], blobData, isSDKRelative});
       break;
+    }
     default:
       // Unknown metadata record, possibly for use by a future version of the
       // module format.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1058,9 +1058,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   }
 
   for (auto const &dep : options.Dependencies) {
-    FileDependency.emit(ScratchRecord, dep.Size,
-                        dep.ModificationTime,
-                        dep.Path);
+    FileDependency.emit(ScratchRecord, dep.Size, dep.ModificationTime,
+                        dep.SDKRelative, dep.Path);
   }
 
   SmallVector<ModuleDecl::ImportedModule, 8> allImports;

--- a/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/SomeCModule.h
+++ b/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/SomeCModule.h
@@ -1,0 +1,1 @@
+extern int x;

--- a/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/module.modulemap
+++ b/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/module.modulemap
@@ -1,0 +1,3 @@
+module SomeCModule {
+  header "SomeCModule.h"
+}

--- a/test/ParseableInterface/ModuleCache/SDKDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies.swiftinterface
@@ -1,0 +1,24 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name SDKDependencies
+
+// RUN: %empty-directory(%t)
+
+// RUN: echo 'import SDKDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %S/Inputs/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: test -f %t/MCP/SDKDependencies*.swiftmodule
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP/SDKDependencies*.swiftmodule
+
+// Baseline: running the same command again doesn't rebuild the cached module.
+// RUN: echo 'import SDKDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %S/Inputs/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SDKDependencies*.swiftmodule
+
+// Try moving the SDK but not changing the contents.
+// RUN: cp -r %S/Inputs/mock-sdk %t/mock-sdk
+// RUN: echo 'import SDKDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SDKDependencies*.swiftmodule
+
+// Now try changing the contents.
+// RUN: echo "// size change" >> %t/mock-sdk/usr/include/SomeCModule.h
+// RUN: echo 'import SDKDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-new.py %t/MCP/SDKDependencies*.swiftmodule
+
+import SomeCModule

--- a/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -1,0 +1,44 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name SystemDependencies
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mock-sdk %t/mock-sdk
+
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d
+// RUN: test -f %t/MCP/SystemDependencies*.swiftmodule
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t/dummy.d
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP/SystemDependencies*.swiftmodule
+
+// Baseline: running the same command again doesn't rebuild the cached module.
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SystemDependencies*.swiftmodule
+
+// Now try changing the contents.
+// RUN: echo "// size change" >> %t/mock-sdk/usr/include/SomeCModule.h
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SystemDependencies*.swiftmodule
+
+// Okay, now let's try again with system dependency tracking on.
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: test -f %t/MCP-system/SystemDependencies*.swiftmodule
+// RUN: %FileCheck -check-prefix CHECK %s < %t/dummy.d
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP-system/SystemDependencies*.swiftmodule
+
+// Baseline: running the same command again doesn't rebuild the cached module.
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP-system/SystemDependencies*.swiftmodule
+
+// Now try changing the contents.
+// RUN: echo "// size change" >> %t/mock-sdk/usr/include/SomeCModule.h
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -enable-parseable-module-interface -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-new.py %t/MCP-system/SystemDependencies*.swiftmodule
+
+// Check that it picked a different cache key.
+// RUN: %empty-directory(%t/MCP-combined)
+// RUN: cp -n %t/MCP/SystemDependencies*.swiftmodule %t/MCP-combined
+// RUN: cp -n %t/MCP-system/SystemDependencies*.swiftmodule %t/MCP-combined
+
+// NEGATIVE-NOT: SomeCModule.h
+// CHECK: SomeCModule.h
+
+import SomeCModule


### PR DESCRIPTION
Honor -track-system-dependencies when building swiftinterfaces into swiftmodules on demand, then start distinguishing SDK and non-SDK dependencies to allow for relocating SDKs.

One interesting thing here is that the decision of whether or not to track system dependencies ends up going into the cache key for a swiftmodule built from a parseable interface, because it affects that module's up-to-date check. If we didn't include `-track-system-dependencies` in the cache key, we could end up tracking system dependencies for some modules but not others in the same build.

There's a bit of a bug here where `-track-system-dependencies` is *not* honored if the top-level invocation isn't tracking *any* dependencies, but given how uncommon this flag and that situation are in practice that's probably okay for now.

Still TODO: honor this for `-build-swiftmodule-from-parseable-interface` as well. That's currently not tracking dependencies at all and it probably should.