### PR TITLE
SwiftShims: update shims copying logic

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -84,35 +84,7 @@ endif()
 # First extract the "version" used for Clang's resource directory.
 string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" CLANG_VERSION
   "${LLVM_PACKAGE_VERSION}")
-
-# Function to find LLVM or Clang headers
-function(find_llvm_clang_headers suffix description out_var)
-  file(TO_CMAKE_PATH "${SWIFT_PATH_TO_CLANG_BUILD}" PATH_TO_CLANG_BUILD)
-
-  set(headers_locations
-      "${LLVM_LIBRARY_DIR}${suffix}"
-      "${PATH_TO_CLANG_BUILD}/${CMAKE_CFG_INTDIR}/lib${suffix}"
-      "${PATH_TO_CLANG_BUILD}/${LLVM_BUILD_TYPE}/lib${suffix}")
-
-  set(headers_location)
-  foreach(loc ${headers_locations})
-    if(EXISTS "${loc}")
-      set(headers_location "${loc}")
-      set(${out_var} "${loc}" PARENT_SCOPE)
-      break()
-    endif()
-  endforeach()
-  if("${headers_location}" STREQUAL "")
-    message(FATAL_ERROR "${description} headers were not found in any of the following locations: ${headers_locations}")
-  endif()
-endfunction()
-
-if(SWIFT_BUILT_STANDALONE)
-  find_llvm_clang_headers("/clang/${CLANG_VERSION}" "Clang"
-    clang_headers_location)
-else() # NOT SWIFT_BUILT_STANDALONE
-  set(clang_headers_location "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION}")
-endif()
+set(clang_headers_location "${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION}")
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set(cmake_symlink_option "copy_directory")
@@ -152,7 +124,7 @@ swift_install_symlink_component(clang-resource-dir-symlink
 # Possibly install Clang headers under Clang's resource directory in case we
 # need to use a different version of the headers than the installed Clang. This
 # should be used in conjunction with clang-resource-dir-symlink.
-file(TO_CMAKE_PATH "${SWIFT_PATH_TO_CLANG_BUILD}"
+file(TO_CMAKE_PATH "${LLVM_LIBRARY_OUTPUT_INTDIR}"
   _SWIFT_SHIMS_PATH_TO_CLANG_BUILD)
 swift_install_in_component(clang-builtin-headers-in-clang-resource-dir
     DIRECTORY "${_SWIFT_SHIMS_PATH_TO_CLANG_BUILD}/lib/clang"


### PR DESCRIPTION
Update the shims logic to make sure that it works for Xcode as well.
Rather than adding additional rules, just simplify it down to the one
canonical way in modern LLVM land.  The headers are always installed to
the LLVM_LIBRARY_OUTPUT_INTDIR which will be defined for us in both the
standalone and unified build mode.  This allows us to just remove all
the work to find the headers since they will always be in one location.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
