### PR TITLE
 [Constraint solver] Compute common apply result type in the solver.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -334,7 +334,7 @@ static void recordShadowedDeclsAfterSignatureMatch(
 /// Look through the given set of declarations (that all have the same name),
 /// recording those that are shadowed by another declaration in the
 /// \c shadowed set.
-static void recordShadowDeclsAfterObjCInitMatch(
+static void recordShadowedDeclsForImportedInits(
                                 ArrayRef<ConstructorDecl *> ctors,
                                 llvm::SmallPtrSetImpl<ValueDecl *> &shadowed) {
   assert(ctors.size() > 1 && "No collisions");
@@ -372,18 +372,21 @@ static void recordShadowedDecls(ArrayRef<ValueDecl *> decls,
   llvm::SmallDenseMap<CanType, llvm::TinyPtrVector<ValueDecl *>> collisions;
   llvm::SmallVector<CanType, 2> collisionTypes;
   llvm::SmallDenseMap<NominalTypeDecl *, llvm::TinyPtrVector<ConstructorDecl *>>
-    objCInitializerCollisions;
-  llvm::TinyPtrVector<NominalTypeDecl *> objCInitializerCollisionNominals;
+    importedInitializerCollisions;
+  llvm::TinyPtrVector<NominalTypeDecl *> importedInitializerCollectionTypes;
 
   for (auto decl : decls) {
-    // Specifically keep track of Objective-C initializers, which can come from
-    // either init methods or factory methods.
-    if (decl->hasClangNode()) {
+    // Specifically keep track of imported initializers, which can come from
+    // Objective-C init methods, Objective-C factory methods, renamed C
+    // functions, or be synthesized by the importer.
+    if (decl->hasClangNode() ||
+        (isa<NominalTypeDecl>(decl->getDeclContext()) &&
+         cast<NominalTypeDecl>(decl->getDeclContext())->hasClangNode())) {
       if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
         auto nominal = ctor->getDeclContext()->getSelfNominalTypeDecl();
-        auto &knownInits = objCInitializerCollisions[nominal];
+        auto &knownInits = importedInitializerCollisions[nominal];
         if (knownInits.size() == 1) {
-          objCInitializerCollisionNominals.push_back(nominal);
+          importedInitializerCollectionTypes.push_back(nominal);
         }
         knownInits.push_back(ctor);
       }
@@ -431,9 +434,9 @@ static void recordShadowedDecls(ArrayRef<ValueDecl *> decls,
                                            shadowed);
   }
 
-  // Check whether we have shadowing for Objective-C initializer collisions.
-  for (auto nominal : objCInitializerCollisionNominals) {
-    recordShadowDeclsAfterObjCInitMatch(objCInitializerCollisions[nominal],
+  // Check whether we have shadowing for imported initializer collisions.
+  for (auto nominal : importedInitializerCollectionTypes) {
+    recordShadowedDeclsForImportedInits(importedInitializerCollisions[nominal],
                                         shadowed);
   }
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1123,10 +1123,6 @@ namespace {
       
       if (outputTy.isNull()) {
         outputTy = CS.createTypeVariable(resultLocator, TVO_CanBindToLValue);
-      } else {
-        // TODO: Generalize this for non-subscript-expr anchors, so that e.g.
-        // keypath lookup benefits from the peephole as well.
-        CS.setFavoredType(anchor, outputTy.getPointer());
       }
 
       // FIXME: This can only happen when diagnostics successfully type-checked
@@ -1170,6 +1166,13 @@ namespace {
                        FunctionType::get(params, outputTy),
                        memberTy,
                        fnLocator);
+
+      Type fixedOutputType =
+          CS.getFixedTypeRecursive(outputTy, /*wantRValue=*/false);
+      if (!fixedOutputType->isTypeVariableOrMember()) {
+        CS.setFavoredType(anchor, fixedOutputType.getPointer());
+        outputTy = fixedOutputType;
+      }
 
       return outputTy;
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2516,8 +2516,6 @@ namespace {
     }
 
     Type visitApplyExpr(ApplyExpr *expr) {
-      Type outputTy;
-
       auto fnExpr = expr->getFn();
 
       if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
@@ -2526,65 +2524,9 @@ namespace {
           return resultOfTypeOperation(typeOperation, expr->getArg());
       }
 
-      if (auto fnType = CS.getType(fnExpr)->getAs<AnyFunctionType>()) {
-        outputTy = fnType->getResult();
-      } else if (auto OSR = dyn_cast<OverloadedDeclRefExpr>(fnExpr)) {
-        // Determine if the overloads are all functions that share a common
-        // return type.
-        Type commonType;
-        for (auto OD : OSR->getDecls()) {
-          auto OFD = dyn_cast<AbstractFunctionDecl>(OD);
-          if (!OFD) {
-            commonType = Type();
-            break;
-          }
-
-          auto OFT = OFD->getInterfaceType()->getAs<AnyFunctionType>();
-          if (!OFT) {
-            commonType = Type();
-            break;
-          }
-
-          // Look past the self parameter.
-          if (OFD->getDeclContext()->isTypeContext()) {
-            OFT = OFT->getResult()->getAs<AnyFunctionType>();
-            if (!OFT) {
-              commonType = Type();
-              break;
-            }
-          }
-
-          Type resultType = OFT->getResult();
-
-          // If there are any type parameters in the result,
-          if (resultType->hasTypeParameter()) {
-            commonType = Type();
-            break;
-          }
-
-          if (commonType.isNull()) {
-            commonType = resultType;
-          } else if (!commonType->isEqual(resultType)) {
-            commonType = Type();
-            break;
-          }
-        }
-
-        if (commonType) {
-          outputTy = commonType;
-        }
-      }
-      
-      // The function subexpression has some rvalue type T1 -> T2 for fresh
-      // variables T1 and T2.
-      if (outputTy.isNull()) {
-        outputTy = CS.createTypeVariable(
-            CS.getConstraintLocator(expr, ConstraintLocator::FunctionResult));
-      } else {
-        // Since we know what the output type is, we can set it as the favored
-        // type of this expression.
-        CS.setFavoredType(expr, outputTy.getPointer());
-      }
+      // The result type is a fresh type variable.
+      Type resultType = CS.createTypeVariable(
+          CS.getConstraintLocator(expr, ConstraintLocator::FunctionResult));
 
       // A direct call to a ClosureExpr makes it noescape.
       FunctionType::ExtInfo extInfo;
@@ -2598,11 +2540,20 @@ namespace {
       AnyFunctionType::decomposeInput(CS.getType(expr->getArg()), params);
 
       CS.addConstraint(ConstraintKind::ApplicableFunction,
-                       FunctionType::get(params, outputTy, extInfo),
+                       FunctionType::get(params, resultType, extInfo),
                        CS.getType(expr->getFn()),
         CS.getConstraintLocator(expr, ConstraintLocator::ApplyFunction));
 
-      return outputTy;
+      // If we ended up resolving the result type variable to a concrete type,
+      // set it as the favored type for this expression.
+      Type fixedType =
+          CS.getFixedTypeRecursive(resultType, /*wantRvalue=*/true);
+      if (!fixedType->isTypeVariableOrMember()) {
+        CS.setFavoredType(expr, fixedType.getPointer());
+        resultType = fixedType;
+      }
+
+      return resultType;
     }
 
     Type getSuperType(VarDecl *selfDecl,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4826,6 +4826,15 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   if (auto typeVar = desugar2->getAs<TypeVariableType>()) {
     auto choices = getUnboundBindOverloads(typeVar);
     if (Type resultType = findCommonResultType(choices)) {
+      ASTContext &ctx = getASTContext();
+      if (ctx.LangOpts.DebugConstraintSolver) {
+        auto &log = ctx.TypeCheckerDebug->getStream();
+        log.indent(solverState ? solverState->depth * 2 + 2 : 0)
+          << "(common result type for $T" << typeVar->getID() << " is "
+          << resultType.getString()
+          << ")\n";
+      }
+
       addConstraint(ConstraintKind::Bind, func1->getResult(), resultType,
                     locator);
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1791,7 +1791,7 @@ public:
 }
 
 Type ConstraintSystem::findCommonResultType(ArrayRef<OverloadChoice> choices) {
-  // Local function to consider this s new overload choice, updating the
+  // Local function to consider this new overload choice, updating the
   // "common type". Returns true if this overload cannot be integrated into
   // the common type, at which point there is no "common type".
   Type commonType;
@@ -1842,7 +1842,7 @@ Type ConstraintSystem::findCommonOverloadType(
     ArrayRef<OverloadChoice> choices,
     ArrayRef<OverloadChoice> outerAlternatives,
     ConstraintLocator *locator) {
-  // Local function to consider this s new overload choice, updating the
+  // Local function to consider this new overload choice, updating the
   // "common type". Returns true if this overload cannot be integrated into
   // the common type, at which point there is no "common type".
   Type commonType;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3082,16 +3082,6 @@ private:
 
   Constraint *selectApplyDisjunction();
 
-  bool simplifyForConstraintPropagation();
-  void collectNeighboringBindOverloadDisjunctions(
-      llvm::SetVector<Constraint *> &neighbors);
-  bool isBindOverloadConsistent(Constraint *bindConstraint,
-                                llvm::SetVector<Constraint *> &workList);
-  void reviseBindOverloadDisjunction(Constraint *disjunction,
-                                     llvm::SetVector<Constraint *> &workList,
-                                     bool *foundConsistent);
-  bool areBindPairConsistent(Constraint *first, Constraint *second);
-
   /// Solve the system of constraints generated from provided expression.
   ///
   /// \param expr The expression to generate constraints from.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2326,6 +2326,12 @@ public:
                           const DeclRefExpr *base = nullptr,
                           OpenedTypeMap *replacements = nullptr);
 
+  /// Given a set of overload choices, try to find a common result type when
+  /// they are called.
+  ///
+  /// \returns the common type amongst the set of overload choices.
+  Type findCommonResultType(ArrayRef<OverloadChoice> choices);
+
   /// Given a set of overload choices, try to find a common structure amongst
   /// all of them.
   ///
@@ -3057,6 +3063,20 @@ private:
 
   /// Collect the current inactive disjunction constraints.
   void collectDisjunctions(SmallVectorImpl<Constraint *> &disjunctions);
+
+  // Given a type variable, attempt to find the disjunction of
+  // bind overloads associated with it. This may return null in cases where
+  // the disjunction has either not been created or binds the type variable
+  // in some manner other than by binding overloads.
+  Constraint *getUnboundBindOverloadDisjunction(TypeVariableType *tyvar);
+
+  /// Given a type variable that might represent an overload set, retrieve
+  ///
+  /// \returns the set of overload choices to which this type variable
+  /// could be bound, or an empty vector if the type variable is not
+  /// solely resolved by an overload set.
+  SmallVector<OverloadChoice, 2> getUnboundBindOverloads(
+                                                  TypeVariableType *tyvar);
 
   /// Solve the system of constraints after it has already been
   /// simplified.

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
@@ -14,6 +14,9 @@ extern struct IAMStruct1 IAMStruct1CreateSimple(double value)
 extern struct IAMStruct1 IAMStruct1CreateSpecialLabel(void)
     __attribute__((swift_name("Struct1.init(specialLabel:)")));
 
+extern struct IAMStruct1 IAMStruct1CreateFull(double x, double y, double z)
+    __attribute__((swift_name("Struct1.init(x:y:z:)")));
+
 extern struct IAMStruct1 IAMStruct1Invert(struct IAMStruct1 s)
     __attribute__((swift_name("Struct1.inverted(self:)")));
 

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -5,3 +5,7 @@ import ImportAsMemberSubmodules
 
 let _: IAMSOuter.Inner?
 let _: IAMMultipleNested.Inner? // expected-error {{ambiguous type name 'Inner' in 'IAMMultipleNested'}}
+
+func testCreateShadowing(d: Double) -> Struct1 {
+  return Struct1(x: d, y: d, z: d)
+}

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+struct X {
+  func g(_: Int) -> Int { return 0 }
+  func g(_: Double) -> Int { return 0 }
+
+  subscript(_: Int) -> String { return "" }
+  subscript(_: Double) -> String { return "" }
+}
+
+struct Y {
+  func g(_: Int) -> Double { return 0 }
+  func g(_: Double) -> Double { return 0 }
+
+  subscript(_: Int) -> Substring { return "" }
+  subscript(_: Double) -> Substring { return "" }
+}
+
+func f(_: Int) -> X { return X() }
+func f(_: Double) -> Y { return Y() }
+
+func testCallCommonType() {
+  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK-NEXT: (common result type for $T{{[0-9]+}} is Int)
+  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
+  // CHECK-NEXT: (common result type for $T{{[0-9]+}} is Double)
+  _ = f(0).g(0)
+}
+
+func testSubscriptCommonType() {
+  // FIXME: This will work once we have more filtering of subscripts.
+  // CHECK: subscript_expr
+  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK-NOT: (common result type for $T{{[0-9]+}} is String)
+  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
+  // CHECK-NOT: (common result type for $T{{[0-9]+}} is Substring)
+  _ = f(0)[0]
+}


### PR DESCRIPTION
Constraint generation for function application expressions contains a simple
hack to try to find the common result type for an overload set containing
callable things. Instead, perform this “common result type” computation
when simplifying an applicable function constraint, so it is more
widely applicable.