### PR TITLE
[Parse] Treat '@unknown' as the start of a statement

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -92,6 +92,18 @@ bool Parser::isStartOfStmt() {
     // putting a label on something inappropriate in parseStmt().
     return isStartOfStmt();
   }
+
+  case tok::at_sign: {
+    // Might be a statement or case attribute. The only one of these we have
+    // right now is `@unknown default`, so hardcode a check for an attribute
+    // without any parens.
+    if (!peekToken().is(tok::identifier))
+      return false;
+    Parser::BacktrackingScope backtrack(*this);
+    consumeToken(tok::at_sign);
+    consumeToken(tok::identifier);
+    return isStartOfStmt();
+  }
   }
 }
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -609,3 +609,38 @@ switch x {
 @unknown default: // expected-error {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
   break
 }
+
+func testReturnBeforeUnknownDefault() {
+  switch x { // expected-error {{switch must be exhaustive}}
+  case 1:
+    return
+  @unknown default: // expected-note {{remove '@unknown' to handle remaining values}}
+    break
+  }
+}
+
+func testReturnBeforeIncompleteUnknownDefault() {
+  switch x { // expected-error {{switch must be exhaustive}}
+  case 1:
+    return
+  @unknown default // expected-error {{expected ':' after 'default'}}
+  // expected-note@-1 {{remove '@unknown' to handle remaining values}}
+  }
+}
+
+func testReturnBeforeIncompleteUnknownDefault2() {
+  switch x { // expected-error {{switch must be exhaustive}} expected-note {{do you want to add a default clause?}}
+  case 1:
+    return
+  @unknown // expected-error {{unknown attribute 'unknown'}}
+  } // expected-error {{expected declaration}}
+}
+
+func testIncompleteArrayLiteral() {
+  switch x { // expected-error {{switch must be exhaustive}}
+  case 1:
+    _ = [1 // expected-error {{expected ']' in container literal expression}} expected-note {{to match this opening '['}}
+  @unknown default: // expected-note {{remove '@unknown' to handle remaining values}}
+    ()
+  }
+}


### PR DESCRIPTION
...allowing a plain `return` to work in a switch in a Void-returning function.

[SR-9920](https://bugs.swift.org/browse/SR-9920)