### PR TITLE
Fix Response Files on Windows

### DIFF
--- a/test/Driver/response-file-merge-modules.swift
+++ b/test/Driver/response-file-merge-modules.swift
@@ -2,11 +2,11 @@
 // RUN: %swiftc_driver -driver-print-jobs -module-name merge -emit-module %S/Inputs/main.swift %S/Inputs/lib.swift @%t.resp 2>&1 > %t.jobs.txt
 // RUN: %FileCheck %s < %t.jobs.txt -check-prefix=MERGE
 
-// MERGE: bin/swift{{c?}}
-// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -emit-module -primary-file {{[^ ]+}}/Inputs/main.swift {{[^ ]+}}/Inputs/lib.swift
-// MERGE: -emit-module-doc-path [[PARTIAL_MODULE_A:[^ ]+]].swiftdoc
-// MERGE: bin/swift{{c?}}
-// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -emit-module {{[^ ]+}}/Inputs/main.swift -primary-file {{[^ ]+}}/Inputs/lib.swift
-// MERGE: -emit-module-doc-path [[PARTIAL_MODULE_B:[^ ]+]].swiftdoc
-// MERGE: bin/swift{{c?}}
-// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -merge-modules -emit-module [[PARTIAL_MODULE_A]].swiftmodule [[PARTIAL_MODULE_B]].swiftmodule
+// MERGE: bin{{/|\\\\}}swift{{c?}}
+// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp{{"?}} # -frontend -emit-module -primary-file {{[^ ]+}}/Inputs/main.swift{{"?}} {{[^ ]+}}/Inputs/lib.swift
+// MERGE: -emit-module-doc-path {{"?}}[[PARTIAL_MODULE_A:[^ ]+]].swiftdoc
+// MERGE: bin{{/|\\\\}}swift{{c?}}
+// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp{{"?}} # -frontend -emit-module {{[^ ]+}}/Inputs/main.swift{{"?}} -primary-file {{[^ ]+}}/Inputs/lib.swift
+// MERGE: -emit-module-doc-path {{"?}}[[PARTIAL_MODULE_B:[^ ]+]].swiftdoc
+// MERGE: bin{{/|\\\\}}swift{{c?}}
+// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp{{"?}} # -frontend -merge-modules -emit-module {{"?}}[[PARTIAL_MODULE_A]].swiftmodule{{"?}} {{"?}}[[PARTIAL_MODULE_B]].swiftmodule

--- a/test/Driver/response-file.swift
+++ b/test/Driver/response-file.swift
@@ -28,12 +28,13 @@
 // RUN: %target-build-swift -typecheck @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=LONG
 // LONG: warning: result of call to 'abs' is unused
 // RUN: %empty-directory(%t/tmp)
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver %s @%t.5.resp -save-temps -o %t/main
-// RUN: ls %t/tmp/arguments-*.resp
+// RUN: env TMPDIR=%t/tmp/ TMP=%t/tmp/ %target-swiftc_driver %s @%t.5.resp -save-temps -o %t/main
+// RUN: ls %t/tmp | grep arguments.*resp
 // RUN: %target-build-swift -typecheck -v @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=VERBOSE
-// VERBOSE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -typecheck -primary-file
-// RUN: not %target-swiftc_driver %s @%t.5.resp -Xfrontend -debug-crash-immediately 2>&1 | %FileCheck %s -check-prefix=CRASH
-// CRASH: Program arguments: {{[^ ]*}}swift -frontend -c -primary-file
+// VERBOSE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp{{"?}} # -frontend -typecheck -primary-file
+// RUN: not %target-swiftc_driver %s @%t.5.resp -Xfrontend -debug-crash-immediately 2>&1 | %FileCheck %s -check-prefix=TRACE
+// TRACE: Program arguments: {{[^ ]*}}swift{{c?(\.EXE)?}} -frontend -c -primary-file
+
 
 #if TEST0
 abs(-5)

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -29,6 +29,7 @@
 #include "swift/FrontendTool/FrontendTool.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Errno.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"
@@ -44,6 +45,10 @@
 
 #include <memory>
 #include <stdlib.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 using namespace swift;
 using namespace swift::driver;
@@ -174,6 +179,26 @@ static int run_driver(StringRef ExecName,
 }
 
 int main(int argc_, const char **argv_) {
+#if defined(_WIN32)
+  LPWSTR *wargv_ = CommandLineToArgvW(GetCommandLineW(), &argc_);
+  std::vector<std::string> utf8Args;
+  // We use UTF-8 as the internal character encoding. On Windows,
+  // arguments passed to wmain are encoded in UTF-16
+  for (int i = 0; i < argc_; i++) {
+    const wchar_t *wideArg = wargv_[i];
+    int wideArgLen = std::wcslen(wideArg);
+    utf8Args.push_back("");
+    llvm::ArrayRef<char> uRef((const char *)wideArg,
+                              (const char *)(wideArg + wideArgLen));
+    llvm::convertUTF16ToUTF8String(uRef, utf8Args[i]);
+  }
+
+  std::vector<const char *> utf8CStrs;
+  std::transform(utf8Args.begin(), utf8Args.end(),
+                 std::back_inserter(utf8CStrs),
+                 std::mem_fn(&std::string::c_str));
+  argv_ = utf8CStrs.data();
+#endif
   // Expand any response files in the command line argument vector - arguments
   // may be passed through response files in the event of command line length
   // restrictions.
@@ -182,17 +207,22 @@ int main(int argc_, const char **argv_) {
   llvm::StringSaver Saver(Allocator);
   llvm::cl::ExpandResponseFiles(
       Saver,
-      llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows() ?
-      llvm::cl::TokenizeWindowsCommandLine :
-      llvm::cl::TokenizeGNUCommandLine,
+      llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()
+          ? llvm::cl::TokenizeWindowsCommandLine
+          : llvm::cl::TokenizeGNUCommandLine,
       ExpandedArgs);
 
   // Initialize the stack trace using the parsed argument vector with expanded
   // response files.
-  int ExpandedArgc = ExpandedArgs.size();
-  const char **ExpandedArgv = ExpandedArgs.data();
-  PROGRAM_START(ExpandedArgc, ExpandedArgv);
-  ArrayRef<const char *> argv(ExpandedArgv, ExpandedArgc);
+
+  // PROGRAM_START/InitLLVM overwrites the passed in arguments with UTF-8
+  // versions of them on Windows. This also has the effect of overwriting the
+  // response file expansion. Since we handle the UTF-8 conversion above, we
+  // pass in a copy and throw away the modifications.
+  int ThrowawayExpandedArgc = ExpandedArgs.size();
+  const char **ThrowawayExpandedArgv = ExpandedArgs.data();
+  PROGRAM_START(ThrowawayExpandedArgc, ThrowawayExpandedArgv);
+  ArrayRef<const char *> argv(ExpandedArgs);
 
   // Check if this invocation should execute a subcommand.
   StringRef ExecName = llvm::sys::path::stem(argv[0]);


### PR DESCRIPTION
This prevents response files on Windows from being overridden after they
are read.

Note that this is https://github.com/apple/swift/pull/20885 but without the unicode changes. The [patch upstream](https://reviews.llvm.org/D56754) has been taking a while and response files would help a lot with building Foundation on Windows.