### PR TITLE
build: use the just-built clang for runtime unittests

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -1,6 +1,27 @@
 if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
    ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
 
+  if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+    if(NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      message(FATAL_ERROR "Building the swift runtime is not supported with ${CMAKE_C_COMPILER_ID}. Use the just-built clang instead.")
+    else()
+      message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")
+    endif()
+  else()
+    # If we use Clang-cl or MSVC, CMake provides default compiler and linker flags that are incompatible
+    # with the frontend of Clang or Clang++.
+    if(SWIFT_COMPILER_IS_MSVC_LIKE)
+      set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang-cl")
+      set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang-cl")
+    else()
+      set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
+      set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+    endif()
+
+    set(CMAKE_C_COMPILER_LAUNCHER "")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "")
+  endif()
+
   set(swift_runtime_test_extra_libraries)
   if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
     list(APPEND swift_runtime_test_extra_libraries 


### PR DESCRIPTION
The runtime is meant to be built with the just built clang (as this
absolutely requires clang) as the runtime is a target library.  The host
tools can be built with the host compiler.  Swap out the compiler for
the unittests as we do for the runtime itself.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
