### PR TITLE
Resilient witness table emission cleanup

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2039,7 +2039,8 @@ struct TargetGenericWitnessTable {
     return WitnessTablePrivateSizeInWordsAndRequiresInstantiation >> 1;
   }
 
-  /// Whether the witness table is known to require instantiation.
+  /// This bit doesn't really mean anything. Currently, the compiler always
+  /// sets it when emitting a generic witness table.
   uint16_t requiresInstantiation() const {
     return WitnessTablePrivateSizeInWordsAndRequiresInstantiation & 0x01;
   }

--- a/lib/IRGen/ConformanceDescription.h
+++ b/lib/IRGen/ConformanceDescription.h
@@ -51,9 +51,6 @@ public:
   /// Whether this witness table requires runtime specialization.
   const unsigned requiresSpecialization : 1;
 
-  /// Whether this witness table contains dependent associated type witnesses.
-  const unsigned hasDependentAssociatedTypeWitnesses : 1;
-
   /// The instantiation function, to be run at the end of witness table
   /// instantiation.
   llvm::Constant *instantiationFn = nullptr;
@@ -66,13 +63,11 @@ public:
                          llvm::Constant *pattern,
                          uint16_t witnessTableSize,
                          uint16_t witnessTablePrivateSize,
-                         bool requiresSpecialization,
-                         bool hasDependentAssociatedTypeWitnesses)
+                         bool requiresSpecialization)
     : conformance(conformance), wtable(wtable), pattern(pattern),
       witnessTableSize(witnessTableSize),
       witnessTablePrivateSize(witnessTablePrivateSize),
-      requiresSpecialization(requiresSpecialization),
-      hasDependentAssociatedTypeWitnesses(hasDependentAssociatedTypeWitnesses)
+      requiresSpecialization(requiresSpecialization)
   {
   }
 };

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2040,7 +2040,7 @@ namespace {
       // WitnessTablePrivateSizeInWordsAndRequiresInstantiation
       B.addInt(IGM.Int16Ty,
                (Description.witnessTablePrivateSize << 1) |
-                Description.hasDependentAssociatedTypeWitnesses);
+                Description.requiresSpecialization);
       // Instantiation function
       B.addRelativeAddressOrNull(Description.instantiationFn);
       // Private data
@@ -2296,10 +2296,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
                                      wtableBuilder.getTablePrivateSize(),
                                      isDependentConformance(
                                        conf,
-                                       /*considerResilience=*/true),
-                                     isDependentConformance(
-                                       conf,
-                                       /*considerResilience=*/false));
+                                       /*considerResilience=*/true));
 
   // Build the instantiation function, we if need one.
   description.instantiationFn = wtableBuilder.buildInstantiationFunction();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -794,8 +794,7 @@ public:
 
   bool isResilientConformance(const NormalProtocolConformance *conformance);
   bool isResilientConformance(const RootProtocolConformance *root);
