### PR TITLE
[Constraint solver] Move constraint optimization into a solver scope.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3678,12 +3678,7 @@ Expr *ConstraintSystem::generateConstraints(Expr *expr) {
   ConstraintGenerator cg(*this);
   ConstraintWalker cw(cg);
   
-  Expr* result = expr->walk(cw);
-  
-  if (result)
-    this->optimizeConstraints(result);
-
-  return result;
+  return expr->walk(cw);
 }
 
 Type ConstraintSystem::generateConstraints(Pattern *pattern,


### PR DESCRIPTION
Rather than performing constraint optimization immediately after
constraint generation, delay it until we introduce the first solver
scope. This allows us to back out the results of constraint
optimization when salvaging the system.
