### PR TITLE
Enable linker dead stripping on Darwin

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -494,10 +494,12 @@ function(_add_variant_link_flags)
   #
   # TODO: Evaluate/enable -f{function,data}-sections --gc-sections for bfd,
   # gold, and lld.
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    # See rdar://48283130: This gives 6MB+ size reductions for swift and
-    # SourceKitService, and much larger size reductions for sil-opt etc.
-    list(APPEND result "-Wl,-dead_strip")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      # See rdar://48283130: This gives 6MB+ size reductions for swift and
+      # SourceKitService, and much larger size reductions for sil-opt etc.
+      list(APPEND result "-Wl,-dead_strip")
+    endif()
   endif()
 
   set("${LFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -488,6 +488,18 @@ function(_add_variant_link_flags)
     endif()
   endif()
 
+  # Enable dead stripping. Portions of this logic were copied from llvm's
+  # `add_link_opts` function (which, perhaps, should have been used here in the
+  # first place, but at this point it's hard to say whether that's feasible).
+  #
+  # TODO: Evaluate/enable -f{function,data}-sections --gc-sections for bfd,
+  # gold, and lld.
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # See rdar://48283130: This gives 6MB+ size reductions for swift and
+    # SourceKitService, and much larger size reductions for sil-opt etc.
+    list(APPEND result "-Wl,-dead_strip")
+  endif()
+
   set("${LFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
   set("${LFLAGS_LINK_LIBRARIES_VAR_NAME}" "${link_libraries}" PARENT_SCOPE)
   set("${LFLAGS_LIBRARY_SEARCH_DIRECTORIES_VAR_NAME}" "${library_search_directories}" PARENT_SCOPE)


### PR DESCRIPTION
See r://48283130. This shaves 6MB+ off of swift and SourceKitService,
26.8MB off of swift-llvm-opt, 29.4MB off sil-passpipeline-dumper, etc.