### PR TITLE
[ownership] Serialize/strip ownership at the beginning of the Onone p…

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -639,24 +639,23 @@ SILPassPipelinePlan
 SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
 
-  // First specialize user-code.
-  P.startPipeline("Prespecialization");
-  P.addUsePrespecialized();
+  // First serialize the SIL if we are asked to.
+  P.startPipeline("Serialization");
+  P.addSerializeSILPass();
 
+  // And then strip ownership...
+  if (!Options.StripOwnershipDuringDiagnosticsPipeline)
+    P.addOwnershipModelEliminator();
+
+  // Finally perform some small transforms.
   P.startPipeline("Rest of Onone");
+  P.addUsePrespecialized();
 
   // Has only an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();
 
   // Has only an effect if the -gsil option is specified.
   P.addSILDebugInfoGenerator();
-
-  // Finally serialize the SIL if we are asked to.
-  P.addSerializeSILPass();
-
-  // And then strip ownership before we IRGen.
-  if (!Options.StripOwnershipDuringDiagnosticsPipeline)
-    P.addOwnershipModelEliminator();
 
   return P;
 }


### PR DESCRIPTION
…ass pipeline so we strip ownership before use-prespecialized.

I am doing this to avoid having to update the parts of the generic specializer
that use prespecialized depends upon.

In terms of performance This shouldn't matter. I am only moving this earlier
than 3 passes. Each is ok to move after serialization. Specifically:

1. UsePrespecialized: We only perform prespecialization for a fixed set of APIs
from the swift standard library. Any other -Onone code that links in our
serialized -Onone code will also run that pass, so we are guaranteed that our
code will always have prespecialization applied.

2. AssumeSingleThreaded: Again, the other -Onone code will run this. Also this
is experimental code that isn't always on.

3. SILDebugInfoGenerator: Again, this is experimental code that isn't always
on. It makes sense that it should be here since we are still printing SIL with
ownership removed. So for it to match, we must emit the code at the end of the
pipeline. So this is an even better result.
