### PR TITLE
[AutoDiff] TF-249: Enable `@differentiable` on initializers.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -397,7 +397,8 @@ DECL_ATTR(_private, PrivateImport,
 
 // SWIFT_ENABLE_TENSORFLOW
 DECL_ATTR(differentiable, Differentiable,
-  OnAccessor | OnFunc | OnVar | LongAttribute | AllowMultipleAttributes,
+  OnAccessor | OnConstructor | OnFunc | OnVar | LongAttribute |
+  AllowMultipleAttributes,
   83)
 DECL_ATTR(differentiating, Differentiating,
   OnFunc | LongAttribute | AllowMultipleAttributes,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -481,24 +481,6 @@ swift::matchWitness(
         cast<AbstractFunctionDecl>(witness)->hasThrows())
       return RequirementMatch(witness, MatchKind::RethrowsConflict);
 
-    // SWIFT_ENABLE_TENSORFLOW
-    // Differentiation attributes must match completely or the generated
-    // functions will have the wrong signature.
-    {
-      auto *reqDifferentiationAttr =
-          reqAttrs.getAttribute<DifferentiableAttr>(/*AllowInvalid*/ true);
-      auto *witnessDifferentiationAttr =
-          witnessAttrs.getAttribute<DifferentiableAttr>(
-              /*AllowInvalid*/ true);
-      if (reqDifferentiationAttr &&
-          (!reqDifferentiationAttr->getParameterIndices() ||
-           !witnessDifferentiationAttr ||
-           !witnessDifferentiationAttr->getParameterIndices() ||
-           !witnessDifferentiationAttr->parametersMatch(
-               *reqDifferentiationAttr)))
-        return RequirementMatch(witness, MatchKind::DifferentiableConflict);
-    }
-
     // We want to decompose the parameters to handle them separately.
     decomposeFunctionType = true;
   } else if (auto *witnessASD = dyn_cast<AbstractStorageDecl>(witness)) {
@@ -676,6 +658,25 @@ swift::matchWitness(
     if (auto result = matchTypes(std::get<0>(types), std::get<1>(types))) {
       return std::move(result.getValue());
     }
+  }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // Differentiation attributes must match completely or the generated
+  // functions will have the wrong signature.
+  auto *reqDiffAttr =
+      reqAttrs.getAttribute<DifferentiableAttr>(/*AllowInvalid*/ true);
+  auto *witnessDiffAttr =
+      witnessAttrs.getAttribute<DifferentiableAttr>(/*AllowInvalid*/ true);
+  if (reqDiffAttr && (!reqDiffAttr->getParameterIndices() ||
+                      !witnessDiffAttr ||
+                      !witnessDiffAttr->getParameterIndices() ||
+                      !witnessDiffAttr->parametersMatch(*reqDiffAttr))) {
+    if (auto *vdWitness = dyn_cast<VarDecl>(witness))
+      return RequirementMatch(
+          getStandinForAccessor(vdWitness, AccessorKind::Get),
+          MatchKind::DifferentiableConflict);
+    else
+      return RequirementMatch(witness, MatchKind::DifferentiableConflict);
   }
 
   // Now finalize the match.
@@ -2246,6 +2247,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     {
       llvm::raw_string_ostream stream(diffAttrReq);
       req->getAttrs().getAttribute<DifferentiableAttr>()->print(stream, req);
+      diffAttrReq = StringRef(stream.str()).trim();
     }
     diags.diagnose(match.Witness,
                    diag::protocol_witness_missing_differentiable_attr,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -663,6 +663,8 @@ swift::matchWitness(
   // SWIFT_ENABLE_TENSORFLOW
   // Differentiation attributes must match completely or the generated
   // functions will have the wrong signature.
+  // TODO(TF-285): Handle multiple `@differentiable` attributes on protocol
+  // requirements. Only missing attributes should be diagnosed.
   auto *reqDiffAttr =
       reqAttrs.getAttribute<DifferentiableAttr>(/*AllowInvalid*/ true);
   auto *witnessDiffAttr =
@@ -2246,6 +2248,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     std::string diffAttrReq;
     {
       llvm::raw_string_ostream stream(diffAttrReq);
+      // TODO(TF-285): Handle multiple `@differentiable` attributes on protocol
+      // requirements. Only missing attributes should be diagnosed.
       req->getAttrs().getAttribute<DifferentiableAttr>()->print(stream, req);
       diffAttrReq = StringRef(stream.str()).trim();
     }

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s --check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s --check-prefix=CHECK-AST
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s --check-prefix=CHECK-SILGEN
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
@@ -7,17 +7,18 @@ public struct Foo : Differentiable {
 }
 
 // CHECK-AST-LABEL: @_fieldwiseDifferentiable public struct Foo : Differentiable {
-// CHECK-AST:   @_hasStorage @differentiable(wrt: (self))
-// CHECK-AST:   public var a: Float { get set }
-// CHECK-AST:   @_fieldwiseDifferentiable struct AllDifferentiableVariables
-// CHECK-AST:     typealias AllDifferentiableVariables = Foo.AllDifferentiableVariables
-// CHECK-AST:     typealias TangentVector = Foo.AllDifferentiableVariables
-// CHECK-AST:     typealias CotangentVector = Foo.AllDifferentiableVariables
-// CHECK-AST:   typealias TangentVector = Foo.AllDifferentiableVariables
-// CHECK-AST:   typealias CotangentVector = Foo.AllDifferentiableVariables
+// CHECK-AST:   @differentiable(wrt: (self))
+// CHECK-AST:   public var a: Float
+// CHECK-AST:   internal init(a: Float)
+// CHECK-AST:   @_fieldwiseDifferentiable public struct AllDifferentiableVariables
+// CHECK-AST:     public typealias AllDifferentiableVariables = Foo.AllDifferentiableVariables
+// CHECK-AST:     public typealias TangentVector = Foo.AllDifferentiableVariables
+// CHECK-AST:     public typealias CotangentVector = Foo.AllDifferentiableVariables
+// CHECK-AST:   public typealias TangentVector = Foo.AllDifferentiableVariables
+// CHECK-AST:   public typealias CotangentVector = Foo.AllDifferentiableVariables
 
 // CHECK-SILGEN-LABEL: // Foo.a.getter
-// CHECK-SILGEN: sil [transparent] [serialized] [differentiable source 0 wrt 0] @$s33derived_differentiable_properties3FooV1aSfvg : $@convention(method) (Foo) -> Float
+// CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0] @$s33derived_differentiable_properties3FooV1aSfvg : $@convention(method) (Foo) -> Float
 
 struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
   var a: Float
@@ -26,38 +27,41 @@ let _: @differentiable (AdditiveTangentIsSelf) -> Float = { x in
   x.a + x.a
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
-// CHECK-AST-NOT:     @differentiable
-// CHECK-AST:         typealias TangentVector = AdditiveTangentIsSelf
-// CHECK-AST:         typealias CotangentVector = AdditiveTangentIsSelf
-// CHECK-AST:         typealias AllDifferentiableVariables = AdditiveTangentIsSelf
+// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
+// CHECK-AST:         internal var a: Float
+// CHECK-AST:         internal init(a: Float)
+// CHECK-AST:         internal typealias TangentVector = AdditiveTangentIsSelf
+// CHECK-AST:         internal typealias CotangentVector = AdditiveTangentIsSelf
+// CHECK-AST:         internal typealias AllDifferentiableVariables = AdditiveTangentIsSelf
 
 struct TestNoDerivative : Differentiable {
   var w: Float
   @noDerivative var technicallyDifferentiable: Float
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable struct TestNoDerivative : Differentiable {
-// CHECK-AST:         @_hasStorage var w: Float { get set }
-// CHECK-AST:         @_hasStorage @noDerivative var technicallyDifferentiable: Float { get set }
-// CHECK-AST:         @_fieldwiseDifferentiable struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, VectorNumeric
-// CHECK-AST:           typealias AllDifferentiableVariables = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:           typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:           typealias CotangentVector = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:         typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:         typealias CotangentVector = TestNoDerivative.AllDifferentiableVariables
+// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct TestNoDerivative : Differentiable {
+// CHECK-AST:         var w: Float
+// CHECK-AST:         @noDerivative internal var technicallyDifferentiable: Float
+// CHECK-AST:         internal init(w: Float, technicallyDifferentiable: Float)
+// CHECK-AST:         @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, VectorNumeric
+// CHECK-AST:           internal typealias AllDifferentiableVariables = TestNoDerivative.AllDifferentiableVariables
+// CHECK-AST:           internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
+// CHECK-AST:           internal typealias CotangentVector = TestNoDerivative.AllDifferentiableVariables
+// CHECK-AST:         internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
+// CHECK-AST:         internal typealias CotangentVector = TestNoDerivative.AllDifferentiableVariables
 
 struct TestKeyPathIterable : Differentiable, KeyPathIterable {
   var w: Float
   @noDerivative var technicallyDifferentiable: Float
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable struct TestKeyPathIterable : Differentiable, KeyPathIterable {
-// CHECK-AST:         @_hasStorage var w: Float { get set }
-// CHECK-AST:         @_hasStorage @noDerivative var technicallyDifferentiable: Float { get set }
-// CHECK-AST:         @_fieldwiseDifferentiable struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, KeyPathIterable, VectorNumeric
-// CHECK-AST:           typealias AllDifferentiableVariables = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:           typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:           typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:         typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:         typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
+// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct TestKeyPathIterable : Differentiable, KeyPathIterable {
+// CHECK-AST:         var w: Float
+// CHECK-AST:         @noDerivative internal var technicallyDifferentiable: Float
+// CHECK-AST:         internal init(w: Float, technicallyDifferentiable: Float)
+// CHECK-AST:         @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, KeyPathIterable, VectorNumeric
+// CHECK-AST:           internal typealias AllDifferentiableVariables = TestKeyPathIterable.AllDifferentiableVariables
+// CHECK-AST:           internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
+// CHECK-AST:           internal typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
+// CHECK-AST:         internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
+// CHECK-AST:         internal typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -481,16 +481,47 @@ protocol DiffReq : Differentiable {
   func f2(_ x: Float, _ y: Float) -> Float
 }
 
-// expected-error @+1 {{does not conform to protocol}}
+// expected-error @+1 {{does not conform to protocol 'DiffReq'}}
 struct ConformingWithErrors : DiffReq {
-  // expected-note @+1 {{@differentiable(wrt: (self, x))}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (self, x))'}}
   func f1(_ x: Float) -> Float {
     return x
   }
 
-  // expected-note @+2 {{@differentiable(wrt: (self, x, y))}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: (self, x, y))'}}
   @differentiable(wrt: (self, x))
   func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
+  }
+}
+
+protocol DifferentiableInit : Differentiable {
+  // expected-note @+2 {{protocol requires initializer 'init(x:y:)' with type '(x: Float, y: Float)'}}
+  @differentiable
+  init(x: Float, y: Float)
+
+  // expected-note @+2 {{protocol requires initializer 'init(x:y:)' with type '(x: Float, y: Int)'}}
+  @differentiable(wrt: x)
+  init(x: Float, y: Int)
+}
+// expected-error @+1 {{does not conform to protocol 'DifferentiableInit'}}
+struct DifferentiableInitStruct : DifferentiableInit {
+  var x: Float
+  var y: Float
+
+  // FIXME(TF-284): Fix unexpected diagnostic.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: (x, y))'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x))'}}
+  init(x: Float, y: Float) {
+    self.x = x
+    self.y = y
+  }
+
+  // FIXME(TF-284): Fix unexpected diagnostic.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: (x))'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))'}}
+  init(x: Float, y: Int) {
+    self.x = x
+    self.y = Float(y)
   }
 }

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -169,6 +169,23 @@ SimpleMathTests.test("StructMemberwiseInitializer") {
     return foo.computed * foo.stored
   }
   expectEqual(16, 𝛁product)
+
+  struct Custom : AdditiveArithmetic, Differentiable {
+    var x: Float
+
+    // Custom initializer with `@differentiable`.
+    @differentiable
+    init(x: Float) {
+      print(x)
+      self.x = x
+    }
+  }
+
+  let 𝛁custom = pullback(at: Float(4), in: { input -> Custom in
+    let foo = Custom(x: input)
+    return foo + foo
+  })(Custom.CotangentVector(x: 1))
+  expectEqual(2, 𝛁foo)
 }
 
 runAllTests()


### PR DESCRIPTION
`@differentiable` may now be declared on initializers.
Differentiation of initializers is already supported by the
existing differentiation infrastructure.

Resolves [TF-249](https://bugs.swift.org/browse/TF-249).

Introduces [TF-284](https://bugs.swift.org/browse/TF-284): unexpected error for unmet `@differentiable`
protocol initializer requirements.