### PR TITLE
build: build ICU for XCTest

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -392,6 +392,7 @@ mixin-preset=buildbot_incremental_base
 # Build and test XCTest. On Linux, the build script is aware of the dependency
 # on Foundation, so that is built as well. On OS X, Foundation is built as part
 # of the XCTest Xcode project.
+libicu
 xctest
 
 dash-dash
@@ -401,6 +402,7 @@ dash-dash
 # being run.
 skip-test-cmark
 skip-test-swift
+skip-test-libicu
 skip-test-libdispatch
 skip-test-foundation
 


### PR DESCRIPTION
The XCTest framework uses Foundation which relies on ICU.  Ensure that
we build ICU to have a new enough ICU.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
