### PR TITLE
[test] Add proper search paths for XCTest in verify_all_overlays.py

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1339,6 +1339,10 @@ else:
 config.substitutions.insert(0, ('%platform-module-dir', platform_module_dir))
 config.substitutions.insert(0, ('%platform-sdk-overlay-dir', platform_sdk_overlay_dir))
 
+if run_vendor != 'apple':
+    extra_frameworks_dir = ''
+config.substitutions.append(('%xcode-extra-frameworks-dir', extra_frameworks_dir))
+
 config.substitutions.append(('%target-swiftmodule-name', run_cpu + '.swiftmodule'))
 config.substitutions.append(('%target-swiftdoc-name', run_cpu + '.swiftdoc'))
 

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python
 # RUN: ${python} %s %target-swiftmodule-name %platform-sdk-overlay-dir \
-# RUN:              %target-sil-opt -sdk %sdk -enable-sil-verify-all
+# RUN:              %target-sil-opt -sdk %sdk -enable-sil-verify-all \
+# RUN:                              -F "%xcode-extra-frameworks-dir"
 
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test
 
-# XFAIL: OS=macosx || OS=ios || OS=tvos
+# XFAIL: OS=macosx
 # https://bugs.swift.org/browse/SR-9847
 
 from __future__ import print_function
@@ -22,6 +23,7 @@ for module_file in os.listdir(sdk_overlay_dir):
     module_name, ext = os.path.splitext(module_file)
     if ext != ".swiftmodule":
         continue
+    # Skip the standard library because it's tested elsewhere.
     if module_name == "Swift":
         continue
     print("# " + module_name)


### PR DESCRIPTION
This turns out to be the only problem on iOS and tvOS. Oops! macOS still has some actual failing overlays as tracked by [SR-9847](https://bugs.swift.org/browse/SR-9847).

(We should also add this search path to ParseableInterface/verify_all_overlays.py.)

rdar://problem/48458622