### PR TITLE
[CSSimplify] Implode parameters into a tuple through a type variable

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -894,12 +894,8 @@ do {
   }
 
   func foo(_ arr: [Int]) {
-    // FIXME: This behavior related to tuple splat being allowed
-    //        in conversion between a single dependent member
-    //        parameter and empty parameter functions e.g.
-    //        () -> Void `convertable to` (T.V) -> Void.
     _ = S(arr, id: \.self_) {
-      // expected-error@-1 {{type '_' has no member 'self_'}}
+      // expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{30-30=_ in }}
       return 42
     }
   }


### PR DESCRIPTION
There are cases where SE-0110 allows tuple splatting behavior,
so to aid diagnostics let's use a new type variable to represent
a tuple type formed from existing arguments instead of imploding
them directly.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
