### PR TITLE
LoadableByAddress handle constructors + bug fixes

### DIFF
--- a/test/IRGen/big_types_constructors.sil
+++ b/test/IRGen/big_types_constructors.sil
@@ -16,13 +16,27 @@ public struct BigStruct {
   var i8 : Int32 = 8
 }
 
+public struct BigBigStruct {
+  var s : BigStruct
+}
+
+public enum LargeTupleEnum {
+  case Empty1
+  case Empty2
+  case Full((BigStruct, Int32))
+}
+
 // CHECK-LABEL: sil @test_tuple : $@convention(thin) (@in_constant BigStruct) -> @out (BigStruct, Int32) {
 // CHECK: bb0(%0 : $*(BigStruct, Int32), %1 : $*BigStruct):
-// CHECK: [[BIG:%.*]] = load %{{.*}} : $*BigStruct
+// CHECK: [[ALLOCBIG:%.*]] = alloc_stack $(BigStruct, Int32)
 // CHECK: [[INTLIT:%.*]] = integer_literal $Builtin.Int32, 42
 // CHECK: [[INTLITSTRUCT:%.*]] = struct $Int32 ([[INTLIT]] : $Builtin.Int32)
-// CHECK: [[TUPLE:%.*]] = tuple ([[BIG]] : $BigStruct, [[INTLITSTRUCT]] : $Int32)
-// CHECK: store [[TUPLE]] to %0 : $*(BigStruct, Int32)
+// CHECK: [[TBIGADDR:%.*]] = tuple_element_addr [[ALLOCBIG]] : $*(BigStruct, Int32), 0
+// CHECK: copy_addr [take] %1 to [initialization] [[TBIGADDR]] : $*BigStruct
+// CHECK: [[TINTADDR:%.*]] = tuple_element_addr [[ALLOCBIG]] : $*(BigStruct, Int32), 1
+// CHECK: store [[INTLITSTRUCT]] to [[TINTADDR]] : $*Int32
+// CHECK: copy_addr [take] [[ALLOCBIG]] to [initialization] %0 : $*(BigStruct, Int32)
+// CHECK: dealloc_stack [[ALLOCBIG]] : $*(BigStruct, Int32)
 // CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'test_tuple'
 sil @test_tuple : $@convention(thin) (BigStruct) -> (BigStruct, Int32) {
@@ -33,8 +47,13 @@ bb0(%0 : $BigStruct):
   return %4 : $(BigStruct, Int32)
 }
 
