### PR TITLE
[Sema] TF-288: Handle immutable properties in `Differentiable` derive…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2442,12 +2442,12 @@ ERROR(broken_vector_numeric_requirement,none,
       "VectorNumeric protocol is broken: unexpected requirement", ())
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
-WARNING(differentiable_implicit_noderivative_fixit,none,
+WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
       "stored property %0 has no derivative because it does not conform to "
       "'Differentiable'; add '@noDerivative' to make it explicit",
       (Identifier))
 WARNING(differentiable_constant_property_implicit_noderivative_fixit,none,
-      "'let' properties with an initial value do not have a derivative; add "
+      "'let' properties with a default value do not have a derivative; add "
       "'@noDerivative' to make it explicit",
       ())
 NOTE(protocol_witness_missing_differentiable_attr,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2446,6 +2446,12 @@ WARNING(differentiable_implicit_noderivative_fixit,none,
       "stored property %0 has no derivative because it does not conform to "
       "'Differentiable'; add '@noDerivative' to make it explicit",
       (Identifier))
+WARNING(differentiable_constant_property_implicit_noderivative_fixit,none,
+      "'let' properties with an initial value do not have a derivative; add "
+      "'@noDerivative' to make it explicit",
+      ())
+NOTE(protocol_witness_missing_differentiable_attr,none,
+     "candidate is missing attribute '%0'", (StringRef))
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2448,8 +2448,8 @@ WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
       (Identifier))
 WARNING(differentiable_constant_property_implicit_noderivative_fixit,none,
       "'let' properties with a default value do not have a derivative; add "
-      "'@noDerivative' to make it explicit",
-      ())
+      "'@noDerivative' to make it explicit, or change it to 'var' to allow "
+      "derivatives", ())
 NOTE(protocol_witness_missing_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -871,7 +871,8 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
     assert(loc.isValid() && "Expected valid source location");
     // Diagnose stored property with fixit.
     if (!conformsToDifferentiable) {
-      TC.diagnose(loc, diag::differentiable_implicit_noderivative_fixit,
+      TC.diagnose(loc,
+                  diag::differentiable_nondiff_type_implicit_noderivative_fixit,
                   vd->getName())
           .fixItInsert(vd->getAttributeInsertionLoc(/*forModifier*/ false),
                        "@noDerivative ");

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -57,6 +57,8 @@ getStoredPropertiesForDifferentiation(NominalTypeDecl *nominal,
   for (auto *vd : nominal->getStoredProperties()) {
     if (vd->getAttrs().hasAttribute<NoDerivativeAttr>())
       continue;
+    if (vd->isLet() && vd->hasInitialValue())
+      continue;
     if (!vd->hasInterfaceType())
       C.getLazyResolver()->resolveDeclSignature(vd);
     if (!vd->hasInterfaceType())
@@ -204,8 +206,6 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
   SmallVector<VarDecl *, 16> diffProperties;
   getStoredPropertiesForDifferentiation(structDecl, DC, diffProperties);
   return llvm::all_of(diffProperties, [&](VarDecl *v) {
-    if (v->isLet() && v->hasInitialValue())
-      return false;
     if (!v->hasInterfaceType())
       lazyResolver->resolveDeclSignature(v);
     if (!v->hasInterfaceType())
@@ -685,10 +685,10 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     inherited.push_back(addArithType);
 
   // Associated struct can derive `AdditiveArithmetic` if the associated types
-  // of all members conform to `AdditiveArithmetic`.
+  // of all stored properties conform to `AdditiveArithmetic`.
   bool canDeriveAdditiveArithmetic =
-      llvm::all_of(diffProperties, [&](VarDecl *var) {
-        return TC.conformsToProtocol(getAssociatedType(var, parentDC, id),
+      llvm::all_of(diffProperties, [&](VarDecl *vd) {
+        return TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
                                      addArithProto, parentDC,
                                      ConformanceCheckFlags::Used);
         });
@@ -698,14 +698,14 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   Type sameScalarType;
   bool canDeriveVectorNumeric =
       canDeriveAdditiveArithmetic && !diffProperties.empty() && 
-      llvm::all_of(diffProperties, [&](VarDecl *var) {
-        auto conf = TC.conformsToProtocol(getAssociatedType(var, parentDC, id),
+      llvm::all_of(diffProperties, [&](VarDecl *vd) {
+        auto conf = TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
                                           vecNumProto, nominal,
                                           ConformanceCheckFlags::Used);
         if (!conf)
           return false;
         Type scalarType = ProtocolConformanceRef::getTypeWitnessByName(
-            var->getType(), *conf, C.Id_Scalar, C.getLazyResolver());
+            vd->getType(), *conf, C.Id_Scalar, C.getLazyResolver());
         if (!sameScalarType) {
           sameScalarType = scalarType;
           return true;
@@ -837,9 +837,11 @@ static void addAssociatedTypeAliasDecl(Identifier name,
   C.addSynthesizedDecl(aliasDecl);
 };
 
-// If any stored property in the nominal does not conform to `Differentiable`
-// but does not have an explicit `@noDerivative` attribute, emit a warning and
-// a fixit so that the user will make it explicit.
+// Diagnose stored properties in the nominal that do not have an explicit
+// `@noDerivative` attribute, but either:
+// - Do not conform to `Differentiable`.
+// - Are a `let` stored property with an initial value.
+// Emit a warning and a fixit so that users will make the attribute explicit.
 static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
                                                  NominalTypeDecl *nominal,
                                                  DeclContext* DC) {
@@ -851,19 +853,36 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
     if (!vd->hasInterfaceType())
       continue;
     auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
-    if (vd->getAttrs().hasAttribute<NoDerivativeAttr>() ||
-        TC.conformsToProtocol(varType, diffableProto, nominal,
-                              ConformanceCheckFlags::Used))
+    if (vd->getAttrs().hasAttribute<NoDerivativeAttr>())
       continue;
+    // Check whether to diagnose stored property.
+    bool conformsToDifferentiable =
+        TC.conformsToProtocol(varType, diffableProto, nominal,
+                              ConformanceCheckFlags::Used).hasValue();
+    bool isConstantProperty = vd->isLet() && vd->hasInitialValue();
+    // If stored property should not be diagnosed, continue.
+    if (conformsToDifferentiable && !isConstantProperty)
+      continue;
+    // Otherwise, add an implicit `@noDerivative` attribute.
     nominal->getAttrs().add(
         new (TC.Context) NoDerivativeAttr(/*Implicit*/ true));
     auto loc =
         vd->getLoc().isValid() ? vd->getLoc() : DC->getAsDecl()->getLoc();
     assert(loc.isValid() && "Expected valid source location");
-    TC.diagnose(loc, diag::differentiable_implicit_noderivative_fixit,
-                vd->getName())
+    // Diagnose stored property with fixit.
+    if (!conformsToDifferentiable) {
+      TC.diagnose(loc, diag::differentiable_implicit_noderivative_fixit,
+                  vd->getName())
+          .fixItInsert(vd->getAttributeInsertionLoc(/*forModifier*/ false),
+                       "@noDerivative ");
+      continue;
+    }
+    TC.diagnose(
+          loc,
+          diag::differentiable_constant_property_implicit_noderivative_fixit)
         .fixItInsert(vd->getAttributeInsertionLoc(/*forModifier*/ false),
                      "@noDerivative ");
+
   }
 }
 

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -20,8 +20,10 @@ struct EmptyAdditiveArithmetic : AdditiveArithmetic, Differentiable {}
 
 // Test structs whose stored properties all have a default value.
 struct AllLetStoredPropertiesHaveInitialValue : Differentiable {
-  let x = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
-  let y = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit, or change it to 'var' to allow derivatives}} {{3-3=@noDerivative }}
+  let x = Float(1)
+  // expected-warning @+1 {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit, or change it to 'var' to allow derivatives}} {{3-3=@noDerivative }}
+  let y = Float(1)
 }
 struct AllVarStoredPropertiesHaveInitialValue : Differentiable {
   var x = Float(1)
@@ -29,7 +31,7 @@ struct AllVarStoredPropertiesHaveInitialValue : Differentiable {
 }
 // Test struct with both an empty constructor and memberwise initializer.
 struct AllMixedStoredPropertiesHaveInitialValue : Differentiable {
-  let x = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let x = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative}} {{3-3=@noDerivative }}
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
   static func testMemberwiseInitializer() {
@@ -126,7 +128,7 @@ assertConformsToVectorNumeric(AllMembersVectorNumeric.CotangentVector.self)
 // Test type with immutable, differentiable stored property.
 struct ImmutableStoredProperty : Differentiable {
   var w: Float
-  let fixedBias: Float = .pi // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let fixedBias: Float = .pi // expected-warning {{'let' properties with a default value do not have a derivative}} {{3-3=@noDerivative }}
 }
 _ = ImmutableStoredProperty.TangentVector(w: 1)
 

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -18,10 +18,10 @@ assertConformsToAdditiveArithmetic(Empty.AllDifferentiableVariables.self)
 // Previously, this crashed due to duplicate memberwise initializer synthesis.
 struct EmptyAdditiveArithmetic : AdditiveArithmetic, Differentiable {}
 
-// Test structs whose stored properties all have an initial value.
+// Test structs whose stored properties all have a default value.
 struct AllLetStoredPropertiesHaveInitialValue : Differentiable {
-  let x = Float(1) // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
-  let y = Float(1) // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let x = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let y = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }
 struct AllVarStoredPropertiesHaveInitialValue : Differentiable {
   var x = Float(1)
@@ -29,7 +29,7 @@ struct AllVarStoredPropertiesHaveInitialValue : Differentiable {
 }
 // Test struct with both an empty constructor and memberwise initializer.
 struct AllMixedStoredPropertiesHaveInitialValue : Differentiable {
-  let x = Float(1) // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let x = Float(1) // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
   static func testMemberwiseInitializer() {
@@ -126,7 +126,7 @@ assertConformsToVectorNumeric(AllMembersVectorNumeric.CotangentVector.self)
 // Test type with immutable, differentiable stored property.
 struct ImmutableStoredProperty : Differentiable {
   var w: Float
-  let fixedBias: Float = .pi // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let fixedBias: Float = .pi // expected-warning {{'let' properties with a default value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }
 _ = ImmutableStoredProperty.TangentVector(w: 1)
 

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -19,23 +19,17 @@ assertConformsToAdditiveArithmetic(Empty.AllDifferentiableVariables.self)
 struct EmptyAdditiveArithmetic : AdditiveArithmetic, Differentiable {}
 
 // Test structs whose stored properties all have an initial value.
-// expected-error @+3 {{does not conform to protocol '__Differentiable'}}
-// expected-error @+2 {{does not conform to protocol '_Differentiable'}}
-// expected-error @+1 {{does not conform to protocol 'Differentiable'}}
 struct AllLetStoredPropertiesHaveInitialValue : Differentiable {
-  let x = Float(1)
-  let y = Float(1)
+  let x = Float(1) // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
+  let y = Float(1) // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }
 struct AllVarStoredPropertiesHaveInitialValue : Differentiable {
   var x = Float(1)
   var y = Float(1)
 }
 // Test struct with both an empty constructor and memberwise initializer.
-// expected-error @+3 {{does not conform to protocol '__Differentiable'}}
-// expected-error @+2 {{does not conform to protocol '_Differentiable'}}
-// expected-error @+1 {{does not conform to protocol 'Differentiable'}}
 struct AllMixedStoredPropertiesHaveInitialValue : Differentiable {
-  let x = Float(1)
+  let x = Float(1) // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
   static func testMemberwiseInitializer() {
@@ -130,14 +124,11 @@ assertConformsToVectorNumeric(AllMembersVectorNumeric.TangentVector.self)
 assertConformsToVectorNumeric(AllMembersVectorNumeric.CotangentVector.self)
 
 // Test type with immutable, differentiable stored property.
-// expected-error @+3 {{does not conform to protocol '__Differentiable'}}
-// expected-error @+2 {{does not conform to protocol '_Differentiable'}}
-// expected-error @+1 {{does not conform to protocol 'Differentiable'}}
 struct ImmutableStoredProperty : Differentiable {
   var w: Float
-  let fixedBias: Float = .pi
+  let fixedBias: Float = .pi // expected-warning {{'let' properties with an initial value do not have a derivative; add '@noDerivative' to make it explicit}} {{3-3=@noDerivative }}
 }
-_ = ImmutableStoredProperty.TangentVector(w: 1, fixedBias: 1)
+_ = ImmutableStoredProperty.TangentVector(w: 1)
 
 // Test type whose properties are not all differentiable.
 struct DifferentiableSubset : Differentiable {


### PR DESCRIPTION
…d conformances.

Previously, `Differentiable` derived conformances was not enabled for structs
with `let` stored properties with initial values. (This is because immutable stored
properties can never be updated.)

Now, immutable stored properties are implicitly marked with `@noDerivative`
and are diagnosed with a fixit.

Resolves [TF-288](https://bugs.swift.org/browse/TF-288).