### PR TITLE
const evaluator: array values and initialization

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -114,6 +114,12 @@ private:
 
     /// This represents an index *into* a memory object.
     RK_DerivedAddress,
+
+    /// This represents an array value.
+    RK_Array,
+
+    /// This represents an address of a memory object containing an array.
+    RK_ArrayAddress,
   };
 
   union {
@@ -157,6 +163,12 @@ private:
     /// When this SymbolicValue is of "DerivedAddress" kind, this pointer stores
     /// information about the memory object and access path of the access.
     DerivedAddressValue *derivedAddress;
+
+    /// For RK_Array, this is the elements of the array.
+    ArraySymbolicValue *array;
+
+    /// For RK_ArrayAddress, this is the memory object referenced.
+    SymbolicValueMemoryObject *arrayAddress;
   } value;
 
   RepresentationKind representationKind : 8;
@@ -208,6 +220,9 @@ public:
 
     /// This value represents the address of, or into, a memory object.
     Address,
+
+    /// This represents an array value.
+    Array,
 
     /// These values are generally only seen internally to the system, external
     /// clients shouldn't have to deal with them.
@@ -331,6 +346,20 @@ public:
 
   /// Return just the memory object for an address value.
   SymbolicValueMemoryObject *getAddressValueMemoryObject() const;
+
+  /// Produce an array of elements.
+  static SymbolicValue getArray(ArrayRef<SymbolicValue> elements,
+                                CanType elementType,
+                                ASTContext &astContext);
+  static SymbolicValue
+  getArrayAddress(SymbolicValueMemoryObject *memoryObject) {
+    SymbolicValue result;
+    result.representationKind = RK_ArrayAddress;
+    result.value.directAddress = memoryObject;
+    return result;
+  }
+
+  ArrayRef<SymbolicValue> getArrayValue(CanType &elementType) const;
 
   //===--------------------------------------------------------------------===//
   // Helpers

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -106,6 +106,27 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
     os << "\n";
     break;
   }
+  case RK_Array:
+  case RK_ArrayAddress: {
+    CanType elementType;
+    ArrayRef<SymbolicValue> elements = getArrayValue(elementType);
+    os << "array<" << elementType << ">: " << elements.size();
+    switch (elements.size()) {
+    case 0:
+      os << " elements []\n";
+      return;
+    case 1:
+      os << " elt: ";
+      elements[0].print(os, indent + 2);
+      return;
+    default:
+      os << " elements [\n";
+      for (auto elt : elements)
+        elt.print(os, indent + 2);
+      os.indent(indent) << "]\n";
+      return;
+    }
+  }
   }
 }
 
@@ -137,6 +158,9 @@ SymbolicValue::Kind SymbolicValue::getKind() const {
   case RK_DirectAddress:
   case RK_DerivedAddress:
     return Address;
+  case RK_Array:
+  case RK_ArrayAddress:
+    return Array;
   }
 }
 
@@ -176,6 +200,16 @@ SymbolicValue::cloneInto(ASTContext &astContext) const {
     auto *newMemObject = SymbolicValueMemoryObject::create(
         memObject->getType(), memObject->getValue(), astContext);
     return getAddress(newMemObject, accessPath, astContext);
+  }
+  case RK_Array:
+  case RK_ArrayAddress: {
+    CanType elementType;
+    auto elts = getArrayValue(elementType);
+    SmallVector<SymbolicValue, 4> results;
+    results.reserve(elts.size());
+    for (auto elt : elts)
+      results.push_back(elt.cloneInto(astContext));
+    return getArray(results, elementType, astContext);
   }
   }
 }
@@ -521,6 +555,81 @@ SymbolicValueMemoryObject *SymbolicValue::getAddressValueMemoryObject() const {
 }
 
 //===----------------------------------------------------------------------===//
