### PR TITLE
[5.0] Disable long-running collection tests

### DIFF
--- a/validation-test/stdlib/Collection/DefaultedBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -70,6 +70,10 @@ def test_methods(test):
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -127,6 +127,10 @@ runAllTests()
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -7,6 +7,7 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
+    collectionTypeName,
 )
 
 import itertools

--- a/validation-test/stdlib/Collection/MinimalBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollection.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollectionOfRef.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollectionOfRef.swift
@@ -8,6 +8,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
(This is cherry-picked from https://github.com/apple/swift/pull/22320 and https://github.com/apple/swift/pull/22485)

**Explanation:** Unblocks CI builds by disabling time-consuming Collection validation tests in unoptimized builds. Currently these often take >50 minutes (especially on 32-bit simulator builds), triggering CI timeouts.

**Scope:** Limited to the test suite.

**Radar:** rdar://48321722

**Risk:** Minimal.

**Testing:** Local and CI testing on master; PR tests on swift-5.0-branch

**Reviewer:** @moiseev 