### PR TITLE
[5.0]  [IRGen] Mangle Swift @objc(renamed) protocols as Objective-C in metadata

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -38,6 +38,10 @@ protected:
   /// Optimize out protocol names if a type only conforms to one protocol.
   bool OptimizeProtocolNames = true;
 
+  /// If enabled, use Objective-C runtime names when mangling @objc Swift
+  /// protocols.
+  bool UseObjCProtocolNames = false;
+
   /// If enabled, non-canonical types are allowed and type alias types get a
   /// special mangling.
   bool DWARFMangling;
@@ -171,7 +175,7 @@ public:
   };
   
   static Optional<SpecialContext>
-  getSpecialManglingContext(const ValueDecl *decl);
+  getSpecialManglingContext(const ValueDecl *decl, bool useObjCProtocolNames);
 
   static const clang::NamedDecl *
   getClangDeclForMangling(const ValueDecl *decl);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -748,7 +748,8 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from,
   if (auto Type = dyn_cast<NominalTypeDecl>(from)) {
     // Use a special module context if we have one.
     if (auto context =
-          Mangle::ASTMangler::getSpecialManglingContext(Type, false)) {
+            Mangle::ASTMangler::getSpecialManglingContext(
+              Type, /*UseObjCProtocolNames=*/false)) {
       switch (*context) {
       case Mangle::ASTMangler::ObjCContext:
         return {getAddrOfObjCModuleContextDescriptor(),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -747,7 +747,8 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from,
   // Some types get special treatment.
   if (auto Type = dyn_cast<NominalTypeDecl>(from)) {
     // Use a special module context if we have one.
-    if (auto context = Mangle::ASTMangler::getSpecialManglingContext(Type)) {
+    if (auto context =
+          Mangle::ASTMangler::getSpecialManglingContext(Type, false)) {
       switch (*context) {
       case Mangle::ASTMangler::ObjCContext:
         return {getAddrOfObjCModuleContextDescriptor(),

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -83,6 +83,7 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
                                   llvm::function_ref<void ()> body) {
   Mod = IGM.getSwiftModule();
   OptimizeProtocolNames = false;
+  UseObjCProtocolNames = true;
 
   llvm::SaveAndRestore<bool>
     AllowSymbolicReferencesLocally(AllowSymbolicReferences);

--- a/test/Runtime/associated_type_demangle_objc.swift
+++ b/test/Runtime/associated_type_demangle_objc.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name main -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+@objc(MyObjCProtocol) public protocol MyProtocol { }
+
+public protocol OtherProtocol {
+  associatedtype AssocType
+}
+
+public struct MyThing: OtherProtocol {
+  public typealias AssocType = MyProtocol
+}
+
+func getAssocType<T: OtherProtocol>(_: T.Type) -> Any.Type {
+  return T.AssocType.self
+}
+let RenamedObjCDemangleTests = TestSuite("RenamedObjCDemangle")
+
+RenamedObjCDemangleTests.test("@objc protocols") {
+  expectEqual(getAssocType(MyThing.self), MyProtocol.self)
+}
+
+@objc(MyObjCClass) class MyClass: NSObject { }
+
+struct MyClassWrapper: OtherProtocol {
+  typealias AssocType = MyClass
+}
+
+RenamedObjCDemangleTests.test("@objc classes") {
+  expectEqual(getAssocType(MyClassWrapper.self), MyClass.self)
+}
+
+runAllTests()

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -11,14 +11,24 @@ import Dispatch
 let DemangleToMetadataTests = TestSuite("DemangleToMetadataObjC")
 
 @objc class C : NSObject { }
+@objc(CRenamedInObjC) class CRenamed : NSObject { }
 @objc enum E: Int { case a }
 @objc protocol P1 { }
 protocol P2 { }
 @objc protocol P3: P1 { }
 @objc protocol mainP4 { }
 
+@objc(P5RenamedInObjC) protocol P5 { }
+
 DemangleToMetadataTests.test("@objc classes") {
   expectEqual(type(of: C()), _typeByName("4main1CC")!)
+
+  // @objc class that's been renamed, which can be found by its Objective-C
+  // name...
+  expectEqual(type(of: CRenamed()), _typeByName("So14CRenamedInObjCC")!)
+
+  // ... but not by it's Swift name.
+  expectNil(_typeByName("4main8CRenamed"))
 }
 
 DemangleToMetadataTests.test("@objc enums") {
@@ -40,9 +50,16 @@ DemangleToMetadataTests.test("Objective-C classes") {
 }
 
 func f1_composition_NSCoding(_: NSCoding) { }
+func f1_composition_P5(_: P5) { }
 
 DemangleToMetadataTests.test("Objective-C protocols") {
   expectEqual(type(of: f1_composition_NSCoding), _typeByName("yySo8NSCoding_pc")!)
+
+  // @objc Swift protocols can be found by their Objective-C names...
+  expectEqual(type(of: f1_composition_P5), _typeByName("yySo15P5RenamedInObjC_pc")!)
+
+  // ... but not their Swift names.
+  expectNil(_typeByName("yy4main2P5_pc"))
 }
 
 DemangleToMetadataTests.test("Classes that don't exist") {


### PR DESCRIPTION
When emitting metadata for a Swift-defined @objc protocol that has
provided a specific Objective-C name (e.g., via @objc(renamed)),
mangle such protocols using their Objective-C names so they can be
found at runtime.

Only do this for metadata, because doing it anywhere else would cause
an ABI break. Fixes rdar://problem/47877748.