### PR TITLE
[test] Un-XFAIL a test for watchOS

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -5,7 +5,7 @@
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test
 
-# XFAIL: OS=macosx || OS=ios || OS=tvos || OS=watchos
+# XFAIL: OS=macosx || OS=ios || OS=tvos
 # https://bugs.swift.org/browse/SR-9847
 
 from __future__ import print_function


### PR DESCRIPTION
Whatever bug is happening in [SR-9847](https://bugs.swift.org/browse/SR-9847), the watchOS overlays aren't hitting it.

rdar://problem/48280638