### PR TITLE
s390x fix objc_simd.sil test failure

### DIFF
--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -23,7 +23,7 @@ func forceStuff(x: float4, y: float3) -> (Float, Float, Float, Float) {
 // armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_c_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V*)
 sil @simd_c_args : $@convention(c) (float4) -> float4 {
 entry(%x : @trivial $float4):
   return %x : $float4
@@ -39,7 +39,7 @@ entry(%x : @trivial $float4):
 // armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
-// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_c_args_float3(%T4simd6float3V* noalias nocapture sret, %T4simd6float3V*)
 sil @simd_c_args_float3 : $@convention(c) (float3) -> float3 {
 entry(%x : @trivial $float3):
 // x86_64: [[COERCE:%.*]] = alloca <3 x float>, align 16
@@ -58,7 +58,7 @@ entry(%x : @trivial $float3):
 // armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
-// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
 entry(%x : @trivial $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4


### PR DESCRIPTION
The change is specific to s390x to make it pass on s390x platforms.
