### PR TITLE
Add DifferentiableLifetimeTracked and test/AutoDiff/leakchecking.swift.

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -237,7 +237,11 @@ function(_compile_swift_files
     # SWIFT_ENABLE_TENSORFLOW
     # FIXME: `-enable-resilience` is currently disabled for the TensorFlow
     # module because it causes compilation to crash during IRGen.
-    if(NOT "${SWIFTFILE_MODULE_NAME}" STREQUAL "TensorFlow")
+    # Also, disable it for DifferentiationUnittest because resilience changes
+    # the AD code # that gets generated (leading to additional leaks)
+    # (see: TF-328)
+    if(NOT "${SWIFTFILE_MODULE_NAME}" STREQUAL "TensorFlow" AND
+       NOT "${SWIFTFILE_MODULE_NAME}" STREQUAL "DifferentiationUnittest")
       list(APPEND swift_flags "-Xfrontend" "-enable-resilience")
     endif()
   endif()

--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 if(SWIFT_BUILD_SDK_OVERLAY)
   # SwiftPrivatePthreadExtras makes use of Darwin/Glibc, which is part of the
   # SDK overlay. It can't be built separately from the SDK overlay.
+  add_subdirectory(DifferentiationUnittest)
   add_subdirectory(RuntimeUnittest)
   add_subdirectory(StdlibUnittest)
   add_subdirectory(StdlibUnicodeUnittest)

--- a/stdlib/private/DifferentiationUnittest/CMakeLists.txt
+++ b/stdlib/private/DifferentiationUnittest/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_swift_target_library(swiftDifferentiationUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  GenericLifetimeTracked.swift
+  SWIFT_COMPILE_FLAGS
+  TARGET_SDKS ALL_POSIX_PLATFORMS
+  INSTALL_IN_COMPONENT stdlib-experimental)

--- a/stdlib/private/DifferentiationUnittest/GenericLifetimeTracked.swift
+++ b/stdlib/private/DifferentiationUnittest/GenericLifetimeTracked.swift
@@ -1,0 +1,157 @@
+//===--- GenericLifetimeTracked.swift -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum _GlobalLeakCount {
+  public static var count = 0
+}
+
+/// A type that tracks the number of live instances of a wrapped value type.
+///
+/// `Tracked<T>` is used to check for memory leaks in functions created via
+/// automatic differentiation.
+public struct Tracked<T> {
+  fileprivate class Box {
+    fileprivate let value : T
+    init(_ value: T) {
+      self.value = value
+        _GlobalLeakCount.count += 1
+    }
+    deinit {
+      _GlobalLeakCount.count -= 1
+    }
+  }
+  private let handle: Box
+  public init(_ value: T) {
+    self.handle = Box(value)
+  }
+  public var value: T { return handle.value }
+}
+
+extension Tracked : ExpressibleByFloatLiteral where T : ExpressibleByFloatLiteral {
+  public init(floatLiteral value: T.FloatLiteralType) {
+    self.handle = Box(T(floatLiteral: value))
+  }
+}
+
+extension Tracked : CustomStringConvertible {
+  public var description: String { return "Tracked(\(value))" }
+}
+
+extension Tracked : ExpressibleByIntegerLiteral where T : ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: T.IntegerLiteralType) {
+    self.handle = Box(T(integerLiteral: value))
+  }
+}
+
+extension Tracked : Comparable where T : Comparable {
+  public static func < (lhs: Tracked, rhs: Tracked) -> Bool {
+    return lhs.value < rhs.value
+  }
+  public static func <= (lhs: Tracked, rhs: Tracked) -> Bool {
+    return lhs.value <= rhs.value
+  }
+  public static func > (lhs: Tracked, rhs: Tracked) -> Bool {
+    return lhs.value > rhs.value
+  }
+  public static func >= (lhs: Tracked, rhs: Tracked) -> Bool {
+    return lhs.value >= rhs.value
+  }
+}
+
+extension Tracked : AdditiveArithmetic where T : AdditiveArithmetic {
+  public static var zero: Tracked { return Tracked(T.zero) }
+  public static func + (lhs: Tracked, rhs: Tracked) -> Tracked {
+    return Tracked(lhs.value + rhs.value)
+  }
+  public static func - (lhs: Tracked, rhs: Tracked) -> Tracked {
+    return Tracked(lhs.value - rhs.value)
+  }
+}
+
+extension Tracked : Equatable where T : Equatable {
+  public static func == (lhs: Tracked, rhs: Tracked) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+extension Tracked : SignedNumeric & Numeric where T : SignedNumeric, T == T.Magnitude {
+  public typealias Magnitude = Tracked<T.Magnitude>
+
+  public init?<U>(exactly source: U) where U : BinaryInteger {
+    if let t = T(exactly: source) {
+      self.init(t)
+    }
+    return nil
+  }
+  public var magnitude: Magnitude { return Magnitude(value.magnitude) }
+
+  public static func * (lhs: Tracked, rhs: Tracked) -> Tracked {
+    return Tracked(lhs.value * rhs.value)
+  }
+
+  public static func *= (lhs: inout Tracked, rhs: Tracked) {
+    lhs = Tracked(lhs.value * rhs.value)
+  }
+}
+
+extension Tracked : Strideable where T : Strideable, T.Stride == T.Stride.Magnitude {
+  public typealias Stride = Tracked<T.Stride>
+
+  public func distance(to other: Tracked) -> Stride {
+    return Stride(value.distance(to: other.value))
+  }
+  public func advanced(by n: Stride) -> Tracked {
+    return Tracked(value.advanced(by: n.value))
+  }
+}
+
+// For now, `T` must be restricted to trivial types (like `Float` or `Tensor`)
+extension Tracked : Differentiable where T : Differentiable, T : AdditiveArithmetic
+   , T.AllDifferentiableVariables == T, T.CotangentVector == T, T.TangentVector == T {
+  public typealias AllDifferentiableVariables = Tracked<T.AllDifferentiableVariables>
+  public typealias TangentVector = Tracked<T.TangentVector>
+  public typealias CotangentVector = Tracked<T.CotangentVector>
+  @inlinable @inline(__always)
+  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
+    return Tracked<T.TangentVector>(value.tangentVector(from: cotangent.value))
+  }
+}
+
+@differentiable(vjp: _vjpAdd)
+public func +(_ a: Tracked<Float>, _ b: Tracked<Float>) -> Tracked<Float> {
+  return Tracked<Float>(a.value + b.value)
+}
+
+@usableFromInline
+func _vjpAdd(_ a: Tracked<Float>, _ b: Tracked<Float>)
+    -> (Tracked<Float>, (Tracked<Float>) -> (Tracked<Float>, Tracked<Float>)) {
+  return (Tracked<Float>(a.value + b.value), { r in
+    return (r, r)
+  })
+}
+
+// Differential operators for `Tracked<Float>`.
+public extension Differentiable {
+  @inlinable
+  func gradient(
+    in f: @differentiable (Self) -> Tracked<Float>
+  ) -> CotangentVector {
+    return self.pullback(in: f)(1)
+  }
+
+  @inlinable
+  func gradient<T : Differentiable>(
+    at x: T, in f: @differentiable (Self, T) -> Tracked<Float>
+  ) -> (CotangentVector, T.CotangentVector) {
+    return self.pullback(at: x, in: f)(1)
+  }
+}

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// A test that we can properly differentiate types that require refcounting.
+
+import StdlibUnittest
+import DifferentiationUnittest
+
+var LeakCheckingTests = TestSuite("LeakChecking")
+
+struct ExampleLeakModel : Differentiable {
+  var bias: Tracked<Float> = 2.0
+  func applied(to input: Tracked<Float>) -> Tracked<Float> {
+    var v = input + bias
+    return v
+  }
+}
+
+LeakCheckingTests.test("BasicVarLeakChecking") {
+  do {
+    var model = ExampleLeakModel()
+    let x: Tracked<Float> = 1.0
+    let _ = model.gradient(at: x) { m, x in m.applied(to: x) }
+  }
+  expectEqual(0, _GlobalLeakCount.count, "Leak Detected.")
+}
+
+runAllTests()

