### PR TITLE
[closure-lifetime-fixup] Use the SSAUpdater rather than memory to ext…

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -21,6 +21,7 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFG.h"
 #include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
 #include "swift/SILOptimizer/Utils/StackNesting.h"
 
 #include "llvm/Support/CommandLine.h"
@@ -88,8 +89,33 @@ static SILInstruction *getDeinitSafeClosureDestructionPoint(TermInst *Term) {
   return Term;
 }
 
+static void findReachableExitBlocks(SILInstruction *i,
+                                    SmallVectorImpl<SILBasicBlock *> &result) {
+  SmallVector<SILBasicBlock *, 32> worklist;
+  SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
+
+  visitedBlocks.insert(i->getParent());
+  worklist.push_back(i->getParent());
+
+  while (!worklist.empty()) {
+    auto *bb = worklist.pop_back_val();
+    if (bb->getTerminator()->isFunctionExiting()) {
+      result.push_back(bb);
+      continue;
+    }
+    copy_if(bb->getSuccessorBlocks(), std::back_inserter(worklist),
+            [&](SILBasicBlock *bb) { return visitedBlocks.insert(bb).second; });
+  }
+}
+
 /// Extend the lifetime of the convert_escape_to_noescape's operand to the end
 /// of the function.
+///
+/// NOTE: Since we are lifetime extending a copy that we have introduced, we do
+/// not need to consider destroy_value emitted by SILGen unlike
+/// copy_block_without_escaping which consumes its sentinel parameter. Unlike
+/// that case where we have to consider that destroy_value, we have a simpler
+/// time here.
 static void extendLifetimeToEndOfFunction(SILFunction &Fn,
                                           ConvertEscapeToNoEscapeInst *Cvt) {
   auto EscapingClosure = Cvt->getOperand();
@@ -104,40 +130,78 @@ static void extendLifetimeToEndOfFunction(SILFunction &Fn,
   Cvt->eraseFromParent();
   Cvt = NewCvt;
 
-  // Create an alloc_stack Optional<() -> ()> at the beginning of the function.
-  AllocStackInst *Slot;
-  auto &Context = Cvt->getModule().getASTContext();
-  {
-    SILBuilderWithScope B(Fn.getEntryBlock()->begin());
-    Slot = B.createAllocStack(loc, OptionalEscapingClosureTy);
-    auto *NoneDecl = Context.getOptionalNoneDecl();
-    // Store None to it.
-    B.createStore(
-        loc, B.createEnum(loc, SILValue(), NoneDecl, OptionalEscapingClosureTy),
-        Slot, StoreOwnershipQualifier::Init);
-  }
-  // Insert a copy before the convert_escape_to_noescape and store it to the
-  // alloc_stack location.
-  {
+  // If our Cvt is in the initial block, we do not need to use the SSA updater
+  // since we know Cvt can not be in a loop and must dominate all exits
+  // (*). Just insert a copy of the escaping closure at the Cvt and destroys at
+  // the exit blocks of the function.
+  //
+  // (*) In fact we can't use the SILSSAUpdater::GetValueInMiddleOfBlock.
+  if (Cvt->getParent() == Cvt->getFunction()->getEntryBlock()) {
     SILBuilderWithScope B(Cvt);
-    auto *SomeDecl = Context.getOptionalSomeDecl();
-    B.createDestroyAddr(loc, Slot);
-    auto ClosureCopy = B.createCopyValue(loc, EscapingClosure);
-    B.createStore(
-        loc,
-        B.createEnum(loc, ClosureCopy, SomeDecl, OptionalEscapingClosureTy),
-        Slot, StoreOwnershipQualifier::Init);
+    CopyValueInst *InnerCVI = B.createCopyValue(loc, EscapingClosure);
+    SmallVector<SILBasicBlock *, 4> ExitingBlocks;
+    Fn.findExitingBlocks(ExitingBlocks);
+
+    for (auto *Exit : ExitingBlocks) {
+      auto *Term = Exit->getTerminator();
+      auto *SafeClosureDestructionPt =
+          getDeinitSafeClosureDestructionPoint(Term);
+      SILBuilderWithScope B(SafeClosureDestructionPt);
+      B.createDestroyValue(loc, InnerCVI);
+    }
+    return;
   }
-  // Insert destroys at the function exits.
+
+  // Ok. At this point we know that Cvt is not in the entry block... so we can
+  // use SILSSAUpdater::GetValueInMiddleOfBlock() to extend the object's
+  // lifetime respecting loops.
+  SILSSAUpdater Updater(Cvt->getModule());
+  Updater.Initialize(OptionalEscapingClosureTy);
+
+  // Create an Optional<() -> ()>.none in the entry block of the function and
+  // add it as an available value to the SSAUpdater.
+  //
+  // Since we know that Cvt is not in the entry block and this must be, we know
+  // that it is safe to use the SSAUpdater's getValueInMiddleOfBlock with this
+  // value.
+  Updater.AddAvailableValue(Fn.getEntryBlock(), [&]() -> SILValue {
+    SILBuilderWithScope B(Fn.getEntryBlock()->begin());
+    return B.createOptionalNone(loc, OptionalEscapingClosureTy);
+  }());
+
+  // Create a copy of the convert_escape_to_no_escape and add it as an available
+  // value to the SSA updater.
+  //
+  // NOTE: The SSAUpdater does not support providing multiple values in the same
+  // block without extra work. So the fact that Cvt is not in the entry block
+  // means that we don't have to worry about overwriting the .none value.
+  auto *CVI = [&]() -> CopyValueInst * {
+    SILBuilderWithScope B(Cvt);
+    CopyValueInst *InnerCVI = B.createCopyValue(loc, EscapingClosure);
+    Updater.AddAvailableValue(
+        Cvt->getParent(),
+        B.createOptionalSome(loc, InnerCVI, OptionalEscapingClosureTy));
+    return InnerCVI;
+  }();
+
+  // Then we use the SSA updater to insert a destroy_value before the cvt and at
+  // the reachable exit blocks.
   SmallVector<SILBasicBlock *, 4> ExitingBlocks;
-  Fn.findExitingBlocks(ExitingBlocks);
+  findReachableExitBlocks(Cvt, ExitingBlocks);
+
+  {
+    // Before the copy value, insert an extra destroy_value to handle
+    // loops. Since we used our enum value this is safe.
+    SILBuilderWithScope B(CVI);
+    B.createDestroyValue(loc,
+                         Updater.GetValueInMiddleOfBlock(CVI->getParent()));
+  }
+
   for (auto *Exit : ExitingBlocks) {
     auto *Term = Exit->getTerminator();
     auto *SafeClosureDestructionPt = getDeinitSafeClosureDestructionPoint(Term);
     SILBuilderWithScope B(SafeClosureDestructionPt);
-    B.createDestroyAddr(loc, Slot);
-    SILBuilderWithScope B2(Term);
-    B2.createDeallocStack(loc, Slot);
+    B.createDestroyValue(loc, Updater.GetValueAtEndOfBlock(Exit));
   }
 }
 
@@ -538,88 +602,171 @@ static SILInstruction *getOnlyDestroy(CopyBlockWithoutEscapingInst *CB) {
 ///      %e = is_escaping %closure
 ///      cond_fail %e
 ///      destroy_value %closure
-static bool fixupCopyBlockWithoutEscaping(CopyBlockWithoutEscapingInst *CB) {
-  SmallVector<SILInstruction *, 4> LifetimeEndPoints;
-
+static bool fixupCopyBlockWithoutEscaping(CopyBlockWithoutEscapingInst *CB,
+                                          bool &modifiedCFG) {
   // Find the end of the lifetime of the copy_block_without_escaping
   // instruction.
   auto &Fn  = *CB->getFunction();
+
+  // If we find a single destroy, this destroy is going to be a destroy that may
+  // be in the same block as CB. It is important that we make sure that the
+  // destroy is in a different block than CB or any terminating blocks to ensure
+  // that we can use the SSAUpdater if needed.
   auto *SingleDestroy = getOnlyDestroy(CB);
-  SmallVector<SILBasicBlock *, 4> ExitingBlocks;
-  Fn.findExitingBlocks(ExitingBlocks);
-  if (SingleDestroy) {
-    LifetimeEndPoints.push_back(
-        &*std::next(SILBasicBlock::iterator(SingleDestroy)));
-  } else {
-    // Otherwise, conservatively insert verification at the end of the function.
-    for (auto *Exit : ExitingBlocks)
-      LifetimeEndPoints.push_back(Exit->getTerminator());
+  if (SingleDestroy && SingleDestroy->getParent() == CB->getParent()) {
+    modifiedCFG = true;
+    {
+      SILBuilderWithScope B(SingleDestroy);
+      splitBasicBlockAndBranch(B, SingleDestroy, nullptr, nullptr);
+    }
+
+    {
+      SILBuilderWithScope B(SingleDestroy);
+      auto *Term = SingleDestroy->getParent()->getTerminator();
+      if (Term->isFunctionExiting()) {
+        splitBasicBlockAndBranch(B, &*std::next(SingleDestroy->getIterator()),
+                                 nullptr, nullptr);
+      }
+    }
   }
 
   auto SentinelClosure = CB->getClosure();
   auto Loc = CB->getLoc();
 
+  // At this point, we transform our copy_block_without_escaping into a
+  // copy_block. This has a few important implications:
+  //
+  // 1. copy_block_without_escaping takes the sentinel value at +1. We will need
+  //    to balance that +1.
+  // 2. The destroy_value associated with the copy_block_without_escaping will
+  //    be on the copy_block value.
   SILBuilderWithScope B(CB);
   auto *NewCB = B.createCopyBlock(Loc, CB->getBlock());
   CB->replaceAllUsesWith(NewCB);
   CB->eraseFromParent();
 
-  // Create an stack slot for the closure sentinel and store the sentinel (or
-  // none on other paths.
   auto generatedLoc = RegularLocation::getAutoGeneratedLocation();
-  AllocStackInst *Slot;
-  auto &Context = NewCB->getModule().getASTContext();
+
+  // If CB is in the entry block, we know that our definition of SentinelClosure
+  // must be as well. Thus we know that we do not need to worry about loops or
+  // dominance issues and can just insert destroy_values for the sentinel at the
+  // lifetime end points.
+  if (NewCB->getParent() == NewCB->getFunction()->getEntryBlock()) {
+    // Our single destroy must not be in the entry block since if so, we would
+    // have inserted an edge to appease the SSA updater.
+    if (SingleDestroy) {
+      SILBuilderWithScope B(std::next(SingleDestroy->getIterator()));
+      SILValue V = SentinelClosure;
+      SILValue isEscaping = B.createIsEscapingClosure(
+          Loc, V, IsEscapingClosureInst::ObjCEscaping);
+      B.createCondFail(Loc, isEscaping);
+      B.createDestroyValue(Loc, V);
+      return true;
+    }
+
+    // If we couldn't find a specific destroy_value, lifetime extend to the end
+    // of the function.
+    SmallVector<SILBasicBlock *, 4> ExitingBlocks;
+    Fn.findExitingBlocks(ExitingBlocks);
+    for (auto *Block : ExitingBlocks) {
+      SILBuilderWithScope B(Block->getTerminator());
+      SILValue V = SentinelClosure;
+      SILValue isEscaping = B.createIsEscapingClosure(
+          Loc, V, IsEscapingClosureInst::ObjCEscaping);
+      B.createCondFail(Loc, isEscaping);
+      B.createDestroyValue(Loc, V);
+    }
+
+    return true;
+  }
+
+  // Otherwise, we need to be more careful since we can have loops and may not
+  // transitively dominate all uses of the closure. So we:
+  //
+  // 1. Create an Optional<T>.none at the entry.
+  // 2. Create a destroy_value(val), val = Optional<T>.some(sentinel) in the cvt
+  // block.
+  // 3. Create a destroy_value at all exits of the value.
+  //
+  // and then use the SSAUpdater to ensure that we handle loops correctly.
   auto OptionalEscapingClosureTy =
       SILType::getOptionalType(SentinelClosure->getType());
-  auto *NoneDecl = Context.getOptionalNoneDecl();
+
+  SILSSAUpdater Updater(Fn.getModule());
+  Updater.Initialize(OptionalEscapingClosureTy);
+
+  // Create the Optional.none as the beginning available value.
   {
     SILBuilderWithScope B(Fn.getEntryBlock()->begin());
-    Slot = B.createAllocStack(generatedLoc, OptionalEscapingClosureTy);
-    // Store None to it.
-    B.createStore(generatedLoc,
-                  B.createEnum(generatedLoc, SILValue(), NoneDecl,
-                               OptionalEscapingClosureTy),
-                  Slot, StoreOwnershipQualifier::Init);
+    Updater.AddAvailableValue(
+        Fn.getEntryBlock(),
+        B.createOptionalNone(generatedLoc, OptionalEscapingClosureTy));
   }
-  {
+
+  // Then create the Optional.some(closure sentinel).
+  //
+  // NOTE: We return the appropriate insertion point to insert the destroy_value
+  // before the value (to ensure we handle loops). We need to get all available
+  // values first though.
+  auto *InitialValue = [&]() -> EnumInst * {
     SILBuilderWithScope B(NewCB);
-    // Store the closure sentinel (the copy_block_without_escaping closure
+    // Create the closure sentinel (the copy_block_without_escaping closure
     // operand consumed at +1, so we don't need a copy) to it.
-    B.createDestroyAddr(generatedLoc, Slot); // We could be in a loop.
-    auto *SomeDecl = Context.getOptionalSomeDecl();
-    B.createStore(generatedLoc,
-                  B.createEnum(generatedLoc, SentinelClosure, SomeDecl,
-                               OptionalEscapingClosureTy),
-                  Slot, StoreOwnershipQualifier::Init);
+    auto *Result = B.createOptionalSome(generatedLoc, SentinelClosure,
+                                        OptionalEscapingClosureTy);
+    Updater.AddAvailableValue(Result->getParent(), Result);
+    return Result;
+  }();
+
+  // If we had a single destroy, creating a .none after it and add that as a
+  // value to the SSA updater.
+  if (SingleDestroy) {
+    SILBuilderWithScope B(std::next(SingleDestroy->getIterator()));
+    auto *Result =
+        B.createOptionalNone(generatedLoc, OptionalEscapingClosureTy);
+    Updater.AddAvailableValue(Result->getParent(), Result);
   }
 
-  for (auto LifetimeEndPoint : LifetimeEndPoints) {
-    SILBuilderWithScope B(LifetimeEndPoint);
-    SILValue isEscaping;
-    B.emitScopedBorrowOperation(generatedLoc, Slot, [&](SILValue value) {
-      isEscaping = B.createIsEscapingClosure(
-          Loc, value, IsEscapingClosureInst::ObjCEscaping);
-    });
+  // Now that we have all of our available values, insert a destroy_value before
+  // the initial Optional.some value using the SSA updater to ensure that we
+  // handle loops correctly.
+  {
+    SILBuilderWithScope B(InitialValue);
+    B.createDestroyValue(generatedLoc, Updater.GetValueInMiddleOfBlock(
+                                           InitialValue->getParent()));
+  }
+
+  // And insert an is_escaping_closure, cond_fail, destroy_value at each of the
+  // lifetime end points. This ensures we do not expand our lifetime too much.
+  if (SingleDestroy) {
+    SILBuilderWithScope B(std::next(SingleDestroy->getIterator()));
+    SILValue V = Updater.GetValueInMiddleOfBlock(SingleDestroy->getParent());
+    SILValue isEscaping =
+        B.createIsEscapingClosure(Loc, V, IsEscapingClosureInst::ObjCEscaping);
     B.createCondFail(Loc, isEscaping);
-    B.createDestroyAddr(generatedLoc, Slot);
-    // Store None to it.
-    B.createStore(generatedLoc,
-                  B.createEnum(generatedLoc, SILValue(), NoneDecl,
-                               OptionalEscapingClosureTy),
-                  Slot, StoreOwnershipQualifier::Init);
+    B.createDestroyValue(Loc, V);
   }
 
-  // Insert the dealloc_stack in all exiting blocks.
-  for (auto *ExitBlock: ExitingBlocks) {
-    auto *Terminator = ExitBlock->getTerminator();
-    SILBuilderWithScope B(Terminator);
-    B.createDeallocStack(generatedLoc, Slot);
+  // Then to be careful with regards to loops, insert at each of the destroy
+  // blocks destroy_value to ensure that we obey ownership invariants.
+  {
+    SmallVector<SILBasicBlock *, 4> ExitingBlocks;
+    findReachableExitBlocks(NewCB, ExitingBlocks);
+
+    for (auto *Exit : ExitingBlocks) {
+      auto *Term = Exit->getTerminator();
+      auto *SafeClosureDestructionPt =
+          getDeinitSafeClosureDestructionPoint(Term);
+      SILBuilderWithScope B(SafeClosureDestructionPt);
+      B.createDestroyValue(generatedLoc, Updater.GetValueInMiddleOfBlock(Exit));
+    }
   }
 
   return true;
 }
 
-static bool fixupClosureLifetimes(SILFunction &Fn, bool &checkStackNesting) {
+static bool fixupClosureLifetimes(SILFunction &Fn, bool &checkStackNesting,
+                                  bool &modifiedCFG) {
   bool Changed = false;
 
   // tryExtendLifetimeToLastUse uses a cache of recursive instruction use
@@ -634,7 +781,7 @@ static bool fixupClosureLifetimes(SILFunction &Fn, bool &checkStackNesting) {
 
       // Handle, copy_block_without_escaping instructions.
       if (auto *CB = dyn_cast<CopyBlockWithoutEscapingInst>(Inst)) {
-        Changed |= fixupCopyBlockWithoutEscaping(CB);
+        Changed |= fixupCopyBlockWithoutEscaping(CB, modifiedCFG);
         continue;
       }
 
@@ -688,7 +835,7 @@ class ClosureLifetimeFixup : public SILFunctionTransform {
     bool checkStackNesting = false;
     bool modifiedCFG = false;
 
-    if (fixupClosureLifetimes(*getFunction(), checkStackNesting)) {
+    if (fixupClosureLifetimes(*getFunction(), checkStackNesting, modifiedCFG)) {
       if (checkStackNesting){
         StackNesting SN;
         modifiedCFG =

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -68,16 +68,14 @@ public protocol P {
 // CHECK-LABEL: sil @$s22closure_lifetime_fixup10testModify1pyxz_tAA1PRzSS7ElementRtzlF : $@convention(thin) <T where T : P, T.Element == String> (@inout T) -> () {
 // CHECK: bb0
 // CHECK:  [[PA1:%.*]] = partial_apply [callee_guaranteed]
-// CHECK:  [[ENUM1:%.*]] = enum $Optional<@callee_guaranteed (@in_guaranteed String) -> @out Int>, #Optional.some!enumelt.1, [[PA1]] 
 // CHECK:  [[CVT1:%.*]] = convert_escape_to_noescape [[PA1]]
 // CHECK:  [[PA2:%.*]] = partial_apply [callee_guaranteed]
-// CHECK:  [[ENUM2:%.*]] = enum $Optional<@callee_guaranteed (@in_guaranteed Int) -> @out String>, #Optional.some!enumelt.1, [[PA2]]
 // CHECK:  [[CVT2:%.*]] = convert_escape_to_noescape [[PA2]]
 // CHECK:  [[W:%.*]] = witness_method $T, #P.subscript!modify.1
 // CHECK:  ([[BUFFER:%.*]], [[TOKEN:%.*]]) = begin_apply [[W]]<T, Int>([[CVT1]], [[CVT2]], {{.*}})
 // CHECK:  end_apply [[TOKEN]]
-// CHECK:  release_value [[ENUM1]]
-// CHECK:  release_value [[ENUM2]]
+// CHECK:  strong_release [[PA1]]
+// CHECK:  strong_release [[PA2]]
 public func testModify<T : P>(p: inout T) where T.Element == String {
   p[{Int($0)!}, {String($0)}] += 1
 }

--- a/test/SILOptimizer/closure_lifetime_fixup_objc.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_objc.swift
@@ -19,7 +19,6 @@ public protocol DangerousEscaper {
 
 // Extend the lifetime to the end of this function (2).
 // CHECK:   strong_retain [[ARG]] : $@callee_guaranteed () -> ()
-// CHECK:   [[OPT_CLOSURE:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt.1, [[ARG]] : $@callee_guaranteed () -> ()
 
 // CHECK:   [[NE:%.*]] = convert_escape_to_noescape [[ARG]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK:   [[WITHOUT_ACTUALLY_ESCAPING_THUNK:%.*]] = function_ref @$sIg_Ieg_TR : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
@@ -36,9 +35,6 @@ public protocol DangerousEscaper {
 // CHECK:   [[BLOCK_INVOKE:%.*]] = function_ref @$sIeg_IyB_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> ()) -> ()
 // CHECK:   [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_guaranteed () -> (), invoke [[BLOCK_INVOKE]] : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> ()) -> (), type $@convention(block) @noescape () -> ()
 
-// Optional sentinel (4).
-// CHECK:   [[OPT_SENTINEL:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt.1, [[SENTINEL]] : $@callee_guaranteed () -> ()
-
 // Copy of sentinel closure (5).
 // CHECK:   [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]] : $@convention(block) @noescape () -> ()
 
@@ -53,27 +49,69 @@ public protocol DangerousEscaper {
 
 // Release sentinel closure copy (5).
 // CHECK:   strong_release [[BLOCK_COPY]] : $@convention(block) @noescape () -> ()
-// CHECK:   [[ESCAPED:%.*]] = is_escaping_closure [objc] [[OPT_SENTINEL]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:   [[ESCAPED:%.*]] = is_escaping_closure [objc] [[SENTINEL]]
 // CHECK:   cond_fail [[ESCAPED]] : $Builtin.Int1
 
 // Release of sentinel copy (4).
-// CHECK:   release_value [[OPT_SENTINEL]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:   strong_release [[SENTINEL]]
 
 // Extendend lifetime (2).
-// CHECK:   release_value [[OPT_CLOSURE]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:   strong_release [[ARG]]
 // CHECK:   return
-
+// CHECK: } // end sil function '$s27closure_lifetime_fixup_objc19couldActuallyEscapeyyyyc_AA16DangerousEscaper_ptF'
 public func couldActuallyEscape(_ closure: @escaping () -> (), _ villian: DangerousEscaper) {
   villian.malicious(closure)
 }
 
+// Make sure that we respect the ownership verifier.
+//
+// CHECK-LABEL: sil @$s27closure_lifetime_fixup_objc27couldActuallyEscapeWithLoopyyyyc_AA16DangerousEscaper_ptF : $@convention(thin) (@guaranteed @callee_guaranteed () -> (), @guaranteed DangerousEscaper) -> () {
+public func couldActuallyEscapeWithLoop(_ closure: @escaping () -> (), _ villian: DangerousEscaper) {
+  for _ in 0..<2 {
+    villian.malicious(closure)
+  }
+}
+
 // We need to store nil on the back-edge.
-// CHECK  sil {{.*}}dontCrash
-// CHECK:  is_escaping_closure [objc]
-// CHECK:  cond_fail
-// CHECK:  destroy_addr %0
-// CHECK:  [[NONE:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
-// CHECK:  store [[NONE]] to %0 : $*Optional<@callee_guaranteed () -> ()>
+// CHECK-LABEL: sil @$s27closure_lifetime_fixup_objc9dontCrashyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   [[NONE:%.*]] = enum $Optional<{{.*}}>, #Optional.none!enumelt
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   br bb2
+//
+// CHECK: bb2:
+// CHECK:   br [[LOOP_HEADER_BB:bb[0-9]+]]([[NONE]]
+//
+// CHECK: [[LOOP_HEADER_BB]]([[LOOP_IND_VAR:%.*]] : $Optional
+// CHECK:   switch_enum {{.*}} : $Optional<Int>, case #Optional.some!enumelt.1: [[SUCC_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCC_BB]](
+// CHECK:   [[THUNK_FUNC:%.*]] = function_ref @$sIg_Ieg_TR :
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FUNC]](
+// CHECK:   [[MDI:%.*]] = mark_dependence [[PAI]]
+// CHECK:   strong_retain [[MDI]]
+// CHECK:   [[BLOCK_SLOT:%.*]] = alloc_stack $@block_storage @callee_guaranteed () -> ()
+// CHECK:   [[BLOCK_PROJ:%.*]] = project_block_storage [[BLOCK_SLOT]]
+// CHECK:   store [[MDI]] to [[BLOCK_PROJ]] :
+// CHECK:   [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_SLOT]]
+// CHECK:   release_value [[LOOP_IND_VAR]]
+// CHECK:   [[SOME:%.*]] = enum $Optional<{{.*}}>, #Optional.some!enumelt.1, [[MDI]]
+// CHECK:   [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+// CHECK:   destroy_addr [[BLOCK_PROJ]]
+// CHECK:   [[DISPATCH_SYNC_FUNC:%.*]] = function_ref @dispatch_sync :
+// CHECK:   apply [[DISPATCH_SYNC_FUNC]]({{%.*}}, [[BLOCK_COPY]])
+// CHECK:   strong_release [[BLOCK_COPY]]
+// CHECK:   is_escaping_closure [objc] [[SOME]]
+// CHECK:   release_value [[SOME]]
+// CHECK:   [[NONE_FOR_BACKEDGE:%.*]] = enum $Optional<{{.*}}>, #Optional.none
+// CHECK:   br [[LOOP_HEADER_BB]]([[NONE_FOR_BACKEDGE]] :
+//
+// CHECK: [[NONE_BB]]:
+// CHECK:   release_value [[LOOP_IND_VAR]]
+// CHECK:   return
+// CHECK: } // end sil function '$s27closure_lifetime_fixup_objc9dontCrashyyF'
 public func dontCrash() {
   for i in 0 ..< 2 {
     let queue = DispatchQueue(label: "Foo")
@@ -89,16 +127,43 @@ func getDispatchQueue() -> DispatchQueue
 // CHECK: bb0([[SELF:%.*]] : $C):
 // CHECK:   [[F:%.*]] = function_ref @$s27closure_lifetime_fixup_objc1CCfdyyXEfU_
 // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]]([[SELF]])
-// CHECK:   [[OPT:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt.1, [[PA]]
 // CHECK:   [[DEINIT:%.*]] = objc_super_method [[SELF]] : $C, #NSObject.deinit!deallocator.1.foreign
-// CHECK:   release_value [[OPT]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:   strong_release [[PA]]
 // CHECK:   [[SUPER:%.*]] = upcast [[SELF]] : $C to $NSObject
 // CHECK-NEXT:   apply [[DEINIT]]([[SUPER]]) : $@convention(objc_method) (NSObject) -> ()
 // CHECK-NEXT:   [[T:%.*]] = tuple ()
 // CHECK-NEXT:   return [[T]] : $()
+// CHECK: } // end sil function '$s27closure_lifetime_fixup_objc1CCfD'
 class C: NSObject {
   deinit {
     getDispatchQueue().sync(execute: { _ = self })
+  }
+}
+
+// Make sure even if we have a loop, we do not release the value after calling super.deinit
+// CHECK-LABEL: sil hidden @$s27closure_lifetime_fixup_objc9CWithLoopCfD : $@convention(method) (@owned CWithLoop) -> () {
+// CHECK:        [[METH:%.*]] = objc_super_method
+// CHECK-NEXT:   release_value
+// CHECK-NEXT:   release_value
+// CHECK-NEXT:   upcast {{%.*}} : $CWithLoop to $NSObject
+// CHECK-NEXT:   apply [[METH]]({{%.*}}) : $@convention(objc_method) (NSObject) -> ()
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function '$s27closure_lifetime_fixup_objc9CWithLoopCfD'
+class CWithLoop : NSObject {
+  deinit {
+    for _ in 0..<2 {
+      getDispatchQueue().sync(execute: { _ = self })
+    }
+  }
+}
+
+class CWithLoopReturn : NSObject {
+  deinit {
+    for _ in 0..<2 {
+      getDispatchQueue().sync(execute: { _ = self })
+      return
+    }
   }
 }
 
@@ -106,5 +171,12 @@ class C: NSObject {
 internal typealias MyBlock = @convention(block) () -> Void
 func getBlock(noEscapeBlock: () -> Void ) -> MyBlock {
   return block_create_noescape(noEscapeBlock)
+}
+
+func getBlockWithLoop(noEscapeBlock: () -> Void ) -> MyBlock {
+  for _ in 0..<2 {
+    return block_create_noescape(noEscapeBlock)
+  }
+  return (Optional<MyBlock>.none)!
 }
 

--- a/test/SILOptimizer/definite-init-convert-to-escape.swift
+++ b/test/SILOptimizer/definite-init-convert-to-escape.swift
@@ -39,39 +39,80 @@ public func returnOptionalEscape() -> (() ->())?
 
 // CHECK-LABEL: sil @$s1A19bridgeNoescapeBlockyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
+// CHECK:  [[NONE:%.*]] = enum $Optional<{{.*}}>, #Optional.none!enumelt
 // CHECK:  [[V0:%.*]] = function_ref @_returnOptionalEscape
 // CHECK:  [[V1:%.*]] = apply [[V0]]
 // CHECK:  retain_value [[V1]]
-// CHECK:  switch_enum {{.*}}bb1
-// CHECK: bb1([[V2:%.*]]: $@callee_guaranteed () -> ()):
-// CHECK:  convert_escape_to_noescape %
+// CHECK:  switch_enum [[V1]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+//
+// CHECK: [[SOME_BB]]([[V2:%.*]]: $@callee_guaranteed () -> ()):
+// CHECK:  [[CVT:%.*]] = convert_escape_to_noescape [[V2]]
+// CHECK:  [[SOME:%.*]] = enum $Optional<{{.*}}>, #Optional.some!enumelt.1, [[CVT]]
 // CHECK:  strong_release [[V2]]
-// CHECK: bb5({{.*}} : $Optional<@convention(block) @noescape () -> ()>)
+// CHECK:  br [[NEXT_BB:bb[0-9]+]]([[SOME]] :
+//
+// CHECK: [[NEXT_BB]]([[SOME_PHI:%.*]] :
+// CHECK:   switch_enum [[SOME_PHI]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB_2:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB_2:bb[0-9]+]]
+//
+// CHECK: [[SOME_BB_2]]([[SOME_PHI_PAYLOAD:%.*]] :
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[SOME_PHI_PAYLOAD]])
+// CHECK:   [[MDI:%.*]] = mark_dependence [[PAI]]
+// CHECK:   strong_retain [[MDI]]
+// CHECK:   [[BLOCK_SLOT:%.*]] = alloc_stack
+// CHECK:   [[BLOCK_PROJ:%.*]] = project_block_storage [[BLOCK_SLOT]]
+// CHECK:   store [[MDI]] to [[BLOCK_PROJ]]
+// CHECK:   [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_SLOT]]
+// CHECK:   release_value [[NONE]]
+// CHECK:   [[SOME_2:%.*]] = enum $Optional<{{.*}}>, #Optional.some!enumelt.1, [[MDI]]
+// CHECK:   [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+// CHECK:   [[BLOCK_SOME:%.*]]  = enum $Optional<{{.*}}>, #Optional.some!enumelt.1, [[BLOCK_COPY]]
+// CHECK:   br bb5([[BLOCK_SOME]] : ${{.*}}, [[SOME_2]] :
+//
+// CHECK: bb4:
+// CHECK:   [[NONE_BLOCK:%.*]] = enum $Optional<{{.*}}>, #Optional.none!enumelt
+// CHECK:   br bb5([[NONE_BLOCK]] : {{.*}}, [[NONE]] :
+//
+// CHECK: bb5([[BLOCK_PHI:%.*]] : $Optional<{{.*}}>, [[SWIFT_CLOSURE_PHI:%.*]] :
 // CHECK:  [[F:%.*]] = function_ref @noescapeBlock
-// CHECK:  apply [[F]]({{.*}})
-// CHECK:  release_value [[V1]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:  apply [[F]]([[BLOCK_PHI]])
+// CHECK:  release_value [[BLOCK_PHI]]
+// CHECK:  release_value [[SWIFT_CLOSURE_PHI]]
+// CHECK-NEXT: return
 
 // NOPEEPHOLE-LABEL: sil @$s1A19bridgeNoescapeBlockyyF : $@convention(thin) () -> () {
 // NOPEEPHOLE: bb0:
-// NOPEEPHOLE:  alloc_stack $Optional<@callee_guaranteed () -> ()>
-// NOPEEPHOLE:  [[SLOT:%.*]] = alloc_stack $Optional<@callee_guaranteed () -> ()>
-// NOPEEPHOLE:  [[NONE:%.*]] = enum $Optional
-// NOPEEPHOLE:  store [[NONE]] to [[SLOT]]
+// NOPEEPHOLE:  [[NONE_1:%.*]] = enum $Optional<{{.*}}>, #Optional.none!enumelt
+// NOPEEPHOLE:  [[NONE_2:%.*]] = enum $Optional<{{.*}}>, #Optional.none!enumelt
 // NOPEEPHOLE:  [[V0:%.*]] = function_ref @_returnOptionalEscape
 // NOPEEPHOLE:  [[V1:%.*]] = apply [[V0]]
-// NOPEEPHOLE:  switch_enum {{.*}}bb1
-// NOPEEPHOLE: bb1([[V2:%.*]]: $@callee_guaranteed () -> ()):
-// NOPEEPHOLE:  destroy_addr [[SLOT]]
-// NOPEEPHOLE:  [[SOME:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt.1, [[V2]]
-// NOPEEPHOLE:  store [[SOME]] to [[SLOT]]
-// NOPEEPHOLE:  convert_escape_to_noescape %
-// NOPEEPHOLE-NOT:  strong_release
-// NOPEEPHOLE:  br
-// NOPEEPHOLE: bb5({{.*}} : $Optional<@convention(block) @noescape () -> ()>)
-// NOPEEPHOLE:  [[F:%.*]] = function_ref @noescapeBlock
-// NOPEEPHOLE:  apply [[F]]({{.*}})
-// NOPEEPHOLE:  destroy_addr [[SLOT]]
-// NOPEEPHOLE:  dealloc_stack  [[SLOT]]
+// NOPEEPHOLE:  switch_enum [[V1]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+//
+// NOPEEPHOLE: [[SOME_BB]]([[V2:%.*]]: $@callee_guaranteed () -> ()):
+// NOPEEPHOLE-NEXT:  release_value [[NONE_2]]
+// NOPEEPHOLE-NEXT:  [[SOME:%.*]] = enum $Optional<{{.*}}>, #Optional.some!enumelt.1, [[V2]]
+// NOPEEPHOLE-NEXT:  [[CVT:%.*]] = convert_escape_to_noescape [[V2]]
+// NOPEEPHOLE-NEXT:  [[NOESCAPE_SOME:%.*]] = enum $Optional<{{.*}}>, #Optional.some!enumelt.1, [[CVT]]
+// NOPEEPHOLE-NEXT:  br bb2([[NOESCAPE_SOME]] : $Optional<{{.*}}>, [[SOME]] :
+//
+// NOPEEPHOLE: bb2([[NOESCAPE_SOME:%.*]] : $Optional<{{.*}}>, [[SOME:%.*]] :
+// NOPEEPHOLE:   switch_enum [[NOESCAPE_SOME]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB_2:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB_2:bb[0-9]+]]
+//
+// NOPEEPHOLE: [[SOME_BB_2]](
+// NOPEEPHOLE:   br bb5
+//
+// NOPEEPHOLE: [[NONE_BB_2]]:
+// NOPEEPHOLE:   br bb5
+//
+// NOPEEPHOLE: bb5([[BLOCK_PHI:%.*]] : $Optional<{{.*}}>, [[SWIFT_CLOSURE_PHI:%.*]] :
+// NOPEEPHOLE-NEXT: function_ref noescapeBlock
+// NOPEEPHOLE-NEXT:  [[F:%.*]] = function_ref @noescapeBlock :
+// NOPEEPHOLE-NEXT:  apply [[F]]([[BLOCK_PHI]])
+// NOPEEPHOLE-NEXT:  release_value [[BLOCK_PHI]]
+// NOPEEPHOLE-NEXT:  tuple
+// NOPEEPHOLE-NEXT:  release_value [[SOME]]
+// NOPEEPHOLE-NEXT:  release_value [[SWIFT_CLOSURE_PHI]]
+// NOPEEPHOLE-NEXT: return
+// NOPEEPHOLE: } // end sil function '$s1A19bridgeNoescapeBlockyyF'
 public func bridgeNoescapeBlock() {
   noescapeBlock(returnOptionalEscape())
 }


### PR DESCRIPTION
…end the lifetime to the end of the function.

This beyond being slightly cleaner ensures that we do not try to promote in
PredictableMemOpts any loads from the alloc_stack. Doing this would force us to
insert a copy in ossa which then would break is_escaping_closure even when we
don't escape.

<rdar://problem/46188001>

----

NOTE: I need to finish updating the tests/clean a few things up, but I wanted to get Arnold's feedback.