### PR TITLE
[AutoDiff] Change tuple types' associated vector types, other fixes.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4137,9 +4137,14 @@ Optional<VectorSpace> TypeBase::getAutoDiffAssociatedVectorSpace(
       auto eltSpace = elt.getType()
           ->getAutoDiffAssociatedVectorSpace(kind, lookupConformance);
       if (!eltSpace)
-        return cache(None);
+        continue;
       newElts.push_back(elt.getWithType(eltSpace->getType()));
     }
+    if (newElts.empty())
+      return cache(
+          VectorSpace::getTuple(ctx.TheEmptyTupleType->castTo<TupleType>()));
+    if (newElts.size() == 1)
+      return cache(VectorSpace::getVector(newElts.front().getType()));
     auto *tupleType = TupleType::get(newElts, ctx)->castTo<TupleType>();
     return cache(VectorSpace::getTuple(tupleType));
   }

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -138,6 +138,41 @@ SimpleMathTests.test("TupleSideEffects") {
   */
 }
 
+// Tests TF-321.
+SimpleMathTests.test("TupleNonDifferentiableElements") {
+  func foo(_ x: Float) -> Float {
+    var tuple = (x, 1)
+    tuple.0 = x
+    tuple.1 = 1
+    return tuple.0
+  }
+  expectEqual(1, gradient(at: 1, in: foo))
+
+  func bar(_ x: Float) -> Float {
+    var tuple: (Int, Int, Float, Float) = (1, 1, x, x)
+    tuple.0 = 1
+    tuple.1 = 1
+    tuple.3 = x
+    return tuple.3
+  }
+  expectEqual(1, gradient(at: 1, in: bar))
+
+  struct Wrapper<T> {
+    @differentiable(where T : Differentiable)
+    func baz(_ x: T) -> T {
+      var tuple = (1, 1, x, 1)
+      tuple.0 = 1
+      tuple.2 = x
+      tuple.3 = 1
+      return tuple.2
+    }
+  }
+  expectEqual(1, gradient(at: Float(1), in: { x -> Float in
+    let wrapper = Wrapper<Float>()
+    return wrapper.baz(x)
+  }))
+}
+
 // Tests TF-21.
 SimpleMathTests.test("StructMemberwiseInitializer") {
   struct Foo : AdditiveArithmetic, Differentiable {

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -208,11 +208,4 @@ TensorADTests.testAllBackends("GenericWrapperLayer") {
   expectEqual(Wrapper.CotangentVector(layer: 𝛁dense), 𝛁wrapper)
 }
 
-TensorADTests.testAllBackends("TF-324") {
-  @differentiable(where T : TensorFlowFloatingPoint)
-  func TF_324<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> where T : FloatingPoint {
-    return pow(Tensor(lhs), rhs)
-  }
-}
-
 runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect_crasher.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect_crasher.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-eager-swift
+//
+// Note: GPE testing is disabled because GPE does not interact well with
+// VJP-based AD. See SR-9638.
+//
+// REQUIRES: executable_test
+//
+// FIXME(TF-326): Re-enable `-O` after deserialization failure fix.
+// UNSUPPORTED: swift_test_mode_optimize
+//
+// Tensor indirect passing AD runtime tests.
+
+import TensorFlow
+import StdlibUnittest
+import TensorFlowUnittest
+
+var TensorADTests = TestSuite("TensorIndirectAD")
+
+TensorADTests.testAllBackends("TF-324") {
+  @differentiable(where T : TensorFlowFloatingPoint)
+  func TF_324<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> where T : FloatingPoint {
+    return pow(Tensor(lhs), rhs)
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
- Change associated vector type for tuple types to be a corresponding
  tuple type of element associated vector types, excluding all
  non-differentiable elements.
  - Handle new tuple associated vector types in various visitors.
- Store associated function generic signature in `DifferentiableActivityInfo`
  to check `tuple_element_addr` differentiability.
  - Add `DifferentiableActivityCollection`, which maps associated function
    generic signatures to `DifferentiableActivityInfo`.
- In `@differentiable` type-checking, check whether parameters/results
  conform to `Differentiable` instead of looking up their associated vector
  spaces. Otherwise, tuples with non-differentiable elements are wrongly
  inferred as differentiation parameters.

Resolves [TF-321](https://bugs.swift.org/browse/TF-321).
Exposes [TF-326](https://bugs.swift.org/browse/TF-326): deserialization crash with `-O` for `Tensor` initializer VJPs.