### PR TITLE
[test] -Fsystem $SDK/System/Library/PrivateFrameworks

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # RUN: ${python} %s %target-swiftmodule-name %platform-sdk-overlay-dir \
-# RUN:              %target-sil-opt -sdk %sdk -enable-sil-verify-all \
-# RUN:                              -F "%xcode-extra-frameworks-dir"
+# RUN:     %target-sil-opt -sdk %sdk -enable-sil-verify-all \
+# RUN:       -Fsystem %sdk/System/Library/PrivateFrameworks \
+# RUN:       -F "%xcode-extra-frameworks-dir"
 
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test


### PR DESCRIPTION
Otherwise certain modules don't import correctly when built against an Apple-internal SDK. Should have no effect when using the public SDK, but we try to minimize divergence between the public and Apple-internal test suites.

rdar://problem/48513002