### PR TITLE
[cast-optimizer] Add an "ApplySite" like data structure "SILDynamicCa…

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -23,6 +23,7 @@
 /// | ABSTRACT_VALUE     | Visit abstract single value insts as values             |
 /// | APPLYSITE_INST     | Visit full and partial apply site insts as apply sites. |
 /// | FULLAPPLYSITE_INST | Visit full apply site insts as apply sites.             |
+/// | DYNAMICCAST_INST   | Visit dynamic casts as dynamic casts.                   |
 ///
 /// We describe the triggering variables below:
 ///
@@ -49,7 +50,7 @@
 ///
 /// 4. APPLYSITE_INST(ID, PARENT)
 ///
-///   If defined this will cuase:
+///   If defined this will cause:
 ///
 ///         * APPLYSITE_SINGLE_VALUE_INST
 ///         * APPLYSITE_MULTIPLE_VALUE_INST
@@ -57,6 +58,17 @@
 ///
 ///   to expand to APPLYSITE_INST(ID, PARENT) instead of delegating to
 ///   SINGLE_VALUE_INST.
+///
+/// 5. DYNAMICCAST_INST(ID, PARENT)
+///
+///   If defined this will cause:
+///
+///         * DYNAMICCAST_SINGLE_VALUE_INST
+///         * DYNAMICCAST_TERMINATOR
+///         * DYNAMICCAST_NON_VALUE_INST
+///
+///   To expand to DYNAMICCAST_INST(ID, PARENT) instead of delegating to
+///   SINGLE_VALUE_INST, TERMINATOR, or NON_VALUE_INST
 ///
 //===----------------------------------------------------------------------===//
 
@@ -87,6 +99,20 @@
 #else
 #define SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+#endif
+#endif
+
+/// DYNAMICCAST_SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+///
+/// A SINGLE_VALUE_INST that is a cast instruction. ID is a member of
+/// SILDynamicCastKind.
+#ifndef DYNAMICCAST_SINGLE_VALUE_INST
+#ifdef DYNAMICCAST_INST
+#define DYNAMICCAST_SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  DYNAMICCAST_INST(ID, TEXTUALNAME)
+#else
+#define DYNAMICCAST_SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
 #endif
 #endif
 
@@ -219,12 +245,35 @@
   FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
 #endif
 
+#ifndef DYNAMICCAST_NON_VALUE_INST
+#ifdef DYNAMICCAST_INST
+#define DYNAMICCAST_NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  DYNAMICCAST_INST(ID, NAME)
+#else
+#define DYNAMICCAST_NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+#endif
+#endif
+
 /// TERMINATOR(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
 ///
 ///   ID is a member of TerminatorKind and the name of a subclass of TermInst.
 #ifndef TERMINATOR
 #define TERMINATOR(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+#endif
+
+/// DYNAMICCAST_TERMINATOR(ID, TEXTUAL_NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+///
+///   A terminator that casts its inputs. ID is a member of SILDynamicCastKind.
+#ifndef DYNAMICCAST_TERMINATOR
+#ifdef DYNAMICCAST_INST
+#define DYNAMICCAST_TERMINATOR(ID, TEXTUAL_NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  DYNAMICCAST_INST(ID, TEXTUAL_NAME)
+#else
+#define DYNAMICCAST_TERMINATOR(ID, TEXTUAL_NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  TERMINATOR(ID, TEXTUAL_NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+#endif
 #endif
 
 /// APPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
@@ -484,7 +533,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                       ConversionInst, None, DoesNotRelease)
     // unconditional_checked_cast_value reads the source value and produces
     // a new value with a potentially different representation.
