### PR TITLE
update tensorflow-swift-apis commit hash

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "641d3f1ed1324229ae6a003b00fca08b8ddf516b",
                 "tensorflow-swift-bindings": "c852b63b6ac3c4b53199aab96c021501978b843d",
-                "tensorflow-swift-apis": "ce67f8d06a9fbe194d962a587b8301391e088e55"
+                "tensorflow-swift-apis": "fc55d91721863007416ab4502eb5beef3dca2524"
             }
         }
     }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "641d3f1ed1324229ae6a003b00fca08b8ddf516b",
                 "tensorflow-swift-bindings": "c852b63b6ac3c4b53199aab96c021501978b843d",
-                "tensorflow-swift-apis": "470dbd7e7f27f761fd01686f5526803857e4bb7f"
+                "tensorflow-swift-apis": "ce67f8d06a9fbe194d962a587b8301391e088e55"
             }
         }
     }


### PR DESCRIPTION
We want to update tensorflow-swift-apis before building v0.2, right?

Even if tensorflow-swift-apis isn't completely ready, it would be good to update the commit hash now, to give us more time to fix any failures that might appear.

When tensorflow-swift-apis is completely ready, we can update the commit hash again and it'll be a much smaller and less risky change.