### PR TITLE
[TensorFlow] Make `TensorDataType.cDataType` public

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -284,7 +284,7 @@ private class TraceContext {
     var returnValues = [CTensorHandle?](repeating: nil,
                                         count: maxReturnValueCount)
     var outputReturnValueCount = Int32(maxReturnValueCount)
-    TFE_Execute(op, &returnValues, &outputReturnValueCount, status) 
+    TFE_Execute(op, &returnValues, &outputReturnValueCount, status)
     checkOk(status)
     debugLog("""
                returnValues.count=\(returnValues.count), \
@@ -856,7 +856,7 @@ private func _trace<State : _TensorArrayProtocolEnhanced,
                            "Should not be in tracing mode already!")
 
   // Switch to tracing mode.
-  let dtypes = state._dtypes + Data._typeList.map { $0.cDataType }
+  let dtypes = state._dtypes + Data._typeList.map { $0._cDataType }
   let traceCtx = TraceContext(dtypes: dtypes)
   _RuntimeConfig.traceState = .tracing(traceCtx)
 
@@ -888,14 +888,14 @@ private func _trace<State : _TensorArrayProtocolEnhanced,
   let opType = "MyTraceFn_TAP"
   return finalizeTraceFunction(opType)
 }
-  
+
 private func _graphInternal<State : _TensorArrayProtocolEnhanced,
                            Data : TensorGroup,
                            Result : TensorGroup>(
   with state: State,
   in fn: (State, Data) -> (State, Result?)
 ) -> (State, Data) -> (State, Result?) {
-  let traceContext = _trace(with: state, in : fn) 
+  let traceContext = _trace(with: state, in : fn)
   // The result is a closure that captures and executes the trace graph
   // function in the trace context.
   return { (oldState: State, data: Data) -> (State, Result?) in
@@ -946,8 +946,8 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
   in fn: @escaping (State, Data) -> State
 ) -> (State, Data) -> State {
   let wrappedFn = {
-    // The result argument needs to a type that conforms to TensorGroup. 
-    // We are arbitrarily picking Tensor<Float> here. 
+    // The result argument needs to a type that conforms to TensorGroup.
+    // We are arbitrarily picking Tensor<Float> here.
     (s: State, d: Data) -> (State, Tensor<Float>?) in
       (fn(s, d), nil)
   }

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -28,7 +28,6 @@ import CTensorFlow
 // declarations from the TF C API.
 @_fixed_layout
 public struct TensorDataType {
-  @usableFromInline
   public var _cDataType: TF_DataType
 
   @inlinable

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -29,11 +29,11 @@ import CTensorFlow
 @_fixed_layout
 public struct TensorDataType {
   @usableFromInline
-  internal var cDataType: TF_DataType
+  public var _cDataType: TF_DataType
 
   @inlinable
   internal init(_ cDataType: TF_DataType) {
-    self.cDataType = cDataType
+    self._cDataType = cDataType
   }
 }
 

--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -27,7 +27,7 @@ public class _AnyTensorHandle {
   /// property, and assumes that this is it. Changing the design of
   /// `TensorHandle` will require tweaking the compiler.
   public let _cTensorHandle: CTensorHandle
-  
+
   /// Private initializer from a `CTensorHandle`. Should only be called from
   /// `TensorHandle<Scalar>.init`.
   fileprivate init(base: CTensorHandle) {
@@ -45,7 +45,7 @@ public final class TensorHandle<Scalar> : _AnyTensorHandle
   public init(_owning cTensorHandle: CTensorHandle) {
     super.init(base: cTensorHandle)
   }
-  
+
   @usableFromInline
   convenience init(copyingFromCTensor cTensor: CTensor) {
     let status = TF_NewStatus()
@@ -78,7 +78,7 @@ public final class TensorHandle<Scalar> : _AnyTensorHandle
     bufferInitializer: (UnsafeMutableRawPointer) -> Void
   ) {
     let cTensor = TF_AllocateTensor(
-      Scalar.tensorFlowDataType.cDataType,
+      Scalar.tensorFlowDataType._cDataType,
       shape.map(Int64.init),
       Int32(shape.count),
       byteCount
@@ -143,7 +143,7 @@ extension TensorHandle : TensorSendableReceivable {
     let context = _ExecutionContext.global
     let cTensorHandle = TFE_DequeueNamedTensorFromCtx(
       context.eagerContext, Int32(tensorID),
-      Scalar.tensorFlowDataType.cDataType, status)
+      Scalar.tensorFlowDataType._cDataType, status)
     checkOk(status)
     tensorHandle = TensorHandle<Scalar>(_owning: cTensorHandle!)
     if _RuntimeConfig.printsDebugLog {
@@ -174,7 +174,7 @@ extension TensorHandle : TensorSendableReceivable {
   static func scalar(_ scalar: Scalar) -> TensorHandle<Scalar> {
     debugLog("Creating a tensor from scalar \(scalar).")
     let cTensorHandle = _TFCCreateCTensorHandle(
-        scalar, Scalar.tensorFlowDataType.cDataType)
+        scalar, Scalar.tensorFlowDataType._cDataType)
     return TensorHandle<Scalar>(_owning: cTensorHandle)
   }
 }
@@ -224,7 +224,7 @@ extension ResourceHandle : TensorSendableReceivable {
     checkOk(status)
     TF_DeleteStatus(status)
     debugLog("Done receiving resource tensor of id \(tensorID).")
-    return ResourceHandle(owning: cTensorHandle)    
+    return ResourceHandle(owning: cTensorHandle)
   }
 
   @inlinable
@@ -277,7 +277,7 @@ extension VariantHandle : TensorSendableReceivable {
     checkOk(status)
     TF_DeleteStatus(status)
     debugLog("Done receiving variant tensor of id \(tensorID).")
-    return VariantHandle(owning: cTensorHandle)    
+    return VariantHandle(owning: cTensorHandle)
   }
 
   @inlinable


### PR DESCRIPTION
Making this property public allows us to use it when constructing `#tfop()` statements which require a `dtype` attribute, in code that isn't built as part of the standard library.