### PR TITLE
Reflection: prevent address truncation on ELF64

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -60,6 +60,7 @@ template <> struct ELFTraits<llvm::ELF::ELFCLASS32> {
   using Section = const struct llvm::ELF::Elf32_Shdr;
   using Offset = llvm::ELF::Elf32_Off;
   using Size = llvm::ELF::Elf32_Word;
+  using Address = llvm::ELF::Elf32_Addr;
   static constexpr unsigned char ELFClass = llvm::ELF::ELFCLASS32;
 };
 
@@ -68,6 +69,7 @@ template <> struct ELFTraits<llvm::ELF::ELFCLASS64> {
   using Section = const struct llvm::ELF::Elf64_Shdr;
   using Offset = llvm::ELF::Elf64_Off;
   using Size = llvm::ELF::Elf64_Xword;
+  using Address = llvm::ELF::Elf64_Addr;
   static constexpr unsigned char ELFClass = llvm::ELF::ELFCLASS64;
 };
 
@@ -330,7 +332,7 @@ public:
     auto StrTab = reinterpret_cast<const char *>(StrTabBuf.get());
 
     auto findELFSectionByName = [&](std::string Name)
-        -> std::pair<std::pair<const char *, const char *>, uint32_t> {
+        -> std::pair<std::pair<const char *, const char *>, typename T::Address> {
       // Now for all the sections, find their name.
       for (const typename T::Section *Hdr : SecHdrVec) {
         uint32_t Offset = Hdr->sh_name;


### PR DESCRIPTION
Ensure that we use the address type as specified by ELF rather than
truncate to a 32-bit value.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
