### PR TITLE
[TF API] Make more Tensor APIs differentiable.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -864,6 +864,7 @@ public func pow<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
 
 /// Computes the power of the scalar to the tensor, broadcasting the scalar.
 @inlinable @inline(__always)
+// @differentiable(where T : TensorFlowFloatingPoint)
 public func pow<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
   where T : FloatingPoint {
   return pow(Tensor(lhs), rhs)
@@ -871,6 +872,7 @@ public func pow<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
 
 /// Computes the power of the tensor to the scalar, broadcasting the scalar.
 @inlinable @inline(__always)
+// @differentiable(where T : TensorFlowFloatingPoint)
 public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
   where T : FloatingPoint {
   return pow(lhs, Tensor(rhs))
@@ -888,6 +890,7 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
 /// Computes the element-wise maximum of the scalar and the tensor, broadcasting
 /// the scalar.
 @inlinable @inline(__always)
+//@differentiable(where T : TensorFlowFloatingPoint)
 public func max<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return max(Tensor(lhs), rhs)
@@ -896,6 +899,7 @@ public func max<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
 /// Computes the element-wise maximum of the scalar and the tensor, broadcasting
 /// the scalar.
 @inlinable @inline(__always)
+// @differentiable(where T : TensorFlowFloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
   where T : Numeric & Comparable {
   return max(lhs, Tensor(rhs))
@@ -913,6 +917,7 @@ public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
 /// Computes the element-wise minimum of the scalar and the tensor, broadcasting
 /// the scalar.
 @inlinable @inline(__always)
+// @differentiable(where T : TensorFlowFloatingPoint)
 public func min<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return min(Tensor(lhs), rhs)
@@ -921,6 +926,7 @@ public func min<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T>
 /// Computes the element-wise minimum of the scalar and the tensor, broadcasting
 /// the scalar.
 @inlinable @inline(__always)
+// @differentiable(where T : TensorFlowFloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
   where T : Numeric & Comparable {
   return min(lhs, Tensor(rhs))
@@ -953,7 +959,7 @@ public extension Tensor where Scalar == Bool {
   /// Returns a new tensor containing elements from either `left` or `right`,
   /// depending on the elements of `self`.
   ///
-  /// `self` acts as a amsk that chooses, based on the value at each scalar,
+  /// `self` acts as a mask that chooses, based on the value at each scalar,
   ///  whether the corresponding scalar in the output should be taken from
   /// `left` (if `true`) or `right` (if `false`).
   ///
@@ -962,30 +968,40 @@ public extension Tensor where Scalar == Bool {
   ///   `left` and `right` have rank greater than or equal to 1, then `self`
   ///   must be either have the same shape as `left` or be a 1-D `Tensor` such
   ///   that `self.scalarCount == left[0]`.
-  @inlinable @inline(__always)
+  @available(*, deprecated, message: "Use '.replacing(with:mask:)' instead")
+  @inlinable
   func selecting<T>(_ left: Tensor<T>, _ right: Tensor<T>) -> Tensor<T> {
-    return Raw.select(condition: self, t: left, e: right)
+    return left.replacing(with: right, where: self)
   }
+}
 
-  // FIXME: "Select" is non-broadcasting: `left` and `right` are required to
-  // have the same shapes. An explicit broadcast must be added.
-  @inlinable @inline(__always)
-  func selecting<T>(_ left: T, _ right: Tensor<T>) -> Tensor<T> {
-    return selecting(Tensor<T>(left), right)
+public extension Tensor {
+  /// Replaces elements of this tensor with `other` in the lanes where `mask` is
+  /// `true`.
+  ///
+  /// - Precondition: `self` and `other` must have the same shape. If
+  ///   `self` and `other` are scalar, then `mask` must also be scalar. If
+  ///   `self` and `other` have rank greater than or equal to `1`, then `mask`
+  ///   must be either have the same shape as `self` or be a 1-D `Tensor` such
+  ///   that `mask.scalarCount == self.shape[0]`.
+  @inlinable
+  @differentiable(wrt: (self, other),
+                  vjp: _vjpReplacing where Scalar : TensorFlowFloatingPoint)
+  func replacing(with other: Tensor,
+                 where mask: Tensor<Bool>) -> Tensor {
+    return Raw.select(condition: mask, t: self, e: other)
   }
+}
 
-  // FIXME: "Select" is non-broadcasting: `left` and `right` are required to
-  // have the same shapes. An explicit broadcast must be added.
-  @inlinable @inline(__always)
-  func selecting<T>(_ left: Tensor<T>, _ right: T) -> Tensor<T> {
-    return selecting(left, Tensor<T>(right))
-  }
-
-  // FIXME: "Select" is non-broadcasting: `left` and `right` are required to
-  // have the same shapes. An explicit broadcast must be added.
-  @inlinable @inline(__always)
-  func selecting<T>(_ left: T, _ right: T) -> Tensor<T> {
-    return selecting(Tensor<T>(left), Tensor<T>(right))
+public extension Tensor where Scalar : TensorFlowFloatingPoint {
+  @inlinable
+  internal func _vjpReplacing(with other: Tensor, where mask: Tensor<Bool>)
+    -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    return (replacing(with: other, where: mask), { v in
+      let zeros = Tensor(zeros: v.shape)
+      return (v.replacing(with: zeros, where: mask),
+              zeros.replacing(with: v, where: mask))
+    })
   }
 }
 

--- a/stdlib/public/TensorFlow/TensorShape.swift
+++ b/stdlib/public/TensorFlow/TensorShape.swift
@@ -46,6 +46,11 @@ public struct TensorShape : ExpressibleByArrayLiteral {
     self.init(elements)
   }
 
+  @inlinable @inline(__always)
+  public init(repeating repeatedValue: Int32, count: Int32) {
+    self.init(Array(repeating: repeatedValue, count: Int(count)))
+  }
+
   /// The rank of the shape.
   @inlinable
   public var rank: Int32 {

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -44,8 +44,7 @@ public func sinking_crash(w1: Tensor<Float>) {
 // This crashed the partitioning pass because the end point of the program was
 // calculated to be inside the loop, but the startpoint was outside.
 public func endpointComputationCrash() {
-  var w1 = Tensor<Float>(shape: [2, 4], repeating: 0.5)
-
+  var w1 = Tensor<Float>(repeating: 0.5, shape: [2, 4])
   for _ in 0..<1000 {
     w1 -= w1
   }
@@ -76,8 +75,8 @@ public func testStraightLineXORTraining() {
   let outputBatch = Tensor<Float>([[0.0], [1.0], [1.0], [0.0]])
 
   // Parameters
-  var w1 = Tensor<Float>(shape: [2, 4], repeating: 0.5)
-  var w2 = Tensor<Float>(shape: [4, 1], repeating: 0.5)
+  var w1 = Tensor<Float>(repeating: 0.5, shape: [2, 4])
+  var w2 = Tensor<Float>(repeating: 0.5, shape: [4, 1])
 
   var b1 = Tensor<Float>(zeros: [1, 4])
   var b2 = Tensor<Float>(zeros: [1, 1])
@@ -130,8 +129,8 @@ func opaqueGenericFunction<T>(_ a : T)
 @inline(never)
 public func sinkTensorToScalarCrash() {
   var loss = Float.infinity
-  let w1 = Tensor<Float>(shape: [4, 1], repeating: 0.1)
-  var w2 = Tensor<Float>(shape: [4, 1], repeating: 0.5)
+  let w1 = Tensor<Float>(repeating: 0.1, shape: [4, 1])
+  var w2 = Tensor<Float>(repeating: 0.5, shape: [4, 1])
 
   for _ in 0...10000 {
     w2 -= w1

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -110,8 +110,8 @@ public func tensorShape() -> Tensor<Float> {
 // initializers.
 public func test75407624() {
   let a = Tensor<Float>([1])
-  let b = Tensor<Float>(shape: [1], repeating: 1)
-  let c = Tensor<Float>(shape: [1], repeating: 1)
+  let b = Tensor<Float>(repeating: 1, shape: [1])
+  let c = Tensor<Float>(repeating: 1, shape: [1])
   let d = Tensor<Float>(shape: [2,2], scalars: [1,2,3,4])
   _ = a+b+c+d
 }

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -16,7 +16,7 @@ public func testSelect(conds1: Tensor<Bool>, x1: Tensor<Float>, y1: Tensor<Float
   let x = x1.toAccelerator()
   let y = y1.toAccelerator()
 
-  let result = conds.selecting(x+x, y)*y
+  let result = (x+x).replacing(with: y, where: conds)*y
 
   return result.toHost()
 }


### PR DESCRIPTION
* Make `init(_:)`, `init(repeating:shape:)` and `selecting(_:_:)` be differentiable.
* Attempted to make the scalar-tensor version of `min(_:_:)`, `max(_:_:)`, etc be differentiable, but it triggered [TF-323](https://bugs.swift.org/browse/TF-323).
* Introduce `replacing(with:where:)` as a replacement for `selecting(_:_:)`, for consistency with the accepted SIMD vectors proposal ([SE-0229](https://github.com/apple/swift-evolution/blob/master/proposals/0229-simd.md)).
* Deprecate `init(shape:repeating:)` in favor of `init(repeating:shape:)` for argument order consistency with `Array.init(repeating:shape:)` and [tf.constant](https://www.tensorflow.org/api_docs/python/tf/constant).
* Introduce `TensorShape.init(repeating:count:)`.
* Remove `eye(rowCount:columnCount:batchShape:)` because its body was never implemented (it was added by @lattner :))!

Note: New VJPs are defined in the same file next to their original function because we are going to switch to this model anyway after retroactive derivative registration is feature-complete.