### PR TITLE
[ConstraintSystem] Diagnose extraneous arguments via fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1088,6 +1088,11 @@ ERROR(extra_trailing_closure_in_call,none,
 ERROR(trailing_closure_bad_param,none,
       "trailing closure passed to parameter of type %0 that does not "
       "accept a closure", (Type))
+NOTE(candidate_with_extraneous_args,none,
+      "candidate %0 requires %1 argument%s1, "
+      "but %2 %select{were|was}3 %{select{provided|used in closure body}4",
+      (Type, unsigned, unsigned, bool, bool))
+
 ERROR(no_accessible_initializers,none,
       "%0 cannot be constructed because it has no accessible initializers",
       (Type))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3058,7 +3058,8 @@ public:
         ParamInfo(paramInfo), Arguments(args), CandidateInfo(CCI),
         IsSubscript(isSubscript) {}
 
-  void extraArgument(unsigned extraArgIdx) override {
+  bool extraArguments(ArrayRef<unsigned> extraArgIndices) override {
+    auto extraArgIdx = extraArgIndices.front();
     auto name = Arguments[extraArgIdx].getLabel();
     Expr *arg = ArgExpr;
 
@@ -3094,6 +3095,7 @@ public:
           .highlight(arg->getSourceRange());
 
     Diagnosed = true;
+    return true;
   }
 
   void missingArgument(unsigned missingParamIdx) override {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3078,6 +3078,15 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
     return diagnoseSingleExtraArgument();
   }
 
+  if (ContextualType->getNumParams() == 0) {
+    if (auto argExpr = getArgumentExprFor(getRawAnchor())) {
+      emitDiagnostic(anchor->getLoc(), diag::extra_argument_to_nullary_call)
+          .highlight(argExpr->getSourceRange())
+          .fixItRemove(argExpr->getSourceRange());
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3036,7 +3036,98 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
     addFixIts(emitDiagnostic(diagLoc, diag::argument_out_of_order_named_named,
                              first, second));
   }
+  return true;
+}
 
+bool ExtraneousArgumentsFailure::diagnoseAsError() {
+  // Simplified anchor would point directly to the
+  // argument in case of contextual mismatch.
+  auto *anchor = getAnchor();
+  if (auto *closure = dyn_cast<ClosureExpr>(anchor)) {
+    auto fnType = ContextualType;
+    auto params = closure->getParameters();
+
+    auto diag = emitDiagnostic(
+        params->getStartLoc(), diag::closure_argument_list_tuple, fnType,
+        fnType->getNumParams(), params->size(), (params->size() == 1));
+
+    bool onlyAnonymousParams =
+        std::all_of(params->begin(), params->end(),
+                    [](ParamDecl *param) { return !param->hasName(); });
+
+    // If closure expects no parameters but N was given,
+    // and all of them are anonymous let's suggest removing them.
+    if (fnType->getNumParams() == 0 && onlyAnonymousParams) {
+      auto inLoc = closure->getInLoc();
+      auto &sourceMgr = getASTContext().SourceMgr;
+
+      if (inLoc.isValid())
+        diag.fixItRemoveChars(params->getStartLoc(),
+                              Lexer::getLocForEndOfToken(sourceMgr, inLoc));
+    }
+    return true;
+  }
+
+  if (isContextualMismatch()) {
+    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_argument_value,
+                   getType(anchor), ContextualType);
+    return true;
+  }
+
+  if (ExtraArgs.size() == 1) {
+    return diagnoseSingleExtraArgument();
+  }
+
+  return false;
+}
+
+bool ExtraneousArgumentsFailure::diagnoseAsNote() {
+  auto *anchor = getAnchor();
+  auto numArgs = getTotalNumArguments();
+  emitDiagnostic(anchor->getLoc(), diag::candidate_with_extraneous_args,
+                 ContextualType, ContextualType->getNumParams(), numArgs,
+                 (numArgs == 1), isa<ClosureExpr>(anchor));
+  return true;
+}
+
+bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
+  auto *arguments = getArgumentExprFor(getRawAnchor());
+  if (!arguments)
+    return false;
+
+  const auto &e = ExtraArgs.front();
+  auto index = e.first;
+  auto argument = e.second;
+
+  auto tuple = dyn_cast<TupleExpr>(arguments);
+  auto argExpr = tuple ? tuple->getElement(index)
+                       : cast<ParenExpr>(arguments)->getSubExpr();
+
+  auto loc = argExpr->getLoc();
+  if (tuple && index == tuple->getNumElements() - 1 &&
+      tuple->hasTrailingClosure()) {
+    emitDiagnostic(loc, diag::extra_trailing_closure_in_call)
+        .highlight(argExpr->getSourceRange());
+  } else if (ContextualType->getNumParams() == 0) {
+    auto *PE = dyn_cast<ParenExpr>(arguments);
+    Expr *subExpr = nullptr;
+    if (PE)
+      subExpr = PE->getSubExpr();
+
+    if (subExpr && argument.getPlainType()->isVoid()) {
+      emitDiagnostic(loc, diag::extra_argument_to_nullary_call)
+          .fixItRemove(subExpr->getSourceRange());
+    } else {
+      emitDiagnostic(loc, diag::extra_argument_to_nullary_call)
+          .highlight(argExpr->getSourceRange());
+    }
+  } else if (argument.hasLabel()) {
+    emitDiagnostic(loc, diag::extra_argument_named, argument.getLabel())
+        .highlight(argExpr->getSourceRange());
+  } else {
+    emitDiagnostic(loc, diag::extra_argument_positional)
+        .highlight(argExpr->getSourceRange());
+  }
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1119,6 +1119,40 @@ public:
   bool diagnoseAsError() override;
 };
 
