### PR TITLE
[sourcekitd] Report entities that are implicitly @objc as @objc in the index request responses for compatibility

### DIFF
--- a/test/SourceKit/Indexing/index_objcMembers.swift
+++ b/test/SourceKit/Indexing/index_objcMembers.swift
@@ -1,0 +1,8 @@
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+// REQUIRES: objc_interop
+
+@objcMembers class FixtureClass25: NSObject {
+    var someVar: String?
+    func someMethod() {}
+}

--- a/test/SourceKit/Indexing/index_objcMembers.swift.response
+++ b/test/SourceKit/Indexing/index_objcMembers.swift.response
@@ -1,0 +1,85 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.name: "FixtureClass25",
+      key.usr: "s:17index_objcMembers14FixtureClass25C",
+      key.line: 5,
+      key.column: 20,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "someVar",
+          key.usr: "s:17index_objcMembers14FixtureClass25C7someVarSSSgvp",
+          key.line: 6,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:17index_objcMembers14FixtureClass25C7someVarSSSgvg",
+              key.line: 6,
+              key.column: 9,
+              key.is_dynamic: 1,
+              key.is_implicit: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:17index_objcMembers14FixtureClass25C7someVarSSSgvs",
+              key.line: 6,
+              key.column: 9,
+              key.is_dynamic: 1,
+              key.is_implicit: 1
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "String",
+          key.usr: "s:SS",
+          key.line: 6,
+          key.column: 18
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "someMethod()",
+          key.usr: "s:17index_objcMembers14FixtureClass25C10someMethodyyF",
+          key.line: 7,
+          key.column: 10,
+          key.is_dynamic: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.objc
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:17index_objcMembers14FixtureClass25CACycfc",
+          key.line: 5,
+          key.column: 20,
+          key.is_implicit: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.objc
+            }
+          ]
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.objcMembers
+        }
+      ]
+    }
+  ]
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -104,6 +104,21 @@ private:
     return impl.finishSourceEntity(UID);
   }
 
