### PR TITLE
SIL: Don't serialize imported conformances nested in non-public types

### DIFF
--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -12,10 +12,11 @@
 //
 // This file defines the SILWitnessTable class, which is used to map a protocol
 // conformance for a type to its implementing SILFunctions. This information is
-// (FIXME will be) used by IRGen to create witness tables for protocol dispatch.
+// used by IRGen to create witness tables for protocol dispatch.
+//
 // It can also be used by generic specialization and existential
-// devirtualization passes to promote witness_method and protocol_method
-// instructions to static function_refs.
+// devirtualization passes to promote witness_method instructions to static
+// function_refs.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,7 +25,6 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/ADT/SmallString.h"
 
@@ -171,11 +171,6 @@ bool SILWitnessTable::conformanceIsSerialized(
   auto normalConformance = dyn_cast<NormalProtocolConformance>(conformance);
   if (normalConformance && normalConformance->isResilient())
     return false;
-
-  // Serialize witness tables for conformances synthesized by
-  // the ClangImporter.
-  if (isa<ClangModuleUnit>(conformance->getDeclContext()->getModuleScopeContext()))
-    return true;
 
   if (conformance->getProtocol()->getEffectiveAccess() < AccessLevel::Public)
     return false;

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -487,9 +487,18 @@ public:
     } else {
       // This is the "real" rule; the above case should go away once we
       // figure out what's going on.
-      witnessLinkage = (witnessSerialized
-                        ? SILLinkage::Shared
-                        : SILLinkage::Private);
+
+      // Normally witness thunks can be private.
+      witnessLinkage = SILLinkage::Private;
+
+      // Unless the witness table is going to be serialized.
+      if (witnessSerialized)
+        witnessLinkage = SILLinkage::Shared;
+
+      // Or even if its not serialized, it might be for an imported
+      // conformance in which case it can be emitted multiple times.
+      if (Linkage == SILLinkage::Shared)
+        witnessLinkage = SILLinkage::Shared;
     }
 
     SILFunction *witnessFn = SGM.emitProtocolWitness(

--- a/test/SILGen/Inputs/objc_witnesses_serialized.h
+++ b/test/SILGen/Inputs/objc_witnesses_serialized.h
@@ -1,0 +1,6 @@
+@class Public;
+@class Internal;
+
+enum InternalInner { a, b, c } __attribute__((swift_name("Public.Inner")));
+enum PublicInner { d, e, f } __attribute__((swift_name("Internal.Inner")));
+enum TopLevel { g, h, i };

--- a/test/SILGen/objc_witnesses_serialized.swift
+++ b/test/SILGen/objc_witnesses_serialized.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -import-objc-header %S/Inputs/objc_witnesses_serialized.h | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+func useRawRepresentable<T : RawRepresentable>(_: T) {}
+
+// FIXME: getEffectiveClangContext() is broken and checks
+// for an explicit '@objc' attribute.
+
+@objc public class Public : NSObject {
+  func takesInner(_ value: Inner) {
+    useRawRepresentable(value)
+  }
+}
+
+@objc internal class Internal : NSObject {
+  func takesInner(_ value: Inner) {
+    useRawRepresentable(value)
+  }
+}
+
+func takesTopLevel(_ value: TopLevel) {
+  useRawRepresentable(value)
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$sSo13InternalInnerVSYSCSY8rawValuexSg03RawD0Qz_tcfCTW : $@convention(witness_method: RawRepresentable) (@in UInt32, @thick Public.Inner.Type) -> @out Optional<Public.Inner>
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$sSo13InternalInnerVSYSCSY8rawValue03RawD0QzvgTW : $@convention(witness_method: RawRepresentable) (@in_guaranteed Public.Inner) -> @out UInt32
+
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$sSo11PublicInnerVSYSCSY8rawValuexSg03RawD0Qz_tcfCTW : $@convention(witness_method: RawRepresentable) (@in UInt32, @thick Internal.Inner.Type) -> @out Optional<Internal.Inner>
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$sSo11PublicInnerVSYSCSY8rawValue03RawD0QzvgTW : $@convention(witness_method: RawRepresentable) (@in_guaranteed Internal.Inner) -> @out UInt32
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$sSo8TopLevelVSYSCSY8rawValuexSg03RawD0Qz_tcfCTW : $@convention(witness_method: RawRepresentable) (@in UInt32, @thick TopLevel.Type) -> @out Optional<TopLevel>
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$sSo8TopLevelVSYSCSY8rawValue03RawD0QzvgTW : $@convention(witness_method: RawRepresentable) (@in_guaranteed TopLevel) -> @out UInt32


### PR DESCRIPTION
Apparently you can use a swift_name attribute in Clang to import types
as members of Swift types. If the Swift type is not public, we would
still try to serialize the witness thunks, which tripped SIL verifier
checks since the witnesses themselves were not serialized.

Note that the fix here is to just delete the special case of an
imported conformance; the regular "type is public and protocol is
public" condition suffices here.

Fixes <rdar://problem/48218483>.