### PR TITLE
runtime: enable stack traces on Windows

### DIFF
--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -24,16 +24,42 @@
 #include "ImageInspectionELF.h"
 #include <cstdint>
 #include <cstddef>
+#if defined(__cplusplus)
+#include <memory>
+#endif
 
 namespace swift {
 
 /// This is a platform independent version of Dl_info from dlfcn.h
+#if defined(__cplusplus)
+
+template <typename T>
+struct null_deleter {
+  void operator()(T *) const {}
+  void operator()(typename std::remove_cv<T>::type *value) const {}
+};
+
+template <typename T>
+struct free_deleter {
+  void operator()(T *value) const {
+    free(const_cast<typename std::remove_cv<T>::type *>(value));
+  }
+  void operator()(typename std::remove_cv<T>::type *value) const {
+    free(value);
+  }
+};
+
 struct SymbolInfo {
   const char *fileName;
   void *baseAddress;
-  const char *symbolName;
+#if defined(_WIN32)
+  std::unique_ptr<const char, free_deleter<const char>> symbolName;
+#else
+  std::unique_ptr<const char, null_deleter<const char>> symbolName;
+#endif
   void *symbolAddress;
 };
+#endif
 
 /// Load the metadata from the image necessary to find protocols by name.
 void initializeProtocolLookup();

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -134,7 +134,7 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
 
   info->fileName = dlinfo.dli_fname;
   info->baseAddress = dlinfo.dli_fbase;
-  info->symbolName = dlinfo.dli_sname;
+  info->symbolName.reset(dlinfo.dli_sname);
   info->symbolAddress = dlinfo.dli_saddr;
   return 1;
 }

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -105,7 +105,7 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
 
   info->fileName = dlinfo.dli_fname;
   info->baseAddress = dlinfo.dli_fbase;
-  info->symbolName = dlinfo.dli_sname;
+  info->symbolName.reset(dlinfo.dli_sname);
   info->symbolAddress = dlinfo.dli_saddr;
   return 1;
 }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -67,7 +67,7 @@ template<> void ProtocolConformanceDescriptor::dump() const {
     int ok = lookupSymbol(addr, &info);
     if (!ok)
       return "<unknown addr>";
-    return info.symbolName;
+    return info.symbolName.get();
   };
 
   switch (auto kind = getTypeKind()) {


### PR DESCRIPTION
We would not previously symbolicate the stack trace and as a result
would not display the stack trace.  Add symbolication support to the
runtime to actually make use of the captured stack trace.  This allows
us to get a stack trace when the standard library or swift code reports
a fatal error.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