--- a/validation-test/ParseableInterface/verify_all_overlays.swift
+++ b/validation-test/ParseableInterface/verify_all_overlays.swift
@@ -13,6 +13,10 @@ ios: CloudKit.swiftinterface
 tvos: CloudKit.swiftinterface
 watchos: CloudKit.swiftinterface
 
+// This is added because DifferentiationUnittest does not build with resilience.
+linux-gnu: DifferentiationUnittest.swiftinterface
+macosx: DifferentiationUnittest.swiftinterface
+
 // SWIFT_ENABLE_TENSORFLOW
 linux-gnu: Python.swiftinterface
 macosx: Python.swiftinterface

--- a/validation-test/ParseableInterface/verify_all_overlays_O.swift
+++ b/validation-test/ParseableInterface/verify_all_overlays_O.swift
@@ -13,6 +13,10 @@ ios: CloudKit.swiftinterface
 tvos: CloudKit.swiftinterface
 watchos: CloudKit.swiftinterface
 
+// This is added because DifferentiationUnittest does not build with resilience.
+linux-gnu: DifferentiationUnittest.swiftinterface
+macosx: DifferentiationUnittest.swiftinterface
+
 // SWIFT_ENABLE_TENSORFLOW
 linux-gnu: Python.swiftinterface
 macosx: Python.swiftinterface


### PR DESCRIPTION
These work together to reproduce the memory leak in TF-22.

The hope is that this can be extended to capture more fixes to leak-checking.
resilience had to be disabled on the StdLibUnitTest because it was causing AD to produce different code than what is produced when using tensors.