### PR TITLE
RemoteAST: Try to fix a use-after-free in swift-remoteast-test

### DIFF
--- a/test/RemoteAST/existentials.swift
+++ b/test/RemoteAST/existentials.swift
@@ -5,6 +5,9 @@
 @_silgen_name("printDynamicTypeAndAddressForExistential")
 func printDynamicTypeAndAddressForExistential<T>(_: T)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 struct MyStruct<T, U, V> {
   let x: T
   let y: U
@@ -49,3 +52,5 @@ printDynamicTypeAndAddressForExistential(q)
 // CHECK-NEXT: Any.Type
 let metatype : Any.Type = Any.self
 printDynamicTypeAndAddressForExistential(metatype)
+
+stopRemoteAST()

--- a/test/RemoteAST/existentials_objc.swift
+++ b/test/RemoteAST/existentials_objc.swift
@@ -8,6 +8,9 @@ import Foundation
 @_silgen_name("printDynamicTypeAndAddressForExistential")
 func printDynamicTypeAndAddressForExistential<T>(_: T)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 // CHECK: NSObject
 printDynamicTypeAndAddressForExistential(NSObject() as AnyObject)
 
@@ -41,3 +44,5 @@ class ClassError : NSError {
 
 // CHECK: ClassError
 printDynamicTypeAndAddressForExistential(ClassError() as Error)
+
+stopRemoteAST()

--- a/test/RemoteAST/extensions.swift
+++ b/test/RemoteAST/extensions.swift
@@ -5,6 +5,9 @@
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 extension Int {
   struct Inner { }
 }
@@ -76,3 +79,5 @@ extension A where T: AnyObject {
 
 // CHECK: A<C, Int>.ViaAnyObject
 printType(A<C, Int>.ViaAnyObject.self)
+
+stopRemoteAST()

--- a/test/RemoteAST/foreign_types.swift
+++ b/test/RemoteAST/foreign_types.swift
@@ -10,6 +10,9 @@ import ErrorEnums
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 printType(CCRefrigerator.self)
 // CHECK: found type: CCRefrigerator
 
@@ -30,3 +33,5 @@ printType(Wrapper.MemberEnum.self)
 
 printType(WrapperByAttribute.self)
 // CHECK: found type: WrapperByAttribute{{$}}
+
+stopRemoteAST()

--- a/test/RemoteAST/member_offsets.swift
+++ b/test/RemoteAST/member_offsets.swift
@@ -9,6 +9,9 @@ func printTypeMemberOffset(_: Any.Type, _: StaticString)
 @_silgen_name("printTypeMetadataMemberOffset")
 func printTypeMetadataMemberOffset(_: Any.Type, _: StaticString)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 printTypeMemberOffset((Int,Bool,Float,Bool,Int16).self, "0")
 // CHECK: found offset: 0
 
@@ -78,3 +81,5 @@ printTypeMemberOffset(B<Float>.self, "e")
 
 printTypeMemberOffset(B<Float>.self, "f")
 // CHECK-NEXT: type has no member named 'f'
+
+stopRemoteAST()

--- a/test/RemoteAST/nominal_types.swift
+++ b/test/RemoteAST/nominal_types.swift
@@ -5,6 +5,9 @@
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 printType(Int.self)
 // CHECK: Int
 
@@ -137,3 +140,5 @@ struct N {
   }
 }
 N.testPrivate()
+
+stopRemoteAST()

--- a/test/RemoteAST/objc_classes.swift
+++ b/test/RemoteAST/objc_classes.swift
@@ -11,6 +11,9 @@ func printType(_: Any.Type)
 @_silgen_name("printHeapMetadataType")
 func printDynamicType(_: AnyObject)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 printType(NSString.self)
 // CHECK: NSString
 
@@ -42,3 +45,5 @@ printType(OurObjCProtocol.self)
 
 printType(Optional<OurObjCProtocol>.self)
 // CHECK: Optional<OurObjCProtocol & AnyObject>
+
+stopRemoteAST()

--- a/test/RemoteAST/structural_types.swift
+++ b/test/RemoteAST/structural_types.swift
@@ -5,6 +5,9 @@
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
+@_silgen_name("stopRemoteAST")
+func stopRemoteAST()
+
 typealias Fn1 = () -> ()
 printType(Fn1.self)
 // CHECK: found type: () -> ()
@@ -70,3 +73,5 @@ func foo<T>(_: T) {
 
 foo() { (x: Int) -> Int in return x }
 // CHECK: found type: (Int) -> Int
+
+stopRemoteAST()

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -42,7 +42,6 @@ using namespace swift::remoteAST;
 static ASTContext *context = nullptr;
 
 /// The RemoteAST for the code we're running.
-std::shared_ptr<MemoryReader> reader;
 std::unique_ptr<RemoteASTContext> remoteContext;
 
 static RemoteASTContext &getRemoteASTContext() {
@@ -172,6 +171,14 @@ printDynamicTypeAndAddressForExistential(void *object,
   } else {
     out << result.getFailure().render() << '\n';
   }
+}
+
+// FIXME: swiftcall
+/// func stopRemoteAST(_: AnyObject)
+LLVM_ATTRIBUTE_USED extern "C" void SWIFT_REMOTEAST_TEST_ABI
+stopRemoteAST() {
+  if (remoteContext)
+    remoteContext.reset();
 }
 
 namespace {


### PR DESCRIPTION
Fixes <rdar://problem/48067187>.

We keep a global context alive now, but we have to destroy it before
Swift's ASTContext is torn down.