### PR TITLE
[AST] NFC: Rename get*OrBoundGeneric* to be clearer and shorter

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -969,7 +969,7 @@ public:
   /// Get the declaration context that contains the conforming extension or
   /// nominal type declaration.
   DeclContext *getDeclContext() const {
-    auto bgc = getType()->getClassOrBoundGenericClass();
+    auto bgc = getType()->getClassDecl();
 
     // In some cases, we may not have a BGC handy, in which case we should
     // delegate to the inherited conformance for the decl context.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -441,13 +441,12 @@ public:
     return isObjCExistentialTypeImpl(*this);
   }
 
-  ClassDecl *getClassOrBoundGenericClass() const; // in Types.h
-  StructDecl *getStructOrBoundGenericStruct() const; // in Types.h
-  EnumDecl *getEnumOrBoundGenericEnum() const; // in Types.h
-  NominalTypeDecl *getNominalOrBoundGenericNominal() const; // in Types.h
+  ClassDecl *getClassDecl() const; // in Types.h
+  StructDecl *getStructDecl() const; // in Types.h
+  EnumDecl *getEnumDecl() const; // in Types.h
+  NominalTypeDecl *getNominalTypeDecl() const; // in Types.h
+  GenericTypeDecl *getGenericTypeDecl() const; // in Types.h
   CanType getNominalParent() const; // in Types.h
-  NominalTypeDecl *getAnyNominal() const;
-  GenericTypeDecl *getAnyGeneric() const;
 
   CanType getOptionalObjectType() const {
     return getOptionalObjectTypeImpl(*this);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -727,15 +727,15 @@ public:
 
   /// If this is a class type or a bound generic class type, returns the
   /// (possibly generic) class.
-  ClassDecl *getClassOrBoundGenericClass();
+  ClassDecl *getClassDecl();
   
   /// If this is a struct type or a bound generic struct type, returns
   /// the (possibly generic) class.
-  StructDecl *getStructOrBoundGenericStruct();
+  StructDecl *getStructDecl();
   
   /// If this is an enum or a bound generic enum type, returns the
   /// (possibly generic) enum.
-  EnumDecl *getEnumOrBoundGenericEnum();
+  EnumDecl *getEnumDecl();
   
   /// Determine whether this type may have a superclass, which holds for
   /// classes, bound generic classes, and archetypes that are only instantiable
@@ -766,7 +766,7 @@ public:
     return (is<ArchetypeType>() ||
             is<ModuleType>() ||
             isExistentialType() ||
-            getAnyNominal());
+            getNominalTypeDecl());
   }
 
   /// Retrieve the superclass of this type.
@@ -865,14 +865,10 @@ public:
   /// conceivably be bridged to an Objective-C class type.
   bool isPotentiallyBridgedValueType();
 
-  /// If this is a nominal type or a bound generic nominal type,
-  /// returns the (possibly generic) nominal type declaration.
-  NominalTypeDecl *getNominalOrBoundGenericNominal();
-
   /// If this is a nominal type, bound generic nominal type, or
   /// unbound generic nominal type, return the (possibly generic) nominal type
   /// declaration.
-  NominalTypeDecl *getAnyNominal();
+  NominalTypeDecl *getNominalTypeDecl();
 
   /// Determine whether the given type is representable in the given
   /// foreign language.
@@ -902,7 +898,7 @@ public:
   /// If this is a GenericType, bound generic nominal type, or
   /// unbound generic nominal type, return the (possibly generic) nominal type
   /// declaration.
-  GenericTypeDecl *getAnyGeneric();
+  GenericTypeDecl *getGenericTypeDecl();
 
   /// removeArgumentLabels -  Retrieve a version of this type with all
   /// argument labels removed.
@@ -5236,11 +5232,11 @@ inline bool TypeBase::canDynamicallyBeOptionalType(bool includeExistential) {
   return isArchetypeOrExistential && !T.isAnyClassReferenceType();
 }
 
