### PR TITLE
[GSB] NFC: Improve performance with local DependentMemberType caching

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -935,6 +935,11 @@ private:
     AssociatedTypeDecl,
   };
 
+  /// Cache DependentMemberType results instead of calling
+  /// DependentMemberType::get(). The much smaller hash table is more
+  /// processor cache efficient.
+  mutable llvm::DenseMap<Type, Type> ReplacedSelfCache;
+
   /// The kind of storage we have.
   const StorageKind storageKind;
 
@@ -954,8 +959,9 @@ private:
     /// A protocol conformance used to satisfy the requirement.
     void *conformance;
 
-    /// An associated type to which a requirement is being applied.
-    AssociatedTypeDecl *assocType;
+    /// A precomputed dependent member of an associated type to which a
+    /// requirement is being applied.
+    DependentMemberType *dependentMember;
   } storage;
 
   friend TrailingObjects;
@@ -1093,7 +1099,8 @@ public:
     assert(isAcceptableStorageKind(kind, storageKind) &&
            "RequirementSource kind/storageKind mismatch");
 
-    storage.assocType = assocType;
+    auto ty = assocType->getDeclaredInterfaceType();
+    storage.dependentMember = cast<DependentMemberType>(ty.getPointer());
   }
 
   RequirementSource(Kind kind, const RequirementSource *parent)
@@ -1315,11 +1322,18 @@ public:
     return ProtocolConformanceRef::getFromOpaqueValue(storage.conformance);
   }
 
+  /// Retrieve the precomputed dependent member for the associated type
+  /// declaration for this requirement, if there is one.
+  DependentMemberType *getDependentMember() const {
+    if (storageKind != StorageKind::AssociatedTypeDecl) return nullptr;
+    return storage.dependentMember;
+  }
+
   /// Retrieve the associated type declaration for this requirement, if there
   /// is one.
   AssociatedTypeDecl *getAssociatedType() const {
     if (storageKind != StorageKind::AssociatedTypeDecl) return nullptr;
-    return storage.assocType;
+    return storage.dependentMember->getAssocType();
   }
 
   /// Profiling support for \c FoldingSet.
@@ -1558,6 +1572,11 @@ class GenericSignatureBuilder::PotentialArchetype {
   /// that share a name.
   llvm::MapVector<Identifier, StoredNestedType> NestedTypes;
 
+  /// Cache DependentMemberType results instead of calling
+  /// DependentMemberType::get(). The much smaller hash table is more
+  /// processor cache efficient.
+  mutable llvm::DenseMap<Type, DependentMemberType*> CachedDMTs;
+
   /// Construct a new potential archetype for a concrete declaration.
   PotentialArchetype(PotentialArchetype *parent, AssociatedTypeDecl *assocType)
       : parentOrContext(parent), identifier(assocType) {
@@ -1595,6 +1614,14 @@ public:
   AssociatedTypeDecl *getResolvedType() const {
     assert(getParent() && "Not an associated type");
     return identifier.assocType;
+  }
+
+  /// Retrieve the type declaration to which this nested type was resolved.
+  DependentMemberType *getResolvedDependentMemberType(Type Parent) const {
+    auto *&known = CachedDMTs[Parent];
+    if (!known)
+      known = DependentMemberType::get(Parent, getResolvedType());
+    return known;
   }
 
   /// Determine whether this is a generic parameter.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -818,7 +818,7 @@ const void *RequirementSource::getOpaqueStorage1() const {
     return storage.type;
 
   case StorageKind::AssociatedTypeDecl:
-    return storage.assocType;
+    return storage.dependentMember;
   }
 
   llvm_unreachable("Unhandled StorageKind in switch.");
@@ -918,11 +918,16 @@ bool RequirementSource::isSelfDerivedSource(GenericSignatureBuilder &builder,
 /// the nested type. This limited operation makes sure that it does not
 /// create any new potential archetypes along the way, so it should only be
 /// used in cases where we're reconstructing something that we know exists.
-static Type replaceSelfWithType(Type selfType, Type depTy) {
+static Type replaceSelfWithType(llvm::DenseMap<Type, Type> &cache,
+                                Type selfType, Type depTy) {
   if (auto depMemTy = depTy->getAs<DependentMemberType>()) {
-    Type baseType = replaceSelfWithType(selfType, depMemTy->getBase());
+    Type baseType = replaceSelfWithType(cache, selfType, depMemTy->getBase());
     assert(depMemTy->getAssocType() && "Missing associated type");
-    return DependentMemberType::get(baseType, depMemTy->getAssocType());
+    auto &known = cache[baseType];
+    if (!known) {
+      known = DependentMemberType::get(baseType, depMemTy->getAssocType());
+    }
+    return known;
   }
 
   assert(depTy->is<GenericTypeParamType>() && "missing Self?");
@@ -1366,8 +1371,8 @@ RequirementSource::visitPotentialArchetypesAlongPath(
 
     if (visitor(parentType, this)) return nullptr;
 
-    return replaceSelfWithType(parentType,
-                               getAssociatedType()->getDeclaredInterfaceType());
+    return replaceSelfWithType(ReplacedSelfCache,
+                               parentType, getDependentMember());
   }
 
   case RequirementSource::NestedTypeNameMatch:
@@ -1402,7 +1407,8 @@ RequirementSource::visitPotentialArchetypesAlongPath(
 
     if (visitor(parentType, this)) return nullptr;
 
-    return replaceSelfWithType(parentType, getStoredType());
+    return replaceSelfWithType(ReplacedSelfCache,
+                               parentType, getStoredType());
   }
   }
   llvm_unreachable("unhandled kind");
@@ -1436,7 +1442,7 @@ ProtocolDecl *RequirementSource::getProtocolDecl() const {
     return getProtocolConformance().getRequirement();
 
   case StorageKind::AssociatedTypeDecl:
-    return storage.assocType->getProtocol();
+    return storage.dependentMember->getAssocType()->getProtocol();
   }
 
   llvm_unreachable("Unhandled StorageKind in switch.");
@@ -1607,8 +1613,9 @@ void RequirementSource::print(llvm::raw_ostream &out,
   }
 
   case StorageKind::AssociatedTypeDecl:
-    out << " (" << storage.assocType->getProtocol()->getName()
-        << "::" << storage.assocType->getName() << ")";
+    auto assocType = storage.dependentMember->getAssocType();
+    out << " (" << assocType->getProtocol()->getName()
+        << "::" << assocType->getName() << ")";
     break;
   }
 
@@ -2935,7 +2942,7 @@ Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
 
     // If we've resolved to an associated type, use it.
     if (auto assocType = getResolvedType())
-      return DependentMemberType::get(parentType, assocType);
+      return getResolvedDependentMemberType(parentType);
 
     return DependentMemberType::get(parentType, getNestedName());
   }


### PR DESCRIPTION
This hack is a 3.5% improvement for Swift.swiftmodule (release, no asserts). Your milage may vary.

@DougGregor – It seems like the GSB could try harder to avoid banging on the global DependentMemberTypes DenseMap. What do you think?

CC: @slavapestov @jrose-apple 