### PR TITLE
[SILProfiler] Skip source regions with invalid locations

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -42,6 +42,10 @@ static bool doesClosureHaveBody(AbstractClosureExpr *ACE) {
 
 /// Check whether a root AST node is unmapped, i.e not profiled.
 static bool isUnmapped(ASTNode N) {
+  // Do not map AST nodes with invalid source locations.
+  if (N.getStartLoc().isInvalid() || N.getEndLoc().isInvalid())
+    return true;
+
   if (auto *E = N.dyn_cast<Expr *>()) {
     auto *CE = dyn_cast<AbstractClosureExpr>(E);
 
@@ -396,7 +400,12 @@ class SourceMappingRegion {
 public:
   SourceMappingRegion(ASTNode Node, CounterExpr &Count,
                       Optional<SourceLoc> StartLoc, Optional<SourceLoc> EndLoc)
-      : Node(Node), Count(&Count), StartLoc(StartLoc), EndLoc(EndLoc) {}
+      : Node(Node), Count(&Count), StartLoc(StartLoc), EndLoc(EndLoc) {
+    assert((!StartLoc || StartLoc->isValid()) &&
+           "Expected start location to be valid");
+    assert((!EndLoc || EndLoc->isValid()) &&
+           "Expected start location to be valid");
+  }
 
   SourceMappingRegion(SourceMappingRegion &&Region) = default;
   SourceMappingRegion &operator=(SourceMappingRegion &&RHS) = default;

--- a/test/Profiler/coverage_subscript_autoclosure.swift
+++ b/test/Profiler/coverage_subscript_autoclosure.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-testing -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_subscript_autoclosure %s | %FileCheck %s
+
+struct S {
+  subscript(i: Int, autoclosure: @autoclosure () ->  Int) -> Int {
+    // CHECK-LABEL: sil_coverage_map {{.*}}S.subscript.getter
+    get { // CHECK-NEXT: [[@LINE]]:9 -> [[@LINE+2]]:6 : 0
+      return 0
+    }
+
+    // CHECK-LABEL: sil_coverage_map {{.*}}S.subscript.setter
+    set { // CHECK-NEXT: [[@LINE]]:9 -> [[@LINE+2]]:6 : 0
+
+    }
+  }
+}


### PR DESCRIPTION
It's not possible to emit code coverage mappings for such regions.

rdar://47254122