### PR TITLE
[5.0][IDE][syntax-coloring] Treat unterminated raw strings as strings for syntax coloring purposes

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -178,8 +178,9 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
       }
 
       case tok::unknown: {
-        if (Tok.getRawText().startswith("\"")) {
-          // This is an invalid string literal
+        if (Tok.getRawText().ltrim('#').startswith("\"")) {
+          // This is likely an invalid single-line ("), multi-line ("""),
+          // or raw (#", ##", #""", etc.) string literal.
           Kind = SyntaxNodeKind::String;
           break;
         }

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -197,6 +197,25 @@ class SubCls : MyCls, Prot {}
 func genFn<T : Prot where T.Blarg : Prot2>(_: T) -> Int {}
 
 func f(x: Int) -> Int {
+
+  // CHECK: <str>#"This is a raw string"#</str>
+  #"This is a raw string"#
+
+  // CHECK: <str>##"This is also a raw string"##</str>
+  ##"This is also a raw string"##
+
+  // CHECK: <str>###"This is an unterminated raw string"</str>
+  ###"This is an unterminated raw string"
+
+  // CHECK: <str>#"""This is a multiline raw string"""#</str>
+  #"""This is a multiline raw string"""#
+
+  // CHECK: <str>#"This is an </str>\#<anchor>(</anchor>interpolated<anchor>)</anchor><str> raw string"#</str>
+  #"This is an \#(interpolated) raw string"#
+
+  // CHECK: <str>#"This is a raw string with an invalid \##() interpolation"#</str>
+  #"This is a raw string with an invalid \##() interpolation"#
+
   // CHECK: <str>"This is string </str>\<anchor>(</anchor>genFn({(a:<type>Int</type> -> <type>Int</type>) <kw>in</kw> a})<anchor>)</anchor><str> interpolation"</str>
   "This is string \(genFn({(a:Int -> Int) in a})) interpolation"
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/22845

- **Explanation**: Unterminated string literals get lexed as unknown tokens. For syntax highlighting we check if an unknown token starts with a `"` and highlight it as a string in order to provide feedback to the user as soon as they start writing a string. This check doesn't work for raw string literals, though (e.g. `#"I am "raw" "#` or `##" I am #"raw"# "##`) that were introduced in this release. This patch adjusts the check to trim off any leading `#` characters before checking for an opening quote when determining if an unknown token should be highlighted as a string.
- **Scope**: Affects syntax highlighting of raw strings the user has not yet terminated correctly
- **Issue**: rdar://problem/48269826
- **Risk**: Very low. This only affects the syntax highlighting of unknown tokens and the entire code change is modifying the existing check from `Tok.getRawText().startswith("\"")` to  `Tok.getRawText().ltrim('#').startswith("\"")`
- **Testing**: Extended the syntax highlighting regression tests with unterminated raw strings, and valid raw strings with a varied number of leading/trailing `#` characters and interpolations, and all existing tests pass. Also manually verified raw string highlighting works as expected with these changes in Xcode.
- **Reviewer**: Xi Ge (in the master PR)

Resolves rdar://problem/48269826