### PR TITLE
[AutoDiff] TF-274: Fix usefulness propagation for address-type outputs.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1396,8 +1396,14 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
   assert(usefulValueSets.empty());
   for (auto output : outputValues) {
     usefulValueSets.push_back({});
-    if (output->getType().isDifferentiable(module))
-      usefulValueSets.back().insert(output);
+    if (output->getType().isDifferentiable(module)) {
+      // If the output has an address type, propagate usefulness recursively.
+      if (output->getType().isAddress())
+        propagateUsefulThroughBuffer(output, outputValues.size() - 1);
+      // Otherwise, just mark the output as useful.
+      else
+        usefulValueSets.back().insert(output);
+    }
   }
   // Propagate usefulness through the function in post-dominance order.
   PostDominanceOrder postDomOrder(&*function.findReturnBB(), pdi);

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1396,14 +1396,12 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
   assert(usefulValueSets.empty());
   for (auto output : outputValues) {
     usefulValueSets.push_back({});
-    if (output->getType().isDifferentiable(module)) {
-      // If the output has an address type, propagate usefulness recursively.
-      if (output->getType().isAddress())
-        propagateUsefulThroughBuffer(output, outputValues.size() - 1);
-      // Otherwise, just mark the output as useful.
-      else
-        usefulValueSets.back().insert(output);
-    }
+    // If the output has an address type, propagate usefulness recursively.
+    if (output->getType().isAddress())
+      propagateUsefulThroughBuffer(output, usefulValueSets.size() - 1);
+    // Otherwise, just mark the output as useful.
+    else
+      setUsefulIfDifferentiable(output, usefulValueSets.size() - 1);
   }
   // Propagate usefulness through the function in post-dominance order.
   PostDominanceOrder postDomOrder(&*function.findReturnBB(), pdi);

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -216,9 +216,7 @@ SimpleMathTests.test("StructGeneric") {
     var generic = Generic(x: input, y: input, z: input)
     return generic
   })(Generic<Float>.CotangentVector(x: 1, y: 1, z: 1))
-  // FIXME(TF-274): The true expected result is `3`.
-  // expectEqual(3, 𝛁generic)
-  expectEqual(0, 𝛁generic)
+  expectEqual(3, 𝛁generic)
 
   func fifthPower(_ input: Float) -> Float {
     var generic = Generic(x: input, y: input, z: input)
@@ -227,8 +225,7 @@ SimpleMathTests.test("StructGeneric") {
     return generic.x * generic.y
   }
   // FIXME(TF-274): The true expected result is `405`, like other variants of `fifthPower` above.
-  // expectEqual(405, gradient(at: 3, in: fifthPower))
-  expectEqual(243, gradient(at: 3, in: fifthPower))
+  expectEqual(405, gradient(at: 3, in: fifthPower))
 }
 
 runAllTests()


### PR DESCRIPTION
Recursively propagate usefulness for address-type outputs, instead of only
marking them as useful.

Resolves [TF-274](https://bugs.swift.org/browse/TF-274). Update tests.