### PR TITLE
[5.1] [NFC] Move selector family logic to ObjCSelector

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -592,6 +592,12 @@ public:
                             "only for use within the debugger");
 };
 
+enum class ObjCSelectorFamily : unsigned {
+  None,
+#define OBJC_SELECTOR_FAMILY(LABEL, PREFIX) LABEL,
+#include "swift/AST/ObjCSelectorFamily.def"
+};
+
 /// Represents an Objective-C selector.
 class ObjCSelector {
   /// The storage for an Objective-C selector.
@@ -655,6 +661,8 @@ public:
   ///
   /// \param scratch Scratch space to use.
   StringRef getString(llvm::SmallVectorImpl<char> &scratch) const;
+
+  ObjCSelectorFamily getSelectorFamily() const;
 
   void *getOpaqueValue() const { return Storage.getOpaqueValue(); }
   static ObjCSelector getFromOpaqueValue(void *p) {

--- a/include/swift/AST/ObjCSelectorFamily.def
+++ b/include/swift/AST/ObjCSelectorFamily.def
@@ -1,0 +1,29 @@
+//===--- ObjCSelectorFamily.def - Objective-C Selector Families - C++ ---*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with Objective-C
+// selector families, categories of Objective-C methods with special ARC
+// semantics.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OBJC_SELECTOR_FAMILY
+#define OBJC_SELECTOR_FAMILY(LABEL, PREFIX)
+#endif
+
+OBJC_SELECTOR_FAMILY(Alloc, "alloc")
+OBJC_SELECTOR_FAMILY(Copy, "copy")
+OBJC_SELECTOR_FAMILY(Init, "init")
+OBJC_SELECTOR_FAMILY(MutableCopy, "mutableCopy")
+OBJC_SELECTOR_FAMILY(New, "new")
+
+#undef OBJC_SELECTOR_FAMILY

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/ConvertUTF.h"
+#include "clang/Basic/CharInfo.h"
 using namespace swift;
 
 void *DeclBaseName::SubscriptIdentifierData =
@@ -197,6 +198,30 @@ ObjCSelector::ObjCSelector(ASTContext &ctx, unsigned numArgs,
 
   assert(numArgs == pieces.size() && "Wrong number of selector pieces");
   Storage = DeclName(ctx, Identifier(), pieces);
+}
+
+ObjCSelectorFamily ObjCSelector::getSelectorFamily() const {
+  StringRef text = getSelectorPieces().front().get();
+  while (!text.empty() && text[0] == '_') text = text.substr(1);
+
+  // Does the given selector start with the given string as a prefix, in the
+  // sense of the selector naming conventions?
+  // This implementation matches the one used by
+  // clang::Selector::getMethodFamily, to make sure we behave the same as
+  // Clang ARC. We're not just calling that method here because it means
+  // allocating a clang::IdentifierInfo, which requires a Clang ASTContext.
+  auto hasPrefix = [](StringRef text, StringRef prefix) {
+    if (!text.startswith(prefix)) return false;
+    if (text.size() == prefix.size()) return true;
+    assert(text.size() > prefix.size());
+    return !clang::isLowercase(text[prefix.size()]);
+  };
+
+  if (false) /*for #define purposes*/;
+#define OBJC_SELECTOR_FAMILY(LABEL, PREFIX) \
+  else if (hasPrefix(text, PREFIX)) return ObjCSelectorFamily::LABEL;
+#include "swift/AST/ObjCSelectorFamily.def"
+  else return ObjCSelectorFamily::None;
 }
 
 StringRef ObjCSelector::getString(llvm::SmallVectorImpl<char> &scratch) const {


### PR DESCRIPTION
Cherry-picks changes in #22605 to Swift 5.1.