-    SINGLE_VALUE_INST(UnconditionalCheckedCastValueInst, unconditional_checked_cast_value,
+    DYNAMICCAST_SINGLE_VALUE_INST(UnconditionalCheckedCastValueInst, unconditional_checked_cast_value,
                       ConversionInst, MayRead, MayRelease)
     // unconditional_checked_cast_inst is only MayRead to prevent a subsequent
     // release of the cast's source from being hoisted above the cast:
@@ -497,7 +546,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
     // should never happen.  Since unconditional_checked_cast is a
     // scalar cast that doesn't affect the value's representation, its
     // side effect can then be modeled as None.
-    SINGLE_VALUE_INST(UnconditionalCheckedCastInst, unconditional_checked_cast,
+    DYNAMICCAST_SINGLE_VALUE_INST(UnconditionalCheckedCastInst, unconditional_checked_cast,
                       ConversionInst, MayRead, DoesNotRelease)
     SINGLE_VALUE_INST_RANGE(ConversionInst, UpcastInst, UnconditionalCheckedCastInst)
 
@@ -672,11 +721,11 @@ ABSTRACT_INST(TermInst, SILInstruction)
              TermInst, MayRead, DoesNotRelease)
   TERMINATOR(DynamicMethodBranchInst, dynamic_method_br,
              TermInst, None, DoesNotRelease)
-  TERMINATOR(CheckedCastBranchInst, checked_cast_br,
+  DYNAMICCAST_TERMINATOR(CheckedCastBranchInst, checked_cast_br,
              TermInst, None, DoesNotRelease)
-  TERMINATOR(CheckedCastAddrBranchInst, checked_cast_addr_br,
+  DYNAMICCAST_TERMINATOR(CheckedCastAddrBranchInst, checked_cast_addr_br,
              TermInst, MayHaveSideEffects, MayRelease)
-  TERMINATOR(CheckedCastValueBranchInst, checked_cast_value_br,
+  DYNAMICCAST_TERMINATOR(CheckedCastValueBranchInst, checked_cast_value_br,
              TermInst, None, DoesNotRelease)
   INST_RANGE(TermInst, UnreachableInst, CheckedCastValueBranchInst)
 
@@ -778,7 +827,8 @@ NON_VALUE_INST(DeinitExistentialAddrInst, deinit_existential_addr,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 NON_VALUE_INST(DeinitExistentialValueInst, deinit_existential_value,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
-NON_VALUE_INST(UnconditionalCheckedCastAddrInst, unconditional_checked_cast_addr,
+DYNAMICCAST_NON_VALUE_INST(
+               UnconditionalCheckedCastAddrInst, unconditional_checked_cast_addr,
                SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(UncheckedRefCastAddrInst, unchecked_ref_cast_addr,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
@@ -820,14 +870,18 @@ NODE_RANGE(SILNode, SILPhiArgument, DestructureTupleInst)
 #undef ABSTRACT_VALUE_AND_INST
 #undef FULLAPPLYSITE_TERMINATOR_INST
 #undef APPLYSITE_TERMINATOR_INST
+#undef DYNAMICCAST_TERMINATOR
 #undef TERMINATOR
 #undef NON_VALUE_INST
+#undef DYNAMICCAST_NON_VALUE_INST
 #undef MULTIPLE_VALUE_INST_RESULT
 #undef FULLAPPLYSITE_MULTIPLE_VALUE_INST
 #undef APPLYSITE_MULTIPLE_VALUE_INST
 #undef MULTIPLE_VALUE_INST
 #undef FULLAPPLYSITE_SINGLE_VALUE_INST
 #undef APPLYSITE_SINGLE_VALUE_INST
+#undef DYNAMICCAST_SINGLE_VALUE_INST
+#undef DYNAMICCAST_INST
 #undef SINGLE_VALUE_INST
 #undef FULL_INST
 #undef INST

--- a/include/swift/SILOptimizer/Utils/CastOptimizer.h
+++ b/include/swift/SILOptimizer/Utils/CastOptimizer.h
@@ -1,4 +1,4 @@
-//===--- CastOptimizer.h --------------------------------------------------===//
+//===--- CastOptimizer.h ----------------------------------*- C++ -*-------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -30,6 +30,7 @@
 namespace swift {
 
 class SILOptFunctionBuilder;
+struct SILDynamicCastInst;
 
 /// This is a helper class used to optimize casts.
 class CastOptimizer {
@@ -144,6 +145,7 @@ public:
       UnconditionalCheckedCastAddrInst *Inst);
 
   /// Check if it is a bridged cast and optimize it.
+  ///
   /// May change the control flow.
   SILInstruction *optimizeBridgedCasts(SILInstruction *Inst,
                                        CastConsumptionKind ConsumptionKind,
@@ -151,6 +153,8 @@ public:
                                        SILValue Dest, CanType Source,
                                        CanType Target, SILBasicBlock *SuccessBB,
                                        SILBasicBlock *FailureBB);
+
+  SILInstruction *optimizeBridgedCasts(SILDynamicCastInst cast);
 
   SILValue optimizeMetatypeConversion(ConversionInst *mci,
                                       MetatypeRepresentation representation);

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -608,6 +608,18 @@ SILInstruction *CastOptimizer::optimizeBridgedSwiftToObjCCast(
   return NewI;
 }
 
+SILInstruction *CastOptimizer::optimizeBridgedCasts(SILDynamicCastInst cast) {
+  switch (cast.getKind()) {
+  case SILDynamicCastKind::CheckedCastAddrBranchInst:
+  case SILDynamicCastKind::CheckedCastBranchInst:
+  case SILDynamicCastKind::CheckedCastValueBranchInst:
+  case SILDynamicCastKind::UnconditionalCheckedCastAddrInst:
+  case SILDynamicCastKind::UnconditionalCheckedCastInst:
+  case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
+    llvm_unreachable("unsupported");
+  }
+}
+
 /// Make use of the fact that some of these casts cannot fail.
 /// For example, if the ObjC type is exactly the expected
 /// _ObjectiveCType type, then it would always succeed for


### PR DESCRIPTION
…stInst" that abstracts over all dynamic cast instructions.

I am going to use this to refactor a bunch of the goop in the cast optimizer. At
a high level, we are really just performing a giant switch over the casts to
grab different state. We then take that state and we pass it into the bridge
cast optimizer.

To make such code more compact/easier to understand, I am adding in this commit
a type erased dynamic cast instruction type called "SILDynamicCastInst". In
subsequent commits, I wire up each of the individual instructions to it one at a
time.

As an additional advantage it will enable us to take advantage of covered
switches when ever in the future we introduce new casts.
