### PR TITLE
[benchmark] Janitor Duty: Sweep IV

### DIFF
--- a/benchmark/single-source/ArrayInClass.swift
+++ b/benchmark/single-source/ArrayInClass.swift
@@ -17,11 +17,12 @@ public let ArrayInClass = [
     runFunction: run_ArrayInClass,
     tags: [.validation, .api, .Array],
     setUpFunction: { ac = ArrayContainer() },
-    tearDownFunction: { ac = nil }),
+    tearDownFunction: { ac = nil },
+    legacyFactor: 5),
   BenchmarkInfo(name: "DistinctClassFieldAccesses",
     runFunction: run_DistinctClassFieldAccesses,
-    tags: [.unstable, .api, .Array],
-    setUpFunction: { workload = ClassWithArrs(N: 100_000) },
+    tags: [.validation, .api, .Array],
+    setUpFunction: { workload = ClassWithArrs(N: 10_000) },
     tearDownFunction: { workload = nil }),
 ]
 
@@ -31,7 +32,7 @@ class ArrayContainer {
   final var arr : [Int]
 
   init() {
-    arr = [Int] (repeating: 0, count: 100_000)
+    arr = [Int] (repeating: 0, count: 20_000)
   }
 
   func runLoop(_ N: Int) {

--- a/benchmark/single-source/DictionaryOfAnyHashableStrings.swift
+++ b/benchmark/single-source/DictionaryOfAnyHashableStrings.swift
@@ -21,18 +21,15 @@ public var DictionaryOfAnyHashableStrings = [
     name: "DictionaryOfAnyHashableStrings_insert",
     runFunction: run_DictionaryOfAnyHashableStrings_insert,
     tags: [.abstraction, .runtime, .cpubench],
-    setUpFunction: {
-      keys = buildKeys(500)
-    }
+    setUpFunction: { keys = buildKeys(50) },
+    legacyFactor: 14
   ),
   BenchmarkInfo(
     name: "DictionaryOfAnyHashableStrings_lookup",
     runFunction: run_DictionaryOfAnyHashableStrings_lookup,
     tags: [.abstraction, .runtime, .cpubench],
-    setUpFunction: {
-      keys = buildKeys(500)
-      workload = buildWorkload()
-    }
+    setUpFunction: { keys = buildKeys(50); workload = buildWorkload() },
+    legacyFactor: 24
   ),
 ]
 
@@ -65,7 +62,7 @@ func buildWorkload() -> [AnyHashable: Any] {
 @inline(never)
 public func run_DictionaryOfAnyHashableStrings_insert(_ n: Int) {
   precondition(keys.count > 0)
-  for _ in 0 ... n {
+  for _ in 1...n {
     blackHole(buildWorkload())
   }
 }
@@ -74,7 +71,7 @@ public func run_DictionaryOfAnyHashableStrings_insert(_ n: Int) {
 public func run_DictionaryOfAnyHashableStrings_lookup(_ n: Int) {
   precondition(workload.count > 0)
   precondition(keys.count > 0)
-  for _ in 0 ... n {
+  for _ in 1...n {
     for i in 0 ..< keys.count {
       let key = keys[i]
       CheckResults((workload[key] as! Int) == i)

--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -31,6 +31,8 @@ public let SubstringTest = [
 
 // A string that doesn't fit in small string storage and doesn't fit in Latin-1
 let longWide = "fὢasὢodὢijὢadὢolὢsjὢalὢsdὢjlὢasὢdfὢijὢliὢsdὢjøὢslὢdiὢalὢiὢ"
+let (s1, ss1) = equivalentWithDistinctBuffers()
+let (s2, ss2) = equivalentWithDistinctBuffers()
 
 @inline(never)
 public func run_SubstringFromLongString(_ N: Int) {
@@ -89,7 +91,7 @@ private func equivalentWithDistinctBuffers() -> (String, Substring) {
 
 @inline(never)
 public func run_EqualStringSubstring(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     blackHole(a == b)
   }
@@ -97,7 +99,7 @@ public func run_EqualStringSubstring(_ N: Int) {
 
 @inline(never)
 public func run_EqualSubstringString(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     blackHole(b == a)
   }
@@ -105,8 +107,8 @@ public func run_EqualSubstringString(_ N: Int) {
 
 @inline(never)
 public func run_EqualSubstringSubstring(_ N: Int) {
-  let (_, a) = equivalentWithDistinctBuffers()
-  let (_, b) = equivalentWithDistinctBuffers()
+  let (_, a) = (s1, ss1)
+  let (_, b) = (s2, ss2)
   for _ in 1...N*500 {
     blackHole(a == b)
   }
@@ -114,8 +116,8 @@ public func run_EqualSubstringSubstring(_ N: Int) {
 
 @inline(never)
 public func run_EqualSubstringSubstringGenericEquatable(_ N: Int) {
-  let (_, a) = equivalentWithDistinctBuffers()
-  let (_, b) = equivalentWithDistinctBuffers()
+  let (_, a) = (s1, ss1)
+  let (_, b) = (s2, ss2)
   func check<T>(_ x: T, _ y: T) where T : Equatable {
     blackHole(x == y)
   }
@@ -132,7 +134,7 @@ where T : StringProtocol, U : StringProtocol {
 
 @inline(never)
 public func run _EqualStringSubstringGenericStringProtocol(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     checkEqual(a, b)
   }
@@ -140,7 +142,7 @@ public func run _EqualStringSubstringGenericStringProtocol(_ N: Int) {
 
 @inline(never)
 public func run _EqualSubstringStringGenericStringProtocol(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     checkEqual(b, a)
   }
@@ -148,8 +150,8 @@ public func run _EqualSubstringStringGenericStringProtocol(_ N: Int) {
 
 @inline(never)
 public func run _EqualSubstringSubstringGenericStringProtocol(_ N: Int) {
-  let (_, a) = equivalentWithDistinctBuffers()
-  let (_, b) = equivalentWithDistinctBuffers()
+  let (_, a) = (s1, ss1)
+  let (_, b) = (s2, ss2)
   for _ in 1...N*500 {
     checkEqual(a, b)
   }
@@ -161,7 +163,7 @@ public func run _EqualSubstringSubstringGenericStringProtocol(_ N: Int) {
 /*
 @inline(never)
 public func run _LessStringSubstring(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     blackHole(a < b)
   }
@@ -169,7 +171,7 @@ public func run _LessStringSubstring(_ N: Int) {
 
 @inline(never)
 public func run _LessSubstringString(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     blackHole(b < a)
   }
@@ -178,8 +180,8 @@ public func run _LessSubstringString(_ N: Int) {
 
 @inline(never)
 public func run_LessSubstringSubstring(_ N: Int) {
-  let (_, a) = equivalentWithDistinctBuffers()
-  let (_, b) = equivalentWithDistinctBuffers()
+  let (_, a) = (s1, ss1)
+  let (_, b) = (s2, ss2)
   for _ in 1...N*500 {
     blackHole(a < b)
   }
@@ -187,8 +189,8 @@ public func run_LessSubstringSubstring(_ N: Int) {
 
 @inline(never)
 public func run_LessSubstringSubstringGenericComparable(_ N: Int) {
-  let (_, a) = equivalentWithDistinctBuffers()
-  let (_, b) = equivalentWithDistinctBuffers()
+  let (_, a) = (s1, ss1)
+  let (_, b) = (s2, ss2)
   func check<T>(_ x: T, _ y: T) where T : Comparable {
     blackHole(x < y)
   }
@@ -251,7 +253,7 @@ where T : StringProtocol, U : StringProtocol {
 
 @inline(never)
 public func run _LessStringSubstringGenericStringProtocol(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     checkLess(a, b)
   }
@@ -259,7 +261,7 @@ public func run _LessStringSubstringGenericStringProtocol(_ N: Int) {
 
 @inline(never)
 public func run _LessSubstringStringGenericStringProtocol(_ N: Int) {
-  let (a, b) = equivalentWithDistinctBuffers()
+  let (a, b) = (s1, ss1)
   for _ in 1...N*500 {
     checkLess(b, a)
   }
@@ -267,8 +269,8 @@ public func run _LessSubstringStringGenericStringProtocol(_ N: Int) {
 
 @inline(never)
 public func run _LessSubstringSubstringGenericStringProtocol(_ N: Int) {
-  let (_, a) = equivalentWithDistinctBuffers()
-  let (_, b) = equivalentWithDistinctBuffers()
+  let (_, a) = (s1, ss1)
+  let (_, b) = (s2, ss2)
   for _ in 1...N*500 {
     checkLess(a, b)
   }


### PR DESCRIPTION
More benchmark cleanup:

* Adjust workload, apply legacyFactor and fix the extra loop of the workload causing the measurable setup overhead in `DictionaryOfAnyHashableStrings` benchmarks.
* Legacy factor for `ArrayInClass`.
* Enable previously skipped `DistinctClassFieldAccesses`.
* Remove setup overhead from `[Less,Equal]Substring` benchmarks.