+  std::vector<UIdent> getDeclAttributeUIDs(const Decl *decl) {
+    std::vector<UIdent> uidAttrs =
+      SwiftLangSupport::UIDsFromDeclAttributes(decl->getAttrs());
+
+    // check if we should report an implicit @objc attribute
+    if (!decl->getAttrs().getAttribute(DeclAttrKind::DAK_ObjC)) {
+      if (auto *VD = dyn_cast<ValueDecl>(decl)) {
+        if (VD->isObjC()) {
+            uidAttrs.push_back(SwiftLangSupport::getUIDForObjCAttr());
+        }
+      }
+    }
+    return uidAttrs;
+  }
+
   template <typename F>
   bool withEntityInfo(const IndexSymbol &symbol, F func) {
     EntityInfo info;
@@ -122,8 +137,7 @@ private:
     info.IsTestCandidate = symbol.symInfo.Properties & SymbolProperty::UnitTest;
     std::vector<UIdent> uidAttrs;
     if (!isRef) {
-      uidAttrs =
-        SwiftLangSupport::UIDsFromDeclAttributes(symbol.decl->getAttrs());
+      uidAttrs = getDeclAttributeUIDs(symbol.decl);
       info.Attrs = uidAttrs;
     }
     return func(info);
@@ -142,8 +156,7 @@ private:
     info.IsTestCandidate = relation.symInfo.Properties & SymbolProperty::UnitTest;
     std::vector<UIdent> uidAttrs;
     if (!isRef) {
-      uidAttrs =
-      SwiftLangSupport::UIDsFromDeclAttributes(relation.decl->getAttrs());
+      uidAttrs = getDeclAttributeUIDs(relation.decl);
       info.Attrs = uidAttrs;
     }
     return func(info);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -60,6 +60,24 @@ using swift::index::SymbolRoleSet;
 #define REFACTORING(KIND, NAME, ID) static UIdent Kind##Refactoring##KIND("source.refactoring.kind."#ID);
 #include "swift/IDE/RefactoringKinds.def"
 
+static UIdent Attr_IBAction("source.decl.attribute.ibaction");
+static UIdent Attr_IBOutlet("source.decl.attribute.iboutlet");
+static UIdent Attr_IBDesignable("source.decl.attribute.ibdesignable");
+static UIdent Attr_IBInspectable("source.decl.attribute.ibinspectable");
+static UIdent Attr_GKInspectable("source.decl.attribute.gkinspectable");
+static UIdent Attr_Objc("source.decl.attribute.objc");
+static UIdent Attr_ObjcNamed("source.decl.attribute.objc.name");
+static UIdent Attr_Private("source.decl.attribute.private");
+static UIdent Attr_FilePrivate("source.decl.attribute.fileprivate");
+static UIdent Attr_Internal("source.decl.attribute.internal");
+static UIdent Attr_Public("source.decl.attribute.public");
+static UIdent Attr_Open("source.decl.attribute.open");
+static UIdent Attr_Setter_Private("source.decl.attribute.setter_access.private");
+static UIdent Attr_Setter_FilePrivate("source.decl.attribute.setter_access.fileprivate");
+static UIdent Attr_Setter_Internal("source.decl.attribute.setter_access.internal");
+static UIdent Attr_Setter_Public("source.decl.attribute.setter_access.public");
+static UIdent Attr_Setter_Open("source.decl.attribute.setter_access.open");
+
 std::unique_ptr<LangSupport>
 SourceKit::createSwiftLangSupport(SourceKit::Context &SKCtx) {
   return std::unique_ptr<LangSupport>(new SwiftLangSupport(SKCtx));
@@ -262,6 +280,10 @@ UIdent SwiftLangSupport::getUIDForAccessor(const ValueDecl *D,
 
 SourceKit::UIdent SwiftLangSupport::getUIDForModuleRef() {
   return KindRefModule;
+}
+
+SourceKit::UIdent SwiftLangSupport::getUIDForObjCAttr() {
+  return Attr_Objc;
 }
 
 UIdent SwiftLangSupport::getUIDForRefactoringKind(ide::RefactoringKind Kind){
@@ -639,28 +661,21 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
   // Check special-case names first.
   switch (Attr->getKind()) {
     case DAK_IBAction: {
-      static UIdent Attr_IBAction("source.decl.attribute.ibaction");
       return Attr_IBAction;
     }
     case DAK_IBOutlet: {
-      static UIdent Attr_IBOutlet("source.decl.attribute.iboutlet");
       return Attr_IBOutlet;
     }
     case DAK_IBDesignable: {
-      static UIdent Attr_IBDesignable("source.decl.attribute.ibdesignable");
       return Attr_IBDesignable;
     }
     case DAK_IBInspectable: {
-      static UIdent Attr_IBInspectable("source.decl.attribute.ibinspectable");
       return Attr_IBInspectable;
     }
     case DAK_GKInspectable: {
-      static UIdent Attr_GKInspectable("source.decl.attribute.gkinspectable");
       return Attr_GKInspectable;
     }
     case DAK_ObjC: {
-      static UIdent Attr_Objc("source.decl.attribute.objc");
-      static UIdent Attr_ObjcNamed("source.decl.attribute.objc.name");
       if (cast<ObjCAttr>(Attr)->hasName()) {
         return Attr_ObjcNamed;
       } else {
@@ -668,12 +683,6 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
       }
     }
     case DAK_AccessControl: {
-      static UIdent Attr_Private("source.decl.attribute.private");
-      static UIdent Attr_FilePrivate("source.decl.attribute.fileprivate");
-      static UIdent Attr_Internal("source.decl.attribute.internal");
-      static UIdent Attr_Public("source.decl.attribute.public");
-      static UIdent Attr_Open("source.decl.attribute.open");
-
       switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
         case AccessLevel::Private:
           return Attr_Private;
@@ -688,23 +697,17 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
       }
     }
     case DAK_SetterAccess: {
-      static UIdent Attr_Private("source.decl.attribute.setter_access.private");
-      static UIdent Attr_FilePrivate("source.decl.attribute.setter_access.fileprivate");
-      static UIdent Attr_Internal("source.decl.attribute.setter_access.internal");
-      static UIdent Attr_Public("source.decl.attribute.setter_access.public");
-      static UIdent Attr_Open("source.decl.attribute.setter_access.open");
-
       switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
         case AccessLevel::Private:
-          return Attr_Private;
+          return Attr_Setter_Private;
         case AccessLevel::FilePrivate:
-          return Attr_FilePrivate;
+          return Attr_Setter_FilePrivate;
         case AccessLevel::Internal:
-          return Attr_Internal;
+          return Attr_Setter_Internal;
         case AccessLevel::Public:
-          return Attr_Public;
+          return Attr_Setter_Public;
         case AccessLevel::Open:
-          return Attr_Open;
+          return Attr_Setter_Open;
       }
     }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -325,6 +325,7 @@ public:
                                              swift::AccessorKind AccKind,
                                              bool IsRef = false);
   static SourceKit::UIdent getUIDForModuleRef();
+  static SourceKit::UIdent getUIDForObjCAttr();
   static SourceKit::UIdent getUIDForSyntaxNodeKind(
       swift::ide::SyntaxNodeKind Kind);
   static SourceKit::UIdent getUIDForSyntaxStructureKind(


### PR DESCRIPTION
E.g. Members of an @objcMembers context previous had implicit @objc attributes but now don't (possibly because of the request evaluator changes?). This updates the output of sourcekitd's 'index' request to act as if they still had implicit @objc attributes on them for compatibility.

Resolves rdar://problem/48140265