### PR TITLE
stdlib: define and use `SWIFT_{,UN}LIKELY`

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -739,7 +739,7 @@ class RefCounts {
     do {
       newbits = oldbits;
       bool fast = newbits.incrementStrongExtraRefCount(inc);
-      if (__builtin_expect(!fast, 0)) {
+      if (SWIFT_UNLIKELY(!fast)) {
         if (oldbits.isImmortal())
           return;
         return incrementSlow(oldbits, inc);
@@ -752,7 +752,7 @@ class RefCounts {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
     auto newbits = oldbits;
     bool fast = newbits.incrementStrongExtraRefCount(inc);
-    if (__builtin_expect(!fast, 0)) {
+    if (SWIFT_UNLIKELY(!fast)) {
       if (oldbits.isImmortal())
         return;
       return incrementNonAtomicSlow(oldbits, inc);
@@ -770,7 +770,7 @@ class RefCounts {
 
       newbits = oldbits;
       bool fast = newbits.incrementStrongExtraRefCount(1);
-      if (__builtin_expect(!fast, 0)) {
+      if (SWIFT_UNLIKELY(!fast)) {
         if (oldbits.isImmortal())
           return true;
         return tryIncrementSlow(oldbits);
@@ -787,7 +787,7 @@ class RefCounts {
 
     auto newbits = oldbits;
     bool fast = newbits.incrementStrongExtraRefCount(1);
-    if (__builtin_expect(!fast, 0)) {
+    if (SWIFT_UNLIKELY(!fast)) {
       if (oldbits.isImmortal())
         return true;
       return tryIncrementNonAtomicSlow(oldbits);
@@ -1000,7 +1000,7 @@ class RefCounts {
       newbits = oldbits;
       bool fast =
         newbits.decrementStrongExtraRefCount(dec);
-      if (__builtin_expect(!fast, 0)) {
+      if (SWIFT_UNLIKELY(!fast)) {
         if (oldbits.isImmortal()) {
             return false;
         }

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -26,6 +26,10 @@
 #define __has_attribute(x) 0
 #endif
 
+#if !defined(__has_builtin)
+#define __has_builtin(builtin) 0
+#endif
+
 #if __has_feature(nullability)
 // Provide macros to temporarily suppress warning about the use of
 // _Nullable and _Nonnull.
@@ -158,6 +162,14 @@
 #define SWIFT_RUNTIME_STDLIB_INTERNAL extern "C" SWIFT_LIBRARY_VISIBILITY
 #else
 #define SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_LIBRARY_VISIBILITY
+#endif
+
+#if __has_builtin(__builtin_expect)
+#define SWIFT_LIKELY(expression) (__builtin_expect(!!(expression), 1))
+#define SWIFT_UNLIKELY(expression) (__builtin_expect(!!(expression), 0))
+#else
+#define SWIFT_LIKELY(expression) ((expression))
+#define SWIFT_UNLIKELY(expression) ((expression))
 #endif
 
 // SWIFT_STDLIB_SHIMS_VISIBILITY_H


### PR DESCRIPTION
Rather than directly using the extension `__builtin_expect`, use a macro
to permit the removal of the builtin on compilers which do not support
this (i.e. cl).  This permits us to build the swift compiler with MSVC
again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
