### PR TITLE
Diagnostic: dynamic replacement and replaced function's @objc attribu…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3921,6 +3921,10 @@ ERROR(dynamic_replacement_not_in_extension, none,
       "dynamicReplacement(for:) of %0 is not defined in an extension or at the file level", (DeclName))
 ERROR(dynamic_replacement_must_not_be_dynamic, none,
       "dynamicReplacement(for:) of %0 must not be dynamic itself", (DeclName))
+ERROR(dynamic_replacement_replaced_not_objc_dynamic, none,
+      "%0 is not marked @objc dynamic", (DeclName))
+ERROR(dynamic_replacement_replacement_not_objc_dynamic, none,
+      "%0 is marked @objc dynamic", (DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: @available

--- a/test/attr/attr_objc_dynamic_replacement.swift
+++ b/test/attr/attr_objc_dynamic_replacement.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+//
+// REQUIRES: objc_interop
+
+class Object {
+  @objc dynamic func method(){
+  }
+
+  dynamic func nativeMethod() {
+  }
+}
+
+extension Object {
+  @_dynamicReplacement(for: method()) // expected-error{{'method()' is marked @objc dynamic}}
+  func replacement() {
+  }
+
+  @_dynamicReplacement(for: nativeMethod()) // expected-error{{'nativeMethod()' is not marked @objc dynamic}}
+  @objc dynamic func replacement2() {
+  }
+
+}


### PR DESCRIPTION
…te must match

rdar://48259565