### PR TITLE
[AutoDiff] TF-309, TF-319: Handle `@noDerivative` properties.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -375,6 +375,9 @@ NOTE(autodiff_nondifferentiable_argument,none,
 NOTE(autodiff_nondifferentiable_result,none,
      "cannot differentiate through a non-differentiable result; do you want to "
      "add '.withoutDerivative()'?", ())
+NOTE(autodiff_noderivative_stored_property,none,
+     "cannot differentiate through a '@noDerivative' stored property; do you "
+     "want to add '.withoutDerivative()'?", ())
 NOTE(autodiff_global_let_closure_not_differentiable,none,
      "global constant closure is not differentiable", ())
 NOTE(autodiff_cannot_differentiate_global_var_closures,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -379,8 +379,9 @@ NOTE(autodiff_noderivative_stored_property,none,
      "cannot differentiate through a '@noDerivative' stored property; do you "
      "want to add '.withoutDerivative()'?", ())
 WARNING(autodiff_nonvaried_result_fixit,none,
-        "result does not depend on differentiation arguments and always has a "
-        "zero derivative; do you want to add '.withoutDerivative()'?", ())
+        "result does not depend on differentiation arguments and will always "
+        "have a zero derivative; do you want to add '.withoutDerivative()'?",
+        ())
 NOTE(autodiff_global_let_closure_not_differentiable,none,
      "global constant closure is not differentiable", ())
 NOTE(autodiff_cannot_differentiate_global_var_closures,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -378,6 +378,9 @@ NOTE(autodiff_nondifferentiable_result,none,
 NOTE(autodiff_noderivative_stored_property,none,
      "cannot differentiate through a '@noDerivative' stored property; do you "
      "want to add '.withoutDerivative()'?", ())
+WARNING(autodiff_nonvaried_result_fixit,none,
+        "result does not depend on differentiation arguments and always has a "
+        "zero derivative; do you want to add '.withoutDerivative()'?", ())
 NOTE(autodiff_global_let_closure_not_differentiable,none,
      "global constant closure is not differentiable", ())
 NOTE(autodiff_cannot_differentiate_global_var_closures,none,

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1331,36 +1331,28 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
           if (isVaried(cai->getSrc(), i))
             recursivelySetVaried(cai->getDest(), i);
         }
-        // Handle `struct_extract`.
-        else if (auto *sei = dyn_cast<StructExtractInst>(&inst)) {
-          if (isVaried(sei->getOperand(), i)) {
-            // If `@noDerivative` exists on the field while the struct is
-            // `@_fieldwiseDifferentiable`, this field is not in the set of
-            // differentiable variables that we want to track the variedness of.
-            auto hasNoDeriv = sei->getField()->getAttrs()
-                .hasAttribute<NoDerivativeAttr>();
-            auto structIsFieldwiseDiffable = sei->getStructDecl()->getAttrs()
-                .hasAttribute<FieldwiseDifferentiableAttr>();
-            if (!(hasNoDeriv && structIsFieldwiseDiffable))
-              for (auto result : inst.getResults())
-                setVaried(result, i);
-          }
-        }
-        // Handle `struct_element_addr`.
-        else if (auto *seai = dyn_cast<StructElementAddrInst>(&inst)) {
-          if (isVaried(seai->getOperand(), i)) {
-            // If `@noDerivative` exists on the field while the struct is
-            // `@_fieldwiseDifferentiable`, this field is not in the set of
-            // differentiable variables that we want to track the variedness of.
-            auto hasNoDeriv = seai->getField()->getAttrs()
-                .hasAttribute<NoDerivativeAttr>();
-            auto structIsFieldwiseDiffable = seai->getStructDecl()->getAttrs()
-                .hasAttribute<FieldwiseDifferentiableAttr>();
-            if (!(hasNoDeriv && structIsFieldwiseDiffable))
-              for (auto result : inst.getResults())
-                setVaried(result, i);
-          }
-        }
+
+// If `@noDerivative` exists on the field while the struct is
+// `@_fieldwiseDifferentiable`, this field is not in the set of
+// differentiable variables that we want to track the variedness of.
+#define DIAGNOSE_STRUCT_NO_DERIVATIVE_FIELD(INST) \
+  else if (auto *sei = dyn_cast<INST##Inst>(&inst)) { \
+    if (isVaried(sei->getOperand(), i)) { \
+      auto hasNoDeriv = sei->getField()->getAttrs() \
+          .hasAttribute<NoDerivativeAttr>(); \
+      auto structIsFieldwiseDiffable = sei->getStructDecl()->getAttrs() \
+          .hasAttribute<FieldwiseDifferentiableAttr>(); \
+      if (!(hasNoDeriv && structIsFieldwiseDiffable)) \
+        for (auto result : inst.getResults()) \
+          setVaried(result, i); \
+    } \
+  }
+  // Handle `struct_extract`.
+  DIAGNOSE_STRUCT_NO_DERIVATIVE_FIELD(StructExtract)
+  // Handle `struct_element_addr`.
+  DIAGNOSE_STRUCT_NO_DERIVATIVE_FIELD(StructElementAddr)
+#undef DIAGNOSE_STRUCT_NO_DERIVATIVE_FIELD
+
         // Handle everything else.
         else {
           for (auto &op : inst.getAllOperands())
@@ -3645,6 +3637,37 @@ private:
     assert(insertion.second); (void)insertion;
   }
 
+  SILValue getAdjointProjection(SILValue originalProjection) {
+    // Handle `struct_element_addr`.
+    if (auto *seai = dyn_cast<StructElementAddrInst>(originalProjection)) {
+      auto adjBase = getAdjointBuffer(seai->getOperand());
+      auto *cotangentVectorDecl =
+          adjBase.getType().getStructOrBoundGenericStruct();
+      auto cotanFieldLookup =
+          cotangentVectorDecl->lookupDirect(seai->getField()->getName());
+      assert(cotanFieldLookup.size() == 1);
+      auto *cotanField = cast<VarDecl>(cotanFieldLookup.front());
+      return builder.createStructElementAddr(
+         seai->getLoc(), adjBase.getValue(), cotanField);
+    }
+    // Handle `tuple_element_addr`.
+    if (auto *teai = dyn_cast<TupleElementAddrInst>(originalProjection)) {
+      auto adjBase = getAdjointBuffer(teai->getOperand());
+      return builder.createTupleElementAddr(
+          teai->getLoc(), adjBase.getValue(), teai->getFieldNo());
+    }
+    // Handle `begin_access`.
+    if (auto *bai = dyn_cast<BeginAccessInst>(originalProjection)) {
+      auto adjBase = getAdjointBuffer(bai->getOperand());
+      if (errorOccurred)
+        return (bufferMap[originalProjection] = ValueWithCleanup());
+      return builder.createBeginAccess(
+          bai->getLoc(), adjBase, bai->getAccessKind(), bai->getEnforcement(),
+          /*noNestedConflict*/ false, /*fromBuiltin*/ false);
+    }
+    return SILValue();
+  }
+
   ValueWithCleanup &getAdjointBuffer(SILValue originalBuffer) {
     assert(originalBuffer->getType().isAddress());
     assert(originalBuffer->getFunction() == &getOriginal());
@@ -3653,58 +3676,23 @@ private:
     if (!insertion.second) // not inserted
       return insertion.first->getSecond();
 
-    // Diagnose non-differentiable buffers.
-    if (!originalBuffer->getType().isDifferentiable(getModule())) {
-      getContext().emitNondifferentiabilityError(
-          originalBuffer, getDifferentiationTask());
-      errorOccurred = true;
-      return (bufferMap[originalBuffer] = ValueWithCleanup());
+    // Diagnose `struct_element_addr` instructions to `@noDerivative` fields.
+    if (auto *seai = dyn_cast<StructElementAddrInst>(originalBuffer)) {
+      if (seai->getField()->getAttrs().hasAttribute<NoDerivativeAttr>()) {
+        getContext().emitNondifferentiabilityError(
+            originalBuffer, getDifferentiationTask(),
+            diag::autodiff_noderivative_stored_property);
+        errorOccurred = true;
+        return (bufferMap[originalBuffer] = ValueWithCleanup());
+      }
     }
 
-    // Check whether the original buffer is an address-to-address projection.
-    // If so, recurse until the buffer is such a projection but its operand is
-    // not. Then, get the adjoint buffer of the operand and return a
-    // corresponding projection into it.
-    if (Projection::isAddressProjection(originalBuffer) &&
-        !Projection::isObjectToAddressProjection(originalBuffer)) {
-      // Get operand of the projection (i.e. the base memory).
-      auto *inst = cast<SingleValueInstruction>(originalBuffer);
-      Projection proj(inst);
-      auto loc = inst->getLoc();
-      auto base = inst->getOperand(0);
-      // Get the corresponding projection into the adjoint buffer.
-      SILValue adjProj;
-      auto adjBase = getAdjointBuffer(base);
-      if (proj.getKind() == ProjectionKind::Struct) {
-        auto *origField = proj.getVarDecl(base->getType());
-        auto *cotangentVectorDecl =
-            adjBase.getType().getStructOrBoundGenericStruct();
-        auto cotanFieldLookup =
-            cotangentVectorDecl->lookupDirect(origField->getName());
-        assert(cotanFieldLookup.size() == 1);
-        auto *cotanField = cast<VarDecl>(cotanFieldLookup.front());
-        adjProj = builder.createStructElementAddr(loc, adjBase.getValue(),
-                                                  cotanField);
-      } else {
-        adjProj = proj.createAddressProjection(builder, loc, adjBase.getValue())
-                      .get();
-      }
+    // If the original buffer is a projection, return a corresponding projection
+    // into the adjoint buffer.
+    if (auto adjProj = getAdjointProjection(originalBuffer)) {
       ValueWithCleanup projWithCleanup(
-          adjProj, makeCleanupFromChildren({adjBase.getCleanup()}));
+          adjProj, makeCleanup(adjProj, /*cleanup*/ nullptr));
       return (bufferMap[originalBuffer] = projWithCleanup);
-    }
-    // If the original buffer is a `begin_access` instruction, get the adjoint
-    // buffer of its operand and return a corresponding `begin_access` into it.
-    if (auto *bai = dyn_cast<BeginAccessInst>(originalBuffer)) {
-      auto adjBase = getAdjointBuffer(bai->getOperand());
-      if (errorOccurred)
-        return (bufferMap[originalBuffer] = ValueWithCleanup());
-      auto *adjAccess = builder.createBeginAccess(
-          bai->getLoc(), adjBase, bai->getAccessKind(), bai->getEnforcement(),
-          /*noNestedConflict*/ false, /*fromBuiltin*/ false);
-      ValueWithCleanup accessWithCleanup(
-          adjAccess, makeCleanupFromChildren({adjBase.getCleanup()}));
-      return (bufferMap[originalBuffer] = accessWithCleanup);
     }
 
     // Set insertion point for local allocation builder: before the last local
@@ -4244,10 +4232,6 @@ public:
   }
 
   void visitStructExtractInst(StructExtractInst *sei) {
-    // There does not exist a corresponding cotangent field for original
-    // fields with `@noDerivative` attribute. Emit an error.
-    if (sei->getField()->getAttrs().hasAttribute<NoDerivativeAttr>())
-      return;
     auto loc = sei->getLoc();
     auto &differentiationStrategies =
         getDifferentiationTask()->getStructExtractDifferentiationStrategies();
@@ -4581,6 +4565,17 @@ public:
                      ValueWithCleanup(adjAccess, makeCleanupFromChildren({})));
   }
 
+#define PROPAGATE_CLEANUP(INST) \
+  void visit##INST##Inst(INST##Inst *inst) { \
+    auto adjBase = getAdjointBuffer(inst->getOperand()); \
+    auto adjProj = getAdjointBuffer(inst); \
+    adjProj.setCleanup(makeCleanupFromChildren( \
+        {adjProj.getCleanup(), adjBase.getCleanup()})); \
+  }
+  PROPAGATE_CLEANUP(StructElementAddr)
+  PROPAGATE_CLEANUP(TupleElementAddr)
+#undef PROPAGATE_CLEANUP
+
 #define NOT_DIFFERENTIABLE(INST, DIAG) \
   void visit##INST##Inst(INST##Inst *inst) { \
     getContext().emitNondifferentiabilityError( \
@@ -4606,10 +4601,6 @@ public:
   NO_ADJOINT(StrongRetainUnowned)
   NO_ADJOINT(DestroyValue)
   NO_ADJOINT(DestroyAddr)
-  // Projection operations have no adjoint visitor.
-  // Corresponding adjoint projections are created in `getAdjointBuffer`.
-  NO_ADJOINT(StructElementAddr)
-  NO_ADJOINT(TupleElementAddr)
 #undef NO_DERIVATIVE
 };
 } // end anonymous namespace

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -872,7 +872,7 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
     if (conformsToDifferentiable && !isConstantProperty)
       continue;
     // Otherwise, add an implicit `@noDerivative` attribute.
-    nominal->getAttrs().add(
+    vd->getAttrs().add(
         new (TC.Context) NoDerivativeAttr(/*Implicit*/ true));
     auto loc =
         vd->getLoc().isValid() ? vd->getLoc() : DC->getAsDecl()->getLoc();

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -43,6 +43,18 @@ extension S : Differentiable, VectorNumeric {
 // expected-note @+1 {{property is not differentiable}}
 _ = gradient(at: S(p: 0)) { s in 2 * s.p }
 
+struct NoDerivativeProperty : Differentiable {
+  var x: Float
+  @noDerivative var y: Float
+}
+// expected-error @+1 {{function is not differentiable}}
+_ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s -> Float in
+  var tmp = s
+  // expected-note @+1 {{cannot differentiate through a '@noDerivative' stored property; do you want to add '.withoutDerivative()'?}}
+  tmp.y = tmp.x
+  return tmp.x
+}
+
 //===----------------------------------------------------------------------===//
 // Function composition
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -55,11 +55,11 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s -> Float in
   return tmp.x
 }
 _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s in
-  // expected-warning @+1 {{result does not depend on differentiation arguments and always has a zero derivative; do you want to add '.withoutDerivative()'?}} {{13-13=.withoutDerivative()}}
+  // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{13-13=.withoutDerivative()}}
   return s.y
 }
 _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
