### PR TITLE
Disable merging of read/modify exclusivity access markers.

### DIFF
--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -506,14 +506,19 @@ bb0(%0 : ${ var Int64 }):
 // }
 // Preserve the scope of the outer inout access. Runtime trap expected.
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @$s17enforce_with_opts24testInoutWriteEscapeReadyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ var Int64 }, var, name "x"
 // CHECK: [[BOXADR:%.*]] = project_box [[BOX]] : ${ var Int64 }, 0
 // CHECK: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[BOXADR]] : $*Int64
 // CHECK: apply
-// CHECK-NOT: begin_access
 // CHECK: end_access [[BEGIN]]
-// CHECK-NOT: begin_access
+// CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[BOXADR]] : $*Int64
+// CHECK: load [[BEGIN2]]
+// CHECK: end_access [[BEGIN2]]
 // CHECK-LABEL: } // end sil function '$s17enforce_with_opts24testInoutWriteEscapeReadyyF'
 sil @$s17enforce_with_opts24testInoutWriteEscapeReadyyF : $@convention(thin) () -> () {
 bb0:
@@ -579,14 +584,19 @@ bb0(%0 : ${ var Int64 }):
 // }
 // Preserve the scope of the outer inout access. Runtime trap expected.
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @$s17enforce_with_opts020testInoutWriteEscapeF0yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ var Int64 }, var, name "x"
 // CHECK: [[BOXADR:%.*]] = project_box [[BOX]] : ${ var Int64 }, 0
 // CHECK: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[BOXADR]] : $*Int64
 // CHECK: apply
-// CHECK-NOT: begin_access
 // CHECK: end_access [[BEGIN]]
