### PR TITLE
[API] Add `RawSignificand` constraint to `TensorFlowFloatingPoint`.

### DIFF
--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -75,7 +75,8 @@ public typealias TensorFlowInteger = TensorFlowScalar & BinaryInteger
 
 public protocol TensorFlowFloatingPoint :
   TensorFlowScalar & BinaryFloatingPoint & Differentiable
-  where Self == Self.TangentVector,
+  where Self.RawSignificand: FixedWidthInteger,
+        Self == Self.TangentVector,
         Self == Self.CotangentVector,
         Self == Self.AllDifferentiableVariables {}
 


### PR DESCRIPTION
Add `RawSignificand : FixedWidthInteger` constraint to
`TensorFlowFloatingPoint` for easier use with PRNG APIs (e.g.
`UniformFloatingPointDistribution`), which have the constraint.