### PR TITLE
Fix crash when enum is nested inside a fully-constrained extension

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1840,8 +1840,15 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     return getFunctionInterfaceTypeWithCaptures(funcTy, func);
   }
 
-  case SILDeclRef::Kind::EnumElement:
-    return cast<AnyFunctionType>(vd->getInterfaceType()->getCanonicalType());
+  case SILDeclRef::Kind::EnumElement: {
+    auto funcTy = cast<AnyFunctionType>(
+                                   vd->getInterfaceType()->getCanonicalType());
+    auto sig = getEffectiveGenericSignature(vd->getDeclContext());
+    return CanAnyFunctionType::get(sig,
+                                   funcTy->getParams(),
+                                   funcTy.getResult(),
+                                   funcTy->getExtInfo());
+  }
   
   case SILDeclRef::Kind::Allocator: {
     auto *cd = cast<ConstructorDecl>(vd);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1623,6 +1623,8 @@ static void diagnoseConformanceImpliedByConditionalConformance(
 ProtocolConformance *MultiConformanceChecker::
 checkIndividualConformance(NormalProtocolConformance *conformance,
                            bool issueFixit) {
+  PrettyStackTraceConformance trace(TC.Context, "type-checking", conformance);
+
   std::vector<ValueDecl*> revivedMissingWitnesses;
   switch (conformance->getState()) {
     case ProtocolConformanceState::Incomplete:
@@ -4392,8 +4394,6 @@ void TypeChecker::useBridgedNSErrorConformances(DeclContext *dc, Type type) {
 }
 
 void TypeChecker::checkConformance(NormalProtocolConformance *conformance) {
-  PrettyStackTraceConformance trace(Context, "type-checking", conformance);
-
   MultiConformanceChecker checker(*this);
   checker.addConformance(conformance);
   checker.checkAllConformances();

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -212,6 +212,15 @@ extension Array where Element == AnyObject {
     // CHECK-LABEL: sil hidden [ossa] @$sSa22constrained_extensionsyXlRszlE12DerivedClassCfE : $@convention(method) (@guaranteed Array<AnyObject>.DerivedClass) -> ()
     var e: Element? = nil
   }
+
+  enum NestedEnum {
+    case hay
+    case grain
+
+    func makeHay() -> NestedEnum {
+      return .hay
+    }
+  }
 }
 
 func referenceNestedTypes() {

--- a/validation-test/compiler_crashers_2/0189-sr10033.swift
+++ b/validation-test/compiler_crashers_2/0189-sr10033.swift
@@ -1,0 +1,20 @@
+// RUN: not --crash %target-swift-frontend -typecheck %s
+
+protocol P1 {
+  associatedtype A2 : P2 where A2.A1 == Self
+}
+
+protocol P2 {
+  associatedtype A1 : P1 where A1.A2 == Self
+  var property: Int { get }
+}
+
+extension P2 {
+  var property: Int { return 0 }
+}
+
+class C1 : P1 {
+  class A2 : P2 {
+    typealias A1 = C1
+  }
+}


### PR DESCRIPTION
Also add a debugging aid and a crashing test case reduced from the same user project.

Fixes https://bugs.swift.org/browse/SR-10023.