### PR TITLE
FloatLiteralExpr now is lowered directly into SIL.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -823,11 +823,11 @@ public:
   }
 };
 
-  
 /// Integer literal with a '+' or '-' sign, like '+4' or '- 2'.
 ///
-/// After semantic analysis assigns types, this is guaranteed to only have
-/// a BuiltinIntegerType.
+/// After semantic analysis assigns types, this is guaranteed to have
+/// a BuiltinIntegerType or be a normal type and implicitly be
+/// AnyBuiltinIntegerType.
 class IntegerLiteralExpr : public NumberLiteralExpr {
 public:
   IntegerLiteralExpr(StringRef Val, SourceLoc DigitsLoc, bool Implicit = false)
@@ -855,9 +855,12 @@ public:
 };
 
 /// FloatLiteralExpr - Floating point literal, like '4.0'.  After semantic
-/// analysis assigns types, this is guaranteed to only have a
+/// analysis assigns types, BuiltinTy is guaranteed to only have a
 /// BuiltinFloatingPointType.
 class FloatLiteralExpr : public NumberLiteralExpr {
+  /// This is the type of the builtin literal.
+  Type BuiltinTy;
+
 public:
   FloatLiteralExpr(StringRef Val, SourceLoc Loc, bool Implicit = false)
     : NumberLiteralExpr(ExprKind::FloatLiteral, Val, Loc, Implicit)
@@ -870,6 +873,9 @@ public:
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::FloatLiteral;
   }
+
+  Type getBuiltinType() const { return BuiltinTy; }
+  void setBuiltinType(Type ty) { BuiltinTy = ty; }
 };
 
 /// A Boolean literal ('true' or 'false')

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1831,6 +1831,16 @@ public:
     printCommon(E, "float_literal_expr");
     PrintWithColorRAII(OS, LiteralValueColor)
       << " value=" << E->getDigitsText();
+    PrintWithColorRAII(OS, LiteralValueColor) << " builtin_initializer=";
+    E->getBuiltinInitializer().dump(
+        PrintWithColorRAII(OS, LiteralValueColor).getOS());
+    PrintWithColorRAII(OS, LiteralValueColor) << " initializer=";
+    E->getInitializer().dump(PrintWithColorRAII(OS, LiteralValueColor).getOS());
+    if (!E->getBuiltinType().isNull()) {
+      PrintWithColorRAII(OS, TypeColor) << " builtin_type='";
+      E->getBuiltinType().print(PrintWithColorRAII(OS, TypeColor).getOS());
+      PrintWithColorRAII(OS, TypeColor) << "'";
+    }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -974,8 +974,16 @@ llvm::APFloat FloatLiteralExpr::getValue() const {
   assert(!getType().isNull() && "Semantic analysis has not completed");
   assert(!getType()->hasError() && "Should have a valid type");
 
-  return getFloatLiteralValue(isNegative(), getDigitsText(),
-                  getType()->castTo<BuiltinFloatType>()->getAPFloatSemantics());
+  Type ty = getType();
+  if (!ty->is<BuiltinFloatType>()) {
+    assert(!getBuiltinType().isNull() && "Semantic analysis has not completed");
+    assert(!getBuiltinType()->hasError() && "Should have a valid type");
+    ty = getBuiltinType();
+  }
+
+  return getFloatLiteralValue(
+      isNegative(), getDigitsText(),
+      ty->castTo<BuiltinFloatType>()->getAPFloatSemantics());
 }
 
 StringLiteralExpr::StringLiteralExpr(StringRef Val, SourceRange Range,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5543,10 +5543,21 @@ RValue SILGenFunction::emitLiteral(LiteralExpr *literal, SGFContext C) {
             integerLiteral,
             SILType::getBuiltinIntegerLiteralType(getASTContext()),
             integerLiteral->getRawValue()));
