### PR TITLE
Have Windows Call Signaled Callback on Crashes

### DIFF
--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -143,12 +143,22 @@ bool TaskQueue::execute(TaskBeganCallback Began, TaskFinishedCallback Finished,
       stderrContents = stderrBuffer.get()->getBuffer();
     }
 
-    if (ReturnCode == -2) {
+#if defined(_WIN32)
+    // Wait() sets the upper two bits of the return code to indicate warnings
+    // (10) and errors (11).
+    //
+    // This isn't a true signal on Windows, but we'll treat it as such so that
+    // we clean up after it properly
+    bool crashed = ReturnCode & 0xC0000000;
+#else
       // Wait() returning a return code of -2 indicates the process received
       // a signal during execution.
+    bool crashed = ReturnCode == -2;
+#endif
+    if (crashed) {
       if (Signalled) {
         TaskFinishedResponse Response =
-            Signalled(PI.Pid, ErrMsg, stdoutContents, stderrContents, T->Context, None, TaskProcessInformation(PI.Pid));
+            Signalled(PI.Pid, ErrMsg, stdoutContents, stderrContents, T->Context, ReturnCode, TaskProcessInformation(PI.Pid));
         ContinueExecution = Response != TaskFinishedResponse::StopExecution;
       } else {
         // If we don't have a Signalled callback, unconditionally stop.

--- a/test/Driver/assert.swift
+++ b/test/Driver/assert.swift
@@ -1,5 +1,3 @@
-// Windows programs cannot fail due to a signal
-// UNSUPPORTED: windows
 // RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-assert-immediately 2>&1 | %FileCheck %s
 // RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-assert-after-parse 2>&1 | %FileCheck %s
 

--- a/test/Driver/crash.swift
+++ b/test/Driver/crash.swift
@@ -1,5 +1,3 @@
-// Windows programs cannot fail due to a signal
-// UNSUPPORTED: windows
 // RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-crash-immediately 2>&1 | %FileCheck %s
 
 // RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-crash-after-parse 2>&1 | %FileCheck %s


### PR DESCRIPTION
The signaled callback is treated more as a general crash handler clean
up wise. While it doesn't 100% line up, have Windows call the signaled
callback on exit codes considered to be errors.

See https://github.com/apple/swift/pull/22985#discussion_r261435691