### PR TITLE
[API] Redefine `TensorFlowFloatingPoint`.

### DIFF
--- a/stdlib/public/TensorFlow/CompositeMath.swift
+++ b/stdlib/public/TensorFlow/CompositeMath.swift
@@ -19,7 +19,7 @@
 /// Computes `sigmoid` of the specified tensor element-wise.
 /// Specifically, computes `1 / (1 + exp(-x))`.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpSigmoid(_:) where T : Differentiable)
+@differentiable(vjp: _vjpSigmoid(_:) where T : TensorFlowFloatingPoint)
 public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sigmoid(x)
 }
@@ -27,7 +27,7 @@ public func sigmoid<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes `relu` of the specified tensor element-wise.
 /// Specifically, computes `max(0, x)`.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpRelu(_:) where T : Differentiable)
+@differentiable(vjp: _vjpRelu(_:) where T : TensorFlowFloatingPoint)
 public func relu<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return max(0, x)
 }
@@ -35,7 +35,7 @@ public func relu<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes the softmax of the specified tensor along the last axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: -1)`.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpSoftmax(_:) where T : Differentiable)
+@differentiable(vjp: _vjpSoftmax(_:) where T : TensorFlowFloatingPoint)
 public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.softmax(logits: x)
 }
@@ -43,7 +43,7 @@ public func softmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes the softmax of the specified tensor along the specified axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: axis)`.
 @inlinable @inline(__always)