-  // expected-warning @+1 {{result does not depend on differentiation arguments and always has a zero derivative; do you want to add '.withoutDerivative()'?}} {{7-7=.withoutDerivative()}}
+  // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{7-7=.withoutDerivative()}}
   $0.y
 }
 

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -141,8 +141,6 @@ struct TF_305 : Differentiable {
   @noDerivative let activation: Activation
   @noDerivative let strides: (Int, Int)
 
-  // expected-error @+2 {{function is not differentiable}}
-  // expected-note @+2 {{when differentiating this function definition}}
   @differentiable
   public init(
     filter: Float,
@@ -153,7 +151,7 @@ struct TF_305 : Differentiable {
     self.filter = filter
     self.bias = bias
     self.activation = activation
-    self.strides = strides // expected-note {{expression is not differentiable}}
+    self.strides = strides
   }
 }
 

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -54,6 +54,14 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s -> Float in
   tmp.y = tmp.x
   return tmp.x
 }
+_ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s in
+  // expected-warning @+1 {{result does not depend on differentiation arguments and always has a zero derivative; do you want to add '.withoutDerivative()'?}} {{13-13=.withoutDerivative()}}
+  return s.y
+}
+_ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
+  // expected-warning @+1 {{result does not depend on differentiation arguments and always has a zero derivative; do you want to add '.withoutDerivative()'?}} {{7-7=.withoutDerivative()}}
+  $0.y
+}
 
 //===----------------------------------------------------------------------===//
 // Function composition

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -49,7 +49,8 @@ struct SupervisedTrainer<Model : Layer> {
   var model: Model
   var lossFunction: @differentiable (Model.Output, Model.Output) -> Float
   func fit(y: Model.Output) {
-     _ = gradient(at: Float(1)) { _ in return lossFunction(y, y) }
+    // expected-warning @+1 {{result does not depend on differentiation arguments and always has a zero derivative; do you want to add '.withoutDerivative()'?}} {{58-58=.withoutDerivative()}}
+    _ = gradient(at: Float(1)) { _ in return lossFunction(y, y) }
   }
 }
 

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -49,7 +49,7 @@ struct SupervisedTrainer<Model : Layer> {
   var model: Model
   var lossFunction: @differentiable (Model.Output, Model.Output) -> Float
   func fit(y: Model.Output) {
-    // expected-warning @+1 {{result does not depend on differentiation arguments and always has a zero derivative; do you want to add '.withoutDerivative()'?}} {{58-58=.withoutDerivative()}}
+    // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{58-58=.withoutDerivative()}}
     _ = gradient(at: Float(1)) { _ in return lossFunction(y, y) }
   }
 }

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -60,7 +60,6 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
   @noDerivative public let strides: (Int32, Int32)
   @noDerivative public let padding: Padding
 
-  // TODO(TF-309): Add `@differentiable` initializer using assignments, when supported.
   @differentiable
   public init(
     filter: Tensor<Scalar>,
@@ -69,8 +68,11 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     strides: (Int, Int),
     padding: Padding
   ) {
-    self.init(filter: filter, bias: bias, activation: activation,
-              strides: (Int32(strides.0), Int32(strides.1)), padding: padding)
+    self.filter = filter
+    self.bias = bias
+    self.activation = activation
+    self.strides = (Int32(strides.0), Int32(strides.1))
+    self.padding = padding
   }
 
   @differentiable


### PR DESCRIPTION
- Change derived conformances to correctly mark non-differentiable stored
  properties with `@noDerivative`, not the parent nominal struct.
- Skip variedness propagation for `struct_element_addr` instructions to
  `@noDerivative` properties. Identical logic was previously added for
  `struct_extract`.
- Bail out in `AdjointEmitter::visitStructExtractInst` if the original
  field is `@noDerivative`.
- Add tests to ensure reproducer programs no longer crash.

Resolves [TF-309](https://bugs.swift.org/projects/TF/issues/TF-309) and [TF-319](https://bugs.swift.org/projects/TF/issues/TF-319).