### PR TITLE
[5.0][test] Disable two more collection tests in unoptimized builds

### DIFF
--- a/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
@@ -2,6 +2,10 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import SwiftPrivate
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -2,6 +2,10 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// FIXME: the test is too slow when the standard library is not optimized.
+// rdar://problem/46878013
+// REQUIRES: optimized_stdlib
+
 import SwiftPrivate
 import StdlibUnittest
 import StdlibCollectionUnittest


### PR DESCRIPTION
(This is cherry-picked from https://github.com/apple/swift/pull/22970)

**Explanation:** Unblocks CI builds by disabling two more time-consuming Collection validation tests in builds with unoptimized stdlib.

**Scope:** Limited to the test suite.

**Radar:**  rdar://problem/48418643

**Risk:** Minimal.

**Testing:** Standard PR testing (optimized stdlib only)

**Reviewer:** @moiseev