### PR TITLE
Use tracing to implement some of the dataset APIs

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -320,11 +320,7 @@ private class TraceContext {
   }
 
   /// Bind data to the inputs of the graph and return the specialized graph.
-  func specializeTFFunction<Data: TensorGroup>(with data: Data) -> String {
-    // TODO(bgogul): When we have additional inputs, we will have do a bit more.
-    // We will simply cause such cases to fail temporarily.
-    internalConsistencyCheck(additionalInputTensorCount == 0)
-
+  func specializeTFFunction(with dataTensors: [CTensorHandle]) -> String {
     let specializedGraph = TF_NewGraph()!
 
     TF_GraphCopyFunction(
@@ -338,7 +334,7 @@ private class TraceContext {
 
     // Create and append the inputs to the graph function.
     let traceeInputs = symbolicInputs.dropLast(
-      Int(data._tensorHandleCount + additionalInputTensorCount))
+      dataTensors.count + Int(additionalInputTensorCount))
     var inputs: [TF_Output] = []
     for (i, traceeInput) in traceeInputs.enumerated() {
       let desc = TF_NewOperation(specializedGraph, "Placeholder", "input_\(i)")
@@ -351,7 +347,7 @@ private class TraceContext {
     }
 
     // Wire the data to the corresponding inputs of the tracedOp.
-    for (i, cTensorHandle) in data.cTensorHandles.enumerated() {
+    for (i, cTensorHandle) in dataTensors.enumerated() {
       let cTensor = TFE_TensorHandleResolve(cTensorHandle, status)
       checkOk(status)
       let desc = TF_NewOperation(specializedGraph, "Const", "input_const_\(i)")
@@ -363,7 +359,29 @@ private class TraceContext {
       TF_AddInput(tracedOpDesc, TF_Output(oper: result, index: 0))
     }
 
-    // TODO(bgogul): additional input tensors.
+    var nextConst = dataTensors.count
+    debugLog("Adding \(additionalInputTensorCount) additional input tensors.")
+    for i in 0..<additionalInputTensorCount {
+      let cTensorHandle =
+        TFE_ConsumeInputConcreteTensorFromTraceContext(cTraceContext, UInt32(i))
+      internalConsistencyCheck(cTensorHandle != nil)
+      let cTensor = TFE_TensorHandleResolve(cTensorHandle, status)
+      checkOk(status)
+      let desc = TF_NewOperation(
+        specializedGraph, "Const", "input_const_\(nextConst)")
+      nextConst += 1
+      TF_SetAttrType(desc, "dtype", TFE_TensorHandleDataType(cTensorHandle))
+      TF_SetAttrTensor(desc, "value", cTensor, status)
+      checkOk(status)
+      debugLog("""
+                 Adding additional input tensor of idx \
+                 \(traceeInputs.count+Int(additionalInputTensorCount)):\
+                 \(cTensorHandle!).
+                 """)
+      let result = TF_FinishOperation(desc, status)
+      checkOk(status)
+      TF_AddInput(tracedOpDesc, TF_Output(oper: result, index: 0))
+    }
 
     let tracedOp = TF_FinishOperation(tracedOpDesc, status)
     checkOk(status)
@@ -412,7 +430,7 @@ private class TraceContext {
     if _RuntimeConfig.printsDebugLog {
       var len: Int = 0
       let funcDebugStr = TF_FunctionDebugString(tffunc, &len)!
-      debugLog("Specialied TF_Function is:\n\(String(cString: funcDebugStr))")
+      debugLog("Specialized TF_Function is:\n\(String(cString: funcDebugStr))")
       free(funcDebugStr)
     }
     let eagerContext = _TFCGetGlobalEagerContext()
@@ -838,7 +856,8 @@ extension _TensorArrayProtocolEnhanced {
   }
 }
 
-private func _traceInternal(
+/// Trace `fn` with newly created tensor handles and return a trace context.
+private func _trace(
   with dtypes: [TF_DataType],
   in fn: ([CTensorHandle]) -> [CTensorHandle]) -> TraceContext {
   debugLog("""
@@ -871,64 +890,28 @@ private func _traceInternal(
   return finalizeTraceFunction(opType)
 }
 
-// TODO: rename this to `graph` when it's ready for end users.
-/// Trace `fn` with the given state and return the generated trace context.
-private func _trace<State : _TensorArrayProtocolEnhanced,
-                    Data : TensorGroup,
-                    Result : TensorGroup>(
-  with state: State,
-  in fn: (State, Data) -> (State, Result?)
-) -> TraceContext {
-  debugLog("""
-             Tracing over a function with \(state._tensorHandleCount) input \
-             state tensors and \(Data._typeList.count) input data tensors.
-             """)
-
-  // Verify that we are not already tracing.
-  internalConsistencyCheck(_RuntimeConfig.traceState.context == nil,
-                           "Should not be in tracing mode already!")
-
-  // Switch to tracing mode.
-  let dtypes = state._dtypes + Data._typeList.map { $0._cDataType }
-  let traceCtx = TraceContext(dtypes: dtypes)
-  _RuntimeConfig.traceState = .tracing(traceCtx)
-
-  // Handle inputs.
-  let inputSymbolicTensors = traceCtx.symbolicInputs.map {
-    TFE_NewTensorHandleFromTFOutput($0, TF_OperationOutputType($0))!
-  }
-  internalConsistencyCheck(inputSymbolicTensors.count == dtypes.count)
-  let symbolicState = state._makeInstance(
-    owning: inputSymbolicTensors.dropLast(Data._typeList.count))
-  let symbolicData = Data(
-    _copying: inputSymbolicTensors.dropFirst(
-      Int(state._tensorHandleCount)))
-  // Run tracee to build the trace, adding ops to the trace graph function.
-  // The tracee output can contain a mixture of symbolic and concrete tensors
-  // (see the comment block within TraceContext.finalize()).
-   debugLog("Running tracee in tracing mode.")
-  let (outputState, outputResult) = fn(symbolicState, symbolicData)
-
-  debugLog("Assembling output tensor handles.")
-  traceCtx.tracedOutputs =
-    outputResult != nil
-      ? (outputState.cTensorHandles + outputResult!.cTensorHandles)
-      : outputState.cTensorHandles
-
-
-  debugLog("Finalizing trace graph function.")
-  // TAP means tensor array protocol.
-  let opType = "MyTraceFn_TAP"
-  return finalizeTraceFunction(opType)
-}
-
 private func _graphInternal<State : _TensorArrayProtocolEnhanced,
-                           Data : TensorGroup,
-                           Result : TensorGroup>(
+                            Data : TensorGroup,
+                            Result : TensorGroup>(
   with state: State,
-  in fn: (State, Data) -> (State, Result?)
+  in fn: @escaping (State, Data) -> (State, Result?)
 ) -> (State, Data) -> (State, Result?) {
-  let traceContext = _trace(with: state, in : fn)
+  let wrappedFn = {(inputs: [CTensorHandle]) -> [CTensorHandle] in
+    let symbolicState = state._makeInstance(
+      owning: inputs.dropLast(Data._typeList.count))
+    let symbolicData = Data(
+      _copying: inputs.dropFirst(Int(state._tensorHandleCount)))
+    let (outputState, outputResult) = fn(symbolicState, symbolicData)
+
+    debugLog("Assembling output tensor handles.")
+    let outputs =
+      outputResult != nil
+        ? (outputState.cTensorHandles + outputResult!.cTensorHandles)
+        : outputState.cTensorHandles
+    return outputs
+  }
+  let dtypes = state._dtypes + Data._typeList.map { $0.cDataType }
+  let traceContext = _trace(with: dtypes, in: wrappedFn)
   // The result is a closure that captures and executes the trace graph
   // function in the trace context.
   return { (oldState: State, data: Data) -> (State, Result?) in
@@ -998,16 +981,42 @@ public func _tffunc<State : _TensorArrayProtocolEnhanced,
   with state: State,
   in fn: @escaping (State, Data) -> State
 ) -> (Data) -> (String) {
-  let wrappedFn = {
-    // The result argument needs to be a type that conforms to TensorGroup.
-    // We are arbitrarily picking Tensor<Float> here.
-    (s: State, d: Data) -> (State, Tensor<Float>?) in
-      (fn(s, d), nil)
+  let wrappedFn = {(inputs: [CTensorHandle]) -> [CTensorHandle] in
+    let symbolicState = state._makeInstance(
+      owning: inputs.dropLast(Data._typeList.count))
+    let symbolicData = Data(
+      _copying: inputs.dropFirst(Int(state._tensorHandleCount)))
+    let outputState = fn(symbolicState, symbolicData)
+    return outputState.cTensorHandles
   }
-  let traceContext = _trace(with: state, in: wrappedFn)
+  let dtypes = state._dtypes + Data._typeList.map { $0.cDataType }
+  let traceContext = _trace(with: dtypes, in: wrappedFn)
   return {
-    data in traceContext.specializeTFFunction(with: data)
+    data in traceContext.specializeTFFunction(with: data.cTensorHandles)
   }
+}
+
+/// Trace the given function and return a `TF_Function(In)` that returns `Out`.
+public func _tffunc<In : TensorGroup, Out : TensorGroup>(
+  _ fn: @escaping (In) -> Out
+) -> String {
+  let wrappedFn = {
+    (inputs: [CTensorHandle]) -> [CTensorHandle] in
+    let buffer = UnsafeMutablePointer<CTensorHandle>.allocate(
+      capacity: Int(inputs.count))
+    var ptr = buffer
+    for input in inputs {
+      ptr.initialize(to: input)
+      ptr = ptr.advanced(by: 1)
+    }
+    let symbolicIn = In(_owning: buffer)
+    let symbolicOut = fn(symbolicIn)
+    return symbolicOut.cTensorHandles
+  }
+
+  let dtypes = In._typeList.map { $0.cDataType }
+  let traceContext = _trace(with: dtypes, in: wrappedFn)
+  return traceContext.specializeTFFunction(with : [])
 }
 
 /// Returns a valid TF device string such as

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -910,7 +910,7 @@ private func _graphInternal<State : _TensorArrayProtocolEnhanced,
         : outputState.cTensorHandles
     return outputs
   }
-  let dtypes = state._dtypes + Data._typeList.map { $0.cDataType }
+  let dtypes = state._dtypes + Data._typeList.map { $0._cDataType }
   let traceContext = _trace(with: dtypes, in: wrappedFn)
   // The result is a closure that captures and executes the trace graph
   // function in the trace context.
@@ -989,7 +989,7 @@ public func _tffunc<State : _TensorArrayProtocolEnhanced,
     let outputState = fn(symbolicState, symbolicData)
     return outputState.cTensorHandles
   }
-  let dtypes = state._dtypes + Data._typeList.map { $0.cDataType }
+  let dtypes = state._dtypes + Data._typeList.map { $0._cDataType }
   let traceContext = _trace(with: dtypes, in: wrappedFn)
   return {
     data in traceContext.specializeTFFunction(with: data.cTensorHandles)
@@ -1014,7 +1014,7 @@ public func _tffunc<In : TensorGroup, Out : TensorGroup>(
     return symbolicOut.cTensorHandles
   }
 
-  let dtypes = In._typeList.map { $0.cDataType }
+  let dtypes = In._typeList.map { $0._cDataType }
   let traceContext = _trace(with: dtypes, in: wrappedFn)
   return traceContext.specializeTFFunction(with : [])
 }

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -859,7 +859,8 @@ extension _TensorArrayProtocolEnhanced {
 /// Trace `fn` with newly created tensor handles and return a trace context.
 private func _trace(
   with dtypes: [TF_DataType],
-  in fn: ([CTensorHandle]) -> [CTensorHandle]) -> TraceContext {
+  in fn: ([CTensorHandle]) -> [CTensorHandle]
+) -> TraceContext {
   debugLog("""
              Tracing over a function with \(dtypes.count) inputs.
              """)
@@ -897,7 +898,7 @@ private func _graphInternal<State : _TensorArrayProtocolEnhanced,
   in fn: (State, Data) -> (State, Result?)
 ) -> (State, Data) -> (State, Result?) {
   let traceContext: TraceContext = withoutActuallyEscaping(fn) { escapableFn in
-    let wrappedFn = {(inputs: [CTensorHandle]) -> [CTensorHandle] in
+    let wrappedFn = { (inputs: [CTensorHandle]) -> [CTensorHandle] in
       let symbolicState = state._makeInstance(
         owning: inputs.dropLast(Data._typeList.count))
       let symbolicData = Data(
@@ -981,10 +982,10 @@ public func _graph<State : _TensorArrayProtocolEnhanced,
 public func _tffunc<State : _TensorArrayProtocolEnhanced,
                     Data : TensorGroup>(
   with state: State,
-  in fn:(State, Data) -> State
+  in fn: (State, Data) -> State
 ) -> (Data) -> (String) {
   let traceContext: TraceContext = withoutActuallyEscaping(fn) { escapableFn in
-    let wrappedFn = {(inputs: [CTensorHandle]) -> [CTensorHandle] in
+    let wrappedFn = { (inputs: [CTensorHandle]) -> [CTensorHandle] in
       let symbolicState = state._makeInstance(
         owning: inputs.dropLast(Data._typeList.count))
       let symbolicData = Data(
@@ -1023,7 +1024,7 @@ public func _tffunc<In : TensorGroup, Out : TensorGroup>(
     let dtypes = In._typeList.map { $0._cDataType }
     return _trace(with: dtypes, in: wrappedFn)
   }
-  return traceContext.specializeTFFunction(with : [])
+  return traceContext.specializeTFFunction(with: [])
 }
 
 /// Returns a valid TF device string such as

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1000,7 +1000,8 @@ public func _tffunc<State : _TensorArrayProtocolEnhanced,
   }
 }
 
-/// Trace the given function and return a `TF_Function(In)` that returns `Out`.
+/// Trace the given function and return the name of the corresponding
+/// `TF_Function: In -> Out` that was created.
 public func _tffunc<In : TensorGroup, Out : TensorGroup>(
   _ fn: (In) -> Out
 ) -> String {

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -95,21 +95,19 @@ extension Dataset : Sequence {
   }
 }
 
-/// FIXME(SR-8684): @convention(tensorflow) types crash SILGen when their
-/// parameters or results have generic parameters. This is blocking generic
-/// higher-order dataset transformation functions.
-public extension Dataset where Element == Tensor<Float> {
+public extension Dataset {
+
+  // Note that this Dataset API implementation uses an experimental tracing
+  // feature, which is not robust and does not have great diagnostics yet.
+
   @inlinable @inline(__always)
   func map(
-    _ transform: @convention(tensorflow) (Element) -> Element
+    _ transform: @escaping (Element) -> Element
   ) -> Dataset {
-    // FIXME(SR-8570): If we pass an empty Array<TensorHandle<T>> as
-    // other_arguments and an empty Array<Any.Type> as Targuments, partitioning
-    // won't recognize the attribute:
-    //    error: unknown array attribute
     return Dataset(
       _handle: #tfop(
-        "MapDataset", _handle, [Tensor<Int32>(0)], f: transform,
+        "MapDataset", _handle, [Tensor<Int32>(0)],
+        f$func: _tffunc(transform),
         Targuments$dtype: [Int32.tensorFlowDataType],
         output_types$dtype: Element._typeList,
         output_shapes: Element._unknownShapeList
@@ -119,17 +117,13 @@ public extension Dataset where Element == Tensor<Float> {
 
   @inlinable @inline(__always)
   func filter(
-    _ isIncluded:
-      @convention(tensorflow) (Element) -> Tensor<Bool>
+    _ isIncluded: @escaping (Element) -> Tensor<Bool>
   ) -> Dataset {
-    // FIXME(SR-8570): If we pass an empty Array<TensorHandle<T>> as
-    // other_arguments and an empty Array<Any.Type> as Targuments, partitioning
-    // won't recognize the attribute:
-    //    error: unknown array attribute
     return Dataset(
       _handle: #tfop(
         "FilterDataset", _handle, [Tensor<Int32>(0)],
-        predicate: isIncluded, Targuments$dtype: [Int32.tensorFlowDataType],
+        predicate$func: _tffunc(isIncluded),
+        Targuments$dtype: [Int32.tensorFlowDataType],
         output_types$dtype: Element._typeList,
         output_shapes: Element._unknownShapeList
       )

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -102,7 +102,7 @@ public extension Dataset {
 
   @inlinable @inline(__always)
   func map(
-    _ transform: @escaping (Element) -> Element
+    _ transform: (Element) -> Element
   ) -> Dataset {
     return Dataset(
       _handle: #tfop(
@@ -117,7 +117,7 @@ public extension Dataset {
 
   @inlinable @inline(__always)
   func filter(
-    _ isIncluded: @escaping (Element) -> Tensor<Bool>
+    _ isIncluded: (Element) -> Tensor<Bool>
   ) -> Dataset {
     return Dataset(
       _handle: #tfop(

--- a/test/TensorFlowRuntime/tracer_tffunc.swift
+++ b/test/TensorFlowRuntime/tracer_tffunc.swift
@@ -27,7 +27,6 @@ TracerTests.testAllBackends("SimpleTFFunction") {
     return (Tensor<Int32>(i .< n))
   }
 
-  @TensorFlowGraph
   func body(i: Tensor<Int32>) -> Tensor<Int32> {
     return i + 1
   }
@@ -40,7 +39,7 @@ TracerTests.testAllBackends("SimpleTFFunction") {
       Tensor<Int32>(0),
       T$dtype: [Int32.tensorFlowDataType],
       cond$func: tffunc(Tensor<Int32>(n)),
-      body: body)
+      body$func: _tffunc(body))
   }
 
   expectEqualWithScalarTensor(10, runWhile(10))


### PR DESCRIPTION
This PR does the following: 
  - Allow tracing of arbitrary functions with signature (TensorGroup) -> TensorGroup
  - Uses the extended API to implement the Dataset map and filter functions. 

However, note that this is still quite experimental and may not work well in all cases. 

This also provides a temporary fix for https://bugs.swift.org/browse/TF-94.
