### PR TITLE
[Stdlib] Make SwiftObjectNSObject actually pass on older OSes where the real test is disabled.

### DIFF
--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -51,7 +51,7 @@ if #available(OSX 10.12, iOS 10.0, *) {
   // does not return
 } else {
   // Horrible hack to satisfy FileCheck
-  print("c ##SwiftObjectNSObject.C##")
-  print("d ##SwiftObjectNSObject.D##")
-  print("S ##Swift._SwiftObject##")
+  fputs("c ##SwiftObjectNSObject.C##\n", stderr)
+  fputs("d ##SwiftObjectNSObject.D##\n", stderr)
+  fputs("S ##Swift._SwiftObject##\n", stderr)
 }


### PR DESCRIPTION
It helps to print the fake messages where FileCheck will actually be looking for them.

rdar://problem/48421324