### PR TITLE
[5.1] Match availability of INIntentError and INIntentErrorDomain in a test

### DIFF
--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -13,7 +13,8 @@ let IntentsTestSuite = TestSuite("Intents")
 
 let swiftVersion = "4"
 
-if #available(OSX 10.12, iOS 10.0, watchOS 3.2, *) {
+#if !os(macOS)
+if #available(iOS 10.0, watchOS 3.2, *) {
 
   IntentsTestSuite.test("ErrorDomain/\(swiftVersion)") {
     expectEqual("IntentsErrorDomain", INIntentErrorDomain)
@@ -23,6 +24,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.2, *) {
     expectEqual("IntentsErrorDomain", INIntentError.errorDomain)
   }
 }
+#endif
 
 #if os(iOS)
 if #available(iOS 11.0, *) {

--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -11,7 +11,11 @@ import StdlibUnittest
 
 let IntentsTestSuite = TestSuite("Intents")
 
+#if swift(>=4.2)
+let swiftVersion = "4.2"
+#else
 let swiftVersion = "4"
+#endif
 
 #if !os(macOS)
 if #available(iOS 10.0, watchOS 3.2, *) {


### PR DESCRIPTION
(cherry picked from commit 332476d340a0747d59bab11ce84a8aeab388163e)

This is a 5.1 version of https://github.com/apple/swift/pull/22598