### PR TITLE
[Sema] Fix `getEffectiveMemberwiseInitializer` crash.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3090,8 +3090,15 @@ ConstructorDecl *NominalTypeDecl::getEffectiveMemberwiseInitializer() {
     unsigned numStoredProperties =
         std::distance(getStoredProperties().begin(),
                       getStoredProperties().end());
+    // Return false if constructor does not have interface type set. It is not
+    // possible to determine whether it is a memberwise initializer.
+    if (!ctorDecl->hasInterfaceType())
+      return false;
     auto ctorType =
-        ctorDecl->getMethodInterfaceType()->castTo<AnyFunctionType>();
+        ctorDecl->getMethodInterfaceType()->getAs<AnyFunctionType>();
+    // Return false if constructor does not have a valid method interface type.
+    if (!ctorType)
+      return false;
     // Return false if stored property/initializer parameter count do not match.
     if (numStoredProperties != ctorType->getNumParams())
       return false;

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -299,3 +299,8 @@ struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
   var x: DifferentiableSubset
   var b: Bool // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }
+
+// TF-265: Test invalid initializer (that uses a non-existent type).
+struct InvalidInitializer : Differentiable {
+  init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {} // expected-error {{use of undeclared type 'NonExistentType'}}
+}


### PR DESCRIPTION
Fix `getEffectiveMemberwiseInitializer` crash due to constructors with invalid types.
Add checks for invalid constructors.

Resolves [TF-265](https://bugs.swift.org/projects/TF/issues/TF-265).