### PR TITLE
[Driver] Always fall back to an arclite in the Xcode default toolchain

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -169,7 +169,9 @@ static bool findXcodeClangPath(llvm::SmallVectorImpl<char> &path) {
 
   auto xcrunPath = llvm::sys::findProgramByName("xcrun");
   if (!xcrunPath.getError()) {
-    const char *args[] = {"-f", "clang", nullptr};
+    // Explicitly ask for the default toolchain so that we don't find a Clang
+    // included with an open-source toolchain.
+    const char *args[] = {"-toolchain", "default", "-f", "clang", nullptr};
     sys::TaskQueue queue;
     queue.addTask(xcrunPath->c_str(), args, /*Env=*/llvm::None,
                   /*Context=*/nullptr,


### PR DESCRIPTION
...instead of the current toolchain, which we would have just searched by looking relative to the swiftc binary.

No test because you need to install a second toolchain into Xcode and put it in the TOOLCHAINS variable for this to go wrong in the first place.

[SR-9972](https://bugs.swift.org/browse/SR-9972) / rdar://problem/48044350