### PR TITLE
TF-239: Autocomplete crashes when you use an interpolated string

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1204,7 +1204,10 @@ ConstraintSystem::getTypeOfMemberReference(
     return getTypeOfReference(value, functionRefKind, locator, useDC, base);
   }
 
-  FunctionType::Param baseObjParam(baseObjTy);
+  // SWIFT_ENABLE_TENSORFLOW
+  FunctionType::Param baseObjParam(
+      baseObjTy->getInOutObjectType(), Identifier(),
+      ParameterTypeFlags().withInOut(baseObjTy->is<InOutType>()));
 
   // Don't open existentials when accessing typealias members of
   // protocols.

--- a/test/IDE/complete_tf_239.swift
+++ b/test/IDE/complete_tf_239.swift
@@ -1,0 +1,10 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE | %FileCheck %s
+
+if true {
+    print("\(1)")
+    let foo = #^COMPLETE^#
+}
+
+// CHECK-LABEL: Begin completions
+// CHECK: End completions


### PR DESCRIPTION
When you use an interpolated string, you get an AST full of calls to [StringInterpolation](https://github.com/apple/swift/blob/master/stdlib/public/core/StringInterpolation.swift) methods.

When you make a completion request on some code that uses an interpolated string, the typechecker fails while processing a call to `DefaultStringInterpolation.appendLiteral`. The failure is:
```
swift-ide-test: /usr/local/google/home/marcrasi/swift-base/swift/include/swift/AST/Types.h:2745: swift::AnyFunctionType::Param::Param(swift::Type, swift::Identifier, swift::ParameterTypeFlags): Assertion `!t || !t->is<InOutType>() && "set flags instead"' failed.
Stack dump:
0.	Program arguments: /usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test -target x86_64-unknown-linux-gnu -module-cache-path /usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/swift-test-results/x86_64-unknown-linux-gnu/clang-module-cache -completion-cache-path /usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/swift-test-results/x86_64-unknown-linux-gnu/completion-cache -swift-version 4 -code-completion -source-filename /usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift -code-completion-token=COMPLETE 
1.	While type-checking statement at [/usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift:3:1 - line:6:1] RangeText="if true {
    print("\(1)")
    let bar = 
"
2.	While type-checking statement at [/usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift:3:1 - line:6:1] RangeText="if true {
    print("\(1)")
    let bar = 
"
3.	While type-checking statement at [/usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift:3:9 - line:6:1] RangeText="{
    print("\(1)")
    let bar = 
"
4.	While type-checking expression at [/usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift:4:5 - line:4:17] RangeText="print("\(1)""
5.	While type-checking statement at [/usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift:4:11 - line:4:17] RangeText=""\(1)""
6.	While type-checking expression at [/usr/local/google/home/marcrasi/swift-base/swift/test/IDE/foo.swift:4:11 - line:4:11] RangeText=""
#0 0x0000000003f9e7d4 PrintStackTraceSignalHandler(void*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x3f9e7d4)
#1 0x0000000003f9c930 llvm::sys::RunSignalHandlers() (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x3f9c930)
#2 0x0000000003f9e982 SignalHandler(int) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x3f9e982)
#3 0x00007ff7587eb0c0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x110c0)
#4 0x00007ff74d10afcf gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x32fcf)
#5 0x00007ff74d10c3fa abort (/lib/x86_64-linux-gnu/libc.so.6+0x343fa)
#6 0x00007ff74d103e37 (/lib/x86_64-linux-gnu/libc.so.6+0x2be37)
#7 0x00007ff74d103ee2 (/lib/x86_64-linux-gnu/libc.so.6+0x2bee2)
#8 0x0000000000d11486 swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, swift::DeclContext*, bool, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xd11486)
#9 0x0000000000d11dea swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xd11dea)
#10 0x0000000000cb4215 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xcb4215)
#11 0x0000000000cae5ab (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xcae5ab)
#12 0x000000000110f707 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x110f707)
#13 0x000000000110baab swift::Expr::walk(swift::ASTWalker&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x110baab)
#14 0x0000000000ca9b18 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xca9b18)
#15 0x0000000000cdc6da swift::constraints::ConstraintSystem::solveImpl(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xcdc6da)
#16 0x0000000000cdc2cc swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xcdc2cc)
#17 0x0000000000d64732 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xd64732)
#18 0x0000000000dfa750 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdfa750)
#19 0x0000000000df9927 bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::BraceStmt>(swift::BraceStmt*&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdf9927)
#20 0x0000000000df9847 swift::TypeChecker::typeCheckTapBody(swift::TapExpr*, swift::DeclContext*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdf9847)
#21 0x0000000000e1bc0f swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xe1bc0f)
#22 0x0000000000d647ec swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xd647ec)
#23 0x0000000000dfa750 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdfa750)
#24 0x0000000000dfd577 bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::Stmt>(swift::Stmt*&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdfd577)
#25 0x0000000000dfad1a swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdfad1a)
#26 0x0000000000dfd577 bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::Stmt>(swift::Stmt*&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdfd577)
#27 0x0000000000dfa60a swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdfa60a)
#28 0x0000000000df9927 bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::BraceStmt>(swift::BraceStmt*&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdf9927)
#29 0x0000000000df9a32 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xdf9a32)
#30 0x0000000000e18dcf swift::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0xe18dcf)
#31 0x000000000053981a (anonymous namespace)::CodeCompletionCallbacksImpl::doneParsing() (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x53981a)
#32 0x0000000001062031 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x1062031)
#33 0x0000000000517b9d swift::CompilerInstance::parseAndCheckTypesUpTo(swift::CompilerInstance::ImplicitImports const&, swift::SourceFile::ASTStage_t) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x517b9d)
#34 0x0000000000516f09 swift::CompilerInstance::performSemaUpTo(swift::SourceFile::ASTStage_t) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x516f09)
#35 0x000000000049aeae main (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x49aeae)
#36 0x00007ff74d0f82b1 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b1)
#37 0x00000000004944ea _start (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift-ide-test+0x4944ea)
```

The assertion failure message tells me a way to fix it! Make the type not be inout, and add a ParameterTypeFlag saying that the parameter is inout.

Some notes about the test:
* I can only reproduce the failure when I wrap the interpolated string in a `print`. Maybe that is an important part of what triggers it.
* I can only reproduce the failure when I wrap all the code in a block. Maybe that is an important part of what triggers it.

I'm not sure if this is the right way to fix it, but it seems to work.

This crash also happens in master, so I plan to also send a patch to master. I'll get advice there about whether this is the right way, and I'll integrate any changes back into tensorflow.