### PR TITLE
test: loosen -Xllvm version string matching

### DIFF
--- a/test/Frontend/Xllvm.swift
+++ b/test/Frontend/Xllvm.swift
@@ -2,4 +2,4 @@
 // CHECK-HELP: -version
 
 // RUN: %swift -Xllvm -version -emit-sil %s 2>&1 | %FileCheck %s -check-prefix=CHECK-SIL
-// CHECK-SIL: LLVM (http://llvm.org/)
+// CHECK-SIL: LLVM {{(http://llvm.org/)|version }}


### PR DESCRIPTION
If the LLVM/clang is built with release mode and PACKAGE_VENDOR set, it
will not print the same string but rather the version number.  Permit
either string.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