-public func softmax<T : Differentiable & FloatingPoint>(
+public func softmax<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>, alongAxis axis: Int32
 ) -> Tensor<T> {
   let expx = exp(x)

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -72,8 +72,15 @@ public protocol TensorFlowScalar : _TensorFlowDataTypeCompatible {}
 public typealias TensorFlowNumeric = TensorFlowScalar & Numeric
 public typealias TensorFlowSignedNumeric = TensorFlowScalar & SignedNumeric
 public typealias TensorFlowInteger = TensorFlowScalar & BinaryInteger
-public typealias TensorFlowFloatingPoint
-  = TensorFlowScalar & BinaryFloatingPoint & Differentiable
+
+public protocol TensorFlowFloatingPoint :
+  TensorFlowScalar & BinaryFloatingPoint & Differentiable
+  where Self == Self.TangentVector,
+        Self == Self.CotangentVector,
+        Self == Self.AllDifferentiableVariables {}
+
+extension Float : TensorFlowFloatingPoint {}
+extension Double : TensorFlowFloatingPoint {}
 
 // This is the implementation of the _getScalarOrDie requirement for each
 // concrete type below.  We use this round-about approach to implement the

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -203,7 +203,7 @@ public func gradient<T, U, V, R>(
 // Elementwise binary
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   static func _vjpAdd(
     lhs: Tensor, rhs: Tensor
@@ -248,8 +248,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   }
 }
 
-extension Tensor where Scalar : Differentiable & FloatingPoint,
-                       Scalar == Scalar.CotangentVector {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   static func _vjpAdd(
     lhs: Tensor, rhs: Scalar
@@ -312,7 +311,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint,
 }
 
 @inlinable
-func _vjpMinMaxHelper<T : Differentiable & FloatingPoint>(
+func _vjpMinMaxHelper<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, vector: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
   let denom = 1 + Tensor<T>(x .== y)
@@ -322,7 +321,7 @@ func _vjpMinMaxHelper<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpMax<T : Differentiable & FloatingPoint>(
+func _vjpMax<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
   let value = max(x, y)
@@ -331,7 +330,7 @@ func _vjpMax<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpMin<T : Differentiable & FloatingPoint>(
+func _vjpMin<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
   let value = min(x, y)
@@ -340,7 +339,7 @@ func _vjpMin<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpPow<T : Differentiable & FloatingPoint>(
+func _vjpPow<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
   let value = pow(x, y)
@@ -354,7 +353,7 @@ func _vjpPow<T : Differentiable & FloatingPoint>(
 // Elementwise unary
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   static func _vjpNegate(_ x: Tensor) -> (Tensor, (Tensor) -> Tensor) {
     return (-x, { v in -v })
@@ -362,28 +361,28 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 }
 
 @inlinable
-func _vjpLog<T : Differentiable & FloatingPoint>(
+func _vjpLog<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (log(x), { v in v / x })
 }
 
 @inlinable
-func _vjpSin<T : Differentiable & FloatingPoint>(
+func _vjpSin<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (sin(x), { v in v * cos(x) })
 }
 
 @inlinable
-func _vjpCos<T : Differentiable & FloatingPoint>(
+func _vjpCos<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (cos(x), { v in -v * sin(x) })
 }
 
 @inlinable
-func _vjpTan<T : Differentiable & FloatingPoint>(
+func _vjpTan<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = tan(x)
@@ -391,21 +390,21 @@ func _vjpTan<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpSinh<T : Differentiable & FloatingPoint>(
+func _vjpSinh<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (sinh(x), { v in v * cosh(x) })
 }
 
 @inlinable
-func _vjpCosh<T : Differentiable & FloatingPoint>(
+func _vjpCosh<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (cosh(x), { v in v * sinh(x) })
 }
 
 @inlinable
-func _vjpTanh<T : Differentiable & FloatingPoint>(
+func _vjpTanh<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = tanh(x)
@@ -413,7 +412,7 @@ func _vjpTanh<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpExp<T : Differentiable & FloatingPoint>(
+func _vjpExp<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = exp(x)
@@ -421,21 +420,21 @@ func _vjpExp<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpCeil<T : Differentiable & FloatingPoint>(
+func _vjpCeil<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (ceil(x), { _ in Tensor(0).broadcast(like: x) })
 }
 
 @inlinable
-func _vjpFloor<T : Differentiable & FloatingPoint>(
+func _vjpFloor<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (floor(x), { _ in Tensor(0).broadcast(like: x) })
 }
 
 @inlinable
-func _vjpSqrt<T : Differentiable & FloatingPoint>(
+func _vjpSqrt<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = sqrt(x)
@@ -443,7 +442,7 @@ func _vjpSqrt<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpRsqrt<T : Differentiable & FloatingPoint>(
+func _vjpRsqrt<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = rsqrt(x)
@@ -451,7 +450,7 @@ func _vjpRsqrt<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpLogSoftmax<T : Differentiable & FloatingPoint>(
+func _vjpLogSoftmax<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = logSoftmax(x)
@@ -460,7 +459,7 @@ func _vjpLogSoftmax<T : Differentiable & FloatingPoint>(
   })
 }
 
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   func _vjpSquared() -> (Tensor, (Tensor) -> Tensor) {
     return (squared(), { 2 * self * $0 })
@@ -472,7 +471,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 //===----------------------------------------------------------------------===//
 
 @inlinable
-func _vjpMatmul<Scalar : Differentiable & FloatingPoint>(
+func _vjpMatmul<Scalar : TensorFlowFloatingPoint>(
   _ lhs: Tensor<Scalar>, _ rhs: Tensor<Scalar>
 ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
   let value = matmul(lhs, rhs)
@@ -484,7 +483,7 @@ func _vjpMatmul<Scalar : Differentiable & FloatingPoint>(
 // TODO: We have to define a custom VJP on • because AD can't yet
 // differentiate generic methods. After AD can differentiate generic methods,
 // remove the custom VJP.
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   static func _vjpMatmulOperator(
     lhs: Tensor, rhs: Tensor
@@ -526,7 +525,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 // Shape transformations
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   func _vjpReshaped(
     toShape newShape: Tensor<Int32>
@@ -552,7 +551,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 // Reduction
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   func _vjpMean() -> (Tensor, (Tensor) -> Tensor) {
     return (mean(), { [shape = shapeTensor, count = scalarCountTensor] in
@@ -584,8 +583,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 // Normalization
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : BinaryFloatingPoint & Differentiable,
-                       Scalar == Scalar.CotangentVector {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   // TODO: Verify that these calculations are correct.
   @inlinable
   func _vjpBatchNormalized(
@@ -623,7 +621,7 @@ extension Tensor where Scalar : BinaryFloatingPoint & Differentiable,
 // Convolution and pooling
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : Differentiable & FloatingPoint {
+extension Tensor where Scalar : TensorFlowFloatingPoint {
   /// TensorFlow builtin conv2d gradient helper for the input.
   @inlinable
   @differentiable(
@@ -779,7 +777,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
 //===----------------------------------------------------------------------===//
 
 @inlinable
-func _vjpSigmoid<T : Differentiable & FloatingPoint>(
+func _vjpSigmoid<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = sigmoid(x)
@@ -787,7 +785,7 @@ func _vjpSigmoid<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpSoftmax<T : Differentiable & FloatingPoint>(
+func _vjpSoftmax<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   let value = softmax(x)
@@ -798,7 +796,7 @@ func _vjpSoftmax<T : Differentiable & FloatingPoint>(
 }
 
 @inlinable
-func _vjpRelu<T : Differentiable & FloatingPoint>(
+func _vjpRelu<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (relu(x), { v in Tensor(x .> 0) * v })

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -46,14 +46,14 @@ infix operator .> : ComparisonPrecedence
 
 public extension Differentiable {
   @inlinable
-  func gradient<R : Differentiable & FloatingPoint>(
+  func gradient<R : TensorFlowFloatingPoint>(
     in f: @differentiable (Self) -> Tensor<R>
   ) -> CotangentVector {
     return self.pullback(in: f)(Tensor<R>(1))
   }
 
   @inlinable
-  func valueWithGradient<R : Differentiable & FloatingPoint>(
+  func valueWithGradient<R : TensorFlowFloatingPoint>(
     in f: @differentiable (Self) -> Tensor<R>
   ) -> (value: Tensor<R>, gradient: CotangentVector) {
     let (y, pb) = self.valueWithPullback(in: f)
@@ -61,17 +61,16 @@ public extension Differentiable {
   }
 
   @inlinable
-  func gradient<T : Differentiable, R : Differentiable & FloatingPoint>(
+  func gradient<T : Differentiable, R : TensorFlowFloatingPoint>(
     at x: T, in f: @differentiable (Self, T) -> Tensor<R>
   ) -> (CotangentVector, T.CotangentVector) {
     return self.pullback(at: x, in: f)(Tensor<R>(1))
   }
 
   @inlinable
-  func valueWithGradient<T : Differentiable, R>(
+  func valueWithGradient<T : Differentiable, R : TensorFlowFloatingPoint>(
     at x: T, in f: @differentiable (Self, T) -> Tensor<R>
-  ) -> (value: Tensor<R>, gradient: (CotangentVector, T.CotangentVector))
-    where R : Differentiable & FloatingPoint {
+  ) -> (value: Tensor<R>, gradient: (CotangentVector, T.CotangentVector)) {
     let (y, pb) = self.valueWithPullback(at: x, in: f)
     return (y, pb(Tensor<R>(1)))
   }
@@ -87,7 +86,7 @@ public extension Differentiable {
 public func valueWithGradient<T, R>(
   at x: T, in f: @differentiable (T) -> Tensor<R>
 ) -> (value: Tensor<R>, gradient: T.CotangentVector)
-where T : Differentiable, R : Differentiable & FloatingPoint {
+where T : Differentiable, R : TensorFlowFloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, in: f)
   return (y, pullback(Tensor<R>(1)))
 }
@@ -97,7 +96,7 @@ public func valueWithGradient<T, U, R>(
   at x: T, _ y: U, in f: @differentiable (T, U) -> Tensor<R>
 ) -> (value: Tensor<R>, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, y, in: f)
   return (y, pullback(Tensor<R>(1)))
 }
@@ -108,7 +107,7 @@ public func valueWithGradient<T, U, V, R>(
 ) -> (value: Tensor<R>,
       gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, y, z, in: f)
   return (y, pullback(Tensor<R>(1)))
 }
@@ -119,7 +118,7 @@ public func valueWithGradient<T, U, V, R>(
 public func valueWithGradient<T, R>(
   of f: @escaping @differentiable (T) -> Tensor<R>
 ) -> (T) -> (value: Tensor<R>, gradient: T.CotangentVector)
-  where T : Differentiable, R : Differentiable & FloatingPoint {
+  where T : Differentiable, R : TensorFlowFloatingPoint {
   return { x in valueWithGradient(at: x, in: f) }
 }
 
@@ -129,7 +128,7 @@ public func valueWithGradient<T, U, R>(
 ) -> (T, U)
     -> (value: Tensor<R>, gradient: (T.CotangentVector, U.CotangentVector))
   where T : Differentiable, U : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   return { x, y in valueWithGradient(at: x, y, in: f) }
 }
 
@@ -140,7 +139,7 @@ public func valueWithGradient<T, U, V, R>(
     -> (value: Tensor<R>,
         gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
 }
 
@@ -150,7 +149,7 @@ public func valueWithGradient<T, U, V, R>(
 public func gradient<T, R>(
   at x: T, in f: @differentiable (T) -> Tensor<R>
 ) -> T.CotangentVector
-  where T : Differentiable, R : Differentiable & FloatingPoint {
+  where T : Differentiable, R : TensorFlowFloatingPoint {
   return pullback(at: x, in: f)(Tensor<R>(1))
 }
 
@@ -159,7 +158,7 @@ public func gradient<T, U, R>(
   at x: T, _ y: U, in f: @differentiable (T, U) -> Tensor<R>
 ) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   return pullback(at: x, y, in: f)(Tensor<R>(1))
 }
 
@@ -168,7 +167,7 @@ public func gradient<T, U, V, R>(
   at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> Tensor<R>
 ) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   return pullback(at: x, y, z, in: f)(Tensor<R>(1))
 }
 
@@ -178,7 +177,7 @@ public func gradient<T, U, V, R>(
 public func gradient<T, R>(
   of f: @escaping @differentiable (T) -> Tensor<R>
 ) -> (T) -> T.CotangentVector
-  where T : Differentiable, R : Differentiable & FloatingPoint {
+  where T : Differentiable, R : TensorFlowFloatingPoint {
   return { x in gradient(at: x, in: f) }
 }
 
@@ -187,7 +186,7 @@ public func gradient<T, U, R>(
   of f: @escaping @differentiable (T, U) -> Tensor<R>
 ) -> (T, U) -> (T.CotangentVector, U.CotangentVector)
   where T : Differentiable, U : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   return { x, y in gradient(at: x, y, in: f) }
 }
 
@@ -196,7 +195,7 @@ public func gradient<T, U, V, R>(
   of f: @escaping @differentiable (T, U, V) -> Tensor<R>
 ) -> (T, U, V) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
-        R : Differentiable & FloatingPoint {
+        R : TensorFlowFloatingPoint {
   return { x, y, z in gradient(at: x, y, z, in: f) }
 }
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -82,7 +82,7 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpAdd(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.add(lhs, rhs)
@@ -93,7 +93,7 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpSubtract(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.sub(lhs, rhs)
@@ -110,8 +110,7 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpMultiply(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   public static func * (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) * rhs
@@ -137,22 +136,14 @@ extension Tensor : Differentiable where Scalar : TensorFlowFloatingPoint {
 public extension Tensor where Scalar : Numeric {
   /// Adds the scalar to every scalar of the tensor and produces the sum.
   @inlinable @inline(__always)
-  @differentiable(
-    vjp: _vjpAdd(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
-  )
+  @differentiable(vjp: _vjpAdd(lhs:rhs:) where Scalar : TensorFlowFloatingPoint)
   static func + (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) + rhs
   }
 
   /// Adds the scalar to every scalar of the tensor and produces the sum.
   @inlinable @inline(__always)
-  @differentiable(
-    vjp: _vjpAdd(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
-  )
+  @differentiable(vjp: _vjpAdd(lhs:rhs:) where Scalar : TensorFlowFloatingPoint)
   static func + (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs + Tensor(rhs)
   }
@@ -162,8 +153,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpSubtract(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   static func - (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) - rhs
@@ -174,8 +164,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpSubtract(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   static func - (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs - Tensor(rhs)
@@ -215,7 +204,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpMultiply(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.mul(lhs, rhs)
@@ -226,8 +215,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpMultiply(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   static func * (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs * Tensor(rhs)
@@ -251,7 +239,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpDivide(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.div(lhs, rhs)
@@ -262,8 +250,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpDivide(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   static func / (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) / rhs
@@ -274,8 +261,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpDivide(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint,
-          Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   static func / (lhs: Tensor, rhs: Scalar) -> Tensor {
     return lhs / Tensor(rhs)
@@ -340,7 +326,7 @@ public extension Tensor where Scalar : Numeric {
 @inlinable @inline(__always)
 @differentiable(
   vjp: _vjpMatmul(_:_:)
-  where Scalar : Differentiable & FloatingPoint
+  where Scalar : TensorFlowFloatingPoint
 )
 public func matmul<Scalar : Numeric>(
   _ lhs: Tensor<Scalar>, _ rhs: Tensor<Scalar>
@@ -363,7 +349,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpMatmulOperator(lhs:rhs:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
     return matmul(lhs, rhs)
@@ -633,7 +619,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpTransposed(withPermutations:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func transposed(
     withPermutations permutations: Tensor<Int32>
@@ -646,7 +632,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpTransposed(withPermutations:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func transposed(withPermutations permutations: [Int32]) -> Tensor {
     return transposed(withPermutations: Tensor<Int32>(permutations))
@@ -657,7 +643,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpTransposed(withPermutations:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func transposed(withPermutations permutations: Int32...) -> Tensor {
     return transposed(withPermutations: permutations)
@@ -667,7 +653,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpTransposed()
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func transposed() -> Tensor {
     let defaultPermutations = rankTensor - 1 - Tensor<Int32>(
@@ -771,7 +757,7 @@ public extension Tensor where Scalar : SignedNumeric {
   @inlinable @inline(__always)
   @differentiable(
     vjp: _vjpNegate(_:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   static prefix func - (rhs: Tensor) -> Tensor {
     return Raw.neg(rhs)
@@ -786,91 +772,91 @@ public func abs<T : SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
 
 /// Computes the natural logarithm of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpLog(_:) where T : Differentiable)
+@differentiable(vjp: _vjpLog(_:) where T : TensorFlowFloatingPoint)
 public func log<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.log(x)
 }
 
 /// Computes `sin` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpSin(_:) where T : Differentiable)
+@differentiable(vjp: _vjpSin(_:) where T : TensorFlowFloatingPoint)
 public func sin<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sin(x)
 }
 
 /// Computes `cos` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpCos(_:) where T : Differentiable)
+@differentiable(vjp: _vjpCos(_:) where T : TensorFlowFloatingPoint)
 public func cos<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cos(x)
 }
 
 /// Computes `tan` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpTan(_:) where T : Differentiable)
+@differentiable(vjp: _vjpTan(_:) where T : TensorFlowFloatingPoint)
 public func tan<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tan(x)
 }
 
 /// Computes `sinh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpSinh(_:) where T : Differentiable)
+@differentiable(vjp: _vjpSinh(_:) where T : TensorFlowFloatingPoint)
 public func sinh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sinh(x)
 }
 
 /// Computes `cosh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpCosh(_:) where T : Differentiable)
+@differentiable(vjp: _vjpCosh(_:) where T : TensorFlowFloatingPoint)
 public func cosh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cosh(x)
 }
 
 /// Computes `tanh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpTanh(_:) where T : Differentiable)
+@differentiable(vjp: _vjpTanh(_:) where T : TensorFlowFloatingPoint)
 public func tanh<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tanh(x)
 }
 
 /// Computes the square root of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpSqrt(_:) where T : Differentiable)
+@differentiable(vjp: _vjpSqrt(_:) where T : TensorFlowFloatingPoint)
 public func sqrt<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sqrt(x)
 }
 
 /// Computes the inverse square root of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpRsqrt(_:) where T : Differentiable)
+@differentiable(vjp: _vjpRsqrt(_:) where T : TensorFlowFloatingPoint)
 public func rsqrt<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.rsqrt(x)
 }
 
 /// Computes `exp` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpExp(_:) where T : Differentiable)
+@differentiable(vjp: _vjpExp(_:) where T : TensorFlowFloatingPoint)
 public func exp<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.exp(x)
 }
 
 /// Computes the ceiling of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpCeil(_:) where T : Differentiable)
+@differentiable(vjp: _vjpCeil(_:) where T : TensorFlowFloatingPoint)
 public func ceil<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.ceil(x)
 }
 
 /// Computes the floor of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpFloor(_:) where T : Differentiable)
+@differentiable(vjp: _vjpFloor(_:) where T : TensorFlowFloatingPoint)
 public func floor<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.floor(x)
 }
 
 /// Computes the power of the first tensor to the second tensor.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpPow(_:_:) where T : Differentiable)
+@differentiable(vjp: _vjpPow(_:_:) where T : TensorFlowFloatingPoint)
 public func pow<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : FloatingPoint {
   return Raw.pow(lhs, rhs)
@@ -893,7 +879,7 @@ public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise maximum of two tensors.
 /// - Note: `max` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpMax(_:_:) where T : Differentiable & FloatingPoint)
+@differentiable(vjp: _vjpMax(_:_:) where T : TensorFlowFloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.maximum(lhs, rhs)
@@ -918,7 +904,7 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise minimum of two tensors.
 /// - Note: `min` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpMin(_:_:) where T : Differentiable & FloatingPoint)
+@differentiable(vjp: _vjpMin(_:_:) where T : TensorFlowFloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.minimum(lhs, rhs)
@@ -945,7 +931,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpSquared()
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func squared() -> Tensor {
     return Raw.square(self)
@@ -954,7 +940,7 @@ public extension Tensor where Scalar : Numeric {
 
 /// Computes the log-softmax of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(vjp: _vjpLogSoftmax(_:) where T : Differentiable)
+@differentiable(vjp: _vjpLogSoftmax(_:) where T : TensorFlowFloatingPoint)
 public func logSoftmax<T : FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.logSoftmax(logits: x)
 }
@@ -1190,7 +1176,7 @@ public extension Tensor where Scalar : Numeric {
   // to the variadic method `mean(squeezingAxes:)` with zero indices.
   @differentiable(
     wrt: self, vjp: _vjpMean()
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   @inlinable @inline(__always)
   func mean() -> Tensor {
@@ -1203,7 +1189,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpSum()
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func sum() -> Tensor {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
@@ -1281,7 +1267,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpMean(alongAxes:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func mean(alongAxes axes: [Int32]) -> Tensor {
     return Raw.mean(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
@@ -1292,7 +1278,7 @@ public extension Tensor where Scalar : Numeric {
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
-  @differentiable(wrt: self where Scalar : Differentiable & FloatingPoint)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func mean(alongAxes axes: Int32...) -> Tensor {
     return mean(alongAxes: axes)
   }
@@ -1304,7 +1290,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpSum(alongAxes:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func sum(alongAxes axes: [Int32]) -> Tensor {
     return Raw.sum(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
@@ -1315,7 +1301,7 @@ public extension Tensor where Scalar : Numeric {
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
-  @differentiable(wrt: self where Scalar : Differentiable & FloatingPoint)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func sum(alongAxes axes: Int32...) -> Tensor {
     return sum(alongAxes: axes)
   }
@@ -1325,7 +1311,7 @@ public extension Tensor where Scalar : Numeric {
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
-  @differentiable(wrt: self where Scalar : Differentiable & FloatingPoint)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func variance(alongAxes axes: Int32...) -> Tensor {
     return variance(alongAxes: axes)
   }
@@ -1335,7 +1321,7 @@ public extension Tensor where Scalar : Numeric {
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
-  @differentiable(wrt: self where Scalar : Differentiable & FloatingPoint)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func variance(alongAxes axes: [Int32]) -> Tensor {
     let mean = self.mean(alongAxes: axes)
     let squaredDiff = (self - mean).squared()
@@ -1610,7 +1596,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
   @inlinable
   @differentiable(
     wrt: (self, offset, scale), vjp: _vjpBatchNormalized
-    where Scalar : Differentiable, Scalar == Scalar.CotangentVector
+    where Scalar : TensorFlowFloatingPoint
   )
   func batchNormalized(
     alongAxis axis: Int32,
@@ -1663,7 +1649,7 @@ public extension Tensor where Scalar : FloatingPoint {
   @inlinable @inline(__always)
   @differentiable(
     wrt: (self, filter), vjp: _vjpConvolved2D(filter:strides:padding:)
-    where Scalar : Differentiable
+    where Scalar : TensorFlowFloatingPoint
   )
   func convolved2D(
     withFilter filter: Tensor,
@@ -1688,7 +1674,7 @@ public extension Tensor where Scalar : FloatingPoint {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpMaxPooled(kernelSize:strides:padding:)
-    where Scalar : Differentiable
+    where Scalar : TensorFlowFloatingPoint
   )
   func maxPooled(
     kernelSize: (Int32, Int32, Int32, Int32),
@@ -1713,7 +1699,7 @@ public extension Tensor where Scalar : FloatingPoint {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpAveragePooled(kernelSize:strides:padding:)
-    where Scalar : Differentiable
+    where Scalar : TensorFlowFloatingPoint
   )
   func averagePooled(
     kernelSize: (Int32, Int32, Int32, Int32),

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -120,9 +120,7 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
 
 extension Tensor : ShapedVectorNumeric where Scalar : Numeric {}
 
-extension Tensor : Differentiable
-  where Scalar : Differentiable & FloatingPoint
-{
+extension Tensor : Differentiable where Scalar : TensorFlowFloatingPoint {
   public typealias TangentVector = Tensor
   public typealias CotangentVector = Tensor
   public typealias AllDifferentiableVariables = Tensor

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -648,7 +648,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpReshaped(toShape:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
     return Raw.reshape(self, shape: newShape)
@@ -672,7 +672,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpExpandingShape(at:)
-    where Scalar : Differentiable & FloatingPoint
+    where Scalar : TensorFlowFloatingPoint
   )
   func expandingShape(at shapeIndex: Int32) -> Tensor {
     return Raw.expandDims(self, dim: Tensor<Int32>(shapeIndex))

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -117,9 +117,7 @@ ModelADTests.testAllBackends("XORTraining") {
 }
 
 ModelADTests.testAllBackends("WithRespectToModel") {
-  struct Foo<Scalar>: Differentiable
-    where Scalar: FloatingPoint & Differentiable & TensorFlowScalar {
-
+  struct Foo<Scalar>: Differentiable where Scalar: TensorFlowFloatingPoint {
     var bar: Tensor<Scalar>
     var baz: Tensor<Scalar>
 

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -14,9 +14,7 @@ import TensorFlowUnittest
 var TensorADTests = TestSuite("TensorIndirectAD")
 
 TensorADTests.testAllBackends("Generic") {
-  func indirect<Scalar : Differentiable & FloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar>
-    where Scalar == Scalar.CotangentVector
-  {
+  func indirect<Scalar : TensorFlowFloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar> {
     return (x + 3) * (x + 3)
   }
   expectEqual(Tensor(8), gradient(at: Tensor(1), in: indirect))

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -22,7 +22,7 @@ TensorADTests.testAllBackends("TestSimpleGrad") {
 }
 
 TensorADTests.testAllBackends("TestGenericGrad") {
-  func square<T : FloatingPoint & Differentiable>(_ x: Tensor<T>) -> Tensor<T> {
+  func square<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     return x * x
   }
   expectEqual([0.2, 0.4, 0.6], gradient(at: Tensor([0.1, 0.2, 0.3]), in: square))

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -28,6 +28,14 @@ TensorADTests.testAllBackends("TestGenericGrad") {
   expectEqual([0.2, 0.4, 0.6], gradient(at: Tensor([0.1, 0.2, 0.3]), in: square))
 }
 
+TensorADTests.testAllBackends("TestScalarGenericGrad") {
+  // Tests TF-287.
+  func negate<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    return 1 - x
+  }
+  expectEqual(Tensor(-1), gradient(at: Tensor([0.1, 0.2, 0.3]), in: negate))
+}
+
 TensorADTests.testAllBackends("+") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a + b }
   expectTrue((Tensor(1), Tensor(1)) == gradient(at: Tensor(0), Tensor(0), in: f))


### PR DESCRIPTION
- Redefine `TensorFlowFloatingPoint` as a constrained protocol with
  `Self == TangentVector == CotangentVector == AllDifferentiableVariables`.
- Redefine `Tensor` differential operators and `Differentiable` conditional
  conformance in terms of `TensorFlowFloatingPoint`.

This ensures that functions generic over `TensorFlowFloatingPoint` can be
differentiable without extra `T == T.CotangentVector` constraints.

Resolves [TF-287](https://bugs.swift.org/browse/TF-287).