### PR TITLE
[test] Disable two more collection tests in unoptimized builds

### DIFF
--- a/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
@@ -2,6 +2,10 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import SwiftPrivate
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -2,6 +2,10 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import SwiftPrivate
 import StdlibUnittest
 import StdlibCollectionUnittest


### PR DESCRIPTION
https://github.com/apple/swift/pull/22844 disabled a bunch of exhaustive collection tests in unoptimized stdlib builds, but it missed a couple that were hiding amongst a forest of gyb-generated test files.

This PR unblocks CI builds that are still failing due to test timeouts.

rdar://problem/48418643