### PR TITLE
cmake: switch host libraries to use `target_link_libraries`

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -64,11 +64,6 @@ add_swift_host_library(swiftAST STATIC
   TypeWalker.cpp
   USRGeneration.cpp
 
-  LINK_LIBRARIES
-    swiftMarkup
-    swiftBasic
-    swiftSyntax
-
   INTERFACE_LINK_LIBRARIES
     # Clang dependencies.
     # FIXME: Clang should really export these in some reasonable manner.
@@ -98,6 +93,10 @@ add_swift_host_library(swiftAST STATIC
 
   ${EXTRA_AST_FLAGS}
   )
+target_link_libraries(swiftAST PRIVATE
+  swiftBasic
+  swiftMarkup
+  swiftSyntax)
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these

--- a/lib/ASTSectionImporter/CMakeLists.txt
+++ b/lib/ASTSectionImporter/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_host_library(swiftASTSectionImporter STATIC
   ASTSectionImporter.cpp
-  LINK_LIBRARIES swiftBasic
   LLVM_COMPONENT_DEPENDS core)
+target_link_libraries(swiftASTSectionImporter PRIVATE
+  swiftBasic)
 

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -105,10 +105,10 @@ add_swift_host_library(swiftBasic STATIC
   UnicodeExtendedGraphemeClusters.cpp.gyb
 
   C_COMPILE_FLAGS ${UUID_INCLUDE}
-  LINK_LIBRARIES
-    swiftDemangling
-    ${UUID_LIBRARIES}
   LLVM_COMPONENT_DEPENDS support)
+target_link_libraries(swiftBasic PRIVATE
+  swiftDemangling
+  ${UUID_LIBRARIES})
 
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -16,10 +16,10 @@ add_swift_host_library(swiftClangImporter STATIC
   ImportName.cpp
   ImportType.cpp
   SwiftLookupTable.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftParse
 )
+target_link_libraries(swiftClangImporter PRIVATE
+  swiftAST
+  swiftParse)
 
 # This property is only set by calls to clang_tablegen. It will not be set on
 # standalone builds, so it can always be safely passed.

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -19,8 +19,11 @@ set(swiftDriver_targetDefines)
 
 add_swift_host_library(swiftDriver STATIC
   ${swiftDriver_sources}
-  DEPENDS SwiftOptions
-  LINK_LIBRARIES swiftAST swiftBasic swiftOption)
+  DEPENDS SwiftOptions)
+target_link_libraries(swiftDriver PRIVATE
+  swiftAST
+  swiftBasic
+  swiftOption)
 
 # Generate the static-stdlib-args.lnk file used by -static-stdlib option
 # for 'GenericUnix' (eg linux)

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -11,14 +11,14 @@ add_swift_host_library(swiftFrontend STATIC
   PrintingDiagnosticConsumer.cpp
   SerializedDiagnosticConsumer.cpp
   DEPENDS
-    SwiftOptions
-  LINK_LIBRARIES
-    swiftSIL
-    swiftMigrator
-    swiftOption
-    swiftParseSIL
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSema
-    swiftSerialization)
+    SwiftOptions)
+target_link_libraries(swiftFrontend PRIVATE
+  swiftSIL
+  swiftMigrator
+  swiftOption
+  swiftParseSIL
+  swiftSILGen
+  swiftSILOptimizer
+  swiftSema
+  swiftSerialization)
 

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -5,19 +5,23 @@ add_swift_host_library(swiftFrontendTool STATIC
   TBD.cpp
   DEPENDS
     swift-syntax-generated-headers SwiftOptions
-  LINK_LIBRARIES
-    swiftIndex
-    swiftIDE
-    swiftTBDGen swiftIRGen swiftSIL swiftSILGen swiftSILOptimizer
-    swiftDemangling
-    swiftImmediate
-    swiftSerialization
-    swiftPrintAsObjC
-    swiftFrontend
-    swiftClangImporter
-    swiftDWARFImporter
-    swiftOption
   INTERFACE_LINK_LIBRARIES
     clangAPINotes
     clangBasic
 )
