### PR TITLE
Generalize alloc_box test for different platforms

### DIFF
--- a/test/IRGen/alloc_box.swift
+++ b/test/IRGen/alloc_box.swift
@@ -9,7 +9,7 @@ func f() -> Bool? { return nil }
 })()
 
 // CHECK-LABEL: @"$s9alloc_boxyyXEfU_"
-// CHECK: <label>:9:
 // CHECK-NOT: call void @swift_setDeallocating
 // CHECK: call void @swift_deallocUninitializedObject
-
+// CHECK-NOT: call void @swift_setDeallocating
+// CHECK: ret void


### PR DESCRIPTION
<!-- What's in this pull request? -->
Different platforms may number their labels a bit differently. For example, on s390x, the check match `label:10:` instead of `lable:9:`. By removing the exact number, I am trying to generalize this test for more platforms.