### PR TITLE
[CMake] Provide a way to build the minimum things necessary for the syntax parser library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,8 @@ endif()
 option(SWIFT_BUILD_SYNTAXPARSERLIB
     "Build the Swift Syntax Parser library"
     ${SWIFT_BUILD_SYNTAXPARSERLIB_default})
+option(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+    "Only build the Swift Syntax Parser library" FALSE)
 option(SWIFT_BUILD_SOURCEKIT
     "Build SourceKit"
     ${SWIFT_BUILD_SOURCEKIT_default})

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -804,6 +804,10 @@ public:
   using ASTVisitor::visit;
 
   bool visit(Decl *D) {
+    #if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+      return false; // not needed for the parser library.
+    #endif
+
     if (!shouldPrint(D, true))
       return false;
 
@@ -1479,6 +1483,10 @@ bool ShouldPrintChecker::shouldPrint(const Pattern *P,
 
 bool ShouldPrintChecker::shouldPrint(const Decl *D,
                                      const PrintOptions &Options) {
+  #if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+    return false; // not needed for the parser library.
+  #endif
+
   if (auto *ED= dyn_cast<ExtensionDecl>(D)) {
     if (Options.printExtensionContentAsMembers(ED))
       return false;

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1527,6 +1527,10 @@ static bool isValidCmpXChgOrdering(StringRef SuccessString,
 }
 
 ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
+  #if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+    return nullptr; // not needed for the parser library.
+  #endif
+
   SmallVector<Type, 4> Types;
   StringRef OperationName = getBuiltinBaseName(Context, Id.str(), Types);
 

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -3,6 +3,39 @@ if (SWIFT_FORCE_OPTIMIZED_TYPECHECKER)
   set(EXTRA_AST_FLAGS "FORCE_BUILD_OPTIMIZED")
 endif()
 
+if(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
+  set(SWIFTAST_INTERFACE_LINK_LIBRARIES)
+  set(SWIFTAST_LLVM_COMPONENT_DEPENDS)
+else()
+  set(SWIFTAST_INTERFACE_LINK_LIBRARIES
+    # Clang dependencies.
+    # FIXME: Clang should really export these in some reasonable manner.
+    clangCodeGen
+    clangIndex
+    clangFormat
+    clangToolingCore
+    clangFrontendTool
+    clangFrontend
+    clangDriver
+    clangSerialization
+    clangParse
+    clangSema
+    clangAnalysis
+    clangEdit
+    clangRewriteFrontend
+    clangRewrite
+    clangAST
+    clangLex
+    clangAPINotes
+    clangBasic
+  )
+  set(SWIFTAST_LLVM_COMPONENT_DEPENDS
+    bitreader bitwriter coroutines coverage irreader debuginfoDWARF
+    profiledata instrumentation object objcarcopts mc mcparser
+    bitreader bitwriter lto ipo option core support ${LLVM_TARGETS_TO_BUILD}
+  )
+endif()
+
 add_swift_host_library(swiftAST STATIC
   AccessScopeChecker.cpp
   AccessRequests.cpp
@@ -65,38 +98,32 @@ add_swift_host_library(swiftAST STATIC
   USRGeneration.cpp
 
   INTERFACE_LINK_LIBRARIES
-    # Clang dependencies.
-    # FIXME: Clang should really export these in some reasonable manner.
-    clangCodeGen
-    clangIndex
-    clangFormat
-    clangToolingCore
-    clangFrontendTool
-    clangFrontend
-    clangDriver
-    clangSerialization
-    clangParse
-    clangSema
-    clangAnalysis
-    clangEdit
-    clangRewriteFrontend
-    clangRewrite
-    clangAST
-    clangLex
-    clangAPINotes
-    clangBasic
+    ${SWIFTAST_INTERFACE_LINK_LIBRARIES}
 
   LLVM_COMPONENT_DEPENDS
-    bitreader bitwriter coroutines coverage irreader debuginfoDWARF
-    profiledata instrumentation object objcarcopts mc mcparser
-    bitreader bitwriter lto ipo option core support ${LLVM_TARGETS_TO_BUILD}
+    ${SWIFTAST_LLVM_COMPONENT_DEPENDS}
 
   ${EXTRA_AST_FLAGS}
   )
-target_link_libraries(swiftAST PRIVATE
-  swiftBasic
-  swiftMarkup
-  swiftSyntax)
+
+if(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
+  # Add clangBasic as a single direct dependency to avoid bringing along some
+  # llvm libraries that we don't need.
+  if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
+    set(clangBasicDep "${LLVM_LIBRARY_OUTPUT_INTDIR}/clangBasic.lib")
+  else()
+    set(clangBasicDep "${LLVM_LIBRARY_OUTPUT_INTDIR}/libclangBasic.a")
+  endif()
+  target_link_libraries(swiftAST PRIVATE
+    swiftBasic
+    swiftSyntax
+    ${clangBasicDep})
+else()
+  target_link_libraries(swiftAST PRIVATE
+    swiftBasic
+    swiftMarkup
+    swiftSyntax)
+endif()
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -106,9 +106,12 @@ add_swift_host_library(swiftBasic STATIC
 
   C_COMPILE_FLAGS ${UUID_INCLUDE}
   LLVM_COMPONENT_DEPENDS support)
-target_link_libraries(swiftBasic PRIVATE
-  swiftDemangling
-  ${UUID_LIBRARIES})
+
+if(NOT SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
+  target_link_libraries(swiftBasic PRIVATE
+    swiftDemangling
+    ${UUID_LIBRARIES})
+endif()
 
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")


### PR DESCRIPTION
These changes allow to optionally perform a very fast build that is targeted to only produce the syntax parser library.
Part of addressing rdar://48153331