### PR TITLE
IRGen: eliminate some nondeterminism due to UB

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -2360,9 +2360,9 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
           Builder.emitBlock(matchInlineBB);
           {
             ConditionalDominanceScope inlineCondition(IGF);
-            emitAssignWithCopyCall(IGF, metadata,
-                                   castToOpaquePtr(IGF, destBuffer),
-                                   castToOpaquePtr(IGF, srcBuffer));
+            auto dstAddress = castToOpaquePtr(IGF, destBuffer);
+            auto srcAddress = castToOpaquePtr(IGF, srcBuffer);
+            emitAssignWithCopyCall(IGF, metadata, dstAddress, srcAddress);
             Builder.CreateBr(doneBB);
           }
 
@@ -2425,10 +2425,11 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
           Builder.emitBlock(destInlineBB);
           {
             ConditionalDominanceScope destInlineCondition(IGF);
-            // Move asside so that we can destroy later.
-            emitInitializeWithTakeCall(IGF, destMetadata,
-                                       castToOpaquePtr(IGF, tmpBuffer),
-                                       castToOpaquePtr(IGF, destBuffer));
+            // Move aside so that we can destroy later.
+            auto tmpAddress = castToOpaquePtr(IGF, tmpBuffer);
+            auto destAddress = castToOpaquePtr(IGF, destBuffer);
+            emitInitializeWithTakeCall(IGF, destMetadata, tmpAddress,
+                                       destAddress);
             auto *srcInlineBB = IGF.createBasicBlock("dest-inline-src-inline");
             auto *srcOutlineBB =
                 IGF.createBasicBlock("dest-inline-src-outline");
@@ -2440,9 +2441,10 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
             {
               // initializeWithCopy(dest, src)
               ConditionalDominanceScope domScope(IGF);
-              emitInitializeWithCopyCall(IGF, srcMetadata,
-                                         castToOpaquePtr(IGF, destBuffer),
-                                         castToOpaquePtr(IGF, srcBuffer));
+              auto destAddress = castToOpaquePtr(IGF, destBuffer);
+              auto srcAddress = castToOpaquePtr(IGF, srcBuffer);
+              emitInitializeWithCopyCall(IGF, srcMetadata, destAddress,
+                                         srcAddress);
               Builder.CreateBr(contBB2);
             }
 
@@ -2484,9 +2486,10 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
             {
               // initializeWithCopy(dest, src)
               ConditionalDominanceScope domScope(IGF);
-              emitInitializeWithCopyCall(IGF, srcMetadata,
-                                         castToOpaquePtr(IGF, destBuffer),
-                                         castToOpaquePtr(IGF, srcBuffer));
+              auto destAddress = castToOpaquePtr(IGF, destBuffer);
+              auto srcAddress = castToOpaquePtr(IGF, srcBuffer);
+              emitInitializeWithCopyCall(IGF, srcMetadata, destAddress,
+                                         srcAddress);
               Builder.CreateBr(contBB2);
             }
 


### PR DESCRIPTION
The order of evaluation of arguments for parameters is unspecified by
the language specification.  Windows evaluates the arguments in a
different order.  Hoist the function calls for parameters to enforce
ordering.  This reduces the nondeterminism in IRGen on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
