### PR TITLE
[5.1] Replace mapIntoContext with DWARF Archetype name lookup.

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -24,11 +24,9 @@
 using namespace swift;
 using namespace irgen;
 
-DebugTypeInfo::DebugTypeInfo(DeclContext *DC, GenericEnvironment *GE,
-                             swift::Type Ty, llvm::Type *StorageTy, Size size,
+DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size size,
                              Alignment align, bool HasDefaultAlignment)
-    : DeclCtx(DC), GenericEnv(GE), Type(Ty.getPointer()),
-      StorageType(StorageTy), size(size), align(align),
+    : Type(Ty.getPointer()), StorageType(StorageTy), size(size), align(align),
       DefaultAlignment(HasDefaultAlignment) {
   assert(StorageType && "StorageType is a nullptr");
   assert(align.getValue() != 0);
@@ -43,9 +41,7 @@ static bool hasDefaultAlignment(swift::Type Ty) {
   return true;
 }
 
-DebugTypeInfo DebugTypeInfo::getFromTypeInfo(DeclContext *DC,
-                                             GenericEnvironment *GE,
-                                             swift::Type Ty,
+DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty,
                                              const TypeInfo &Info) {
   Size size;
   if (Info.isFixedSize()) {
@@ -56,13 +52,11 @@ DebugTypeInfo DebugTypeInfo::getFromTypeInfo(DeclContext *DC,
     // encounter one.
     size = Size(0);
   }
-  return DebugTypeInfo(DC, GE, Ty.getPointer(), Info.getStorageType(), size,
+  return DebugTypeInfo(Ty.getPointer(), Info.getStorageType(), size,
                        Info.getBestKnownAlignment(), hasDefaultAlignment(Ty));
 }
 
-DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
-                                              GenericEnvironment *GE,
-                                              VarDecl *Decl, swift::Type Ty,
+DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
                                               const TypeInfo &Info) {
 
   auto DeclType = Decl->getInterfaceType();
@@ -77,12 +71,12 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
   // the type hasn't been mucked with by an optimization pass.
   auto *Type = Sugared->isEqual(RealType) ? DeclType.getPointer()
                                           : RealType.getPointer();
-  return getFromTypeInfo(DC, GE, Type, Info);
+  return getFromTypeInfo(Type, Info);
 }
 
 DebugTypeInfo DebugTypeInfo::getMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                          Size size, Alignment align) {
-  DebugTypeInfo DbgTy(nullptr, nullptr, Ty.getPointer(), StorageTy, size,
+  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
                       align, true);
   assert(!DbgTy.isArchetype() && "type metadata cannot contain an archetype");
   return DbgTy;
@@ -93,18 +87,14 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
                                        Alignment align) {
   // Prefer the original, potentially sugared version of the type if
   // the type hasn't been mucked with by an optimization pass.
-  DeclContext *DC = nullptr;
-  GenericEnvironment *GE = nullptr;
   auto LowTy = GV->getLoweredType().getASTType();
   auto *Type = LowTy.getPointer();
   if (auto *Decl = GV->getDecl()) {
-    DC = Decl->getDeclContext();
-    GE = DC->getGenericEnvironmentOfContext();
     auto DeclType = Decl->getType();
     if (DeclType->isEqual(LowTy))
       Type = DeclType.getPointer();
   }
-  DebugTypeInfo DbgTy(DC, GE, Type, StorageTy, size, align,
+  DebugTypeInfo DbgTy(Type, StorageTy, size, align,
                       hasDefaultAlignment(Type));
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isArchetype() &&
@@ -116,8 +106,7 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
 DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
                                           llvm::Type *StorageType, Size size,
                                           Alignment align) {
-  DebugTypeInfo DbgTy(nullptr, nullptr,
-                      theClass->getInterfaceType().getPointer(), StorageType,
+  DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(), StorageType,
                       size, align, true);
   assert(!DbgTy.isArchetype() && "type of objc class cannot be an archetype");
   return DbgTy;

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -37,14 +37,6 @@ class TypeInfo;
 /// for a type.
 class DebugTypeInfo {
 public:
-  /// The DeclContext of the function. This might not be the DeclContext of
-  /// the variable if inlining took place.
-  DeclContext *DeclCtx = nullptr;
-
-  /// The generic environment of the type. Ideally we should need only this and
-  /// retire the DeclCtxt.
-  GenericEnvironment *GenericEnv = nullptr;
-
   /// The type we need to emit may be different from the type
   /// mentioned in the Decl, for example, stripped of qualifiers.
   TypeBase *Type = nullptr;
@@ -56,19 +48,16 @@ public:
   bool DefaultAlignment = true;
 
   DebugTypeInfo() {}
-  DebugTypeInfo(DeclContext *DC, GenericEnvironment *GE, swift::Type Ty,
-                llvm::Type *StorageTy, Size SizeInBytes, Alignment AlignInBytes,
-                bool HasDefaultAlignment);
+  DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size SizeInBytes,
+                Alignment AlignInBytes, bool HasDefaultAlignment);
   /// Create type for a local variable.
-  static DebugTypeInfo getLocalVariable(DeclContext *DeclCtx,
-                                        GenericEnvironment *GE, VarDecl *Decl,
+  static DebugTypeInfo getLocalVariable(VarDecl *Decl,
                                         swift::Type Ty, const TypeInfo &Info);
   /// Create type for an artificial metadata variable.
   static DebugTypeInfo getMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                    Size size, Alignment align);
   /// Create a standalone type from a TypeInfo object.
-  static DebugTypeInfo getFromTypeInfo(DeclContext *DC, GenericEnvironment *GE,
-                                       swift::Type Ty, const TypeInfo &Info);
+  static DebugTypeInfo getFromTypeInfo(swift::Type Ty, const TypeInfo &Info);
   /// Global variables.
   static DebugTypeInfo getGlobal(SILGlobalVariable *GV, llvm::Type *StorageType,
                                  Size size, Alignment align);
@@ -80,8 +69,6 @@ public:
   TypeBase *getType() const { return Type; }
 
   TypeDecl *getDecl() const;
-  DeclContext *getDeclContext() const { return DeclCtx; }
-  GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
 
   // Determine whether this type is an Archetype itself.
   bool isArchetype() const {
@@ -106,7 +93,6 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   }
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
-        nullptr, nullptr,
         llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
         swift::irgen::Size(0), swift::irgen::Alignment(0), false);
   }

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -46,16 +46,23 @@ public:
   Size size = Size(0);
   Alignment align = Alignment(0);
   bool DefaultAlignment = true;
+  bool IsMetadataType = false;
 
   DebugTypeInfo() {}
   DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size SizeInBytes,
-                Alignment AlignInBytes, bool HasDefaultAlignment);
+                Alignment AlignInBytes, bool HasDefaultAlignment,
+                bool IsMetadataType);
+
   /// Create type for a local variable.
   static DebugTypeInfo getLocalVariable(VarDecl *Decl,
                                         swift::Type Ty, const TypeInfo &Info);