-inline ClassDecl *TypeBase::getClassOrBoundGenericClass() {
-  return getCanonicalType().getClassOrBoundGenericClass();
+inline ClassDecl *TypeBase::getClassDecl() {
+  return getCanonicalType().getClassDecl();
 }
 
-inline ClassDecl *CanType::getClassOrBoundGenericClass() const {
+inline ClassDecl *CanType::getClassDecl() const {
   if (auto classTy = dyn_cast<ClassType>(*this))
     return classTy->getDecl();
 
@@ -5250,11 +5246,11 @@ inline ClassDecl *CanType::getClassOrBoundGenericClass() const {
   return nullptr;
 }
 
-inline StructDecl *TypeBase::getStructOrBoundGenericStruct() {
-  return getCanonicalType().getStructOrBoundGenericStruct();
+inline StructDecl *TypeBase::getStructDecl() {
+  return getCanonicalType().getStructDecl();
 }
 
-inline StructDecl *CanType::getStructOrBoundGenericStruct() const {
+inline StructDecl *CanType::getStructDecl() const {
   if (auto structTy = dyn_cast<StructType>(*this))
     return structTy->getDecl();
 
@@ -5264,11 +5260,11 @@ inline StructDecl *CanType::getStructOrBoundGenericStruct() const {
   return nullptr;
 }
 
-inline EnumDecl *TypeBase::getEnumOrBoundGenericEnum() {
-  return getCanonicalType().getEnumOrBoundGenericEnum();
+inline EnumDecl *TypeBase::getEnumDecl() {
+  return getCanonicalType().getEnumDecl();
 }
 
-inline EnumDecl *CanType::getEnumOrBoundGenericEnum() const {
+inline EnumDecl *CanType::getEnumDecl() const {
   if (auto enumTy = dyn_cast<EnumType>(*this))
     return enumTy->getDecl();
 
@@ -5278,30 +5274,24 @@ inline EnumDecl *CanType::getEnumOrBoundGenericEnum() const {
   return nullptr;
 }
 
-inline NominalTypeDecl *TypeBase::getNominalOrBoundGenericNominal() {
-  return getCanonicalType().getNominalOrBoundGenericNominal();
-}
-
-inline NominalTypeDecl *CanType::getNominalOrBoundGenericNominal() const {
-  if (auto Ty = dyn_cast<NominalOrBoundGenericNominalType>(*this))
-    return Ty->getDecl();
-  return nullptr;
-}
-
-inline NominalTypeDecl *TypeBase::getAnyNominal() {
-  return getCanonicalType().getAnyNominal();
+inline NominalTypeDecl *TypeBase::getNominalTypeDecl() {
+  return getCanonicalType().getNominalTypeDecl();
 }
 
 inline Type TypeBase::getNominalParent() {
   return castTo<AnyGenericType>()->getParent();
 }
 
-inline GenericTypeDecl *TypeBase::getAnyGeneric() {
-  return getCanonicalType().getAnyGeneric();
+inline GenericTypeDecl *TypeBase::getGenericTypeDecl() {
+  return getCanonicalType().getGenericTypeDecl();
 }
 
-  
-  
+inline GenericTypeDecl *CanType::getGenericTypeDecl() const {
+  if (auto Ty = dyn_cast<AnyGenericType>(*this))
+    return Ty->getDecl();
+  return nullptr;
+}
+
 inline bool TypeBase::isBuiltinIntegerType(unsigned n) {
   if (auto intTy = dyn_cast<BuiltinIntegerType>(getCanonicalType()))
     return intTy->getWidth().isFixedWidth()

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -318,9 +318,9 @@ public:
     assert(isValid());
     assert((getKind() == ProjectionKind::Struct ||
             getKind() == ProjectionKind::Class));
-    assert(BaseType.getNominalOrBoundGenericNominal() &&
+    assert(BaseType.getNominalTypeDecl() &&
            "This should only be called with a nominal type");
-    auto *NDecl = BaseType.getNominalOrBoundGenericNominal();
+    auto *NDecl = BaseType.getNominalTypeDecl();
     auto Iter = NDecl->getStoredProperties().begin();
     std::advance(Iter, getIndex());
     return *Iter;
@@ -329,8 +329,8 @@ public:
   EnumElementDecl *getEnumElementDecl(SILType BaseType) const {
     assert(isValid());
     assert(getKind() == ProjectionKind::Enum);
-    assert(BaseType.getEnumOrBoundGenericEnum() && "Expected enum type");
-    auto Iter = BaseType.getEnumOrBoundGenericEnum()->getAllElements().begin();
+    assert(BaseType.getEnumDecl() && "Expected enum type");
+    auto Iter = BaseType.getEnumDecl()->getAllElements().begin();
     std::advance(Iter, getIndex());
     return *Iter;
   }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1413,7 +1413,7 @@ public:
     SILType opTy = operand->getType();
     if (opTy.is<TupleType>())
       return createDestructureTuple(loc, operand);
-    if (opTy.getStructOrBoundGenericStruct())
+    if (opTy.getStructDecl())
       return createDestructureStruct(loc, operand);
     llvm_unreachable("Can not emit a destructure for this type of operand.");
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4732,7 +4732,7 @@ public:
   }
 
   StructDecl *getStructDecl() const {
-    auto s = getType().getStructOrBoundGenericStruct();
+    auto s = getType().getStructDecl();
     assert(s && "A struct should always have a StructDecl associated with it");
     return s;
   }
@@ -5083,7 +5083,7 @@ public:
   EnumElementDecl *getElement() const { return Element; }
 
   EnumDecl *getEnumDecl() const {
-    auto *E = getOperand()->getType().getEnumOrBoundGenericEnum();
+    auto *E = getOperand()->getType().getEnumDecl();
     assert(E && "Operand of unchecked_enum_data must be of enum type");
     return E;
   }
@@ -5154,7 +5154,7 @@ public:
   EnumElementDecl *getElement() const { return Element; }
 
   EnumDecl *getEnumDecl() const {
-    auto *E = getOperand()->getType().getEnumOrBoundGenericEnum();
+    auto *E = getOperand()->getType().getEnumDecl();
     assert(E && "Operand of unchecked_take_enum_data_addr must be of enum"
                 " type");
     return E;
@@ -5555,7 +5555,7 @@ public:
   }
 
   StructDecl *getStructDecl() const {
-    auto s = getOperand()->getType().getStructOrBoundGenericStruct();
+    auto s = getOperand()->getType().getStructDecl();
     assert(s);
     return s;
   }
@@ -5598,7 +5598,7 @@ public:
   }
 
   StructDecl *getStructDecl() const {
-    auto s = getOperand()->getType().getStructOrBoundGenericStruct();
+    auto s = getOperand()->getType().getStructDecl();
     assert(s);
     return s;
   }
@@ -5633,7 +5633,7 @@ public:
   }
 
   ClassDecl *getClassDecl() const {
-    auto s = getOperand()->getType().getClassOrBoundGenericClass();
+    auto s = getOperand()->getType().getClassDecl();
     assert(s);
     return s;
   }
@@ -5652,7 +5652,7 @@ class RefTailAddrInst
 
 public:
   ClassDecl *getClassDecl() const {
-    auto s = getOperand()->getType().getClassOrBoundGenericClass();
+    auto s = getOperand()->getType().getClassDecl();
     assert(s);
     return s;
   }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -198,23 +198,23 @@ public:
 
   /// Retrieve the ClassDecl for a type that maps to a Swift class or
   /// bound generic class type.
-  ClassDecl *getClassOrBoundGenericClass() const {
-    return getASTType().getClassOrBoundGenericClass();
+  ClassDecl *getClassDecl() const {
+    return getASTType().getClassDecl();
   }
   /// Retrieve the StructDecl for a type that maps to a Swift struct or
   /// bound generic struct type.
-  StructDecl *getStructOrBoundGenericStruct() const {
-    return getASTType().getStructOrBoundGenericStruct();
+  StructDecl *getStructDecl() const {
+    return getASTType().getStructDecl();
   }
   /// Retrieve the EnumDecl for a type that maps to a Swift enum or
   /// bound generic enum type.
-  EnumDecl *getEnumOrBoundGenericEnum() const {
-    return getASTType().getEnumOrBoundGenericEnum();
+  EnumDecl *getEnumDecl() const {
+    return getASTType().getEnumDecl();
   }
   /// Retrieve the NominalTypeDecl for a type that maps to a Swift
   /// nominal or bound generic nominal type.
-  NominalTypeDecl *getNominalOrBoundGenericNominal() const {
-    return getASTType().getNominalOrBoundGenericNominal();
+  NominalTypeDecl *getNominalTypeDecl() const {
+    return getASTType().getNominalTypeDecl();
   }
   
   /// True if the type is an address type.
@@ -369,9 +369,9 @@ public:
 
   static bool isClassOrClassMetatype(Type t) {
     if (auto *meta = t->getAs<AnyMetatypeType>()) {
-      return bool(meta->getInstanceType()->getClassOrBoundGenericClass());
+      return bool(meta->getInstanceType()->getClassDecl());
     } else {
-      return bool(t->getClassOrBoundGenericClass());
+      return bool(t->getClassDecl());
     }
   }
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -487,7 +487,7 @@ Type ASTBuilder::createProtocolCompositionType(
   std::vector<Type> members;
   for (auto protocol : protocols)
     members.push_back(protocol->getDeclaredType());
-  if (superclass && superclass->getClassOrBoundGenericClass())
+  if (superclass && superclass->getClassDecl())
     members.push_back(superclass);
   return ProtocolCompositionType::get(Ctx, members, isClassBound);
 }
@@ -656,7 +656,7 @@ bool ASTBuilder::validateParentType(TypeDecl *decl, Type parent) {
 
   if (isa<NominalTypeDecl>(decl)) {
     // The parent should be a nominal type when desugared.
-    auto *parentNominal = parent->getAnyNominal();
+    auto *parentNominal = parent->getNominalTypeDecl();
     if (!parentNominal || parentNominal != parentDecl) {
       return false;
     }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -913,7 +913,7 @@ void ASTMangler::appendType(Type type) {
       if (auto typeAlias = dyn_cast<TypeAliasType>(type.getPointer()))
         Decl = typeAlias->getDecl();
       else
-        Decl = type->getAnyGeneric();
+        Decl = type->getGenericTypeDecl();
       if (shouldMangleAsGeneric(type)) {
         // Try to mangle the entire name as a substitution.
         if (tryMangleTypeSubstitution(tybase))
@@ -934,7 +934,7 @@ void ASTMangler::appendType(Type type) {
         addTypeSubstitution(type);
         return;
       }
-      appendAnyGenericType(type->getAnyGeneric());
+      appendAnyGenericType(type->getGenericTypeDecl());
       return;
     }
 
@@ -949,7 +949,7 @@ void ASTMangler::appendType(Type type) {
 
     case TypeKind::DynamicSelf: {
       auto dynamicSelf = cast<DynamicSelfType>(tybase);
-      if (dynamicSelf->getSelfType()->getAnyNominal()) {
+      if (dynamicSelf->getSelfType()->getNominalTypeDecl()) {
         appendType(dynamicSelf->getSelfType());
         return appendOperator("XD");
       }
@@ -1260,7 +1260,7 @@ void ASTMangler::appendRetroactiveConformances(Type type) {
     if (type->hasUnboundGenericType())
       return;
 
-    auto nominal = type->getAnyNominal();
+    auto nominal = type->getNominalTypeDecl();
     if (!nominal) return;
 
     module = Mod ? Mod : nominal->getModuleContext();
@@ -2404,7 +2404,7 @@ ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance) {
     appendModule(Mod);
 
   contextSig =
-    conformingType->getAnyNominal()->getGenericSignatureOfContext();
+    conformingType->getNominalTypeDecl()->getGenericSignatureOfContext();
 
   if (GenericSignature *Sig = conformance->getGenericSignature()) {
     appendGenericSignature(Sig, contextSig);
@@ -2425,7 +2425,7 @@ void ASTMangler::appendProtocolConformanceRef(
   } else if (isRetroactiveConformance(conformance)) {
     appendModule(conformance->getDeclContext()->getParentModule());
   } else if (conformance->getDeclContext()->getParentModule() ==
-               conformance->getType()->getAnyNominal()->getParentModule()) {
+               conformance->getType()->getNominalTypeDecl()->getParentModule()) {
     appendOperator("HP");
   } else {
     appendOperator("Hp");

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1083,7 +1083,7 @@ public:
     }
     
     void verifyChecked(EnumIsCaseExpr *E) {
-      auto nom = E->getSubExpr()->getType()->getAnyNominal();
+      auto nom = E->getSubExpr()->getType()->getNominalTypeDecl();
       if (!nom || !isa<EnumDecl>(nom)) {
         Out << "enum_is_decl operand is not an enum: ";
         E->getSubExpr()->getType().print(Out);
@@ -1307,7 +1307,7 @@ public:
         abort();
       }
 
-      if (!E->getType()->getClassOrBoundGenericClass()) {
+      if (!E->getType()->getClassDecl()) {
         Out << "ProtocolMetatypeToObject does not produce class:\n";
         E->dump(Out);
         Out << "\n";
@@ -1353,7 +1353,7 @@ public:
       
       // Ensure we don't convert an array to a void pointer this way.
       
-      if (fromElement->getNominalOrBoundGenericNominal() == Ctx.getArrayDecl()
+      if (fromElement->getNominalTypeDecl() == Ctx.getArrayDecl()
           && toElement->isEqual(Ctx.TheEmptyTupleType)) {
         Out << "InOutToPointer is converting an array to a void pointer; "
                "ArrayToPointer should be used instead:\n";
@@ -1377,7 +1377,7 @@ public:
       // The source may be optionally inout.
       auto fromArray = E->getSubExpr()->getType()->getInOutObjectType();
       
-      if (fromArray->getNominalOrBoundGenericNominal() != Ctx.getArrayDecl()) {
+      if (fromArray->getNominalTypeDecl() != Ctx.getArrayDecl()) {
         Out << "ArrayToPointer does not convert from array:\n";
         E->dump(Out);
         Out << "\n";
@@ -1398,7 +1398,7 @@ public:
       PrettyStackTraceExpr debugStack(Ctx,
                                       "verifying StringToPointer", E);
       
-      if (E->getSubExpr()->getType()->getNominalOrBoundGenericNominal()
+      if (E->getSubExpr()->getType()->getNominalTypeDecl()
             != Ctx.getStringDecl()) {
         Out << "StringToPointer does not convert from string:\n";
         E->dump(Out);
@@ -1439,8 +1439,8 @@ public:
         abort();
       }
 
-      if (!destTy->getClassOrBoundGenericClass() ||
-          !(srcTy->getClassOrBoundGenericClass() ||
+      if (!destTy->getClassDecl() ||
+          !(srcTy->getClassDecl() ||
             srcTy->is<DynamicSelfType>())) {
         Out << "DerivedToBaseExpr does not involve class types:\n";
         E->dump(Out);
@@ -2898,7 +2898,7 @@ public:
       // Verify that the optionality of the result type of the
       // initializer matches the failability of the initializer.
       if (!CD->isInvalid() &&
-          CD->getDeclContext()->getDeclaredInterfaceType()->getAnyNominal() !=
+          CD->getDeclContext()->getDeclaredInterfaceType()->getNominalTypeDecl() !=
               Ctx.getOptionalDecl()) {
         bool resultIsOptional = (bool) CD->getResultInterfaceType()->getOptionalObjectType();
         auto declIsOptional = CD->getFailability() != OTK_None;
@@ -3363,7 +3363,7 @@ public:
       }
 
       // If the destination is a class, walk the supertypes of the source.
-      if (destTy->getClassOrBoundGenericClass()) {
+      if (destTy->getClassDecl()) {
         if (!destTy->isBindableToSuperclassOf(srcTy)) {
           srcTy.print(Out);
           Out << " is not a superclass of ";

--- a/lib/AST/AccessScopeChecker.cpp
+++ b/lib/AST/AccessScopeChecker.cpp
@@ -71,7 +71,7 @@ TypeAccessScopeChecker::walkToTypePre(Type T) {
   ValueDecl *VD;
   if (auto *BNAD = dyn_cast<TypeAliasType>(T.getPointer()))
     VD = BNAD->getDecl();
-  else if (auto *NTD = T->getAnyNominal())
+  else if (auto *NTD = T->getNominalTypeDecl())
     VD = NTD;
   else
     VD = nullptr;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -200,7 +200,7 @@ public:
   AvailabilityInferenceTypeWalker(ASTContext &AC) : AC(AC) {}
 
   Action walkToTypePre(Type ty) override {
-    if (auto *nominalDecl = ty->getAnyNominal()) {
+    if (auto *nominalDecl = ty->getNominalTypeDecl()) {
       AvailabilityInfo.intersectWith(
           AvailabilityInference::availableRange(nominalDecl, AC));
     }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -220,7 +220,7 @@ void ConformanceLookupTable::inheritConformances(ClassDecl *classDecl,
 
     for (const auto &inherited : classDecl->getInherited()) {
       if (auto inheritedType = inherited.getType()) {
-        if (inheritedType->getClassOrBoundGenericClass()) {
+        if (inheritedType->getClassDecl()) {
           superclassLoc = inherited.getSourceRange().Start;
           return superclassLoc;
         }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -905,7 +905,7 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
 
   case DeclKind::TypeAlias: {
     Type type = cast<TypeAliasDecl>(VD)->getDeclaredInterfaceType();
-    auto *nominal = type->getAnyNominal();
+    auto *nominal = type->getNominalTypeDecl();
     if (!nominal)
       return ImportKind::Type;
     return getBestImportKind(nominal);
@@ -3983,7 +3983,7 @@ void ProtocolDecl::setSuperclass(Type superclass) {
          && "superclass must be interface type");
   LazySemanticInfo.SuperclassType.setPointerAndInt(superclass, true);
   LazySemanticInfo.SuperclassDecl.setPointerAndInt(
-    superclass ? superclass->getClassOrBoundGenericClass() : nullptr,
+    superclass ? superclass->getClassDecl() : nullptr,
     true);
 }
 
@@ -6480,7 +6480,7 @@ bool FuncDecl::isPotentialIBActionTarget() const {
 }
 
 Type TypeBase::getSwiftNewtypeUnderlyingType() {
-  auto structDecl = getStructOrBoundGenericStruct();
+  auto structDecl = getStructDecl();
   if (!structDecl)
     return {};
 
@@ -6517,7 +6517,7 @@ void ClassDecl::setSuperclass(Type superclass) {
          && "superclass must be interface type");
   LazySemanticInfo.SuperclassType.setPointerAndInt(superclass, true);
   LazySemanticInfo.SuperclassDecl.setPointerAndInt(
-    superclass ? superclass->getClassOrBoundGenericClass() : nullptr,
+    superclass ? superclass->getClassDecl() : nullptr,
     true);
 }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2075,7 +2075,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   // FIXME: Shouldn't we always look here?
   if (!bestAssocType && concreteDecls.empty()) {
     Type typeToSearch = concreteType ? concreteType : superclass;
-    auto *decl = typeToSearch ? typeToSearch->getAnyNominal() : nullptr;
+    auto *decl = typeToSearch ? typeToSearch->getNominalTypeDecl() : nullptr;
     if (decl) {
       SmallVector<ValueDecl *, 2> foundMembers;
       decl->getParentModule()->lookupQualified(
@@ -3851,7 +3851,7 @@ static Type substituteConcreteType(GenericSignatureBuilder &builder,
     auto parentPA = basePA->getEquivalenceClassIfPresent();
     parentType =
         parentPA->concreteType ? parentPA->concreteType : parentPA->superclass;
-    auto parentDecl = parentType->getAnyNominal();
+    auto parentDecl = parentType->getNominalTypeDecl();
 
     subMap = parentType->getMemberSubstitutionMap(parentDecl->getParentModule(),
                                                   concreteDecl);
@@ -4544,7 +4544,7 @@ bool GenericSignatureBuilder::updateSuperclass(
                        type.getDependentType(*this))->viaDerived(*this);
     addLayoutRequirementDirect(type,
                          LayoutConstraint::getLayoutConstraint(
-                             superclass->getClassOrBoundGenericClass()->isObjC()
+                             superclass->getClassDecl()->isObjC()
                                  ? LayoutConstraintKind::Class
                                  : LayoutConstraintKind::NativeClass,
                              getASTContext()),
@@ -4628,7 +4628,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
 
   // Check whether we have a reasonable constraint type at all.
   if (!constraintType->isExistentialType() &&
-      !constraintType->getClassOrBoundGenericClass()) {
+      !constraintType->getClassDecl()) {
     if (source.getLoc().isValid() && !constraintType->hasError()) {
       auto subjectType = subject.dyn_cast<Type>();
       if (!subjectType)
@@ -5348,7 +5348,7 @@ public:
       return Action::Continue;
 
     // Infer from generic nominal types.
-    auto decl = ty->getAnyNominal();
+    auto decl = ty->getNominalTypeDecl();
     if (!decl) return Action::Continue;
 
     auto genericSig = decl->getGenericSignature();

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -696,7 +696,7 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
   if (type->is<UnresolvedType>())
     return ProtocolConformanceRef(protocol);
 
-  auto nominal = type->getAnyNominal();
+  auto nominal = type->getNominalTypeDecl();
 
   // If we don't have a nominal type, there are no conformances.
   if (!nominal || isa<ProtocolDecl>(nominal)) return None;
@@ -717,7 +717,7 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
     // Dig out the conforming nominal type.
     auto rootConformance = inherited->getRootNormalConformance();
     auto conformingClass
-      = rootConformance->getType()->getClassOrBoundGenericClass();
+      = rootConformance->getType()->getClassDecl();
 
     // Map up to our superclass's type.
     auto superclassTy = type->getSuperclassForDecl(conformingClass);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1986,7 +1986,7 @@ static bool finishLookup(const DeclContext *dc, NLOptions options,
 /// directly references, to facilitate name lookup into those types.
 static void extractDirectlyReferencedNominalTypes(
               Type type, SmallVectorImpl<NominalTypeDecl *> &decls) {
-  if (auto nominal = type->getAnyNominal()) {
+  if (auto nominal = type->getNominalTypeDecl()) {
     decls.push_back(nominal);
     return;
   }
@@ -2004,7 +2004,7 @@ static void extractDirectlyReferencedNominalTypes(
 
     // Look into the superclasses of this archetype.
     if (auto superclass = archetypeTy->getSuperclass()) {
-      if (auto superclassDecl = superclass->getClassOrBoundGenericClass())
+      if (auto superclassDecl = superclass->getClassDecl())
         decls.push_back(superclassDecl);
     }
 
@@ -2020,7 +2020,7 @@ static void extractDirectlyReferencedNominalTypes(
     }
 
     if (auto superclass = layout.explicitSuperclass) {
-      auto *superclassDecl = superclass->getClassOrBoundGenericClass();
+      auto *superclassDecl = superclass->getClassDecl();
       if (superclassDecl)
         decls.push_back(superclassDecl);
     }
@@ -2567,7 +2567,7 @@ static DirectlyReferencedTypeDecls directReferencesForType(Type type) {
     return { 1, aliasType->getDecl() };
 
   // If there is a generic declaration, return it.
-  if (auto genericDecl = type->getAnyGeneric())
+  if (auto genericDecl = type->getGenericTypeDecl())
     return { 1, genericDecl };
 
   if (type->isExistentialType()) {
@@ -2576,7 +2576,7 @@ static DirectlyReferencedTypeDecls directReferencesForType(Type type) {
 
     // Superclass.
     if (auto superclassType = layout.explicitSuperclass) {
-      if (auto superclassDecl = superclassType->getAnyGeneric()) {
+      if (auto superclassDecl = superclassType->getGenericTypeDecl()) {
         result.push_back(superclassDecl);
       }
     }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -396,7 +396,7 @@ RootProtocolConformance::isWeakImported(ModuleDecl *fromModule,
     return true;
 
   // If the conforming type is weak imported, so are any of its conformances.
-  if (auto *nominal = getType()->getAnyNominal())
+  if (auto *nominal = getType()->getNominalTypeDecl())
     if (nominal->isWeakImported(fromModule, fromContext))
       return true;
 
@@ -424,7 +424,7 @@ bool NormalProtocolConformance::isRetroactive() const {
 
   // If the conformance occurs in the same module as the conforming type
   // definition, this is not a retroactive conformance.
-  if (auto nominal = getType()->getAnyNominal()) {
+  if (auto nominal = getType()->getNominalTypeDecl()) {
     auto nominalModule = nominal->getParentModule();
 
     // Consider the overlay module to be the "home" of a nominal type
@@ -455,7 +455,7 @@ bool NormalProtocolConformance::isResilient() const {
   // FIXME: Looking at the type is not the right long-term solution. We need an
   // explicit mechanism for declaring conformances as 'fragile', or even
   // individual witnesses.
-  if (!getType()->getAnyNominal()->isResilient())
+  if (!getType()->getNominalTypeDecl()->isResilient())
     return false;
 
   switch (getDeclContext()->getParentModule()->getResilienceStrategy()) {
@@ -1021,7 +1021,7 @@ void SpecializedProtocolConformance::computeConditionalRequirements() const {
     // Substitute the conditional requirements so that they're phrased in
     // terms of the specialized types, not the conformance-declaring decl's
     // types.
-    auto nominal = GenericConformance->getType()->getAnyNominal();
+    auto nominal = GenericConformance->getType()->getNominalTypeDecl();
     auto module = nominal->getModuleContext();
     auto subMap = getType()->getContextSubstitutionMap(module, nominal);
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -369,7 +369,7 @@ Optional<Requirement> RequirementRequest::getCachedResult() const {
         !reqRepr.getConstraintLoc().wasValidated())
       return None;
 
-    return Requirement(reqRepr.getConstraint()->getClassOrBoundGenericClass()
+    return Requirement(reqRepr.getConstraint()->getClassDecl()
                          ? RequirementKind::Superclass
                          : RequirementKind::Conformance,
                        reqRepr.getSubject(),

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -423,10 +423,10 @@ CanType TypeJoin::visitProtocolType(CanType second) {
     return TheAnyType;
 
   auto *firstDecl =
-    cast<ProtocolDecl>(First->getNominalOrBoundGenericNominal());
+    cast<ProtocolDecl>(First->getNominalTypeDecl());
 
   auto *secondDecl =
-    cast<ProtocolDecl>(second->getNominalOrBoundGenericNominal());
+    cast<ProtocolDecl>(second->getNominalTypeDecl());
 
   if (firstDecl->getInheritedProtocols().empty() &&
       secondDecl->getInheritedProtocols().empty())

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -329,8 +329,8 @@ bool ide::printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS) {
   printDeclUSR(nominal, OS);
   for (auto Inherit : ED->getInherited()) {
     if (auto T = Inherit.getType()) {
-      if (T->getAnyNominal())
-        return printDeclUSR(T->getAnyNominal(), OS);
+      if (T->getNominalTypeDecl())
+        return printDeclUSR(T->getNominalTypeDecl(), OS);
     }
   }
   return true;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2568,7 +2568,7 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
       ext = nullptr;
       importedDecl = nullptr;
 
-      // Note: We can't use getAnyGeneric() here because `aliasedTy`
+      // Note: We can't use getGenericTypeDecl() here because `aliasedTy`
       // might be typealias.
       if (auto Ty = dyn_cast<TypeAliasType>(aliasedTy.getPointer()))
         importedDecl = Ty->getDecl();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -769,7 +769,7 @@ makeIndirectFieldAccessors(ClangImporter::Implementation &Impl,
   assert (anonymousFieldDecl && "anonymous field not generated");
 
   auto anonymousFieldType = anonymousFieldDecl->getInterfaceType();
-  auto anonymousFieldTypeDecl = anonymousFieldType->getStructOrBoundGenericStruct();
+  auto anonymousFieldTypeDecl = anonymousFieldType->getStructDecl();
 
   VarDecl *anonymousInnerFieldDecl = nullptr;
   for (auto decl : anonymousFieldTypeDecl->lookupDirect(importedFieldDecl->getName())) {
@@ -2419,7 +2419,7 @@ namespace {
                   dyn_cast<TypeAliasType>(SwiftType.getPointer()))
               return NAT->getDecl();
 
-            auto *NTD = SwiftType->getAnyNominal();
+            auto *NTD = SwiftType->getNominalTypeDecl();
             assert(NTD);
             return NTD;
           }
@@ -3759,7 +3759,7 @@ namespace {
       // If the declaration we attached the 'objc' attribute to is within a
       // class, record it in the class.
       if (auto contextTy = decl->getDeclContext()->getDeclaredInterfaceType()) {
-        if (auto classDecl = contextTy->getClassOrBoundGenericClass()) {
+        if (auto classDecl = contextTy->getClassDecl()) {
           if (auto method = dyn_cast<AbstractFunctionDecl>(decl)) {
             if (name)
               classDecl->recordObjCMethod(method, *name);
@@ -3796,7 +3796,7 @@ namespace {
                     llvm::function_ref<bool(AbstractFunctionDecl *fn)> filter) {
       // We only need to perform this check for classes.
       auto classDecl
-        = dc->getDeclaredInterfaceType()->getClassOrBoundGenericClass();
+        = dc->getDeclaredInterfaceType()->getClassDecl();
       if (!classDecl)
         return false;
 
@@ -4472,7 +4472,7 @@ namespace {
         if (!nsObjectTy)
           return nullptr;
         const ClassDecl *nsObjectDecl =
-          nsObjectTy->getClassOrBoundGenericClass();
+          nsObjectTy->getClassDecl();
 
         auto result = createFakeRootClass(Impl.SwiftContext.Id_Protocol,
                                       nsObjectDecl->getDeclContext());
@@ -4601,7 +4601,7 @@ namespace {
       // If the superclass is runtime-only, our class is also. This only
       // matters in the case above.
       if (superclassType) {
-        auto superclassDecl = cast<ClassDecl>(superclassType->getAnyNominal());
+        auto superclassDecl = cast<ClassDecl>(superclassType->getNominalTypeDecl());
         auto kind = superclassDecl->getForeignClassKind();
         if (kind != ClassDecl::ForeignKind::Normal)
           result->setForeignClassKind(kind);
@@ -5243,7 +5243,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
 
   // Local function to add a known protocol only when the
   // underlying type conforms to it.
-  auto computedNominal = computedPropertyUnderlyingType->getAnyNominal();
+  auto computedNominal = computedPropertyUnderlyingType->getNominalTypeDecl();
   auto transferKnown = [&](KnownProtocolKind kind) {
     if (!computedNominal)
       return false;
@@ -7989,7 +7989,7 @@ ClangImporter::Implementation::importDeclContextOf(
 
         // Look through typealiases.
         if (auto typealias = dyn_cast<TypeAliasDecl>(decl))
-          importedDC = typealias->getDeclaredInterfaceType()->getAnyNominal();
+          importedDC = typealias->getDeclaredInterfaceType()->getNominalTypeDecl();
         else // Map to a nominal type declaration.
           importedDC = dyn_cast<NominalTypeDecl>(decl);
         break;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1390,7 +1390,7 @@ static T *dynCastIgnoringCompatibilityAlias(Decl *D) {
   if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(D)) {
     if (!alias->isCompatibilityAlias())
       return nullptr;
-    D = alias->getDeclaredInterfaceType()->getAnyNominal();
+    D = alias->getDeclaredInterfaceType()->getNominalTypeDecl();
   }
   return dyn_cast_or_null<T>(D);
 }
@@ -1403,7 +1403,7 @@ static T *castIgnoringCompatibilityAlias(Decl *D) {
   if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(D)) {
     assert(alias->isCompatibilityAlias() &&
            "non-compatible typealias found where nominal was expected");
-    D = alias->getDeclaredInterfaceType()->getAnyNominal();
+    D = alias->getDeclaredInterfaceType()->getNominalTypeDecl();
   }
   return cast_or_null<T>(D);
 }

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -728,7 +728,7 @@ static bool isPublicOrUsableFromInline(Type ty) {
     // to be able to print it by desugaring.
     if (auto *aliasTy = dyn_cast<TypeAliasType>(typePart.getPointer()))
       return !isPublicOrUsableFromInline(aliasTy->getDecl());
-    if (auto *nominal = typePart->getAnyNominal())
+    if (auto *nominal = typePart->getNominalTypeDecl())
       return !isPublicOrUsableFromInline(nominal);
     return false;
   });

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1965,7 +1965,7 @@ public:
                    ->getDeclaredTypeInContext();
     if (BaseTy) {
       BaseTy = BaseTy->getInOutObjectType()->getMetatypeInstanceType();
-      if (auto NTD = BaseTy->getAnyNominal()) {
+      if (auto NTD = BaseTy->getNominalTypeDecl()) {
         auto *Module = NTD->getParentModule();
         auto Conformance = Module->lookupConformance(
             BaseTy, ATD->getProtocol());
@@ -3262,7 +3262,7 @@ public:
       if (op->getName().str() == "??")
         return;
       // 'T == nil'
-      if (auto NT = rhsTy->getNominalOrBoundGenericNominal())
+      if (auto NT = rhsTy->getNominalTypeDecl())
         if (NT->getName() ==
             CurrDeclContext->getASTContext().Id_OptionalNilComparisonType)
           return;
@@ -3369,7 +3369,7 @@ public:
         }
 
         // Check for conformance to the literal protocol.
-        if (auto *NTD = T->getAnyNominal()) {
+        if (auto *NTD = T->getNominalTypeDecl()) {
           SmallVector<ProtocolConformance *, 2> conformances;
           if (NTD->lookupConformance(module, P, conformances)) {
             foundConformance = true;
@@ -3522,7 +3522,7 @@ public:
       // and for some clients this approximation is good enough.
       CompletionContext->MayUseImplicitMemberExpr =
           std::any_of(ExpectedTypes.begin(), ExpectedTypes.end(), [](Type T) {
-            if (auto *NTD = T->getAnyNominal())
+            if (auto *NTD = T->getNominalTypeDecl())
               return isa<EnumDecl>(NTD);
             return false;
           });
@@ -3538,7 +3538,7 @@ public:
       bool addedKeyPath = false;
       for (auto T : ExpectedTypes) {
         T = T->lookThroughAllOptionalTypes();
-        if (auto structDecl = T->getStructOrBoundGenericStruct()) {
+        if (auto structDecl = T->getStructDecl()) {
           if (!addedSelector &&
               structDecl->getName() == Ctx.Id_Selector &&
               structDecl->getParentModule()->getName() == Ctx.Id_ObjectiveC) {
@@ -3549,7 +3549,7 @@ public:
           }
         }
 
-        if (!addedKeyPath && T->getAnyNominal() == Ctx.getStringDecl()) {
+        if (!addedKeyPath && T->getNominalTypeDecl() == Ctx.getStringDecl()) {
           addPoundKeyPath(/*needPound=*/true);
           if (addedSelector) break;
           addedKeyPath = true;
@@ -3678,7 +3678,7 @@ public:
     if (!Ty)
       return;
     ExprType = Ty;
-    auto *TheEnumDecl = dyn_cast_or_null<EnumDecl>(Ty->getAnyNominal());
+    auto *TheEnumDecl = dyn_cast_or_null<EnumDecl>(Ty->getNominalTypeDecl());
     if (!TheEnumDecl)
       return;
     for (auto Element : TheEnumDecl->getAllElements()) {
@@ -5123,7 +5123,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   }
 
   case CompletionKind::GenericParams:
-    if (auto GT = ParsedTypeLoc.getType()->getAnyGeneric()) {
+    if (auto GT = ParsedTypeLoc.getType()->getGenericTypeDecl()) {
       if (auto Params = GT->getGenericParams()) {
         for (auto GP : Params->getParams()) {
           Lookup.addGenericTypeParamRef(GP,

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -107,7 +107,7 @@ void ConformingMethodListCallbacks::resolveExpectedTypes(
 
   for (auto name : names) {
     if (auto ty = Demangle::getTypeForMangling(ctx, name)) {
-      if (auto Proto = dyn_cast_or_null<ProtocolDecl>(ty->getAnyGeneric()))
+      if (auto Proto = dyn_cast_or_null<ProtocolDecl>(ty->getGenericTypeDecl()))
         result.push_back(Proto);
     }
   }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -62,8 +62,8 @@ PrintOptions PrintOptions::printTypeInterface(Type T) {
   result.PrintExtensionFromConformingProtocols = true;
   result.TransformContext = TypeTransformContext(T);
   result.printExtensionContentAsMembers = [T](const ExtensionDecl *ED) {
-    return isExtensionApplied(*T->getNominalOrBoundGenericNominal()->
-                              getDeclContext(), T, ED);
+    return isExtensionApplied(*T->getNominalTypeDecl()->getDeclContext(),
+                              T, ED);
   };
   result.CurrentPrintabilityChecker.reset(new ModulePrinterPrintableChecker());
   return result;
@@ -471,7 +471,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       }
       if (auto *CD = dyn_cast<ClassDecl>(Back)) {
         if (auto Super = CD->getSuperclass())
-          Unhandled.push_back(Super->getAnyNominal());
+          Unhandled.push_back(Super->getNominalTypeDecl());
       }
     }
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -170,7 +170,7 @@ printTypeInterface(ModuleDecl *M, Type Ty, ASTPrinter &Printer,
     return true;
   }
   Ty = Ty->getRValueType();
-  if (auto ND = Ty->getNominalOrBoundGenericNominal()) {
+  if (auto ND = Ty->getNominalTypeDecl()) {
     PrintOptions Options = PrintOptions::printTypeInterface(Ty.getPointer());
     ND->print(Printer, Options);
     printTypeNameToString(Ty, TypeName);

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1787,7 +1787,7 @@ findConcatenatedExpressions(ResolvedRangeInfo Info, ASTContext &Ctx) {
       // FIXME: we should have ErrorType instead of null.
       if (E->getType().isNull())
         return true;
-      auto ExprType = E->getType()->getNominalOrBoundGenericNominal();
+      auto ExprType = E->getType()->getNominalTypeDecl();
       //Only binary concatenation operators should exist in expression
       if (E->getKind() == ExprKind::Binary) {
         auto *BE = dyn_cast<BinaryExpr>(E);
@@ -2401,7 +2401,7 @@ collectAvailableRefactoringsAtCursor(SourceFile *SF, unsigned Line,
 static EnumDecl* getEnumDeclFromSwitchStmt(SwitchStmt *SwitchS) {
   if (auto SubjectTy = SwitchS->getSubjectExpr()->getType()) {
     // FIXME: Support more complex subject like '(Enum1, Enum2)'.
-    return dyn_cast_or_null<EnumDecl>(SubjectTy->getAnyNominal());
+    return dyn_cast_or_null<EnumDecl>(SubjectTy->getNominalTypeDecl());
   }
   return nullptr;
 }

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -61,7 +61,7 @@ static bool isHoistable(AllocStackInst *Inst, irgen::IRGenModule &Mod) {
   // Don't hoist weakly imported (weakly linked) types.
   bool foundWeaklyImported =
       SILTy.getASTType().findIf([&Mod](CanType type) -> bool {
-        if (auto nominal = type->getNominalOrBoundGenericNominal())
+        if (auto nominal = type->getNominalTypeDecl())
           if (nominal->isWeakImported(Mod.getSwiftModule(),
                                       Mod.getAvailabilityContext())) {
             return true;

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -36,7 +36,7 @@ DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size size,
 /// Determine whether this type has a custom @_alignment attribute.
 static bool hasDefaultAlignment(swift::Type Ty) {
   if (auto CanTy = Ty->getCanonicalType())
-    if (auto *TyDecl = CanTy.getNominalOrBoundGenericNominal())
+    if (auto *TyDecl = CanTy.getNominalTypeDecl())
       if (TyDecl->getAttrs().getAttribute<AlignmentAttr>())
         return false;
   return true;

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -252,11 +252,11 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
                                          const InterestingKeysCallback &keys) {
   // Objective-C generics don't preserve their generic parameters at runtime,
   // so they aren't able to fulfill type metadata requirements.
-  if (type.getAnyNominal()->hasClangNode()) {
+  if (type.getNominalTypeDecl()->hasClangNode()) {
     return false;
   }
   
-  auto *nominal = type.getAnyNominal();
+  auto *nominal = type.getNominalTypeDecl();
   if (!nominal->isGenericContext() || isa<ProtocolDecl>(nominal)) {
     return false;
   }

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -177,9 +177,9 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
   ClassDecl *destClass = nullptr;
   if (auto archetypeTy = toType.getAs<ArchetypeType>()) {
     if (auto superclassTy = archetypeTy->getSuperclass())
-      destClass = superclassTy->getClassOrBoundGenericClass();
+      destClass = superclassTy->getClassDecl();
   } else {
-    destClass = toType.getClassOrBoundGenericClass();
+    destClass = toType.getClassDecl();
     assert(destClass != nullptr);
   }
 

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -299,12 +299,12 @@ ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
     // Handle Int and UInt specially. On Apple platforms, these correspond to
     // the NSInteger and NSUInteger typedefs, so map them back to those typedefs
     // if they're available, to ensure we get consistent ObjC @encode strings.
-    if (swiftType->getAnyNominal() == IGM.Context.getIntDecl()) {
+    if (swiftType->getNominalTypeDecl() == IGM.Context.getIntDecl()) {
       if (auto NSIntegerTy = getClangBuiltinTypeFromTypedef(sema, "NSInteger")){
         Cache.insert({swiftType, NSIntegerTy});
         return;
       }
-    } else if (swiftType->getAnyNominal() == IGM.Context.getUIntDecl()) {
+    } else if (swiftType->getNominalTypeDecl() == IGM.Context.getUIntDecl()) {
       if (auto NSUIntegerTy =
             getClangBuiltinTypeFromTypedef(sema, "NSUInteger")) {
         Cache.insert({swiftType, NSUIntegerTy});

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6137,7 +6137,7 @@ namespace {
 
 const EnumImplStrategy &
 irgen::getEnumImplStrategy(IRGenModule &IGM, SILType ty) {
-  assert(ty.getEnumOrBoundGenericEnum() && "not an enum");
+  assert(ty.getEnumDecl() && "not an enum");
   auto *ti = &IGM.getTypeInfo(ty);
   if (auto *loadableTI = dyn_cast<LoadableTypeInfo>(ti))
     return loadableTI->as<LoadableEnumTypeInfo>().Strategy;

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1791,7 +1791,7 @@ llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                                      llvm::Value *object,
                                                      CanType objectType,
                                                      bool suppressCast) {
-  ClassDecl *theClass = objectType.getClassOrBoundGenericClass();
+  ClassDecl *theClass = objectType.getClassDecl();
   if (theClass && isKnownNotTaggedPointer(IGF.IGM, theClass))
     return emitLoadOfHeapMetadataRef(IGF, object,
                                      getIsaEncodingForType(IGF.IGM, objectType),
@@ -1900,7 +1900,7 @@ IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
 
   // This needs to be kept up-to-date with hasKnownSwiftMetadata.
 
-  if (auto theClass = type->getClassOrBoundGenericClass()) {
+  if (auto theClass = type->getClassDecl()) {
     // We can access the isas of pure Swift classes directly.
     if (getRootClass(theClass)->hasKnownSwiftImplementation())
       return IsaEncoding::Pointer;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1785,7 +1785,7 @@ static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
                                        MetadataDependencyCollector *collector) {
   auto &IGM = IGF.IGM;
 
-  auto *target = T.getNominalOrBoundGenericNominal();
+  auto *target = T.getNominalTypeDecl();
   llvm::Value *fieldVector
     = emitAddressOfFieldOffsetVector(IGF, metadata, target)
       .getAddress();
@@ -3949,7 +3949,7 @@ namespace {
 } // end anonymous namespace
 
 bool irgen::requiresForeignTypeMetadata(CanType type) {
-  if (NominalTypeDecl *nominal = type->getAnyNominal()) {
+  if (NominalTypeDecl *nominal = type->getNominalTypeDecl()) {
     return requiresForeignTypeMetadata(nominal);
   }
 
@@ -4053,7 +4053,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   }
 
   // Keep type metadata around for all types.
-  addRuntimeResolvableType(type->getAnyNominal());
+  addRuntimeResolvableType(type->getNominalTypeDecl());
   
   // If the enclosing type is also an imported type, force its metadata too.
   if (auto enclosing = type->getNominalParent()) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -526,7 +526,7 @@ static llvm::Value *emitSuperArgument(IRGenFunction &IGF,
                                            /*allow uninitialized*/ true);
   } else {
     searchClass = cast<MetatypeType>(searchClass).getInstanceType();
-    ClassDecl *searchClassDecl = searchClass.getClassOrBoundGenericClass();
+    ClassDecl *searchClassDecl = searchClass.getClassDecl();
     switch (IGF.IGM.getClassMetadataStrategy(searchClassDecl)) {
     case ClassMetadataStrategy::Resilient:
     case ClassMetadataStrategy::Singleton:

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -170,7 +170,7 @@ llvm::Constant *IRGenModule::getTypeRef(CanType type, MangledTypeRefRole role) {
   case MangledTypeRefRole::Metadata:
     // Note that we're using all of the nominal types referenced by this type.
     type.findIf([&](CanType type) -> bool {
-      if (auto nominal = type.getAnyNominal())
+      if (auto nominal = type.getNominalTypeDecl())
         this->IRGen.noteUseOfTypeMetadata(nominal);
       return false;
     });
@@ -274,7 +274,7 @@ protected:
       // In effect they're treated like an opaque blob, which is OK
       // for now, at least until we want to import C++ types or
       // something like that.
-      if (auto Nominal = t->getAnyNominal())
+      if (auto Nominal = t->getNominalTypeDecl())
         if (Nominal->hasClangNode()) {
           if (isa<StructDecl>(Nominal) ||
               isa<EnumDecl>(Nominal))
@@ -366,7 +366,7 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
   void layout() override {
     // If the conforming type is generic, we just want to emit the
     // unbound generic type here.
-    auto *Nominal = Conformance->getType()->getAnyNominal();
+    auto *Nominal = Conformance->getType()->getNominalTypeDecl();
     assert(Nominal && "Structural conformance?");
 
     PrettyStackTraceDecl DebugStack("emitting associated type metadata",

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -405,7 +405,7 @@ namespace {
     SILType TheStruct;
   public:
     StructNonFixedOffsets(SILType type) : TheStruct(type) {
-      assert(TheStruct.getStructOrBoundGenericStruct());
+      assert(TheStruct.getStructDecl());
     }
     
     llvm::Value *getOffsetForIndex(IRGenFunction &IGF, unsigned index) override {
@@ -414,7 +414,7 @@ namespace {
       // Get the field offset vector from the struct metadata.
       llvm::Value *metadata = IGF.emitTypeMetadataRefForLayout(TheStruct);
       Address fieldVector = emitAddressOfFieldOffsetVector(IGF, metadata,
-                                    TheStruct.getStructOrBoundGenericStruct());
+                                    TheStruct.getStructDecl());
       
       // Grab the indexed offset.
       fieldVector = IGF.Builder.CreateConstArrayGEP(fieldVector, index,
@@ -425,7 +425,7 @@ namespace {
     MemberAccessStrategy getFieldAccessStrategy(IRGenModule &IGM,
                                                 unsigned nonFixedIndex) {
       auto start =
-        IGM.getMetadataLayout(TheStruct.getStructOrBoundGenericStruct())
+        IGM.getMetadataLayout(TheStruct.getStructDecl())
           .getFieldOffsetVectorOffset();
 
       // FIXME: Handle resilience
@@ -588,13 +588,13 @@ namespace {
     }
 
     SILType getType(VarDecl *field) {
-      assert(field->getDeclContext() == TheStruct->getAnyNominal());
+      assert(field->getDeclContext() == TheStruct->getNominalTypeDecl());
       auto silType = SILType::getPrimitiveAddressType(TheStruct);
       return silType.getFieldType(field, IGM.getSILModule());
     }
 
     StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {
-      return StructLayout(IGM, TheStruct->getAnyNominal(),
+      return StructLayout(IGM, TheStruct->getNominalTypeDecl(),
                           LayoutKind::NonHeapObject,
                           LayoutStrategy::Optimal, fieldTypes, StructTy);
     }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1741,7 +1741,7 @@ const TypeInfo *TypeConverter::convertType(CanType ty) {
   case TypeKind::DynamicSelf: {
     // DynamicSelf has the same representation as its superclass type.
     auto dynamicSelf = cast<DynamicSelfType>(ty);
-    auto nominal = dynamicSelf->getSelfType()->getAnyNominal();
+    auto nominal = dynamicSelf->getSelfType()->getNominalTypeDecl();
     return convertAnyNominalType(ty, nominal);
   }
   case TypeKind::BuiltinNativeObject:
@@ -2137,14 +2137,14 @@ TypeConverter::getMetatypeTypeInfo(MetatypeRepresentation representation) {
 
 /// createNominalType - Create a new nominal type.
 llvm::StructType *IRGenModule::createNominalType(CanType type) {
-  assert(type.getNominalOrBoundGenericNominal());
+  assert(type.getNominalTypeDecl());
 
   // We share type infos for different instantiations of a generic type
   // when the archetypes have the same exemplars.  We cannot mangle
   // archetypes, and the mangling does not have to be unique, so we just
   // mangle the unbound generic form of the type.
   if (type->hasArchetype())
-    type = type.getNominalOrBoundGenericNominal()->getDeclaredType()
+    type = type.getNominalTypeDecl()->getDeclaredType()
                                                  ->getCanonicalType();
 
   IRGenMangler Mangler;
@@ -2240,7 +2240,7 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
     if (tuple->getNumElements() == 1)
       return t.getTupleElementType(0);
 
-  if (auto structDecl = t.getStructOrBoundGenericStruct()) {
+  if (auto structDecl = t.getStructDecl()) {
     // If the struct has to be accessed resiliently from this resilience domain,
     // we can't assume anything about its layout.
     if (IGM.isResilient(structDecl, expansion))
@@ -2267,7 +2267,7 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
     return SILType();
   }
 
-  if (auto enumDecl = t.getEnumOrBoundGenericEnum()) {
+  if (auto enumDecl = t.getEnumDecl()) {
     // If the enum has to be accessed resiliently from this resilience domain,
     // we can't assume anything about its layout.
     if (IGM.isResilient(enumDecl, expansion))

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -406,7 +406,7 @@ static CanType getFormalTypeInContext(CanType abstractType, DeclContext *dc) {
 /// unbound generic types --- return the formal type within the type's
 /// primary defining context.
 static CanType getFormalTypeInContext(CanType abstractType) {
-  if (auto nominal = abstractType.getAnyNominal())
+  if (auto nominal = abstractType.getNominalTypeDecl())
     return getFormalTypeInContext(abstractType, nominal);
   return abstractType;
 }
@@ -818,7 +818,7 @@ static void addValueWitness(IRGenModule &IGM,
       flags = flags.withIncomplete(true);
     }
 
-    if (concreteType.getEnumOrBoundGenericEnum())
+    if (concreteType.getEnumDecl())
       flags = flags.withEnumWitnesses(true);
 
     return B.addInt32(flags.getOpaqueValue());
@@ -848,7 +848,7 @@ static void addValueWitness(IRGenModule &IGM,
   case ValueWitness::GetEnumTag:
   case ValueWitness::DestructiveProjectEnumData:
   case ValueWitness::DestructiveInjectEnumTag:
-    assert(concreteType.getEnumOrBoundGenericEnum());
+    assert(concreteType.getEnumDecl());
     goto standard;
   }
   llvm_unreachable("bad value witness kind");
@@ -864,7 +864,7 @@ static void addValueWitness(IRGenModule &IGM,
 
 static bool shouldAddEnumWitnesses(CanType abstractType) {
   // Needs to handle UnboundGenericType.
-  return dyn_cast_or_null<EnumDecl>(abstractType.getAnyNominal()) != nullptr;
+  return dyn_cast_or_null<EnumDecl>(abstractType.getNominalTypeDecl()) != nullptr;
 }
 
 static llvm::StructType *getValueWitnessTableType(IRGenModule &IGM,
@@ -934,7 +934,7 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type) {
   if (IGM.useDllStorage())
     return nullptr;
   
-  if (auto nom = type->getAnyNominal()) {
+  if (auto nom = type->getNominalTypeDecl()) {
     // TODO: Generic metadata patterns relative-reference their VWT, which won't
     // work if the VWT is in a different module without supporting indirection
     // through the GOT.

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1588,7 +1588,7 @@ private:
       TypeDecl = AliasDecl;
       Context = AliasDecl->getParent();
       ClangDecl = AliasDecl->getClangDecl();
-    } else if (auto *ND = DbgTy.getType()->getNominalOrBoundGenericNominal()) {
+    } else if (auto *ND = DbgTy.getType()->getNominalTypeDecl()) {
       TypeDecl = ND;
       Context = ND->getParent();
       ClangDecl = ND->getClangDecl();

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -199,7 +199,7 @@ mangleProtocolForLLVMTypeName(ProtocolCompositionType *type) {
       // archetypes, and the mangling does not have to be unique, so we just
       // mangle the unbound generic form of the type.
       if (superclass->hasArchetype()) {
-        superclass = superclass->getClassOrBoundGenericClass()
+        superclass = superclass->getClassDecl()
           ->getDeclaredType();
       }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -755,7 +755,7 @@ bool IRGenerator::canEmitWitnessTableLazily(SILWitnessTable *wt) {
     return true;
 
   NominalTypeDecl *ConformingTy =
-    wt->getConformingType()->getNominalOrBoundGenericNominal();
+    wt->getConformingType()->getNominalTypeDecl();
 
   switch (ConformingTy->getEffectiveAccess()) {
     case AccessLevel::Private:

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -363,7 +363,7 @@ public:
 
   void noteUseOfTypeMetadata(Type type) {
     type.visit([&](Type t) {
-      if (auto *nominal = t->getAnyNominal())
+      if (auto *nominal = t->getNominalTypeDecl())
         noteUseOfTypeMetadata(nominal);
     });
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1995,7 +1995,7 @@ void IRGenSILFunction::visitValueMetatypeInst(swift::ValueMetatypeInst *i) {
   
   Explosion e;
   
-  if (instanceTy.getClassOrBoundGenericClass()) {
+  if (instanceTy.getClassDecl()) {
     e.add(emitDynamicTypeOfHeapObject(*this,
                            getClassBaseValue(*this, i->getOperand()),
                            metaTy->getRepresentation(), instanceTy));
@@ -4022,8 +4022,8 @@ void IRGenSILFunction::visitAllocStackInst(swift::AllocStackInst *i) {
     return;
 
   Type Desugared = Decl->getType()->getDesugaredType();
-  if (Desugared->getClassOrBoundGenericClass() ||
-      Desugared->getStructOrBoundGenericStruct())
+  if (Desugared->getClassDecl() ||
+      Desugared->getStructDecl())
     zeroInit(dyn_cast<llvm::AllocaInst>(addr.getAddress().getAddress()));
   emitDebugInfoForAllocStack(i, type, addr.getAddress().getAddress());
 }
@@ -4848,7 +4848,7 @@ void IRGenSILFunction::visitBridgeObjectToRefInst(
   llvm::Value *taggedRef = nullptr;
   llvm::Value *boBits = nullptr;
   
-  ClassDecl *Cl = i->getType().getClassOrBoundGenericClass();
+  ClassDecl *Cl = i->getType().getClassDecl();
   if (IGM.TargetInfo.hasObjCTaggedPointers() &&
       (!Cl || !isKnownNotTaggedPointer(IGM, Cl))) {
     boBits = Builder.CreatePtrToInt(bo, IGM.SizeTy);
@@ -5472,7 +5472,7 @@ void IRGenSILFunction::visitSuperMethodInst(swift::SuperMethodInst *i) {
     // Load the superclass of the static type of the 'self' value.
     llvm::Value *superMetadata;
     auto instanceTy = CanType(baseType.getASTType()->getMetatypeInstanceType());
-    if (!IGM.hasResilientMetadata(instanceTy.getClassOrBoundGenericClass(),
+    if (!IGM.hasResilientMetadata(instanceTy.getClassDecl(),
                                   ResilienceExpansion::Maximal)) {
       // It's still possible that the static type of 'self' is not resilient, in
       // which case we can assume its superclass.

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -101,7 +101,7 @@ static bool isLargeLoadableType(GenericEnvironment *GenericEnv, SILType t,
     canType = GenericEnv->mapTypeIntoContext(canType)->getCanonicalType();
   }
 
-  if (canType.getAnyGeneric()) {
+  if (canType.getGenericTypeDecl()) {
     assert(t.isObject() && "Expected only two categories: address and object");
     assert(!canType->hasTypeParameter());
     const TypeInfo &TI = Mod.getTypeInfoForLowered(canType);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1101,7 +1101,7 @@ public:
                 TypeDecl *origTypeDecl = typeAliasDecl
                   ->getDeclaredInterfaceType()
                   ->getDesugaredType()
-                  ->getNominalOrBoundGenericNominal();
+                  ->getNominalTypeDecl();
                 if (origTypeDecl) {
                   printOrDumpDecl(origTypeDecl, doPrint);
                   typeDecl = origTypeDecl;

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -865,7 +865,7 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
         if (!reportRef(TAD, IdLoc, Info, None))
           return false;
         if (auto Ty = TAD->getUnderlyingTypeLoc().getType()) {
-          NTD = Ty->getAnyNominal();
+          NTD = Ty->getNominalTypeDecl();
           isImplicit = true;
         }
       } else {
@@ -880,7 +880,7 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
   }
 
   if (Ty.getType()) {
-    if (auto nominal = Ty.getType()->getAnyNominal())
+    if (auto nominal = Ty.getType()->getNominalTypeDecl())
       if (!reportRelatedRef(nominal, Ty.getLoc(), /*isImplicit=*/false, Relations, Related))
         return false;
   }
@@ -972,7 +972,7 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
 NominalTypeDecl *
 IndexSwiftASTWalker::getTypeLocAsNominalTypeDecl(const TypeLoc &Ty) {
   if (Type T = Ty.getType())
-    return T->getAnyNominal();
+    return T->getNominalTypeDecl();
   if (auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty.getTypeRepr())) {
     auto Comp = T->getComponentRange().back();
     if (auto NTD = dyn_cast_or_null<NominalTypeDecl>(Comp->getBoundDecl()))
@@ -1218,7 +1218,7 @@ bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
       auto paramList = D->getParameters();
       if (!paramList->getArray().empty()) {
         auto param = paramList->get(0);
-        if (auto nominal = param->getType()->getAnyNominal()) {
+        if (auto nominal = param->getType()->getNominalTypeDecl()) {
           addRelation(Info, (SymbolRoleSet) SymbolRole::RelationIBTypeOf, nominal);
         }
       }
@@ -1310,7 +1310,7 @@ bool IndexSwiftASTWalker::initFuncRefIndexSymbol(ValueDecl *D, SourceLoc Loc,
     else if (auto MetaT = ReceiverTy->getAs<MetatypeType>())
       ReceiverTy = MetaT->getInstanceType();
 
-    if (auto TyD = ReceiverTy->getAnyNominal()) {
+    if (auto TyD = ReceiverTy->getNominalTypeDecl()) {
       if (addRelation(Info, (SymbolRoleSet) SymbolRole::RelationReceivedBy, TyD))
         return true;
       if (isDynamicCall(BaseE, D))

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1033,7 +1033,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
       auto Found = false;
       if (auto *Base = MRE->getBase()) {
-        if (hasRevertRawRepresentableChange(Base->getType()->getAnyNominal())) {
+        if (hasRevertRawRepresentableChange(Base->getType()->getNominalTypeDecl())) {
           Found = true;
         }
       }
@@ -1056,7 +1056,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       auto Found = false;
       if (auto *CRC = dyn_cast<ConstructorRefCallExpr>(CE->getFn())) {
         if (auto *TE = dyn_cast<TypeExpr>(CRC->getBase())) {
-          if (hasRevertRawRepresentableChange(TE->getInstanceType()->getAnyNominal()))
+          if (hasRevertRawRepresentableChange(TE->getInstanceType()->getNominalTypeDecl()))
             Found = true;
         }
       }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1183,7 +1183,7 @@ static ValueDecl *lookupMember(Parser &P, Type Ty, DeclBaseName Name,
   if (auto MetaTy = CheckTy->getAs<AnyMetatypeType>())
     CheckTy = MetaTy->getInstanceType();
 
-  if (auto nominal = CheckTy->getAnyNominal()) {
+  if (auto nominal = CheckTy->getNominalTypeDecl()) {
     auto found = nominal->lookupDirect(Name);
     Lookup.append(found.begin(), found.end());
   } else if (auto moduleTy = CheckTy->getAs<ModuleType>()) {

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -122,7 +122,7 @@ public:
       return Result<uint64_t>::emplaceFailure(Failure::DependentArgument);
 
     // Split into cases.
-    if (auto typeDecl = type->getNominalOrBoundGenericNominal()) {
+    if (auto typeDecl = type->getNominalTypeDecl()) {
       return getOffsetOfField(type, typeDecl, optMetadata, memberName);
     } else if (auto tupleType = type->getAs<TupleType>()) {
       return getOffsetOfTupleElement(tupleType, optMetadata, memberName);
@@ -519,7 +519,7 @@ public:
     // of the reference.
     auto payloadAddress = result->PayloadAddress;
     if (!result->IsBridgedError &&
-        typeResult->getClassOrBoundGenericClass()) {
+        typeResult->getClassDecl()) {
       auto pointerval = Reader.readPointerValue(
           payloadAddress.getAddressData());
       if (!pointerval)
@@ -547,7 +547,7 @@ public:
     // address returned is the class instance itself and not the address
     // of the reference.
     auto payloadAddress = result->PayloadAddress;
-    if (typeResult->getClassOrBoundGenericClass()) {
+    if (typeResult->getClassDecl()) {
       auto pointerval = Reader.readPointerValue(
           payloadAddress.getAddressData());
       if (!pointerval)

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -154,7 +154,7 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
 
   // Class metatypes bridge to ObjC metatypes.
   if (auto metaTy = t->getAs<MetatypeType>()) {
-    if (metaTy->getInstanceType()->getClassOrBoundGenericClass()
+    if (metaTy->getInstanceType()->getClassDecl()
         // Self argument of an ObjC protocol
         || metaTy->getInstanceType()->is<GenericTypeParamType>()) {
       return MetatypeType::get(metaTy->getInstanceType(),

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -322,7 +322,7 @@ void SILLinkerVisitor::visitAllocRefInst(AllocRefInst *ARI) {
     return;
 
   // Grab the class decl from the alloc ref inst.
-  ClassDecl *D = ARI->getType().getClassOrBoundGenericClass();
+  ClassDecl *D = ARI->getType().getClassDecl();
   if (!D)
     return;
 
@@ -334,7 +334,7 @@ void SILLinkerVisitor::visitMetatypeInst(MetatypeInst *MI) {
     return;
 
   CanType instTy = MI->getType().castTo<MetatypeType>().getInstanceType();
-  ClassDecl *C = instTy.getClassOrBoundGenericClass();
+  ClassDecl *C = instTy.getClassDecl();
   if (!C)
     return;
 

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -422,7 +422,7 @@ OperandOwnershipKindClassifier::checkTerminatorArgumentMatchesDestBB(
       destBB->getArgument(opIndex)->getOwnershipKind();
 
   // Then if we do not have an enum, make sure that the conventions match.
-  if (!getType().getEnumOrBoundGenericEnum()) {
+  if (!getType().getEnumDecl()) {
     auto lifetimeConstraint =
         destBlockArgOwnershipKind.getForwardingLifetimeConstraint();
     return Map::compatibilityMap(destBlockArgOwnershipKind, lifetimeConstraint);
@@ -561,7 +561,7 @@ OperandOwnershipKindClassifier::visitReturnInst(ReturnInst *ri) {
   auto base = *mergedBase;
 
   // TODO: This may not be needed once trivial is any.
-  if (getType().getEnumOrBoundGenericEnum()) {
+  if (getType().getEnumDecl()) {
     return visitEnumArgument(base);
   }
 
@@ -690,7 +690,7 @@ OperandOwnershipKindMap OperandOwnershipKindClassifier::visitApplyParameter(
 
   // Check if we have an enum. If not, then we just check against the passed in
   // convention.
-  if (!getType().getEnumOrBoundGenericEnum()) {
+  if (!getType().getEnumDecl()) {
     // We allow for owned to be passed to apply parameters.
     if (kind != ValueOwnershipKind::Owned) {
       return Map::compatibilityMap(

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -217,7 +217,7 @@ Projection::createAddressProjection(SILBuilder &B, SILLocation Loc,
 
   // We can only create an address projection from an object, unless we have a
   // class.
-  if (BaseTy.getClassOrBoundGenericClass() || !BaseTy.isAddress())
+  if (BaseTy.getClassDecl() || !BaseTy.isAddress())
     return nullptr;
 
   // Ok, we now know that the type of Base and the type represented by the base
@@ -256,7 +256,7 @@ Projection::createAddressProjection(SILBuilder &B, SILLocation Loc,
 
 void Projection::getFirstLevelProjections(SILType Ty, SILModule &Mod,
                                   llvm::SmallVectorImpl<Projection> &Out) {
-  if (auto *S = Ty.getStructOrBoundGenericStruct()) {
+  if (auto *S = Ty.getStructDecl()) {
     unsigned Count = 0;
     for (auto *VDecl : S->getStoredProperties()) {
       (void) VDecl;
@@ -284,7 +284,7 @@ void Projection::getFirstLevelProjections(SILType Ty, SILModule &Mod,
     return;
   }
 
-  if (auto *C = Ty.getClassOrBoundGenericClass()) {
+  if (auto *C = Ty.getClassDecl()) {
     unsigned Count = 0;
     for (auto *VDecl : C->getStoredProperties()) {
       (void) VDecl;
@@ -616,7 +616,7 @@ ProjectionPath::expandTypeIntoLeafProjectionPaths(SILType B, SILModule *Mod,
     //
     // The worklist would never be empty in this case !.
     //
-    if (Ty.getClassOrBoundGenericClass()) {
+    if (Ty.getClassDecl()) {
       LLVM_DEBUG(llvm::dbgs() << "    Found class. Finished projection list\n");
       Paths.push_back(PP);
       continue;
@@ -677,7 +677,7 @@ hasUncoveredNonTrivials(SILType B, SILModule *Mod, ProjectionPathSet &CPaths) {
 
     // There is at least one projection path that leads to a type with
     // reference semantics.
-    if (Ty.getClassOrBoundGenericClass()) {
+    if (Ty.getClassDecl()) {
       Paths.push_back(PP);
       continue;
     }
@@ -763,7 +763,7 @@ Projection::
 createAggFromFirstLevelProjections(SILBuilder &B, SILLocation Loc,
                                    SILType BaseType,
                                    llvm::SmallVectorImpl<SILValue> &Values) {
-  if (BaseType.getStructOrBoundGenericStruct()) {
+  if (BaseType.getStructDecl()) {
     return B.createStruct(Loc, BaseType, Values);
   }
 
@@ -985,7 +985,7 @@ createNextLevelChildren(ProjectionTree &Tree) {
     return;
   }
 
-  if (auto *SD = Ty.getStructOrBoundGenericStruct()) {
+  if (auto *SD = Ty.getStructDecl()) {
     LLVM_DEBUG(llvm::dbgs() << "        Found a struct!\n");
     createNextLevelChildrenForStruct(Tree, SD);
     return;
@@ -1009,7 +1009,7 @@ createAggregate(SILBuilder &B, SILLocation Loc, ArrayRef<SILValue> Args) const {
 
   SILType Ty = getType();
 
-  if (Ty.getStructOrBoundGenericStruct()) {
+  if (Ty.getStructDecl()) {
     return B.createStruct(Loc, Ty, Args);
   }
 

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -80,7 +80,7 @@ swift::getLinkageForProtocolConformance(const RootProtocolConformance *C,
   if (isa<ClangModuleUnit>(C->getDeclContext()->getModuleScopeContext()))
     return SILLinkage::Shared;
 
-  auto typeDecl = C->getType()->getNominalOrBoundGenericNominal();
+  auto typeDecl = C->getType()->getNominalTypeDecl();
   AccessLevel access = std::min(C->getProtocol()->getEffectiveAccess(),
                                 typeDecl->getEffectiveAccess());
   switch (access) {
@@ -108,7 +108,7 @@ bool SILModule::isTypeMetadataAccessible(CanType type) {
     // Note that this function returns true if the type is *illegal* to use.
 
     // Ignore non-nominal types.
-    auto decl = type.getNominalOrBoundGenericNominal();
+    auto decl = type.getNominalTypeDecl();
     if (!decl)
       return false;
 

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -511,7 +511,7 @@ void SILBuilder::emitDestructureValueOperation(
 
   // If we do not have a tuple or a struct, add to our results list and return.
   SILType type = v->getType();
-  if (!(type.is<TupleType>() || type.getStructOrBoundGenericStruct())) {
+  if (!(type.is<TupleType>() || type.getStructDecl())) {
     results.emplace_back(v);
     return;
   }
@@ -540,7 +540,7 @@ void SILBuilder::emitDestructureAddressOperation(
 
   // If we do not have a tuple or a struct, add to our results list.
   SILType type = v->getType();
-  if (!(type.is<TupleType>() || type.getStructOrBoundGenericStruct())) {
+  if (!(type.is<TupleType>() || type.getStructDecl())) {
     results.emplace_back(v);
     return;
   }

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -660,7 +660,7 @@ static SymbolicValue getIndexedElement(SymbolicValue aggregate,
 
   SymbolicValue elt = aggregate.getAggregateValue()[elementNo];
   Type eltType;
-  if (auto *decl = type->getStructOrBoundGenericStruct()) {
+  if (auto *decl = type->getStructDecl()) {
     auto it = decl->getStoredProperties().begin();
     std::advance(it, elementNo);
     eltType = (*it)->getType();
@@ -704,7 +704,7 @@ static SymbolicValue setIndexedElement(SymbolicValue aggregate,
   if (aggregate.getKind() == SymbolicValue::UninitMemory) {
     unsigned numMembers;
     // We need to have either a struct or a tuple type.
-    if (auto *decl = type->getStructOrBoundGenericStruct()) {
+    if (auto *decl = type->getStructDecl()) {
       numMembers = std::distance(decl->getStoredProperties().begin(),
                                  decl->getStoredProperties().end());
     } else if (auto tuple = type->getAs<TupleType>()) {
@@ -725,7 +725,7 @@ static SymbolicValue setIndexedElement(SymbolicValue aggregate,
 
   ArrayRef<SymbolicValue> oldElts = aggregate.getAggregateValue();
   Type eltType;
-  if (auto *decl = type->getStructOrBoundGenericStruct()) {
+  if (auto *decl = type->getStructDecl()) {
     auto it = decl->getStoredProperties().begin();
     std::advance(it, elementNo);
     eltType = (*it)->getType();

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -458,7 +458,7 @@ bool SILFunction::hasSelfMetadataParam() const {
       selfTy = dynamicSelfTy.getSelfType();
   }
 
-  return !!selfTy.getClassOrBoundGenericClass();
+  return !!selfTy.getClassDecl();
 }
 
 bool SILFunction::hasName(const char *Name) const {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -105,7 +105,7 @@ SILFunctionType::getWitnessMethodClass() const {
     assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
     auto superclass = genericSig->getSuperclassBound(paramTy);
     if (superclass)
-      return superclass->getClassOrBoundGenericClass();
+      return superclass->getClassDecl();
   }
 
   return nullptr;
@@ -397,7 +397,7 @@ static bool isClangTypeMoreIndirectThanSubstType(SILModule &M,
       return isClangTypeMoreIndirectThanSubstType(M,
                     clangTy->getPointeeType().getTypePtr(), CanType(eltTy));
 
-    if (substTy->getAnyNominal() ==
+    if (substTy->getNominalTypeDecl() ==
           M.getASTContext().getOpaquePointerDecl())
       // TODO: We could conceivably have an indirect opaque ** imported
       // as COpaquePointer. That shouldn't ever happen today, though,
@@ -407,8 +407,8 @@ static bool isClangTypeMoreIndirectThanSubstType(SILModule &M,
 
     if (clangTy->getPointeeType()->getAs<clang::RecordType>()) {
       // CF type as foreign class
-      if (substTy->getClassOrBoundGenericClass() &&
-          substTy->getClassOrBoundGenericClass()->getForeignClassKind() ==
+      if (substTy->getClassDecl() &&
+          substTy->getClassDecl()->getForeignClassKind() ==
             ClassDecl::ForeignKind::CFType) {
         return false;
       }
@@ -1449,7 +1449,7 @@ public:
         return ResultConvention::UnownedInnerPointer;
 
       auto type = tl.getLoweredType();
-      if (type.unwrapOptionalType().getStructOrBoundGenericStruct()
+      if (type.unwrapOptionalType().getStructDecl()
           == type.getASTContext().getUnmanagedDecl())
         return ResultConvention::UnownedInnerPointer;
       return ResultConvention::Unowned;
@@ -1950,7 +1950,7 @@ static bool isClassOrProtocolMethod(ValueDecl *vd) {
   Type contextType = vd->getDeclContext()->getDeclaredInterfaceType();
   if (!contextType)
     return false;
-  return contextType->getClassOrBoundGenericClass()
+  return contextType->getClassDecl()
     || contextType->isClassExistentialType();
 }
 

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -877,7 +877,7 @@ StructInst::StructInst(SILDebugLocation Loc, SILType Ty,
           Elems, Loc, Ty,
           HasOwnership ? *mergeSILValueOwnership(Elems)
                        : ValueOwnershipKind(ValueOwnershipKind::Any)) {
-  assert(!Ty.getStructOrBoundGenericStruct()->hasUnreferenceableStorage());
+  assert(!Ty.getStructDecl()->hasUnreferenceableStorage());
 }
 
 ObjectInst *ObjectInst::create(SILDebugLocation Loc, SILType Ty,
@@ -1458,7 +1458,7 @@ namespace {
     assert(inst->hasDefault() && "doesn't have a default");
     SILType enumType = enumValue->getType();
 
-    EnumDecl *decl = enumType.getEnumOrBoundGenericEnum();
+    EnumDecl *decl = enumType.getEnumDecl();
     assert(decl && "switch_enum operand is not an enum");
 
     const SILFunction *F = inst->getFunction();
@@ -1550,7 +1550,7 @@ NullablePtr<EnumElementDecl>
 SwitchEnumInstBase::getUniqueCaseForDestination(SILBasicBlock *BB) {
   SILValue value = getOperand();
   SILType enumType = value->getType();
-  EnumDecl *decl = enumType.getEnumOrBoundGenericEnum();
+  EnumDecl *decl = enumType.getEnumDecl();
   assert(decl && "switch_enum operand is not an enum");
   (void)decl;
 
@@ -2365,7 +2365,7 @@ static void computeAggregateFirstLevelSubtypeInfo(
 DestructureStructInst *DestructureStructInst::create(SILModule &M,
                                                      SILDebugLocation Loc,
                                                      SILValue Operand) {
-  assert(Operand->getType().getStructOrBoundGenericStruct() &&
+  assert(Operand->getType().getStructDecl() &&
          "Expected a struct typed operand?!");
 
   llvm::SmallVector<SILType, 8> Types;

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -139,7 +139,7 @@ SILType SILType::getFieldType(VarDecl *field, SILModule &M) const {
                               field, nullptr)->getCanonicalType();
   }
   auto loweredTy = M.Types.getLoweredType(origFieldTy, substFieldTy);
-  if (isAddress() || getClassOrBoundGenericClass() != nullptr) {
+  if (isAddress() || getClassDecl() != nullptr) {
     return loweredTy.getAddressType();
   } else {
     return loweredTy.getObjectType();
@@ -147,7 +147,7 @@ SILType SILType::getFieldType(VarDecl *field, SILModule &M) const {
 }
 
 SILType SILType::getEnumElementType(EnumElementDecl *elt, SILModule &M) const {
-  assert(elt->getDeclContext() == getEnumOrBoundGenericEnum());
+  assert(elt->getDeclContext() == getEnumDecl());
   assert(elt->hasAssociatedValues());
 
   if (auto objectType = getASTType().getOptionalObjectType()) {
@@ -253,7 +253,7 @@ bool SILType::aggregateContainsRecord(SILType Record, SILModule &Mod) const {
     }
 
     // Then if we have an enum...
-    if (EnumDecl *E = Ty.getEnumOrBoundGenericEnum()) {
+    if (EnumDecl *E = Ty.getEnumDecl()) {
       for (auto Elt : E->getAllElements())
         if (Elt->hasAssociatedValues())
           Worklist.push_back(Ty.getEnumElementType(Elt, Mod));
@@ -261,7 +261,7 @@ bool SILType::aggregateContainsRecord(SILType Record, SILModule &Mod) const {
     }
 
     // Then if we have a struct address...
-    if (StructDecl *S = Ty.getStructOrBoundGenericStruct())
+    if (StructDecl *S = Ty.getStructDecl())
       for (VarDecl *Var : S->getStoredProperties())
         Worklist.push_back(Ty.getFieldType(Var, Mod));
 
@@ -277,7 +277,7 @@ bool SILType::aggregateContainsRecord(SILType Record, SILModule &Mod) const {
 }
 
 bool SILType::aggregateHasUnreferenceableStorage() const {
-  if (auto s = getStructOrBoundGenericStruct()) {
+  if (auto s = getStructDecl()) {
     return s->hasUnreferenceableStorage();
   }
   return false;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -155,7 +155,7 @@ void verifyKeyPathComponent(SILModule &M,
           require(param.getConvention()
                     == ParameterConvention::Direct_Unowned,
                   "indices pointer should be trivial");
-          require(param.getType()->getAnyNominal()
+          require(param.getType()->getNominalTypeDecl()
                     == C.getUnsafeRawPointerDecl(),
                   "indices pointer should be an UnsafeRawPointer");
         }
@@ -166,7 +166,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(substEqualsType->getResults()[0].getConvention()
                   == ResultConvention::Unowned,
                 "result should be unowned");
-        require(substEqualsType->getResults()[0].getType()->getAnyNominal()
+        require(substEqualsType->getResults()[0].getType()->getNominalTypeDecl()
                   == C.getBoolDecl(),
                 "result should be Bool");
       }
@@ -186,7 +186,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(param.getConvention()
                   == ParameterConvention::Direct_Unowned,
                 "indices pointer should be trivial");
-        require(param.getType()->getAnyNominal()
+        require(param.getType()->getNominalTypeDecl()
                   == C.getUnsafeRawPointerDecl(),
                 "indices pointer should be an UnsafeRawPointer");
         
@@ -196,7 +196,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(substHashType->getResults()[0].getConvention()
                   == ResultConvention::Unowned,
                 "result should be unowned");
-        require(substHashType->getResults()[0].getType()->getAnyNominal()
+        require(substHashType->getResults()[0].getType()->getNominalTypeDecl()
                   == C.getIntDecl(),
                 "result should be Int");
       }
@@ -279,7 +279,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(indicesParam.getConvention()
                   == ParameterConvention::Direct_Unowned,
                 "indices pointer should be trivial");
-        require(indicesParam.getType()->getAnyNominal()
+        require(indicesParam.getType()->getNominalTypeDecl()
                   == C.getUnsafeRawPointerDecl(),
                 "indices pointer should be an UnsafeRawPointer");
       }
@@ -333,7 +333,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(indicesParam.getConvention()
                   == ParameterConvention::Direct_Unowned,
                 "indices pointer should be trivial");
-        require(indicesParam.getType()->getAnyNominal()
+        require(indicesParam.getType()->getNominalTypeDecl()
                   == C.getUnsafeRawPointerDecl(),
                 "indices pointer should be an UnsafeRawPointer");
       }
@@ -1022,7 +1022,7 @@ public:
   }
 
   void checkAllocRefInst(AllocRefInst *AI) {
-    require(AI->isObjC() || AI->getType().getClassOrBoundGenericClass(),
+    require(AI->isObjC() || AI->getType().getClassDecl(),
             "alloc_ref must allocate class");
     checkAllocRefBase(AI);
   }
@@ -1411,7 +1411,7 @@ public:
           return true;
         if (t.getASTType() == t.getASTContext().TheNativeObjectType)
           return true;
-        if (auto clas = t.getClassOrBoundGenericClass())
+        if (auto clas = t.getClassDecl())
           // Must be a class defined in Swift.
           return clas->hasKnownSwiftImplementation();
         return false;
@@ -1888,7 +1888,7 @@ public:
     require(MU->getModule().getStage() == SILStage::Raw,
             "mark_uninitialized instruction can only exist in raw SIL");
     require(Src->getType().isAddress() ||
-            Src->getType().getClassOrBoundGenericClass() ||
+            Src->getType().getClassDecl() ||
             Src->getType().getAs<SILBoxType>(),
             "mark_uninitialized must be an address, class, or box type");
     require(Src->getType() == MU->getType(),"operand and result type mismatch");
@@ -2088,7 +2088,7 @@ public:
   }
   
   void checkStructInst(StructInst *SI) {
-    auto *structDecl = SI->getType().getStructOrBoundGenericStruct();
+    auto *structDecl = SI->getType().getStructDecl();
     require(structDecl, "StructInst must return a struct");
     require(!structDecl->hasUnreferenceableStorage(),
             "Cannot build a struct with unreferenceable storage from elements "
@@ -2116,7 +2116,7 @@ public:
   }
 
   void checkEnumInst(EnumInst *UI) {
-    EnumDecl *ud = UI->getType().getEnumOrBoundGenericEnum();
+    EnumDecl *ud = UI->getType().getEnumDecl();
     require(ud, "EnumInst must return an enum");
     require(UI->getElement()->getParentEnum() == ud,
             "EnumInst case must be a case of the result enum type");
@@ -2138,7 +2138,7 @@ public:
   }
 
   void checkInitEnumDataAddrInst(InitEnumDataAddrInst *UI) {
-    EnumDecl *ud = UI->getOperand()->getType().getEnumOrBoundGenericEnum();
+    EnumDecl *ud = UI->getOperand()->getType().getEnumDecl();
     require(ud, "InitEnumDataAddrInst must take an enum operand");
     require(UI->getElement()->getParentEnum() == ud,
             "InitEnumDataAddrInst case must be a case of the enum operand type");
@@ -2161,7 +2161,7 @@ public:
   }
 
   void checkUncheckedEnumDataInst(UncheckedEnumDataInst *UI) {
-    EnumDecl *ud = UI->getOperand()->getType().getEnumOrBoundGenericEnum();
+    EnumDecl *ud = UI->getOperand()->getType().getEnumDecl();
     require(ud, "UncheckedEnumData must take an enum operand");
     require(UI->getElement()->getParentEnum() == ud,
             "UncheckedEnumData case must be a case of the enum operand type");
@@ -2183,7 +2183,7 @@ public:
   }
 
   void checkUncheckedTakeEnumDataAddrInst(UncheckedTakeEnumDataAddrInst *UI) {
-    EnumDecl *ud = UI->getOperand()->getType().getEnumOrBoundGenericEnum();
+    EnumDecl *ud = UI->getOperand()->getType().getEnumDecl();
     require(ud, "UncheckedTakeEnumDataAddrInst must take an enum operand");
     require(UI->getElement()->getParentEnum() == ud,
             "UncheckedTakeEnumDataAddrInst case must be a case of the enum operand type");
@@ -2209,7 +2209,7 @@ public:
               || IUAI->getOperand()->getType().is<BoundGenericEnumType>(),
             "InjectEnumAddrInst must take an enum operand");
     require(IUAI->getElement()->getParentEnum()
-              == IUAI->getOperand()->getType().getEnumOrBoundGenericEnum(),
+              == IUAI->getOperand()->getType().getEnumDecl(),
             "InjectEnumAddrInst case must be a case of the enum operand type");
     require(IUAI->getOperand()->getType().isAddress(),
             "InjectEnumAddrInst must take an address operand");
@@ -2290,7 +2290,7 @@ public:
   void checkDeallocRefInst(DeallocRefInst *DI) {
     require(DI->getOperand()->getType().isObject(),
             "Operand of dealloc_ref must be object");
-    auto *cd = DI->getOperand()->getType().getClassOrBoundGenericClass();
+    auto *cd = DI->getOperand()->getType().getClassDecl();
     require(cd, "Operand of dealloc_ref must be of class type");
 
     if (!DI->canAllocOnStack()) {
@@ -2302,13 +2302,13 @@ public:
   void checkDeallocPartialRefInst(DeallocPartialRefInst *DPRI) {
     require(DPRI->getInstance()->getType().isObject(),
             "First operand of dealloc_partial_ref must be object");
-    auto class1 = DPRI->getInstance()->getType().getClassOrBoundGenericClass();
+    auto class1 = DPRI->getInstance()->getType().getClassDecl();
     require(class1,
             "First operand of dealloc_partial_ref must be of class type");
     require(DPRI->getMetatype()->getType().is<MetatypeType>(),
             "Second operand of dealloc_partial_ref must be a metatype");
     auto class2 = DPRI->getMetatype()->getType().castTo<MetatypeType>()
-        ->getInstanceType()->getClassOrBoundGenericClass();
+        ->getInstanceType()->getClassDecl();
     require(class2,
             "Second operand of dealloc_partial_ref must be a class metatype");
     while (class1 != class2) {
@@ -2405,7 +2405,7 @@ public:
             "cannot struct_extract from address");
     require(EI->getType().isObject(),
             "result of struct_extract cannot be address");
-    StructDecl *sd = operandTy.getStructOrBoundGenericStruct();
+    StructDecl *sd = operandTy.getStructDecl();
     require(sd, "must struct_extract from struct");
     require(!sd->isResilient(F.getModule().getSwiftModule(),
                              F.getResilienceExpansion()),
@@ -2449,7 +2449,7 @@ public:
     SILType operandTy = EI->getOperand()->getType();
     require(operandTy.isAddress(),
             "must derive struct_element_addr from address");
-    StructDecl *sd = operandTy.getStructOrBoundGenericStruct();
+    StructDecl *sd = operandTy.getStructDecl();
     require(sd, "struct_element_addr operand must be struct address");
     require(!sd->isResilient(F.getModule().getSwiftModule(),
                              F.getResilienceExpansion()),
@@ -2481,7 +2481,7 @@ public:
     require(EI->getField()->hasStorage(),
             "cannot get address of computed property with ref_element_addr");
     SILType operandTy = EI->getOperand()->getType();
-    ClassDecl *cd = operandTy.getClassOrBoundGenericClass();
+    ClassDecl *cd = operandTy.getClassDecl();
     require(cd, "ref_element_addr operand must be a class instance");
     require(!cd->isResilient(F.getModule().getSwiftModule(),
                              F.getResilienceExpansion()),
@@ -2504,7 +2504,7 @@ public:
     require(RTAI->getType().isAddress(),
             "result of ref_tail_addr must be lvalue");
     SILType operandTy = RTAI->getOperand()->getType();
-    ClassDecl *cd = operandTy.getClassOrBoundGenericClass();
+    ClassDecl *cd = operandTy.getClassDecl();
     require(cd, "ref_tail_addr operand must be a class instance");
     require(!cd->isResilient(F.getModule().getSwiftModule(),
                              F.getResilienceExpansion()),
@@ -2514,7 +2514,7 @@ public:
 
   void checkDestructureStructInst(DestructureStructInst *DSI) {
     SILType operandTy = DSI->getOperand()->getType();
-    StructDecl *sd = operandTy.getStructOrBoundGenericStruct();
+    StructDecl *sd = operandTy.getStructDecl();
     require(sd, "must struct_extract from struct");
     require(!sd->isResilient(F.getModule().getSwiftModule(),
                              F.getResilienceExpansion()),
@@ -2712,7 +2712,7 @@ public:
     // The method ought to appear in the class vtable.
     require(VerifyClassMethodVisitor(
                              operandType.getASTType()->getMetatypeInstanceType()
-                                       ->getClassOrBoundGenericClass(),
+                                       ->getClassDecl(),
                              member).Seen,
             "method does not appear in the class's vtable");
   }
@@ -2743,13 +2743,13 @@ public:
     auto decl = CMI->getMember().getDecl();
     auto methodClass = decl->getDeclContext()->getDeclaredInterfaceType();
 
-    require(methodClass->getClassOrBoundGenericClass(),
+    require(methodClass->getClassDecl(),
             "super_method must look up a class method");
 
     // The method ought to appear in the class vtable.
     require(VerifyClassMethodVisitor(
                              operandType.getASTType()->getMetatypeInstanceType()
-                                       ->getClassOrBoundGenericClass(),
+                                       ->getClassDecl(),
                              member).Seen,
             "method does not appear in the class's vtable");    
   }
@@ -2772,7 +2772,7 @@ public:
     if (auto metatypeType = dyn_cast<MetatypeType>(operandInstanceType))
       operandInstanceType = metatypeType.getInstanceType();
 
-    if (operandInstanceType.getClassOrBoundGenericClass()) {
+    if (operandInstanceType.getClassDecl()) {
       auto overrideTy = TC.getConstantOverrideType(member);
       requireSameType(
           OMI->getType(), SILType::getPrimitiveObjectType(overrideTy),
@@ -2820,7 +2820,7 @@ public:
     auto decl = member.getDecl();
     auto methodClass = decl->getDeclContext()->getDeclaredInterfaceType();
 
-    require(methodClass->getClassOrBoundGenericClass(),
+    require(methodClass->getClassDecl(),
             "objc_super_method must look up a class method");
   }
 
@@ -3329,9 +3329,9 @@ public:
     }
 
     if (isExact) {
-      require(fromCanTy.getClassOrBoundGenericClass(),
+      require(fromCanTy.getClassDecl(),
               "downcast operand must be a class type");
-      require(toCanTy.getClassOrBoundGenericClass(),
+      require(toCanTy.getClassDecl(),
               "downcast must convert to a class type");
       require(SILType::getPrimitiveObjectType(fromCanTy).
               isBindableToSuperclassOf(SILType::getPrimitiveObjectType(toCanTy)),
@@ -3510,7 +3510,7 @@ public:
               "upcast operand must be a class or class metatype instance");
       CanType opInstTy(UI->getOperand()->getType().castTo<MetatypeType>()
                          ->getInstanceType());
-      auto instClass = instTy->getClassOrBoundGenericClass();
+      auto instClass = instTy->getClassDecl();
       require(instClass,
               "upcast must convert a class metatype to a class metatype");
       
@@ -3544,7 +3544,7 @@ public:
           FromTy.getASTType().getOptionalObjectType());
     }
 
-    auto ToClass = ToTy.getClassOrBoundGenericClass();
+    auto ToClass = ToTy.getClassDecl();
     require(ToClass,
             "upcast must convert a class instance to a class type");
       if (ToClass->usesObjCGenericsModel()) {
@@ -3801,7 +3801,7 @@ public:
   }
 
   void checkSelectEnumCases(SelectEnumInstBase *I) {
-    EnumDecl *eDecl = I->getEnumOperand()->getType().getEnumOrBoundGenericEnum();
+    EnumDecl *eDecl = I->getEnumOperand()->getType().getEnumDecl();
     require(eDecl, "select_enum operand must be an enum");
 
     // Find the set of enum elements for the type so we can verify
@@ -3941,7 +3941,7 @@ public:
             "switch_enum operand must be an object");
 
     SILType uTy = SOI->getOperand()->getType();
-    EnumDecl *uDecl = uTy.getEnumOrBoundGenericEnum();
+    EnumDecl *uDecl = uTy.getEnumDecl();
     require(uDecl, "switch_enum operand is not an enum");
 
     // Find the set of enum elements for the type so we can verify
@@ -4026,7 +4026,7 @@ public:
             "switch_enum_addr operand must be an address");
 
     SILType uTy = SOI->getOperand()->getType();
-    EnumDecl *uDecl = uTy.getEnumOrBoundGenericEnum();
+    EnumDecl *uDecl = uTy.getEnumDecl();
     require(uDecl, "switch_enum_addr operand must be an enum");
 
     // Find the set of enum elements for the type so we can verify
@@ -4241,7 +4241,7 @@ public:
             "objc_protocol must be applied to an @objc protocol");
     auto classTy = OPI->getType();
     require(classTy.isObject(), "objc_protocol must produce a value");
-    auto classDecl = classTy.getClassOrBoundGenericClass();
+    auto classDecl = classTy.getClassDecl();
     require(classDecl, "objc_protocol must produce a class instance");
     require(classDecl->getName() == F.getASTContext().Id_Protocol,
             "objc_protocol must produce an instance of ObjectiveC.Protocol class");

--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -175,7 +175,7 @@ bool SILWitnessTable::conformanceIsSerialized(
   if (conformance->getProtocol()->getEffectiveAccess() < AccessLevel::Public)
     return false;
 
-  auto *nominal = conformance->getType()->getAnyNominal();
+  auto *nominal = conformance->getType()->getNominalTypeDecl();
   return nominal->getEffectiveAccess() >= AccessLevel::Public;
 }
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -881,7 +881,7 @@ namespace {
     void lowerChildren(SILModule &M, SmallVectorImpl<Child> &children)
     const override {
       auto silTy = getLoweredType();
-      auto structDecl = silTy.getStructOrBoundGenericStruct();
+      auto structDecl = silTy.getStructDecl();
       assert(structDecl);
       
       for (auto prop : structDecl->getStoredProperties()) {
@@ -2145,7 +2145,7 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
           //
           // However, only do this if its a 'let'; if the capture is
           // mutable, we're going to be capturing a box or an address.
-          if (captureType->getClassOrBoundGenericClass() &&
+          if (captureType->getClassDecl() &&
               capturedVar->isLet()) {
             if (selfCapture)
               selfCapture = selfCapture->mergeFlags(capture);
@@ -2466,7 +2466,7 @@ TypeConverter::getContextBoxTypeForCapture(ValueDecl *captured,
 CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
                                                       EnumElementDecl *elt) {
 
-  auto *enumDecl = enumType.getEnumOrBoundGenericEnum();
+  auto *enumDecl = enumType.getEnumDecl();
 
   assert(elt->getDeclContext() == enumDecl);
   assert(elt->isIndirect() || elt->getParentEnum()->isIndirect());
@@ -2502,7 +2502,7 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
 
 static void countNumberOfInnerFields(unsigned &fieldsCount, SILModule &Module,
                                      SILType Ty) {
-  if (auto *structDecl = Ty.getStructOrBoundGenericStruct()) {
+  if (auto *structDecl = Ty.getStructDecl()) {
     // FIXME: Expansion
     assert(!structDecl->isResilient(Module.getSwiftModule(),
                                     ResilienceExpansion::Minimal) &&
@@ -2527,7 +2527,7 @@ static void countNumberOfInnerFields(unsigned &fieldsCount, SILModule &Module,
     }
     return;
   }
-  if (auto *enumDecl = Ty.getEnumOrBoundGenericEnum()) {
+  if (auto *enumDecl = Ty.getEnumDecl()) {
     if (enumDecl->isIndirect()) {
       return;
     }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -966,7 +966,7 @@ bool SILGenModule::requiresIVarDestroyer(ClassDecl *cd) {
   // the superclass is not @objc.
   return (hasNonTrivialIVars(cd) &&
           cd->getSuperclass() &&
-          !cd->getSuperclass()->getClassOrBoundGenericClass()->hasClangNode());
+          !cd->getSuperclass()->getClassDecl()->hasClangNode());
 }
 
 /// TODO: This needs a better name.

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -66,7 +66,7 @@ MetatypeInst *SILGenBuilder::createMetatype(SILLocation loc, SILType metatype) {
   case MetatypeRepresentation::ObjC: {
     // Walk the type recursively to look for substitutions we may need.
     theMetatype.getInstanceType().findIf([&](Type t) -> bool {
-      auto *decl = t->getAnyNominal();
+      auto *decl = t->getNominalTypeDecl();
       if (!decl)
         return false;
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -121,7 +121,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
 
   emitConstructorMetatypeArg(SGF, ctor);
 
-  auto *decl = selfTy.getStructOrBoundGenericStruct();
+  auto *decl = selfTy.getStructDecl();
   assert(decl && "not a struct?!");
 
   // If we have an indirect return slot, initialize it in-place.

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -54,7 +54,7 @@ void SILGenFunction::emitDestroyingDestructor(DestructorDecl *dd) {
   SILType classTy = selfValue->getType();
   if (cd->hasSuperclass()) {
     Type superclassTy = dd->mapTypeIntoContext(cd->getSuperclass());
-    ClassDecl *superclass = superclassTy->getClassOrBoundGenericClass();
+    ClassDecl *superclass = superclassTy->getClassDecl();
     auto superclassDtorDecl = superclass->getDestructor();
     SILDeclRef dtorConstant =
       SILDeclRef(superclassDtorDecl, SILDeclRef::Kind::Destroyer);
@@ -114,7 +114,7 @@ void SILGenFunction::emitDeallocatingDestructor(DestructorDecl *dd) {
   // Form a reference to the destroying destructor.
   SILDeclRef dtorConstant(dd, SILDeclRef::Kind::Destroyer);
   auto classTy = initialSelfValue->getType();
-  auto classDecl = classTy.getASTType()->getAnyNominal();
+  auto classDecl = classTy.getASTType()->getNominalTypeDecl();
   ManagedValue dtorValue;
   SILType dtorTy;
   auto subMap = classTy.getASTType()
@@ -229,7 +229,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   // Form a reference to the superclass -dealloc.
   Type superclassTy = dd->mapTypeIntoContext(cd->getSuperclass());
   assert(superclassTy && "Emitting Objective-C -dealloc without superclass?");
-  ClassDecl *superclass = superclassTy->getClassOrBoundGenericClass();
+  ClassDecl *superclass = superclassTy->getClassDecl();
   auto superclassDtorDecl = superclass->getDestructor();
   auto superclassDtor = SILDeclRef(superclassDtorDecl,
                                    SILDeclRef::Kind::Deallocator)

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -348,14 +348,14 @@ static RValue emitCollectionDowncastExpr(SILGenFunction &SGF,
   // Get the intrinsic function.
   auto &ctx = SGF.getASTContext();
   FuncDecl *fn = nullptr;
-  if (fromCollection->getAnyNominal() == ctx.getArrayDecl()) {
+  if (fromCollection->getNominalTypeDecl() == ctx.getArrayDecl()) {
     fn = conditional ? SGF.SGM.getArrayConditionalCast(loc)
                      : SGF.SGM.getArrayForceCast(loc);
-  } else if (fromCollection->getAnyNominal() == ctx.getDictionaryDecl()) {
+  } else if (fromCollection->getNominalTypeDecl() == ctx.getDictionaryDecl()) {
     fn = (conditional
            ? SGF.SGM.getDictionaryDownCastConditional(loc)
            : SGF.SGM.getDictionaryDownCast(loc));
-  } else if (fromCollection->getAnyNominal() == ctx.getSetDecl()) {
+  } else if (fromCollection->getNominalTypeDecl() == ctx.getSetDecl()) {
     fn = (conditional
            ? SGF.SGM.getSetDownCastConditional(loc)
            : SGF.SGM.getSetDownCast(loc));

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -110,7 +110,7 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &SGF,
 /// Emit a value of a certain integer-like type.
 static SILValue emitIntValue(SILGenFunction &SGF, SILLocation loc,
                              SILType type, unsigned value) {
-  if (auto structDecl = type.getStructOrBoundGenericStruct()) {
+  if (auto structDecl = type.getStructDecl()) {
     auto properties = structDecl->getStoredProperties();
     assert(std::next(properties.begin()) == properties.end());
     SILType fieldType = type.getFieldType(*properties.begin(), SGF.SGM.M);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -696,7 +696,7 @@ SILValue SILGenFunction::emitUnwrapIntegerResult(SILLocation loc,
   // This is a loop because we want to handle types that wrap integer types,
   // like ObjCBool (which may be Bool or Int8).
   while (!value->getType().is<BuiltinIntegerType>()) {
-    auto structDecl = value->getType().getStructOrBoundGenericStruct();
+    auto structDecl = value->getType().getStructDecl();
     assert(structDecl && "value for error result wasn't of struct type!");
     assert(std::next(structDecl->getStoredProperties().begin())
            == structDecl->getStoredProperties().end());

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2983,7 +2983,7 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       if (BaseFormalType->mayHaveSuperclass()) {
         LV.add<RefElementComponent>(Storage, Options, varStorageType, typeData);
       } else {
-        assert(BaseFormalType->getStructOrBoundGenericStruct());
+        assert(BaseFormalType->getStructDecl());
         LV.add<StructElementComponent>(Storage, varStorageType, typeData);
       }
 
@@ -3059,7 +3059,7 @@ LValue SILGenLValue::visitKeyPathApplicationExpr(KeyPathApplicationExpr *e,
                                                  LValueOptions options) {
   auto keyPathExpr = e->getKeyPath();
   auto keyPathKind =
-    *keyPathExpr->getType()->getAnyNominal()->getKeyPathTypeKind();
+    *keyPathExpr->getType()->getNominalTypeDecl()->getKeyPathTypeKind();
 
   // Determine the base access strategy based on the strategy of this access.
   SGFAccessKind subAccess;
@@ -3946,8 +3946,8 @@ RValue SILGenFunction::emitRValueForStorageLoad(
 
   // rvalue MemberRefExprs are produced in two cases: when accessing a 'let'
   // decl member, and when the base is a (non-lvalue) struct.
-  assert(baseFormalType->getAnyNominal() &&
-         base.getType().getASTType()->getAnyNominal() &&
+  assert(baseFormalType->getNominalTypeDecl() &&
+         base.getType().getASTType()->getNominalTypeDecl() &&
          "The base of an rvalue MemberRefExpr should be an rvalue value");
 
   // If the accessed field is stored, emit a StructExtract on the base.

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1763,7 +1763,7 @@ CaseBlocks::CaseBlocks(
   CaseInfos.reserve(rows.size());
   CaseCounts.reserve(rows.size());
 
-  auto enumDecl = sourceType.getEnumOrBoundGenericEnum();
+  auto enumDecl = sourceType.getEnumDecl();
 
   llvm::SmallDenseMap<EnumElementDecl *, unsigned, 16> caseToIndex;
   for (auto &row : rows) {
@@ -2802,7 +2802,7 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
 
     // Special case: if it's a single @objc enum, we can print the raw value.
     CanType ty = S->getSubjectExpr()->getType()->getCanonicalType();
-    if (auto *singleEnumDecl = ty->getEnumOrBoundGenericEnum()) {
+    if (auto *singleEnumDecl = ty->getEnumDecl()) {
       if (singleEnumDecl->isObjC()) {
         emitDiagnoseOfUnexpectedEnumCaseValue(*this, location,
                                               subject.getFinalManagedValue(),

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -332,7 +332,7 @@ RValue Transform::transform(RValue &&input,
 // Single @objc protocol value metatypes can be converted to the ObjC
 // Protocol class type.
 static bool isProtocolClass(Type t) {
-  auto classDecl = t->getClassOrBoundGenericClass();
+  auto classDecl = t->getClassDecl();
   if (!classDecl)
     return false;
 
@@ -476,10 +476,10 @@ ManagedValue Transform::transform(ManagedValue v,
   }
 
   //  - upcasts for classes
-  if (outputSubstType->getClassOrBoundGenericClass() &&
-      inputSubstType->getClassOrBoundGenericClass()) {
-    auto class1 = inputSubstType->getClassOrBoundGenericClass();
-    auto class2 = outputSubstType->getClassOrBoundGenericClass();
+  if (outputSubstType->getClassDecl() &&
+      inputSubstType->getClassDecl()) {
+    auto class1 = inputSubstType->getClassDecl();
+    auto class2 = outputSubstType->getClassDecl();
 
     // CF <-> Objective-C via toll-free bridging.
     if ((class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType) ^
@@ -501,10 +501,10 @@ ManagedValue Transform::transform(ManagedValue v,
   }
 
   // - upcasts for collections
-  if (outputSubstType->getStructOrBoundGenericStruct() &&
-      inputSubstType->getStructOrBoundGenericStruct()) {
-    auto *inputStruct = inputSubstType->getStructOrBoundGenericStruct();
-    auto *outputStruct = outputSubstType->getStructOrBoundGenericStruct();
+  if (outputSubstType->getStructDecl() &&
+      inputSubstType->getStructDecl()) {
+    auto *inputStruct = inputSubstType->getStructDecl();
+    auto *outputStruct = outputSubstType->getStructDecl();
 
     // Attempt collection upcast only if input and output declarations match.
     if (inputStruct == outputStruct) {
@@ -527,7 +527,7 @@ ManagedValue Transform::transform(ManagedValue v,
   }
 
   //  - upcasts from an archetype
-  if (outputSubstType->getClassOrBoundGenericClass()) {
+  if (outputSubstType->getClassDecl()) {
     if (auto archetypeType = dyn_cast<ArchetypeType>(inputSubstType)) {
       if (archetypeType->getSuperclass()) {
         // Replace the cleanup with a new one on the superclass value so we
@@ -609,7 +609,7 @@ ManagedValue Transform::transform(ManagedValue v,
 
   // - T : Hashable to AnyHashable
   if (isa<StructType>(outputSubstType) &&
-      outputSubstType->getAnyNominal() ==
+      outputSubstType->getNominalTypeDecl() ==
         SGF.getASTContext().getAnyHashableDecl()) {
     auto *protocol = SGF.getASTContext().getProtocol(
         KnownProtocolKind::Hashable);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -244,7 +244,7 @@ public:
   void visitAncestor(ClassDecl *ancestor) {
     auto superTy = ancestor->getSuperclass();
     if (superTy)
-      visitAncestor(superTy->getClassOrBoundGenericClass());
+      visitAncestor(superTy->getClassDecl());
 
     addVTableEntries(ancestor);
   }

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -567,7 +567,7 @@ std::string AccessSummaryAnalysis::getSubPathDescription(
   for (unsigned index : reversed(reversedIndices)) {
     os << ".";
 
-    if (StructDecl *D = containingType.getStructOrBoundGenericStruct()) {
+    if (StructDecl *D = containingType.getStructDecl()) {
       auto iter = D->getStoredProperties().begin();
       std::advance(iter, index);
       VarDecl *var = *iter;

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -459,7 +459,7 @@ static bool typedAccessTBAAMayAlias(SILType LTy, SILType RTy, SILModule &Mod) {
   if (RTy.is<BuiltinRawPointerType>())
     return true;
 
-  ClassDecl *LTyClass = LTy.getClassOrBoundGenericClass();
+  ClassDecl *LTyClass = LTy.getClassDecl();
 
   // The Builtin reference types can alias any class instance.
   if (LTyClass) {
@@ -487,19 +487,19 @@ static bool typedAccessTBAAMayAlias(SILType LTy, SILType RTy, SILModule &Mod) {
     return false;
 
   // Structs do not alias non-structs.
-  StructDecl *LTyStruct = LTy.getStructOrBoundGenericStruct();
-  StructDecl *RTyStruct = RTy.getStructOrBoundGenericStruct();
+  StructDecl *LTyStruct = LTy.getStructDecl();
+  StructDecl *RTyStruct = RTy.getStructDecl();
   if ((LTyStruct && !RTyStruct) || (!LTyStruct && RTyStruct))
     return false;
 
   // Enums do not alias non-enums.
-  EnumDecl *LTyEnum = LTy.getEnumOrBoundGenericEnum();
-  EnumDecl *RTyEnum = RTy.getEnumOrBoundGenericEnum();
+  EnumDecl *LTyEnum = LTy.getEnumDecl();
+  EnumDecl *RTyEnum = RTy.getEnumDecl();
   if ((LTyEnum && !RTyEnum) || (!LTyEnum && RTyEnum))
     return false;
 
   // Classes do not alias non-classes.
-  ClassDecl *RTyClass = RTy.getClassOrBoundGenericClass();
+  ClassDecl *RTyClass = RTy.getClassDecl();
   if ((LTyClass && !RTyClass) || (!LTyClass && RTyClass))
     return false;
 

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -276,7 +276,7 @@ CalleeList CalleeCache::getCalleeList(SILInstruction *I) const {
   auto Ty = I->getOperand(0)->getType();
   while (auto payloadTy = Ty.getOptionalObjectType())
     Ty = payloadTy;
-  auto Class = Ty.getClassOrBoundGenericClass();
+  auto Class = Ty.getClassDecl();
   if (!Class || Class->hasClangNode() || !Class->hasDestructor())
     return CalleeList();
   SILDeclRef Destructor = SILDeclRef(Class->getDestructor());

--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -64,7 +64,7 @@ bool DestructorAnalysis::isSafeType(CanType Ty) {
   //   * either it implements the _DestructorSafeContainer protocol and
   //     all the type parameters are safe types.
   //   * or all stored properties are safe types.
-  if (auto *Struct = Ty->getStructOrBoundGenericStruct()) {
+  if (auto *Struct = Ty->getStructDecl()) {
 
     if (implementsDestructorSafeContainerProtocol(Struct) &&
         areTypeParametersSafe(Ty))

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1041,7 +1041,7 @@ static bool mayContainReference(SILType Ty, SILModule *Mod) {
   if (Ty.getASTType() == Mod->getASTContext().TheRawPointerType)
     return true;
 
-  if (auto *Str = Ty.getStructOrBoundGenericStruct()) {
+  if (auto *Str = Ty.getStructDecl()) {
     for (auto *Field : Str->getStoredProperties()) {
       if (mayContainReference(Ty.getFieldType(Field, *Mod), Mod))
         return true;
@@ -1055,7 +1055,7 @@ static bool mayContainReference(SILType Ty, SILModule *Mod) {
     }
     return false;
   }
-  if (auto En = Ty.getEnumOrBoundGenericEnum()) {
+  if (auto En = Ty.getEnumDecl()) {
     for (auto *ElemDecl : En->getAllElements()) {
       if (ElemDecl->hasAssociatedValues()
           && mayContainReference(Ty.getEnumElementType(ElemDecl, *Mod), Mod))
@@ -1196,7 +1196,7 @@ bool EscapeAnalysis::buildConnectionGraphForDestructor(
   // destructors for its components.
   while (auto payloadTy = Ty.getOptionalObjectType())
     Ty = payloadTy;
-  auto Class = Ty.getClassOrBoundGenericClass();
+  auto Class = Ty.getClassDecl();
   if (!Class || !Class->hasDestructor())
     return false;
   auto Destructor = Class->getDestructor();
@@ -1608,7 +1608,7 @@ analyzeSelectInst(SelectInst *SI, ConnectionGraph *ConGraph) {
 bool EscapeAnalysis::deinitIsKnownToNotCapture(SILValue V) {
   for (;;) {
     // The deinit of an array buffer does not capture the array elements.
-    if (V->getType().getNominalOrBoundGenericNominal() == ArrayType)
+    if (V->getType().getNominalTypeDecl() == ArrayType)
       return true;
 
     // The deinit of a box does not capture its content.

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -378,7 +378,7 @@ SILValue RCIdentityFunctionInfo::stripRCIdentityPreservingArgs(SILValue V,
 
   // At this point, we know that we have *some* NoPayloadEnums. If FirstIV is
   // not an enum, then we must bail. We do not try to analyze this case.
-  if (!FirstIV->getType().getEnumOrBoundGenericEnum())
+  if (!FirstIV->getType().getEnumDecl())
     return SILValue();
 
   // Now we know that FirstIV is an enum and that all payloaded enum cases after

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -99,7 +99,7 @@ bool ExistentialSpecializer::findConcreteTypeFromSoleConformingType(
     return false;
   assert(ArgType.isExistentialType());
   /// Find the protocol decl.
-  auto *PD = dyn_cast<ProtocolDecl>(SwiftArgType->getAnyNominal());
+  auto *PD = dyn_cast<ProtocolDecl>(SwiftArgType->getNominalTypeDecl());
   if (!PD)
     return false;
 

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -358,7 +358,7 @@ protected:
           assert(MI->getNumOperands() - MI->getNumTypeDependentOperands() == 1
                  && "method insts except witness_method must have 1 operand");
           ClassDecl *MethodCl = MI->getOperand(0)->getType().
-                                  getClassOrBoundGenericClass();
+                                  getClassDecl();
           MethodInfo *mi = getMethodInfo(funcDecl, /*isWitnessTable*/ false);
           ensureAliveClassMethod(mi, dyn_cast<FuncDecl>(funcDecl), MethodCl);
         } else if (auto *FRI = dyn_cast<FunctionRefInst>(&I)) {

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -107,12 +107,12 @@ class GlobalPropertyOpt {
   llvm::SmallVector<Entry *, 32> WorkList;
   
   bool isArrayType(SILType type) {
-    return type.getNominalOrBoundGenericNominal() == ArrayType &&
+    return type.getNominalTypeDecl() == ArrayType &&
            !type.isAddress();
   }
   
   bool isArrayAddressType(SILType type) {
-    return type.getNominalOrBoundGenericNominal() == ArrayType &&
+    return type.getNominalTypeDecl() == ArrayType &&
            type.isAddress();
   }
   
@@ -121,7 +121,7 @@ class GlobalPropertyOpt {
   bool isTupleWithArray(CanType type) {
     if (auto tuple = dyn_cast<TupleType>(type)) {
       for (Type subType : tuple->getElementTypes()) {
-        if (CanType(subType).getNominalOrBoundGenericNominal() == ArrayType)
+        if (CanType(subType).getNominalTypeDecl() == ArrayType)
           return true;
       }
     }

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -923,7 +923,7 @@ public:
 };
 
 static bool hasArrayType(SILValue Value, SILModule &M) {
-  return Value->getType().getNominalOrBoundGenericNominal() ==
+  return Value->getType().getNominalTypeDecl() ==
            M.getASTContext().getArrayDecl();
 }
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1669,7 +1669,7 @@ protected:
 static SILValue createStructExtract(SILBuilder &B, SILLocation Loc,
                                     SILValue Opd, unsigned FieldNo) {
   SILType Ty = Opd->getType();
-  auto SD = Ty.getStructOrBoundGenericStruct();
+  auto SD = Ty.getStructDecl();
   auto Properties = SD->getStoredProperties();
   unsigned Counter = 0;
   for (auto *D : Properties)

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -80,7 +80,7 @@ static unsigned getElementCountRec(SILModule &Module, SILType T,
   // for each of the tuple members.
   if (IsSelfOfNonDelegatingInitializer) {
     // Protocols never have a stored properties.
-    if (auto *NTD = T.getNominalOrBoundGenericNominal()) {
+    if (auto *NTD = T.getNominalTypeDecl()) {
       unsigned NumElements = 0;
       for (auto *VD : NTD->getStoredProperties())
         NumElements +=
@@ -173,7 +173,7 @@ static SILType getElementTypeRec(SILModule &Module, SILType T, unsigned EltNo,
   // Stored properties with tuple types are tracked with independent lifetimes
   // for each of the tuple members.
   if (IsSelfOfNonDelegatingInitializer) {
-    if (auto *NTD = T.getNominalOrBoundGenericNominal()) {
+    if (auto *NTD = T.getNominalTypeDecl()) {
       bool HasStoredProperties = false;
       for (auto *VD : NTD->getStoredProperties()) {
         HasStoredProperties = true;
@@ -242,7 +242,7 @@ SILValue DIMemoryObjectInfo::emitElementAddress(
     // classes.  Stored properties with tuple types are tracked with independent
     // lifetimes for each of the tuple members.
     if (IsSelf) {
-      if (auto *NTD = PointeeType.getNominalOrBoundGenericNominal()) {
+      if (auto *NTD = PointeeType.getNominalTypeDecl()) {
         bool HasStoredProperties = false;
         for (auto *VD : NTD->getStoredProperties()) {
           if (!HasStoredProperties) {
@@ -347,7 +347,7 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
 
   // If this is indexing into a field of 'self', look it up.
   if (isNonDelegatingInit() && !isDerivedClassSelfOnly()) {
-    if (auto *NTD = MemorySILType.getNominalOrBoundGenericNominal()) {
+    if (auto *NTD = MemorySILType.getNominalTypeDecl()) {
       bool HasStoredProperty = false;
       for (auto *VD : NTD->getStoredProperties()) {
         HasStoredProperty = true;
@@ -390,7 +390,7 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
 
   auto &Module = MemoryInst->getModule();
 
-  auto *NTD = MemorySILType.getNominalOrBoundGenericNominal();
+  auto *NTD = MemorySILType.getNominalTypeDecl();
   if (!NTD) {
     // Otherwise, we miscounted elements?
     assert(Element == 0 && "Element count problem");
@@ -534,7 +534,7 @@ public:
 
     // If this is a delegating initializer, collect uses specially.
     if (IsSelfOfNonDelegatingInitializer &&
-        TheMemory.getType()->getClassOrBoundGenericClass() != nullptr) {
+        TheMemory.getType()->getClassDecl() != nullptr) {
       assert(!TheMemory.isDerivedClassSelfOnly() &&
              "Should have been handled outside of here");
       // If this is a class pointer, we need to look through ref_element_addrs.
@@ -1089,7 +1089,7 @@ void ElementUseCollector::collectUses(SILValue Pointer, unsigned BaseEltNo) {
 /// constructor.  The memory object has class type.
 void ElementUseCollector::collectClassSelfUses() {
   assert(IsSelfOfNonDelegatingInitializer &&
-         TheMemory.getType()->getClassOrBoundGenericClass() != nullptr);
+         TheMemory.getType()->getClassDecl() != nullptr);
 
   // For efficiency of lookup below, compute a mapping of the local ivars in the
   // class to their element number.
@@ -1097,7 +1097,7 @@ void ElementUseCollector::collectClassSelfUses() {
 
   {
     SILType T = TheMemory.MemorySILType;
-    auto *NTD = T.getNominalOrBoundGenericNominal();
+    auto *NTD = T.getNominalTypeDecl();
     unsigned NumElements = 0;
     for (auto *VD : NTD->getStoredProperties()) {
       EltNumbering[VD] = NumElements;
@@ -1811,7 +1811,7 @@ static bool shouldPerformClassInitSelf(const DIMemoryObjectInfo &MemoryInfo) {
     return true;
 
   return MemoryInfo.isNonDelegatingInit() &&
-         MemoryInfo.getType()->getClassOrBoundGenericClass() != nullptr &&
+         MemoryInfo.getType()->getClassDecl() != nullptr &&
          MemoryInfo.isDerivedClassSelfOnly();
 }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -97,7 +97,7 @@ public:
   /// True if the memory object is the 'self' argument of a struct initializer.
   bool isStructInitSelf() const {
     if (MemoryInst->isRootSelf() || MemoryInst->isCrossModuleRootSelf()) {
-      if (auto decl = getType()->getAnyNominal()) {
+      if (auto decl = getType()->getNominalTypeDecl()) {
         if (isa<StructDecl>(decl)) {
           return true;
         }
@@ -123,7 +123,7 @@ public:
       return false;
 
     if (!MemoryInst->isVar()) {
-      if (auto decl = getType()->getAnyNominal()) {
+      if (auto decl = getType()->getNominalTypeDecl()) {
         if (isa<ClassDecl>(decl)) {
           return true;
         }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -999,7 +999,7 @@ void LifetimeChecker::handleStoreUse(unsigned UseID) {
     else
       selfTy = TheMemory.getType();
 
-    StructDecl *theStruct = selfTy->getStructOrBoundGenericStruct();
+    StructDecl *theStruct = selfTy->getStructDecl();
     assert(theStruct);
 
     diagnose(Module, Use.Inst->getLoc(),
@@ -1261,7 +1261,7 @@ void LifetimeChecker::handleEscapeUse(const DIMemoryUse &Use) {
         diagnose(Module, Inst->getLoc(), diag::self_before_selfinit_value_type);
         if (!HasSuggestedNoArgSelfInit && FullyUninitialized) {
           auto *maybeStruct =
-              TheMemory.getType().getStructOrBoundGenericStruct();
+              TheMemory.getType().getStructDecl();
           maybeSuggestNoArgSelfInit(Module, Inst->getLoc(), maybeStruct);
           HasSuggestedNoArgSelfInit = true;
         }
@@ -1598,7 +1598,7 @@ bool LifetimeChecker::diagnoseReturnWithoutInitializingStoredProperties(
   if (TheMemory.isCrossModuleStructInitSelf() &&
       TheMemory.HasDummyElement) {
     Type selfTy = TheMemory.getType();
-    const StructDecl *theStruct = selfTy->getStructOrBoundGenericStruct();
+    const StructDecl *theStruct = selfTy->getStructDecl();
     assert(theStruct);
 
     bool fullyUnitialized;

--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -66,7 +66,7 @@ static bool hasRecursiveCallInPath(SILBasicBlock &Block,
         // Though, this has the added bonus of not looking into vtables
         // outside the current module.  Because we're not doing IPA, let
         // alone cross-module IPA, this is all well and good.
-        auto *BGC = ClassType.getNominalOrBoundGenericNominal();
+        auto *BGC = ClassType.getNominalTypeDecl();
         if (BGC && BGC->getModuleContext() != TargetModule) {
           continue;
         }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -40,7 +40,7 @@ STATISTIC(NumAllocRemoved, "Number of allocations completely removed");
 // from Swift.
 static StructDecl *
 getFullyReferenceableStruct(SILType Ty) {
-  auto SD = Ty.getStructOrBoundGenericStruct();
+  auto SD = Ty.getStructDecl();
   if (!SD || SD->hasUnreferenceableStorage())
     return nullptr;
   return SD;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -692,7 +692,7 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
     if (!ArgType.isExistentialType() || ArgType.isAnyObject() ||
         SwiftArgType->isAny())
       return None;
-    PD = dyn_cast<ProtocolDecl>(SwiftArgType->getAnyNominal());
+    PD = dyn_cast<ProtocolDecl>(SwiftArgType->getNominalTypeDecl());
   }
 
   if (!PD)

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -617,7 +617,7 @@ SILInstruction *SILCombiner::visitStoreInst(StoreInst *si) {
     if (iterAddrType.aggregateHasUnreferenceableStorage())
       break;
 
-    auto *decl = iterAddrType.getStructOrBoundGenericStruct();
+    auto *decl = iterAddrType.getStructDecl();
     assert(
         !decl->isResilient(mod.getSwiftModule(), f->getResilienceExpansion()) &&
         "This code assumes resilient structs can not have fragile fields. If "
@@ -1618,7 +1618,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
   if (auto *MI = dyn_cast<MetatypeInst>(MDVal)) {
     auto &Mod = ARDI->getModule();
     auto SILInstanceTy = MI->getType().getMetatypeInstanceType(Mod);
-    if (!SILInstanceTy.getClassOrBoundGenericClass())
+    if (!SILInstanceTy.getClassDecl())
       return nullptr;
 
     NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
@@ -1641,7 +1641,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     if (CCBI && CCBI->isExact() && ARDI->getParent() == CCBI->getSuccessBB()) {
       auto &Mod = ARDI->getModule();
       auto SILInstanceTy = CCBI->getCastType().getMetatypeInstanceType(Mod);
-      if (!SILInstanceTy.getClassOrBoundGenericClass())
+      if (!SILInstanceTy.getClassDecl())
         return nullptr;
       NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                        ARDI->isObjC(), false,
@@ -1704,7 +1704,7 @@ visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *CBOI) {
     return nullptr;
 
   auto type = URC->getOperand()->getType().getASTType();
-  if (ClassDecl *cd = type->getClassOrBoundGenericClass()) {
+  if (ClassDecl *cd = type->getClassDecl()) {
     if (!cd->isObjC()) {
       auto int1Ty = SILType::getBuiltinIntegerType(1, Builder.getASTContext());
       SILValue zero = Builder.createIntegerLiteral(CBOI->getLoc(),

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -323,14 +323,14 @@ public:
       assert(AppendContentsOf && "Must be AppendContentsOf call");
 
       NominalTypeDecl *AppendSelfArray = AppendContentsOf.getSelf()->getType().
-        getASTType()->getAnyNominal();
+        getASTType()->getNominalTypeDecl();
 
       // In case if it's not an Array, but e.g. an ContiguousArray
       if (AppendSelfArray != Ctx.getArrayDecl())
         continue;
 
       SILType ArrayType = Repl.Array->getType();
-      auto *NTD = ArrayType.getASTType()->getAnyNominal();
+      auto *NTD = ArrayType.getASTType()->getNominalTypeDecl();
       SubstitutionMap ArraySubMap = ArrayType.getASTType()
         ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
       

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -62,7 +62,7 @@ using UserList = llvm::SmallSetVector<SILInstruction *, 16>;
 // so its destructor cannot be extended at runtime.
 static SILFunction *getDestructor(AllocRefInst *ARI) {
   // We only support classes.
-  ClassDecl *ClsDecl = ARI->getType().getClassOrBoundGenericClass();
+  ClassDecl *ClsDecl = ARI->getType().getClassDecl();
   if (!ClsDecl)
     return nullptr;
 

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -28,7 +28,7 @@ class ObjectOutliner {
   int GlobIdx = 0;
 
   bool isCOWType(SILType type) {
-    return type.getNominalOrBoundGenericNominal() == ArrayDecl;
+    return type.getNominalTypeDecl() == ArrayDecl;
   }
 
   bool isValidUseOfObject(SILInstruction *Val, bool isCOWObject,
@@ -310,7 +310,7 @@ bool ObjectOutliner::optimizeObjectAllocation(
   }
 
   SILType Ty = ARI->getType();
-  ClassDecl *Cl = Ty.getClassOrBoundGenericClass();
+  ClassDecl *Cl = Ty.getClassDecl();
   if (!Cl)
     return false;
   llvm::SmallVector<VarDecl *, 16> Fields;
@@ -443,7 +443,7 @@ void ObjectOutliner::replaceFindStringCall(ApplyInst *FindStringCall) {
     return;
 
   SILType cacheType = FTy->getParameters()[2].getSILStorageType().getObjectType();
-  NominalTypeDecl *cacheDecl = cacheType.getNominalOrBoundGenericNominal();
+  NominalTypeDecl *cacheDecl = cacheType.getNominalTypeDecl();
   if (!cacheDecl)
     return;
 

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -565,7 +565,7 @@ public:
   LoadInst *isLoadInstToHandle(SILInstruction *Inst) {
     if (auto *LI = dyn_cast<LoadInst>(Inst)) {
       if (!ArrayType ||
-          LI->getType().getNominalOrBoundGenericNominal() != ArrayType) {
+          LI->getType().getNominalTypeDecl() != ArrayType) {
         return LI;
       }
     }

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -132,7 +132,7 @@ bool ReleaseDevirtualizer::createDeallocCall(SILType AllocType,
                                             SILValue object) {
   LLVM_DEBUG(llvm::dbgs() << "  create dealloc call\n");
 
-  ClassDecl *Cl = AllocType.getClassOrBoundGenericClass();
+  ClassDecl *Cl = AllocType.getClassDecl();
   assert(Cl && "no class type allocated with alloc_ref");
 
   // Find the destructor of the type.
@@ -144,7 +144,7 @@ bool ReleaseDevirtualizer::createDeallocCall(SILType AllocType,
     return false;
 
   CanSILFunctionType DeallocType = Dealloc->getLoweredFunctionType();
-  auto *NTD = AllocType.getASTType()->getAnyNominal();
+  auto *NTD = AllocType.getASTType()->getNominalTypeDecl();
   auto AllocSubMap = AllocType.getASTType()
     ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
 

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -315,7 +315,7 @@ void BBEnumTagDataflowState::handlePredCondSelectEnum(CondBranchInst *CondBr) {
 
   // If the enum only has 2 values and its tag isn't the true branch, then we
   // know the true branch must be the other tag.
-  if (EnumDecl *E = Operand->getType().getEnumOrBoundGenericEnum()) {
+  if (EnumDecl *E = Operand->getType().getEnumDecl()) {
     // We can't do this optimization on non-exhaustive enums.
     const SILFunction *Fn = CondBr->getFunction();
     bool IsExhaustive =
@@ -1582,7 +1582,7 @@ static bool tryToSinkRefCountAcrossSelectEnum(CondBranchInst *CondBr,
   // If the enum only has 2 values and its tag isn't the true branch, then we
   // know the true branch must be the other tag.
   EnumElementDecl *Elts[2] = {TrueElement.get(), nullptr};
-  EnumDecl *E = SEI->getEnumOperand()->getType().getEnumOrBoundGenericEnum();
+  EnumDecl *E = SEI->getEnumOperand()->getType().getEnumDecl();
   if (!E)
     return false;
 

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -128,7 +128,7 @@ bool SROAMemoryUseAnalyzer::analyze() {
   SILType Type = AI->getType();
 
   TT = Type.getAs<TupleType>();
-  SD = Type.getStructOrBoundGenericStruct();
+  SD = Type.getStructDecl();
   bool HasUnrefField = AI->getElementType().aggregateHasUnreferenceableStorage();
 
   // Check that the allocated type is a struct or a tuple and that there are

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1562,7 +1562,7 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
   // select_enum with the first case and swap our operands. This simplifies
   // later dominance based processing.
   if (auto *SEI = dyn_cast<SelectEnumInst>(BI->getCondition())) {
-    EnumDecl *E = SEI->getEnumOperand()->getType().getEnumOrBoundGenericEnum();
+    EnumDecl *E = SEI->getEnumOperand()->getType().getEnumDecl();
 
     auto AllElts = E->getAllElements();
     auto Iter = AllElts.begin();
@@ -2669,7 +2669,7 @@ bool ArgumentSplitter::createNewArguments() {
 
   // Only handle struct and tuple type.
   SILType Ty = Arg->getType();
-  if (!Ty.getStructOrBoundGenericStruct() && !Ty.is<TupleType>())
+  if (!Ty.getStructDecl() && !Ty.is<TupleType>())
     return false;
 
   // Get the first level projection for the struct or tuple type.
@@ -2828,7 +2828,7 @@ static bool splitBBArguments(SILFunction &Fn) {
       SILType ArgTy = Arg->getType();
 
       if (!ArgTy.isObject() ||
-          (!ArgTy.is<TupleType>() && !ArgTy.getStructOrBoundGenericStruct())) {
+          (!ArgTy.is<TupleType>() && !ArgTy.getStructDecl())) {
         continue;
       }
 
@@ -3127,7 +3127,7 @@ static bool simplifySwitchEnumToSelectEnum(SILBasicBlock *BB, unsigned ArgNum,
     // If it does, then pick one of those cases as a default.
 
     // Count the number of possible case tags for a given enum type
-    auto *Enum = SEI->getOperand()->getType().getEnumOrBoundGenericEnum();
+    auto *Enum = SEI->getOperand()->getType().getEnumDecl();
     unsigned ElemCount = 0;
     for (auto E : Enum->getAllElements()) {
       if (E)

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -396,7 +396,7 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
 
   CheckedCastBranchInst *LastCCBI = nullptr;
 
-  ClassDecl *CD = ClassType.getClassOrBoundGenericClass();
+  ClassDecl *CD = ClassType.getClassDecl();
   assert(CD && "Expected decl for class type!");
 
   if (!CHA->hasKnownDirectSubclasses(CD)) {

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -749,7 +749,7 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
   auto calleeFnType = callee->getLoweredFunctionType();
   assert(
       !calleeFnType->hasSelfParam() ||
-      !calleeFnType->getSelfInstanceType()->getClassOrBoundGenericClass() &&
+      !calleeFnType->getSelfInstanceType()->getClassDecl() &&
       "class methods are not supported");
   if (calleeFnType->getGenericSignature()) {
     // Get the substitution map of the call.  This maps from the callee's space

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1077,7 +1077,7 @@ bool maybeExplicitFPCons(BuiltinInst *BI, const BuiltinInfo &Builtin) {
   // construction of Double could be a part of an explicit conversion
   // and suppress the warning.
   auto &astCtx = BI->getModule().getASTContext();
-  auto *typeDecl = callExpr->getType()->getCanonicalType().getAnyNominal();
+  auto *typeDecl = callExpr->getType()->getCanonicalType().getNominalTypeDecl();
   return (typeDecl && typeDecl == astCtx.getDoubleDecl());
 }
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -239,7 +239,7 @@ SILValue swift::getInstanceWithExactDynamicType(SILValue S, SILModule &M,
     if (!SinglePred) {
       if (!isa<SILFunctionArgument>(Arg))
         break;
-      auto *CD = Arg->getType().getClassOrBoundGenericClass();
+      auto *CD = Arg->getType().getClassDecl();
       // Check if this class is effectively final.
       if (!CD || !isKnownFinalClass(CD, M, CHA))
         break;
@@ -332,7 +332,7 @@ SILType swift::getExactDynamicType(SILValue S, SILModule &M,
       if (FArg->getType().is<AnyMetatypeType>()) {
         return SILType();
       }
-      auto *CD = FArg->getType().getClassOrBoundGenericClass();
+      auto *CD = FArg->getType().getClassDecl();
       // If it is not class and it is a trivial type, then it
       // should be the exact type.
       if (!CD && FArg->getType().isTrivial(M)) {
@@ -417,7 +417,7 @@ getSubstitutionsForCallee(SILModule &M,
   if (auto metatypeType = baseSelfType->getAs<MetatypeType>())
     baseSelfType = metatypeType->getInstanceType();
 
-  auto *baseClassDecl = baseSelfType->getClassOrBoundGenericClass();
+  auto *baseClassDecl = baseSelfType->getClassDecl();
   assert(baseClassDecl && "not a class method");
 
   unsigned baseDepth = 0;
@@ -440,7 +440,7 @@ getSubstitutionsForCallee(SILModule &M,
   Type calleeSelfType = AI.getOrigCalleeType()->getSelfParameter().getType();
   if (auto metatypeType = calleeSelfType->getAs<MetatypeType>())
     calleeSelfType = metatypeType->getInstanceType();
-  auto *calleeClassDecl = calleeSelfType->getClassOrBoundGenericClass();
+  auto *calleeClassDecl = calleeSelfType->getClassDecl();
   assert(calleeClassDecl && "self is not a class type");
 
   // Add generic parameters from the method itself, ignoring any generic
@@ -647,7 +647,7 @@ SILFunction *swift::getTargetClassMethod(SILModule &M,
   if (ClassOrMetatypeType.is<MetatypeType>())
     ClassOrMetatypeType = ClassOrMetatypeType.getMetatypeInstanceType(M);
 
-  auto *CD = ClassOrMetatypeType.getClassOrBoundGenericClass();
+  auto *CD = ClassOrMetatypeType.getClassDecl();
   return M.lookUpFunctionInVTable(CD, Member);
 }
 
@@ -1127,7 +1127,7 @@ ApplySite swift::tryDevirtualizeApply(ApplySite AI,
     if (ClassType.is<MetatypeType>())
       ClassType = ClassType.getMetatypeInstanceType(M);
 
-    auto *CD = ClassType.getClassOrBoundGenericClass();
+    auto *CD = ClassType.getClassDecl();
 
     if (isEffectivelyFinalMethod(FAS, ClassType, CD, CHA))
       return tryDevirtualizeClassMethod(FAS, Instance, ORE,
@@ -1195,7 +1195,7 @@ bool swift::canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA) 
     if (ClassType.is<MetatypeType>())
       ClassType = ClassType.getMetatypeInstanceType(M);
 
-    auto *CD = ClassType.getClassOrBoundGenericClass();
+    auto *CD = ClassType.getClassDecl();
 
     if (isEffectivelyFinalMethod(AI, ClassType, CD, CHA))
       return canDevirtualizeClassMethod(AI, Instance->getType(),

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -74,7 +74,7 @@ static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
   unsigned Depth = 0;
   unsigned Width = 0;
   if (auto *BGT = t->getAs<BoundGenericType>()) {
-    auto *NTD = BGT->getNominalOrBoundGenericNominal();
+    auto *NTD = BGT->getNominalTypeDecl();
     if (NTD) {
       auto StoredProperties = NTD->getStoredProperties();
       Width += std::distance(StoredProperties.begin(), StoredProperties.end());

--- a/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
@@ -43,7 +43,7 @@ void
 LSValue::reduceInner(LSLocation &Base, SILModule *M, LSLocationValueMap &Values,
                      SILInstruction *InsertPt) {
   // If this is a class reference type, we have reached end of the type tree.
-  if (Base.getType(M).getClassOrBoundGenericClass())
+  if (Base.getType(M).getClassDecl())
     return;
 
   // This a don't expand node.
@@ -191,7 +191,7 @@ static bool
 getSubLocations(LSLocationList &SubLocations, LSLocation Base, SILModule *M,
              const LSLocationList &Locs) {
   // If this is a class reference type, we have reached end of the type tree.
-  if (Base.getType(M).getClassOrBoundGenericClass())
+  if (Base.getType(M).getClassDecl())
     return false;
 
   // Don't expand if it would be too complex. As Locs is a list (and not a set)

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1524,7 +1524,7 @@ bool swift::shouldExpand(SILModule &Module, SILType Ty) {
 /// TODO: Cache the "simple" flag for types to avoid repeating checks.
 bool swift::isSimpleType(SILType SILTy, SILModule& Module) {
   // Classes can never be initialized statically at compile-time.
-  if (SILTy.getClassOrBoundGenericClass()) {
+  if (SILTy.getClassDecl()) {
     return false;
   }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -192,12 +192,12 @@ bool ConstraintSystem::PotentialBindings::isViable(
   // resolution.
   auto type = binding.BindingType;
   if (type->hasTypeVariable()) {
-    auto *NTD = type->getAnyNominal();
+    auto *NTD = type->getNominalTypeDecl();
     if (!NTD)
       return true;
 
     for (auto &existing : Bindings) {
-      auto *existingNTD = existing.BindingType->getAnyNominal();
+      auto *existingNTD = existing.BindingType->getNominalTypeDecl();
       if (existingNTD && NTD == existingNTD)
         return false;
     }
@@ -552,13 +552,13 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       // specialization of this generic within our list.
       // FIXME: This assumes that, e.g., the default literal
       // int/float/char/string types are never generic.
-      auto nominal = defaultType->getAnyNominal();
+      auto nominal = defaultType->getNominalTypeDecl();
       if (!nominal)
         continue;
 
       bool matched = false;
       for (auto exactType : exactTypes) {
-        if (auto exactNominal = exactType->getAnyNominal()) {
+        if (auto exactNominal = exactType->getNominalTypeDecl()) {
           // FIXME: Check parents?
           if (nominal == exactNominal) {
             matched = true;
@@ -735,7 +735,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
         // overwrite the binding in place because the non-optional type
         // will fail to type-check against the nil-literal conformance.
         auto nominalBindingDecl =
-            binding.BindingType->getRValueType()->getAnyNominal();
+            binding.BindingType->getRValueType()->getNominalTypeDecl();
         bool conformsToExprByNilLiteral = false;
         if (nominalBindingDecl) {
           SmallVector<ProtocolConformance *, 2> conformances;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3095,7 +3095,7 @@ bool FailureDiagnosis::diagnoseImplicitSelfErrors(
 
       // If base is present but it doesn't represent a valid nominal,
       // we can't use current candidate as one of the choices.
-      if (base && !base->getInterfaceType()->getNominalOrBoundGenericNominal())
+      if (base && !base->getInterfaceType()->getNominalTypeDecl())
         continue;
 
       auto context = decl->getDeclContext();
@@ -3202,7 +3202,7 @@ diagnoseInstanceMethodAsCurriedMemberOnType(CalleeCandidateInfo &CCI,
         }
         assert(TypeDC->isTypeContext() && "Expected type decl context!");
 
-        if (TypeDC->getSelfNominalTypeDecl() == instanceType->getAnyNominal()) {
+        if (TypeDC->getSelfNominalTypeDecl() == instanceType->getNominalTypeDecl()) {
           if (propertyInitializer)
             TC.diagnose(UDE->getLoc(), diag::instance_member_in_initializer,
                         UDE->getName());
@@ -3923,7 +3923,7 @@ bool FailureDiagnosis::diagnoseParameterErrors(CalleeCandidateInfo &CCI,
                                                ArrayRef<Identifier> argLabels) {
   if (auto *MTT = CS.getType(fnExpr)->getAs<MetatypeType>()) {
     auto instTy = MTT->getInstanceType();
-    if (instTy->getAnyNominal()) {
+    if (instTy->getNominalTypeDecl()) {
       // If we are invoking a constructor on a nominal type and there are
       // absolutely no candidates, then they must all be private.
       if (CCI.empty() || (CCI.size() == 1 && CCI.candidates[0].getDecl() &&
@@ -4533,7 +4533,7 @@ static bool isCastToTypedPointer(ConstraintSystem &CS, const Expr *Fn,
   if (auto ArgOptType = ArgType->getOptionalObjectType())
     ArgType = ArgOptType;
 
-  auto *InitNom = InitType->getAnyNominal();
+  auto *InitNom = InitType->getNominalTypeDecl();
   if (!InitNom)
     return false;
 
@@ -4541,7 +4541,7 @@ static bool isCastToTypedPointer(ConstraintSystem &CS, const Expr *Fn,
       && InitNom != Ctx.getUnsafePointerDecl()) {
     return false;
   }
-  auto *ArgNom = ArgType->getAnyNominal();
+  auto *ArgNom = ArgType->getNominalTypeDecl();
   if (!ArgNom)
     return false;
 
@@ -6209,7 +6209,7 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
     }
 
     // Determine whether we're looking into a Foundation collection.
-    if (auto classDecl = newType->getClassOrBoundGenericClass()) {
+    if (auto classDecl = newType->getClassDecl()) {
       if (classDecl->isObjC() && classDecl->hasClangNode()) {
         SmallString<32> scratch;
         StringRef objcClassName = classDecl->getObjCRuntimeName(scratch);
@@ -7403,7 +7403,7 @@ static void noteGenericParameterSource(const TypeLoc &loc,
   // If we didn't find the type in the TypeRepr, fall back to the type in the
   // type checked expression.
   if (!FoundDecl) {
-    if (const GenericTypeDecl *generic = loc.getType()->getAnyGeneric())
+    if (const GenericTypeDecl *generic = loc.getType()->getGenericTypeDecl())
       if (hasGenericParameter(generic, paramTy))
         FoundDecl = generic;
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -564,7 +564,7 @@ namespace {
     // conforms to the literal protocol and test against it directly.
     // This helps to avoid 'widening' the favored type to the default type for
     // the literal.
-    if (otherArgTy && otherArgTy->getAnyNominal()) {
+    if (otherArgTy && otherArgTy->getNominalTypeDecl()) {
       return otherArgTy->isEqual(paramTy) &&
              tc.conformsToProtocol(otherArgTy, literalProto, CS.DC,
                                    ConformanceCheckFlags::InExpression);

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -181,12 +181,12 @@ namespace {
 /// Determines whether the first type is nominally a superclass of the second
 /// type, ignore generic arguments.
 static bool isNominallySuperclassOf(Type type1, Type type2) {
-  auto nominal1 = type1->getAnyNominal();
+  auto nominal1 = type1->getNominalTypeDecl();
   if (!nominal1)
     return false;
 
   for (auto super2 = type2; super2; super2 = super2->getSuperclass()) {
-    if (super2->getAnyNominal() == nominal1)
+    if (super2->getNominalTypeDecl() == nominal1)
       return true;
   }
 
@@ -1152,14 +1152,14 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // Post-1.0, we'll need to remove this hack in favor of richer constraint
     // declarations.
     if (!(score1 || score2)) {
-      if (auto nominalType2 = type2->getNominalOrBoundGenericNominal()) {
+      if (auto nominalType2 = type2->getNominalTypeDecl()) {
         if ((nominalType2->getName() ==
              cs.TC.Context.Id_OptionalNilComparisonType)) {
           ++score2;
         }
       }
 
-      if (auto nominalType1 = type1->getNominalOrBoundGenericNominal()) {
+      if (auto nominalType1 = type1->getNominalTypeDecl()) {
         if ((nominalType1->getName() ==
              cs.TC.Context.Id_OptionalNilComparisonType)) {
           ++score1;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1685,7 +1685,7 @@ void ConstraintSystem::sortDesignatedTypes(
 
   size_t nextType = 0;
   for (auto argType : argInfo.getTypes()) {
-    auto *nominal = argType->getAnyNominal();
+    auto *nominal = argType->getNominalTypeDecl();
     for (size_t i = nextType; i < nominalTypes.size(); ++i) {
       if (nominal == nominalTypes[i]) {
         std::swap(nominalTypes[nextType], nominalTypes[i]);
@@ -1710,7 +1710,7 @@ void ConstraintSystem::sortDesignatedTypes(
     // ExpressibleByNilLiteral does not have a default type.
     if (!defaultType)
       continue;
-    auto *nominal = defaultType->getAnyNominal();
+    auto *nominal = defaultType->getNominalTypeDecl();
     for (size_t i = nextType + 1; i < nominalTypes.size(); ++i) {
       if (nominal == nominalTypes[i]) {
         std::swap(nominalTypes[nextType], nominalTypes[i]);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1777,7 +1777,7 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
                                        ClassDecl *classDecl,
                                        Type superclassTy,
                                        ConstructorDecl *superclassCtor) {
-  auto *superclassDecl = superclassTy->getAnyNominal();
+  auto *superclassDecl = superclassTy->getNominalTypeDecl();
 
   auto *moduleDecl = classDecl->getParentModule();
   auto subMap = superclassTy->getContextSubstitutionMap(
@@ -1994,7 +1994,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   auto *superclassCtorDecl =
       superclassCtor->getDeclContext()->getSelfNominalTypeDecl();
   Type superclassTy = classDecl->getSuperclass();
-  NominalTypeDecl *superclassDecl = superclassTy->getAnyNominal();
+  NominalTypeDecl *superclassDecl = superclassTy->getNominalTypeDecl();
   if (superclassCtorDecl != superclassDecl) {
     return nullptr;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -194,7 +194,7 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
       if (auto defaultType = TC.getDefaultType(literalProtocol, DC)) {
         // Check whether the nominal types match. This makes sure that we
         // properly handle Array vs. Array<T>.
-        if (defaultType->getAnyNominal() != type->getAnyNominal())
+        if (defaultType->getNominalTypeDecl() != type->getNominalTypeDecl())
           increaseScore(SK_NonDefaultLiteral);
       }
     }
@@ -1145,7 +1145,7 @@ static void addSelfConstraint(ConstraintSystem &cs, Type objectTy, Type selfTy,
   assert(!selfTy->is<ProtocolType>());
 
   // Otherwise, use a subtype constraint for classes to cope with inheritance.
-  if (selfTy->getClassOrBoundGenericClass()) {
+  if (selfTy->getClassDecl()) {
     cs.addConstraint(ConstraintKind::Subtype, objectTy, selfTy,
                      cs.getConstraintLocator(locator));
     return;
@@ -1709,7 +1709,7 @@ static bool isNonFinalClass(Type type) {
   if (auto dynamicSelf = type->getAs<DynamicSelfType>())
     type = dynamicSelf->getSelfType();
 
-  if (auto classDecl = type->getClassOrBoundGenericClass())
+  if (auto classDecl = type->getClassDecl())
     return !classDecl->isFinal();
 
   if (auto archetype = type->getAs<ArchetypeType>())

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -282,7 +282,7 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
   // type.
   auto codingKeysType = codingKeysTypeDecl->getDeclaredInterfaceType();
   if (isa<TypeAliasDecl>(codingKeysTypeDecl))
-    codingKeysTypeDecl = codingKeysType->getAnyNominal();
+    codingKeysTypeDecl = codingKeysType->getNominalTypeDecl();
 
   // Ensure that the type we found conforms to the CodingKey protocol.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
@@ -424,7 +424,7 @@ static EnumDecl *lookupEvaluatedCodingKeysEnum(ASTContext &C,
 
   auto *codingKeysDecl = codingKeyDecls.front();
   if (auto *typealiasDecl = dyn_cast<TypeAliasDecl>(codingKeysDecl))
-    codingKeysDecl = typealiasDecl->getDeclaredInterfaceType()->getAnyNominal();
+    codingKeysDecl = typealiasDecl->getDeclaredInterfaceType()->getNominalTypeDecl();
 
   return dyn_cast<EnumDecl>(codingKeysDecl);
 }
@@ -621,7 +621,7 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *)
       varType = referenceType->getReferentType();
     }
 
-    if (varType->getAnyNominal() == C.getOptionalDecl())
+    if (varType->getNominalTypeDecl() == C.getOptionalDecl())
       methodName = C.Id_encodeIfPresent;
 
     SmallVector<Identifier, 2> argNames{Identifier(), C.Id_forKey};
@@ -852,7 +852,7 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
         varType = referenceType->getReferentType();
       }
 
-      if (varType->getAnyNominal() == C.getOptionalDecl()) {
+      if (varType->getNominalTypeDecl() == C.getOptionalDecl()) {
         methodName = C.Id_decodeIfPresent;
 
         // The type we request out of decodeIfPresent needs to be unwrapped

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -343,7 +343,7 @@ static bool canSynthesizeCodingKey(DerivedConformance &derived) {
     rawType = parentDC->mapTypeIntoContext(rawType);
 
     auto &C = derived.TC.Context;
-    auto *nominal = rawType->getCanonicalType()->getAnyNominal();
+    auto *nominal = rawType->getCanonicalType()->getNominalTypeDecl();
     if (nominal != C.getStringDecl() && nominal != C.getIntDecl())
       return false;
   }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -312,7 +312,7 @@ deriveBodyEquatable_enum_uninhabited_eq(AbstractFunctionDecl *eqDecl, void *) {
   auto aParam = args->get(0);
   auto bParam = args->get(1);
 
-  assert(!cast<EnumDecl>(aParam->getType()->getAnyNominal())->hasCases());
+  assert(!cast<EnumDecl>(aParam->getType()->getNominalTypeDecl())->hasCases());
 
   SmallVector<ASTNode, 1> statements;
   SmallVector<ASTNode, 0> cases;
@@ -344,7 +344,7 @@ deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
   auto aParam = args->get(0);
   auto bParam = args->get(1);
 
-  auto enumDecl = cast<EnumDecl>(aParam->getType()->getAnyNominal());
+  auto enumDecl = cast<EnumDecl>(aParam->getType()->getNominalTypeDecl());
 
   // Generate the conversion from the enums to integer indices.
   SmallVector<ASTNode, 6> statements;
@@ -401,7 +401,7 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
   auto bParam = args->get(1);
 
   Type enumType = aParam->getType();
-  auto enumDecl = cast<EnumDecl>(aParam->getType()->getAnyNominal());
+  auto enumDecl = cast<EnumDecl>(aParam->getType()->getNominalTypeDecl());
 
   SmallVector<ASTNode, 6> statements;
   SmallVector<ASTNode, 4> cases;
@@ -515,7 +515,7 @@ static void deriveBodyEquatable_struct_eq(AbstractFunctionDecl *eqDecl,
   auto aParam = args->get(0);
   auto bParam = args->get(1);
 
-  auto structDecl = cast<StructDecl>(aParam->getType()->getAnyNominal());
+  auto structDecl = cast<StructDecl>(aParam->getType()->getNominalTypeDecl());
 
   SmallVector<ASTNode, 6> statements;
 
@@ -618,10 +618,10 @@ deriveEquatable_eq(DerivedConformance &derived,
   if (parentDC->getParentModule()->getResilienceStrategy() ==
       ResilienceStrategy::Resilient) {
     generatedIdentifier = C.Id_EqualsOperator;
-  } else if (selfIfaceTy->getEnumOrBoundGenericEnum()) {
+  } else if (selfIfaceTy->getEnumDecl()) {
     generatedIdentifier = C.Id_derived_enum_equals;
   } else {
-    assert(selfIfaceTy->getStructOrBoundGenericStruct());
+    assert(selfIfaceTy->getStructDecl());
     generatedIdentifier = C.Id_derived_struct_equals;
   }
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -308,7 +308,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
 #endif
 
   bool isStringEnum =
-    (rawTy->getNominalOrBoundGenericNominal() == C.getStringDecl());
+    (rawTy->getNominalTypeDecl() == C.getStringDecl());
   llvm::SmallVector<Expr *, 16> stringExprs;
 
   Type enumType = parentDC->getDeclaredTypeInContext();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -95,7 +95,7 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
           auto parentDC = enumDecl->getDeclContext();
           ASTContext &C = parentDC->getASTContext();
 
-          auto nominal = rawType->getAnyNominal();
+          auto nominal = rawType->getNominalTypeDecl();
           return nominal == C.getStringDecl() || nominal == C.getIntDecl();
         }
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -686,7 +686,7 @@ public:
         if (ty->is<ProtocolCompositionType>())
           if (auto superclass = ty->getExistentialLayout().explicitSuperclass)
             ty = superclass;
-        return ty->getAnyNominal() == superclassDecl;
+        return ty->getNominalTypeDecl() == superclassDecl;
       });
       // Sanity check: we couldn't find the superclass for whatever reason
       // (possibly because it's synthetic or something), so don't bother
@@ -1231,7 +1231,7 @@ public:
         if (ty->is<ProtocolCompositionType>())
           if (auto superclass = ty->getExistentialLayout().explicitSuperclass)
             ty = superclass;
-        return ty->getAnyNominal() == superclassDecl;
+        return ty->getNominalTypeDecl() == superclassDecl;
       });
       // Sanity check: we couldn't find the superclass for whatever reason
       // (possibly because it's synthetic or something), so don't bother

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -374,7 +374,7 @@ isAcceptableOutletType(Type type, bool &isArray, TypeChecker &TC) {
   if (type->isObjCExistentialType() || type->isAny())
     return None; // @objc existential types are okay
 
-  auto nominal = type->getAnyNominal();
+  auto nominal = type->getNominalTypeDecl();
 
   if (auto classDecl = dyn_cast_or_null<ClassDecl>(nominal)) {
     if (classDecl->isObjC())
@@ -846,7 +846,7 @@ static bool checkObjectOrOptionalObjectType(TypeChecker &TC, Decl *D,
   if (auto unwrapped = ty->getOptionalObjectType())
     ty = unwrapped;
 
-  if (auto classDecl = ty->getClassOrBoundGenericClass()) {
+  if (auto classDecl = ty->getClassDecl()) {
     // @objc class types are okay.
     if (!classDecl->isObjC()) {
       TC.diagnose(D, diag::ibaction_nonobjc_class_argument,
@@ -1061,7 +1061,7 @@ void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
       // Do a rough check to allow any ObjC-representable struct or enum type
       // on iOS.
       Type ty = paramList->get(0)->getType();
-      if (auto nominal = ty->getAnyNominal())
+      if (auto nominal = ty->getNominalTypeDecl())
         if (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal))
           if (!nominal->isOptionalDecl())
             if (ty->isTriviallyRepresentableIn(ForeignLanguage::ObjectiveC,
@@ -1472,7 +1472,7 @@ void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {
     return;
   }
   // Only classes can have required constructors.
-  if (parentTy->getClassOrBoundGenericClass()) {
+  if (parentTy->getClassDecl()) {
     // The constructor must be declared within the class itself.
     // FIXME: Allow an SDK overlay to add a required initializer to a class
     // defined in Objective-C

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -108,7 +108,7 @@ public:
         // Pseudogeneric classes don't use their generic parameters so we
         // don't need to visit them.
         if (AFR.isObjC()) {
-          if (auto clas = dyn_cast_or_null<ClassDecl>(ty->getAnyNominal())) {
+          if (auto clas = dyn_cast_or_null<ClassDecl>(ty->getNominalTypeDecl())) {
             if (clas->usesObjCGenericsModel()) {
               return Action::SkipChildren;
             }
@@ -626,7 +626,7 @@ public:
         return false;
 
       if (auto clas = dyn_cast_or_null<ClassDecl>(
-                         cast->getCastTypeLoc().getType()->getAnyNominal())) {
+                         cast->getCastTypeLoc().getType()->getNominalTypeDecl())) {
         if (clas->usesObjCGenericsModel()) {
           return false;
         }

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -215,7 +215,7 @@ void CircularityChecker::run() {
 /// \return true if a problem was found and all further processing
 ///   should be aborted.
 bool CircularityChecker::expandType(CanType type, unsigned depth) {
-  if (auto D = type.getAnyNominal()) {
+  if (auto D = type.getNominalTypeDecl()) {
     return expandNominal(type, D, depth);
   } else if (auto tuple = dyn_cast<TupleType>(type)) {
     return expandTuple(tuple, depth);
@@ -323,10 +323,10 @@ bool CircularityChecker::addMember(CanType parentType, ValueDecl *member,
 
   if (isa<TupleType>(memberType)) {
     // Ok, visit tuples.
-  } else if (memberType.getStructOrBoundGenericStruct()) {
+  } else if (memberType.getStructDecl()) {
     // Ok, visit structs.
     // TODO: skip non-generic types in different modules?
-  } else if (auto E = memberType.getEnumOrBoundGenericEnum()) {
+  } else if (auto E = memberType.getEnumDecl()) {
     // Ok, visit non-indirect enums.
     if (E->isIndirect()) return false;
     // TODO: skip non-generic types in different modules?

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4021,13 +4021,13 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       // Ok, we are casting between class-like things. Let's see if we have
       // explicit superclass bounds.
       Type toSuperclass;
-      if (toType->getClassOrBoundGenericClass())
+      if (toType->getClassDecl())
         toSuperclass = toType;
       else
         toSuperclass = toType->getSuperclass();
 
       Type fromSuperclass;
-      if (fromType->getClassOrBoundGenericClass())
+      if (fromType->getClassDecl())
         fromSuperclass = fromType;
       else
         fromSuperclass = fromType->getSuperclass();
@@ -4116,7 +4116,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // The runtime doesn't support casts to CF types and always lets them succeed.
   // This "always fails" diagnosis makes no sense when paired with the CF
   // one.
-  auto clas = toType->getClassOrBoundGenericClass();
+  auto clas = toType->getClassDecl();
   if (clas && clas->getForeignClassKind() == ClassDecl::ForeignKind::CFType)
     return CheckedCastKind::ValueCast;
   
@@ -4125,7 +4125,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // covariance, or for APIs where the generic parameter annotations in the
   // ObjC headers are inaccurate.
   if (clas && clas->usesObjCGenericsModel()) {
-    if (fromType->getClassOrBoundGenericClass() == clas)
+    if (fromType->getClassDecl() == clas)
       return CheckedCastKind::ValueCast;
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -122,7 +122,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
   }
 
   // Special diagnostic for classes.
-  if (auto *CD = T->getClassOrBoundGenericClass()) {
+  if (auto *CD = T->getClassDecl()) {
     if (!CD->isObjC())
       diags.diagnose(TypeRange.Start, diag::not_objc_swift_class)
           .highlight(TypeRange);
@@ -156,7 +156,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
 
     // See if the superclass is not @objc.
     if (auto superclass = layout.explicitSuperclass) {
-      if (!superclass->getClassOrBoundGenericClass()->isObjC()) {
+      if (!superclass->getClassDecl()->isObjC()) {
         diags.diagnose(TypeRange.Start, diag::not_objc_class_constraint,
                        superclass);
         return;
@@ -337,7 +337,7 @@ static bool checkObjCInForeignClassContext(const ValueDecl *VD,
   if (!type)
     return false;
 
-  auto clas = type->getClassOrBoundGenericClass();
+  auto clas = type->getClassDecl();
   if (!clas)
     return false;
 
@@ -1221,7 +1221,7 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
 
 /// Determine whether the given type is a C integer type.
 static bool isCIntegerType(Type type) {
-  auto nominal = type->getAnyNominal();
+  auto nominal = type->getNominalTypeDecl();
   if (!nominal) return false;
 
   ASTContext &ctx = nominal->getASTContext();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -672,7 +672,7 @@ namespace {
     /// a supertype of the given type.
     Type getSuperMemberDeclType(ValueDecl *baseDecl) const {
       auto selfType = decl->getDeclContext()->getSelfInterfaceType();
-      if (selfType->getClassOrBoundGenericClass()) {
+      if (selfType->getClassDecl()) {
         selfType = selfType->getSuperclass();
         assert(selfType && "No superclass type?");
       }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -122,7 +122,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     }
 
     // Determine whether we're looking into a Foundation collection.
-    if (auto classDecl = newType->getClassOrBoundGenericClass()) {
+    if (auto classDecl = newType->getClassDecl()) {
       if (classDecl->isObjC() && classDecl->hasClangNode()) {
         SmallString<32> scratch;
         StringRef objcClassName = classDecl->getObjCRuntimeName(scratch);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1019,7 +1019,7 @@ RequirementRequest::evaluate(Evaluator &evaluator,
   case RequirementReprKind::TypeConstraint: {
     Type subject = resolveType(reqRepr.getSubjectLoc());
     Type constraint = resolveType(reqRepr.getConstraintLoc());
-    return Requirement(constraint->getClassOrBoundGenericClass()
+    return Requirement(constraint->getClassDecl()
                          ? RequirementKind::Superclass
                          : RequirementKind::Conformance,
                        subject, constraint);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -464,7 +464,7 @@ public:
     Type ty = TC.resolveIdentifierType(TypeResolution::forContextual(DC), repr,
                                        options);
     
-    auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
+    auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getNominalTypeDecl());
     if (!enumDecl)
       return nullptr;
 
@@ -578,7 +578,7 @@ public:
       // See first if the entire repr resolves to a type.
       Type enumTy = TC.resolveIdentifierType(TypeResolution::forContextual(DC),
                                              prefixRepr, options);
-      if (!dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal()))
+      if (!dyn_cast_or_null<EnumDecl>(enumTy->getNominalTypeDecl()))
         return nullptr;
 
       referencedElement
@@ -787,7 +787,7 @@ static void requestLayoutForMetadataSources(TypeChecker &tc, Type type) {
     // parameter is of dependent type then the body of a function with said
     // parameter could potentially require the generic type's layout to
     // recover them.
-    if (auto *nominalDecl = type->getAnyNominal()) {
+    if (auto *nominalDecl = type->getNominalTypeDecl()) {
       tc.requestNominalLayout(nominalDecl);
     }
   });
@@ -1225,7 +1225,7 @@ recur:
   case PatternKind::Expr: {
     assert(cast<ExprPattern>(P)->isResolved()
            && "coercing unresolved expr pattern!");
-    if (type->getAnyNominal() == Context.getBoolDecl()) {
+    if (type->getNominalTypeDecl() == Context.getBoolDecl()) {
       // The type is Bool.
       // Check if the pattern is a Bool literal
       auto EP = cast<ExprPattern>(P);
@@ -1365,7 +1365,7 @@ recur:
           // so we have to do this check here. Additionally, .Some
           // isn't a static VarDecl, so the existing mechanics in
           // extractEnumElement won't work.
-          if (type->getAnyNominal() == Context.getOptionalDecl()) {
+          if (type->getNominalTypeDecl() == Context.getOptionalDecl()) {
             if (EEP->getName().str() == "None" ||
                 EEP->getName().str() == "Some") {
               SmallString<4> Rename;
@@ -1417,7 +1417,7 @@ recur:
       // the context type to resolve the parameters.
       else if (parentTy->hasUnboundGenericType()) {
         if (parentTy->is<UnboundGenericType>() &&
-            parentTy->getAnyNominal() == type->getAnyNominal()) {
+            parentTy->getNominalTypeDecl() == type->getNominalTypeDecl()) {
           enumTy = type;
         } else {
           diagnose(EEP->getLoc(), diag::ambiguous_enum_pattern_type,

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -800,7 +800,7 @@ Type AssociatedTypeInference::computeFixedTypeWitness(
   // require a fixed type for this associated type.
   Type dependentType = assocType->getDeclaredInterfaceType();
   Type resultType;
-  for (auto conformedProto : adoptee->getAnyNominal()->getAllProtocols()) {
+  for (auto conformedProto : adoptee->getNominalTypeDecl()->getAllProtocols()) {
     if (!conformedProto->inheritsFrom(assocType->getProtocol()))
       continue;
 
@@ -891,7 +891,7 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
     return Type();
 
   // Can we derive conformances for this protocol and adoptee?
-  NominalTypeDecl *derivingTypeDecl = adoptee->getAnyNominal();
+  NominalTypeDecl *derivingTypeDecl = adoptee->getNominalTypeDecl();
   if (!DerivedConformance::derivesProtocolConformance(dc, derivingTypeDecl,
                                                       proto))
     return Type();
@@ -1741,7 +1741,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
           if (failed.Result.isError())
             continue;
 
-          if ((!failed.TypeWitness->getAnyNominal() ||
+          if ((!failed.TypeWitness->getNominalTypeDecl() ||
                failed.TypeWitness->isExistentialType()) &&
               failed.Result.isConformanceRequirement()) {
             diags.diagnose(failed.Witness,
@@ -1750,7 +1750,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
                            failed.Result.getRequirement());
             continue;
           }
-          if (!failed.TypeWitness->getClassOrBoundGenericClass() &&
+          if (!failed.TypeWitness->getClassDecl() &&
               failed.Result.isSuperclassRequirement()) {
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_inherit_impossible,

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -97,7 +97,7 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
     if (!inheritedType) continue;
 
     // If we found a class, return it.
-    if (inheritedType->getClassOrBoundGenericClass()) {
+    if (inheritedType->getClassDecl()) {
       return inheritedType;
     }
 
@@ -105,7 +105,7 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
     if (inheritedType->isExistentialType()) {
       if (auto superclassType =
             inheritedType->getExistentialLayout().explicitSuperclass) {
-        if (superclassType->getClassOrBoundGenericClass()) {
+        if (superclassType->getClassDecl()) {
           return superclassType;
         }
       }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -242,7 +242,7 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
                                                     Expr *E,
                                                     Type ResultType,
                                                     ModuleDecl *module) {
-  auto *NTD = ResultType->getAnyNominal();
+  auto *NTD = ResultType->getNominalTypeDecl();
   if (!NTD)
     return;
   auto optionSetType = dyn_cast_or_null<ProtocolDecl>(Ctx.getOptionSetDecl());
@@ -762,7 +762,7 @@ public:
                        TC.Context.Id_next, {}, diag::iterator_protocol_broken);
     if (!iteratorNext) return nullptr;
     // Check that next() produces an Optional<T> value.
-    if (iteratorNext->getType()->getAnyNominal()
+    if (iteratorNext->getType()->getNominalTypeDecl()
           != TC.Context.getOptionalDecl()) {
       TC.diagnose(S->getForLoc(), diag::iterator_protocol_broken);
       return nullptr;
@@ -1719,7 +1719,7 @@ static bool checkSuperInit(TypeChecker &tc, ConstructorDecl *fromCtor,
   if (!ctor->isDesignatedInit()) {
     if (!implicitlyGenerated) {
       auto selfTy = fromCtor->getDeclContext()->getSelfInterfaceType();
-      if (auto classTy = selfTy->getClassOrBoundGenericClass()) {
+      if (auto classTy = selfTy->getClassDecl()) {
         assert(classTy->getSuperclass());
         tc.diagnose(apply->getArg()->getLoc(), diag::chain_convenience_init,
                     classTy->getSuperclass());

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -743,7 +743,7 @@ namespace {
         if (tp->isBool()) {
           arr.push_back(Space::forBool(true));
           arr.push_back(Space::forBool(false));
-        } else if (auto *E = tp->getEnumOrBoundGenericEnum()) {
+        } else if (auto *E = tp->getEnumDecl()) {
           // Look into each case of the enum and decompose it in turn.
           auto children = E->getAllElements();
           std::transform(children.begin(), children.end(),
@@ -819,7 +819,7 @@ namespace {
 
       static bool canDecompose(Type tp, const DeclContext *DC) {
         return tp->is<TupleType>() || tp->isBool() ||
-               tp->getEnumOrBoundGenericEnum();
+               tp->getEnumDecl();
       }
 
       // Search the space for a reason to downgrade exhaustiveness errors to
@@ -1082,7 +1082,7 @@ namespace {
         assert(defaultReason == RequiresDefault::No);
         Type subjectType = Switch->getSubjectExpr()->getType();
         bool shouldIncludeFutureVersionComment = false;
-        if (auto *theEnum = subjectType->getEnumOrBoundGenericEnum()) {
+        if (auto *theEnum = subjectType->getEnumDecl()) {
           shouldIncludeFutureVersionComment =
               theEnum->getParentModule()->isSystemModule();
         }
@@ -1406,7 +1406,7 @@ namespace {
       }
       case PatternKind::EnumElement: {
         auto *VP = cast<EnumElementPattern>(item);
-        TC.validateDecl(item->getType()->getEnumOrBoundGenericEnum());
+        TC.validateDecl(item->getType()->getEnumDecl());
         
         auto *SP = VP->getSubPattern();
         if (!SP) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3100,7 +3100,7 @@ Type TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
     Type ty = resolveType(tyR, options.withoutContext());
     if (!ty || ty->hasError()) return ty;
 
-    auto nominalDecl = ty->getAnyNominal();
+    auto nominalDecl = ty->getNominalTypeDecl();
     if (nominalDecl && isa<ClassDecl>(nominalDecl)) {
       if (checkSuperclass(tyR->getStartLoc(), ty))
         continue;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3676,7 +3676,7 @@ public:
     MF.configureGenericEnvironment(extension, genericEnvID);
 
     auto baseTy = MF.getType(baseID);
-    auto nominal = baseTy->getAnyNominal();
+    auto nominal = baseTy->getNominalTypeDecl();
     assert(!baseTy->hasUnboundGenericType());
     extension->getExtendedTypeLoc().setType(baseTy);
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1642,7 +1642,7 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
         Out, ScratchRecord,
         abbrCode,
         addDeclRef(normal->getProtocol()),
-        addDeclRef(normal->getType()->getAnyNominal()),
+        addDeclRef(normal->getType()->getNominalTypeDecl()),
         addModuleRef(normal->getDeclContext()->getParentModule()));
     }
     break;
@@ -2627,7 +2627,7 @@ static void collectDependenciesFromType(llvm::SmallSetVector<Type, 4> &seen,
                                         Type ty,
                                         const ModuleDecl *excluding) {
   ty.visit([&](Type next) {
-    auto *nominal = next->getAnyNominal();
+    auto *nominal = next->getNominalTypeDecl();
     if (!nominal)
       return;
     // FIXME: Types in the same module are still important for enums. It's
@@ -2767,7 +2767,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     // Make sure the base type has registered itself as a provider of generic
     // parameters.
-    auto baseNominal = baseTy->getAnyNominal();
+    auto baseNominal = baseTy->getNominalTypeDecl();
     (void)addDeclRef(baseNominal);
 
     auto conformances = extension->getLocalConformances(

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -284,7 +284,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info) {
     if (proto &&
         Req.getKind() == RequirementKind::Conformance &&
         Req.getFirstType()->isEqual(proto->getSelfInterfaceType()) &&
-        Req.getSecondType()->getAnyNominal() == proto)
+        Req.getSecondType()->getNominalTypeDecl() == proto)
       continue;
 
     std::string ReqStr;
@@ -453,7 +453,7 @@ static bool initDocEntityInfo(const TextEntity &Entity,
 static const TypeDecl *getTypeDeclFromType(Type Ty) {
   if (auto alias = dyn_cast<TypeAliasType>(Ty.getPointer()))
     return alias->getDecl();
-  return Ty->getAnyNominal();
+  return Ty->getNominalTypeDecl();
 }
 
 static void passInherits(const ValueDecl *D, DocInfoConsumer &Consumer) {
@@ -535,7 +535,7 @@ static void reportRelated(ASTContext &Ctx, const Decl *D,
       // If underlying type exists, report the inheritance and conformance of the
       // underlying type.
       auto Ty = TAD->getDeclaredInterfaceType();
-      if (auto NM = Ty->getAnyNominal()) {
+      if (auto NM = Ty->getNominalTypeDecl()) {
         passInherits(NM->getInherited(), Consumer);
         passConforms(NM->getSatisfiedProtocolRequirements(/*Sorted=*/true),
                      Consumer);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -719,7 +719,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   auto BaseType = findBaseTypeForReplacingArchetype(VD, ContainerTy);
   bool InSynthesizedExtension = false;
   if (BaseType) {
-    if (auto Target = BaseType->getAnyNominal()) {
+    if (auto Target = BaseType->getNominalTypeDecl()) {
       SynthesizedExtensionAnalyzer Analyzer(Target,
                                           PrintOptions::printModuleInterface());
       InSynthesizedExtension = Analyzer.isInSynthesizedExtension(VD);
@@ -739,7 +739,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     SwiftLangSupport::printUSR(VD, OS);
     if (InSynthesizedExtension) {
         OS << LangSupport::SynthesizedUSRSeparator;
-        SwiftLangSupport::printUSR(BaseType->getAnyNominal(), OS);
+        SwiftLangSupport::printUSR(BaseType->getNominalTypeDecl(), OS);
     }
   }
   unsigned USREnd = SS.size();
@@ -800,7 +800,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   unsigned GroupBegin = SS.size();
   {
     llvm::raw_svector_ostream OS(SS);
-    auto *GroupVD = InSynthesizedExtension ? BaseType->getAnyNominal() : VD;
+    auto *GroupVD = InSynthesizedExtension ? BaseType->getNominalTypeDecl() : VD;
     if (auto OP = GroupVD->getGroupName())
       OS << OP.getValue();
   }

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -888,12 +888,12 @@ static StringRef getTypeName(SDKContext &Ctx, Type Ty,
   if (auto *NAT = dyn_cast<TypeAliasType>(Ty.getPointer())) {
     return NAT->getDecl()->getNameStr();
   }
-  if (Ty->getAnyNominal()) {
+  if (Ty->getNominalTypeDecl()) {
     if (IsImplicitlyUnwrappedOptional) {
       assert(Ty->getOptionalObjectType());
       return StringRef("ImplicitlyUnwrappedOptional");
     }
-    return Ty->getAnyNominal()->getNameStr();
+    return Ty->getNominalTypeDecl()->getNameStr();
   }
 #define TYPE(id, parent)                                                      \
   if (Ty->getKind() == TypeKind::id) {                                        \
@@ -1098,7 +1098,7 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Type Ty, TypeInitInfo Info) :
   if (isFunctionTypeNoEscape(Ty))
     TypeAttrs.push_back(TypeAttrKind::TAK_noescape);
   // If this is a nominal type, get its Usr.
-  if (auto *ND = Ty->getAnyNominal()) {
+  if (auto *ND = Ty->getNominalTypeDecl()) {
     Usr = calculateUsr(Ctx, ND);
   }
 }
@@ -1160,7 +1160,7 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD)
   // Get enum raw type name if this is an enum.
   if (auto *ED = dyn_cast<EnumDecl>(VD)) {
     if (auto RT = ED->getRawType()) {
-      if (auto *D = RT->getNominalOrBoundGenericNominal()) {
+      if (auto *D = RT->getNominalTypeDecl()) {
         EnumRawTypeName = D->getName().str();
       }
     }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2216,7 +2216,7 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
       if (auto typeDecl = dyn_cast<TypeDecl>(result.getValueDecl())) {
         if (auto typeAliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
           TypeDecl *origTypeDecl = typeAliasDecl->getDeclaredInterfaceType()
-            ->getAnyNominal();
+            ->getNominalTypeDecl();
           if (origTypeDecl) {
             origTypeDecl->print(*Printer, Options);
             typeDecl = origTypeDecl;


### PR DESCRIPTION
The get\*OrBoundGeneric\* methods are, in practice, simple getters that extract a Decl node. Let's rename the APIs accordingly and make them shorter at the same time. This is similar to the DeclContext changes made by Jordan Rose in: 537954fb9338951ce94dbe8549bbc7f0e2b1395f

- getNominalOrBoundGenericNominal -> getNominalDecl
- getStructOrBoundGenericStruct -> getStructDecl
- getClassOrBoundGenericClass -> getClassDecl
- getEnumOrBoundGenericEnum -> getEnumDecl

This is purely a mechanical change.