### PR TITLE
Add a leaking test case for SILGenPattern that was already fixed.

### DIFF
--- a/test/Interpreter/switch.swift
+++ b/test/Interpreter/switch.swift
@@ -222,4 +222,19 @@ SwitchTestSuite.test("TupleUnforwarding") {
   }
 }
 
+protocol P {}
+
+SwitchTestSuite.test("Protocol Conformance Check Leaks") {
+  do {
+    let x = LifetimeTracked(0)
+    let y = LifetimeTracked(1)
+    switch (x, y) {
+    case (is P, is P):
+      break
+    default:
+      break
+    }
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
We used to leak y in this example. This adds the test case to ensure that we do
not leak ever again.

rdar://40287604
