### PR TITLE
[SIL Diagnostics] Improve diagnostics for yield-once coroutines

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -369,7 +369,20 @@ NOTE(previous_yield, none, "previous yield was here", ())
 ERROR(possible_return_before_yield, none,
       "accessor must yield on all paths before returning", ())
 
-NOTE(one_yield, none, "yield along one path is here", ())
+NOTE(branch_doesnt_yield, none,
+     "missing yield when the condition is %select{false|true}0", (bool))
+
+NOTE(named_case_doesnt_yield, none, "missing yield in the %0 case",
+    (Identifier))
+
+NOTE(case_doesnt_yield, none, "missing yield in "
+     "%select{this|the nil|the non-nil}0 case", (unsigned))
+
+NOTE(switch_value_case_doesnt_yield, none, "missing yield in the %0 case",
+    (StringRef))
+
+NOTE(try_branch_doesnt_yield, none, "missing yield when error is "
+     "%select{not |}0thrown", (bool))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7189,6 +7189,15 @@ public:
     assert(hasDefault() && "doesn't have a default");
     return getSuccessorBuf()[getNumCases()];
   }
+
+  Optional<unsigned> getUniqueCaseForDestination(SILBasicBlock *bb) const {
+    for (unsigned i = 0; i < getNumCases(); ++i) {
+      if (getCase(i).second == bb) {
+        return i + 1;
+      }
+    }
+    return None;
+  }
 };
 
 /// Common implementation for the switch_enum and

--- a/include/swift/SIL/SILSuccessor.h
+++ b/include/swift/SIL/SILSuccessor.h
@@ -113,6 +113,12 @@ public:
       return *this;
     }
 
