### PR TITLE
Update checkout for 'tensorflow/swift-apis' and remove circular dependency from tests

### DIFF
--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -23,47 +23,48 @@ ModelADTests.testAllBackends("XORTraining") {
   struct Classifier: Layer {
     var l1, l2: Dense<Float>
     init(hiddenSize: Int) {
-        l1 = Dense<Float>(inputSize: 2, outputSize: hiddenSize, activation: relu)
-        l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+      l1 = Dense<Float>(inputSize: 2, outputSize: hiddenSize, activation: relu)
+      l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
     }
     @differentiable(wrt: (self, input))
-    func applied(to input: Tensor<Float>) -> Tensor<Float> {
-        let h1 = l1.applied(to: input)
-        return l2.applied(to: h1)
+    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
+      let h1 = l1.applied(to: input, in: context)
+      return l2.applied(to: h1, in: context)
     }
   }
   var classifier = Classifier(hiddenSize: 4)
+  let trainingContext = Context(learningPhase: .training)
   let optimizer = SGD<Classifier, Float>()
   let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
   let y: Tensor<Float> = [0, 1, 1, 0]
   for _ in 0..<1000 {
-      let (loss, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
-          let ŷ = classifier.applied(to: x)
-          return meanSquaredError(predicted: ŷ, expected: y)
-      }
-      optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
+    let (loss, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
+      let ŷ = classifier.applied(to: x, in: trainingContext)
+      return meanSquaredError(predicted: ŷ, expected: y)
+    }
+    optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
   }
-  print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
+  let inferenceContext = Context(learningPhase: .inference)
+  print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]], in: inferenceContext))
 }
 
 ModelADTests.testAllBackends("WithRespectToModel") {
   struct Foo<Scalar>: Differentiable
     where Scalar: FloatingPoint & Differentiable & TensorFlowScalar {
-  
+
     var bar: Tensor<Scalar>
     var baz: Tensor<Scalar>
-  
+
     @differentiable(wrt: (self, input))
     func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return bar + input
+      return bar + input
     }
   }
-  
   let x = Tensor<Float>(0)
   var model = Foo<Float>(bar: x, baz: x)
-  
+  let context = Context(learningPhase: inference)
   let d = gradient(at: model) { model in
-      model.applied(to: x)
+    model.applied(to: x, in: context)
   }
   expectEqual(Foo<Float>.AllDifferentiableVariables(bar: Tensor(1.0), baz: Tensor(0.0)), d)
 }

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -12,8 +12,9 @@ var ModelADTests = TestSuite("ModelAD")
 ModelADTests.testAllBackends("SimpleLayerAD") {
   let ones = Tensor<Float>(ones: [2, 2])
   let dense = Dense<Float>(inputSize: 2, outputSize: 2, activation: { $0 })
+  let context = Context(learningPhase: .inference)
   let grad = gradient(at: dense) { dense in
-    dense.applied(to: ones).sum()
+    dense.applied(to: ones, in: context).sum()
   }
   expectEqual([[2, 2], [2, 2]], grad.weight)
   expectEqual([2, 2], grad.bias)
@@ -62,7 +63,7 @@ ModelADTests.testAllBackends("WithRespectToModel") {
   }
   let x = Tensor<Float>(0)
   var model = Foo<Float>(bar: x, baz: x)
-  let context = Context(learningPhase: inference)
+  let context = Context(learningPhase: .inference)
   let d = gradient(at: model) { model in
     model.applied(to: x, in: context)
   }

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -2,6 +2,11 @@
 // REQUIRES: executable_test
 //
 // Machine learning API AD runtime tests.
+//
+// NOTE: This file contains a mini high-level machine learning library. If you
+// need to test other things from the `tensorflow/swift-apis` (aka.
+// `DeepLearning`) library, please **copy** their definitions here instead of
+// using those APIs directly. This helps avoid circular dependencies.
 
 import TensorFlow
 import StdlibUnittest
@@ -9,12 +14,76 @@ import TensorFlowUnittest
 
 var ModelADTests = TestSuite("ModelAD")
 
+public protocol Layer: Differentiable & KeyPathIterable
+  where AllDifferentiableVariables : KeyPathIterable {
+  associatedtype Input: Differentiable
+  associatedtype Output: Differentiable
+  @differentiable(wrt: (self, input))
+  func applied(to input: Input) -> Output
+}
+
+@_fixed_layout
+public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
+  public var weight: Tensor<Scalar>
+  public var bias: Tensor<Scalar>
+  public typealias Activation =
+    @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
+  @noDerivative public let activation: Activation
+
+  // FIXME(SR-9716): Remove this once the bug is fixed or worked around.
+  public var allKeyPaths: [PartialKeyPath<Dense>] {
+    return [\Dense.weight, \Dense.bias]
+  }
+
+  @differentiable(wrt: (self, input))
+  public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+    return activation(matmul(input, weight) + bias)
+  }
+}
+
+public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
+  init(inputSize: Int, outputSize: Int, activation: @escaping Activation) {
+    self.init(weight: Tensor(
+                glorotUniform: [Int32(inputSize), Int32(outputSize)]
+              ),
+              bias: Tensor(zeros: [Int32(outputSize)]),
+              activation: activation)
+  }
+}
+
+public protocol Optimizer {
+  associatedtype Model: Layer
+  associatedtype Scalar: FloatingPoint
+  var learningRate: Scalar { get }
+  mutating func update(_ variables: inout Model.AllDifferentiableVariables,
+                       along vector: Model.CotangentVector)
+}
+
+public class RiemannSGD<Model: Layer, Scalar: FloatingPoint>: Optimizer
+  where Model.TangentVector: VectorNumeric,
+        Model.TangentVector.Scalar == Scalar {
+  public var learningRate: Scalar
+
+  public init(
+    learningRate: Scalar,
+    modelType: Model.Type = Model.self,
+    scalarType: Scalar.Type = Scalar.self
+  ) {
+    self.learningRate = learningRate
+  }
+
+  public func update(_ model: inout Model.AllDifferentiableVariables,
+                     along vector: Model.CotangentVector) {
+    model = model.moved(
+      along: learningRate * (.zero - model.tangentVector(from: vector)))
+  }
+}
+
 ModelADTests.testAllBackends("SimpleLayerAD") {
   let ones = Tensor<Float>(ones: [2, 2])
   let dense = Dense<Float>(inputSize: 2, outputSize: 2, activation: { $0 })
-  let context = Context(learningPhase: .inference)
   let grad = gradient(at: dense) { dense in
-    dense.applied(to: ones, in: context).sum()
+    dense.applied(to: ones).sum()
   }
   expectEqual([[2, 2], [2, 2]], grad.weight)
   expectEqual([2, 2], grad.bias)
@@ -28,25 +97,23 @@ ModelADTests.testAllBackends("XORTraining") {
       l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
     }
     @differentiable(wrt: (self, input))
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-      let h1 = l1.applied(to: input, in: context)
-      return l2.applied(to: h1, in: context)
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+      let h1 = l1.applied(to: input)
+      return l2.applied(to: h1)
     }
   }
   var classifier = Classifier(hiddenSize: 4)
