### PR TITLE
[AutoDiff] TF-189: Fix pullback type calculation.

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -155,17 +155,14 @@ namespace {
       auto extInfo = type->getExtInfo();
       auto nondiffExtInfo = extInfo.withDifferentiable(false);
       auto origTy = type->getWithExtInfo(nondiffExtInfo);
-      // TODO: Use the parameter indices and diff order in the @differentiable
-      // function type.
       auto jvpTy = origTy->getAutoDiffAssociatedFunctionType(
-          SmallBitVector(type->getNumParameters(), true), /*resultIndex*/ 0,
+          type->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
           /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP, M,
           LookUpConformanceInModule(M.getSwiftModule()));
       auto vjpTy = origTy->getAutoDiffAssociatedFunctionType(
-          SmallBitVector(type->getNumParameters(), true), /*resultIndex*/ 0,
+          type->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
           /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::VJP, M,
           LookUpConformanceInModule(M.getSwiftModule()));
-
       RecursiveProperties props;
       props.addSubobject(classifyType(origTy, M, Sig, Expansion));
       props.addSubobject(classifyType(jvpTy, M, Sig, Expansion));

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -49,9 +49,11 @@ public func test1() -> Vector {
 // CHECK: [[CLOSURE_THICK_NOESC:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_THICK]] : $@callee_guaranteed (Vector) -> Float to $@noescape @callee_guaranteed (Vector) -> Float
 // CHECK: autodiff_function [wrt 0] [order 1] [[CLOSURE_THICK_NOESC]] : $@noescape @callee_guaranteed (Vector) -> Float
 
+
+// TF-189: `TF189` is a non-trivial type but `TF189.AllDifferentiableVariables` is trivial.
+// Should pass verification.
 @_fixed_layout
 public class NonTrivial {}
-
 @_fixed_layout
 public struct TF189: Differentiable {
   @noDerivative public let x: Double
@@ -67,5 +69,3 @@ public struct TF189: Differentiable {
     return input
   }
 }
-
-// CHECK: sil hidden @AD__$s18simple_real_vector5TF189V3foo5inputAA6Vector{{.*}}___vjp_src_0_wrt_0_1 : $@convention(thin) (@guaranteed TF189, Vector) -> (Vector, @owned @callee_guaranteed (Vector) -> (TF189.AllDifferentiableVariables, Vector))

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -48,3 +48,24 @@ public func test1() -> Vector {
 // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (Vector) -> Float to $@callee_guaranteed (Vector) -> Float
 // CHECK: [[CLOSURE_THICK_NOESC:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_THICK]] : $@callee_guaranteed (Vector) -> Float to $@noescape @callee_guaranteed (Vector) -> Float
 // CHECK: autodiff_function [wrt 0] [order 1] [[CLOSURE_THICK_NOESC]] : $@noescape @callee_guaranteed (Vector) -> Float
+
+@_fixed_layout
+public class NonTrivial {}
+
+@_fixed_layout
+public struct TF189: Differentiable {
+  @noDerivative public let x: Double
+  @noDerivative public let nonTrivial: NonTrivial
+
+  func foo(input: Vector) -> Vector {
+    return self.pullback(at: input) { m, x in
+      m.applied(to: x)
+    }(.zero).1
+  }
+
+  func applied(to input: Vector) -> Vector {
+    return input
+  }
+}
+
+// CHECK: sil hidden @AD__$s18simple_real_vector5TF189V3foo5inputAA6Vector{{.*}}___vjp_src_0_wrt_0_1 : $@convention(thin) (@guaranteed TF189, Vector) -> (Vector, @owned @callee_guaranteed (Vector) -> (TF189.AllDifferentiableVariables, Vector))


### PR DESCRIPTION
The cotangent type may not be of the same triviality as the corresponding original type. Fix that.

Resolves [TF-189](https://bugs.swift.org/browse/TF-189).