+target_link_libraries(swiftFrontendTool PRIVATE
+    swiftClangImporter
+    swiftDemangling
+    swiftDWARFImporter
+    swiftFrontend
+    swiftIDE
+    swiftImmediate
+    swiftIndex
+    swiftIRGen
+    swiftOption
+    swiftPrintAsObjC
+    swiftSerialization
+    swiftSIL
+    swiftSILGen
+    swiftSILOptimizer
+    swiftTBDGen)

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -15,13 +15,13 @@ add_swift_host_library(swiftIDE STATIC
   IDETypeChecking.cpp
   APIDigesterData.cpp
   SourceEntityWalker.cpp
-  TypeContextInfo.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftFrontend
-    swiftClangImporter
-    swiftDWARFImporter
-    swiftParse
-    swiftSema
-    swiftIndex)
+  TypeContextInfo.cpp)
+target_link_libraries(swiftIDE PRIVATE
+  swiftAST
+  swiftClangImporter
+  swiftDWARFImporter
+  swiftFrontend
+  swiftIndex
+  swiftParse
+  swiftSema)
 

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -50,12 +50,6 @@ add_swift_host_library(swiftIRGen STATIC
   SwiftTargetInfo.cpp
   TypeLayoutDumper.cpp
   TypeLayoutVerifier.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftLLVMPasses
-    swiftSIL
-    swiftSILGen
-    swiftSILOptimizer
 
   INTERFACE_LINK_LIBRARIES
     # Clang dependencies.
@@ -67,3 +61,9 @@ add_swift_host_library(swiftIRGen STATIC
     target
     transformutils
 )
+target_link_libraries(swiftIRGen PRIVATE
+  swiftAST
+  swiftLLVMPasses
+  swiftSIL
+  swiftSILGen
+  swiftSILOptimizer)

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -1,17 +1,17 @@
 add_swift_host_library(swiftImmediate STATIC
   Immediate.cpp
   REPL.cpp
-  LINK_LIBRARIES
-    swiftIDE
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftIRGen
   LLVM_COMPONENT_DEPENDS
     executionengine
     linker
     mcjit
     transformutils)
+target_link_libraries(swiftImmediate PRIVATE
+  swiftFrontend
+  swiftIDE
+  swiftIRGen
+  swiftSILGen
+  swiftSILOptimizer)
 
 if(HAVE_UNICODE_LIBEDIT)
   target_link_libraries(swiftImmediate PRIVATE edit)

--- a/lib/Index/CMakeLists.txt
+++ b/lib/Index/CMakeLists.txt
@@ -2,6 +2,6 @@ add_swift_host_library(swiftIndex STATIC
   Index.cpp
   IndexDataConsumer.cpp
   IndexRecord.cpp
-  IndexSymbol.cpp
-  LINK_LIBRARIES
-    swiftAST)
+  IndexSymbol.cpp)
+target_link_libraries(swiftIndex PRIVATE
+  swiftAST)

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -1,10 +1,9 @@
 add_swift_host_library(swiftMarkup STATIC
   AST.cpp
   LineList.cpp
-  Markup.cpp
-  
-  LINK_LIBRARIES
-    libcmark_static)
+  Markup.cpp)
+target_link_libraries(swiftMarkup PRIVATE
+  libcmark_static)
 target_compile_definitions(swiftMarkup
                            PRIVATE
                              CMARK_STATIC_DEFINE)

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -54,8 +54,10 @@ add_swift_host_library(swiftMigrator STATIC
   Migrator.cpp
   MigrationState.cpp
   OptionalTryMigratorPass.cpp
-  RewriteBufferEditsReceiver.cpp
-  LINK_LIBRARIES swiftSyntax swiftIDE)
+  RewriteBufferEditsReceiver.cpp)
+target_link_libraries(swiftMigrator PRIVATE
+  swiftIDE
+  swiftSyntax)
 
 add_dependencies(swiftMigrator
   "symlink_migrator_data")

--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_host_library(swiftOption STATIC
   Options.cpp
   SanitizerOptions.cpp
   DEPENDS SwiftOptions
-  LINK_LIBRARIES swiftBasic
   FILE_DEPENDS SwiftOptions)
+target_link_libraries(swiftOption PRIVATE
+  swiftBasic)
 

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -24,10 +24,9 @@ add_swift_host_library(swiftParse STATIC
   PersistentParserState.cpp
   Scope.cpp
   SyntaxParsingCache.cpp
-  SyntaxParsingContext.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftSyntax
-)
+  SyntaxParsingContext.cpp)
+target_link_libraries(swiftParse PRIVATE
+  swiftAST
+  swiftSyntax)
 
 add_dependencies(swiftParse swift-parse-syntax-generated-headers)

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_swift_host_library(swiftParseSIL STATIC
-  ParseSIL.cpp
-  LINK_LIBRARIES
-    swiftSyntaxParse
-    swiftSema
-    swiftSIL
-)
+  ParseSIL.cpp)
+target_link_libraries(swiftParseSIL PRIVATE
+  swiftSema
+  swiftSIL
+  swiftSyntaxParse)
 

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_swift_host_library(swiftPrintAsObjC STATIC
-  PrintAsObjC.cpp
-  LINK_LIBRARIES
-    swiftIDE
-    swiftFrontend
-    swiftClangImporter
-    swiftAST)
+  PrintAsObjC.cpp)
+target_link_libraries(swiftPrintAsObjC PRIVATE
+  swiftAST
+  swiftClangImporter
+  swiftFrontend
+  swiftIDE)
 

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 add_swift_host_library(swiftRemoteAST STATIC
   RemoteAST.cpp
   InProcessMemoryReader.cpp
-  ${REMOTE_LIB_HEADERS}
-  LINK_LIBRARIES
-    swiftSema swiftIRGen)
+  ${REMOTE_LIB_HEADERS})
+target_link_libraries(swiftRemoteAST PRIVATE
+  swiftIRGen
+  swiftSema)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -46,11 +46,10 @@ add_swift_host_library(swiftSIL STATIC
   SILWitnessTable.cpp
   TypeLowering.cpp
   ValueOwnership.cpp
-  ValueUtils.cpp
-  LINK_LIBRARIES
-    swiftSerialization
-    swiftSema
-)
+  ValueUtils.cpp)
+target_link_libraries(swiftSIL PRIVATE
+  swiftSema
+  swiftSerialization)
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftSIL depends on these

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -29,7 +29,6 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenProlog.cpp
   SILGenStmt.cpp
   SILGenThunk.cpp
