### PR TITLE
[capture-promotion] Instead of using create*Borrow, use emit*BorrowOp…

### DIFF
--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -485,7 +485,7 @@ ClosureCloner::populateCloned() {
     if (Cloned->hasOwnership() &&
         MappedValue.getOwnershipKind() != ValueOwnershipKind::Any) {
       SILLocation Loc(const_cast<ValueDecl *>((*I)->getDecl()));
-      MappedValue = getBuilder().createBeginBorrow(Loc, MappedValue);
+      MappedValue = getBuilder().emitBeginBorrowOperation(Loc, MappedValue);
     }
     entryArgs.push_back(MappedValue);
 
@@ -578,7 +578,7 @@ void ClosureCloner::visitDestroyValueInst(DestroyValueInst *Inst) {
           Value.getOwnershipKind() != ValueOwnershipKind::Any) {
         auto *BBI = cast<BeginBorrowInst>(Value);
         Value = BBI->getOperand();
-        B.createEndBorrow(Inst->getLoc(), BBI, Value);
+        B.emitEndBorrowOperation(Inst->getLoc(), BBI);
       }
 
       typeLowering.emitDestroyValue(B, Inst->getLoc(), Value);

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -30,6 +30,7 @@ sil @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
 sil @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
 sil @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
 sil @destructured_baz_user : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
+sil @guaranteed_nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
 // CHECK-LABEL: sil [ossa] @test_capture_promotion
 sil [ossa] @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> (Int, Builtin.Int64) {
@@ -470,4 +471,37 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %1 : @owned $<τ_0_0> { var τ_0
   destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Baz>
   %t = tuple()
   return %t : $()
+}
+
+
+
+// Make sure that we properly handle guaranteed arguments when specializing here.
+sil [ossa] @capture_promotion_callee_guaranteed_box : $@convention(thin) (@guaranteed { var Builtin.NativeObject }) -> () {
+bb0(%0 : @guaranteed ${ var Builtin.NativeObject }):
+  %1 = project_box %0 : ${ var Builtin.NativeObject }, 0
+  %2 = begin_access [read] [unknown] %1 : $*Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  end_access %2 : $*Builtin.NativeObject
+  %4 = function_ref @guaranteed_nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %4(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Just make sure that we specialized so that the ownership verifier can make
+// sure we emitted ownership correctly.
+//
+// CHECK-LABEL: sil [ossa] @capture_promotion_caller_guaranteed_box : $@convention(thin) (@owned Builtin.NativeObject) -> @owned @callee_owned () -> () {
+// CHECK: [[FUNC_REF:%.*]] = function_ref @$s39capture_promotion_callee_guaranteed_boxTf2i_n :
+// CHECK: apply [[FUNC_REF]](
+// CHECK: } // end sil function 'capture_promotion_caller_guaranteed_box'
+sil [ossa] @capture_promotion_caller_guaranteed_box : $@convention(thin) (@owned Builtin.NativeObject) -> @owned @callee_owned () -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = alloc_box ${ var Builtin.NativeObject }
+  %2 = project_box %1 : ${ var Builtin.NativeObject }, 0
+  store %0 to [init] %2 : $*Builtin.NativeObject
+  %3 = function_ref @capture_promotion_callee_guaranteed_box : $@convention(thin) (@guaranteed { var Builtin.NativeObject }) -> ()
+  %pai = partial_apply %3(%1) : $@convention(thin) (@guaranteed { var Builtin.NativeObject }) -> ()
+  return %pai : $@callee_owned () -> ()
 }


### PR DESCRIPTION
…eration

This fixes a bug where we were inserting a begin_borrow on a guaranteed
parameter, but never paired it with an end_borrow so the verifier was unhappy.
