### PR TITLE
[TF-256] fix deserialization errors when differentiating wrt subset of params

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 470; // Last change: serialize @differentiating attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 471; // Last change: add parameter differentiability to SILFunctionType serialization
 
 using DeclIDField = BCFixed<31>;
 
@@ -273,6 +273,14 @@ enum class ParameterConvention : uint8_t {
   Indirect_In_Constant,
 };
 using ParameterConventionField = BCFixed<4>;
+
+// SWIFT_ENABLE_TENSORFLOW
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
+enum class SILParameterDifferentiability : uint8_t {
+  DifferentiableOrNotApplicable,
+  NotDifferentiable,
+};
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -828,7 +836,9 @@ namespace decls_block {
     BCFixed<30>,           // number of yields
     BCFixed<30>,           // number of results
     GenericSignatureIDField, // generic signature
-    BCArray<TypeIDField>   // parameter types/conventions, alternating
+    // SWIFT_ENABLE_TENSORFLOW
+    BCArray<TypeIDField>   // for each parameter: type, convention, and (if
+                           // function is differentiable) differentiability,
                            // followed by result types/conventions, alternating
                            // followed by error result type/convention
     // Optionally a protocol conformance (for witness_methods)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4192,6 +4192,15 @@ SILFunctionType::SILFunctionType(GenericSignature *genericSig, ExtInfo ext,
              "Cannot return an @noescape function type");
     }
   }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // Make sure that NotDifferentiable parameters only exist on differentiable
+  // functions.
+  if (!ext.isDifferentiable())
+    for (auto param : getParameters())
+      assert(param.getDifferentiability() ==
+                 SILParameterDifferentiability::DifferentiableOrNotApplicable &&
+             "non-differentiable function has NotDifferentiable parameter");
 #endif
 }
 

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -678,8 +678,18 @@ getExtracteeType(SILValue function, Extractee extractee,
                  unsigned differentiationOrder, SILModule &module) {
   auto fnTy = function->getType().castTo<SILFunctionType>();
   assert(fnTy->getExtInfo().isDifferentiable());
-  auto originalFnTy =
-      fnTy->getWithExtInfo(fnTy->getExtInfo().withDifferentiable(false));
+
+  auto originalFnExtInfo = fnTy->getExtInfo().withDifferentiable(false);
+  SmallVector<SILParameterInfo, 4> originalFnParameters;
+  for (auto &param : fnTy->getParameters())
+    originalFnParameters.push_back(SILParameterInfo(
+        param.getType(), param.getConvention(),
+        SILParameterDifferentiability::DifferentiableOrNotApplicable));
+  auto originalFnTy = SILFunctionType::get(
+      fnTy->getGenericSignature(), originalFnExtInfo, fnTy->getCoroutineKind(),
+      fnTy->getCalleeConvention(), originalFnParameters, fnTy->getYields(),
+      fnTy->getResults(), fnTy->getOptionalErrorResult(), fnTy->getASTContext(),
+      fnTy->getWitnessMethodConformanceOrNone());
 
   auto kindOpt = extractee.getExtracteeAsAssociatedFunction();
   if (!kindOpt) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3680,6 +3680,17 @@ static uint8_t getRawStableParameterConvention(swift::ParameterConvention pc) {
   llvm_unreachable("bad parameter convention kind");
 }
 
+/// Translate from AST SILParameterDifferentiability enum to the Serialization
+/// enum values, which are guaranteed to be stable.
+static uint8_t
+getRawSILParameterDifferentiability(swift::SILParameterDifferentiability pd) {
+  switch (pd) {
+  SIMPLE_CASE(SILParameterDifferentiability, DifferentiableOrNotApplicable)
+  SIMPLE_CASE(SILParameterDifferentiability, NotDifferentiable)
+  }
+  llvm_unreachable("bad parameter differentiability kind");
+}
+
 /// Translate from the AST ResultConvention enum to the
 /// Serialization enum values, which are guaranteed to be stable.
 static uint8_t getRawStableResultConvention(swift::ResultConvention rc) {
@@ -3972,6 +3983,10 @@ void Serializer::writeType(Type ty) {
       variableData.push_back(addTypeRef(param.getType()));
       unsigned conv = getRawStableParameterConvention(param.getConvention());
       variableData.push_back(TypeID(conv));
+      // SWIFT_ENABLE_TENSORFLOW
+      if (fnTy->isDifferentiable())
+        variableData.push_back(TypeID(
+            getRawSILParameterDifferentiability(param.getDifferentiability())));
     }
     for (auto yield : fnTy->getYields()) {
       variableData.push_back(addTypeRef(yield.getType()));

--- a/test/AutoDiff/deserialization_crashers.swift
+++ b/test/AutoDiff/deserialization_crashers.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-sib %s -o %t/tmp.sib
+// RUN: %target-sil-opt %t/tmp.sib
+
+// TF-256: Crashes when deserializing witness thunk for requirement requiring
+// differentiability wrt a subset of parameters.
+protocol DifferentiableWRTSubset : Differentiable {
+  @differentiable(wrt: (self))
+  func f(x: Float) -> Float
+
+  @differentiable(wrt: (x))
+  func g(x: Float) -> Float
+}
+
+struct TF256 : DifferentiableWRTSubset {
+  var param: Float = 0
+
+  @differentiable(wrt: (self))
+  func f(x: Float) -> Float { return x + param }
+
+  @differentiable(wrt: (x))
+  func g(x: Float) -> Float { return x + param }
+}


### PR DESCRIPTION
* Adds parameter differentiability to SILFunctionType serialization.
* Clears parameter differentiability when constructing the original SILFunctionType from a differentiable SILFunctionType. (Also adds an assertion to catch it earlier if we forget in the future).
* Adds a test.

This should fix https://bugs.swift.org/browse/TF-256.