### PR TITLE
[Diagnostics] Diagnose missing arguments in closures via fixes

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2762,6 +2762,8 @@ public:
     bool operator!=(Param const &b) const { return !(*this == b); }
 
     Param getWithoutLabel() const { return Param(Ty, Identifier(), Flags); }
+
+    Param withType(Type newType) const { return Param(newType, Label, Flags); }
   };
 
   class CanParam : public Param {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -877,6 +877,28 @@ public:
   bool diagnoseAsError() override;
 };
 
+class MissingArgumentsFailure final : public FailureDiagnostic {
+  using Param = AnyFunctionType::Param;
+
+  FunctionType *Fn;
+  unsigned NumSynthesized;
+
+public:
+  MissingArgumentsFailure(Expr *root, ConstraintSystem &cs,
+                          FunctionType *funcType,
+                          unsigned numSynthesized,
+                          ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator), Fn(funcType),
+        NumSynthesized(numSynthesized) {}
+
+  bool diagnoseAsError() override;
+
+private:
+  /// If missing arguments come from trailing closure,
+  /// let's produce tailored diagnostics.
+  bool diagnoseTrailingClosure(ClosureExpr *closure);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -344,7 +344,9 @@ AllowInvalidInitRef::create(RefKind kind, ConstraintSystem &cs, Type baseTy,
 }
 
 bool AddMissingArguments::diagnose(Expr *root, bool asNote) const {
-  return false;
+  MissingArgumentsFailure failure(root, getConstraintSystem(), Fn,
+                                  NumSynthesized, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AddMissingArguments *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -342,3 +342,16 @@ AllowInvalidInitRef::create(RefKind kind, ConstraintSystem &cs, Type baseTy,
   return new (cs.getAllocator()) AllowInvalidInitRef(
       cs, kind, baseTy, init, isStaticallyDerived, baseRange, locator);
 }
+
+bool AddMissingArguments::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+AddMissingArguments *
+AddMissingArguments::create(ConstraintSystem &cs, FunctionType *funcType,
+                            llvm::ArrayRef<Param> synthesizedArgs,
+                            ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<Param>(synthesizedArgs.size());
+  void *mem = cs.getAllocator().Allocate(size, alignof(AddMissingArguments));
+  return new (mem) AddMissingArguments(cs, funcType, synthesizedArgs, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1264,8 +1264,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     if (diff < 0) {
       for (unsigned i = func1Params.size(),
                     n = func2Params.size(); i != n; ++i) {
-        auto *argLoc =
-            getConstraintLocator(anchor, LocatorPathElt::getTupleElement(i));
+        auto *argLoc = getConstraintLocator(
+            anchor, LocatorPathElt::getSynthesizedArgument(i));
 
         auto arg = func2Params[i].withType(createTypeVariable(argLoc));
         func1Params.push_back(arg);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1063,6 +1063,108 @@ static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
   llvm_unreachable("Unhandled ConstraintKind in switch.");
 }
 
+/// Check whether given parameter list represents a single tuple
+/// or type variable which could be later resolved to tuple.
+/// This is useful for SE-0110 related fixes in `matchFunctionTypes`.
+static bool isSingleTupleParam(ASTContext &ctx,
+                               ArrayRef<AnyFunctionType::Param> params) {
+  if (params.size() != 1)
+    return false;
+
+  const auto &param = params.front();
+  if (param.isVariadic() || param.isInOut())
+    return false;
+
+  auto paramType = param.getPlainType();
+  // Support following case which was allowed until 5:
+  //
+  // func bar(_: (Int, Int) -> Void) {}
+  // let foo: ((Int, Int)?) -> Void = { _ in }
+  //
+  // bar(foo) // Ok
+  if (!ctx.isSwiftVersionAtLeast(5))
+    paramType = paramType->lookThroughAllOptionalTypes();
+
+  // Parameter should have a label and be either a tuple tuple type,
+  // or a type variable which might later be assigned a tuple type,
+  // e.g. opened generic parameter.
+  return !param.hasLabel() &&
+         (paramType->is<TupleType>() || paramType->is<TypeVariableType>());
+}
+
+/// Attempt to fix missing arguments by introducing type variables
+/// and inferring their types from parameters.
+static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
+                                FunctionType *funcType,
+                                SmallVectorImpl<AnyFunctionType::Param> &args,
+                                SmallVectorImpl<AnyFunctionType::Param> &params,
+                                unsigned numMissing,
+                                ConstraintLocatorBuilder locator) {
+  assert(args.size() < params.size());
+
+  auto &ctx = cs.getASTContext();
+  // If there are N parameters but a single closure argument
+  // (which might be anonymous), it's most likely used as a
+  // tuple e.g. `$0.0`.
+  Optional<TypeBase *> argumentTuple;
+  if (isa<ClosureExpr>(anchor) && isSingleTupleParam(ctx, args)) {
+    auto isParam = [](const Expr *expr) {
+      if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
+        if (auto *decl = DRE->getDecl())
+          return isa<ParamDecl>(decl);
+      }
+      return false;
+    };
+
+    const auto &arg = args.back();
+    if (auto *argTy = arg.getPlainType()->getAs<TypeVariableType>()) {
+      anchor->forEachChildExpr([&](Expr *expr) -> Expr * {
+        if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
+          if (!isParam(UDE->getBase()))
+            return expr;
+
+          auto name = UDE->getName().getBaseIdentifier();
+          unsigned index = 0;
+          if (!name.str().getAsInteger(10, index) ||
+              llvm::any_of(params, [&](const AnyFunctionType::Param &param) {
+                return param.getLabel() == name;
+              })) {
+            argumentTuple.emplace(argTy);
+            args.pop_back();
+            return nullptr;
+          }
+        }
+        return expr;
+      });
+    }
+  }
+
+  for (unsigned i = args.size(), n = params.size(); i != n; ++i) {
+    auto *argLoc = cs.getConstraintLocator(
+        anchor, LocatorPathElt::getSynthesizedArgument(i));
+    args.push_back(params[i].withType(cs.createTypeVariable(argLoc)));
+  }
+
+  ArrayRef<AnyFunctionType::Param> argsRef(args);
+  auto *fix =
+      AddMissingArguments::create(cs, funcType, argsRef.take_back(numMissing),
+                                  cs.getConstraintLocator(locator));
+
+  if (cs.recordFix(fix))
+    return true;
+
+  // If the argument was a single "tuple", let's bind newly
+  // synthesized arguments to it.
+  if (argumentTuple) {
+    cs.addConstraint(ConstraintKind::Bind, *argumentTuple,
+                     FunctionType::composeInput(ctx, args,
+                                                /*canonicalVararg=*/false),
+                     cs.getConstraintLocator(anchor));
+  }
+
+  return false;
+}
+
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
@@ -1137,33 +1239,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   // Add a very narrow exception to SE-0110 by allowing functions that
   // take multiple arguments to be passed as an argument in places
   // that expect a function that takes a single tuple (of the same
-  // arity).
-  auto isSingleParam = [&](ArrayRef<AnyFunctionType::Param> params) {
-    if (params.size() != 1)
-      return false;
-
-    const auto &param = params.front();
-    if (param.isVariadic() || param.isInOut())
-      return false;
-
-    auto paramType = param.getPlainType();
-    // Support following case which was allowed until 5:
-    // ``swift
-    // func bar(_: (Int, Int) -> Void) {}
-    // let foo: ((Int, Int)?) -> Void = { _ in }
-    //
-    // bar(foo) // Ok
-    // ```
-    if (!getASTContext().isSwiftVersionAtLeast(5))
-      paramType = paramType->lookThroughAllOptionalTypes();
-
-    // Parameter should have a label and be either a tuple tuple type,
-    // or a type variable which might later be assigned a tuple type,
-    // e.g. opened generic parameter.
-    return !param.hasLabel() &&
-           (paramType->is<TupleType>() || paramType->is<TypeVariableType>());
-  };
-
+  // arity);
   auto canImplodeParams = [&](ArrayRef<AnyFunctionType::Param> params) {
     if (params.size() == 1)
       return false;
@@ -1194,12 +1270,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         });
 
     if (last != path.rend()) {
+      auto &ctx = getASTContext();
       if (last->getKind() == ConstraintLocator::ApplyArgToParam) {
-        if (isSingleParam(func2Params) &&
+        if (isSingleTupleParam(ctx, func2Params) &&
             canImplodeParams(func1Params)) {
           implodeParams(func1Params);
-        } else if (!getASTContext().isSwiftVersionAtLeast(5) &&
-                   isSingleParam(func1Params) &&
+        } else if (!ctx.isSwiftVersionAtLeast(5) &&
+                   isSingleTupleParam(ctx, func1Params) &&
                    canImplodeParams(func2Params)) {
           auto *simplified = locator.trySimplifyToExpr();
           // We somehow let tuple unsplatting function conversions
@@ -1236,7 +1313,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
     if (last != path.rend()) {
       if (last->getKind() == ConstraintLocator::ApplyArgToParam) {
-        if (isSingleParam(func1Params) &&
+        if (isSingleTupleParam(getASTContext(), func1Params) &&
             func1Params[0].getOldType()->isVoid()) {
           if (func2Params.empty()) {
             func2Params.emplace_back(getASTContext().TheEmptyTupleType);
@@ -1262,68 +1339,9 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     // If there are missing arguments, let's add them
     // using parameter as a template.
     if (diff < 0) {
-      // If there are N parameters but a single closure argument
-      // (which might be anonymous), it's most likely used as a
-      // tuple e.g. `$0.0`.
-      Optional<TypeBase *> argumentTuple;
-      if (isa<ClosureExpr>(anchor) && isSingleParam(func1Params)) {
-        auto isParam = [](const Expr *expr) {
-          if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
-            if (auto *decl = DRE->getDecl())
-              return isa<ParamDecl>(decl);
-          }
-          return false;
-        };
-
-        const auto &arg = func1Params.back();
-        if (auto *argTy = arg.getPlainType()->getAs<TypeVariableType>()) {
-          anchor->forEachChildExpr([&](Expr *expr) -> Expr * {
-            if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
-              if (!isParam(UDE->getBase()))
-                return expr;
-
-              auto name = UDE->getName().getBaseIdentifier();
-              unsigned index = 0;
-              if (!name.str().getAsInteger(10, index) ||
-                  llvm::any_of(func2Params,
-                               [&](const AnyFunctionType::Param &param) {
-                                 return param.getLabel() == name;
-                               })) {
-                argumentTuple.emplace(argTy);
-                func1Params.pop_back();
-                return nullptr;
-              }
-            }
-            return expr;
-          });
-        }
-      }
-
-      for (unsigned i = func1Params.size(),
-                    n = func2Params.size(); i != n; ++i) {
-        auto *argLoc = getConstraintLocator(
-            anchor, LocatorPathElt::getSynthesizedArgument(i));
-
-        auto arg = func2Params[i].withType(createTypeVariable(argLoc));
-        func1Params.push_back(arg);
-      }
-
-      ArrayRef<AnyFunctionType::Param> argsRef(func1Params);
-      auto *fix = AddMissingArguments::create(*this, func2,
-                                              argsRef.take_back(abs(diff)),
-                                              getConstraintLocator(locator));
-
-      if (recordFix(fix))
+      if (fixMissingArguments(*this, anchor, func2, func1Params, func2Params,
+                              abs(diff), locator))
         return getTypeMatchFailure(argumentLocator);
-
-      // If the argument was a single "tuple", let's bind newly
-      // synthesized arguments to it.
-      if (argumentTuple) {
-        addConstraint(ConstraintKind::Bind, *argumentTuple,
-                      FunctionType::composeInput(getASTContext(), func1Params,
-                                                 /*canonicalVararg=*/false),
-                      getConstraintLocator(anchor));
-      }
     } else {
       // TODO(diagnostics): Add handling of extraneous arguments.
       return getTypeMatchFailure(argumentLocator);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -74,6 +74,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case ImplicitlyUnwrappedDisjunctionChoice:
     case DynamicLookupResult:
     case ContextualType:
+    case SynthesizedArgument:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -260,6 +261,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case ContextualType:
       out << "contextual type";
+      break;
+
+    case SynthesizedArgument:
+      out << " synthesized argument #" << llvm::utostr(elt.getValue());
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -125,6 +125,8 @@ public:
     DynamicLookupResult,
     /// The desired contextual type passed in to the constraint system.
     ContextualType,
+    /// The missing argument synthesized by the solver.
+    SynthesizedArgument,
   };
 
   /// Determine the number of numeric values used for the given path
@@ -162,6 +164,7 @@ public:
     case NamedTupleElement:
     case TupleElement:
     case KeyPathComponent:
+    case SynthesizedArgument:
       return 1;
 
     case TypeParameterRequirement:
@@ -217,6 +220,7 @@ public:
     case ImplicitlyUnwrappedDisjunctionChoice:
     case DynamicLookupResult:
     case ContextualType:
+    case SynthesizedArgument:
       return 0;
 
     case FunctionArgument:
@@ -361,6 +365,10 @@ public:
                          static_cast<unsigned>(kind));
     }
 
+    static PathElement getSynthesizedArgument(unsigned position) {
+      return PathElement(SynthesizedArgument, position);
+    }
+
     /// Retrieve the kind of path element.
     PathElementKind getKind() const {
       switch (static_cast<StoredKind>(storedKind)) {
@@ -446,6 +454,10 @@ public:
 
     bool isConditionalRequirement() const {
       return getKind() == PathElementKind::ConditionalRequirement;
+    }
+
+    bool isSynthesizedArgument() const {
+      return getKind() == PathElementKind::SynthesizedArgument;
     }
   };
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -875,3 +875,28 @@ struct rdar43866352<Options> {
     callback = { (options: Options) in } // expected-error {{cannot assign value of type '(inout Options) -> ()' to type '(inout _) -> Void'}}
   }
 }
+
+extension Hashable {
+  var self_: Self {
+    return self
+  }
+}
+
+do {
+  struct S<
+      C : Collection,
+      I : Hashable,
+      R : Numeric
+  > {
+    init(_ arr: C,
+         id: KeyPath<C.Element, I>,
+         content: @escaping (C.Element) -> R) {}
+  }
+
+  func foo(_ arr: [Int]) {
+    _ = S(arr, id: \.self_) {
+      // expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{30-30=_ in }}
+      return 42
+    }
+  }
+}

--- a/test/Constraints/tuple-arguments-unsupported.swift
+++ b/test/Constraints/tuple-arguments-unsupported.swift
@@ -11,11 +11,11 @@ test3(.success()) // expected-error {{missing argument for parameter #1 in call}
 
 func toString(indexes: Int?...) -> String {
   let _ = indexes.reduce(0) { print($0); return $0.0 + ($0.1 ?? 0)}
-  // expected-error@-1 {{contextual closure type '(_, Int?) throws -> _' expects 2 arguments, but 1 was used in closure body}}
+  // expected-error@-1 {{contextual closure type '(Int, Int?) throws -> Int' expects 2 arguments, but 1 was used in closure body}}
   let _ = indexes.reduce(0) { (true ? $0 : (1, 2)).0 + ($0.1 ?? 0) }
-  // expected-error@-1 {{contextual closure type '(_, Int?) throws -> _' expects 2 arguments, but 1 was used in closure body}}
+  // expected-error@-1 {{contextual closure type '(Int, Int?) throws -> Int' expects 2 arguments, but 1 was used in closure body}}
   _ = ["Hello", "Foo"].sorted { print($0); return $0.0.count > ($0).1.count }
-  // expected-error@-1 {{argument passed to call that takes no arguments}}
+  // expected-error@-1 {{contextual closure type '(String, String) throws -> Bool' expects 2 arguments, but 1 was used in closure body}}
 }
 
 func doit(_ x: Int) -> Bool { return x > 0 }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -200,6 +200,7 @@ public class CorePromise<U> : Thenable { // expected-error{{type 'CorePromise<U>
     public func then(_ success: @escaping (_ t: U, _: CorePromise<U>) -> U) -> Self {
         return self.then() { (t: U) -> U in // expected-error{{contextual closure type '(U, CorePromise<U>) -> U' expects 2 arguments, but 1 was used in closure body}}
             return success(t: t, self)
+            // expected-error@-1 {{extraneous argument label 't:' in call}}
         }
     }
 }


### PR DESCRIPTION
While trying to match function types, detect and fix any missing
arguments (by introducing type variables), such arguments would
get type information from corresponding parameters and aid in
producing solutions which are much easier to diagnose.

Diagnostic only supports closures at the moment, but could 
be easily expanded to other types of situations e.g. function/member calls.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
