### PR TITLE
[AutoDiff] Fix AdjointGen type-remapping.

### DIFF
--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -208,4 +208,11 @@ TensorADTests.testAllBackends("GenericWrapperLayer") {
   expectEqual(Wrapper.CotangentVector(layer: 𝛁dense), 𝛁wrapper)
 }
 
+TensorADTests.testAllBackends("TF-324") {
+  @differentiable(where T : TensorFlowFloatingPoint)
+  func TF_324<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> where T : FloatingPoint {
+    return pow(Tensor(lhs), rhs)
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
- Create `AdjointEmitter::getRemappedCotangentType`, which always performs
  type-remapping before looking up associated cotangent types.
  - Remapping before cotangent lookup is necessary because remapping may add
    crucial `Differentiable` conformances to archetype types.
  - Errors due to remapping after cotangent lookup are eliminated.
- Fix "result does not depend on differentiation arguments" warning to check
  variedness based on parameter indices.

Resolves [TF-324](https://bugs.swift.org/projects/TF/issues/TF-324).