### PR TITLE
[AutoDiff] Fix incorrect original function type calculation in type lowering.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4155,6 +4155,8 @@ public:
   CanSILFunctionType getWithDifferentiability(
       unsigned differentiationOrder, const SmallBitVector &parameterIndices);
 
+  CanSILFunctionType getWithoutDifferentiability();
+
   /// Returns the type of a differentiation function that is associated with
   /// a function of this type.
   CanSILFunctionType getAutoDiffAssociatedFunctionType(

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -154,6 +154,20 @@ CanSILFunctionType SILFunctionType::getWithDifferentiability(
              getWitnessMethodConformanceOrNone());
 }
 
+CanSILFunctionType SILFunctionType::getWithoutDifferentiability() {
+  if (!isDifferentiable())
+    return CanSILFunctionType(this);
+  auto nondiffExtInfo = getExtInfo().withDifferentiable(false);
+  SmallVector<SILParameterInfo, 8> newParams;
+  for (auto &param : getParameters())
+    newParams.push_back(param.getWithDifferentiability(
+        SILParameterDifferentiability::DifferentiableOrNotApplicable));
+  return SILFunctionType::get(getGenericSignature(), nondiffExtInfo,
+                              getCoroutineKind(), getCalleeConvention(),
+                              newParams, getYields(), getResults(),
+                              getOptionalErrorResult(), getASTContext());
+}
+
 CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
     const SmallBitVector &parameterIndices, unsigned resultIndex,
     unsigned differentiationOrder,

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -152,17 +152,13 @@ namespace {
     RecursiveProperties getDifferentiableSILFunctionTypeRecursiveProperties(
         CanSILFunctionType type) {
       assert(type->isDifferentiable());
-      auto extInfo = type->getExtInfo();
-      auto nondiffExtInfo = extInfo.withDifferentiable(false);
-      auto origTy = type->getWithExtInfo(nondiffExtInfo);
-      // TODO: Use the parameter indices and diff order in the @differentiable
-      // function type.
+      auto origTy = type->getWithoutDifferentiability();
       auto jvpTy = origTy->getAutoDiffAssociatedFunctionType(
-          SmallBitVector(type->getNumParameters(), true), /*resultIndex*/ 0,
+          type->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
           /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP, M,
           LookUpConformanceInModule(M.getSwiftModule()));
       auto vjpTy = origTy->getAutoDiffAssociatedFunctionType(
-          SmallBitVector(type->getNumParameters(), true), /*resultIndex*/ 0,
+          type->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
           /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::VJP, M,
           LookUpConformanceInModule(M.getSwiftModule()));
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2347,6 +2347,7 @@ ADContext::createPrimalValueStruct(const DifferentiationTask *task,
     pvStruct->setAccess(AccessLevel::Internal);
   }
   pvStruct->computeType();
+  assert(pvStruct->hasInterfaceType());
   file.addVisibleDecl(pvStruct);
   LLVM_DEBUG({
     auto &s = getADDebugStream();


### PR DESCRIPTION
When computing the original function type from a `@differentiable` function type in `getDifferentiableSILFunctionTypeRecursiveProperties`, we are supposed to drop all parameter differentiability.

[TF-199](https://bugs.swift.org/browse/TF-199) is still blocked by a "no interface was set" assertion caused by some pass in the optimization pipeline.