### PR TITLE
[test] Fix loaded_module_trace.swift for arch's that sort before "M"

### DIFF
--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -9,9 +9,9 @@
 // CHECK: "name":"loaded_module_trace"
 // CHECK: "arch":"{{[^"]*}}"
 // CHECK: "swiftmodules":[
-// CHECK: "{{[^"]*\\[/\\]}}Module2.swiftmodule"
-// CHECK: "{{[^"]*\\[/\\]}}Swift.swiftmodule{{(\\[/\\][^"]+[.]swiftmodule)?}}"
-// CHECK: "{{[^"]*\\[/\\]}}SwiftOnoneSupport.swiftmodule{{(\\[/\\][^"]+[.]swiftmodule)?}}"
+// CHECK-DAG: "{{[^"]*\\[/\\]}}Module2.swiftmodule"
+// CHECK-DAG: "{{[^"]*\\[/\\]}}Swift.swiftmodule{{(\\[/\\][^"]+[.]swiftmodule)?}}"
+// CHECK-DAG: "{{[^"]*\\[/\\]}}SwiftOnoneSupport.swiftmodule{{(\\[/\\][^"]+[.]swiftmodule)?}}"
 // CHECK: ]
 // CHECK: }
 


### PR DESCRIPTION
This field is reverse-path-sorted, so the order depends on what architecture we're compiling for. That's not what's being tested, so just use a CHECK-DAG.

Another follow-up to #21797.

rdar://problem/48377454