-// CHECK-NOT: begin_access
+// CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[BOXADR]] : $*Int64
+// CHECK: load [[BEGIN2]]
+// CHECK: end_access [[BEGIN2]]
 // CHECK-LABEL: } // end sil function '$s17enforce_with_opts020testInoutWriteEscapeF0yyF'
 sil @$s17enforce_with_opts020testInoutWriteEscapeF0yyF : $@convention(thin) () -> () {
 bb0:
@@ -999,14 +1009,21 @@ bb0:
 // public func testOldToNewMapWrite) {
 // Checks merging of 3 scopes resulting in a larger modify scope
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @testOldToNewMapWrite : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]] : $*X
-// CHECK-NEXT: load [[BEGIN]] : $*X
-// CHECK: store {{.*}} to [[BEGIN]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
-// CHECK-NOT: begin_access
+// CHECK: [[BEGIN2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK-NEXT: store {{.*}} to [[BEGIN2]] : $*X
+// CHECK-NEXT: end_access [[BEGIN2]] : $*X
+// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK-NEXT: load [[BEGIN3]] : $*X
+// CHECK-NEXT: end_access [[BEGIN3]] : $*X
 // CHECK-LABEL: } // end sil function 'testOldToNewMapWrite'
 sil @testOldToNewMapWrite : $@convention(thin) () -> () {
 bb0:
@@ -1031,15 +1048,20 @@ bb0:
 // public func testDataFlowAcrossBBs() {
 // Checks merging of scopes across basic blocks - propagating that information
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @testDataFlowAcrossBBs : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
+// CHECK-NEXT: end_access [[BEGIN]] : $*X
 // CHECK-NEXT: br bb1
 // CHECK: br bb2
-// CHECK: load [[BEGIN]] : $*X
-// CHECK-NEXT: end_access [[BEGIN]] : $*X
-// CHECK-NOT: begin_access
+// CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK-NEXT: load [[BEGIN2]] : $*X
+// CHECK-NEXT: end_access [[BEGIN2]] : $*X
 // CHECK-LABEL: } // end sil function 'testDataFlowAcrossBBs'
 sil @testDataFlowAcrossBBs : $@convention(thin) () -> () {
 bb0:
@@ -1063,15 +1085,20 @@ bb2:
 // public func testDataFlowAcrossInnerLoop() {
 // Checks merging of scopes across an inner loop
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @testDataFlowAcrossInnerLoop : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
+// CHECK-NEXT: end_access [[BEGIN]] : $*X
 // CHECK-NEXT: br bb1
 // CHECK: cond_br {{.*}}, bb1, bb2
-// CHECK: load [[BEGIN]] : $*X
-// CHECK-NEXT: end_access [[BEGIN]] : $*X
-// CHECK-NOT: begin_access
+// CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK-NEXT: load [[BEGIN2]] : $*X
+// CHECK-NEXT: end_access [[BEGIN2]] : $*X
 // CHECK-LABEL: } // end sil function 'testDataFlowAcrossInnerLoop'
 sil @testDataFlowAcrossInnerLoop : $@convention(thin) () -> () {
 bb0:
@@ -1248,13 +1275,19 @@ bb4:
 // Checks detection of irreducible control flow / bail + parts that we *can* merge
 // See disableCrossBlock in the algorithm: this detects this corner case
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @testIrreducibleGraph2 : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
-// CHECK-NEXT: br bb1
-// CHECK: load [[BEGIN]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
+// CHECK-NEXT: br bb1
+// CHECK: [[BEGIN1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK-NEXT: load [[BEGIN1]] : $*X
+// CHECK-NEXT: end_access [[BEGIN1]] : $*X
 // CHECK: cond_br {{.*}}, bb2, bb3
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
@@ -1390,13 +1423,19 @@ bb0(%0 : $RefElemNoConflictClass):
 // During the merge optimization,
 // Check that we don't merge cross strongly component boundaries for now
 //
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // CHECK-LABEL: sil @testStronglyConnectedComponent : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
-// CHECK-NEXT: br bb1
-// CHECK: load [[BEGIN]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
+// CHECK-NEXT: br bb1
+// CHECK: [[BEGIN1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK-NEXT: load [[BEGIN1]] : $*X
+// CHECK-NEXT: end_access [[BEGIN1]] : $*X
 // CHECK: cond_br {{.*}}, bb2, bb3
 // CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
@@ -1555,3 +1594,59 @@ bb3(%1 : $*X):
   return %10 : $()
 }
 
+// --- rdar://48239213: Fatal access conflict detected.
+//
+// The read/modify pair of accesses in testReadModifyConflictPair
+// cannot be merged without introducing a false conflict.
+
+public class TestClass {
+  @_hasStorage @_hasInitialValue var flags: Int64 { get set }
+}
+
+// CHECK-LABEL: sil hidden [noinline] @readFlags : $@convention(method) (Int64, @guaranteed TestClass) -> Bool {
+// CHECK: bb0(%0 : $Int64, %1 : $TestClass):
+// CHECK:   [[ADR:%.*]] = ref_element_addr %1 : $TestClass, #TestClass.flags
+// CHECK:   begin_access [read] [dynamic] [no_nested_conflict] [[ADR]] : $*Int64
+// CHECK:   load %4 : $*Builtin.Int64
+// CHECK:   end_access
+// CHECK-LABEL: } // end sil function 'readFlags'
+sil hidden [noinline] @readFlags : $@convention(method) (Int64, @guaranteed TestClass) -> Bool {
+bb0(%0 : $Int64, %1 : $TestClass):
+  %2 = ref_element_addr %1 : $TestClass, #TestClass.flags
+  %3 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Int64
+  %4 = struct_element_addr %3 : $*Int64, #Int64._value
+  %5 = load %4 : $*Builtin.Int64
+  end_access %3 : $*Int64
+  %7 = struct_extract %0 : $Int64, #Int64._value
+  %8 = builtin "cmp_eq_Int64"(%5 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  %9 = struct $Bool (%8 : $Builtin.Int1)
+  return %9 : $Bool
+}
+
+// CHECK-LABEL: sil @testReadModifyConflictPair : $@convention(method) (@guaranteed TestClass) -> () {
+// CHECK: bb0(%0 : $TestClass):
+// CHECK:   [[ADR:%.*]] = ref_element_addr %0 : $TestClass, #TestClass.flags
+// CHECK:   begin_access [read] [dynamic] [no_nested_conflict] [[ADR]] : $*Int64
+// CHECK:   load
+// CHECK:   end_access
+// CHECK:   apply {{.*}} : $@convention(method) (Int64, @guaranteed TestClass) -> Bool
+// CHECK:   begin_access [modify] [dynamic] [no_nested_conflict] [[ADR]] : $*Int64
+// CHECK:   store
+// CHECK:   end_access
+// CHECK-LABEL: } // end sil function 'testReadModifyConflictPair'
+sil @testReadModifyConflictPair : $@convention(method) (@guaranteed TestClass) -> () {
+bb0(%0 : $TestClass):
+  %1 = ref_element_addr %0 : $TestClass, #TestClass.flags
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  %5 = function_ref @readFlags : $@convention(method) (Int64, @guaranteed TestClass) -> Bool
+  %6 = apply %5(%3, %0) : $@convention(method) (Int64, @guaranteed TestClass) -> Bool
+  %7 = integer_literal $Builtin.Int64, 3
+  %8 = struct $Int64 (%7 : $Builtin.Int64)
+  %9 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %8 to %9 : $*Int64
+  end_access %9 : $*Int64
+  %12 = tuple ()
+  return %12 : $()
+}

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -9,26 +9,36 @@ func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
   return x &+ y
 }
 
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest1yySiF : $@convention(thin)
 // TESTSIL: bb0
 // TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
 // TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: end_access [[B1]]
 // TESTSIL: bb5
-// TESTSIL: [[B2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B2]]
-// TESTSIL: store {{.*}} to [[B2]]
-// TESTSIL: end_access [[B2]]
+// TESTSIL: [[B2a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: load [[B2a]]
+// TESTSIL: end_access [[B2a]]
+// TESTSIL: [[B2b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: store {{.*}} to [[B2b]]
+// TESTSIL: end_access [[B2b]]
 // TESTSIL: bb6
-// TESTSIL: [[B3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B3]]
-// TESTSIL: store {{.*}} to [[B3]]
-// TESTSIL: end_access [[B3]]
+// TESTSIL: [[B3a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: load [[B3a]]
+// TESTSIL: end_access [[B3a]]
+// TESTSIL: [[B3b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: store {{.*}} to [[B3b]]
+// TESTSIL: end_access [[B3b]]
 // TESTSIL: bb7
-// TESTSIL: [[B4:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B4]]
-// TESTSIL: store {{.*}} to [[B4]]
-// TESTSIL: end_access [[B4]]
+// TESTSIL: [[B4a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: load [[B4a]]
+// TESTSIL: end_access [[B4a]]
+// TESTSIL: [[B4b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: store {{.*}} to [[B4b]]
+// TESTSIL: end_access [[B4b]]
 // TESTSIL-NOT: begin_access
 // TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest1yySiF'
 @inline(never)
@@ -48,21 +58,29 @@ public func MergeTest1(_ N: Int) {
   }
 }
 
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
 // TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest2yySiF : $@convention(thin)
 // TESTSIL: bb0
 // TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
 // TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: end_access [[B1]]
 // TESTSIL: bb6
-// TESTSIL: [[B2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B2]]
-// TESTSIL: store {{.*}} to [[B2]]
-// TESTSIL: end_access [[B2]]
+// TESTSIL: [[B2a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: load [[B2a]]
+// TESTSIL: end_access [[B2a]]
+// TESTSIL: [[B2b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: store {{.*}} to [[B2b]]
+// TESTSIL: end_access [[B2b]]
 // TESTSIL: bb7
-// TESTSIL: [[B3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B3]]
-// TESTSIL: store {{.*}} to [[B3]]
-// TESTSIL: end_access [[B3]]
+// TESTSIL: [[B3a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: load [[B3a]]
+// TESTSIL: end_access [[B3a]]
+// TESTSIL: [[B3b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: store {{.*}} to [[B3b]]
+// TESTSIL: end_access [[B3b]]
 // TESTSIL-NOT: begin_access
 // TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest2yySiF'
 @inline(never)
@@ -81,13 +99,17 @@ public func MergeTest2(_ N: Int) {
   }
 }
 
-// TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest3yySiF : $@convention(thin)
-// TESTSIL: bb0
-// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
-// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL: end_access [[B1]]
-// TESTSIL-NOT: begin_access
-// TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest3yySiF'
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
+// FIXME_TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest3yySiF : $@convention(thin)
+// FIXME_TESTSIL: bb0
+// FIXME_TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
+// FIXME_TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL: end_access [[B1]]
+// FIXME_TESTSIL-NOT: begin_access
+// FIXME_TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest3yySiF'
 @inline(never)
 public func MergeTest3(_ N: Int) {
   let range = 0..<10000
@@ -99,23 +121,27 @@ public func MergeTest3(_ N: Int) {
   }
 }
 
-// TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest4yySiF : $@convention(thin)
-// TESTSIL: bb0
-// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
-// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL: end_access [[B1]]
-// TESTSIL: bb7
-// TESTSIL: [[B2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B2]]
-// TESTSIL: store {{.*}} to [[B2]]
-// TESTSIL: end_access [[B2]]
-// TESTSIL: bb8
-// TESTSIL: [[B3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B3]]
-// TESTSIL: store {{.*}} to [[B3]]
-// TESTSIL: end_access [[B3]]
-// TESTSIL-NOT: begin_access
-// TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest4yySiF'
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
+// FIXME_TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest4yySiF : $@convention(thin)
+// FIXME_TESTSIL: bb0
+// FIXME_TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
+// FIXME_TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL: end_access [[B1]]
+// FIXME_TESTSIL: bb7
+// FIXME_TESTSIL: [[B2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL-NEXT: load [[B2]]
+// FIXME_TESTSIL: store {{.*}} to [[B2]]
+// FIXME_TESTSIL: end_access [[B2]]
+// FIXME_TESTSIL: bb8
+// FIXME_TESTSIL: [[B3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL-NEXT: load [[B3]]
+// FIXME_TESTSIL: store {{.*}} to [[B3]]
+// FIXME_TESTSIL: end_access [[B3]]
+// FIXME_TESTSIL-NOT: begin_access
+// FIXME_TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest4yySiF'
 @inline(never)
 public func MergeTest4(_ N: Int) {
   let range = 0..<10000
@@ -130,28 +156,32 @@ public func MergeTest4(_ N: Int) {
   }
 }
 
-// TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest5yySiF : $@convention(thin)
-// TESTSIL: bb0
-// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
-// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL: end_access [[B1]]
-// TESTSIL: bb6
-// TESTSIL: [[B2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B2]]
-// TESTSIL: store {{.*}} to [[B2]]
-// TESTSIL: end_access [[B2]]
-// TESTSIL: bb7
-// TESTSIL: [[B3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B3]]
-// TESTSIL: store {{.*}} to [[B3]]
-// TESTSIL: end_access [[B3]]
-// TESTSIL: bb8
-// TESTSIL: [[B4:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B4]]
-// TESTSIL: store {{.*}} to [[B4]]
-// TESTSIL: end_access [[B4]]
-// TESTSIL-NOT: begin_access
-// TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest5yySiF'
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
+// FIXME_TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest5yySiF : $@convention(thin)
+// FIXME_TESTSIL: bb0
+// FIXME_TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
+// FIXME_TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL: end_access [[B1]]
+// FIXME_TESTSIL: bb6
+// FIXME_TESTSIL: [[B2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL-NEXT: load [[B2]]
+// FIXME_TESTSIL: store {{.*}} to [[B2]]
+// FIXME_TESTSIL: end_access [[B2]]
+// FIXME_TESTSIL: bb7
+// FIXME_TESTSIL: [[B3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL-NEXT: load [[B3]]
+// FIXME_TESTSIL: store {{.*}} to [[B3]]
+// FIXME_TESTSIL: end_access [[B3]]
+// FIXME_TESTSIL: bb8
+// FIXME_TESTSIL: [[B4:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL-NEXT: load [[B4]]
+// FIXME_TESTSIL: store {{.*}} to [[B4]]
+// FIXME_TESTSIL: end_access [[B4]]
+// FIXME_TESTSIL-NOT: begin_access
+// FIXME_TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest5yySiF'
 @inline(never)
 public func MergeTest5(_ N: Int) {
   let range = 0..<10000
@@ -169,13 +199,17 @@ public func MergeTest5(_ N: Int) {
   }
 }
 
-// TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest6yySiF : $@convention(thin)
-// TESTSIL: bb0
-// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
-// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL: end_access [[B1]]
-// TESTSIL-NOT: begin_access
-// TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest6yySiF'
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
+// FIXME_TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest6yySiF : $@convention(thin)
+// FIXME_TESTSIL: bb0
+// FIXME_TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
+// FIXME_TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL: end_access [[B1]]
+// FIXME_TESTSIL-NOT: begin_access
+// FIXME_TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest6yySiF'
 @inline(never)
 public func MergeTest6(_ N: Int) {
   let range = 0..<10000
@@ -195,13 +229,17 @@ public func MergeTest6(_ N: Int) {
 public func foo() {
 }
 
-// TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest7yySiF : $@convention(thin)
-// TESTSIL: bb0
-// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
-// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL: end_access [[B1]]
-// TESTSIL-NOT: begin_access
-// TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest7yySiF'
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
+// FIXME_TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest7yySiF : $@convention(thin)
+// FIXME_TESTSIL: bb0
+// FIXME_TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
+// FIXME_TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL: end_access [[B1]]
+// FIXME_TESTSIL-NOT: begin_access
+// FIXME_TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest7yySiF'
 @inline(never)
 public func MergeTest7(_ N: Int) {
   let range = 0..<10000
@@ -217,13 +255,17 @@ public func MergeTest7(_ N: Int) {
   }
 }
 
-// TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest8yySiF : $@convention(thin)
-// TESTSIL: bb0
-// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
-// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL: end_access [[B1]]
-// TESTSIL-NOT: begin_access
-// TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest8yySiF'
+// FIXME: The optimization should be able to merge these accesses, but
+// it must first prove that no other conflicting read accesses occur
+// within the existing read access scopes.
+//
+// FIXME_TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity10MergeTest8yySiF : $@convention(thin)
+// FIXME_TESTSIL: bb0
+// FIXME_TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
+// FIXME_TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// FIXME_TESTSIL: end_access [[B1]]
+// FIXME_TESTSIL-NOT: begin_access
+// FIXME_TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity10MergeTest8yySiF'
 @inline(never)
 public func MergeTest8(_ N: Int) {
   let range = 0..<10000


### PR DESCRIPTION
When two access scopes have different access types, it is not safe to
merge them into one access. Doing so will introduce false conflicts
which manifest as crashes in user code.

To do this optimization, we would need additional data flow information
about *potential* read conflicts before converting a read to a modify
access.

Fixes rdar://48239213: Fatal access conflict detected.