### PR TITLE
swift-reflection-dump: use elaborated type name

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -80,7 +80,7 @@ static T unwrap(llvm::Expected<T> value) {
 }
 
 using NativeReflectionContext
-  = ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
+    = swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
 
 class ObjectMemoryReader : public MemoryReader {
   const std::vector<const ObjectFile *> &ObjectFiles;


### PR DESCRIPTION
cl is unable to differentiate between the `swift::ReflectionContext` and
`swift::reflection::ReflectionContext`.  Use the elaborated typename to
uniquely identify the type.  This allows us to build
`swift-reflection-dump` with cl again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