+    pred_iterator operator++(int) {
+      auto old = *this;
+      ++*this;
+      return old;
+    }
+
     pred_iterator operator+(unsigned distance) const {
       auto copy = *this;
       if (distance == 0)

--- a/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
+++ b/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
@@ -22,8 +22,10 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Stmt.h"
 #include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/CFG.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/DenseSet.h"
 
 using namespace swift;
@@ -48,31 +50,53 @@ class YieldOnceCheck : public SILFunctionTransform {
     enum YieldState { BeforeYield, AfterYield, Conflict } yieldState;
 
   private:
-    // The following state is maintained for emitting diagnostics.
+    // The following states are maintained for emitting diagnostics.
 
     /// For AfterYield and Conflict states, this field records the yield
     /// instruction that was seen while propagating the state.
     SILInstruction *yieldInst;
 
-    BBState(YieldState yState, SILInstruction *yieldI)
-        : yieldState(yState), yieldInst(yieldI) {}
+    /// For Conflict state, these fields record the basic blocks that
+    /// propagated the 'AfterYield' and 'BeforeYield' states which resulted
+    /// in the Conflict.
+    SILBasicBlock *yieldingPred;
+    SILBasicBlock *nonYieldingPred;
+
+    BBState(YieldState yState, SILInstruction *yieldI, SILBasicBlock *yieldPred,
+            SILBasicBlock *noYieldPred)
+        : yieldState(yState), yieldInst(yieldI), yieldingPred(yieldPred),
+          nonYieldingPred(noYieldPred) {}
 
   public:
-    static BBState getInitialState() { return BBState(BeforeYield, nullptr); }
+    static BBState getInitialState() {
+      return BBState(BeforeYield, nullptr, nullptr, nullptr);
+    }
 
     static BBState getAfterYieldState(SILInstruction *yieldI) {
       assert(yieldI);
-      return BBState(AfterYield, yieldI);
+      return BBState(AfterYield, yieldI, nullptr, nullptr);
     }
 
-    static BBState getConflictState(SILInstruction *yieldI) {
-      assert(yieldI);
-      return BBState(Conflict, yieldI);
+    static BBState getConflictState(SILInstruction *yieldI,
+                                    SILBasicBlock *yieldPred,
+                                    SILBasicBlock *noYieldPred) {
+      assert(yieldI && yieldPred && noYieldPred);
+      return BBState(Conflict, yieldI, yieldPred, noYieldPred);
     }
 
     SILInstruction *getYieldInstruction() const {
       assert(yieldState == AfterYield || yieldState == Conflict);
       return yieldInst;
+    }
+
+    SILBasicBlock *getYieldingPred() {
+      assert(yieldState == Conflict);
+      return yieldingPred;
+    }
+
+    SILBasicBlock *getNonYieldingPred() {
+      assert(yieldState == Conflict);
+      return nonYieldingPred;
     }
   };
 
@@ -157,9 +181,16 @@ class YieldOnceCheck : public SILFunctionTransform {
   /// \param mergeBlock the basic block that is reached with two states
   /// \param oldState the previous state at the entry of the basic block
   /// \param newState the current state at the entry of the basic block
+  /// \param newStatePred the predecessor of 'mergeBlock' that has propagated
+  ///        the 'newState'.
+  /// \param bbToStateMap a map from the basic blocks visited by the analysis
+  ///        to the BBStates in which they were seen. This is used to identify
+  ///        blocks that propagate conflicting states when the merge results
+  ///        in a conflict.
   /// \return the new state obtained by merging the oldState with the newState
   static BBState merge(SILBasicBlock *mergeBlock, BBState oldState,
-                       BBState newState) {
+                       BBState newState, SILBasicBlock *newStatePred,
+                       llvm::DenseMap<SILBasicBlock *, BBState> &bbToStateMap) {
     auto oldYieldState = oldState.yieldState;
     auto newYieldState = newState.yieldState;
 
@@ -182,11 +213,27 @@ class YieldOnceCheck : public SILFunctionTransform {
            (newYieldState == BBState::BeforeYield &&
             oldYieldState == BBState::AfterYield));
 
-    SILInstruction *yieldInst = (newYieldState == BBState::AfterYield)
-                                    ? newState.getYieldInstruction()
-                                    : oldState.getYieldInstruction();
+    // For diagnostics, find another predecessor of 'mergeBlock' that was
+    // previously seen by the analysis. This predecessor would have
+    // propagated the 'oldState'.
+    SILBasicBlock *oldStatePred = nullptr;
+    for (auto predBB : mergeBlock->getPredecessorBlocks()) {
+      if (predBB != newStatePred && bbToStateMap.count(predBB)) {
+        oldStatePred = predBB;
+        break;
+      }
+    }
+    assert(oldStatePred);
 
-    return BBState::getConflictState(yieldInst);
+    if (oldState.yieldState == BBState::BeforeYield) {
+      return BBState::getConflictState(newState.getYieldInstruction(),
+                                       /* yieldPred */ newStatePred,
+                                       /* noYieldPred */ oldStatePred);
+    } else {
+      return BBState::getConflictState(oldState.getYieldInstruction(),
+                                       /* yieldPred */ oldStatePred,
+                                       /* noYieldPred */ newStatePred);
+    }
   }
 
   /// Perform a data-flow analysis to check whether there is exactly one
@@ -195,6 +242,7 @@ class YieldOnceCheck : public SILFunctionTransform {
   /// the control-flow graph.
   void diagnoseYieldOnceUsage(SILFunction &fun) {
     llvm::DenseMap<SILBasicBlock *, BBState> bbToStateMap;
+
     SmallVector<SILBasicBlock *, 16> worklist;
 
     auto *entryBB = fun.getEntryBlock();
@@ -234,7 +282,7 @@ class YieldOnceCheck : public SILFunctionTransform {
           continue;
         }
 
-        emitDiagnostics(error, fun);
+        emitDiagnostics(error, fun, bbToStateMap);
         return;
       }
 
@@ -255,7 +303,7 @@ class YieldOnceCheck : public SILFunctionTransform {
         // previous states and propagate it if it is different from the
         // old state.
         const auto &oldState = insertResult.first->second;
-        auto mergedState = merge(succBB, oldState, nextState);
+        auto mergedState = merge(succBB, oldState, nextState, bb, bbToStateMap);
 
         if (mergedState.yieldState == oldState.yieldState)
           continue;
@@ -271,11 +319,12 @@ class YieldOnceCheck : public SILFunctionTransform {
     }
 
     if (returnBeforeYieldError.hasValue()) {
-      emitDiagnostics(returnBeforeYieldError.getValue(), fun);
+      emitDiagnostics(returnBeforeYieldError.getValue(), fun, bbToStateMap);
     }
   }
 
-  void emitDiagnostics(YieldError &error, SILFunction &fun) {
+  void emitDiagnostics(YieldError &error, SILFunction &fun,
+                       llvm::DenseMap<SILBasicBlock *, BBState> &visitedBBs) {
     ASTContext &astCtx = fun.getModule().getASTContext();
 
     switch (error.errorKind) {
@@ -299,9 +348,162 @@ class YieldOnceCheck : public SILFunctionTransform {
       diagnose(astCtx, error.termInst->getLoc().getSourceLoc(),
                diag::possible_return_before_yield);
 
-      // Add a note that points to the yield instruction found.
-      auto *yieldInst = error.inState.getYieldInstruction();
-      diagnose(astCtx, yieldInst->getLoc().getSourceLoc(), diag::one_yield);
+      // Here, the yield state of 'error' is Conflict.
+      auto &conflictState = error.inState;
+
+      // Emit a note that pin points the branch construct that resulted in
+      // this conflict. Note that a conflict state is created at a merge block
+      // when along one incoming edge the analysis sees a BeforeYield state
+      // and along another it sees an AfterYield state.
+      // Also note that, by the definition of the merge operation,
+      // 'error.yieldingPred()' is the immediate predecessor of the merge block
+      // that propagates AfterYield state, and 'error.nonYieldingPred()' is
+      // the immediate predecessor of the merge block that propagates a
+      // BeforeYield state.
+      auto yieldPred = conflictState.getYieldingPred();
+      auto noYieldPred = conflictState.getNonYieldingPred();
+
+      // Step 1: find a branching SIL instruction where one branch has
+      // 'yieldPred' and another branch has 'noYieldPred'. For instance,
+      // in the following example, cond_br is the instruction to find.
+      //              cond_br bb1, bb2
+      //              bb1:
+      //                  yield resume yieldPred, unwind err
+      //              bb2:
+      //                  br noYieldPred
+      //              yieldPred:
+      //                  br mergePoint
+      //              noYieldPred:
+      //                  br mergePoint
+      //              mergePoint:
+      //                  ...
+      // Intuitively, the conflicting branch is the instruction where
+      // 'yieldPred' and 'noYieldPred' meet when traversing the CFG in the
+      // reverse order. More formally, the branching instruction is a
+      // "lowest common ancestor" of 'yieldPred' and 'noYieldPred' in the
+      // the DAG obtained from the CFG by ignoring back edges of loops.
+      //
+      // Note that the lowest common ancestor may not be unique in a DAG.
+      // But, any such ancestor could be considered as the conflicting branch as
+      // 'yieldPred' and 'noYieldPred' will belong to two different branches of
+      // every such ancestor.
+
+      // Find all transitive predecessors of 'yieldPred' that were visited
+      // during the analysis
+      SmallPtrSet<SILBasicBlock *, 8> predecessorsOfYieldPred;
+      for (auto *predBB :
+           llvm::breadth_first<llvm::Inverse<SILBasicBlock *>>(yieldPred)) {
+        if (visitedBBs.count(predBB)) {
+          predecessorsOfYieldPred.insert(predBB);
+        }
+      }
+
+      // Find the first predecessor of 'noYieldPred' that is also a predecessor
+      // of 'yieldPred', in the breadth-first search order of the reversed CFG.
+      SILBasicBlock *lowestCommonAncestorBB = nullptr;
+      SmallPtrSet<SILBasicBlock *, 8> predecessorsOfNoYieldPred;
+      for (auto *pred :
+           llvm::breadth_first<llvm::Inverse<SILBasicBlock *>>(noYieldPred)) {
+        if (!visitedBBs.count(pred)) {
+          continue;
+        }
+        if (predecessorsOfYieldPred.count(pred)) {
+          lowestCommonAncestorBB = pred;
+          break;
+        }
+        predecessorsOfNoYieldPred.insert(pred);
+      }
+      assert(lowestCommonAncestorBB);
+
+      auto *conflictingBranch = lowestCommonAncestorBB->getTerminator();
+
+      // Step 2: Find the target basic block of the 'conflictingBranch' that
+      // doesn't yield.
+      SILBasicBlock *noYieldTarget = nullptr;
+      for (auto *succ : lowestCommonAncestorBB->getSuccessorBlocks()) {
+        if (predecessorsOfNoYieldPred.count(succ)) {
+          noYieldTarget = succ;
+          break;
+        }
+      }
+      assert(noYieldTarget);
+
+      // Step 3: Report specialized diagnostics for each kind of conflicting
+      // branch.
+
+      // For conditional-branch instructions, which correspond to the
+      // conditions of 'if', 'where' or 'guard' statements, report for what
+      // truth value the branch doesn't yield.
+      if (auto *condbr = dyn_cast<CondBranchInst>(conflictingBranch)) {
+        diagnose(astCtx, condbr->getLoc().getSourceLoc(),
+                 diag::branch_doesnt_yield,
+                 /*non-yielding branch*/ condbr->getTrueBB() == noYieldTarget);
+        return;
+      }
+
+      // For switch_enum instructions, report the case that doesn't yield.
+      enum SwitchCaseKind { Default, OptionNil, OptionSome };
+
+      if (auto *switchEnum = dyn_cast<SwitchEnumInstBase>(conflictingBranch)) {
+        auto enumCaseLoc = noYieldTarget->begin()->getLoc().getSourceLoc();
+
+        if (switchEnum->hasDefault() &&
+            switchEnum->getDefaultBB() == noYieldTarget) {
+          diagnose(astCtx, enumCaseLoc, diag::case_doesnt_yield, Default);
+          return;
+        }
+
+        // Find the case identifier that doesn't yield.
+        NullablePtr<EnumElementDecl> enumElemDecl =
+            switchEnum->getUniqueCaseForDestination(noYieldTarget);
+        assert(enumElemDecl.isNonNull());
+
+        // Specialize diagnostics for cases of an optional.
+        if (enumElemDecl.get() == astCtx.getOptionalNoneDecl()) {
+          diagnose(astCtx, enumCaseLoc, diag::case_doesnt_yield, OptionNil);
+        } else if (enumElemDecl.get() == astCtx.getOptionalSomeDecl()) {
+          diagnose(astCtx, enumCaseLoc, diag::case_doesnt_yield, OptionSome);
+        } else {
+          diagnose(astCtx, enumCaseLoc, diag::named_case_doesnt_yield,
+                   enumElemDecl.get()->getName());
+        }
+        return;
+      }
+
+      // For switch_value instructions, report the case number that doesn't
+      // yield.
+      if (auto *switchValue = dyn_cast<SwitchValueInst>(conflictingBranch)) {
+        auto enumCaseLoc = noYieldTarget->begin()->getLoc().getSourceLoc();
+
+        if (switchValue->hasDefault() &&
+            switchValue->getDefaultBB() == noYieldTarget) {
+          diagnose(astCtx, enumCaseLoc, diag::case_doesnt_yield, Default);
+          return;
+        }
+        // Find the case that doesn't yield.
+        Optional<unsigned> caseNumberOpt =
+            switchValue->getUniqueCaseForDestination(noYieldTarget);
+        assert(caseNumberOpt.hasValue());
+
+        auto caseNumber = caseNumberOpt.getValue();
+        diagnose(
+            astCtx, enumCaseLoc, diag::switch_value_case_doesnt_yield,
+            (Twine(caseNumber) + llvm::getOrdinalSuffix(caseNumber)).str());
+        return;
+      }
+
+      // For try-apply instructions, report whether throwing or non-throwing
+      // case doesn't yield.
+      if (auto *tryApply = dyn_cast<TryApplyInst>(conflictingBranch)) {
+        diagnose(astCtx, tryApply->getLoc().getSourceLoc(),
+                 diag::try_branch_doesnt_yield,
+                 /*does error case not yield?*/ tryApply->getErrorBB() ==
+                     noYieldTarget);
+        return;
+      }
+
+      llvm_unreachable("unexpected branch resulting in conflicting yield "
+                       "states found in generalized accessor");
     }
     }
   }

--- a/test/SILOptimizer/generalized_accessors.sil
+++ b/test/SILOptimizer/generalized_accessors.sil
@@ -58,11 +58,11 @@ unwind
 sil @testPartialReturnWithoutYield : $@yield_once @convention(thin) (TestYield) -> @yields Int64 {
 bb0(%0 : $TestYield):
 %1 = struct_extract %0 : $TestYield, #TestYield.flag
-cond_br %1, bb1, bb3
+cond_br %1, bb1, bb3					   // expected-note {{missing yield when the condition is false}}
 
 bb1:
 %5 = struct_extract %0 : $TestYield, #TestYield.stored
-yield %5 : $Int64, resume bb2, unwind bb5   // expected-note {{yield along one path is here}}
+yield %5 : $Int64, resume bb2, unwind bb5
 
 bb2:
 br bb4
@@ -86,14 +86,14 @@ bb0(%0 : $TestYield):
 %5 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
 %6 = struct $Bool (%5 : $Builtin.Int1)
 %7 = struct_extract %6 : $Bool, #Bool._value
-cond_br %7, bb1, bb2
+cond_br %7, bb1, bb2						// expected-note {{missing yield when the condition is true}}
 
 bb1:
 br bb4
 
 bb2:
 %10 = struct_extract %0 : $TestYield, #TestYield.stored
-yield %10 : $Int64, resume bb3, unwind bb5    // expected-note {{yield along one path is here}}
+yield %10 : $Int64, resume bb3, unwind bb5
 
 bb3:
 br bb4

--- a/test/SILOptimizer/generalized_accessors.swift
+++ b/test/SILOptimizer/generalized_accessors.swift
@@ -18,16 +18,16 @@ struct TestReturnPathWithoutYield {
 
   var computed: Int {
     mutating _read {
-      if flag {
-        yield stored // expected-note {{yield along one path is here}}
+      if flag {   // expected-note {{missing yield when the condition is false}}
+        yield stored
       }
       flag = true
     } // expected-error {{accessor must yield on all paths before returning}}
 
     _modify {
       // Diagnostics should attach a note to the earliest conflicting branch.
-      if flag {
-        yield &stored // expected-note {{yield along one path is here}}
+      if flag {   // expected-note {{missing yield when the condition is false}}
+        yield &stored
       }
 
       if !flag {
@@ -43,23 +43,49 @@ struct TestIfElseWithoutYield {
 
   var computed: Int {
     mutating _read {
-      if flag {
-        yield stored // expected-note {{yield along one path is here}}
+      if flag {       // expected-note {{missing yield when the condition is false}}
+        yield stored
       } else {
         flag = true
       }
     } // expected-error {{accessor must yield on all paths before returning}}
 
     _modify {
-      if flag {
+      if flag {       // expected-note {{missing yield when the condition is true}}
         flag = true
       } else {
-        yield &stored // expected-note {{yield along one path is here}}
+        yield &stored
       }
     } // expected-error {{accessor must yield on all paths before returning}}
   }
 }
 
+struct TestNestedIfs {
+  var stored: Int
+  var flag: Bool
+
+  // Diagnostics should attach a note to the innermost conflicting branch, which
+  // is the point of first conflict.
+  var computed: Int {
+    _read {
+      if flag {
+        if stored > 0 { // expected-note {{missing yield when the condition is false}}
+          yield stored
+        }
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      if flag {
+        if stored > 0 { // expected-note {{missing yield when the condition is true}}
+        } else {
+          yield &stored
+        }
+      }
+      flag = true
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
 
 struct TestMultipleYields {
   var stored: Int
@@ -164,13 +190,13 @@ struct TestYieldInSwitch {
     _modify {
       switch cp {
       case .north:
-        yield &stored // expected-note {{yield along one path is here}}
+        yield &stored
       case .south:
         stored = 10
       case .east:
         yield &stored
       case .west:
-        stored = 12
+        stored = 12 // expected-note {{missing yield in the 'west' case}}
       }
       cp = .north
     } // expected-error {{accessor must yield on all paths before returning}}
@@ -200,11 +226,94 @@ struct TestYieldInSwitchWithFallThrough {
       case .north:
         fallthrough
       case .south:
-        yield &stored // expected-note {{yield along one path is here}}
+        yield &stored
+      case .east:
+        fallthrough  // expected-note {{missing yield in the 'east' case}}
+      case .west:
+        stored = 12
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestYieldInSwitchWithoutCaseNames {
+  var stored: Int
+  var cp: CompassPoint
+
+  var computed: Int {
+    _read {
+      switch cp {
+      case .north:
+        yield stored
+      case _:
+        break // expected-note {{missing yield in this case}}
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      switch cp {
+      case .north:
+        yield &stored
+      case _ where stored < 0: // expected-note {{missing yield in this case}}
+        stored = 12
+      case .south:
+        fallthrough
       case .east:
         fallthrough
       case .west:
-        stored = 12
+        yield &stored
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  var computed2: Int {
+    _read {
+      switch cp {
+      case .north:
+        yield stored
+      case _ where stored < 0: // expected-note {{missing yield when the condition is false}}
+        yield stored
+      default:
+        break
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      switch cp {
+      case .north:
+        yield &stored
+      case _ where stored < 0: // expected-note {{missing yield in this case}}
+        break
+      default:
+        yield &stored
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  var computed3: Int {
+    _read {
+      switch cp {
+      case .north:
+        yield stored
+      case _ where stored < 0: // expected-note {{missing yield in this case}}
+        break
+      case .south:
+        fallthrough
+      case .east:
+        yield stored
+      case .west:
+        break
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      switch cp {
+      case .north:
+        break
+      case _ where stored < 0: // expected-note {{missing yield when the condition is true}}
+        break
+      default:
+        yield &stored
       }
     } // expected-error {{accessor must yield on all paths before returning}}
   }
@@ -216,11 +325,11 @@ struct TestExplicitReturn {
 
   var computed: Int {
     mutating _read {
-      if stored > 0 {
+      if stored > 0 {  // expected-note {{missing yield when the condition is true}}
         return
       }
       if flag {
-        yield stored // expected-note {{yield along one path is here}}
+        yield stored
       } else {
         yield stored
       }
@@ -231,9 +340,9 @@ struct TestExplicitReturn {
       if stored > 0 {
         return
       }
-      if stored == 0 {
+      if stored == 0 { // expected-note {{missing yield when the condition is false}}
         if flag {
-          yield &stored // expected-note {{yield along one path is here}}
+          yield &stored
         } else {
           yield &stored
         }
@@ -273,23 +382,75 @@ struct TestYieldsInGuards {
 }
 
 struct TestYieldsInGuards2 {
+  var flag: Bool
+  var defaultStorage: Int
+
+  var computed: Int {
+    _read {
+      guard flag else { // expected-note {{missing yield when the condition is false}}
+        return
+      }
+      yield defaultStorage
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      guard flag else { // expected-note {{missing yield when the condition is true}}
+        yield &defaultStorage
+        return
+      }
+      defaultStorage += 1
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestYieldsInLetPatterns {
   var storedOpt: Int?
   var defaultStorage: Int
 
   var computed: Int {
     _read {
-      guard let stored = storedOpt else {
-        return
+      if let stored = storedOpt { // expected-note {{missing yield in the nil case}}
+        yield stored
       }
-      yield stored // expected-note {{yield along one path is here}}
     } // expected-error {{accessor must yield on all paths before returning}}
 
     _modify {
-      guard let stored = storedOpt else {
-        yield &defaultStorage // expected-note {{yield along one path is here}}
+      if var stored = storedOpt { // expected-note {{missing yield in the non-nil case}}
+        stored += 1
+        return
+      }
+      yield &defaultStorage
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  enum Either<L, R> {
+    case left(L)
+    case right(R)
+  }
+
+  var intOrBool: Either<Int, Bool>
+  var computed2: Int {
+    _read {
+      if case .left(let x) = intOrBool { // expected-note {{missing yield in the 'right' case}}
+        yield x
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      guard let stored = storedOpt else { // expected-note {{missing yield in the non-nil case}}
+        yield &defaultStorage
         return
       }
       storedOpt = stored + 1
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  var cp: CompassPoint
+  var computed3: Int {
+    _read {
+      if case .north = cp  { // expected-note {{missing yield in this case}}
+        yield 0
+      }
     } // expected-error {{accessor must yield on all paths before returning}}
   }
 }
@@ -320,18 +481,18 @@ struct TestYieldInDoCatch2 {
   var computed: Int {
     _read {
       do {
-        try aThrowingFunction()
-        yield stored  // expected-note {{yield along one path is here}}
+        try aThrowingFunction() // expected-note {{missing yield when error is thrown}}
+        yield stored
       } catch {
       }
     } // expected-error {{accessor must yield on all paths before returning}}
 
     _modify {
       do {
-        try aThrowingFunction()
+        try aThrowingFunction() // expected-note {{missing yield when error is not thrown}}
       }
       catch {
-        yield &stored  // expected-note {{yield along one path is here}}
+        yield &stored
       }
     } // expected-error {{accessor must yield on all paths before returning}}
   }
@@ -359,9 +520,9 @@ struct TestMutipleTries {
     _modify {
       do {
         try aThrowingFunction()
-        yield &stored           // expected-note {{yield along one path is here}}
+        yield &stored
 
-        try aThrowingFunction()
+        try aThrowingFunction() // expected-note {{missing yield when error is thrown}}
       }
       catch {
       }
@@ -377,10 +538,10 @@ struct TestMutipleTries {
         if flag {
           try aThrowingFunction()
         } else {
-          try aThrowingFunction()
+          try aThrowingFunction() // expected-note {{missing yield when error is thrown}}
         }
 
-        yield stored // expected-note {{yield along one path is here}}
+        yield stored
       } catch {
       }
     } // expected-error {{accessor must yield on all paths before returning}}
@@ -390,10 +551,10 @@ struct TestMutipleTries {
         switch bin {
         case .one:
           try aThrowingFunction()
-          yield &stored // expected-note {{yield along one path is here}}
+          yield &stored
 
         case .two:
-          try aThrowingFunction()
+          try aThrowingFunction() // expected-note {{missing yield when error is thrown}}
           yield &stored
         }
       } catch {
@@ -407,10 +568,10 @@ struct TestMutipleTries {
         if flag {
           try aThrowingFunction()
         } else {
-          try aThrowingFunction()
+          try aThrowingFunction() // expected-note {{missing yield when error is not thrown}}
         }
       } catch {
-        yield stored // expected-note {{yield along one path is here}}
+        yield stored
       }
     } // expected-error {{accessor must yield on all paths before returning}}
 
@@ -420,10 +581,10 @@ struct TestMutipleTries {
         case .one:
           try aThrowingFunction()
         case .two:
-          try aThrowingFunction()
+          try aThrowingFunction() // expected-note {{missing yield when error is not thrown}}
         }
       } catch {
-        yield &stored // expected-note {{yield along one path is here}}
+        yield &stored
       }
     } // expected-error {{accessor must yield on all paths before returning}}
   }
@@ -439,9 +600,12 @@ struct TestMutipleCatches {
   var stored: Int
   var computed: Int {
     _read {
+      // This is a very interesting test, where the error is on the try.
+      // It could have been been better if it is on the switch case in the
+      // error case.
       do {
-        try aThrowingFunction()
-        yield stored            // expected-note {{yield along one path is here}}
+        try aThrowingFunction() // expected-note {{missing yield when error is thrown}}
+        yield stored
       } catch NumError.One {
         yield stored
       } catch NumError.Two {
@@ -449,6 +613,19 @@ struct TestMutipleCatches {
       } catch NumError.Three {
       } catch {
         yield stored
+      }
+    }  // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      do {
+        try aThrowingFunction() // expected-note {{missing yield when error is not thrown}}
+      } catch NumError.One {
+        yield &stored
+      } catch NumError.Two {
+        yield &stored
+      } catch NumError.Three {
+      } catch {
+        yield &stored
       }
     }  // expected-error {{accessor must yield on all paths before returning}}
   }
@@ -466,9 +643,9 @@ struct TestYieldWithLabeledBreaks {
       ifstmt: if flag {
         switch bin {
         case .one:
-          yield stored // expected-note {{yield along one path is here}}
+          yield stored
         case .two:
-          break ifstmt
+          break ifstmt // expected-note {{missing yield in the 'two' case}}
         }
       }
     } // expected-error {{accessor must yield on all paths before returning}}
@@ -483,6 +660,71 @@ struct TestYieldWithLabeledBreaks {
           break loop
         }
       }
+    }
+  }
+}
+
+// Test switches over non-enum values.
+
+struct TestYieldInSwitchWhere {
+  var stored: Int
+  var computed: Int {
+    _read {
+      switch stored {
+      case let x where x > 0:
+        yield stored
+      case let x where x < 0: // expected-note {{missing yield when the condition is true}}
+        return
+      default:
+        yield 3
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestYieldInSwitchValue {
+  var stored: Bool
+  var computed: Int {
+    _read {
+      switch stored {
+      case true:
+        yield 0
+      case false:
+        return    // expected-note {{missing yield in the 2nd case}}
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestYieldInSwitchEnumAddr<T> {
+  var storedOpt: T?
+  var computed: T {
+    _read {
+      if let stored = storedOpt {
+        yield stored
+      }                   // expected-note {{missing yield in the nil case}}
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+// Test checked casts.
+
+struct TestYieldInCheckedCast<T> {
+  var stored: T
+  var computed: Int {
+    _read {
+      if let x = (stored as? Int) {
+        yield x
+      }                   // expected-note {{missing yield in the nil case}}
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestYieldInForcedUnwrappingt<T> {
+  var stored: T?
+  var computed: T {
+    _read {
+      yield stored!
     }
   }
 }


### PR DESCRIPTION
The commit improves diagnostics for the conflict case i.e, when the coroutines yield in some paths but not in all paths. This commit adds more tests and updates the existing tests to reflect the improved diagnostic message.