### PR TITLE
Sema: Fix inconsistent behavior with SE-0110-related compatibility hack

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1184,7 +1184,10 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
           // We somehow let tuple unsplatting function conversions
           // through in some cases in Swift 4, so let's let that
           // continue to work, but only for Swift 4.
-          if (simplified && isa<DeclRefExpr>(simplified)) {
+          if (simplified &&
+              (isa<DeclRefExpr>(simplified) ||
+               isa<OverloadedDeclRefExpr>(simplified) ||
+               isa<UnresolvedDeclRefExpr>(simplified))) {
             implodeParams(func2Params);
           }
         }

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1642,10 +1642,17 @@ public extension Optional {
 }
 
 // https://bugs.swift.org/browse/SR-6837
+
+// FIXME: Can't overlaod local functions so these must be top-level
+func takePairOverload(_ pair: (Int, Int?)) {}
+func takePairOverload(_: () -> ()) {}
+
 do {
   func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
   func takePair(_ pair: (Int, Int?)) {}
   takeFn(fn: takePair) // Allow for -swift-version 4, but not later
+  takeFn(fn: takePairOverload) // Allow for -swift-version 4, but not later
+
   takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
   // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
   takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1645,10 +1645,16 @@ public extension Optional {
 }
 
 // https://bugs.swift.org/browse/SR-6837
+
+// FIXME: Can't overlaod local functions so these must be top-level
+func takePairOverload(_ pair: (Int, Int?)) {} // expected-note {{found this candidate}}
+func takePairOverload(_: () -> ()) {} // expected-note {{found this candidate}}
+
 do {
   func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
   func takePair(_ pair: (Int, Int?)) {}
   takeFn(fn: takePair) // expected-error {{cannot convert value of type '((Int, Int?)) -> ()' to expected argument type '(Int, Int?) -> ()'}}
+  takeFn(fn: takePairOverload) // expected-error {{ambiguous reference to member 'takePairOverload'}}
   takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
   // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
   takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later


### PR DESCRIPTION
Back when SE-0110 was implemented we decided that passing a function value
taking multiple parameters would be allowed where a function value taking
a single tuple argument was expected.

Due to quirks in the old function type representation, the "splat" in the
other direction sometimes worked too. When we redid the function type
representation we added a simulation of the old quirk for -swift-version 4
mode.

However this simulation was itself problematic because it only worked when
the function value being passed was a non-overloaded declaration reference.

Slightly broaden the hack to the overloaded case, to prevent user
confusion when adding or removing overloads.