### PR TITLE
swift-api-digester: use elaborated typename

### DIFF
--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -477,7 +477,7 @@ SDKNodeType *SDKNodeDeclType::getRawValueType() const {
   return nullptr;
 }
 
-bool SDKNodeDeclType::isConformingTo(KnownProtocolKind Kind) const {
+bool SDKNodeDeclType::isConformingTo(swift::ide::api::KnownProtocolKind Kind) const {
   switch (Kind) {
 #define KNOWN_PROTOCOL(NAME)                                                \
     case KnownProtocolKind::NAME:                                           \


### PR DESCRIPTION
cl is unable to disambiguate between `swift::KnownProtocolKind` and
`swift::ide::api::KnownProtocolKind`.  Use the elaborated typename to
disambiguate the type.  This allows us to build `swift-api-digester`
with cl again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
