### PR TITLE
Name platform-specific module files using a normalized target triple

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -590,8 +590,8 @@ ERROR(cannot_return_value_from_void_func,none,
 
 ERROR(sema_no_import,Fatal,
       "no such module '%0'", (StringRef))
-ERROR(sema_no_import_arch,Fatal,
-      "could not find module '%0' for architecture '%1'; "
+ERROR(sema_no_import_target,Fatal,
+      "could not find module '%0' for target '%1'; "
       "found: %2", (StringRef, StringRef, StringRef))
 ERROR(sema_no_import_repl,none,
       "no such module '%0'", (StringRef))

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -78,7 +78,7 @@ namespace swift {
   /// Computes the normalized target triple used as the most preferred name for
   /// module loading.
   ///
-  /// For platforms with module stability, this canonicalizes architecture,
+  /// For platforms with fat binaries, this canonicalizes architecture,
   /// vendor, and OS names, strips OS versions, and makes inferred environments
   /// explicit. For other platforms, it returns the unmodified triple.
   ///

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -74,6 +74,17 @@ namespace swift {
   ///
   /// This is a stop-gap until full Triple support (ala Clang) exists within swiftc.
   StringRef getMajorArchitectureName(const llvm::Triple &triple);
+
+  /// Computes the normalized target triple used as the most preferred name for
+  /// module loading.
+  ///
+  /// For platforms with module stability, this canonicalizes architecture,
+  /// vendor, and OS names, strips OS versions, and makes inferred environments
+  /// explicit. For other platforms, it returns the unmodified triple.
+  ///
+  /// The input triple should already be "normalized" in the sense that
+  /// llvm::Triple::normalize() would not affect it.
+  llvm::Triple getTargetSpecificModuleTriple(const llvm::Triple &triple);
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PLATFORM_H

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -68,10 +68,10 @@ protected:
   /// to list the architectures that \e are present.
   ///
   /// \returns true if an error diagnostic was emitted
-  virtual bool maybeDiagnoseArchitectureMismatch(SourceLoc sourceLocation,
-                                                 StringRef moduleName,
-                                                 StringRef archName,
-                                                 StringRef directoryPath) {
+  virtual bool maybeDiagnoseTargetMismatch(SourceLoc sourceLocation,
+                                           StringRef moduleName,
+                                           StringRef archName,
+                                           StringRef directoryPath) {
     return false;
   }
 
@@ -139,10 +139,10 @@ class SerializedModuleLoader : public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) override;
 
-  bool maybeDiagnoseArchitectureMismatch(SourceLoc sourceLocation,
-                                         StringRef moduleName,
-                                         StringRef archName,
-                                         StringRef directoryPath) override;
+  bool maybeDiagnoseTargetMismatch(SourceLoc sourceLocation,
+                                   StringRef moduleName,
+                                   StringRef archName,
+                                   StringRef directoryPath) override;
 
 public:
   virtual ~SerializedModuleLoader();

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -109,7 +109,7 @@ std::error_code SerializedModuleLoader::findModuleFilesInDirectory(
                                                      ModuleDocBuffer);
 }
 
-bool SerializedModuleLoader::maybeDiagnoseArchitectureMismatch(
+bool SerializedModuleLoader::maybeDiagnoseTargetMismatch(
     SourceLoc sourceLocation, StringRef moduleName, StringRef archName,
     StringRef directoryPath) {
   llvm::vfs::FileSystem &fs = *Ctx.SourceMgr.getFileSystem();
@@ -139,7 +139,7 @@ bool SerializedModuleLoader::maybeDiagnoseArchitectureMismatch(
     return false;
   }
 
-  Ctx.Diags.diagnose(sourceLocation, diag::sema_no_import_arch, moduleName,
+  Ctx.Diags.diagnose(sourceLocation, diag::sema_no_import_target, moduleName,
                      archName, foundArchs);
   return true;
 }
@@ -208,8 +208,8 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
 
     // We can only get here if all targetFileNamePairs failed with
     // 'std::errc::no_such_file_or_directory'.
-    if (maybeDiagnoseArchitectureMismatch(moduleID.second,
-            moduleName, normalizedTarget.str(), currPath)) {
+    if (maybeDiagnoseTargetMismatch(moduleID.second, moduleName,
+                                    normalizedTarget.str(), currPath)) {
       return false;
     } else {
       return None;

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
@@ -60,12 +60,12 @@
 // RUN: %empty-directory(%t/Lib.swiftmodule)
 // RUN: touch %t/Lib.swiftmodule/garbage.swiftmodule
 // RUN: touch %t/Lib.swiftmodule/garbage.swiftinterface
-// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
-// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
+// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
 // RUN: not env SWIFT_FORCE_MODULE_LOADING=only-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
-// RUN: not env SWIFT_FORCE_MODULE_LOADING=only-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
+// RUN: not env SWIFT_FORCE_MODULE_LOADING=only-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
 // (default)
-// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -I %t %s 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
+// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -I %t %s 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
 
 // 8. Only the interface is present but for the wrong architecture.
 // (Diagnostics for the module only are tested elsewhere.)

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
@@ -81,7 +81,7 @@
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
 // BAD-MODULE: [[@LINE-2]]:8: error: malformed module file: {{.*}}Lib.swiftmodule
-// WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for architecture '[[ARCH]]'; found: garbage
+// WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: garbage
 
 struct X {}
 let _: X = Lib.testValue

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
@@ -60,12 +60,12 @@
 // RUN: %empty-directory(%t/Lib.framework/Modules/Lib.swiftmodule)
 // RUN: touch %t/Lib.framework/Modules/Lib.swiftmodule/garbage.swiftmodule
 // RUN: touch %t/Lib.framework/Modules/Lib.swiftmodule/garbage.swiftinterface
-// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
-// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
+// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: not env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
 // RUN: not env SWIFT_FORCE_MODULE_LOADING=only-parseable %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
-// RUN: not env SWIFT_FORCE_MODULE_LOADING=only-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
+// RUN: not env SWIFT_FORCE_MODULE_LOADING=only-serialized %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
 // (default)
-// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -F %t %s 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%target-cpu %s
+// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -F %t %s 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
 
 // 8. Only the interface is present but for the wrong architecture.
 // (Diagnostics for the module only are tested elsewhere.)

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
@@ -81,7 +81,7 @@
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
 // BAD-MODULE: [[@LINE-2]]:8: error: malformed module file: {{.*}}Lib.swiftmodule
-// WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for architecture '[[ARCH]]'; found: garbage
+// WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: garbage
 
 struct X {}
 let _: X = Lib.testValue

--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -5,13 +5,13 @@
 // RUN: touch %t/new_module.swiftmodule/ppc65.swiftmodule
 // RUN: touch %t/new_module.swiftmodule/i387.swiftdoc
 // RUN: touch %t/new_module.swiftmodule/ppc65.swiftdoc
-// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%target-cpu
+// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%module-target-triple
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/new_module.framework/Modules/new_module.swiftmodule/
 // RUN: touch %t/new_module.framework/Modules/new_module.swiftmodule/i387.swiftmodule
 // RUN: touch %t/new_module.framework/Modules/new_module.swiftmodule/ppc65.swiftmodule
-// RUN: not %target-swift-frontend %s -F %t -typecheck -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%target-cpu
+// RUN: not %target-swift-frontend %s -F %t -typecheck -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%module-target-triple
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/new_module.swiftmodule

--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -18,7 +18,7 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK-EMPTY -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%target
 
 // CHECK-ALL-NOT: error:
-// CHECK: {{.*}} error: could not find module 'new_module' for architecture '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}
+// CHECK: {{.*}} error: could not find module 'new_module' for target '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}
 // CHECK-NEXT: import new_module
 // CHECK-NEXT: 		^
 // CHECK-ALL: error: no such module 'new_module'

--- a/test/Serialization/load-target-fallback.swift
+++ b/test/Serialization/load-target-fallback.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+
+// Tests that we prefer the normalized target triple name for a .swiftmodule,
+// but fall back to the legacy architecture name if necessary.
+
+// RUN: mkdir %t/TargetLibrary.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o %t/TargetLibrary.swiftmodule/%module-target-triple.swiftmodule %S/Inputs/def_func.swift -module-name TargetLibrary
+// RUN: touch %t/TargetLibrary.swiftmodule/%target-cpu.swiftmodule
+
+import TargetLibrary
+
+// RUN: mkdir %t/ArchLibrary.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o %t/ArchLibrary.swiftmodule/%target-cpu.swiftmodule %S/Inputs/def_func.swift -module-name ArchLibrary
+
+import ArchLibrary
+
+// RUN: mkdir -p %t/TargetModule.framework/Modules/TargetModule.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o %t/TargetModule.framework/Modules/TargetModule.swiftmodule/%module-target-triple.swiftmodule %S/Inputs/def_func.swift -module-name TargetModule
+// RUN: touch %t/TargetModule.framework/Modules/TargetModule.swiftmodule/%target-cpu.swiftmodule
+
+import TargetModule
+
+// RUN: mkdir -p %t/ArchModule.framework/Modules/ArchModule.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o %t/ArchModule.framework/Modules/ArchModule.swiftmodule/%target-cpu.swiftmodule %S/Inputs/def_func.swift -module-name ArchModule
+
+import ArchModule
+
+// RUN: %target-swift-frontend %s -typecheck -I %t -F %t

--- a/test/Serialization/load-target-normalization.swift
+++ b/test/Serialization/load-target-normalization.swift
@@ -1,0 +1,133 @@
+// RUN: %empty-directory(%t/ForeignModule.swiftmodule)
+// RUN: touch %t/ForeignModule.swiftmodule/garbage-garbage-garbage.swiftmodule
+
+// Test format: We try to import ForeignModule with architectures besides
+// garbage-garbage-garbage and check the target triple listed in the error
+// message to make sure it was normalized correctly. This works in lieu of a
+// mechanism to query the compiler for normalized triples.
+//
+// The extra flags in the RUN lines serve the following purposes:
+//
+// * "-parse-stdlib" ensures we don't reject any of these for not having an
+//   appropriate standard library built.
+// * "-Xcc -arch -Xcc i386" makes sure the clang importer doesn't reject triples
+//   clang considers invalid.
+
+import ForeignModule
+
+// CHECK: error: could not find module 'ForeignModule'
+// CHECK-SAME: '[[NORM]]'
+
+// Run lines for individual test cases follow.
+
+//
+// OSES
+//
+
+// OS version numbers should be stripped.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-macosx10.42 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+
+// macos, macosx, and darwin should all normalize to macos.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-macos10.42 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-macosx10.42 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-darwin46.0 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+
+// ios, tvos, watchos should be accepted.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64-apple-ios40.0 2>&1 | %FileCheck -DNORM=arm64-apple-ios %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64-apple-tvos40 2>&1 | %FileCheck -DNORM=arm64-apple-tvos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64-apple-watchos9.1.1 2>&1 | %FileCheck -DNORM=arm64-apple-watchos %s
+
+// Other OSes should be passed through without version stripping. We can't test
+// a totally garbage case because we'll get diag::error_unsupported_target_os.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-linux40.04 2>&1 | %FileCheck -DNORM=x86_64-apple-linux40.04 %s
+
+//
+// VENDORS
+//
+
+// If the OS looks like an Apple OS, vendor should be normalized to apple.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-unknown-macos10.42 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64--ios40.0 2>&1 | %FileCheck -DNORM=arm64-apple-ios %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64-ibm-tvos40 2>&1 | %FileCheck -DNORM=arm64-apple-tvos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64-snapple-watchos9.1.1 2>&1 | %FileCheck -DNORM=arm64-apple-watchos %s
+
+//
+// ARCHITECTURES
+//
+
+// arm64 and aarch64 are normalized to arm64.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target arm64-apple-ios40.0 2>&1 | %FileCheck -DNORM=arm64-apple-ios %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target aarch64-apple-ios40.0 2>&1 | %FileCheck -DNORM=arm64-apple-ios %s
+
+// armv7s, armv7k, armv7 should be accepted.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target armv7s-apple-ios40.0 2>&1 | %FileCheck -DNORM=armv7s-apple-ios %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target armv7k-apple-ios40.0 2>&1 | %FileCheck -DNORM=armv7k-apple-ios %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target armv7-apple-ios40.0 2>&1 | %FileCheck -DNORM=armv7-apple-ios %s
+
+// x86_64h should be accepted.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64h-apple-macos10.11 2>&1 | %FileCheck -DNORM=x86_64h-apple-macos %s
+
+// x64_64 and amd64 are normalized to x86_64.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-macos10.11 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target amd64-apple-macos10.11 2>&1 | %FileCheck -DNORM=x86_64-apple-macos %s
+
+// i[3-9]86 are normalized to i386.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i486-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i586-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i686-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i786-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i886-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i986-apple-macos10.11 2>&1 | %FileCheck -DNORM=i386-apple-macos %s
+
+// Other arches should be passed through. We can't test a totally garbage case
+// because we'll get diag::error_unsupported_target_arch.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target powerpc64-apple-macos10.11 2>&1 | %FileCheck -DNORM=powerpc64-apple-macos %s
+
+//
+// ENVIRONMENTS
+//
+
+// simulator should be permitted on the non-Mac operating systems.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-ios40.0-simulator 2>&1 | %FileCheck -DNORM=x86_64-apple-ios-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-tvos40-simulator 2>&1 | %FileCheck -DNORM=x86_64-apple-tvos-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-watchos9.1.1-simulator 2>&1 | %FileCheck -DNORM=x86_64-apple-watchos-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-ios40.0-simulator 2>&1 | %FileCheck -DNORM=i386-apple-ios-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-tvos40-simulator 2>&1 | %FileCheck -DNORM=i386-apple-tvos-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-watchos9.1.1-simulator 2>&1 | %FileCheck -DNORM=i386-apple-watchos-simulator %s
+
+// simulator should be inferred when an Intel architecture is used with iOS, tvOS, or watchOS.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-ios40.0 2>&1 | %FileCheck -DNORM=x86_64-apple-ios-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-tvos40 2>&1 | %FileCheck -DNORM=x86_64-apple-tvos-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-watchos9.1.1 2>&1 | %FileCheck -DNORM=x86_64-apple-watchos-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-ios40.0 2>&1 | %FileCheck -DNORM=i386-apple-ios-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-tvos40 2>&1 | %FileCheck -DNORM=i386-apple-tvos-simulator %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-watchos9.1.1 2>&1 | %FileCheck -DNORM=i386-apple-watchos-simulator %s
+
+// Other environments should be passed through.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-ios40.0-in_spaaaaaaace 2>&1 | %FileCheck -DNORM=i386-apple-ios-in_spaaaaaaace %s
+
+//
+// DARWIN ONLY
+//
+
+// Non-isDarwinOS() OSes should have no normalization applied.
+
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-unknown-linux40.04 2>&1 | %FileCheck -DNORM=x86_64-unknown-linux40.04 %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target aarch64--linux-android 2>&1 | %FileCheck -DNORM=aarch64--linux-android %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target amd64-ibm-linux40.04 2>&1 | %FileCheck -DNORM=amd64-ibm-linux40.04 %s
+// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i986-snapple-haiku 2>&1 | %FileCheck -DNORM=i986-snapple-haiku %s

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -624,7 +624,14 @@ def use_interpreter_for_simple_runs():
     config.target_run_simple_swift_parameterized = make_simple_target_run(parameterized=True)
     config.available_features.add('interpret')
 
+target_specific_module_triple = config.variant_triple
+
 if run_vendor == 'apple':
+    target_specific_module_triple = '{}-apple-{}'.format(
+        { 'aarch64': 'arm64', 'amd64': 'x86_64' }.get(run_cpu, run_cpu),
+        { 'macosx': 'macos', 'darwin': 'macos' }.get(run_os, run_os)
+    )
+
     config.available_features.add('objc_interop')
     config.target_object_format = "macho"
     config.target_shared_library_prefix = 'lib'
@@ -693,6 +700,8 @@ if run_vendor == 'apple':
             config.available_features.add('DARWIN_SIMULATOR=tvos')
             lit_config.note("Testing AppleTV simulator " + config.variant_triple)
             xcrun_sdk_name = "appletvsimulator"
+
+        target_specific_module_triple += "-simulator"
 
         config.target_cc_options = (
             "-arch %s -m%s-simulator-version-min=%s %s" %
@@ -986,6 +995,8 @@ else:
     lit_config.fatal("Don't know how to define target_run and "
                      "target_build_swift for platform " + config.variant_triple)
 
+config.substitutions.append(('%module-target-triple',
+                             target_specific_module_triple))
 
 # Different OS's require different prefixes for the environment variables to be
 # propagated to the calling contexts.


### PR DESCRIPTION
Swift currently looks up platform-specific .swiftmodule, .swiftdoc, and .swiftinterface files by architecture name:

```
Foo.swiftmodule/
    x86_64.swiftmodule
    x86_64.swiftdoc
    arm64.swiftmodule
    arm64.swiftdoc
```

As part of module stability, we'd like to clean this up by using a normalized form of the target triple instead:

```
Foo.swiftmodule/
    x86_64-apple-ios-simulator.swiftmodule
    x86_64-apple-ios-simulator.swiftdoc
    arm64-apple-ios.swiftmodule
    arm64-apple-ios.swiftdoc
```

We will still support the architecture-only names for backwards compatibility, but we'll prefer the target triple names.

Normalization covers architectures ("amd64" -> "x86_64"), OSes ("macosx10.11" -> "macos"), and vendors ("unknown" -> "apple"); it also makes implicit "simulator" environments explicit. Apple platforms are the only ones that currently build for multiple architectures in practice, so normalization is only applied on those; other platforms will look for the full triple passed to the compiler (if they ever see a swiftmodule directory, which again, they won't).

-----

This PR is best reviewed commit-by-commit. The first three commits should be NFC; if they aren't, I'd like to know, because I may have broken something subtle. There is a diagnostic I'd like to add too, but I'll do that in a separate PR.

(@aciidb0mb3r, this shouldn't break you, but you may want to be aware of it.)

Resolves <rdar://problem/47094708>.