### PR TITLE
Sema: Fix crash with non-Optional weak @IBOutlet

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2400,9 +2400,14 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
       attr->setInvalid();
     }
 
-    // While @IBOutlet can be weak, it must be optional. Let it diagnose.
-    if (!isOptional && !var->getAttrs().hasAttribute<IBOutletAttr>()) {
+    if (!isOptional) {
       attr->setInvalid();
+
+      // @IBOutlet has its own diagnostic when the property type is
+      // non-optional.
+      if (var->getAttrs().hasAttribute<IBOutletAttr>())
+        break;
+
       auto diag = diagnose(var->getStartLoc(),
                            diag::invalid_ownership_not_optional,
                            ownershipKind,

--- a/test/attr/attr_iboutlet.swift
+++ b/test/attr/attr_iboutlet.swift
@@ -161,3 +161,12 @@ class NonObjC {}
     if outlet4 != nil {}
   }
 }
+
+// https://bugs.swift.org/browse/SR-9889
+@objc class NonOptionalWeak {
+  // expected-error@+3 {{@IBOutlet property has non-optional type 'OX'}}
+  // expected-note @+2 {{add '?' to form the optional type 'OX?'}}
+  // expected-note @+1 {{add '!' to form an implicitly unwrapped optional}}
+  @IBOutlet weak var something: OX
+  init() { }
+}


### PR DESCRIPTION
We were skipping the diagnostic to allow @IBOutlet to diagnose the
non-Optional type, but we still have to mark our ownership attribute
as invalid so that we don't attempt to form the ReferenceStorageType
with a non-Optional underlying type.

Fixes <https://bugs.swift.org/browse/SR-9889>, <rdar://problem/48088046>.