+// Arrays
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+/// This is the representation of an array.
+struct ArraySymbolicValue final
+    : private llvm::TrailingObjects<ArraySymbolicValue, SymbolicValue> {
+  friend class llvm::TrailingObjects<ArraySymbolicValue, SymbolicValue>;
+
+  const CanType elementType;
+
+  /// This is the number of indices in the derived address.
+  const unsigned numElements;
+
+  static ArraySymbolicValue *create(ArrayRef<SymbolicValue> elements,
+                                    CanType elementType,
+                                    ASTContext &astContext) {
+    auto byteSize =
+        ArraySymbolicValue::totalSizeToAlloc<SymbolicValue>(elements.size());
+    auto rawMem = astContext.Allocate(byteSize, alignof(ArraySymbolicValue));
+
+    //  Placement initialize the object.
+    auto asv = ::new (rawMem) ArraySymbolicValue(elementType, elements.size());
+    std::uninitialized_copy(elements.begin(), elements.end(),
+                            asv->getTrailingObjects<SymbolicValue>());
+    return asv;
+  }
+
+  /// Return the element constants for this aggregate constant.  These are
+  /// known to all be constants.
+  ArrayRef<SymbolicValue> getElements() const {
+    return {getTrailingObjects<SymbolicValue>(), numElements};
+  }
+
+  // This is used by the llvm::TrailingObjects base class.
+  size_t numTrailingObjects(OverloadToken<SymbolicValue>) const {
+    return numElements;
+  }
+
+private:
+  ArraySymbolicValue() = delete;
+  ArraySymbolicValue(const ArraySymbolicValue &) = delete;
+  ArraySymbolicValue(CanType elementType, unsigned numElements)
+      : elementType(elementType), numElements(numElements) {}
+};
+} // end namespace swift
+
+/// Produce an array of elements.
+SymbolicValue SymbolicValue::getArray(ArrayRef<SymbolicValue> elements,
+                                      CanType elementType,
+                                      ASTContext &astContext) {
+  // TODO: Could compress the empty array representation if there were a reason
+  // to.
+  auto asv = ArraySymbolicValue::create(elements, elementType, astContext);
+  SymbolicValue result;
+  result.representationKind = RK_Array;
+  result.value.array = asv;
+  return result;
+}
+
+ArrayRef<SymbolicValue>
+SymbolicValue::getArrayValue(CanType &elementType) const {
+  assert(getKind() == Array);
+  auto val = *this;
+  if (representationKind == RK_ArrayAddress)
+    val = value.arrayAddress->getValue();
+
+  assert(val.representationKind == RK_Array);
+
+  elementType = val.value.array->elementType;
+  return val.value.array->getElements();
+}
+
+//===----------------------------------------------------------------------===//
 // Higher level code
 //===----------------------------------------------------------------------===//
 
