### PR TITLE
unittests: add a hack to use the host compiler

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -1,13 +1,15 @@
 if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
    ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
 
-  if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+  if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    # Do nothing
+  elseif(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
     if(NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
       message(FATAL_ERROR "Building the swift runtime is not supported with ${CMAKE_C_COMPILER_ID}. Use the just-built clang instead.")
-    else()
-      message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")
     endif()
   else()
+    message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")
+
     # If we use Clang-cl or MSVC, CMake provides default compiler and linker flags that are incompatible
     # with the frontend of Clang or Clang++.
     if(SWIFT_COMPILER_IS_MSVC_LIKE)


### PR DESCRIPTION
Unfortunately, ASAN breaks with the just built compiler.  The runtime
and the runtime tests should really use the same compiler.  As a
workaround, if the host compiler is clang, just use that for the time
being.  This should fix the build on the ASAN bots.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
