### PR TITLE
SimplifyCFG: Simplify switch_enum on optional classes used by objc method calls

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -192,6 +192,7 @@ namespace {
     bool simplifyArgument(SILBasicBlock *BB, unsigned i);
     bool simplifyArgs(SILBasicBlock *BB);
     void findLoopHeaders();
+    bool simplifySwitchEnumOnObjcClassOptional(SwitchEnumInst *SEI);
   };
 
 } // end anonymous namespace
@@ -1731,6 +1732,212 @@ bool SimplifyCFG::simplifySwitchEnumUnreachableBlocks(SwitchEnumInst *SEI) {
   return true;
 }
 
+/// Checks that the someBB only contains obj_method calls (possibly chained) on
+/// the optional value.
+///
+/// switch_enum %optionalValue, case #Optional.some!enumelt.1: someBB
+///
+/// someBB(%optionalPayload):
+///    %1 = objc_method %optionalPayload
+///    %2 = apply %1(..., %optionalPayload) // self position
+///    %3 = unchecked_ref_cast %2
+///    %4 = objc_method %3
+///    %... = apply %4(..., %3)
+///    br mergeBB(%...)
+static bool containsOnlyObjMethodCallOnOptional(SILValue optionalValue,
+                                                SILBasicBlock *someBB,
+                                                SILValue &outBranchArg,
+                                                SILValue &outOptionalPayload) {
+  SILValue optionalPayload;
+  SmallVector<SILValue, 4> optionalPayloads;
+  if (someBB->getNumArguments() == 1) {
+    optionalPayload = someBB->getArgument(0);
+    optionalPayloads.push_back(optionalPayload);
+  } else if (someBB->getNumArguments() != 0)
+    return false;
+
+  SmallVector<SILValue, 4> objCApplies;
+  for (auto &i : *someBB) {
+    SILInstruction *inst = &i;
+    if (onlyAffectsRefCount(inst))
+      continue;
+    if (inst->isDebugInstruction())
+      continue;
+    // An objc_method has no sideffects.
+    if (isa<ObjCMethodInst>(inst))
+      continue;
+
+    // An uncheckedEnumData has no sideeffects.
+    if (auto *uncheckedEnumData = dyn_cast<UncheckedEnumDataInst>(inst)) {
+      if (uncheckedEnumData->getOperand() != optionalValue)
+        continue;
+      optionalPayload = uncheckedEnumData;
+      optionalPayloads.push_back(uncheckedEnumData);
+      continue;
+    }
+
+    // An unchecked_ref_cast is safe.
+    if (auto *refCast = dyn_cast<UncheckedRefCastInst>(inst)) {
+      // An unchecked_ref_cast on a safe objc_method apply behaves like the
+      // optional (it is null if the optional was null).
+      if (refCast->getType().getClassOrBoundGenericClass() &&
+          std::find(objCApplies.begin(), objCApplies.end(),
+                    refCast->getOperand()) != objCApplies.end())
+        optionalPayloads.push_back(refCast);
+      continue;
+    }
+
+    // Applies on objc_methods where self is either the optional payload or the
+    // result of another 'safe' apply are safe.
+    if (auto *objcMethod = dyn_cast<ApplyInst>(inst)) {
+      if (!isa<ObjCMethodInst>(objcMethod->getCallee()))
+        return false;
+      if (std::find(optionalPayloads.begin(), optionalPayloads.end(),
+                    objcMethod->getSelfArgument()) == optionalPayloads.end())
+        return false;
+      objCApplies.push_back(objcMethod);
+      continue;
+    }
+
+    // The branch should forward one of the objc_method call.
+    if (auto *br = dyn_cast<BranchInst>(inst)) {
+      if (br->getNumArgs() == 0 || br->getNumArgs() > 1)
+        return false;
+      auto branchArg = br->getArg(0);
+      if (std::find(objCApplies.begin(), objCApplies.end(), branchArg) ==
+          objCApplies.end())
+        return false;
+      outBranchArg = branchArg;
+      continue;
+    }
+    // Unexpected instruction.
+    return false;
+  }
+  if (!optionalPayload)
+    return false;
+  outOptionalPayload = optionalPayload;
+  return true;
+}
+
+/// Check that all that noneBB does is forwarding none.
+/// The only other allowed operation are ref count operations.
+static bool onlyForwardsNone(SILBasicBlock *noneBB, SILBasicBlock *someBB,
+                             SwitchEnumInst *SEI) {
+  // It all the basic blocks leading up to the ultimate block we only expect
+  // reference count instructions.
+  while (noneBB->getSingleSuccessorBlock() != someBB->getSingleSuccessorBlock()) {
+    for (auto &i : *noneBB) {
+      auto *inst = &i;
+      if (isa<BranchInst>(inst) || onlyAffectsRefCount(inst) ||
+          inst->isDebugInstruction())
+        continue;
+      return false;
+    }
+    noneBB = noneBB->getSingleSuccessorBlock();
+  }
+  // The ultimate block forwards the Optional<...>.none value.
+  SILValue optionalNone;
+  for (auto &i : *noneBB) {
+    auto *inst = &i;
+    if (onlyAffectsRefCount(inst) || inst->isDebugInstruction())
+      continue;
+    if (auto *none = dyn_cast<EnumInst>(inst)) {
+      if (none->getElement() !=
+          SEI->getModule().getASTContext().getOptionalNoneDecl())
+        return false;
+      optionalNone = none;
+      continue;
+    }
+    if (auto *noneBranch = dyn_cast<BranchInst>(inst)) {
+      if (noneBranch->getNumArgs() != 1 ||
+          (noneBranch->getArg(0) != SEI->getOperand() &&
+           noneBranch->getArg(0) != optionalNone))
+        return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+/// Check whether \p noneBB has the same ultimate successor as the successor to someBB.
+///  someBB       noneBB
+///   \             |
+///    \            ... (more bbs?)
+///     \           /
+///       ulimateBB
+static bool hasSameUlitmateSuccessor(SILBasicBlock *noneBB, SILBasicBlock *someBB) {
+  auto *someSuccessorBB = someBB->getSingleSuccessorBlock();
+  if (!someSuccessorBB)
+    return false;
+  auto *noneSuccessorBB = noneBB->getSingleSuccessorBlock();
+  while (noneSuccessorBB != nullptr && noneSuccessorBB != someSuccessorBB)
+    noneSuccessorBB = noneSuccessorBB->getSingleSuccessorBlock();
+  return noneSuccessorBB == someSuccessorBB;
+}
+
+/// Simplify switch_enums on class enums that branch to objc_method calls on
+/// that optional on the #Optional.some side to always branch to the some side.
+///
+/// switch_enum %optionalValue, case #Optional.some!enumelt.1: someBB,
+///                             case #Optional.none: noneBB
+///
+/// someBB(%optionalPayload):
+///    %1 = objc_method %optionalPayload
+///    %2 = apply %1(..., %optionalPayload) // self position
+///    br mergeBB(%2)
+///
+/// noneBB:
+///    %4 = enum #Optional.none
+///    br mergeBB(%4)
+bool SimplifyCFG::simplifySwitchEnumOnObjcClassOptional(SwitchEnumInst *SEI) {
+  auto optional = SEI->getOperand();
+  auto optionalPayloadType = optional->getType().getOptionalObjectType();
+  if (!optionalPayloadType ||
+      !optionalPayloadType.getClassOrBoundGenericClass())
+    return false;
+
+  if (SEI->getNumCases() != 2)
+    return false;
+
+  auto *noneBB = SEI->getCase(0).second;
+  auto *someBB = SEI->getCase(1).second;
+  if (noneBB == someBB)
+    return false;
+  auto someDecl = SEI->getModule().getASTContext().getOptionalSomeDecl();
+  if (SEI->getCaseDestination(someDecl) != someBB)
+    std::swap(someBB, noneBB);
+
+  if (!hasSameUlitmateSuccessor(noneBB, someBB))
+    return false;
+
+  if (!onlyForwardsNone(noneBB, someBB, SEI))
+    return false;
+
+  SILValue branchArg;
+  SILValue optionalPayload;
+  if (!containsOnlyObjMethodCallOnOptional(optional, someBB, branchArg,
+                                           optionalPayload))
+    return false;
+
+  SILBuilderWithScope Builder(SEI);
+  auto *payloadCast = Builder.createUncheckedRefCast(SEI->getLoc(), optional,
+                                                     optionalPayloadType);
+  optionalPayload->replaceAllUsesWith(payloadCast);
+  auto *switchBB = SEI->getParent();
+  if (someBB->getNumArguments())
+    Builder.createBranch(SEI->getLoc(), someBB, SILValue(payloadCast));
+  else
+    Builder.createBranch(SEI->getLoc(), someBB);
+
+  SEI->eraseFromParent();
+  addToWorklist(switchBB);
+  simplifyAfterDroppingPredecessor(noneBB);
+  addToWorklist(someBB);
+  ++NumConstantFolded;
+  return true;
+}
+
 /// simplifySwitchEnumBlock - Simplify a basic block that ends with a
 /// switch_enum instruction that gets its operand from an enum
 /// instruction.
@@ -2316,7 +2523,9 @@ bool SimplifyCFG::simplifyBlocks() {
     case TermKind::SwitchEnumInst: {
       auto *SEI = cast<SwitchEnumInst>(TI);
       if (simplifySwitchEnumBlock(SEI)) {
-        Changed = false;
+        Changed = true;
+      } else if (simplifySwitchEnumOnObjcClassOptional(SEI)) {
+        Changed = true;
       } else {
         Changed |= simplifySwitchEnumUnreachableBlocks(SEI);
       }

--- a/test/SILOptimizer/Inputs/objc_optional.h
+++ b/test/SILOptimizer/Inputs/objc_optional.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface Test : NSObject
+  @property (nullable) Test *otherTest;
+@end

--- a/test/SILOptimizer/simplify_switch_enum_objc.sil
+++ b/test/SILOptimizer/simplify_switch_enum_objc.sil
@@ -1,4 +1,7 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+
+// REQUIRES: objc_interop
+
 import Swift
 import Foundation
 

--- a/test/SILOptimizer/simplify_switch_enum_objc.sil
+++ b/test/SILOptimizer/simplify_switch_enum_objc.sil
@@ -1,0 +1,380 @@
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+import Swift
+import Foundation
+
+class Test : NSObject {
+  @objc var other : Test? { get set }
+}
+
+
+// CHECK-LABEL: sil hidden @one_call : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Optional<Test>, [[ARG1:%.*]] : $Optional<Test>):
+// CHECK:   switch_enum [[ARG0]] : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb3
+// CHECK: bb1([[ARG0_PAYLOAD:%.*]] : $Test):
+// CHECK:   [[ARG1_PAYLOAD:%.*]] = unchecked_ref_cast [[ARG1]] : $Optional<Test> to $Test
+// CHECK:   [[GETTER:%.*]] = objc_method [[ARG1_PAYLOAD]] : $Test, #Test.other!getter.1.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[GETTER]]([[ARG1_PAYLOAD]])
+// CHECK:   [[SETTER:%.*]] = objc_method [[ARG0_PAYLOAD]] : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+// CHECK:   apply [[SETTER]]([[RESULT]], [[ARG0_PAYLOAD]])
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb2
+// CHECK: }
+
+sil hidden @one_call : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @one_call2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Optional<Test>, [[ARG1:%.*]] : $Optional<Test>):
+// CHECK:   switch_enum [[ARG0]] : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb3
+// CHECK: bb1([[ARG0_PAYLOAD:%.*]] : $Test):
+// CHECK:   [[ARG1_PAYLOAD:%.*]] = unchecked_ref_cast [[ARG1]] : $Optional<Test> to $Test
+// CHECK:   [[GETTER:%.*]] = objc_method [[ARG1_PAYLOAD]] : $Test, #Test.other!getter.1.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[GETTER]]([[ARG1_PAYLOAD]])
+// CHECK:   [[SETTER:%.*]] = objc_method [[ARG0_PAYLOAD]] : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+// CHECK:   apply [[SETTER]]([[RESULT]], [[ARG0_PAYLOAD]])
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb2
+// CHECK: }
+
+sil hidden @one_call2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2:
+  %9 = unchecked_enum_data %1 : $Optional<Test>, #Optional.some!enumelt.1
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+sil @some_sideeffect : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil hidden @sideeffect
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @sideeffect : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  %12 = function_ref @some_sideeffect : $@convention(thin) () -> ()
+  apply %12() : $@convention(thin) () -> ()
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @sideeffect2
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @sideeffect2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %12 = function_ref @some_sideeffect : $@convention(thin) () -> ()
+  apply %12() : $@convention(thin) () -> ()
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @not_on_optional
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @not_on_optional : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%6) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @forwards_wrong_value
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @forwards_wrong_value : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%0 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @forwards_wrong_value2
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @forwards_wrong_value2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  br bb3(%0 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @two_chained_calls
+// CHECK: bb0([[ARG0:%.*]] : $Optional<Test>, [[ARG1:%.*]] : $Optional<Test>):
+// CHECK: switch_enum [[ARG0]]
+// CHECK: bb1([[ARG0_PAYLOAD:%.*]] : $Test):
+// CHECK:   [[PAYLOAD:%.*]] = unchecked_ref_cast [[ARG1]]
+// CHECK:   [[METH:%.*]] = objc_method [[PAYLOAD]] : $Test, #Test.other!getter.1.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[METH]]([[PAYLOAD]])
+// CHECK:   [[PAYLOAD2:%.*]] = unchecked_ref_cast [[RESULT]]
+// CHECK:   [[METH2:%.*]] = objc_method [[PAYLOAD2]] : $Test, #Test.other!getter.1.foreign
+// CHECK:   [[RESULT2:%.*]] = apply [[METH2]]([[PAYLOAD2]])
+// CHECK:   [[SETTER:%.*]] = objc_method [[ARG0_PAYLOAD]] : $Test, #Test.other!setter.1.foreign
+// CHECK:   apply [[SETTER]]([[RESULT2]], [[ARG0_PAYLOAD]]) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb2
+// CHECK: }
+
+sil hidden @two_chained_calls : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb9
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt.1: bb3, case #Optional.none!enumelt: bb2
+
+bb2:
+  br bb8
+
+bb3(%10 : $Test):
+  %11 = objc_method %10 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %12 = apply %11(%10) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  switch_enum %12 : $Optional<Test>, case #Optional.none!enumelt: bb4, case #Optional.some!enumelt.1: bb5
+
+bb4:
+  release_value %12 : $Optional<Test>
+  strong_release %10 : $Test
+  br bb8
+
+bb5:
+  %17 = unchecked_enum_data %12 : $Optional<Test>, #Optional.some!enumelt.1
+  strong_retain %17 : $Test
+  release_value %12 : $Optional<Test>
+  strong_release %10 : $Test
+  %21 = objc_method %17 : $Test, #Test.other!getter.1.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %22 = apply %21(%17) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %17 : $Test
+  br bb6(%22 : $Optional<Test>)
+
+bb6(%25 : $Optional<Test>):
+  %26 = objc_method %6 : $Test, #Test.other!setter.1.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %27 = apply %26(%25, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %25 : $Optional<Test>
+  strong_release %6 : $Test
+  br bb7
+
+bb7:
+  %31 = tuple ()
+  return %31 : $()
+
+bb8:
+  %33 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb6(%33 : $Optional<Test>)
+
+bb9:
+  br bb7
+}

--- a/test/SILOptimizer/simplify_switch_enum_objc.swift
+++ b/test/SILOptimizer/simplify_switch_enum_objc.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -Osize -emit-sil -module-name objc_bridged_results %s -import-objc-header %S/Inputs/objc_optional.h | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+import Foundation
+
+// CHECK-LABEL: sil @$s20objc_bridged_results20testOptionalShortCutyySo4TestCSg_AEtF
+// CHECK: bb0
+// CHECK: switch_enum
+// CHECK: bb1
+// CHECK-NOT: switch_enum
+// CHECK: apply
+// CHECK-NOT: switch_enum
+// CHECK: apply
+// CHECK-NOT: switch_enum
+// CHECK: br bb2
+// CHECK: bb2:
+// CHECK: return
+// CHECK: bb3:
+// CHECK: br bb2
+public func testOptionalShortCut(_ t: Optional<Test>, _ v: Optional<Test>) {
+  t?.other = v?.other?.other
+}
+
+public class InClass {
+  var t: Test?
+  var v: Test?
+
+// CHECK-LABEL: sil @$s20objc_bridged_results7InClassC20testOptionalShortCutyyF
+// CHECK: bb0
+// CHECK:  switch_enum
+// CHECK: bb1
+// CHECK:  apply
+// CHECK:  apply
+// CHECK:  br bb2
+// CHECK: bb2:
+// CHECK:  return
+// CHECK: bb3:
+// CHECK:  br bb2
+  public func testOptionalShortCut() {
+    t?.other = v?.other
+  }
+
+// CHECK-LABEL: sil @$s20objc_bridged_results7InClassC21testOptionalShortCut2yyF
+// CHECK: bb0
+// CHECK:  switch_enum
+// CHECK: bb1
+// CHECK:  br bb5
+// CHECK: bb2:
+// CHECK:  apply
+// CHECK:  switch_enum
+// CHECK: bb3:
+// CHECK:  br bb5
+// CHECK: bb4:
+// CHECK:  objc_method
+// CHECK:  apply
+// CHECK:  objc_method
+// CHECK:  apply
+// CHECK:  objc_method
+// CHECK:  apply
+// CHECK:  br bb5
+// CHECK: bb5:
+// CHECK:  return
+  public func testOptionalShortCut2() {
+    t?.other?.other = v?.other?.other
+  }
+}


### PR DESCRIPTION

In the statement

  optional1?.objc_setter = optional2?.objc_getter?.objc_getter

we can eliminate all optional switches expect for the first switch on
optional1. We must only execute the setter if optional1 has some value.

We can simplify the following switch_enum with a branch as long all
sideffecting instructions in someBB are objc_method calls on the
optional payload or on another objc_method call that transitively uses
the payload.

 switch_enum %optionalValue, case #Optional.some!enumelt.1: someBB,
                             case #Optional.none: noneBB

 someBB(%optionalPayload):
    %1 = objc_method %optionalPayload
    %2 = apply %1(..., %optionalPayload) // self position
    br mergeBB(%2)

 noneBB:
    %4 = enum #Optional.none
    br mergeBB(%4)

rdar://48007302