### PR TITLE
Revert "[test] Dictionary: Skip a failing index validation test"

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5239,9 +5239,7 @@ DictionaryTestSuite.test("Values.MutationDoesNotInvalidateIndices.Native") {
 }
 
 #if _runtime(_ObjC)
-DictionaryTestSuite.test("Values.MutationDoesNotInvalidateIndices.Bridged")
-  .skip(.always("rdar://problem/47973577"))
-  .code {
+DictionaryTestSuite.test("Values.MutationDoesNotInvalidateIndices.Bridged") {
   let objects: [NSNumber] = [1, 2, 3, 4]
   let keys: [NSString] = ["Blanche", "Rose", "Dorothy", "Sophia"]
   let ns = NSDictionary(objects: objects, forKeys: keys)


### PR DESCRIPTION
Reverts apple/swift#22903. 

@eeckstein fixed the underlying issue in https://github.com/apple/swift/pull/22949.

rdar://problem/48488027