### PR TITLE
IRGen: cast the argument type for the OpaqueExtentialTypeInfo assignm…

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -842,8 +842,11 @@ public:
     // Use copy-on-write existentials?
     auto fn = getAssignBoxedOpaqueExistentialBufferFunction(
         IGF.IGM, getLayout(), objPtrTy);
-    auto call =
-        IGF.Builder.CreateCall(fn, {dest.getAddress(), src.getAddress()});
+    auto destAddress = IGF.Builder.CreateBitCast(
+        dest.getAddress(), cast<llvm::Function>(fn)->arg_begin()[0].getType());
+    auto srcAddress = IGF.Builder.CreateBitCast(
+        src.getAddress(), cast<llvm::Function>(fn)->arg_begin()[1].getType());
+    auto call = IGF.Builder.CreateCall(fn, {destAddress, srcAddress});
     call->setCallingConv(IGF.IGM.DefaultCC);
     call->setDoesNotThrow();
     return;


### PR DESCRIPTION
…ent op

Ensure that the function parameter types match, as this triggers an assertion
failure otherwise.  Thanks to Dave Zarzycki for finding this!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
