### PR TITLE
[AutoDiff] TF-208: Remove setter from `Differentiable.allDifferentiableVariables` requirement.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -973,7 +973,7 @@ static void addOpaqueAccessorToStorage(TypeChecker &TC,
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// Made public so that DerivedConformanceParameterized can call it.
+/// Made public so that DerivedConformanceDifferentiable can call it.
 void swift::addExpectedOpaqueAccessorsToStorage(TypeChecker &TC,
                                                 AbstractStorageDecl *storage) {
   // Nameless vars from interface files should not have any accessors.

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -461,9 +461,10 @@ DerivedConformance::declareDerivedProperty(Identifier name,
   auto &C = TC.Context;
   auto parentDC = getConformanceContext();
 
-  VarDecl *propDecl = new (C) VarDecl(/*IsStatic*/isStatic, VarDecl::Specifier::Var,
-                                      /*IsCaptureList*/false, SourceLoc(), name,
-                                      parentDC);
+  VarDecl *propDecl = new (C) VarDecl(/*IsStatic*/ isStatic,
+                                      VarDecl::Specifier::Var,
+                                      /*IsCaptureList*/ false, SourceLoc(),
+                                      name, parentDC);
   propDecl->setImplicit();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -130,6 +130,10 @@ extension Tensor : Differentiable
   public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
   }
+  public var allDifferentiableVariables: AllDifferentiableVariables {
+    get { return self }
+    set { self = newValue }
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -72,7 +72,7 @@ public protocol __Differentiable {
   associatedtype AllDifferentiableVariables : Differentiable
 
   /// All differentiable variables in this type.
-  var allDifferentiableVariables: AllDifferentiableVariables { get set }
+  var allDifferentiableVariables: AllDifferentiableVariables { get }
 
   /// Returns `self` moved along the value space towards the given tangent
   /// vector. In Riemannian geometry (mathematics), this represents an
@@ -109,8 +109,7 @@ public protocol Differentiable : _Differentiable
 
 public extension Differentiable where AllDifferentiableVariables == Self {
   var allDifferentiableVariables: AllDifferentiableVariables {
-    get { return self }
-    set { self = newValue }
+    return self
   }
 }
 

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -101,16 +101,13 @@ public protocol Differentiable : _Differentiable
         TangentVector.CotangentVector == CotangentVector,
         CotangentVector.TangentVector == CotangentVector,
         CotangentVector.CotangentVector == TangentVector,
+        // NOTE: Tests fail due to these two missing conformances.
+        // CotangentVector.AllDifferentiableVariables == CotangentVector,
+        // TangentVector.AllDifferentiableVariables == TangentVector,
         AllDifferentiableVariables.AllDifferentiableVariables ==
           AllDifferentiableVariables,
         AllDifferentiableVariables.TangentVector == TangentVector,
         AllDifferentiableVariables.CotangentVector == CotangentVector {
-}
-
-public extension Differentiable where AllDifferentiableVariables == Self {
-  var allDifferentiableVariables: AllDifferentiableVariables {
-    return self
-  }
 }
 
 // FIXME: The `Self : AdditiveArithmetic` constraint should be implied by

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1882,6 +1882,10 @@ extension ${Self} : Differentiable {
   public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
   }
+  public var allDifferentiableVariables: AllDifferentiableVariables {
+    get { return self }
+    set { self = newValue }
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -304,3 +304,11 @@ struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
 struct InvalidInitializer : Differentiable {
   init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {} // expected-error {{use of undeclared type 'NonExistentType'}}
 }
+
+struct AllDiffableWithLetHasNoSetter : Differentiable {
+  var a: Float = 0.2
+  let b: Float = 0.3
+}
+let valWithoutAllDiffSetter = AllDiffableWithLetHasNoSetter()
+// expected-error {{setter not found TODO}}
+valWithoutAllDiffSetter.allDifferentiableVariables = valWithoutAllDiffSetter.allDifferentiableVariables

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -306,9 +306,18 @@ struct InvalidInitializer : Differentiable {
 }
 
 struct AllDiffableWithLetHasNoSetter : Differentiable {
-  var a: Float = 0.2
-  let b: Float = 0.3
+  var mutable: Float
+  let immutable: Float
 }
-let valWithoutAllDiffSetter = AllDiffableWithLetHasNoSetter()
-// expected-error {{setter not found TODO}}
+let valWithoutAllDiffSetter = AllDiffableWithLetHasNoSetter(mutable: 1, immutable: 1)
+// expected-error @+1 {{'allDifferentiableVariables' is immutable}}
 valWithoutAllDiffSetter.allDifferentiableVariables = valWithoutAllDiffSetter.allDifferentiableVariables
+
+struct GenericAllDiffableWithLetHasNoSetter<T : Differentiable> : Differentiable {
+  // Though this stored property is mutable, `mutable.allDifferentiableVariables` may not be.
+  var mutable: T
+  func test() {
+    // expected-error @+1 {{'allDifferentiableVariables' is immutable}}
+    self.allDifferentiableVariables = self.allDifferentiableVariables
+  }
+}


### PR DESCRIPTION
**`allDifferentiableVariables` should only have a setter if all non-`@noDerivative` members have a setter.**

* Change the protocol definition so that it won't require conforming types to have a settable `allDifferentiableVariables`.
* Updates derived conformance to not synthesize a setter for `allDifferentiableVariables` when a member is not settable.

WIP notes: The derived conformance piece is not complete yet. `derivedBody_allDifferentiableVariablesSetter` is synthesizing some incorrect assignment expressions.