### PR TITLE
[Python] Add `Strideable` conformance, remove slice initializer.

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -701,24 +701,8 @@ public struct PythonInterface {
 }
 
 //===----------------------------------------------------------------------===//
-// Helpers for Python slice and tuple types
+// Helpers for Python tuple types
 //===----------------------------------------------------------------------===//
-
-private func pySlice(_ start: PythonConvertible?,
-                     _ stop: PythonConvertible?,
-                     _ step: PythonConvertible? = nil) -> OwnedPyObjectPointer {
-  let startP = start?.ownedPyObject
-  let stopP = stop?.ownedPyObject
-  let stepP = step?.ownedPyObject
-
-  // `PySlice_New` takes each operand at +0, and returns +1.
-  let result = PySlice_New(startP, stopP, stepP)!
-
-  Py_DecRef(startP)
-  Py_DecRef(stopP)
-  Py_DecRef(stepP) // `Py_DecRef` is `nil` safe.
-  return result
-}
 
 // Create a Python tuple object with the specified elements.
 private func pyTuple<T : Collection>(_ vals: T) -> OwnedPyObjectPointer
@@ -733,23 +717,6 @@ private func pyTuple<T : Collection>(_ vals: T) -> OwnedPyObjectPointer
 }
 
 public extension PythonObject {
-  // FIXME: This should be subsumed by Swift ranges and strides. Python has a
-  // very extravagant model though, it isn't clear how best to represent this
-  // in Swift.
-  //
-  // Initial thoughts are that we should sugar the obvious cases (so you can
-  // use 0...100 in a subscript) but then provide this method for the fully
-  // general case.
-  //
-  // We also need conditional conformances to allow range if PythonObject is to
-  // be a Slice. We can probably get away with a bunch of overloads for now
-  // given that slices are typically used with concrete operands.
-  init(sliceStart start: PythonConvertible?,
-                  stop: PythonConvertible?,
-                  step: PythonConvertible? = nil) {
-    self.init(owning: pySlice(start, stop, step))
-  }
-
   // Tuples require explicit support because tuple types cannot conform to
   // protocols.
   init(tupleOf elements: PythonConvertible...) {
@@ -1094,7 +1061,7 @@ extension Range : PythonConvertible where Bound : PythonConvertible {
 
   public var pythonObject: PythonObject {
     _ = Python // Ensure Python is initialized.
-    return PythonObject(sliceStart: lowerBound, stop: upperBound, step: nil)
+    return Python.slice(lowerBound, upperBound, Python.None)
   }
 }
 
@@ -1111,7 +1078,7 @@ extension PartialRangeFrom : PythonConvertible where Bound : PythonConvertible {
 
   public var pythonObject: PythonObject {
     _ = Python // Ensure Python is initialized.
-    return PythonObject(sliceStart: lowerBound, stop: nil, step: nil)
+    return Python.slice(lowerBound, Python.None, Python.None)
   }
 }
 
@@ -1128,7 +1095,7 @@ extension PartialRangeUpTo : PythonConvertible where Bound : PythonConvertible {
 
   public var pythonObject: PythonObject {
     _ = Python // Ensure Python is initialized.
-    return PythonObject(sliceStart: nil, stop: upperBound, step: nil)
+    return Python.slice(Python.None, upperBound, Python.None)
   }
 }
 
@@ -1191,6 +1158,18 @@ extension PythonObject : SignedNumeric {
 
   public var magnitude: PythonObject {
     return self < 0 ? -self : self
+  }
+}
+
+extension PythonObject : Strideable {
+  public typealias Stride = PythonObject
+
+  public func distance(to other: PythonObject) -> Stride {
+    return other - self
+  }
+
+  public func advanced(by stride: Stride) -> PythonObject {
+    return self + stride
   }
 }
 

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -84,6 +84,20 @@ PythonRuntimeTestSuite.test("PartialRangeUpTo") {
   expectNil(PartialRangeUpTo<Int>(PythonObject(5...)))
 }
 
+PythonRuntimeTestSuite.test("Strideable") {
+  let strideTo = stride(from: PythonObject(0), to: 100, by: 2)
+  expectEqual(0, strideTo.min()!)
+  expectEqual(98, strideTo.max()!)
+  expectEqual([0, 2, 4, 6, 8], Array(strideTo.prefix(5)))
+  expectEqual([90, 92, 94, 96, 98], Array(strideTo.suffix(5)))
+
+  let strideThrough = stride(from: PythonObject(0), through: 100, by: 2)
+  expectEqual(0, strideThrough.min()!)
+  expectEqual(100, strideThrough.max()!)
+  expectEqual([0, 2, 4, 6, 8], Array(strideThrough.prefix(5)))
+  expectEqual([92, 94, 96, 98, 100], Array(strideThrough.suffix(5)))
+}
+
 PythonRuntimeTestSuite.test("BinaryOps") {
   expectEqual(42, PythonObject(42))
   expectEqual(42, PythonObject(2) + PythonObject(40))


### PR DESCRIPTION
Add `Strideable` conformance to `PythonObject`.
This enables `stride(from:to:by:)` and `stride(from:through:by:)`
with `PythonObject`.

Remove unnecessary `init(sliceStart:end:step:)` initializer.
Instead, directly call the builtin `Python.slice()`.

Note: conditionally conforming `StrideTo` and `StrideThrough` to
`PythonConvertible` would enable indexing into `PythonObject` arrays
using them. However, this is difficult because `_stride` is an internal
stored property in `StrideTo` and `StrideThrough`.