### PR TITLE
stdlib: make cl based compilation reasonable

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -18,7 +18,11 @@ list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-verify-syntax-tree"
 
 # Build the runtime with -Wall to catch, e.g., uninitialized variables
 # warnings.
-list(APPEND SWIFT_RUNTIME_CXX_FLAGS "-Wall")
+if(SWIFT_COMPILER_IS_MSVC_LIKE)
+  list(APPEND SWIFT_RUNTIME_CXX_FLAGS "/W3")
+else()
+  list(APPEND SWIFT_RUNTIME_CXX_FLAGS "-Wall")
+endif()
 
 set(SWIFT_RUNTIME_CORE_CXX_FLAGS "${SWIFT_RUNTIME_CXX_FLAGS}")
 set(SWIFT_RUNTIME_CORE_LINK_FLAGS "${SWIFT_RUNTIME_LINK_FLAGS}")


### PR DESCRIPTION
`-Wall` with the clang-cl interface gives us `-Weverything` effectively,
which really reduces the effectiveness of the warnings.  Switch to `/W3`
which is roughly equivalent to `-Wall` in clang mode.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
