### PR TITLE
[AutoDiff] Enable same-file retroactive derivative registration.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2748,6 +2748,10 @@ ERROR(differentiating_attr_unexpected_diff_params_type,none,
       "unexpected differentiation parameters type; got %0, but expected %1", (Type, Type))
 ERROR(differentiating_attr_overload_not_found,none,
       "%0 does not have expected type %1", (DeclName, Type))
+ERROR(differentiating_attr_not_in_same_file_as_original,none,
+      "derivative not in the same file as the original function", ())
+ERROR(differentiating_attr_original_already_has_derivative,none,
+      "a derivative already exists for %0", (DeclName))
 
 // @compilerEvaluable
 ERROR(compiler_evaluable_bad_context,none,

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1806,8 +1806,15 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
     auto *task =
         context.lookUpMinimalDifferentiationTask(originalFn, desiredIndices);
     if (!task) {
+      // If the function is intentionally marked as being opauqe to
+      // differentiation, then we should not create a task for it.
+      if (originalFn->hasSemanticsAttr("autodiff.opaque")) {
+        context.emitNondifferentiabilityError(original, parentTask,
+            diag::autodiff_opaque_function_not_differentiable);
+        return None;
+      }
+      // Check and diagnose non-differentiable arguments.
       auto originalFnTy = originalFn->getLoweredFunctionType();
-
       for (unsigned paramIndex : range(originalFnTy->getNumParameters())) {
         if (desiredIndices.isWrtParameter(paramIndex) &&
             !originalFnTy->getParameters()[paramIndex]
@@ -1818,7 +1825,7 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
           return None;
         }
       }
-
+      // Check and diagnose non-differentiable results.
       if (!originalFnTy->getResults()[desiredIndices.source]
                .getSILStorageType()
                .isDifferentiable(context.getModule())) {
@@ -1826,13 +1833,14 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
             original, parentTask, diag::autodiff_nondifferentiable_result);
         return None;
       }
-
+      // Check and diagnose external declarations.
       if (originalFn->isExternalDeclaration()) {
         context.emitNondifferentiabilityError(
             original, parentTask,
             diag::autodiff_external_nondifferentiable_function);
         return None;
       }
+      // Sanity check passed. Create a differentiation task.
       task = context.registerDifferentiationTask(originalFn, desiredIndices,
                                                  invoker);
     }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -191,13 +191,13 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   for (auto *DA : diffAttrs) {
     // FIXME: When we get rid of `vjp:` and `jvp:` arguments in `@differentiable`,
     // we will no longer need to see whether they are specified.
-    if (!DA->getJVP()) {
+    if (!DA->getJVPFunction()) {
       auto *id = AutoDiffAssociatedFunctionIdentifier::get(
           AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
           DA->getParameterIndices(), AFD->getASTContext());
       addSymbol(SILDeclRef(AFD).asAutoDiffAssociatedFunction(id));
     }
-    if (!DA->getVJP()) {
+    if (!DA->getVJPFunction()) {
       auto *id = AutoDiffAssociatedFunctionIdentifier::get(
           AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
           DA->getParameterIndices(), AFD->getASTContext());
@@ -273,13 +273,13 @@ void TBDGenVisitor::visitVarDecl(VarDecl *VD) {
   for (auto *DA : diffAttrs) {
     // FIXME: When we get rid of `vjp:` and `jvp:` arguments in `@differentiable`,
     // we will no longer need to see whether they are specified.
-    if (!DA->getJVP()) {
+    if (!DA->getJVPFunction()) {
       auto *id = AutoDiffAssociatedFunctionIdentifier::get(
           AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
           DA->getParameterIndices(), VD->getASTContext());
       addSymbol(SILDeclRef(VD->getGetter()).asAutoDiffAssociatedFunction(id));
     }
-    if (!DA->getVJP()) {
+    if (!DA->getVJPFunction()) {
       auto *id = AutoDiffAssociatedFunctionIdentifier::get(
           AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
           DA->getParameterIndices(), VD->getASTContext());

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -70,4 +70,18 @@ CustomDerivativesTests.test("Checkpointing") {
   expectEqual(2, count)
 }
 
+
+@_semantics("autodiff.opaque")
+func functionWithRetroDeriv(x: Float) -> Float {
+  return x
+}
+@differentiating(functionWithRetroDeriv)
+func retroDeriv(x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (value: x, pullback: { _ in 100 })
+}
+
+CustomDerivativesTests.test("Retroactive") {
+  expectEqual(100, gradient(at: 3, in: functionWithRetroDeriv))
+}
+
 runAllTests()

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -75,6 +75,7 @@ func vjpFooExtraGenericRequirements<T : FloatingPoint & Differentiable & BinaryI
 // Test static methods.
 
 extension AdditiveArithmetic where Self : Differentiable {
+  // expected-error @+1 {{derivative not in the same file as the original function}}
   @differentiating(+)
   static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)) {
     return (x + y, { v in (v, v) })
@@ -82,6 +83,7 @@ extension AdditiveArithmetic where Self : Differentiable {
 }
 
 extension FloatingPoint where Self : Differentiable, Self == Self.CotangentVector {
+  // expected-error @+1 {{derivative not in the same file as the original function}}
   @differentiating(+)
   static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
     return (x + y, { v in (v, v) })


### PR DESCRIPTION
### Overview

Retroactive derivative registration, a.k.a. the `@differentiating` attribute, is the ultimate direction we'd like to go for. There are two critical goals:
1. Eliminating the JVP and VJP concepts from the user land. Today's situation is that the `jvp:` and `vjp:` attribute arguments are still needed for registering a derivative via a `@differentiable` attribute on the original function definition. The user is not supposed to know what a JVP/VJP is in order to define a derivative. When `@differentiating` is added, we would like to eliminate `vjp:` and `vjp:` attribute arguments from the `@differentiable` attribute.
2. Make differentiation as extensible as the rest of Swift (retroactive conformances, etc). Users should be able to make a function from an imported module be differentiable, and export the derivative to other files and modules that import the module containing the retroactive derivative.

Implementation-wise, cross-file/cross-module retroactive derivative registration requires a top-level differentiability witness construct in SIL that behaves like SIL protocol witnesses. For more implementation information, see [this forum discussion](https://forums.swift.org/t/help-needed-with-retroactive-differentiability/19927/6?u=rxwei). This PR is **not** doing that. However, same-file retroactive derivative registration is fairly easy to do -- all it takes is to make each `@differentiating` imply a `@differentiable` attribute on the original function. In other words, the `@differentiable` attribute (or more precisely the `[differentiable]` SIL function attribute) is acting like a differentiability witness in a SIL module already, so we can just make use of that.

### Changes

This PR adds support for same-file retroactive derivative registration. So long as the original function exists in the same file as the derivative with a `@differentiating` attribute, derivative registration works. The detailed implementation steps are as follows:
* When type-checking a `@differentiating` attribute, after resolving the original function declaration, check to see if the original function is in the same file as the retroactive derivative. If not, emit a diagnostic.
* Find an existing `@differentiable` attribute on the original function that is w.r.t. all parameters. If it exists, treat that attribute as the witness. If not, create a new `@differentiable` attribute that covers all parameters and treat that as the witness.
* If the `@differentiable` attribute already has an associated function (JVP/VJP) that the retroactive derivative represents, emit a diagnostic.
* Set the corresponding associated function in the `@differentiable` attribute to be the retroactive derivative.

Now, basic things work as demonstrated in the following example. A `@differentiating` attribute makes it work as if the original function had a `@differentiable` attribute.

```swift
func functionWithRetroDeriv(x: Float) -> Float {
  return x
}
@differentiating(functionWithRetroDeriv)
func retroDeriv(x: Float) -> (value: Float, pullback: (Float) -> Float) {
  return (value: x, pullback: { _ in 100 })
}
gradient(at: 3, in: functionWithRetroDeriv) // => 100
```

### Known unhandled

* When the derivative function has a different canonical generic signature as the original function and when the original function does not have an all-parameter `@differentiable` attribute that specifies the derivative function's generic constraints w.r.t. the original function, the behavior is undefined. This will be fixed in a follow-up PR.

* We do not support `wrt:` in a `@differentiating` attribute yet, so we can't use this on functions with non-differentiable parameters.

* The `@differentiating` attribute is not registered in `gyb_syntax_support` yet, so syntax verification would fail if we use `@differentiating` in the standard library. But we can live with this for now.

Resolves [TF-278](https://bugs.swift.org/browse/TF-278).