-  /// Create type for an artificial metadata variable.
+  /// Create type for global type metadata.
   static DebugTypeInfo getMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                    Size size, Alignment align);
+  /// Create type for an artificial metadata variable.
+  static DebugTypeInfo getArchetype(swift::Type Ty, llvm::Type *StorageTy,
+                                    Size size, Alignment align);
+
   /// Create a standalone type from a TypeInfo object.
   static DebugTypeInfo getFromTypeInfo(swift::Type Ty, const TypeInfo &Info);
   /// Global variables.
@@ -65,6 +72,9 @@ public:
   static DebugTypeInfo getObjCClass(ClassDecl *theClass,
                                     llvm::Type *StorageType, Size size,
                                     Alignment align);
+  /// Error type.
+  static DebugTypeInfo getErrorResult(swift::Type Ty, llvm::Type *StorageType,
+                                      Size size, Alignment align);
 
   TypeBase *getType() const { return Type; }
 
@@ -94,7 +104,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
         llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
-        swift::irgen::Size(0), swift::irgen::Alignment(0), false);
+        swift::irgen::Size(0), swift::irgen::Alignment(0), false, false);
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -100,19 +100,27 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   llvm::DenseSet<ModuleDecl *> ImportedModules;
 
   llvm::BumpPtrAllocator DebugInfoNames;
-  StringRef CWDName;                    /// The current working directory.
-  SmallString<0> ConfigMacros;          /// User-provided -D macro definitions.
-  llvm::DICompileUnit *TheCU = nullptr; /// The current compilation unit.
-  llvm::DIFile *MainFile = nullptr;     /// The main file.
-  llvm::DIModule *MainModule = nullptr; /// The current module.
-  llvm::DIScope *EntryPointFn =
-      nullptr;                     /// Scope of SWIFT_ENTRY_POINT_FUNCTION.
+  /// The current working directory.
+  StringRef CWDName;
+  /// User-provided -D macro definitions.
+  SmallString<0> ConfigMacros;
+  /// The current compilation unit.
+  llvm::DICompileUnit *TheCU = nullptr;
+  /// The main file.
+  llvm::DIFile *MainFile = nullptr;
+  /// The current module.
+  llvm::DIModule *MainModule = nullptr;
+  /// Scope of SWIFT_ENTRY_POINT_FUNCTION.
+  llvm::DIScope *EntryPointFn = nullptr;
   /// The artificial type decls for named archetypes.
   llvm::StringMap<TypeAliasDecl *> MetadataTypeDeclCache;