+class ExtraneousArgumentsFailure final : public FailureDiagnostic {
+  FunctionType *ContextualType;
+  SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> ExtraArgs;
+
+public:
+  ExtraneousArgumentsFailure(
+      Expr *root, ConstraintSystem &cs, FunctionType *contextualType,
+      ArrayRef<std::pair<unsigned, AnyFunctionType::Param>> extraArgs,
+      ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator),
+        ContextualType(resolveType(contextualType)->castTo<FunctionType>()),
+        ExtraArgs(extraArgs.begin(), extraArgs.end()) {}
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+
+private:
+  bool diagnoseSingleExtraArgument() const;
+
+  unsigned getTotalNumArguments() const {
+    return ContextualType->getNumParams() + ExtraArgs.size();
+  }
+
+  bool isContextualMismatch() const {
+    auto *locator = getLocator();
+    auto path = locator->getPath();
+
+    assert(!path.empty());
+    const auto &last = path.back();
+    return last.getKind() == ConstraintLocator::ContextualType ||
+           last.getKind() == ConstraintLocator::ApplyArgToParam;
+  }
+};
+
 class OutOfOrderArgumentFailure final : public FailureDiagnostic {
   using ParamBinding = SmallVector<unsigned, 1>;
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -506,6 +506,19 @@ AddMissingArguments::create(ConstraintSystem &cs, FunctionType *funcType,
   return new (mem) AddMissingArguments(cs, funcType, synthesizedArgs, locator);
 }
 
+bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+RemoveExtraneousArguments *
+RemoveExtraneousArguments::create(ConstraintSystem &cs,
+                                  llvm::ArrayRef<unsigned> extraArgs,
+                                  ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<unsigned>(extraArgs.size());
+  void *mem = cs.getAllocator().Allocate(size, alignof(RemoveExtraneousArguments));
+  return new (mem) RemoveExtraneousArguments(cs, extraArgs, locator);
+}
+
 bool MoveOutOfOrderArgument::diagnose(Expr *root, bool asNote) const {
   OutOfOrderArgumentFailure failure(root, getConstraintSystem(), ArgIdx,
                                     PrevArgIdx, Bindings, getLocator());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -507,7 +507,10 @@ AddMissingArguments::create(ConstraintSystem &cs, FunctionType *funcType,
 }
 
 bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
-  return false;
+  ExtraneousArgumentsFailure failure(root, getConstraintSystem(),
+                                     ContextualType, getExtraArguments(),
+                                     getLocator());
+  return failure.diagnose(asNote);
 }
 
 RemoveExtraneousArguments *RemoveExtraneousArguments::create(

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -510,12 +510,10 @@ bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
   return false;
 }
 
-RemoveExtraneousArguments *
-RemoveExtraneousArguments::create(ConstraintSystem &cs,
-                                  FunctionType *contextualType,
-                                  llvm::ArrayRef<unsigned> extraArgs,
-                                  ConstraintLocator *locator) {
-  unsigned size = totalSizeToAlloc<unsigned>(extraArgs.size());
+RemoveExtraneousArguments *RemoveExtraneousArguments::create(
+    ConstraintSystem &cs, FunctionType *contextualType,
+    llvm::ArrayRef<IndexedParam> extraArgs, ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<IndexedParam>(extraArgs.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(RemoveExtraneousArguments));
   return new (mem)
       RemoveExtraneousArguments(cs, contextualType, extraArgs, locator);

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -512,11 +512,13 @@ bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
 
 RemoveExtraneousArguments *
 RemoveExtraneousArguments::create(ConstraintSystem &cs,
+                                  FunctionType *contextualType,
                                   llvm::ArrayRef<unsigned> extraArgs,
                                   ConstraintLocator *locator) {
   unsigned size = totalSizeToAlloc<unsigned>(extraArgs.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(RemoveExtraneousArguments));
-  return new (mem) RemoveExtraneousArguments(cs, extraArgs, locator);
+  return new (mem)
+      RemoveExtraneousArguments(cs, contextualType, extraArgs, locator);
 }
 
 bool MoveOutOfOrderArgument::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1025,13 +1025,15 @@ class RemoveExtraneousArguments final
     private llvm::TrailingObjects<RemoveExtraneousArguments, unsigned> {
   friend TrailingObjects;
 
+  FunctionType *ContextualType;
   unsigned NumExtraneous;
 
   RemoveExtraneousArguments(ConstraintSystem &cs,
+                            FunctionType *contextualType,
                             llvm::ArrayRef<unsigned> extraArgs,
                             ConstraintLocator *locator)
-    : ConstraintFix(cs, FixKind::RemoveExtraneousArguments, locator),
-      NumExtraneous(extraArgs.size()) {
+      : ConstraintFix(cs, FixKind::RemoveExtraneousArguments, locator),
+        ContextualType(contextualType), NumExtraneous(extraArgs.size()) {
     std::uninitialized_copy(extraArgs.begin(), extraArgs.end(),
                             getExtraArgumentsBuf().begin());
   }
@@ -1044,6 +1046,7 @@ class RemoveExtraneousArguments final
   }
 
   static RemoveExtraneousArguments *create(ConstraintSystem &cs,
+                                           FunctionType *contextualType,
                                            llvm::ArrayRef<unsigned> extraArgs,
                                            ConstraintLocator *locator);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1270,8 +1270,9 @@ namespace {
       SmallVector<AnyFunctionType::Param, 8> params;
       AnyFunctionType::decomposeInput(constrParamType, params);
 
+      auto funcType = constr->getMethodInterfaceType()->castTo<FunctionType>();
       ::matchCallArguments(
-          CS, args, params, ConstraintKind::ArgumentConversion,
+          CS, funcType, args, params, ConstraintKind::ArgumentConversion,
           CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument));
 
       Type result = tv;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -858,26 +858,29 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
 
 class ArgumentFailureTracker : public MatchCallArgumentListener {
   ConstraintSystem &CS;
+  FunctionType *ContextualType;
+
   ArrayRef<AnyFunctionType::Param> Arguments;
   ArrayRef<AnyFunctionType::Param> Parameters;
+
   SmallVectorImpl<ParamBinding> &Bindings;
   ConstraintLocatorBuilder Locator;
 
 public:
-  ArgumentFailureTracker(ConstraintSystem &cs,
+  ArgumentFailureTracker(ConstraintSystem &cs, FunctionType *contextualType,
                          ArrayRef<AnyFunctionType::Param> args,
                          ArrayRef<AnyFunctionType::Param> params,
                          SmallVectorImpl<ParamBinding> &bindings,
                          ConstraintLocatorBuilder locator)
-      : CS(cs), Arguments(args), Parameters(params), Bindings(bindings),
-        Locator(locator) {}
+      : CS(cs), ContextualType(contextualType), Arguments(args),
+        Parameters(params), Bindings(bindings), Locator(locator) {}
 
   bool extraArguments(ArrayRef<unsigned> argIndices) override {
     if (!CS.shouldAttemptFixes())
       return true;
 
     return CS.recordFix(RemoveExtraneousArguments::create(
-        CS, argIndices, CS.getConstraintLocator(Locator)));
+        CS, ContextualType, argIndices, CS.getConstraintLocator(Locator)));
   }
 
   bool missingLabel(unsigned paramIndex) override {
@@ -937,7 +940,8 @@ public:
 
 // Match the argument of a call to the parameter.
 ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
-    ConstraintSystem &cs, ArrayRef<AnyFunctionType::Param> args,
+    ConstraintSystem &cs, FunctionType *contextualType,
+    ArrayRef<AnyFunctionType::Param> args,
     ArrayRef<AnyFunctionType::Param> params, ConstraintKind subKind,
     ConstraintLocatorBuilder locator) {
   // Extract the parameters.
@@ -959,13 +963,11 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
 
   // Match up the call arguments to the parameters.
   SmallVector<ParamBinding, 4> parameterBindings;
-  ArgumentFailureTracker listener(cs, argsWithLabels, params, parameterBindings,
-                                  locator);
-  if (constraints::matchCallArguments(argsWithLabels, params,
-                                      paramInfo,
-                                      hasTrailingClosure,
-                                      cs.shouldAttemptFixes(), listener,
-                                      parameterBindings)) {
+  ArgumentFailureTracker listener(cs, contextualType, argsWithLabels, params,
+                                  parameterBindings, locator);
+  if (constraints::matchCallArguments(
+          argsWithLabels, params, paramInfo, hasTrailingClosure,
+          cs.shouldAttemptFixes(), listener, parameterBindings)) {
     if (!cs.shouldAttemptFixes())
       return cs.getTypeMatchFailure(locator);
 
@@ -1330,6 +1332,7 @@ static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
 }
 
 static bool fixExtraneousArguments(ConstraintSystem &cs,
+                                   FunctionType *contextualType,
                                    SmallVectorImpl<AnyFunctionType::Param> &args,
                                    int numExtraneous,
                                    ConstraintLocatorBuilder locator) {
@@ -1350,7 +1353,7 @@ static bool fixExtraneousArguments(ConstraintSystem &cs,
   } while (--numExtraneous);
 
   return cs.recordFix(RemoveExtraneousArguments::create(
-      cs, extraneous, cs.getConstraintLocator(locator)));
+      cs, contextualType, extraneous, cs.getConstraintLocator(locator)));
 }
 
 ConstraintSystem::TypeMatchResult
@@ -1572,7 +1575,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     } else {
       // If there are extraneous arguments, let's remove
       // them from the list.
-      if (fixExtraneousArguments(*this, func1Params, diff, locator))
+      if (fixExtraneousArguments(*this, func2, func1Params, diff, locator))
         return getTypeMatchFailure(argumentLocator);
     }
   }
@@ -6220,7 +6223,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
 
     // The argument type must be convertible to the input type.
     if (::matchCallArguments(
-            *this, func1->getParams(), func2->getParams(), subKind,
+            *this, func2, func1->getParams(), func2->getParams(), subKind,
             outerLocator.withPathElement(ConstraintLocator::ApplyArgument))
             .isFailure())
       return SolutionKind::Error;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -34,7 +34,9 @@ using namespace constraints;
 
 MatchCallArgumentListener::~MatchCallArgumentListener() { }
 
-void MatchCallArgumentListener::extraArgument(unsigned argIdx) { }
+bool MatchCallArgumentListener::extraArguments(ArrayRef<unsigned> argIndices) {
+  return true;
+}
 
 void MatchCallArgumentListener::missingArgument(unsigned paramIdx) { }
 
@@ -557,12 +559,15 @@ matchCallArguments(ArrayRef<AnyFunctionType::Param> args,
       }
     }
 
-    // If we still haven't claimed all of the arguments, fail.
+    // If we still haven't claimed all of the arguments,
+    // fail if there is no recovery.
     if (numClaimedArgs != numArgs) {
-      nextArgIdx = 0;
-      skipClaimedArgs();
-      listener.extraArgument(nextArgIdx);
-      return true;
+      SmallVector<unsigned, 4> extraneous;
+      for (auto index : indices(claimedArgs)) {
+        if (!claimedArgs[index])
+          extraneous.push_back(index);
+      }
+      return listener.extraArguments(extraneous);
     }
 
     // FIXME: If we had the actual parameters and knew the body names, those

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7122,6 +7122,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowTypeOrInstanceMember:
   case FixKind::AllowInvalidPartialApplication:
   case FixKind::AllowInvalidInitRef:
+  case FixKind::RemoveExtraneousArguments:
   case FixKind::AllowClosureParameterDestructuring:
   case FixKind::MoveOutOfOrderArgument:
   case FixKind::AllowInaccessibleMember:

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -281,8 +281,9 @@ CalleeCandidateInfo::ClosenessResultTy CalleeCandidateInfo::evaluateCloseness(
     CandidateCloseness getResult() const {
       return result;
     }
-    void extraArgument(unsigned argIdx) override {
+    bool extraArguments(ArrayRef<unsigned> argIndices) override {
       result = CC_ArgumentCountMismatch;
+      return true;
     }
     void missingArgument(unsigned paramIdx) override {
       result = CC_ArgumentCountMismatch;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3774,8 +3774,11 @@ public:
   /// Indicates that the argument at the given index does not match any
   /// parameter.
   ///
-  /// \param argIdx The index of the extra argument.
-  virtual void extraArgument(unsigned argIdx);
+  /// \param argIndices The indices of the extra arguments.
+  ///
+  /// \returns true to indicate that this should cause a failure, false
+  /// otherwise.
+  virtual bool extraArguments(ArrayRef<unsigned> argIndices);
 
   /// Indicates that no argument was provided for the parameter at the given
   /// indices.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3859,6 +3859,7 @@ bool matchCallArguments(ArrayRef<AnyFunctionType::Param> args,
 
 ConstraintSystem::TypeMatchResult
 matchCallArguments(ConstraintSystem &cs,
+                   FunctionType *contextualType,
                    ArrayRef<AnyFunctionType::Param> args,
                    ArrayRef<AnyFunctionType::Param> params,
                    ConstraintKind subKind,


### PR DESCRIPTION
If there are more arguments than parameters, let's fix this by
ignoring (if possible) or removing extraneous arguments. Ignored
arguments could default to `Any` if they don't get any other
contextual type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