-  SILGenType.cpp
-  LINK_LIBRARIES
-    swiftSIL
-)
+  SILGenType.cpp)
+target_link_libraries(swiftSILGen PRIVATE
+  swiftSIL)

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -34,5 +34,6 @@ add_subdirectory(UtilityPasses)
 add_subdirectory(Utils)
 
 add_swift_host_library(swiftSILOptimizer STATIC
-  ${SILOPTIMIZER_SOURCES}
-  LINK_LIBRARIES swiftSIL)
+  ${SILOPTIMIZER_SOURCES})
+target_link_libraries(swiftSILOptimizer PRIVATE
+  swiftSIL)

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -59,10 +59,10 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckSwitchStmt.cpp
   TypeCheckType.cpp
   TypeChecker.cpp
-  LINK_LIBRARIES
-    swiftParse
-    swiftAST
-    swiftSerialization
-  ${EXTRA_TYPECHECKER_FLAGS}
-)
+
+  ${EXTRA_TYPECHECKER_FLAGS})
+target_link_libraries(swiftSema PRIVATE
+  swiftAST
+  swiftParse
+  swiftSerialization)
 

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -6,7 +6,7 @@ add_swift_host_library(swiftSerialization STATIC
   SerializedModuleLoader.cpp
   SerializedSILLoader.cpp
   SerializeDoc.cpp
-  SerializeSIL.cpp
-  LINK_LIBRARIES
-    swiftClangImporter)
+  SerializeSIL.cpp)
+target_link_libraries(swiftSerialization PRIVATE
+  swiftClangImporter)
 

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -2,10 +2,10 @@ add_swift_host_library(swiftDemangle
                   SHARED
                     SwiftDemangle.cpp
                     MangleHack.cpp
-                  LINK_LIBRARIES
-                    swiftDemangling
                   C_COMPILE_FLAGS
                     -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+target_link_libraries(swiftDemangle PRIVATE
+  swiftDemangling)
 
 swift_install_in_component(compiler
     TARGETS swiftDemangle

--- a/lib/SyntaxParse/CMakeLists.txt
+++ b/lib/SyntaxParse/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_swift_host_library(swiftSyntaxParse STATIC
   RawSyntaxTokenCache.cpp
-  SyntaxTreeCreator.cpp
-  LINK_LIBRARIES
-    swiftParse
-    swiftSyntax
-)
+  SyntaxTreeCreator.cpp)
+target_link_libraries(swiftSyntaxParse PRIVATE
+  swiftParse
+  swiftSyntax)

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -3,9 +3,9 @@ add_subdirectory(tapi)
 add_swift_host_library(swiftTBDGen STATIC
   ${TAPI_SOURCES}
   TBDGen.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftSIL
   LLVM_COMPONENT_DEPENDS
     demangle
 )
+target_link_libraries(swiftTBDGen PRIVATE
+  swiftAST
+  swiftSIL)

--- a/tools/libSwiftSyntaxParser/CMakeLists.txt
+++ b/tools/libSwiftSyntaxParser/CMakeLists.txt
@@ -5,12 +5,10 @@ set(LLVM_EXPORTED_SYMBOL_FILE
     ${CMAKE_CURRENT_SOURCE_DIR}/libSwiftSyntaxParser.exports)
 
 add_swift_host_library(libSwiftSyntaxParser SHARED
-	c-include-check.c
-  libSwiftSyntaxParser.cpp
-
-  LINK_LIBRARIES
-    swiftParse
-)
+  c-include-check.c
+  libSwiftSyntaxParser.cpp)
+target_link_libraries(libSwiftSyntaxParser PRIVATE
+  swiftParse)
 set_target_properties(libSwiftSyntaxParser
     PROPERTIES
     OUTPUT_NAME ${SYNTAX_PARSER_LIB_NAME})


### PR DESCRIPTION
This is a follow up to the discussion on #22740 to switch the host
libraries to use the `target_link_libraries` rather than the
`LINK_LIBRARIES` special handling.  This allows the dependency to be
properly tracked by CMake and allows us to use the more modern syntax.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
