### PR TITLE
[AutoDiff] TF-{295,285}: Make '@differentiable' default parameters include 'self' on instance methods.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -199,6 +199,12 @@ public:
   /// `AutoDiffParameterIndices::parameters` for documentation about the order.
   void setParameter(unsigned parameterIndex);
 
+  /// Sets the parameters at indices in the specified range.
+  void setParameters(unsigned lowerBound, unsigned upperBound);
+
+  /// Sets all parameters.
+  void setAllParameters();
+
   /// Returns the number of parameters.
   unsigned size() { return parameters.size(); }
 };

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2446,8 +2446,6 @@ WARNING(differentiable_implicit_noderivative_fixit,none,
       "stored property %0 has no derivative because it does not conform to "
       "'Differentiable'; add '@noDerivative' to make it explicit",
       (Identifier))
-NOTE(protocol_witness_missing_differentiable_attr,none,
-     "candidate is missing attribute '%0'", (StringRef))
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))
@@ -2728,6 +2726,8 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
       "layout requirement are not supported by '@differentiable' attribute", ())
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
+NOTE(protocol_witness_missing_specific_differentiable_attr,none,
+     "candidate is missing attribute '%0'", (StringRef))
 
 // @differentiang
 ERROR(differentiating_attr_expected_result_tuple,none,

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -262,8 +262,8 @@ static unsigned getNumAutoDiffParameterIndices(AnyFunctionType *fnTy) {
 }
 
 AutoDiffParameterIndicesBuilder::AutoDiffParameterIndicesBuilder(
-    AnyFunctionType *functionType, bool setAllParams) :
-    parameters(getNumAutoDiffParameterIndices(functionType), setAllParams) {
+    AnyFunctionType *functionType, bool setAllParams)
+    : parameters(getNumAutoDiffParameterIndices(functionType), setAllParams) {
 }
 
 AutoDiffParameterIndices *
@@ -274,6 +274,15 @@ AutoDiffParameterIndicesBuilder::build(ASTContext &C) const {
 void AutoDiffParameterIndicesBuilder::setParameter(unsigned paramIndex) {
   assert(paramIndex < parameters.size() && "paramIndex out of bounds");
   parameters.set(paramIndex);
+}
+
+void AutoDiffParameterIndicesBuilder::setParameters(unsigned lowerBound,
+                                                    unsigned upperBound) {
+  parameters.set(lowerBound, upperBound);
+}
+
+void AutoDiffParameterIndicesBuilder::setAllParameters() {
+  parameters.set();
 }
 
 Type VectorSpace::getType() const {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2248,7 +2248,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
       assert(da);
       std::string diffAttrReq;
       llvm::raw_string_ostream stream(diffAttrReq);
-      da->print(stream);
+      da->print(stream, req);
       diags.diagnose(match.Witness,
           diag::protocol_witness_missing_specific_differentiable_attr,
           StringRef(stream.str()).trim());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -661,24 +661,22 @@ swift::matchWitness(
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  // Differentiation attributes must match completely or the generated
-  // functions will have the wrong signature.
-  // TODO(TF-285): Handle multiple `@differentiable` attributes on protocol
-  // requirements. Only missing attributes should be diagnosed.
-  auto *reqDiffAttr =
-      reqAttrs.getAttribute<DifferentiableAttr>(/*AllowInvalid*/ true);
-  auto *witnessDiffAttr =
-      witnessAttrs.getAttribute<DifferentiableAttr>(/*AllowInvalid*/ true);
-  if (reqDiffAttr && (!reqDiffAttr->getParameterIndices() ||
-                      !witnessDiffAttr ||
-                      !witnessDiffAttr->getParameterIndices() ||
-                      !witnessDiffAttr->parametersMatch(*reqDiffAttr))) {
-    if (auto *vdWitness = dyn_cast<VarDecl>(witness))
-      return RequirementMatch(
-          getStandinForAccessor(vdWitness, AccessorKind::Get),
-          MatchKind::DifferentiableConflict);
-    else
-      return RequirementMatch(witness, MatchKind::DifferentiableConflict);
+  // '@differentiable' attributes must match completely.
+  for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
+    auto witnessDiffAttrs =
+        witnessAttrs.getAttributes<DifferentiableAttr, /*AllowInvalid*/ true>();
+    bool reqDiffAttrMatch = llvm::any_of(witnessDiffAttrs,
+        [&](const DifferentiableAttr *witnessDiffAttr) {
+          return witnessDiffAttr->parametersMatch(*reqDiffAttr);
+        });
+    if (!reqDiffAttrMatch) {
+      if (auto *vdWitness = dyn_cast<VarDecl>(witness))
+        return RequirementMatch(
+            getStandinForAccessor(vdWitness, AccessorKind::Get),
+            MatchKind::DifferentiableConflict);
+      else
+        return RequirementMatch(witness, MatchKind::DifferentiableConflict);
+    }
   }
 
   // Now finalize the match.
@@ -2244,19 +2242,19 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     diags.diagnose(match.Witness, diag::protocol_witness_not_objc);
     break;
   // SWIFT_ENABLE_TENSORFLOW
-  case MatchKind::DifferentiableConflict:
-    std::string diffAttrReq;
-    {
+  case MatchKind::DifferentiableConflict: {
+    for (auto *da : req->getAttrs()
+             .getAttributes<DifferentiableAttr, /*allowInvalid*/ true>()) {
+      assert(da);
+      std::string diffAttrReq;
       llvm::raw_string_ostream stream(diffAttrReq);
-      // TODO(TF-285): Handle multiple `@differentiable` attributes on protocol
-      // requirements. Only missing attributes should be diagnosed.
-      req->getAttrs().getAttribute<DifferentiableAttr>()->print(stream, req);
-      diffAttrReq = StringRef(stream.str()).trim();
+      da->print(stream);
+      diags.diagnose(match.Witness,
+          diag::protocol_witness_missing_specific_differentiable_attr,
+          StringRef(stream.str()).trim());
     }
-    diags.diagnose(match.Witness,
-                   diag::protocol_witness_missing_differentiable_attr,
-                   diffAttrReq);
     break;
+  }
   }
 }
 

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -111,14 +111,14 @@ _ = gradient(at: 0) { x in if_else(0, true) }
 
 var a: Float = 3.0
 protocol P {
-  @differentiable
+  @differentiable(wrt: x)
   func foo(x: Float) -> Float
 }
 
 enum T : P {
   // expected-note @+2 {{when differentiating this function definition}}
   // expected-error @+1 {{function is not differentiable}}
-  @differentiable func foo(x: Float) -> Float {
+  @differentiable(wrt: x) func foo(x: Float) -> Float {
     // expected-note @+1 {{cannot differentiate writes to global variables}}
     a = a + x
     return a
@@ -127,7 +127,7 @@ enum T : P {
 
 // expected-note @+2 {{when differentiating this function definition}}
 // expected-error @+1 {{function is not differentiable}}
-@differentiable func foo(x: Float) -> Float {
+@differentiable(wrt: x) func foo(x: Float) -> Float {
   // expected-note @+1 {{cannot differentiate writes to global variables}}
   a = a + x
   return a

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -7,7 +7,7 @@ public struct Foo : Differentiable {
 }
 
 // CHECK-AST-LABEL: @_fieldwiseDifferentiable public struct Foo : Differentiable {
-// CHECK-AST:   @differentiable(wrt: (self))
+// CHECK-AST:   @differentiable
 // CHECK-AST:   public var a: Float
 // CHECK-AST:   internal init(a: Float)
 // CHECK-AST:   @_fieldwiseDifferentiable public struct AllDifferentiableVariables

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -161,7 +161,7 @@ extension JVPStruct : Differentiable {
 }
 
 extension JVPStruct {
-  @differentiable(jvp: wrtAllNonSelfJVP)
+  @differentiable(wrt: x, jvp: wrtAllNonSelfJVP)
   func wrtAllNonSelf(x: Float) -> Float {
     return x + p
   }
@@ -318,7 +318,7 @@ extension VJPStruct : Differentiable {
 }
 
 extension VJPStruct {
-  @differentiable(vjp: wrtAllNonSelfVJP)
+  @differentiable(wrt: x, vjp: wrtAllNonSelfVJP)
   func wrtAllNonSelf(x: Float) -> Float {
     return x + p
   }
@@ -422,7 +422,7 @@ func vjpWhere2<Scalar : Numeric & Differentiable>(x: Tensor<Scalar>) -> (Tensor<
 
 struct A<T> {
   struct B<U, V> {
-    @differentiable(where T : Differentiable, V : Differentiable, V.TangentVector == V)
+    @differentiable(wrt: x where T : Differentiable, V : Differentiable, V.TangentVector == V)
     func whereInGenericContext<T>(x: T) -> T {
       return x
     }
@@ -510,18 +510,50 @@ struct DifferentiableInitStruct : DifferentiableInit {
   var y: Float
 
   // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: (x, y))'}}
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x))'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: x)'}}
   init(x: Float, y: Float) {
     self.x = x
     self.y = y
   }
 
   // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: (x))'}}
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
   init(x: Float, y: Int) {
     self.x = x
     self.y = Float(y)
+  }
+}
+
+
+protocol NotRefiningDiffable {
+  @differentiable(wrt: x)
+  // expected-note @+1 {{protocol requires function 'a' with type '(Float) -> Float'; do you want to add a stub?}}
+  func a(_ x: Float) -> Float
+}
+
+// expected-error @+1 {{type 'CertainlyNotDiffableWrtSelf' does not conform to protocol 'NotRefiningDiffable'}}
+struct CertainlyNotDiffableWrtSelf : NotRefiningDiffable {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: x)'}}
+  func a(_ x: Float) -> Float { return x * 5.0 }
+}
+
+
+protocol TF285 : Differentiable {
+  @differentiable(wrt: (x, y))
+  @differentiable(wrt: x)
+  // expected-note @+1 {{protocol requires function 'foo(x:y:)' with type '(Float, Float) -> Float'; do you want to add a stub?}}
+  func foo(x: Float, y: Float) -> Float
+}
+
+// expected-error @+1 {{type 'TF285MissingOneDiffAttr' does not conform to protocol 'TF285'}}
+struct TF285MissingOneDiffAttr : TF285 {
+  // Requirement is missing an attribute.
+  @differentiable(wrt: x)
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))}}
+  func foo(x: Float, y: Float) -> Float {
+    return x
   }
 }

--- a/test/AutoDiff/existential.swift
+++ b/test/AutoDiff/existential.swift
@@ -6,13 +6,13 @@ import StdlibUnittest
 var ExistentialTests = TestSuite("Existential")
 
 protocol A {
-  @differentiable
-  func a(_: Float) -> Float
+  @differentiable(wrt: x)
+  func a(_ x: Float) -> Float
 }
 func b(g: A) -> Float { return (3.0 as Float).gradient() { x in g.a(x) } }
 
 struct B : A {
-  @differentiable
+  @differentiable(wrt: x)
   func a(_ x: Float) -> Float { return x * 5.0 }
 }
 

--- a/test/AutoDiff/sildeclref_parse.sil
+++ b/test/AutoDiff/sildeclref_parse.sil
@@ -3,7 +3,7 @@
 import Swift
 
 protocol Proto {
-  @differentiable()
+  @differentiable(wrt: (x, y))
   func f(_ x: Float, _ y: Float) -> Float
 }
 

--- a/test/AutoDiff/witness_table_irgen.sil
+++ b/test/AutoDiff/witness_table_irgen.sil
@@ -7,12 +7,12 @@ import Swift
 import SwiftShims
 
 protocol DifferentiableRequirement {
-  @differentiable()
+  @differentiable(wrt: x)
   func f(_ x: Float) -> Float
 }
 
 struct DifferentiableConformance : DifferentiableRequirement {
-  @differentiable(jvp: df, vjp: pf)
+  @differentiable(wrt: x, jvp: df, vjp: pf)
   func f(_ x: Float) -> Float
   func df(_ x: Float) -> (Float, (Float) -> Float)
   func pf(_ x: Float) -> (Float, (Float) -> Float)

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
 
 protocol Proto : Differentiable {
-  @differentiable()
+  @differentiable(wrt: (x, y))
   func function1(_ x: Float, _ y: Float) -> Float
 
   @differentiable(wrt: (self, x, y))
   func function2(_ x: Float, _ y: Float) -> Float
 
-  @differentiable(wrt: (y))
+  @differentiable(wrt: y)
   func function3(_ x: Float, _ y: Float) -> Float
 }
 
@@ -28,7 +28,7 @@ struct S : Proto, VectorNumeric {
     return (p, { dp in S(p: dp) })
   }
 
-  @differentiable()
+  @differentiable(wrt: (x, y))
   func function1(_ x: Float, _ y: Float) -> Float {
     return x + y + p
   }

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -12,7 +12,7 @@ func jvpSimple(x: Float) -> Float {
   return x
 }
 
-// CHECK-DAG: @differentiable(wrt: (x), jvp: jvpSimpleJVP)
+// CHECK-DAG: @differentiable(jvp: jvpSimpleJVP)
 // CHECK-DAG: func jvpSimpleJVP(x: Float) -> (Float, (Float) -> Float)
 func jvpSimpleJVP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
@@ -23,13 +23,13 @@ func vjpSimple(x: Float) -> Float {
   return x
 }
 
-// CHECK-DAG: @differentiable(wrt: (x), vjp: vjpSimpleVJP)
+// CHECK-DAG: @differentiable(vjp: vjpSimpleVJP)
 // CHECK-DAG: func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float)
 func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
 }
 
-// CHECK-DAG: @differentiable(wrt: (x), vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
 func testWhereClause<T : Numeric>(x: T) -> T {
@@ -43,9 +43,9 @@ func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector
 
 protocol P {}
 extension P {
-  // CHECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable, Self : P)
+  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where Self : Differentiable, Self : P)
   // CHECK-DAG: func testWhereClause() -> Self
-  @differentiable(wrt: (self), vjp: vjpTestWhereClause where Self : Differentiable)
+  @differentiable(wrt: self, vjp: vjpTestWhereClause where Self : Differentiable)
   func testWhereClause() -> Self {
     return self
   }
@@ -59,7 +59,7 @@ extension P where Self : Differentiable {
 // NOTE: The failing tests involve where clauses with member type constraints.
 // They pass type-checking but crash during serialization.
 
-// CHECK-DAG: @differentiable(wrt: (x), vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T : Numeric, T == T.CotangentVector)
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T : Numeric, T == T.CotangentVector)
 // CHECK-DAG: func testWhereClauseMemberTypeConstraint<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
 func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
@@ -72,9 +72,9 @@ func vjpTestWhereClauseMemberTypeConstraint<T>(x: T) -> (T, (T) -> T)
 }
 
 extension P {
-  // CHECK-DAG: @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self : P, Self == Self.CotangentVector)
+  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self : P, Self == Self.CotangentVector)
   // CHECK-DAG: func testWhereClauseMemberTypeConstraint() -> Self
-  @differentiable(wrt: (self), vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
+  @differentiable(wrt: self, vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
   func testWhereClauseMemberTypeConstraint() -> Self {
     return self
   }

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -33,7 +33,7 @@ TensorADTests.testAllBackends("Concrete") {
 }
 
 extension Tensor where Scalar : Differentiable & FloatingPoint {
-  @differentiable(vjp: vjpFoo)
+  @differentiable(wrt: x, vjp: vjpFoo)
   func foo(_ x: Scalar) -> Scalar {
     return x
   }


### PR DESCRIPTION
### Semantic change

Since method differentiating w.r.t. `self` is more common than not w.r.t. `self` in an instance method, we make `@differentiable`'s implied parameter list include `self`.

```swift
protocol P : Differentiable {
  @differentiable // equivalent to `@differentiable(wrt: (self, a, b))`
  func foo(a: Float, b: Float) -> Float
}
```

No changes to static methods since metatypes are never differentiable.

### Compiler changes

* Imply `self` when type-checking a `@differentiable` that does not have a `wrt:` parameter list on an instance method.
* Fix the `@differentiable` protocol requirement matching logic to handle multiple attributes.
* Make `DifferentiableAttr::print` print parsed parameters instead of canonical parameter indices. This is important because protocol witness diagnostics are making use of this printout.
  * Without a lot of special logic, canonical parameter indices would make things look like `@differentiable()`, `@differentiable(wrt: (x))`, etc, which are really not what we want in a diagnostic to encourage users to write. Parsed parameters are a lot simpler and intuitive: What you see in the protocol declaration is what you get in a diagnostic.
* Add more parameter-setting utilities to `AutoDiffParameterIndicesBuilder`.

Resolves [TF-295](https://bugs.swift.org/browse/TF-295) and [TF-285](https://bugs.swift.org/browse/TF-285).