### PR TITLE
ParseableInterface test verify_all_overlays.py watchos

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -17,6 +17,7 @@
 # macosx: XCTest
 # ios: XCTest
 # tvos: XCTest
+# watchos: XCTest
 
 from __future__ import print_function
 


### PR DESCRIPTION
Add missing expected failure for watchos.

rdar://48442827