### PR TITLE
[CSSimplify] Tuple splat should account for single dependent member p…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1085,11 +1085,11 @@ static bool isSingleTupleParam(ASTContext &ctx,
   if (!ctx.isSwiftVersionAtLeast(5))
     paramType = paramType->lookThroughAllOptionalTypes();
 
-  // Parameter should have a label and be either a tuple tuple type,
-  // or a type variable which might later be assigned a tuple type,
-  // e.g. opened generic parameter.
+  // Parameter should not have a label and be either a tuple,
+  // type variable or a dependent member, which might later be
+  // assigned (or resolved to) a tuple type, e.g. opened generic parameter.
   return !param.hasLabel() &&
-         (paramType->is<TupleType>() || paramType->is<TypeVariableType>());
+         (paramType->is<TupleType>() || paramType->isTypeVariableOrMember());
 }
 
 /// Attempt to fix missing arguments by introducing type variables

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -894,8 +894,12 @@ do {
   }
 
   func foo(_ arr: [Int]) {
+    // FIXME: This behavior related to tuple splat being allowed
+    //        in conversion between a single dependent member
+    //        parameter and empty parameter functions e.g.
+    //        () -> Void `convertable to` (T.V) -> Void.
     _ = S(arr, id: \.self_) {
-      // expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{30-30=_ in }}
+      // expected-error@-1 {{type '_' has no member 'self_'}}
       return 42
     }
   }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1692,3 +1692,26 @@ do {
   func f(_: Int...) {}
   let _ = [(1, 2, 3)].map(f) // expected-error {{cannot invoke 'map' with an argument list of type '((Int...) -> ())'}}
 }
+
+// rdar://problem/48443263 - cannot convert value of type '() -> Void' to expected argument type '(_) -> Void'
+
+protocol P_48443263 {
+  associatedtype V
+}
+
+func rdar48443263() {
+  func foo<T : P_48443263>(_: T, _: (T.V) -> Void) {}
+
+  struct S1 : P_48443263 {
+    typealias V = Void
+  }
+
+  struct S2: P_48443263 {
+    typealias V = Int
+  }
+
+  func bar(_ s1: S1, _ s2: S2, _ fn: () -> Void) {
+    foo(s1, fn) // Ok because s.V is Void
+    foo(s2, fn) // expected-error {{cannot convert value of type '() -> Void' to expected argument type '(_) -> Void'}}
+  }
+}


### PR DESCRIPTION
…arameters

12a65fffee949c8755d0ccca748e3442efdf0727 restricted tuple splat
to a single tuple or type variable parameter, but it has to
support dependent member types as well because they could be
resolved to `Void` (or empty tuple).

Resolves: rdar://problem/48443263

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
