### PR TITLE
[CSDiagnostics] Use correct overload locator when requirement belongs…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -134,6 +134,7 @@ ProtocolConformance *RequirementFailure::getConformanceForConditionalReq(
 
 ValueDecl *RequirementFailure::getDeclRef() const {
   auto &cs = getConstraintSystem();
+  auto &TC = getTypeChecker();
 
   auto *anchor = getRawAnchor();
   auto *locator = cs.getConstraintLocator(anchor);
@@ -156,7 +157,7 @@ ValueDecl *RequirementFailure::getDeclRef() const {
   } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
     ConstraintLocatorBuilder member(locator);
 
-    if (UDE->getName().isSimpleName(DeclBaseName::createConstructor())) {
+    if (TC.getSelfForInitDelegationInConstructor(getDC(), UDE)) {
       member = member.withPathElement(PathEltKind::ConstructorMember);
     } else {
       member = member.withPathElement(PathEltKind::Member);

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -677,3 +677,13 @@ protocol C {
 protocol D {
   associatedtype Foo where Foo: String // expected-error {{type 'Self.Foo' constrained to non-protocol, non-class type 'String'}}
 }
+
+func member_ref_with_explicit_init() {
+  struct S<T: P> { // expected-note {{where 'T' = 'Int'}}
+    init(_: T) {}
+    init(_: T, _ other: Int = 42) {}
+  }
+
+  _ = S.init(42)
+  // expected-error@-1 {{generic struct 'S' requires that 'Int' conform to 'P'}}
+}


### PR DESCRIPTION
… to explicit `init` ref

Previously the logic to determine path to the selected overload
in such case was simplistic and only checked the name to be
of constructor, but `ConstructorMember` path is formed only if
member reference is a constructor delegation e.g. `self.init` or
`super.init` in an initializer context.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
