### PR TITLE
Runtime: remove keypath functions in the compiler build

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -805,6 +805,7 @@ const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type
 SWIFT_RUNTIME_EXPORT
 const HeapObject *swift_getKeyPath(const void *pattern, const void *arguments);
 
+#if defined(swiftCore_EXPORTS)
 /// Given a pointer to a borrowed value of type `Root` and a
 /// `KeyPath<Root, Value>`, project a pointer to a borrowed value of type
 /// `Value`.
@@ -826,6 +827,7 @@ swift_modifyAtWritableKeyPath;
 SWIFT_RUNTIME_EXPORT
 YieldOnceCoroutine<OpaqueValue* (const OpaqueValue *root, void *keyPath)>::type
 swift_modifyAtReferenceWritableKeyPath;
+#endif
 
 SWIFT_RUNTIME_EXPORT
 void swift_enableDynamicReplacementScope(const DynamicReplacementScope *scope);


### PR DESCRIPTION
The host tools may be built with the host compiler.  cl objects to the
"extern C" function returning a C++ type which the keypath functions do.
However, these declarations are needed only in the runtime, which is
always built with clang.  Preprocess away the declarations during the
build of the compiler.  This allows us to build with cl once more.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
