### PR TITLE
[ownership] Change is_escaping_closure to accept any ownership as an …

### DIFF
--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -150,7 +150,6 @@ NO_OPERAND_INST(Unwind)
         ValueOwnershipKind::OWNERSHIP,                                         \
         UseLifetimeConstraint::USE_LIFETIME_CONSTRAINT);                       \
   }
-CONSTANT_OWNERSHIP_INST(Guaranteed, MustBeLive, IsEscapingClosure)
 CONSTANT_OWNERSHIP_INST(Guaranteed, MustBeLive, RefElementAddr)
 CONSTANT_OWNERSHIP_INST(Guaranteed, MustBeLive, OpenExistentialValue)
 CONSTANT_OWNERSHIP_INST(Guaranteed, MustBeLive, OpenExistentialBoxValue)
@@ -266,6 +265,7 @@ ACCEPTS_ANY_OWNERSHIP_INST(ExistentialMetatype)
 ACCEPTS_ANY_OWNERSHIP_INST(ValueMetatype)
 ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
 ACCEPTS_ANY_OWNERSHIP_INST(ValueToBridgeObject)
+ACCEPTS_ANY_OWNERSHIP_INST(IsEscapingClosure)
 #undef ACCEPTS_ANY_OWNERSHIP_INST
 
 // Trivial if trivial typed, otherwise must accept owned?

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1135,3 +1135,24 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+sil [ossa] @owned_partial_apply_is_escaping_closure : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @no_arg_or_output_function : $@convention(thin) () -> ()
+  %1 = partial_apply %0() : $@convention(thin) () -> ()
+  %2 = is_escaping_closure %1 : $@callee_owned () -> ()
+  %3 = begin_borrow %1 : $@callee_owned () -> ()
+  %4 = is_escaping_closure %3 : $@callee_owned () -> ()
+  end_borrow %3 : $@callee_owned () -> ()
+  destroy_value %1 : $@callee_owned () -> ()
+
+  %5 = partial_apply [callee_guaranteed] %0() : $@convention(thin) () -> ()
+  %6 = is_escaping_closure %5 : $@callee_guaranteed () -> ()
+  %7 = begin_borrow %5 : $@callee_guaranteed () -> ()
+  %8 = is_escaping_closure %7 : $@callee_guaranteed () -> ()
+  end_borrow %7 : $@callee_guaranteed () -> ()
+  destroy_value %5 : $@callee_guaranteed () -> ()
+
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…operand instead of requiring guaranteed.

This is a point use that even makes sense for owned values.
