### PR TITLE
[AutoDiff] Handle multiple `@differentiable` attributes in TBDGen.

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -187,7 +187,8 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   // SWIFT_ENABLE_TENSORFLOW
   // The AutoDiff pass creates an order-1 JVP and VJP for every function with a
   // `@differentiable` attribute.
-  if (auto *DA = AFD->getAttrs().getAttribute<DifferentiableAttr>()) {
+  auto diffAttrs = AFD->getAttrs().getAttributes<DifferentiableAttr>();
+  for (auto *DA : diffAttrs) {
     // FIXME: When we get rid of `vjp:` and `jvp:` arguments in `@differentiable`,
     // we will no longer need to see whether they are specified.
     if (!DA->getJVP()) {
@@ -268,7 +269,8 @@ void TBDGenVisitor::visitVarDecl(VarDecl *VD) {
   // SWIFT_ENABLE_TENSORFLOW
   // The AutoDiff pass creates an order-1 JVP and VJP for every var with a
   // `@differentiable` attribute.
-  if (auto *DA = VD->getAttrs().getAttribute<DifferentiableAttr>()) {
+  auto diffAttrs = VD->getAttrs().getAttributes<DifferentiableAttr>();
+  for (auto *DA : diffAttrs) {
     // FIXME: When we get rid of `vjp:` and `jvp:` arguments in `@differentiable`,
     // we will no longer need to see whether they are specified.
     if (!DA->getJVP()) {


### PR DESCRIPTION
Resolves [TF-276](https://bugs.swift.org/browse/TF-276).