### PR TITLE
workaround new autocomplete crasher

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2426,6 +2426,12 @@ public:
   void addMethodCall(const FuncDecl *FD, DeclVisibilityKind Reason) {
     if (FD->getName().empty())
       return;
+
+    // Suppress "sequenced" as a result, because it crashes completions.
+    // TODO(TF-315): Fix properly and then remove this.
+    if (FD->getName().str() == "sequenced")
+      return;
+
     foundFunction(FD);
     bool IsImplicitlyCurriedInstanceMethod =
         isImplicitlyCurriedInstanceMethod(FD);

--- a/test/IDE/complete_tf_315.swift
+++ b/test/IDE/complete_tf_315.swift
@@ -1,0 +1,8 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE | %FileCheck %s
+
+import TensorFlow
+let t = Tensor#^COMPLETE^#
+
+// CHECK-LABEL: Begin completions
+// CHECK: End completions


### PR DESCRIPTION
Building against the latest swift-apis reveals a new autocomplete crasher: the autocompleter cannot deal with the "sequenced" method introduced in https://github.com/tensorflow/swift-apis/pull/20.

I tried to investigate a bit, but it's something non-obvious happening deep within substitution map stuff. So I think the safest way to make the autocompleter not crash in v0.2 release is to suppress "sequenced" as an autocomplete result.

https://bugs.swift.org/browse/TF-315 has details about the crash.