### PR TITLE
cmake: make swiftRemoteMirror export interfaces on Windows

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1195,6 +1195,11 @@ function(_add_swift_library_single target name)
     "${SWIFTLIB_SINGLE_FORCE_BUILD_OPTIMIZED_keyword}"
     RESULT_VAR_NAME c_compile_flags
     )
+  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS)
+    if(libkind STREQUAL SHARED)
+      list(APPEND c_compile_flags -D_WINDLL)
+    endif()
+  endif()
   _add_variant_link_flags(
     SDK "${SWIFTLIB_SINGLE_SDK}"
     ARCH "${SWIFTLIB_SINGLE_ARCHITECTURE}"


### PR DESCRIPTION
Unfortunately, `swift-reflection-test` links against the *TARGET*
library `swiftRemoteMirror`.  The linked library is built as a target
library, which means that we use the custom library target construction
which suffixes the target with a variant spelling.  Because the number
of variants is really high, we pass along the explicit EXPORTS macro
manually.  However, we also build the library as a static library for
the *HOST*.  This means that we need the sources to be aware of whether
they are built statically or dyanmically.  This is accomplished by means
of the `_WINDLL` macro.  The target library is shared and is built using
the custom wrapper for the library construction, which will create all
the variants and then use `_compute_variant_c_flags` which does not get
told what type of library is being built, so it assumes static and does
not append `_WINDLL`.  This results in the shared library not exposing
any interfaces on Windows.  When this happens, link will helpfully elide
the import library.  The result of that is that the
swift-reflection-test binary will fail to link due to no import library
for the RemoteMirror.  Explicitly add the -D_WINDLL if appropriate
manually after we have computed the C flags.  *siiiiiiigh*

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
