### PR TITLE
[AutoDiff] TF-159: Diagnose differentiation through 'inout' arguments.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -364,13 +364,8 @@ ERROR(pound_assert_failure,none,
 // Automatic differentiation diagnostics
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
-ERROR(autodiff_unsupported_type,none,
-      "differentiating '%0' is not supported yet", (Type))
 ERROR(autodiff_function_not_differentiable,none,
       "function is not differentiable", ())
-NOTE(autodiff_function_indirect_params_or_result_unsupported,none,
-     "differentiating functions with parameters or result of unknown size "
-     "is not supported yet", ())
 NOTE(autodiff_external_nondifferentiable_function,none,
      "cannot differentiate an external function that has not been marked "
      "'@differentiable'", ())
@@ -412,14 +407,12 @@ NOTE(autodiff_when_differentiating_function_definition,none,
      "when differentiating this function definition", ())
 NOTE(autodiff_expression_is_not_differentiable,none,
      "expression is not differentiable", ())
-NOTE(autodiff_nested_function_call_multiple_return_active,none,
-     "function call is being differentiated from multiple return values", ())
+NOTE(autodiff_cannot_differentiate_through_inout_arguments,none,
+     "cannot differentiate through 'inout' arguments", ())
 NOTE(autodiff_control_flow_not_supported,none,
      "differentiating control flow is not supported yet", ())
 NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not supported yet", ())
-NOTE(autodiff_nested_not_supported,none,
-     "nested differentiation is not supported yet", ())
 NOTE(autodiff_missing_return,none,
      "missing return for differentiation", ())
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1378,7 +1378,7 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
             auto structIsFieldwiseDiffable = sei->getStructDecl()->getAttrs()
                 .hasAttribute<FieldwiseDifferentiableAttr>();
             if (!(hasNoDeriv && structIsFieldwiseDiffable))
-              for (auto result: inst.getResults())
+              for (auto result : inst.getResults())
                 setVaried(result, i);
           }
         }
@@ -1423,6 +1423,10 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
             checkAndSetUseful(dirRes);
           for (auto indRes : ai->getIndirectSILResults())
             checkAndSetUseful(indRes);
+          auto paramInfos = ai->getSubstCalleeConv().getParameters();
+          for (auto i : indices(paramInfos))
+            if (paramInfos[i].isIndirectInOut())
+              checkAndSetUseful(ai->getArgumentsWithoutIndirectResults()[i]);
         }
         // Handle `store`.
         else if (auto *si = dyn_cast<StoreInst>(&inst)) {
@@ -2553,8 +2557,6 @@ public:
     auto structLoweredTy =
         getContext().getTypeConverter().getLoweredType(structTy);
     auto primValsVal = builder.createStruct(loc, structLoweredTy, primalValues);
-    // FIXME: Handle tapes.
-    //
     // If the original result was a tuple, return a tuple of all elements in the
     // original result tuple and the primal value struct value.
     auto origResTy = origResInPrimal->getType();
@@ -2867,25 +2869,44 @@ public:
         LookUpConformanceInModule(swiftModule));
   }
 
+  // If an `apply` has active results or active inout parameters, replace it
+  // with an `apply` of its VJP.
   void visitApplyInst(ApplyInst *ai) {
     auto &context = getContext();
-    // Special handling logic only applies when `apply` has active results. If
-    // not, just do standard cloning.
+    // Special handling logic only applies when `apply` has active results or
+    // active arguments at an active 'inout' parameter position. If not, just do
+    // standard cloning.
     SmallVector<SILValue, 4> allResults;
     allResults.push_back(ai);
     allResults.append(ai->getIndirectSILResults().begin(),
                       ai->getIndirectSILResults().end());
-    if (llvm::none_of(allResults, [&](SILValue result) {
+    auto hasActiveResults = llvm::any_of(allResults, [&](SILValue result) {
       return activityInfo.isActive(result, synthesis.indices);
-    })) {
-      LLVM_DEBUG(getADDebugStream() << "Not active:\n" << *ai << '\n');
+    });
+    // Check for active 'inout' arguments.
+    auto paramInfos = ai->getSubstCalleeConv().getParameters();
+    bool hasActiveInoutParams = false;
+    for (unsigned i : swift::indices(paramInfos))
+      if (paramInfos[i].isIndirectInOut() &&
+          activityInfo.isActive(ai->getArgumentsWithoutIndirectResults()[i],
+                                synthesis.indices))
+        hasActiveInoutParams = true;
+    // Reject funtions with active inout arguments. It's not supported yet.
+    if (hasActiveInoutParams) {
+      context.emitNondifferentiabilityError(ai, getDifferentiationTask(),
+          diag::autodiff_cannot_differentiate_through_inout_arguments);
+      errorOccurred = true;
+      return;
+    }
+    // If there's no active results, this function should not be differentiated.
+    // Do standard cloning.
+    if (!hasActiveResults) {
+      LLVM_DEBUG(getADDebugStream() << "No active results:\n" << *ai << '\n');
       SILClonerWithScopes::visitApplyInst(ai);
       return;
     }
 
-    // This instruction is active. Replace it with a call to the VJP.
-
-    // Get the indices required for differentiating this function.
+    // Get the parameter indices required for differentiating this function.
     LLVM_DEBUG(getADDebugStream() << "Primal-transforming:\n" << *ai << '\n');
     SmallVector<unsigned, 8> activeParamIndices;
     SmallVector<unsigned, 8> activeResultIndices;
@@ -2901,14 +2922,12 @@ public:
                    activeResultIndices.begin(), activeResultIndices.end(),
                    [&s](unsigned i) { s << i; }, [&s] { s << ", "; });
                s << "}\n";);
