### PR TITLE
Fix a couple of check-swift-validation-optimize test failures

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -548,7 +548,8 @@ bool Decl::isWeakImported(ModuleDecl *fromModule,
     return false;
 
   auto containingContext =
-      AvailabilityInference::availableRange(this, fromModule->getASTContext());
+      AvailabilityInference::availableRange(this,
+                                            containingModule->getASTContext());
   if (!fromContext.isContainedIn(containingContext))
     return true;
 

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -155,7 +155,7 @@ SILFunctionBuilder::getOrCreateFunction(SILLocation loc, SILDeclRef constant,
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
 
-    if (decl->isWeakImported(mod.getSwiftModule(), availCtx))
+    if (decl->isWeakImported(/*forModule=*/nullptr, availCtx))
       F->setWeakLinked();
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {

--- a/validation-test/Evolution/Inputs/backward_deploy_always_emit_into_client.swift
+++ b/validation-test/Evolution/Inputs/backward_deploy_always_emit_into_client.swift
@@ -1,0 +1,20 @@
+public func getVersion() -> Int {
+#if BEFORE
+  return 0
+#else
+  return 1
+#endif
+}
+
+#if AFTER
+@_weakLinked @usableFromInline func weakFunction() -> String {
+  return "new"
+}
+
+@_alwaysEmitIntoClient public func serializedFunction() -> String {
+  if getVersion() == 1 {
+    return weakFunction()
+  }
+  return "old"
+}
+#endif

--- a/validation-test/Evolution/test_backward_deploy_always_emit_into_client.swift
+++ b/validation-test/Evolution/test_backward_deploy_always_emit_into_client.swift
@@ -1,0 +1,14 @@
+// RUN: %target-resilience-test --backward-deployment
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import backward_deploy_always_emit_into_client
+
+
+var BackwardDeployTopLevelTest = TestSuite("BackwardDeployAlwaysEmitIntoClient")
+
+BackwardDeployTopLevelTest.test("BackwardDeployAlwaysEmitIntoClient") {
+  expectEqual(serializedFunction(), getVersion() == 1 ? "new" : "old")
+}
+
+runAllTests()

--- a/validation-test/Runtime/old_runtime_crash_without_fixed_layout.swift
+++ b/validation-test/Runtime/old_runtime_crash_without_fixed_layout.swift
@@ -29,7 +29,7 @@ public class ClassWithResilientField {
 @_optimize(none) func blackHole<T>(_: T) {}
 
 @_optimize(none) func forceMetadata() {
-  blackHole(ClassWithResilientField.self)
+  blackHole(ClassWithResilientField())
 }
 
 if #available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *) {


### PR DESCRIPTION
A bot runs tests in this configuration. One failure was a test where the relevant runtime call was optimized away. The other problem was a regression from https://github.com/apple/swift/pull/22736. I added a reduced test case that doesn't depend on the optimizer.