### PR TITLE
[Sema] TF-240, TF-260: Fix `Differentiable` derived conformances cras…

### DIFF
--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -65,3 +65,23 @@ struct TestKeyPathIterable : Differentiable, KeyPathIterable {
 // CHECK-AST:           internal typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
 // CHECK-AST:         internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
 // CHECK-AST:         internal typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
+
+struct GenericCotanMember<T : Differentiable> : Differentiable, AdditiveArithmetic {
+  var x: T.CotangentVector
+}
+
+// TODO(TF-316): Revisit after `Differentiable` derived conformances behavior is standardized.
+// `AllDifferentiableVariables` and `CotangentVector` structs need not both be synthesized.
+
+// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct GenericCotanMember<T> : Differentiable, AdditiveArithmetic where T : Differentiable {
+// CHECK-AST:         var x: T.CotangentVector
+// CHECK-AST:         internal init(x: T.CotangentVector)
+// CHECK-AST:         internal typealias TangentVector = GenericCotanMember<T>
+// CHECK-AST-LABEL:   @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable
+// CHECK-AST:           internal typealias TangentVector = GenericCotanMember<T>
+// CHECK-AST:           internal typealias CotangentVector = GenericCotanMember<T>.CotangentVector
+// CHECK-AST:           internal typealias AllDifferentiableVariables = GenericCotanMember<T>.AllDifferentiableVariables
+// CHECK-AST-LABEL:   @_fieldwiseDifferentiable internal struct CotangentVector : Differentiable, AdditiveArithmetic
+// CHECK-AST:           internal typealias TangentVector = GenericCotanMember<T>.CotangentVector
+// CHECK-AST:           internal typealias CotangentVector = GenericCotanMember<T>
+// CHECK-AST:           internal typealias AllDifferentiableVariables = GenericCotanMember<T>.CotangentVector

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -247,6 +247,10 @@ extension GenericConstrained : Differentiable
 // expected-warning @+1 {{stored property '_buffer' has no derivative because it does not conform to 'Differentiable'; add '@noDerivative' to make it explicit}}
 extension Array : Differentiable where Element : Differentiable {}
 
+struct TF_260<T : Differentiable> : Differentiable & AdditiveArithmetic {
+  var x: T.CotangentVector
+}
+
 // Test errors.
 
 // Test manually customizing vector space types.


### PR DESCRIPTION
…hers.

- Enable nominal types' implicit parents as valid `Differentiable`
  associated types in `canDeriveDifferentiable`.
  - This is crucial for preventing assertion failures.
- Relax `freshlySynthesized` assertions.
  - With the current design, it is not always the case that all
    three `Differentiable` associated types are freshly synthesized
    at once. Some redesign is necessary.

Todos:
- Clarify/standardize `Differentiable` derived conformances behavior.
  - Sometimes, `CotangentVector` and `AllDifferentiableVariables` may both
    be synthesized when only `AllDifferentiableVariables` is necessary.
  - Other times, `AllDifferentiables` may be synthesized as a typealias of
    `CotangentVector` when the reverse behavior may be desirable.
  - Add `print-ast` tests to verify behavior.
- Handle `Differentiable` derived conformances for structs whose parent
  also conforms to `Differentiable`.
  - This is important for enforcing some `Differentiable` protocol
    constraints, like:
    ```
    X.AllDifferentiableVariables.AllDifferentiableVariables ==
    X.AllDifferentiableVariables
    ```

Resolves [TF-240](https://bugs.swift.org/browse/TF-240) and [TF-260](https://bugs.swift.org/browse/TF-260).
Filed [TF-316](https://bugs.swift.org/browse/TF-316) for standardizing `Differentiable` derived conformances behavior.