### PR TITLE
[AutoDiff] TF-277: Fix type-remapping crash.

### DIFF
--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -443,7 +443,7 @@ void swift::findClosuresForFunctionValue(
         continue;
       }
       // SWIFT_ENABLE_TENSORFLOW
-      if (AutoDiffFunctionInst* ADFI = dyn_cast<AutoDiffFunctionInst>(I)) {
+      if (auto *ADFI = dyn_cast<AutoDiffFunctionInst>(I)) {
         worklistInsert(ADFI->getOperand(0));
         continue;
       }

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -442,6 +442,11 @@ void swift::findClosuresForFunctionValue(
         worklistInsert(SVI->getOperand(0));
         continue;
       }
+      // SWIFT_ENABLE_TENSORFLOW
+      if (AutoDiffFunctionInst* ADFI = dyn_cast<AutoDiffFunctionInst>(I)) {
+        worklistInsert(ADFI->getOperand(0));
+        continue;
+      }
     }
     // Look through Optionals.
     if (V->getType().getOptionalObjectType()) {

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2991,9 +2991,9 @@ public:
   /// Primal has qualified ownership. We assign store ownership qualifier while
   /// cloning the `store` instruction.
   void visitStoreInst(StoreInst *si) {
-    auto destTy = si->getDest()->getType().getASTType();
+    auto destTy = getOpType(si->getDest()->getType());
     auto loc = remapLocation(si->getLoc());
-    auto soq = getBufferSOQ(getOpASTType(destTy), *getPrimal());
+    auto soq = getBufferSOQ(destTy.getASTType(), *getPrimal());
     getBuilder().createStore(loc, getOpValue(si->getSrc()),
                              getOpValue(si->getDest()), soq);
   }
@@ -3001,9 +3001,9 @@ public:
   /// Primal has qualified ownership. We assign load ownership qualified while
   /// cloning the `load` instruction.
   void visitLoadInst(LoadInst *li) {
-    auto srcTy = li->getOperand()->getType().getASTType();
+    auto srcTy = getOpType(li->getOperand()->getType());
     auto loc = remapLocation(li->getLoc());
-    auto loq = getBufferLOQ(getOpASTType(srcTy), *getPrimal());
+    auto loq = getBufferLOQ(srcTy.getASTType(), *getPrimal());
     mapValue(
         li, getBuilder().createLoad(loc, getOpValue(li->getOperand()), loq));
   }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2987,26 +2987,6 @@ public:
         recursivelyDeleteTriviallyDeadInstructions(
             getOpValue(origCallee)->getDefiningInstruction());
   }
-
-  /// Primal has qualified ownership. We assign store ownership qualifier while
-  /// cloning the `store` instruction.
-  void visitStoreInst(StoreInst *si) {
-    auto destTy = getOpType(si->getDest()->getType());
-    auto loc = remapLocation(si->getLoc());
-    auto soq = getBufferSOQ(destTy.getASTType(), *getPrimal());
-    getBuilder().createStore(loc, getOpValue(si->getSrc()),
-                             getOpValue(si->getDest()), soq);
-  }
-
-  /// Primal has qualified ownership. We assign load ownership qualified while
-  /// cloning the `load` instruction.
-  void visitLoadInst(LoadInst *li) {
-    auto srcTy = getOpType(li->getOperand()->getType());
-    auto loc = remapLocation(li->getLoc());
-    auto loq = getBufferLOQ(srcTy.getASTType(), *getPrimal());
-    mapValue(
-        li, getBuilder().createLoad(loc, getOpValue(li->getOperand()), loq));
-  }
 };
 } // end anonymous namespace
 

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -41,4 +41,16 @@ extension Tensor where Scalar : Numeric {
 }
 _ = pullback(at: Tensor<Float>(1), in: { $0.variance() })
 
+// Tests TF-277.
+protocol Layer : Differentiable {
+  associatedtype Output : Differentiable
+}
+struct SupervisedTrainer<Model : Layer> {
+  var model: Model
+  var lossFunction: @differentiable (Model.Output, Model.Output) -> Float
+  func fit(y: Model.Output) {
+     _ = gradient(at: Float(1)) { _ in return lossFunction(y, y) }
+  }
+}
+
 // TODO: add more tests.


### PR DESCRIPTION
Previously, `getOpASTType` was used in `visitLoadInst` and `visitStoreInst` to
remap SIL types that were converted to canonical types. However, this led to an
assertion failure regarding remapping lowered types.

Now, `getOpType` is used to remap SIL types, and the remapped types are then
converted to canonical types.

Resolves [TF-277](https://bugs.swift.org/browse/TF-277).

---

Thanks to @pschuh for finding the fix in `lib/SIL/InstructionUtils.cpp`.

---

Update by @rxwei: Removing `PrimalGenCloner::visitLoadInst` and `PrimalGenCloner::visitStoreInst` is the final solution, because they weren't supposed to be here in the first place if there were no bugs with the cloner. As a result, they are removed and the type mapping changes becomes unnecessary.