-  llvm::DIType *InternalType;      /// Catch-all type for opaque internal types.
+  /// Catch-all type for opaque internal types.
+  llvm::DIType *InternalType = nullptr;
 
-  SILLocation::DebugLoc LastDebugLoc; /// The last location that was emitted.
-  const SILDebugScope *LastScope;     /// The scope of that last location.
+  /// The last location that was emitted.
+  SILLocation::DebugLoc LastDebugLoc;
+  /// The scope of that last location.
+  const SILDebugScope *LastScope = nullptr;
 
   /// Used by pushLoc.
   SmallVector<std::pair<SILLocation::DebugLoc, const SILDebugScope *>, 8>
@@ -1587,8 +1595,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
                                        llvm::Module &M,
                                        StringRef MainOutputFilenameForDebugInfo)
     : Opts(Opts), CI(CI), SM(IGM.Context.SourceMgr), M(M), DBuilder(M),
-      IGM(IGM), DebugPrefixMap(Opts.DebugPrefixMap),
-      InternalType(nullptr), LastDebugLoc({}), LastScope(nullptr) {
+      IGM(IGM), DebugPrefixMap(Opts.DebugPrefixMap) {
   assert(Opts.DebugInfoLevel > IRGenDebugInfoLevel::None &&
          "no debug info should be generated");
   llvm::SmallString<256> SourcePath;

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -149,7 +149,8 @@ public:
 
   /// Emit debug metadata for type metadata (for generic types). So meta.
   void emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,
-                        unsigned Depth, unsigned Index, StringRef AssocType);
+                        unsigned Depth, unsigned Index, StringRef ArchetypeName,
+                        StringRef AssocType);
 
   /// Return the DIBuilder.
   llvm::DIBuilder &getBuilder();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3645,12 +3645,12 @@ void IRGenSILFunction::emitErrorResultVar(SILResultInfo ErrorInfo,
                              Var->Name, Var->ArgNo, false);
   if (!IGM.DebugInfo)
     return;
-  DebugTypeInfo DTI(ErrorInfo.getType(),
-                    ErrorResultSlot->getType(), IGM.getPointerSize(),
-                    IGM.getPointerAlignment(), true);
-  IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, DTI, getDebugScope(),
-                                         nullptr, Var->Name, Var->ArgNo,
-                                         IndirectValue, ArtificialValue);
+  auto DbgTy = DebugTypeInfo::getErrorResult(
+      ErrorInfo.getType(), ErrorResultSlot->getType(), IGM.getPointerSize(),
+      IGM.getPointerAlignment());
+  IGM.DebugInfo->emitVariableDeclaration(
+      Builder, Storage, DbgTy, getDebugScope(), nullptr, Var->Name, Var->ArgNo,
+      IndirectValue, ArtificialValue);
 }
 
 void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -366,7 +366,7 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
   }
   auto *typeParam = cast<GenericTypeParamType>(oocTy);
   IGF.IGM.DebugInfo->emitTypeMetadata(IGF, data, typeParam->getDepth(),
-                                      typeParam->getIndex(), AssocType);
+                                      typeParam->getIndex(), name, AssocType);
 }
 
 void

--- a/test/DebugInfo/protocol-extension.swift
+++ b/test/DebugInfo/protocol-extension.swift
@@ -17,4 +17,4 @@ public extension P {
 
 // CHECK: ![[SELFMETA]] = !DILocalVariable(name: "$\CF\84_0_0",
 // CHECK-SAME: type: ![[SELFTY:[0-9]+]], flags: DIFlagArtificial)
-// CHECK: ![[SELFTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$swift.type"
+// CHECK: ![[SELFTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Self"

--- a/test/DebugInfo/typearg.swift
+++ b/test/DebugInfo/typearg.swift
@@ -12,7 +12,7 @@ class AClass : AProtocol {
 // CHECK: ![[TYPEARG]] = !DILocalVariable(name: "$\CF\84_0_0"
 // CHECK-SAME:                            type: ![[SWIFTMETATYPE:[^,)]+]]
 // CHECK-SAME:                            flags: DIFlagArtificial
-// CHECK: ![[SWIFTMETATYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$swift.type",
+// CHECK: ![[SWIFTMETATYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "T",
 // CHECK-SAME:                                baseType: ![[VOIDPTR:[0-9]+]]
 // CHECK: ![[VOIDPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null
 func aFunction<T : AProtocol>(_ x: T) {


### PR DESCRIPTION
This cherry-picks https://github.com/apple/swift/pull/22752 to the 5.1 branch.
rdar://problem/47798056