### PR TITLE
[build] Update for clang build system change

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -34,7 +34,7 @@ add_swift_tool_symlink(swift-format swift editor-integration)
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)
-  add_dependencies(swift clang-headers)
+  add_dependencies(swift clang-resource-headers)
 endif()
 
 swift_install_in_component(compiler

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -13,6 +13,6 @@ endif()
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)
-  add_dependencies(swift clang-headers)
+  add_dependencies(swift clang-resource-headers)
 endif()
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -744,7 +744,7 @@ install-xctest
 install-libicu
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;license;sourcekit-inproc
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd
 install-libcxx
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
@@ -1133,7 +1133,7 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd
 install-libcxx
 
 # Path to the .tar.gz package we would create.

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2142,7 +2142,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${SKIP_BUILD_LLVM}" ] ; then
                     # We can't skip the build completely because the standalone
                     # build of Swift depend on these.
-                    build_targets=(llvm-tblgen clang-headers intrinsics_gen clang-tablegen-targets)
+                    build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)
                 fi
 
                 if [ "${HOST_LIBTOOL}" ] ; then


### PR DESCRIPTION
https://reviews.llvm.org/D58791 renames the clang-headers target to
clang-resource-headers; the clang-headers name will be repurposed for a
different target afterward. Update Swift's build system to use the new
target name.