### PR TITLE
SwiftRemoteMirror: fix static library builds for Windows

### DIFF
--- a/include/swift/SwiftRemoteMirror/Platform.h
+++ b/include/swift/SwiftRemoteMirror/Platform.h
@@ -23,7 +23,11 @@ extern "C" {
 # elif defined(__MACH__)
 #   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
 # else
-#   define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllexport)
+#   if defined(_WINDLL)
+#     define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllexport)
+#   else
+#     define SWIFT_REMOTE_MIRROR_LINKAGE
+#   endif
 # endif
 #else
 # if defined(__ELF__)
@@ -31,7 +35,11 @@ extern "C" {
 # elif defined(__MACH__)
 #   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
 # else
-#   define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllimport)
+#   if defined(_WINDLL)
+#     define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllimport)
+#   else
+#     define SWIFT_REMOTE_MIRROR_LINKAGE
+#   endif
 # endif
 #endif
 

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -30,6 +30,7 @@ if(SWIFT_INCLUDE_TOOLS)
 
   add_swift_host_library(swiftRemoteMirror STATIC
     SwiftRemoteMirror.cpp)
+  target_compile_definitions(swiftRemoteMirror PRIVATE _LIB)
   target_compile_options(swiftRemoteMirror PRIVATE
     ${SWIFT_RUNTIME_CXX_FLAGS})
   set_property(TARGET swiftRemoteMirror APPEND_STRING PROPERTY LINK_FLAGS


### PR DESCRIPTION
We were previously treating all the builds as shared, which is not the
case for the host library build of SwiftRemoteMirror.  The warnings were
lost in the interminable spew from the build which is now fixed and this
stands out.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
