### PR TITLE
[Sema] SR-9851 - Add parens when needed for nil coalescing fixits

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7626,9 +7626,13 @@ bool swift::exprNeedsParensOutsideFollowingOperator(
   Expr *parent;
   unsigned index;
   std::tie(parent, index) = getPrecedenceParentAndIndex(expr, rootExpr);
-  if (!parent || isa<TupleExpr>(parent) || isa<ParenExpr>(parent)) {
+  if (!parent || isa<TupleExpr>(parent)) {
     return false;
   }
+
+  if (auto parenExp = dyn_cast<ParenExpr>(parent))
+    if (!parenExp->isImplicit())
+      return false;
 
   if (parent->isInfixOperator()) {
     auto parentPG = TC.lookupPrecedenceGroupForInfixOperator(DC, parent);

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -287,3 +287,11 @@ let _: Int = thing?.e?.a() // expected-error {{value of optional type 'Int?' mus
 let _: Int? = thing?.e?.b // expected-error {{value of optional type 'Int??' must be unwrapped to a value of type 'Int?'}}
 // expected-note@-1{{coalesce}}
 // expected-note@-2{{force-unwrap}}
+
+// SR-9851 - https://bugs.swift.org/browse/SR-9851
+func coalesceWithParensRootExprFix() {
+  let optionalBool: Bool? = false
+  if !optionalBool { }  // expected-error{{value of optional type 'Bool?' must be unwrapped to a value of type 'Bool'}}
+  // expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}}{{7-7=(}}{{19-19= ?? <#default value#>)}}
+  // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-9851

<!-- What's in this pull request? -->
This is a fix for parens not being added on certain nil coalescing fix-its due to a root expression not being passed down to `exprNeedsParensOutsideFollowingOperator`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9851](https://bugs.swift.org/browse/SR-9851).