### PR TITLE
[AutoDiff] [Sema] TF-305: Fix `@differentiable` initializer crash.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2706,6 +2706,8 @@ ERROR(differentiable_attr_wrt_self_instance_method_only,none,
 ERROR(differentiable_attr_cannot_diff_wrt_objects_or_existentials,none,
       "class objects and protocol existentials (%0) cannot be differentiated "
       "with respect to", (Type))
+ERROR(differentiable_attr_cannot_diff_wrt_functions,none,
+      "functions (%0) cannot be differentiated with respect to", (Type))
 ERROR(differentiable_attr_duplicate,none,
       "duplicate '@differentiable' attribute", ())
 ERROR(differentiable_attr_function_not_same_type_context,none,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4125,9 +4125,9 @@ Optional<VectorSpace> TypeBase::getAutoDiffAssociatedVectorSpace(
         kind, lookupConformance);
     if (!resultSpace)
       return cache(None);
-    return VectorSpace::getFunction(
+    return cache(VectorSpace::getFunction(
         makeFunctionType(fnTy, fnTy->getParams(), resultSpace->getType(),
-                         fnTy->getOptGenericSignature()));
+                         fnTy->getOptGenericSignature())));
   }
 
   // Tuples' tangent/cotangent is a tuple of each element's Tangent/Cotangent.

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -133,6 +133,30 @@ enum T : P {
   return a
 }
 
+// Test `@differentiable` on initializer with assignments.
+struct TF_305 : Differentiable {
+  var filter: Float
+  var bias: Float
+  typealias Activation = @differentiable (Float) -> Float
+  @noDerivative let activation: Activation
+  @noDerivative let strides: (Int, Int)
+
+  // expected-error @+2 {{function is not differentiable}}
+  // expected-note @+2 {{when differentiating this function definition}}
+  @differentiable
+  public init(
+    filter: Float,
+    bias: Float,
+    activation: @escaping Activation,
+    strides: (Int, Int)
+  ) {
+    self.filter = filter
+    self.bias = bias
+    self.activation = activation
+    self.strides = strides // expected-note {{expression is not differentiable}}
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Classes and existentials (unsupported yet)
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
- Handle function-typed parameters during `@differentiable` attribute
  type-checking.
  - Diagnose diagnose function-typed differentiation parameters, since
    function-typed values cannot yet be differentiated wrt.
  - Do not infer function-typed parameters to be differentiation parameters.
  - Add multiple tests.
- Diagnose non-differentiable buffers in `getAdjointBuffer`.
  - This is necessary now that activity analysis runs on all types after https://github.com/apple/swift/pull/22848.
  - Add test based on [TF-305](https://bugs.swift.org/projects/TF/issues/TF-305) reproducer.
- Gardening.

Resolves [TF-305](https://bugs.swift.org/projects/TF/issues/TF-305).
- `@differentiable` no longer crashes on initializers with non-differentiable
  or function-typed parameters.

Exposes [TF-309](https://bugs.swift.org/projects/TF/issues/TF-309).
- Memberwise initializers with non-differentiable parameters cannot be
  differentiated.