### PR TITLE
[TF] Update checkout 'tensorflow/swift-apis'.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "95f8fd4f30b1e59ea3cb64fbf0036bd7474842cc",
                 "tensorflow-swift-bindings": "10e591340134c37a6c3a1df735a7334a77d5cbc7",
-                "tensorflow-swift-apis": "ba8b82cf98770583d0a94a3b7fb38d15128e9ba6"
+                "tensorflow-swift-apis": "34de02a8ddb58af3b9bcc03f172613616e4436f1"
             }
         }
     }


### PR DESCRIPTION
Update checkout to https://github.com/tensorflow/swift-apis/commit/34de02a8ddb58af3b9bcc03f172613616e4436f1. Three changes are to be integrated in our toolchains:
- Remove SR-9595 workarounds.
- Rename the "gradient" argument to "vector" in `Optimizer.update(_:along:)` for generality.
- Switch `Tensor` initializers to use the Philox random number generator by default to improve performance.
  - Significantly faster PRNG solutions coming soon.