### PR TITLE
[AutoDiff] Remove the method mode from 'Builtin.autodiffApply'.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -349,7 +349,7 @@ getNumAutoDiffAssociatedFunctions(unsigned differentiationOrder);
 bool getBuiltinAutoDiffApplyConfig(StringRef operationName,
                                    AutoDiffAssociatedFunctionKind &kind,
                                    unsigned &arity, unsigned &order,
-                                   bool &rethrows, bool &isMethod);
+                                   bool &rethrows);
 } // end namespace autodiff
 
 class BuiltinFloatType;

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -69,7 +69,7 @@ autodiff::getNumAutoDiffAssociatedFunctions(unsigned differentiationOrder) {
 
 bool autodiff::getBuiltinAutoDiffApplyConfig(
     StringRef operationName, AutoDiffAssociatedFunctionKind &kind,
-    unsigned &arity, unsigned &order, bool &rethrows, bool &isMethod) {
+    unsigned &arity, unsigned &order, bool &rethrows) {
   // SWIFT_ENABLE_TENSORFLOW
   if (!operationName.startswith("autodiffApply_"))
     return false;
@@ -108,13 +108,6 @@ bool autodiff::getBuiltinAutoDiffApplyConfig(
     rethrows = true;
   } else {
     rethrows = false;
-  }
-  // Parse '_method'.
-  if (operationName.startswith("_method")) {
-    operationName = operationName.drop_front(strlen("_method"));
-    isMethod = true;
-  } else {
-    isMethod = false;
   }
   return operationName.empty();
 }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1181,9 +1181,9 @@ static ManagedValue emitBuiltinAutoDiffApply(SILGenFunction &SGF,
   auto builtinName = builtinDecl->getName().str();
   AutoDiffAssociatedFunctionKind kind;
   unsigned arity, order;
-  bool rethrows, isMethod;
+  bool rethrows;
   auto successfullyParsed = autodiff::getBuiltinAutoDiffApplyConfig(
-      builtinName, kind, arity, order, rethrows, isMethod);
+      builtinName, kind, arity, order, rethrows);
   assert(successfullyParsed);
   return emitBuiltinAutoDiffApplyAssociatedFunction(kind, arity, order,
                                                     rethrows, SGF, loc,

--- a/test/AutoDiff/core_builtins.swift
+++ b/test/AutoDiff/core_builtins.swift
@@ -35,35 +35,3 @@ func evaldiff2<T: Differentiable, U: Differentiable, V: Differentiable>(_ f: @di
 // CHECK-LABEL: @{{.*}}evaldiff2{{.*}}
 // CHECK: bb0({{.*}} : @trivial $*V, [[DIFFED:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V, {{.*}} : @trivial $*T, {{.*}} : @trivial $*U):
 // CHECK:   autodiff_function_extract [jvp] [order 1] [[DIFFED]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V // user: %14
-
-func methoddiff<T: Differentiable, U: Differentiable, R: Differentiable>(_ f: @differentiable (T) -> (U) -> R, _ x: T, _ y: U)
-    -> (R, (T.TangentVector, U.TangentVector) -> R.TangentVector)
-  where T == T.TangentVector, U == U.TangentVector {
-  return Builtin.autodiffApply_jvp_method(f, x, y)
-}
-
-// CHECK-SIL-LABEL: @{{.*}}methoddiff{{.*}}
-// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : @trivial $*R, [[ORIG_FN:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> @out R, [[ORIG_FN_ARG1:%.*]] : @trivial $*T, [[ORIG_FN_ARG2:%.*]] : @trivial $*U):
-// CHECK-SIL:   [[ORIG_FN_ARG1_COPY:%.*]] = alloc_stack $T
-// CHECK-SIL:   copy_addr [[ORIG_FN_ARG1]] to [initialization] [[ORIG_FN_ARG1_COPY]] : $*T
-// CHECK-SIL:   [[ORIG_FN_ARG2_COPY:%.*]] = alloc_stack $U
-// CHECK-SIL:   copy_addr [[ORIG_FN_ARG2]] to [initialization] [[ORIG_FN_ARG2_COPY]] : $*U
-// CHECK-SIL:   [[JVP_FN:%.*]] = autodiff_function_extract [jvp] [order 1] [[ORIG_FN]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> @out R
-// CHECK-SIL:   [[JVP_FN_PARTIAL_APPLIED:%.*]] = apply [[JVP_FN]]([[ORIG_FN_ARG1_COPY]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> @owned @callee_guaranteed (@in_guaranteed U) -> (@out R, @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector)
-// CHECK-SIL:   destroy_addr [[ORIG_FN_ARG1_COPY]]
-// CHECK-SIL:   [[JVP_RES_BUF:%.*]] = alloc_stack $(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector)
-// CHECK-SIL:   [[JVP_RES_BUF_0:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector), 0
-// CHECK-SIL:   [[DIFFERENTIAL:%.*]] = apply [[JVP_FN_PARTIAL_APPLIED]]([[JVP_RES_BUF_0]], [[ORIG_FN_ARG2_COPY]]) : $@callee_guaranteed (@in_guaranteed U) -> (@out R, @owned @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector)
-// CHECK-SIL:   destroy_value [[JVP_FN_PARTIAL_APPLIED]]
-// CHECK-SIL:   destroy_addr [[ORIG_FN_ARG2_COPY]] : $*U
-// CHECK-SIL:   [[JVP_RES_BUF_1:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector), 1
-// CHECK-SIL:   store [[DIFFERENTIAL]] to [init] [[JVP_RES_BUF_1]] : $*@callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector
-// CHECK-SIL:   [[JVP_RES_BUF_0:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector), 0
-// CHECK-SIL:   [[JVP_RES_BUF_1:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector), 1
-// CHECK-SIL:   [[DIFFERENTIAL:%.*]] = load [take] [[JVP_RES_BUF_1]] : $*@callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector
-// CHECK-SIL:   copy_addr [take] [[JVP_RES_BUF_0]] to [initialization] [[ORIG_RES_BUF]] : $*R
-// CHECK-SIL:   dealloc_stack [[JVP_RES_BUF]] : $*(R, @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector)
-// CHECK-SIL:   dealloc_stack [[ORIG_FN_ARG2_COPY]] : $*U
-// CHECK-SIL:   dealloc_stack [[ORIG_FN_ARG1_COPY]] : $*T
-// CHECK-SIL:   return [[DIFFERENTIAL]] : $@callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out R.TangentVector
-


### PR DESCRIPTION
Before indirect passing was supported, the `_method` configuration in `Builtin.autodiffApply_vjp_method` was used to directly apply a method's VJP as if its arguments were flattened like SIL. Not only was it a workaround, as a trade-off, it also introduced some semantic incorrectness in `@differentiable` functions: It made `@differentiable (T) -> (U) -> V` mean that `U` was also a differentiation parameter in the function, but `@differentiable` should not apply to inner curry levels.

After indirect passing support landed, we removed the method-specific differential operator from the standard library (#22637). So the `_method` mode in `Builtin.autodiffApply` becomes dead code. This PR removes that and simplifies the infrastructure.