### PR TITLE
[Constraint solver] Do argument label matching during apply simplification

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3582,22 +3582,7 @@ namespace {
 
     void associateArgumentLabels(Expr *fn, State labels,
                                  bool labelsArePermanent) {
-      // Dig out the function, looking through, parentheses, ?, and !.
-      do {
-        fn = fn->getSemanticsProvidingExpr();
-
-        if (auto force = dyn_cast<ForceValueExpr>(fn)) {
-          fn = force->getSubExpr();
-          continue;
-        }
-
-        if (auto bind = dyn_cast<BindOptionalExpr>(fn)) {
-          fn = bind->getSubExpr();
-          continue;
-        }
-
-        break;
-      } while (true);
+      fn = getArgumentLabelTargetExpr(fn);
 
       // Record the labels.
       if (!labelsArePermanent)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3607,6 +3607,14 @@ namespace {
         return { true, expr };
       }
 
+      if (auto unresolvedMember = dyn_cast<UnresolvedMemberExpr>(expr)) {
+        associateArgumentLabels(unresolvedMember,
+                                { unresolvedMember->getArgumentLabels(),
+                                  unresolvedMember->hasTrailingClosure() },
+                                /*labelsArePermanent=*/true);
+        return { true, expr };
+      }
+
       // FIXME: other expressions have argument labels, but this is an
       // optimization, so stage it in later.
       return { true, expr };

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3614,6 +3614,14 @@ namespace {
         return { true, expr };
       }
 
+      if (auto subscript = dyn_cast<SubscriptExpr>(expr)) {
+        associateArgumentLabels(subscript,
+                                { subscript->getArgumentLabels(),
+                                  subscript->hasTrailingClosure() },
+                                /*labelsArePermanent=*/true);
+        return { true, expr };
+      }
+
       // FIXME: other expressions have argument labels, but this is an
       // optimization, so stage it in later.
       return { true, expr };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -110,9 +110,12 @@ bool constraints::areConservativelyCompatibleArgumentLabels(
       baseType = baseType->getRValueType();
     break;
 
+  case OverloadChoiceKind::KeyPathApplication:
+    // Key path applications are written as if subscript[keyPath:].
+    return !hasTrailingClosure && labels.size() == 1 && labels[0].is("keyPath");
+
   case OverloadChoiceKind::BaseType:
   case OverloadChoiceKind::DynamicMemberLookup:
-  case OverloadChoiceKind::KeyPathApplication:
   case OverloadChoiceKind::TupleIndex:
     return true;
   }

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -218,7 +218,7 @@ protected:
 
   void recordDisjunctionChoice(ConstraintLocator *disjunctionLocator,
                                unsigned index) const {
-    CS.DisjunctionChoices.push_back({disjunctionLocator, index});
+    CS.recordDisjunctionChoice(disjunctionLocator, index);
   }
 
   Score getCurrentScore() const { return CS.CurrentScore; }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1534,7 +1534,7 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
                        ->castTo<AnyFunctionType>()->getParams();
       type = FunctionType::get(indices, elementTy);
     } else if (auto var = dyn_cast<VarDecl>(decl)) {
-      type = var->getInterfaceType();
+      type = var->getValueInterfaceType();
       if (doesStorageProduceLValue(var, overload.getBaseType(), useDC))
         type = LValueType::get(type);
     } else if (isa<FuncDecl>(decl) || isa<EnumElementDecl>(decl)) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1488,6 +1488,11 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
   if (isa<TypeDecl>(decl))
     return Type();
 
+  // Declarations returning unwrapped optionals don't have a single effective
+  // type.
+  if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
+    return Type();
+
   // Retrieve the interface type.
   auto type = decl->getInterfaceType();
   if (!type) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3544,6 +3544,10 @@ matchCallArguments(ConstraintSystem &cs,
                    ArrayRef<AnyFunctionType::Param> params,
                    ConstraintLocatorBuilder locator);
 
+/// Given an expression that is the target of argument labels (for a call,
+/// subscript, etc.), find the underlying target expression.
+Expr *getArgumentLabelTargetExpr(Expr *fn);
+
 /// Attempt to prove that arguments with the given labels at the
 /// given parameter depth cannot be used with the given value.
 /// If this cannot be proven, conservatively returns true.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2353,9 +2353,8 @@ public:
   /// Attempt to simplify the set of overloads corresponding to a given
   /// function application constraint.
   ///
-  /// \param fnType The type that describes the function being applied.
-  /// When there is a set of overloads, this will generally be a type
-  /// variable that can be used to find the set of overloads.
+  /// \param fnTypeVar The type variable that describes the set of
+  /// overloads for the function.
   ///
   /// \param argFnType The call signature, which includes the call arguments
   /// (as the function parameters) and the expected result type of the
@@ -2367,7 +2366,7 @@ public:
   /// \returns \c fnType, or some simplified form of it if this function
   /// was able to find a single overload or derive some common structure
   /// among the overloads.
-  Type simplifyAppliedOverloads(Type fnType,
+  Type simplifyAppliedOverloads(TypeVariableType *fnTypeVar,
                                 const FunctionType *argFnType,
                                 Optional<ArgumentLabelState> argumentLabels,
                                 ConstraintLocatorBuilder locator);
@@ -3129,7 +3128,7 @@ private:
   /// \returns One of \c Solved (only a single term remained),
   /// \c Unsolved (more than one disjunction terms remain), or
   /// \c Error (all terms were filtered out).
-  SolutionKind filterDisjunctions(Constraint *disjunction,
+  SolutionKind filterDisjunction(Constraint *disjunction,
                                   bool restoreOnFail,
                                   llvm::function_ref<bool(Constraint *)> pred);
 

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -48,3 +48,35 @@ func testCommonTypeIUO() {
   // CHECK-NOT: common result type
     _ = f(0).iuo(0)
 }
+
+struct Z {
+  init(a: Int) { }
+  init(a: Double) { }
+
+  init(b: Int) { }
+  init?(b: Double) { }
+}
+
+func testCommonTypeInit() {
+  // CHECK: common result type for {{.*}} is Z
+  _ = Z(a: 0)
+
+  // CHECK-NOT: common result type
+  _ = Z(b: 0)
+}
+
+class DynamicSelf {
+  func foo(_ a: Int) -> Self { return self }
+  func foo(_ a: Double) -> Self { return self }
+}
+
+class InheritsDynamicSelf: DynamicSelf {
+}
+
+func testCommonTypeDynamicSelf(ds: DynamicSelf, ids: InheritsDynamicSelf) {
+  // CHECK: common result type for {{.*}} is DynamicSelf
+  _ = ds.foo(0)
+  // CHECK: common result type for {{.*}} is InheritsDynamicSelf
+  _ = ids.foo(0)
+}
+

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -7,6 +7,9 @@ struct X {
 
   subscript(_: Int) -> String { return "" }
   subscript(_: Double) -> String { return "" }
+
+  func iuo(_: Int) -> Int! { return 0 }
+  func iuo(_: Double) -> Int! { return 0 }
 }
 
 struct Y {
@@ -15,6 +18,9 @@ struct Y {
 
   subscript(_: Int) -> Substring { return "" }
   subscript(_: Double) -> Substring { return "" }
+
+  func iuo(_: Int) -> Double! { return 0 }
+  func iuo(_: Double) -> Double! { return 0 }
 }
 
 func f(_: Int) -> X { return X() }
@@ -29,11 +35,16 @@ func testCallCommonType() {
 }
 
 func testSubscriptCommonType() {
-  // FIXME: This will work once we have more filtering of subscripts.
   // CHECK: subscript_expr
   // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
-  // CHECK-NOT: (common result type for $T{{[0-9]+}} is String)
+  // CHECK: (common result type for $T{{[0-9]+}} is String)
   // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
-  // CHECK-NOT: (common result type for $T{{[0-9]+}} is Substring)
+  // CHECK: (common result type for $T{{[0-9]+}} is Substring)
   _ = f(0)[0]
+}
+
+func testCommonTypeIUO() {
+  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK-NOT: common result type
+    _ = f(0).iuo(0)
 }

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -630,7 +630,7 @@ let arr = [BottleLayout]()
 let layout = BottleLayout(count:1)
 let ix = arr.firstIndex(of:layout) // expected-error {{argument type 'BottleLayout' does not conform to expected type 'Equatable'}}
 
-let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{missing argument label 'ascii:' in call}}
+let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{initializer 'init(_:)' requires that 'Unicode.Scalar' conform to 'BinaryInteger'}}
 
 // https://bugs.swift.org/browse/SR-9068
 func compare<C: Collection, Key: Hashable, Value: Equatable>(c: C)

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+// This test ensures that we are filtering out overloads based on argument
+// labels, arity, etc., before those terms are visited. 
+
+func foo(_: Int) { }
+func foo(_: Int, _: Int) { }
+func foo(_: Int, _: Int, _: Int) { }
+
+func testModuleScope(i: Int) {
+  // CHECK: (disabled disjunction term {{.*}} (Int) -> ()
+  // CHECK-NEXT: (disabled disjunction term {{.*}} (Int, Int, Int) -> ()
+  // CHECK: (introducing single enabled disjunction term {{.*}} (Int, Int) -> ()
+  foo(i, i)
+}

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -19,6 +19,10 @@ struct X {
   subscript(_: Int) -> Int { return 0 }
   subscript(_: Int, _: Int) -> Double { return 0 }
   subscript(_: Int, _: Int, _: Int) -> String { return "" }
+
+  init(_: Int) { }
+  init(_: Int, _: Int) { }
+  init(_: Int, _: Int, _: Int) { }
 }
 
 func testSubscript(x: X, i: Int) {
@@ -27,4 +31,11 @@ func testSubscript(x: X, i: Int) {
   // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:_:_:)
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.subscript(_:_:)
   _ = x[i, i]
+}
+
+func testUnresolvedMember(i: Int) -> X {
+  // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:)
+  // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:_:)
+  // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
+  return .init(i, i)
 }

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -14,3 +14,15 @@ func testModuleScope(i: Int) {
   // CHECK: (introducing single enabled disjunction term {{.*}} (Int, Int) -> ()
   foo(i, i)
 }
+
+struct X {
+  subscript(_: Int) -> Int { return 0 }
+  subscript(_: Int, _: Int) -> Double { return 0 }
+  subscript(_: Int, _: Int, _: Int) -> String { return "" }
+}
+
+func testSubscript(x: X, i: Int) {
+  // CHECK: disabled disjunction term {{.*}}X.subscript(_:)
+  // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:_:_:)
+  _ = x[i, i]
+}

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -22,7 +22,9 @@ struct X {
 }
 
 func testSubscript(x: X, i: Int) {
-  // CHECK: disabled disjunction term {{.*}}X.subscript(_:)
+  // CHECK: disabled disjunction term {{.*}} bound to key path application
+  // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:)
   // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:_:_:)
+  // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.subscript(_:_:)
   _ = x[i, i]
 }

--- a/test/Constraints/overload_filtering_objc.swift
+++ b/test/Constraints/overload_filtering_objc.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+// REQUIRES: objc_interop
+
+// This test ensures that we are filtering out overloads based on argument
+// labels, arity, etc., before those terms are visited. 
+
+import Foundation
+
+@objc protocol P {
+  func foo(_ i: Int) -> Int
+  func foo(_ d: Double) -> Int
+
+  @objc optional func opt(_ i: Int) -> Int
+  @objc optional func opt(double: Double) -> Int
+  
+  subscript(i: Int) -> String { get }
+}
+
+func testOptional(obj: P) {
+  // FIXME: When we remove argument-label filtering from member name lookup,
+  // this will start failing and need to be replaced with "disabled disjunction
+  // term".
+  //
+  // CHECK-NOT: disjunction
+  _ = obj.opt?(1)
+}

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -291,7 +291,9 @@ switch staticMembers {
   case .init(0): break
   case .init(_): break // expected-error{{'_' can only appear in a pattern}}
   case .init(let x): break // expected-error{{cannot appear in an expression}}
-  case .init(opt: 0): break // expected-error{{pattern cannot match values of type 'StaticMembers'}}
+case .init(opt: 0): break // expected-error{{value of optional type 'StaticMembers?' must be unwrapped to a value of type 'StaticMembers'}}
+  // expected-note@-1{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  // expected-note@-2{{coalesce using '??' to provide a default when the optional value contains 'nil'}}
 
   case .prop: break
   // TODO: repeated error message

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -91,7 +91,7 @@ struct SR718 {
   subscript(a a : UInt) -> Int { return 0 }
 }
 
-SR718()[a: Int()] // expected-error {{extraneous argument label 'a:' in subscript}}
+SR718()[a: Int()] // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
 
 // rdar://problem/25601561 - Qol: Bad diagnostic for failed assignment from Any to more specific type
 

--- a/test/decl/func/keyword-argument-defaults.swift
+++ b/test/decl/func/keyword-argument-defaults.swift
@@ -108,7 +108,7 @@ func testSubscripts(_ i: Int, s: String, x: Y) {
   var i2 = x[i]
   var i3 = x[x: i] // expected-error{{extraneous argument label 'x:' in subscript}}
   var s2 = x[y: s]
-  var s3 = x[s]  // expected-error{{missing argument label 'y:' in subscript}}
+  var s3 = x[s]  // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
 }
 
 // Operators

--- a/validation-test/Sema/type_checker_perf/fast/rdar20818064.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20818064.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+func wrap<T>(_ key: String, _ value: T) -> T { return value }
+func wrap<T: ExpressibleByIntegerLiteral>(_ key: String, _ value: T) -> T { return value }
+func wrap<T: ExpressibleByFloatLiteral>(_ key: String, _ value: T) -> T { return value }
+func wrap<T: ExpressibleByStringLiteral>(_ key: String, _ value: T) -> T { return value }
+
+func wrapped(i: Int) -> Int {
+  // FIXME: When this stops being "too complex", turn the integer value into
+  // an integer literal.
+  // expected-error@+1{{reasonable time}}
+  return wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i)
+}


### PR DESCRIPTION
When simplifying a function application constraint, check the argument
labels for that application against the disjunction containing the overload
set, disabling any overloads with mis-matching labels. This is staging for
several different directions:

* Eliminating the argument label matching from performMemberLookup, where it
does not belong
* More aggressively filtering the overload set when we have some concrete
information about argument types
* Identifying favored constraints when we have some concrete information
about argument types

At present, the only easily-visible effect of this change is that
we now properly handle argument label matching for non-member functions,
subscripts, and unresolved member references (e.g., `.foo(bar: 0)`). It also
improves the common-result-type computation a bit, although the effect of
that is harder to see.