-    CanType ty = integerManaged.getType().getASTType()->getCanonicalType();
+    CanType ty = integerManaged.getType().getASTType();
     builtinLiteralArgs = RValue(*this, {integerManaged}, ty);
     builtinInit = integerLiteral->getBuiltinInitializer();
     init = integerLiteral->getInitializer();
+  } else if (auto floatLiteral = dyn_cast<FloatLiteralExpr>(literal)) {
+    auto *litTy = floatLiteral->getBuiltinType()->castTo<BuiltinFloatType>();
+    ManagedValue floatManaged = ManagedValue::forUnmanaged(B.createFloatLiteral(
+        floatLiteral,
+        SILType::getBuiltinFloatType(litTy->getFPKind(), getASTContext()),
+        floatLiteral->getValue()));
+
+    CanType ty = floatManaged.getType().getASTType();
+    builtinLiteralArgs = RValue(*this, {floatManaged}, ty);
+    builtinInit = floatLiteral->getBuiltinInitializer();
+    init = floatLiteral->getInitializer();
   } else {
     ASTContext &ctx = getASTContext();
     SourceLoc loc = literal->getStartLoc();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -959,8 +959,11 @@ RValue RValueEmitter::visitIntegerLiteralExpr(IntegerLiteralExpr *E,
 }
 RValue RValueEmitter::visitFloatLiteralExpr(FloatLiteralExpr *E,
                                             SGFContext C) {
-  return RValue(SGF, E,
-                ManagedValue::forUnmanaged(SGF.B.createFloatLiteral(E)));
+  if (E->getType()->is<BuiltinFloatType>())
+    return RValue(SGF, E,
+                  ManagedValue::forUnmanaged(SGF.B.createFloatLiteral(E)));
+
+  return SGF.emitLiteral(E, C);
 }
 
 RValue RValueEmitter::visitBooleanLiteralExpr(BooleanLiteralExpr *E, 

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1122,6 +1122,9 @@ static SILValue foldFPTrunc(BuiltinInst *BI, const BuiltinInfo &Builtin,
       tryExtractLiteralText(flitInst, fplitStr);
 
       auto userType = CE ? CE->getType() : destType;
+      if (auto *FLE = Loc.getAsASTNode<FloatLiteralExpr>()) {
+        userType = FLE->getType();
+      }
       auto diagId = overflow
                         ? diag::warning_float_trunc_overflow
                         : (hexnInexact ? diag::warning_float_trunc_hex_inexact

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -26,8 +26,8 @@ func defarg1(i: Int = 17, d: Double, s: String = "Hello") { }
 
 // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments15testDefaultArg1yyF
 func testDefaultArg1() {
-  // CHECK: [[FLOAT64:%[0-9]+]] = metatype $@thin Double.Type
   // CHECK: [[FLOATLIT:%[0-9]+]] = float_literal $Builtin.FPIEEE{{64|80}}, {{0x4009000000000000|0x4000C800000000000000}}
+  // CHECK: [[FLOAT64:%[0-9]+]] = metatype $@thin Double.Type
   // CHECK: [[LITFN:%[0-9]+]] = function_ref @$sSd20_builtinFloatLiteralSdBf{{[_0-9]*}}__tcfC
   // CHECK: [[FLOATVAL:%[0-9]+]] = apply [[LITFN]]([[FLOATLIT]], [[FLOAT64]])
   // CHECK: [[DEF0FN:%[0-9]+]] = function_ref @$s17default_arguments7defarg1{{.*}}A_

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -19,8 +19,8 @@ struct D {
 // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin Int.Type
 // CHECK:      [[FN:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK-NEXT: [[LEFT:%.*]] = apply [[FN]]([[VALUE]], [[METATYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
-// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin Double.Type
 // CHECK-NEXT: [[VALUE:%.*]] = float_literal $Builtin.FPIEEE{{64|80}}, {{0x400C000000000000|0x4000E000000000000000}}
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin Double.Type
 // CHECK:      [[FN:%.*]] = function_ref @$sSd20_builtinFloatLiteralSdBf{{64|80}}__tcfC : $@convention(method) (Builtin.FPIEEE{{64|80}}, @thin Double.Type) -> Double
 // CHECK-NEXT: [[RIGHT:%.*]] = apply [[FN]]([[VALUE]], [[METATYPE]]) : $@convention(method) (Builtin.FPIEEE{{64|80}}, @thin Double.Type) -> Double
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ([[LEFT]] : $Int, [[RIGHT]] : $Double)

--- a/test/SILGen/generic_literals.swift
+++ b/test/SILGen/generic_literals.swift
@@ -19,13 +19,13 @@ func genericIntegerLiteral<T : ExpressibleByIntegerLiteral>(x: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s16generic_literals0A15FloatingLiteral1xyx_ts018ExpressibleByFloatD0RzlF : $@convention(thin) <T where T : ExpressibleByFloatLiteral> (@in_guaranteed T) -> () {
 func genericFloatingLiteral<T : ExpressibleByFloatLiteral>(x: T) {
   var x = x
-  // CHECK: [[TVAL:%.*]] = alloc_stack $T
-  // CHECK: [[TMETA:%.*]] = metatype $@thick T.Type
-  // CHECK: [[FLT_VAL:%.*]] = alloc_stack $T.FloatLiteralType
-  // CHECK: [[TFLT_META:%.*]] = metatype $@thick T.FloatLiteralType.Type
   // CHECK: [[LIT_VALUE:%.*]] = float_literal $Builtin.FPIEEE{{64|80}}, {{0x4004000000000000|0x4000A000000000000000}}
+  // CHECK: [[TFLT_META:%.*]] = metatype $@thick T.FloatLiteralType.Type
+  // CHECK: [[FLT_VAL:%.*]] = alloc_stack $T.FloatLiteralType
   // CHECK: [[BUILTIN_CONV:%.*]] = witness_method $T.FloatLiteralType, #_ExpressibleByBuiltinFloatLiteral.init!allocator.1
   // CHECK: apply [[BUILTIN_CONV]]<T.FloatLiteralType>([[FLT_VAL]], [[LIT_VALUE]], [[TFLT_META]]) : $@convention(witness_method: _ExpressibleByBuiltinFloatLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinFloatLiteral> (Builtin.FPIEEE{{64|80}}, @thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: [[TMETA:%.*]] = metatype $@thick T.Type
+  // CHECK: [[TVAL:%.*]] = alloc_stack $T
   // CHECK: [[CONV:%.*]] = witness_method $T, #ExpressibleByFloatLiteral.init!allocator.1
   // CHECK: apply [[CONV]]<T>([[TVAL]], [[FLT_VAL]], [[TMETA]]) : $@convention(witness_method: ExpressibleByFloatLiteral) <τ_0_0 where τ_0_0 : ExpressibleByFloatLiteral> (@in τ_0_0.FloatLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats_x86.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats_x86.swift
@@ -25,10 +25,10 @@ func testFPToIntConversion() {
   let uj: Float80 = 1.8446744073709551616E19
   _blackHole(UInt64(uj)) // expected-error {{invalid conversion: '1.8446744073709551616E19' overflows 'UInt64'}}
 
-  _blackHole(Int8(1E309))   // expected-error {{invalid conversion: '1E309' overflows 'Int8'}}
-  _blackHole(UInt8(-1E309)) // expected-error {{negative literal '-1E309' cannot be converted to 'UInt8'}}
-  _blackHole(Int64(1E309))  // expected-error {{invalid conversion: '1E309' overflows 'Int64'}}
-  _blackHole(UInt64(-1E309)) // expected-error {{negative literal '-1E309' cannot be converted to 'UInt64'}}
+  _blackHole(Int8(1E308))   // expected-error {{invalid conversion: '1E308' overflows 'Int8'}}
+  _blackHole(UInt8(-1E308)) // expected-error {{negative literal '-1E308' cannot be converted to 'UInt8'}}
+  _blackHole(Int64(1E308))  // expected-error {{invalid conversion: '1E308' overflows 'Int64'}}
+  _blackHole(UInt64(-1E308)) // expected-error {{negative literal '-1E308' cannot be converted to 'UInt64'}}
 }
 
 func testFloatConvertOverflow() {
@@ -37,11 +37,9 @@ func testFloatConvertOverflow() {
   _blackHole(f1)
   _blackHole(f2)
 
-  // FIXME: False Negative: overflow warning is not produced here. This case
-  // cannot be easily distinguished from explicit conversion at the SIL level.
-  let d4: Double = 1E309
-  let d6: Float64 = -1.0E999
-  let d8: Float64 = -1.7976931348623159E+308
+  let d4: Double = 1E309  // expected-warning {{'1E309' overflows to inf during conversion to 'Double'}}
+  let d6: Float64 = -1.0E999  // expected-warning {{'-1.0E999' overflows to -inf during conversion to 'Double'}}
+  let d8: Float64 = -1.7976931348623159E+308 // expected-warning {{'-1.7976931348623159E+308' overflows to -inf during conversion to 'Double'}}
   _blackHole(d4)
   _blackHole(d6)
   _blackHole(d8)
@@ -64,10 +62,9 @@ func testFloatConvertUnderflow() {
   let f1: Float = 1E-400 // expected-warning {{'1E-400' underflows and loses precision during conversion to 'Float'}}
   _blackHole(f1)
 
-  // FIXME: False Negative: warnings are not produced during Double assignments.
-  let d2: Double = 1E-309
+  let d2: Double = 1E-309  // expected-warning {{'1E-309' underflows and loses precision during conversion to 'Double'}}
   _blackHole(d2)
-  let d4: Double = 5E-324
+  let d4: Double = 5E-324  // expected-warning {{'5E-324' underflows and loses precision during conversion to 'Double'}}
   _blackHole(d4)
 
   // FIXME: if a number is so tiny that it underflows even Float80,
@@ -83,10 +80,9 @@ func testFloatConvertUnderflow() {
 }
 
 func testHexFloatImprecision() {
-  // FIXME: False Negative: warnings are not produced during Double assignments.
-  let d3: Double = 0x1.0000000000001p-1023
+  let d3: Double = 0x1.0000000000001p-1023  // expected-warning {{'0x1.0000000000001p-1023' loses precision during conversion to 'Double'}}
   _blackHole(d3)
-  let d4: Double = 0x1.00000000000001p-1000
+  let d4: Double = 0x1.00000000000001p-1000  // expected-warning {{'0x1.00000000000001p-1000' loses precision during conversion to 'Double'}}
   _blackHole(d4)
 
   // FIXME: if a number is so tiny that it underflows even Float80,

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -250,7 +250,7 @@ let _: GenericClass.TA = GenericClass.TA(a: 1, b: 4.0)
 let _: GenericClass.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // FIXME
 let _: GenericClass.TA = GenericClass.TA<Float>(a: 1, b: 4.0)
 
-let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
@@ -262,7 +262,7 @@ let _: GenericClass<Int>.TA = GenericClass.TA(a: 1, b: 4.0)
 let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to specified type 'GenericClass<Int>.TA'}}
 let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot convert value of type 'MyType<Float, Double>' to specified type 'GenericClass<Int>.TA'}}
 
-let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
@@ -274,7 +274,7 @@ let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 1, b: 4.0)
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to specified type 'GenericClass<Int>.TA<Float>' (aka 'MyType<Int, Float>')}}
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot convert value of type 'MyType<Float, Double>' to specified type 'GenericClass<Int>.TA<Float>' (aka 'MyType<Int, Float>')}}
 
-let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}


### PR DESCRIPTION
For context, String, Nil, Bool, and Int already behave this way.

Note: Swift can compile against 80 or 64 bit floats as the builtin
literal type. Thus, it was necessary to capture this bit somehow in the
FloatLiteralExpr. This was done as another Type field capturing this
info.