-  bool isDependentConformance(const RootProtocolConformance *conformance,
-                              bool considerResilience);
+  bool isDependentConformance(const RootProtocolConformance *conformance);
 
   Alignment getCappedAlignment(Alignment alignment);
 

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -22,8 +22,7 @@ public protocol Runcible {
 // -- witness table
 // CHECK-SAME:           @"$s28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAWP"
 // -- flags
-// CHECK-SAME:           i32 0
-// CHECK-SAME:         },
+// CHECK-SAME:           i32 0 },
 public struct NativeValueType: Runcible {
   public func runce() {}
 }
@@ -36,8 +35,7 @@ public struct NativeValueType: Runcible {
 // -- witness table
 // CHECK-SAME:           @"$s28protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP"
 // -- flags
-// CHECK-SAME:           i32 0
-// CHECK-SAME:         },
+// CHECK-SAME:           i32 0 },
 public class NativeClassType: Runcible {
   public func runce() {}
 }
@@ -50,8 +48,7 @@ public class NativeClassType: Runcible {
 // -- witness table
 // CHECK-SAME:           @"$s28protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAWP"
 // -- flags
-// CHECK-SAME:           i32 0
-// CHECK-SAME:         },
+// CHECK-SAME:           i32 0 },
 public struct NativeGenericType<T>: Runcible {
   public func runce() {}
 }
@@ -86,6 +83,30 @@ extension Int: Runcible {
 extension Size: Runcible {
   public func runce() {}
 }
+
+// A non-dependent type conforming to a protocol with associated conformances
+// does not require a generic witness table.
+public protocol Simple {}
+
+public protocol AssociateConformance {
+  associatedtype X : Simple
+}
+
+public struct Other : Simple {}
+
+public struct Concrete : AssociateConformance {
+  public typealias X = Other
+}
+
+// CHECK-LABEL: @"$s28protocol_conformance_records8ConcreteVAA20AssociateConformanceAAMc" ={{ dllexport | protected | }}constant
+// -- protocol descriptor
+// CHECK-SAME:           @"$s28protocol_conformance_records20AssociateConformanceMp"
+// -- nominal type descriptor
+// CHECK-SAME:           @"$s28protocol_conformance_records8ConcreteVMn"
+// -- witness table
+// CHECK-SAME:           @"$s28protocol_conformance_records8ConcreteVAA20AssociateConformanceAAWP"
+// -- no flags are set, and no generic witness table follows
+// CHECK-SAME:           i32 0 }
 
 // CHECK-LABEL: @"\01l_protocols"
 // CHECK-SAME: @"$s28protocol_conformance_records8RuncibleMp"
@@ -136,7 +157,7 @@ extension Int : OtherResilientProtocol { }
 // -- witness table pattern
 // CHECK-SAME:           @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAWp"
 // -- flags
-// CHECK-SAME:           i32 0
+// CHECK-SAME:           i32 131072,
 // -- number of words in witness table
 // CHECK-SAME:           i16 2,
 // -- number of private words in witness table + bit for "needs instantiation"
@@ -151,5 +172,6 @@ extension Dependent : Associate {
 // CHECK-SAME: @"$s28protocol_conformance_records15NativeClassTypeCAA8RuncibleAAMc"
 // CHECK-SAME: @"$s28protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAMc"
 // CHECK-SAME: @"$s16resilient_struct4SizeV28protocol_conformance_records8RuncibleADMc"
+// CHECK-SAME: @"$s28protocol_conformance_records8ConcreteVAA20AssociateConformanceAAMc"
 // CHECK-SAME: @"$s28protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlMc"
 // CHECK-SAME: @"$sSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsMc"

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -97,8 +97,8 @@ protocol InternalProtocol {
 // -- number of witness table entries
 // CHECK-SAME:   i16 0,
 
-// -- size of private area + 'requires instantiation' bit (not set)
-// CHECK-SAME:   i16 0,
+// -- size of private area + 'requires instantiation' bit
+// CHECK-SAME:   i16 1,
 
 // -- instantiator function
 // CHECK-SAME:   i32 0
@@ -127,8 +127,8 @@ protocol InternalProtocol {
 // -- number of witness table entries
 // CHECK-SAME:   i16 0,
 
-// -- size of private area + 'requires instantiation' bit (not set)
-// CHECK-SAME:   i16 0,
+// -- size of private area + 'requires instantiation' bit
+// CHECK-SAME:   i16 1,
 
 // -- instantiator function
 // CHECK-SAME:   i32 0

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -60,10 +60,18 @@ public struct ConditionallyConforms<Element> { }
 public struct Y { }
 
 // CHECK-USAGE-LABEL: @"$s31protocol_resilience_descriptors1YV010resilient_A022OtherResilientProtocolAAMc" =
+// -- flags: has generic witness table
 // CHECK-USAGE-SAME: i32 131072,
+// -- number of witness table entries
 // CHECK-USAGE-SAME: i16 0,
-// CHECK-USAGE-SAME: i16 0,
-// CHECK-USAGE-SAME: i32 0
+// -- size of private area + 'requires instantiation' bit
+// CHECK-USAGE-SAME: i16 1,
+// -- instantiator function
+// CHECK-USAGE-SAME: i32 0,
+// -- private data area
+// CHECK-USAGE-SAME: {{@[0-9]+}}
+// --
+// CHECK-USAGE-SAME: }
 extension Y: OtherResilientProtocol { }
 
 // CHECK-USAGE: @"$s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAAMc" =


### PR DESCRIPTION
I found some of the code in GenProto.cpp hard to follow while working on https://github.com/apple/swift/pull/22737. Now that the immediate bug fix is done here is a larger cleanup. Should be mostly NFC.