@@ -653,22 +762,32 @@ static SymbolicValue getIndexedElement(SymbolicValue aggregate,
   if (aggregate.getKind() == SymbolicValue::UninitMemory)
     return SymbolicValue::getUninitMemory();
 
-  assert(aggregate.getKind() == SymbolicValue::Aggregate &&
+  assert((aggregate.getKind() == SymbolicValue::Aggregate ||
+          aggregate.getKind() == SymbolicValue::Array) &&
          "the accessPath is invalid for this type");
 
   unsigned elementNo = accessPath.front();
 
-  SymbolicValue elt = aggregate.getAggregateValue()[elementNo];
+  SymbolicValue elt;
   Type eltType;
-  if (auto *decl = type->getStructOrBoundGenericStruct()) {
-    auto it = decl->getStoredProperties().begin();
-    std::advance(it, elementNo);
-    eltType = (*it)->getType();
-  } else if (auto tuple = type->getAs<TupleType>()) {
-    assert(elementNo < tuple->getNumElements() && "invalid index");
-    eltType = tuple->getElement(elementNo).getType();
+
+  // We need to have an array, struct or a tuple type.
+  if (aggregate.getKind() == SymbolicValue::Array) {
+    CanType arrayEltTy;
+    elt = aggregate.getArrayValue(arrayEltTy)[elementNo];
+    eltType = arrayEltTy;
   } else {
-    llvm_unreachable("the accessPath is invalid for this type");
+    elt = aggregate.getAggregateValue()[elementNo];
+    if (auto *decl = type->getStructOrBoundGenericStruct()) {
+      auto it = decl->getStoredProperties().begin();
+      std::advance(it, elementNo);
+      eltType = (*it)->getType();
+    } else if (auto tuple = type->getAs<TupleType>()) {
+      assert(elementNo < tuple->getNumElements() && "invalid index");
+      eltType = tuple->getElement(elementNo).getType();
+    } else {
+      llvm_unreachable("the accessPath is invalid for this type");
+    }
   }
 
   return getIndexedElement(elt, accessPath.drop_front(), eltType);
@@ -718,22 +837,33 @@ static SymbolicValue setIndexedElement(SymbolicValue aggregate,
     aggregate = SymbolicValue::getAggregate(newElts, astCtx);
   }
 
-  assert(aggregate.getKind() == SymbolicValue::Aggregate &&
+  assert((aggregate.getKind() == SymbolicValue::Aggregate ||
+          aggregate.getKind() == SymbolicValue::Array) &&
          "the accessPath is invalid for this type");
 
   unsigned elementNo = accessPath.front();
 
-  ArrayRef<SymbolicValue> oldElts = aggregate.getAggregateValue();
+  ArrayRef<SymbolicValue> oldElts;
   Type eltType;
-  if (auto *decl = type->getStructOrBoundGenericStruct()) {
-    auto it = decl->getStoredProperties().begin();
-    std::advance(it, elementNo);
-    eltType = (*it)->getType();
-  } else if (auto tuple = type->getAs<TupleType>()) {
-    assert(elementNo < tuple->getNumElements() && "invalid index");
-    eltType = tuple->getElement(elementNo).getType();
+
+  // We need to have an array, struct or a tuple type.
+  if (aggregate.getKind() == SymbolicValue::Array) {
+    CanType arrayEltTy;
+    oldElts = aggregate.getArrayValue(arrayEltTy);
+    eltType = arrayEltTy;
   } else {
-    llvm_unreachable("the accessPath is invalid for this type");
+    oldElts = aggregate.getAggregateValue();
+
+    if (auto *decl = type->getStructOrBoundGenericStruct()) {
+      auto it = decl->getStoredProperties().begin();
+      std::advance(it, elementNo);
+      eltType = (*it)->getType();
+    } else if (auto tuple = type->getAs<TupleType>()) {
+      assert(elementNo < tuple->getNumElements() && "invalid index");
+      eltType = tuple->getElement(elementNo).getType();
+    } else {
+      llvm_unreachable("the accessPath is invalid for this type");
+    }
   }
 
   // Update the indexed element of the aggregate.
@@ -742,7 +872,11 @@ static SymbolicValue setIndexedElement(SymbolicValue aggregate,
                                          accessPath.drop_front(), newElement,
                                          eltType, astCtx);
 
-  aggregate = SymbolicValue::getAggregate(newElts, astCtx);
+  if (aggregate.getKind() == SymbolicValue::Aggregate)
+    aggregate = SymbolicValue::getAggregate(newElts, astCtx);
+  else
+    aggregate = SymbolicValue::getArray(newElts, eltType->getCanonicalType(),
+                                        astCtx);
 
   return aggregate;
 }

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -673,3 +673,75 @@ func evaluate<T>(addressOnlyEnum: AddressOnlyEnum<T>) -> Int {
 
 #assert(evaluate(addressOnlyEnum: .double(IntContainer(value: 1))) == 2)
 #assert(evaluate(addressOnlyEnum: .triple(IntContainer(value: 1))) == 3)
+
+//===----------------------------------------------------------------------===//
+// Arrays
+//
+// TODO: The constant evaluator does not implement any array access operations,
+// so these tests cannot test that the implemented array operations produce
+// correct values in the arrays. These tests only test that the implemented
+// array operations do not crash or produce unknown values. As soon as we have
+// array access operations, modify these tests to check the values in the
+// arrays.
+//===----------------------------------------------------------------------===//
+
+// When the const-evaluator evaluates this struct, it forces evaluation of the
+// `arr` value.
+struct ContainsArray {
+  let x: Int
+  let arr: [Int]
+}
+
+func arrayInitEmptyTopLevel() {
+  let c = ContainsArray(x: 1, arr: Array())
+  #assert(c.x == 1)
+}
+
+// expected-note @+1 {{could not fold operation}}
+func arrayInitEmptyLiteralTopLevel() {
+  // TODO: More work necessary for array initialization using literals to work
+  // at the top level.
+  let c = ContainsArray(x: 1, arr: [])
+  // expected-error @+1 {{#assert condition not constant}}
+  #assert(c.x == 1)
+}
+
+func arrayInitLiteral() {
+  // TODO: More work necessary for array initialization using literals to work
+  // at the top level.
+  // expected-note @+1 {{could not fold operation}}
+  let c = ContainsArray(x: 1, arr: [2, 3, 4])
+  // expected-error @+1 {{#assert condition not constant}}
+  #assert(c.x == 1)
+}
+
+func arrayInitNonConstantElementTopLevel(x: Int) {
+  // expected-note @+1 {{could not fold operation}}
+  let c = ContainsArray(x: 1, arr: [x])
+  // expected-error @+1 {{#assert condition not constant}}
+  #assert(c.x == 1)
+}
+
+func arrayInitEmptyFlowSensitive() -> ContainsArray {
+  return ContainsArray(x: 1, arr: Array())
+}
+
+func invokeArrayInitEmptyFlowSensitive() {
+  #assert(arrayInitEmptyFlowSensitive().x == 1)
+}
+
+func arrayInitEmptyLiteralFlowSensitive() -> ContainsArray {
+  return ContainsArray(x: 1, arr: [])
+}
+
+func invokeArrayInitEmptyLiteralFlowSensitive() {
+  #assert(arrayInitEmptyLiteralFlowSensitive().x == 1)
+}
+
+func arrayInitLiteralFlowSensitive() -> ContainsArray {
+  return ContainsArray(x: 1, arr: [2, 3, 4])
+}
+
+func invokeArrayInitLiteralFlowSensitive() {
+  #assert(arrayInitLiteralFlowSensitive().x == 1)
+}


### PR DESCRIPTION
Adds array values, initialization operations, and some tests that initialize arrays but that do not check the contents of the initialized arrays.

This PR includes support for AllocateUninitializedArray, but only in the flow-sensitive case. When I tried completely removing AllocateUninitializedArray (per your suggestion in https://github.com/apple/swift/pull/21703), I realized that it was no longer possible to write tests exercising the `RK_ArrayAddress` representation and the `getIndexedElement`/`setIndexedElement` changes. I think that those are important pieces of basic array support that should be included in the initial PR.

AllocateUninitializedArray in the flow-sensitive case exercises those features, so I added it back. It's still a lot simpler than https://github.com/apple/swift/pull/21703, because most of the AllocateUninitializedArray complexity was in the top level case.