-
-sil hidden @$construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> BigStruct {
+// CHECK-LABEL: sil hidden @construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> @out BigStruct {
+// CHECK: bb0(%0 : $*BigStruct, %1 : $@thin BigStruct.Type):
+// CHECK: [[ALLOCBIG:%.*]] = alloc_stack $BigStruct
+// CHECK: copy_addr [take] [[ALLOCBIG]] to [initialization] %0 : $*BigStruct
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'construct_big_struct'
+sil hidden @construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> BigStruct {
 bb0(%0 : $@thin BigStruct.Type):
   %1 = alloc_stack $BigStruct, var, name "self"   // users: %36, %32, %28, %24, %20, %16, %12, %8, %4, %39
   %2 = integer_literal $Builtin.Int32, 0          // user: %3
@@ -89,16 +108,97 @@ bb0(%0 : $@thin BigStruct.Type):
 // CHECK-LABEL: } // end sil function 'call_test_tuple'
 sil @call_test_tuple : $@convention(thin) () -> () {
 bb0:
-  %0 = metatype $@thin BigStruct.Type             // user: %2
+  %0 = metatype $@thin BigStruct.Type
   // function_ref BigStruct.init()
-  %1 = function_ref @$construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> BigStruct // user: %2
-  %2 = apply %1(%0) : $@convention(method) (@thin BigStruct.Type) -> BigStruct // users: %5, %3
-  debug_value %2 : $BigStruct, let, name "b"      // id: %3
+  %1 = function_ref @construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> BigStruct
+  %2 = apply %1(%0) : $@convention(method) (@thin BigStruct.Type) -> BigStruct
+  debug_value %2 : $BigStruct, let, name "b"
   // function_ref test_tuple(_:)
-  %4 = function_ref @test_tuple : $@convention(thin) (BigStruct) -> (BigStruct, Int32) // user: %5
-  %5 = apply %4(%2) : $@convention(thin) (BigStruct) -> (BigStruct, Int32) // users: %7, %6
+  %4 = function_ref @test_tuple : $@convention(thin) (BigStruct) -> (BigStruct, Int32)
+  %5 = apply %4(%2) : $@convention(thin) (BigStruct) -> (BigStruct, Int32)
   %6 = tuple_extract %5 : $(BigStruct, Int32), 0
   %7 = tuple_extract %5 : $(BigStruct, Int32), 1
-  %8 = tuple ()                                   // user: %9
-  return %8 : $()                                 // id: %9
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil @test_tuple_local_only : $@convention(thin) (@in_constant BigStruct) -> () {
+// CHECK: bb0(%0 : $*BigStruct):
+// CHECK: [[TBIGADDR:%.*]] = tuple_element_addr %{{.*}} : $*(BigStruct, Int32), 0
+// CHECK-NEXT: copy_addr [take] %0 to [initialization] [[TBIGADDR]] : $*BigStruct
+// CHECK: [[TBIGADDR:%.*]] = tuple_element_addr %{{.*}} : $*((BigStruct, Int32), Int32), 0
+// CHECK-NEXT: copy_addr [take] %{{.*}} to [initialization] [[TBIGADDR]] : $*(BigStruct, Int32)
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'test_tuple_local_only'
+sil @test_tuple_local_only : $@convention(thin) (BigStruct) -> () {
+bb0(%0 : $BigStruct):
+  %2 = integer_literal $Builtin.Int32, 42
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  %4 = tuple (%0 : $BigStruct, %3 : $Int32)
+  %5 = tuple (%4: $(BigStruct, Int32), %3 : $Int32)
+  %rt = tuple ()
+  return %rt : $()
+}
+
+// CHECK-LABEL: sil @test_struct_construction : $@convention(thin) (@in_constant BigStruct) -> @out BigBigStruct {
+// CHECK: bb0(%0 : $*BigBigStruct, %1 : $*BigStruct):
+// CHECK: [[ALLOCBIG:%.*]] = alloc_stack $BigBigStruct
+// CHECK-NEXT: [[TBIGADDR:%.*]] = struct_element_addr [[ALLOCBIG]] : $*BigBigStruct, #BigBigStruct.s
+// CHECK-NEXT: copy_addr [take] %1 to [initialization] [[TBIGADDR]] : $*BigStruct
+// CHECK-NEXT: copy_addr [take] [[ALLOCBIG]] to [initialization] %0 : $*BigBigStruct
+// CHECK-NEXT: dealloc_stack [[ALLOCBIG]] : $*BigBigStruct
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'test_struct_construction'
+sil @test_struct_construction : $@convention(thin) (BigStruct) -> BigBigStruct {
+bb0(%0 : $BigStruct):
+  %bigStruct = struct $BigBigStruct (%0 : $BigStruct)
+  return %bigStruct : $BigBigStruct
+}
+
+// CHECK-LABEL: sil @test_tuple_try_apply : $@convention(thin) (@in_guaranteed Int32, @noescape @callee_guaranteed (@guaranteed Int32) -> (@out Optional<(BigStruct, Int32)>, @error Error)) -> (@out Optional<(BigStruct, Int32)>, @error Error) {
+// CHECK: bb0(%0 : $*Optional<(BigStruct, Int32)>, %1 : $*Int32, %2 : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@out Optional<(BigStruct, Int32)>, @error Error)):
+// CHECK: [[ALLOCBIG:%.*]] = alloc_stack $Optional<(BigStruct, Int32)>
+// CHECK: try_apply %2([[ALLOCBIG]], %{{.*}}) : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@out Optional<(BigStruct, Int32)>, @error Error), normal bb1, error bb2
+// CHECK: bb1(%6 : $()):
+// CHECK: copy_addr [take] [[ALLOCBIG]] to [initialization] %0 : $*Optional<(BigStruct, Int32)>
+// CHECK: return %{{.*}} : $()
+// CHECK: bb2(%{{.*}} : $Error):
+// CHECK: throw %{{.*}} : $Error
+// CHECK-LABEL: } // end sil function 'test_tuple_try_apply'
+sil @test_tuple_try_apply : $@convention(thin) (@in_guaranteed Int32, @noescape @callee_guaranteed (@guaranteed Int32) -> (@owned Optional<(BigStruct, Int32)>, @error Error)) -> (@out Optional<(BigStruct, Int32)>, @error Error) {
+bb0(%0 : $*Optional<(BigStruct, Int32)>, %1 : $*Int32, %2 : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@owned Optional<(BigStruct, Int32)>, @error Error)):
+  %3 = load %1 : $*Int32
+  try_apply %2(%3) : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@owned Optional<(BigStruct, Int32)>, @error Error), normal bb1, error bb2
+
+bb1(%5 : $Optional<(BigStruct, Int32)>):
+  store %5 to %0 : $*Optional<(BigStruct, Int32)>
+  %7 = tuple ()
+  return %7 : $()
+
+bb2(%9 : $Error):
+  %10 = builtin "willThrow"(%9 : $Error) : $()
+  throw %9 : $Error
+}
+
+// CHECK-LABEL: sil @test_enum_tuple_try_apply : $@convention(thin) (@in_guaranteed Int32, @noescape @callee_guaranteed (@guaranteed Int32) -> (@out LargeTupleEnum, @error Error)) -> (@out Optional<(BigStruct, Int32)>, @error Error) {
+// CHECK: bb0(%0 : $*Optional<(BigStruct, Int32)>, %1 : $*Int32, %2 : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@out LargeTupleEnum, @error Error)):
+// CHECK: [[ALLOCBIG:%.*]] = alloc_stack $LargeTupleEnum
+// CHECK: try_apply %2([[ALLOCBIG]], %{{.*}}) : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@out LargeTupleEnum, @error Error), normal bb1, error bb2
+// CHECK: bb1(%6 : $()):
+// CHECK: return %{{.*}} : $()
+// CHECK: bb2(%{{.*}} : $Error):
+// CHECK: throw %{{.*}} : $Error
+// CHECK-LABEL: } // end sil function 'test_enum_tuple_try_apply'
+sil @test_enum_tuple_try_apply : $@convention(thin) (@in_guaranteed Int32, @noescape @callee_guaranteed (@guaranteed Int32) -> (@owned LargeTupleEnum, @error Error)) -> (@out Optional<(BigStruct, Int32)>, @error Error) {
+bb0(%0 : $*Optional<(BigStruct, Int32)>, %1 : $*Int32, %2 : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@owned LargeTupleEnum, @error Error)):
+  %3 = load %1 : $*Int32
+  try_apply %2(%3) : $@noescape @callee_guaranteed (@guaranteed Int32) -> (@owned LargeTupleEnum, @error Error), normal bb1, error bb2
+
+bb1(%5 : $LargeTupleEnum):
+  %7 = tuple ()
+  return %7 : $()
+
+bb2(%9 : $Error):
+  %10 = builtin "willThrow"(%9 : $Error) : $()
+  throw %9 : $Error
 }

--- a/test/IRGen/big_types_constructors.sil
+++ b/test/IRGen/big_types_constructors.sil
@@ -1,0 +1,104 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift -c -primary-file %s -enable-large-loadable-types -Xllvm -sil-print-after=loadable-address -sil-verify-all -o %t/big_types_constructors.o 2>&1 | %FileCheck %s
+
+import Swift
+import Builtin
+
+public struct BigStruct {
+  var i0 : Int32 = 0
+  var i1 : Int32 = 1
+  var i2 : Int32 = 2
+  var i3 : Int32 = 3
+  var i4 : Int32 = 4
+  var i5 : Int32 = 5
+  var i6 : Int32 = 6
+  var i7 : Int32 = 7
+  var i8 : Int32 = 8
+}
+
+// CHECK-LABEL: sil @test_tuple : $@convention(thin) (@in_constant BigStruct) -> @out (BigStruct, Int32) {
+// CHECK: bb0(%0 : $*(BigStruct, Int32), %1 : $*BigStruct):
+// CHECK: [[BIG:%.*]] = load %{{.*}} : $*BigStruct
+// CHECK: [[INTLIT:%.*]] = integer_literal $Builtin.Int32, 42
+// CHECK: [[INTLITSTRUCT:%.*]] = struct $Int32 ([[INTLIT]] : $Builtin.Int32)
+// CHECK: [[TUPLE:%.*]] = tuple ([[BIG]] : $BigStruct, [[INTLITSTRUCT]] : $Int32)
+// CHECK: store [[TUPLE]] to %0 : $*(BigStruct, Int32)
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'test_tuple'
+sil @test_tuple : $@convention(thin) (BigStruct) -> (BigStruct, Int32) {
+bb0(%0 : $BigStruct):
+  %2 = integer_literal $Builtin.Int32, 42
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  %4 = tuple (%0 : $BigStruct, %3 : $Int32)
+  return %4 : $(BigStruct, Int32)
+}
+
+
+sil hidden @$construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> BigStruct {
+bb0(%0 : $@thin BigStruct.Type):
+  %1 = alloc_stack $BigStruct, var, name "self"   // users: %36, %32, %28, %24, %20, %16, %12, %8, %4, %39
+  %2 = integer_literal $Builtin.Int32, 0          // user: %3
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        // users: %38, %5
+  %4 = struct_element_addr %1 : $*BigStruct, #BigStruct.i0 // user: %5
+  store %3 to %4 : $*Int32                        // id: %5
+  %6 = integer_literal $Builtin.Int32, 1          // user: %7
+  %7 = struct $Int32 (%6 : $Builtin.Int32)        // users: %38, %9
+  %8 = struct_element_addr %1 : $*BigStruct, #BigStruct.i1 // user: %9
+  store %7 to %8 : $*Int32                        // id: %9
+  %10 = integer_literal $Builtin.Int32, 2         // user: %11
+  %11 = struct $Int32 (%10 : $Builtin.Int32)      // users: %38, %13
+  %12 = struct_element_addr %1 : $*BigStruct, #BigStruct.i2 // user: %13
+  store %11 to %12 : $*Int32                      // id: %13
+  %14 = integer_literal $Builtin.Int32, 3         // user: %15
+  %15 = struct $Int32 (%14 : $Builtin.Int32)      // users: %38, %17
+  %16 = struct_element_addr %1 : $*BigStruct, #BigStruct.i3 // user: %17
+  store %15 to %16 : $*Int32                      // id: %17
+  %18 = integer_literal $Builtin.Int32, 4         // user: %19
+  %19 = struct $Int32 (%18 : $Builtin.Int32)      // users: %38, %21
+  %20 = struct_element_addr %1 : $*BigStruct, #BigStruct.i4 // user: %21
+  store %19 to %20 : $*Int32                      // id: %21
+  %22 = integer_literal $Builtin.Int32, 5         // user: %23
+  %23 = struct $Int32 (%22 : $Builtin.Int32)      // users: %38, %25
+  %24 = struct_element_addr %1 : $*BigStruct, #BigStruct.i5 // user: %25
+  store %23 to %24 : $*Int32                      // id: %25
+  %26 = integer_literal $Builtin.Int32, 6         // user: %27
+  %27 = struct $Int32 (%26 : $Builtin.Int32)      // users: %38, %29
+  %28 = struct_element_addr %1 : $*BigStruct, #BigStruct.i6 // user: %29
+  store %27 to %28 : $*Int32                      // id: %29
+  %30 = integer_literal $Builtin.Int32, 7         // user: %31
+  %31 = struct $Int32 (%30 : $Builtin.Int32)      // users: %38, %33
+  %32 = struct_element_addr %1 : $*BigStruct, #BigStruct.i7 // user: %33
+  store %31 to %32 : $*Int32                      // id: %33
+  %34 = integer_literal $Builtin.Int32, 8         // user: %35
+  %35 = struct $Int32 (%34 : $Builtin.Int32)      // users: %38, %37
+  %36 = struct_element_addr %1 : $*BigStruct, #BigStruct.i8 // user: %37
+  store %35 to %36 : $*Int32                      // id: %37
+  %38 = struct $BigStruct (%3 : $Int32, %7 : $Int32, %11 : $Int32, %15 : $Int32, %19 : $Int32, %23 : $Int32, %27 : $Int32, %31 : $Int32, %35 : $Int32) // user: %40
+  dealloc_stack %1 : $*BigStruct                  // id: %39
+  return %38 : $BigStruct                         // id: %40
+} // end sil function '$construct_big_struct'
+
+// CHECK-LABEL: sil @call_test_tuple : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK: [[ALLOCTUPLE:%.*]] = alloc_stack $(BigStruct, Int32)
+// CHECK: [[ALLOCBIG:%.*]] = alloc_stack $BigStruct
+// CHECK: [[FREF:%.*]] = function_ref @test_tuple : $@convention(thin) (@in_constant BigStruct) -> @out (BigStruct, Int32)
+// CHECK: apply [[FREF]]([[ALLOCTUPLE]], [[ALLOCBIG]]) : $@convention(thin) (@in_constant BigStruct) -> @out (BigStruct, Int32)
+// CHECK: [[LOADTUPLE:%.*]] = load [[ALLOCTUPLE]] : $*(BigStruct, Int32)
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'call_test_tuple'
+sil @call_test_tuple : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thin BigStruct.Type             // user: %2
+  // function_ref BigStruct.init()
+  %1 = function_ref @$construct_big_struct : $@convention(method) (@thin BigStruct.Type) -> BigStruct // user: %2
+  %2 = apply %1(%0) : $@convention(method) (@thin BigStruct.Type) -> BigStruct // users: %5, %3
+  debug_value %2 : $BigStruct, let, name "b"      // id: %3
+  // function_ref test_tuple(_:)
+  %4 = function_ref @test_tuple : $@convention(thin) (BigStruct) -> (BigStruct, Int32) // user: %5
+  %5 = apply %4(%2) : $@convention(thin) (BigStruct) -> (BigStruct, Int32) // users: %7, %6
+  %6 = tuple_extract %5 : $(BigStruct, Int32), 0
+  %7 = tuple_extract %5 : $(BigStruct, Int32), 1
+  %8 = tuple ()                                   // user: %9
+  return %8 : $()                                 // id: %9
+}

