### PR TITLE
unittests: fixes for Swift's custom build system

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -30,6 +30,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
       ${EXECINFO_LIBRARY}
       )
+  elseif(SWIFT_HOST_VARIANT STREQUAL windows)
+    list(APPEND PLATFORM_TARGET_LINK_LIBRARIES DbgHelp)
   endif()
 
   add_swift_unittest(SwiftRuntimeTests

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -25,6 +25,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
       ${EXECINFO_LIBRARY}
       )
+  elseif(SWIFT_HOST_VARIANT STREQUAL windows)
+    list(APPEND PLATFORM_TARGET_LINK_LIBRARIES DbgHelp)
   endif()
 
   add_swift_unittest(SwiftRuntimeLongTests


### PR DESCRIPTION
Because we do not have proper libraries in our system, we cannot attach
interface link libraries, especially in light of the
incorporate_object_library implementation.  Explicitly add the
dependency on DbgHelp for the unit tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
