### PR TITLE
Update some tests so that they pass ownership verification.

### DIFF
--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -21,6 +21,7 @@ extension Int: P {}
 sil [ossa] @concrete_callee1 : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>, @thin Int.Type, @thick P.Type) -> () {
 bb0(%i : $Int, %b : @owned $<τ_0_0> { var τ_0_0 } <Int>, %m : $@thin Int.Type, %p : $@thick P.Type):
   %12 = tuple ()
+  destroy_value %b : $<τ_0_0> { var τ_0_0 } <Int>
   return %12 : $()
 }
 
@@ -54,6 +55,7 @@ bb0(%i : $Int, %p : $@thick P.Type):
 sil [ossa] @generic_callee2 : $@convention(thin) <T, U> (@in T, @owned <τ_0_0> { var τ_0_0 } <U>) -> () {
 bb0(%i : $*T, %b : @owned $<τ_0_0> { var τ_0_0 } <U>):
   %12 = tuple ()
+  destroy_value %b : $<τ_0_0> { var τ_0_0 } <U>
   return %12 : $()
 }
 
@@ -162,6 +164,7 @@ class GenericClass<T, U> {}
 sil [ossa] @generic_callee5 : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> () {
 bb0(%t : @owned $GenericClass<T, U>):
   %12 = tuple ()
+  destroy_value %t : $GenericClass<T, U>
   return %12 : $()
 }
 
@@ -205,6 +208,8 @@ sil_vtable GenericClass {}
 sil [ossa] @pseudogeneric_callee : $@convention(thin) @pseudogeneric <T : AnyObject, U : AnyObject> (@owned T, @owned U) -> () {
 bb0(%t : @owned $T, %u : @owned $U):
   %12 = tuple ()
+  destroy_value %t : $T
+  destroy_value %u : $U
   return %12 : $()
 }
 
@@ -229,8 +234,8 @@ bb0(%thin : $@convention(thin) () -> (), %c : $@convention(c) () -> (), %block :
   return %12 : $()
 }
 
-sil [ossa] @function_caller : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> @owned @callee_guaranteed () -> () {
-bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: @unowned $@convention(block) () -> (), %thick: @unowned $@convention(thick) () -> (), %method: $@convention(method) () -> (), %witness_method: $@convention(witness_method: P) (Int) -> ()):
+sil [ossa] @function_caller : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @owned @convention(block) () -> (), @owned @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> @owned @callee_guaranteed () -> () {
+bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: @owned $@convention(block) () -> (), %thick: @owned $@convention(thick) () -> (), %method: $@convention(method) () -> (), %witness_method: $@convention(witness_method: P) (Int) -> ()):
   %f = function_ref @function_callee : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
   %result = partial_apply [callee_guaranteed] %f(%thin, %c, %block, %thick, %method, %witness_method) : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
   return %result : $@callee_guaranteed () -> ()

--- a/test/Serialization/Inputs/def_basic_objc.sil
+++ b/test/Serialization/Inputs/def_basic_objc.sil
@@ -49,7 +49,8 @@ sil [transparent] [serialized] [ossa] @protocol_conversion : $@convention(thin) 
 entry:
   // CHECK: {{%.*}} = objc_protocol #ObjCProto : $Protocol
   %p = objc_protocol #ObjCProto : $Protocol
-  return %p : $Protocol
+  %p_copy = copy_value %p : $Protocol
+  return %p_copy : $Protocol
 }
 
 @_transparent public func serialize_all() {

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -22,5 +22,6 @@ sil [ossa] @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@ow
 // CHECK: bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>)
 bb0(%0 : @owned $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>):
   %1 = project_box %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>, 0
+  destroy_value %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>
   return undef : $()
 }


### PR DESCRIPTION
I noticed that I enabled ownership verification on all of the simple run swift
tests, but I didn't on the simple build swift tests. I have prepared a commit
that enables that. This commit contains some test fixes needed to make it pass.
