### PR TITLE
[5.1] SILOptimizer: fix a stupid bug in StackNesting which can cause a miscompile in functions with unreachable blocks.

### DIFF
--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -97,7 +97,7 @@ bool StackNesting::solve() {
   bool initVal = false;
   for (BlockInfo &BI : BlockInfos) {
     BI.AliveStackLocsAtEntry.resize(StackLocs.size(), initVal);
-    initVal = false;
+    initVal = true;
   }
 
   // First step: do a forward dataflow analysis to get the live stack locations

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -819,8 +819,6 @@ bb0(%0 : $Int):
 // CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   unreachable
@@ -859,7 +857,6 @@ bb2:
 // CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
 // CHECK:        store
@@ -894,8 +891,6 @@ bb2:
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK-NEXT:   [[STACK:%[0-9]+]] = alloc_stack $Bool
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[STACK]]
-// CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
 // CHECK:        store
@@ -954,7 +949,6 @@ bb2:
 // CHECK:      bb0(%0 : $Int):
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   {{.*}} = alloc_stack $Bool
 // CHECK-NEXT:   {{.*}} = alloc_stack $Bool
 // CHECK-NEXT:   unreachable
@@ -1014,30 +1008,60 @@ bb3:
   return %3 : $Int
 }
 
+// CHECK-LABEL: sil @nesting_and_unreachable7
+// CHECK:      bb0(%0 : $Bool):
+// CHECK-NEXT:   [[AB:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   [[AI:%[0-9]+]] = alloc_stack $Int
+// CHECK-NEXT:   cond_br
+// CHECK:      bb1:
+// CHECK-NEXT:   dealloc_stack [[AI]]
+// CHECK-NEXT:   br bb3
+// CHECK:      bb2:
+// CHECK-NEXT:   dealloc_stack [[AI]]
+// CHECK-NEXT:   br bb3
+// CHECK:      bb3:
+// CHECK-NEXT:   store
+// CHECK-NEXT:   load
+// CHECK-NEXT:   unreachable
+sil @nesting_and_unreachable7 : $@convention(thin) (Bool) -> Bool {
+bb0(%0 : $Bool):
+  %as1 = alloc_stack $Bool
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_release %1 : ${ var Int }
+  br bb3
+
+bb2:
+  strong_release %1 : ${ var Int }
+  br bb3
+
+bb3:
+  store %0 to %as1 : $*Bool
+  %3 = load %as1 : $*Bool
+  unreachable
+}
 // CHECK-LABEL: sil @nesting_and_unreachable_critical_edge
 // CHECK:      bb0(%0 : $Int):
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   cond_br
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
-// CHECK-NEXT:   br bb5
-// CHECK:      bb2:
 // CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   cond_br
-// CHECK:      bb3:
+// CHECK:      bb2:
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
-// CHECK-NEXT:   br bb5
-// CHECK:      bb4:
+// CHECK-NEXT:   br bb4
+// CHECK:      bb3:
 // CHECK:        store
 // CHECK:        dealloc_stack [[STACK2]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
-// CHECK:      bb5:
-// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK:      bb4:
 // CHECK-NEXT:   unreachable
 sil @nesting_and_unreachable_critical_edge : $(Int) -> () {
 bb0(%0 : $Int):

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -814,8 +814,6 @@ bb0(%0 : $Int):
 // CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   unreachable
@@ -854,7 +852,6 @@ bb2:
 // CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
 // CHECK:        store
@@ -889,8 +886,6 @@ bb2:
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK-NEXT:   [[STACK:%[0-9]+]] = alloc_stack $Bool
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[STACK]]
-// CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
 // CHECK:        store
@@ -949,7 +944,6 @@ bb2:
 // CHECK:      bb0(%0 : $Int):
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   {{.*}} = alloc_stack $Bool
 // CHECK-NEXT:   {{.*}} = alloc_stack $Bool
 // CHECK-NEXT:   unreachable
@@ -983,24 +977,19 @@ bb2:
 // CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   cond_br
 // CHECK:      bb1:
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
-// CHECK-NEXT:   br bb5
-// CHECK:      bb2:
 // CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   cond_br
-// CHECK:      bb3:
+// CHECK:      bb2:
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
-// CHECK-NEXT:   br bb5
-// CHECK:      bb4:
+// CHECK-NEXT:   br bb4
+// CHECK:      bb3:
 // CHECK:        store
 // CHECK:        dealloc_stack [[STACK2]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
-// CHECK:      bb5:
-// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK:      bb4:
 // CHECK-NEXT:   unreachable
 sil [ossa] @nesting_and_unreachable_critical_edge : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -494,8 +494,6 @@ bb0:
 // CHECK:   dealloc_stack [[A32]] : $*Builtin.Int32
 // CHECK:   unreachable
 // CHECK: bb2:
-// CHECK:   dealloc_stack [[A32]] : $*Builtin.Int32
-// CHECK:   dealloc_stack [[A16]] : $*Builtin.Int16
 // CHECK:   unreachable
 // CHECK: bb3:
 // CHECK:   dealloc_stack [[A32]] : $*Builtin.Int32

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -4,9 +4,8 @@
 // RUN:   -Xllvm -sil-print-debuginfo -o %t -module-name red 2>&1 | %FileCheck %s
 
 // CHECK: bb5(%33 : @owned $Error):
-// CHECK:   dealloc_stack %6 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:27:68, scope 2
-// CHECK:   dealloc_stack %3 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:27:68, scope 2
-// CHECK:   br bb4(%33 : $Error), loc {{.*}}:27:15, scope 2
+// CHECK:   dealloc_stack %6 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:26:68, scope 2
+// CHECK:   br bb4(%33 : $Error), loc {{.*}}:26:15, scope 2
 
 protocol Patatino {
   init()


### PR DESCRIPTION
rdar://problem/47973577