-  let trainingContext = Context(learningPhase: .training)
-  let optimizer = SGD<Classifier, Float>()
+  let optimizer = RiemannSGD<Classifier, Float>(learningRate: 0.2)
   let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
   let y: Tensor<Float> = [0, 1, 1, 0]
   for _ in 0..<1000 {
-    let (loss, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
-      let ŷ = classifier.applied(to: x, in: trainingContext)
+    let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
+      let ŷ = classifier.applied(to: x)
       return meanSquaredError(predicted: ŷ, expected: y)
     }
     optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
   }
-  let inferenceContext = Context(learningPhase: .inference)
-  print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]], in: inferenceContext))
+  print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
 }
 
 ModelADTests.testAllBackends("WithRespectToModel") {
@@ -63,11 +130,11 @@ ModelADTests.testAllBackends("WithRespectToModel") {
   }
   let x = Tensor<Float>(0)
   var model = Foo<Float>(bar: x, baz: x)
-  let context = Context(learningPhase: .inference)
   let d = gradient(at: model) { model in
-    model.applied(to: x, in: context)
+    model.applied(to: x)
   }
-  expectEqual(Foo<Float>.AllDifferentiableVariables(bar: Tensor(1.0), baz: Tensor(0.0)), d)
+  expectEqual(Foo<Float>.AllDifferentiableVariables(bar: Tensor(1.0),
+                                                    baz: Tensor(0.0)), d)
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -70,6 +70,13 @@ TensorADTests.testAllBackends("ResultSelection") {
   expectEqual((0, 1), gradient(at: Double(3), 3, in: { x, y in indirect(x, y).1 }))
 }
 
+public protocol Layer: Differentiable {
+  associatedtype Input: Differentiable
+  associatedtype Output: Differentiable
+  @differentiable(wrt: (self, input))
+  func applied(to input: Input) -> Output
+}
+
 TensorADTests.testAllBackends("GenericLayerMember") {
   // Tests TF-203.
   struct GenericLayerWrapper<T: Layer> : Layer {

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -70,11 +70,35 @@ TensorADTests.testAllBackends("ResultSelection") {
   expectEqual((0, 1), gradient(at: Double(3), 3, in: { x, y in indirect(x, y).1 }))
 }
 
+// Mini high-level ML library.
 public protocol Layer: Differentiable {
   associatedtype Input: Differentiable
   associatedtype Output: Differentiable
   @differentiable(wrt: (self, input))
   func applied(to input: Input) -> Output
+}
+
+@_fixed_layout
+public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
+  public var weight: Tensor<Scalar>
+  public var bias: Tensor<Scalar>
+  public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
+  @noDerivative public let activation: Activation
+
+  @differentiable(wrt: (self, input))
+  public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+    return activation(matmul(input, weight) + bias)
+  }
+}
+
+public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
+  init(inputSize: Int, outputSize: Int, activation: @escaping Activation) {
+    self.init(weight: Tensor(
+                glorotUniform: [Int32(inputSize), Int32(outputSize)]
+              ),
+              bias: Tensor(zeros: [Int32(outputSize)]),
+              activation: activation)
+  }
 }
 
 TensorADTests.testAllBackends("GenericLayerMember") {

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "95f8fd4f30b1e59ea3cb64fbf0036bd7474842cc",
                 "tensorflow-swift-bindings": "10e591340134c37a6c3a1df735a7334a77d5cbc7",
-                "tensorflow-swift-apis": "34de02a8ddb58af3b9bcc03f172613616e4436f1"
+                "tensorflow-swift-apis": "470dbd7e7f27f761fd01686f5526803857e4bb7f"
             }
         }
     }


### PR DESCRIPTION
* Update 'tensorflow/swift-apis' revision to track https://github.com/tensorflow/swift-apis/commit/470dbd7e7f27f761fd01686f5526803857e4bb7f.
* Resolves [TF-264](https://bugs.swift.org/browse/TF-264): Tests that depend on the DeepLearning library should not be in the compiler repo. Copied a mini ML library to test files.