### PR TITLE
[AST] Set known protocol kind in `ASTContext::getProtocol`.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -910,6 +910,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   for (auto result : results) {
     if (auto protocol = dyn_cast<ProtocolDecl>(result)) {
       getImpl().KnownProtocols[index] = protocol;
+      protocol->setKnownProtocolKind(kind);
       return protocol;
     }
   }


### PR DESCRIPTION
If a known protocol is found in `ASTContext::getProtocol`, set its known
protocol kind. Otherwise, unexpected behavior may occur (e.g. a known protocol
is found in the appropriate module, but later the protocol cannot be found
by derived conformances).