### PR TITLE
Update the VJP for mean(alongAxis:) to be correct.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -567,8 +567,9 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   func _vjpMean(alongAxes axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
     let value = mean(alongAxes: axes)
-    return (value, { [shape = shapeTensor, count = scalarCountTensor] in
-      $0.broadcast(toShape: shape) / Tensor(count)
+    return (value, { [shape = shapeTensor,
+                      count = axes.map { shape[$0] }.reduce(1, *)] in
+      $0.broadcast(toShape: shape) / Tensor(Scalar(count))
     })
   }
 


### PR DESCRIPTION
Only the dimensions of the axis involved should be divided by.