### PR TITLE
Reflection: try holding 32/64 address offset in target machine pointers.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -60,7 +60,6 @@ template <> struct ELFTraits<llvm::ELF::ELFCLASS32> {
   using Section = const struct llvm::ELF::Elf32_Shdr;
   using Offset = llvm::ELF::Elf32_Off;
   using Size = llvm::ELF::Elf32_Word;
-  using Address = llvm::ELF::Elf32_Addr;
   static constexpr unsigned char ELFClass = llvm::ELF::ELFCLASS32;
 };
 
@@ -69,7 +68,6 @@ template <> struct ELFTraits<llvm::ELF::ELFCLASS64> {
   using Section = const struct llvm::ELF::Elf64_Shdr;
   using Offset = llvm::ELF::Elf64_Off;
   using Size = llvm::ELF::Elf64_Xword;
-  using Address = llvm::ELF::Elf64_Addr;
   static constexpr unsigned char ELFClass = llvm::ELF::ELFCLASS64;
 };
 
@@ -202,7 +200,7 @@ public:
                                                RangeEnd - RangeStart);
 
     auto findMachOSectionByName = [&](std::string Name)
-        -> std::pair<std::pair<const char *, const char *>, uint32_t> {
+        -> std::pair<std::pair<const char *, const char *>, uint64_t> {
       for (unsigned I = 0; I < NumSect; ++I) {
         auto S = reinterpret_cast<typename T::Section *>(
             SectionsBuf + (I * sizeof(typename T::Section)));
@@ -233,8 +231,8 @@ public:
         ReflStrMdSec.first.first == nullptr)
       return false;
 
-    auto LocalStartAddress = reinterpret_cast<uintptr_t>(SectBuf.get());
-    auto RemoteStartAddress = static_cast<uintptr_t>(RangeStart);
+    auto LocalStartAddress = reinterpret_cast<uint64_t>(SectBuf.get());
+    auto RemoteStartAddress = static_cast<uint64_t>(RangeStart);
 
     ReflectionInfo info = {
         {{FieldMdSec.first.first, FieldMdSec.first.second}, 0},
@@ -332,7 +330,7 @@ public:
     auto StrTab = reinterpret_cast<const char *>(StrTabBuf.get());
 
     auto findELFSectionByName = [&](std::string Name)
-        -> std::pair<std::pair<const char *, const char *>, typename T::Address> {
+        -> std::pair<std::pair<const char *, const char *>, uint64_t> {
       // Now for all the sections, find their name.
       for (const typename T::Section *Hdr : SecHdrVec) {
         uint32_t Offset = Hdr->sh_name;
@@ -367,9 +365,9 @@ public:
         ReflStrMdSec.first.first == nullptr)
       return false;
 
-    auto LocalStartAddress = reinterpret_cast<uintptr_t>(Buf.get());
+    auto LocalStartAddress = reinterpret_cast<uint64_t>(Buf.get());
     auto RemoteStartAddress =
-        static_cast<uintptr_t>(ImageStart.getAddressData());
+        static_cast<uint64_t>(ImageStart.getAddressData());
 
     ReflectionInfo info = {
         {{FieldMdSec.first.first, FieldMdSec.first.second}, FieldMdSec.second},

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -82,36 +82,36 @@ using GenericSection = ReflectionSection<const void *>;
 struct ReflectionInfo {
   struct {
     FieldSection Metadata;
-    uintptr_t SectionOffset;
+    uint64_t SectionOffset;
   } Field;
 
   struct {
     AssociatedTypeSection Metadata;
-    uintptr_t SectionOffset;
+    uint64_t SectionOffset;
   } AssociatedType;
 
   struct {
     BuiltinTypeSection Metadata;
-    uintptr_t SectionOffset;
+    uint64_t SectionOffset;
   } Builtin;
 
   struct {
     CaptureSection Metadata;
-    uintptr_t SectionOffset;
+    uint64_t SectionOffset;
   } Capture;
 
   struct {
     GenericSection Metadata;
-    uintptr_t SectionOffset;
+    uint64_t SectionOffset;
   } TypeReference;
 
   struct {
     GenericSection Metadata;
-    uintptr_t SectionOffset;
+    uint64_t SectionOffset;
   } ReflectionString;
 
-  uintptr_t LocalStartAddress;
-  uintptr_t RemoteStartAddress;
+  uint64_t LocalStartAddress;
+  uint64_t RemoteStartAddress;
 };
 
 struct ClosureContextInfo {
@@ -506,11 +506,11 @@ public:
 
   /// Get the raw capture descriptor for a remote capture descriptor
   /// address.
-  const CaptureDescriptor *getCaptureDescriptor(uintptr_t RemoteAddress);
+  const CaptureDescriptor *getCaptureDescriptor(uint64_t RemoteAddress);
 
   /// Get the unsubstituted capture types for a closure context.
   ClosureContextInfo getClosureContextInfo(const CaptureDescriptor &CD,
-                                           uintptr_t Offset);
+                                           uint64_t Offset);
 
   ///
   /// Dumping typerefs, field declarations, associated types

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-typedef uintptr_t swift_typeref_t;
+typedef uint64_t swift_typeref_t;
 
 /// Represents one of the Swift reflection sections of an image.
 typedef struct swift_reflection_section {
@@ -37,37 +37,37 @@ typedef struct swift_reflection_section {
 typedef struct swift_reflection_info {
   struct {
     swift_reflection_section_t section;
-    uintptr_t offset;
+    uint64_t offset;
   } field;
 
   struct {
     swift_reflection_section_t section;
-    uintptr_t offset;
+    uint64_t offset;
   } associated_types;
 
   struct {
     swift_reflection_section_t section;
-    uintptr_t offset;
+    uint64_t offset;
   } builtin_types;
 
   struct {
     swift_reflection_section_t section;
-    uintptr_t offset;
+    uint64_t offset;
   } capture;
 
   struct {
     swift_reflection_section_t section;
-    uintptr_t offset;
+    uint64_t offset;
   } type_references;
 
   struct {
     swift_reflection_section_t section;
-    uintptr_t offset;
+    uint64_t offset;
   } reflection_strings;
 
   // Start address in local and remote address spaces.
-  uintptr_t LocalStartAddress;
-  uintptr_t RemoteStartAddress;
+  uint64_t LocalStartAddress;
+  uint64_t RemoteStartAddress;
 } swift_reflection_info_t;
 
 /// The layout kind of a Swift type.


### PR DESCRIPTION
When compiling for a 32 bit machine, `uintptr_t` from `ReflectionInfo` will
be the integer sized to hold a 32 bit pointer, so a 64 bit pointer might
not fit.

This commit removes the solution in
0f20c486e0a806c13dede961a7f53eacc71cafd0 and does a runtime check that
the calculated offset will fit into the target machine `uintptr_t`, which
might not be true for 32 bits machines trying to read 64 bits images,
which should not be that common (and those images have to have offsets
bigger than what a 32 bits number can hold).

This broke the Android ARMv7 CI build: https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/1858/

/cc @compnerd hopefully this will not have a problem in `cl.exe`?