### PR TITLE
[AutoDiff] TF-282: Handle `begin_access` in `getAdjointBuffer`.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3652,9 +3652,20 @@ private:
         adjProj = proj.createAddressProjection(builder, loc, adjBase.getValue())
                       .get();
       }
-      ValueWithCleanup bufWithCleanup(
+      ValueWithCleanup projWithCleanup(
           adjProj, makeCleanupFromChildren({adjBase.getCleanup()}));
-      return (bufferMap[originalBuffer] = bufWithCleanup);
+      return (bufferMap[originalBuffer] = projWithCleanup);
+    }
+    // If the original buffer is a `begin_access` instruction, get the adjoint
+    // buffer of its operand and return a corresponding `begin_access` into it.
+    if (auto *bai = dyn_cast<BeginAccessInst>(originalBuffer)) {
+      auto adjBase = getAdjointBuffer(bai->getOperand());
+      auto *adjAccess = builder.createBeginAccess(
+          bai->getLoc(), adjBase, bai->getAccessKind(), bai->getEnforcement(),
+          /*noNestedConflict*/ false, /*fromBuiltin*/ false);
+      ValueWithCleanup accessWithCleanup(
+          adjAccess, makeCleanupFromChildren({adjBase.getCleanup()}));
+      return (bufferMap[originalBuffer] = accessWithCleanup);
     }
 
     // Set insertion point for local allocation builder: before the last local

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -203,6 +203,18 @@ SimpleMathTests.test("StructSideEffects") {
     return tuple.point.x * tuple.point.y
   }
   expectEqual(405, gradient(at: 3, in: mix))
+
+  // Test TF-282.
+  struct Add : Differentiable {
+    var bias: Float
+    func applied(to input: Float) -> Float {
+      var tmp = input
+      tmp = tmp + bias
+      return tmp
+    }
+  }
+  let model = Add(bias: 1)
+  expectEqual(Add.CotangentVector(bias: 1), gradient(at: model) { m in m.applied(to: 1) })
 }
 
 SimpleMathTests.test("StructGeneric") {


### PR DESCRIPTION
`begin_access` is not considered a projection, but should be handled
like a projection in `getAdjointBuffer`.

The adjoint buffer for `begin_access` should be a corresponding
`begin_access` into the underlying buffer's adjoint buffer.

Resolves [TF-282](https://bugs.swift.org/browse/TF-282).