--- a/test/IRGen/big_types_constructors_source.swift
+++ b/test/IRGen/big_types_constructors_source.swift
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift -c -primary-file %s -enable-large-loadable-types -Xllvm -sil-print-after=loadable-address -sil-verify-all -o %t/big_types_constructors_source.o 2>&1 | %FileCheck %s
+
+struct Big<T> {
+  var a0 : T
+  var a1 : T
+  var a2 : T
+  var a3 : T
+  var a4 : T
+  var a5 : T
+  var a6 : T
+  var a7 : T
+  var a8 : T
+  init(_ t: T) {
+    a0 = t
+    a1 = t
+    a2 = t
+    a3 = t
+    a4 = t
+    a5 = t
+    a6 = t
+    a7 = t
+    a8 = t
+  }
+}
+
+// CHECK-LABEL: sil hidden @$s29big_types_constructors_source10nonGenericAA3BigVys5Int32VG_AGt_AGyctSgyF : $@convention(thin) () -> @out Optional<((Big<Int32>, Big<Int32>), @callee_guaranteed () -> @out Big<Int32>)>
+// CHECK: bb0(%0 : $*Optional<((Big<Int32>, Big<Int32>), @callee_guaranteed () -> @out Big<Int32>)>):
+// CHECK: [[ENUMCONSTRUCT:%.*]] = enum $Optional<((Big<Int32>, Big<Int32>), @callee_guaranteed () -> @out Big<Int32>)>, #Optional.none!enumelt
+// CHECK: store [[ENUMCONSTRUCT]] to %0 : $*Optional<((Big<Int32>, Big<Int32>), @callee_guaranteed () -> @out Big<Int32>)>
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '$s29big_types_constructors_source10nonGenericAA3BigVys5Int32VG_AGt_AGyctSgyF'
+func nonGeneric() -> ((Big<Int32>, Big<Int32>), () -> Big<Int32>)? {
+  return nil
+}
+
+// CHECK-LABEL: sil hidden @$s29big_types_constructors_source11nonGeneric2AA3BigVys5Int32VG_AGt_AGyctyF : $@convention(thin) () -> @out (Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>)
+// CHECK: bb0(%0 : $*(Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>)):
+// CHECK: [[ALLOCTUPLE:%.*]] = alloc_stack $(Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>)
+// CHECK: [[TELEM0:%.*]] = tuple_element_addr [[ALLOCTUPLE]] : $*(Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>), 0
+// CHECK: store %{{.*}} to [[TELEM0]] : $*Big<Int32>
+// CHECK: [[TELEM1:%.*]] =  tuple_element_addr %1 : $*(Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>), 1
+// CHECK: store %{{.*}} to [[TELEM1]] : $*Big<Int32>
+// CHECK: [[TELEM2:%.*]] = tuple_element_addr %1 : $*(Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>), 2
+// CHECK: store %{{.*}} to [[TELEM2]] : $*@callee_guaranteed () -> @out Big<Int32>
+// CHECK: copy_addr [take] [[ALLOCTUPLE]] to [initialization] %0 : $*(Big<Int32>, Big<Int32>, @callee_guaranteed () -> @out Big<Int32>)
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '$s29big_types_constructors_source11nonGeneric2AA3BigVys5Int32VG_AGt_AGyctyF'
+func nonGeneric2() -> ((Big<Int32>, Big<Int32>), () -> Big<Int32>) {
+  return ((Big(1), Big(2)), { return Big(1) })
+}
+
+func generic<T>(_ t: T) -> ((Big<T>, Big<T>), () -> Big<T>)? {
+  return nil
+}
+
+func generic2<T>(_ t: T) -> ((Big<T>, Big<T>), () -> Big<T>) {
+  return ((Big(t), Big(t)), { return Big(t) })
+}
+
+// CHECK-LABEL: sil hidden @$s29big_types_constructors_source8useStuffyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK: switch_enum_addr %{{.*}} : $*Optional<((Big<Int32>, Big<Int32>), @callee_guaranteed () -> @out Big<Int32>)>, case #Optional.some!enumelt.1: bb7, case #Optional.none!enumelt: bb1
+// CHECK: bb7:
+// CHECK: switch_enum_addr %{{.*}} : $*Optional<((Big<Int32>, Big<Int32>), @callee_guaranteed () -> @out Big<Int32>)>, case #Optional.some!enumelt.1: bb14, case #Optional.none!enumelt: bb8
+// CHECK: bb14:
+// CHECK: bb17(%222 : $Optional<((Big<Int>, Big<Int>), @callee_guaranteed () -> @out Big<Int>)>):
+// CHECK: switch_enum_addr %{{.*}} : $*Optional<((Big<Int>, Big<Int>), @callee_guaranteed () -> @out Big<Int>)>, case #Optional.some!enumelt.1: bb24, case #Optional.none!enumelt: bb18
+// CHECK: bb24:
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '$s29big_types_constructors_source8useStuffyyF'
+func useStuff() {
+  print(nonGeneric()!.0)
+  print(nonGeneric()!.1)
+  print(nonGeneric2().0)
+  print(nonGeneric2().1)
+  print(generic(1)!.0.0)
+  print(generic(1)!.1)
+  print(generic2(1).0)
+  print(generic2(1).1)
+}


### PR DESCRIPTION
radar rdar://problem/48089230

Supports both the re-write of function return values that are multi-element tuples and a more efficient construction for structs and tuples