### PR TITLE
TF-178: Delete variadic tensor subscript

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1515,26 +1515,6 @@ public extension Tensor {
     }
   }
 
-  /// Access the subdimensional tensor at the specified list of indices.
-  /// - Parameter indices: List of indices.
-  /// - Note: this function is more efficient than using `subscript(index:)`
-  ///   multiple times because this produces a single GatherNd op (compared with
-  ///   multiple Gather ops).
-  @inlinable
-  subscript(indices: Int32...) -> Tensor {
-    @inline(__always)
-    get {
-      // NOTE: Rewriting this using Slice is difficult: the main challenge is in
-      // constructing the "sizes" argument, which essentially is
-      // `indices.shapeTensor` but with `indices.count` number of leading 1s.
-      // Since GatherNd is the exact op that performs subdimensional indexing,
-      // it is used here in spite of the fact it may perform allocation(?).
-      // TODO: Consider more clearly distinguishing `subscript(index:)` and
-      // `subscript(indices:)`, since their implementations are quite different.
-      return Raw.gatherNd(params: self, indices: Tensor<Int32>(indices))
-    }
-  }
-
   /// Access the subtensor specified by a contiguous range of indices.
   /// - Parameter bounds: Contiguous range of indices.
   @inlinable

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -135,29 +135,6 @@ TensorTests.testAllBackends("ElementIndexing") {
   expectEqual([43], array0D.scalars)
 }
 
-TensorTests.testAllBackends("NestedElementIndexing") {
-  // NOTE: This tests the `subscript(indices:)` method, which is distinct from
-  // the `subscript(index:)` method.
-  // NOTE: This test could use a clearer name, along with other "indexing"
-  // tests. Note to update corresponding test names in other files
-  // (ranked_tensor.test, shaped_array.test) as well.
-  let tensor3D = Tensor<Float>(shape: [3, 4, 5],
-                               scalars: Array(stride(from: 0.0, to: 60, by: 1)))
-  let element1D = tensor3D[1, 3]
-  let element0D = tensor3D[2, 0, 3]
-
-  let array1D = element1D.array
-  let array0D = element0D.array
-
-  /// Test shapes
-  expectEqual([5], array1D.shape)
-  expectEqual([], array0D.shape)
-
-  /// Test scalars
-  expectEqual(Array(stride(from: 35.0, to: 40, by: 1)), array1D.scalars)
-  expectEqual([43], array0D.scalars)
-}
-
 TensorTests.testAllBackends("SliceIndexing") {
   // XLA compilation error under TPU.
   if _RuntimeConfig.executionMode.isTPU { return }


### PR DESCRIPTION
Some problem in the typechecker crashes the compiler when you try to use the variadic tensor subscript, as described in https://bugs.swift.org/browse/TF-178.

This disables variadic tensor subscripts so that users don't get the crasher.