-
     // FIXME: We don't support multiple active results yet.
     if (activeResultIndices.size() > 1) {
       context.emitNondifferentiabilityError(ai, synthesis.task);
       errorOccurred = true;
       return;
     }
-
     // Form expected indices by assuming there's only one result.
     SILAutoDiffIndices indices(activeResultIndices.front(), activeParamIndices);
 
@@ -3715,13 +3734,26 @@ private:
   
   bool shouldBeDifferentiated(SILInstruction *inst,
                               const SILAutoDiffIndices &indices) {
+    // Anything with an active result should be differentiated.
     if (llvm::any_of(inst->getResults(),
             [&](SILValue val) { return activityInfo.isActive(val, indices); }))
       return true;
-    if (auto *ai = dyn_cast<ApplyInst>(inst))
+    if (auto *ai = dyn_cast<ApplyInst>(inst)) {
+      // Function applications with an active indirect result should be
+      // differentiated.
       for (auto indRes : ai->getIndirectSILResults())
         if (activityInfo.isActive(indRes, indices))
           return true;
+      // Function applications with an inout argument should be differentiated.
+      auto paramInfos = ai->getSubstCalleeConv().getParameters();
+      for (auto i : swift::indices(paramInfos))
+        if (paramInfos[i].isIndirectInOut() &&
+            activityInfo.isActive(
+                ai->getArgumentsWithoutIndirectResults()[i], indices))
+          return true;
+    }
+    // Instructions that may write to memory and has an active operand should
+    // be differentiated.
     if (inst->mayWriteToMemory())
       for (auto &op : inst->getAllOperands())
         if (activityInfo.isActive(op.get(), indices))

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -176,3 +176,26 @@ func roundingGivesError(x: Float) -> Float {
   // expected-note @+1 {{expression is not differentiable}}
   return Float(Int(x))
 }
+
+//===----------------------------------------------------------------------===//
+// Inout arguments
+//===----------------------------------------------------------------------===//
+
+func activeInoutArg(_ x: Float) -> Float {
+  var a = x
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  a += x
+  return a
+}
+// expected-error @+1 {{function is not differentiable}}
+_ = pullback(at: .zero, in: activeInoutArg(_:))
+
+
+func activeInoutArgTuple(_ x: Float) -> Float {
+  var tuple = (x, x)
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  tuple.0 *= x
+  return x * tuple.0
+}
+// expected-error @+1 {{function is not differentiable}}
+_ = pullback(at: .zero, in: activeInoutArgTuple(_:))

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -110,15 +110,6 @@ SimpleMathTests.test("TupleSideEffects") {
   }
   expectEqual(27, gradient(at: 3, in: foo))
 
-  func fooInout(_ x: Float) -> Float {
-    var tuple = (x, x)
-    tuple.0 *= x
-    return x * tuple.0
-  }
-  // FIXME(TF-159): Update after activity analysis handles inout parameters.
-  // expectEqual(27, gradient(at: 3, in: fooInout))
-  expectEqual(12, gradient(at: 3, in: fooInout))
-
   func fifthPower(_ x: Float) -> Float {
     var tuple = (x, x)
     tuple.0 = tuple.0 * x


### PR DESCRIPTION
Differentiation through `inout` arguments is not supported yet. This PR fixes a miscompilation and diagnoses it.

* Extend activity analysis to treat an `apply`'s `inout` arguments both as an input and as an output. This correctly marks those relevant `inout` arguments as ACTIVE.

* In `PrimalGenCloner::visitApplyInst`, check for active `inout` arguments and diagnose them.

* In `AdjointEmitter::shouldBeDifferentiated`, check for active `inout` arguments and return true if they exist. This will be the correct semantics for the future support for differentiation through `inout` arguments.

* Remove unused diagnostics.

* Add tests in `test/AutoDiff/autodiff_diagnostics.swift`.

* Remove an incorrectly added runtime test in `test/AutoDiff/simple_math.swift`. It's incorrect because differentiating through `inout` arguments is _not_ an activity analysis problem, but because our existing VJP formulation never supported `inout` arguments. Changing activity analysis is nowhere enough to make it pass. As such, that test has been removed.

Resolves [TF-159](https://bugs.swift.org/browse/TF-159).