### PR TITLE
[5.1] This test does not verify anything, so typechecking is enough

### DIFF
--- a/validation-test/stdlib/PhotosTests.swift
+++ b/validation-test/stdlib/PhotosTests.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s
 
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos


### PR DESCRIPTION
Related to <rdar://problem/48094005>
Fixes: <rdar://problem/48056095>

(cherry picked from commit 9483ad43b3990d072ab6bb13c402c8a2ddf6e47b)

5.1 version of https://github.com/apple/swift/pull/22633