### PR TITLE
Print nil unwrap location in no-assert builds of stdlib

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -300,7 +300,9 @@ func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
                                     _filenameIsASCII: Builtin.Int1,
                                     _line: Builtin.Word,
                                     _isImplicitUnwrap: Builtin.Int1) {
-  _preconditionFailure(
+  // Cannot use _preconditionFailure as the file and line info would not be
+  // printed.
+  preconditionFailure(
     Bool(_isImplicitUnwrap)
       ? "Unexpectedly found nil while implicitly unwrapping an Optional value"
       : "Unexpectedly found nil while unwrapping an Optional value",

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -25,7 +25,22 @@ OptionalTraps.test("UnwrapNone")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
-  var a: AnyObject? = returnNil()
+  let a: AnyObject? = returnNil()
+  expectCrashLater()
+  let unwrapped: AnyObject = a!
+  _blackHole(unwrapped)
+}
+
+OptionalTraps.test("UnwrapNone/location")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration()
+                        ? "test/stdlib/OptionalTraps.swift, line 45"
+                        : "")
+  .code {
+  expectCrashLater()
+  let a: AnyObject? = returnNil()
   expectCrashLater()
   let unwrapped: AnyObject = a!
   _blackHole(unwrapped)


### PR DESCRIPTION
We've been collecting the location info for some time now, but
apparently never printed it in no-assert builds of the stdlib, which
means this functionality was never available to the users.

With this change, the location will be printed depending on the
debug/release build configuration of the program, not stdlib.

Somewhat addresses: <rdar://problem/42980523>