### PR TITLE
[WIP][Sema] Remove .self on metatypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2929,13 +2929,10 @@ WARNING(store_in_willset,none,
 ERROR(value_of_module_type,none,
       "expected module member name after module name", ())
 
-ERROR(value_of_metatype_type,none,
-      "expected member name or constructor call after type name", ())
-
-NOTE(add_parens_to_type,none,
-     "add arguments after the type to construct a value of the type", ())
-NOTE(add_self_to_type,none,
-     "use '.self' to reference the type object", ())
+WARNING(dot_self_expr_deprecated,none,
+        "use of '.self' to reference a type object is deprecated", ())
+NOTE(fix_dot_self_expr,none,
+     "remove '.self' to silence this warning", ())
 
 WARNING(warn_unqualified_access,none,
         "use of %0 treated as a reference to %1 in %2 %3",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1380,10 +1380,11 @@ public:
 /// MetaTypetype.
 class TypeExpr : public Expr {
   TypeLoc Info;
+  Expr *Unsimplified = nullptr;
   TypeExpr(Type Ty);
 public:
-  // Create a TypeExpr with location information.
-  TypeExpr(TypeLoc Ty);
+  // Create a TypeExpr with location information and an unsimplified version.
+  TypeExpr(TypeLoc Ty, Expr *Unsimplified = nullptr);
 
   // The type of a TypeExpr is always a metatype type.  Return the instance
   // type, ErrorType if an error, or null if not set yet.
@@ -1439,6 +1440,17 @@ public:
   
   SourceRange getSourceRange() const { return Info.getSourceRange(); }
   // TODO: optimize getStartLoc() and getEndLoc() when TypeLoc allows it.
+
+  /// Get the parsed version of this simplified type expr.
+  ///
+  /// This is useful in situations where, for example, the parser parsed an
+  /// ArrayExpr for [Int], but we simplified it down to a TypeExpr with an
+  /// ArrayTypeRepr.
+  Expr *getUnsimplified() const { return Unsimplified; }
+
+  void setUnsimplified(Expr *unsimplified) {
+    Unsimplified = unsimplified;
+  }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Type;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1949,8 +1949,9 @@ Expr *AutoClosureExpr::getSingleExpressionBody() const {
 
 FORWARD_SOURCE_LOCS_TO(UnresolvedPatternExpr, subPattern)
 
-TypeExpr::TypeExpr(TypeLoc TyLoc)
-  : Expr(ExprKind::Type, /*implicit*/false), Info(TyLoc) {
+TypeExpr::TypeExpr(TypeLoc TyLoc, Expr *Unsimplified)
+  : Expr(ExprKind::Type, /*implicit*/false), Info(TyLoc),
+    Unsimplified(Unsimplified) {
   Type Ty = TyLoc.getType();
   if (Ty && Ty->hasCanonicalTypeComputed())
     setType(MetatypeType::get(Ty, Ty->getASTContext()));

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -271,6 +271,9 @@ enum class TypeCheckExprFlags {
   /// as part of the expression diagnostics, which is attempting to narrow
   /// down failure location.
   SubExpressionDiagnostics = 0x400,
+
+  /// If set, skip simplification of potential type expressions.
+  SkipTypeSimplification = 0x800,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;
@@ -1265,7 +1268,8 @@ public:
 
   /// Pre-check the expression, validating any types that occur in the
   /// expression and folding sequence expressions.
-  bool preCheckExpression(Expr *&expr, DeclContext *dc);
+  bool preCheckExpression(Expr *&expr, DeclContext *dc,
+                          bool skipTypeSimplification = false);
 
   /// \name Name lookup
   ///

--- a/test/Constraints/metatypes.swift
+++ b/test/Constraints/metatypes.swift
@@ -3,21 +3,56 @@
 class A {}
 class B : A {}
 
-let test0 : A.Type = A.self
-let test1 : A.Type = B.self
-let test2 : B.Type = A.self // expected-error {{cannot convert value of type 'A.Type' to specified type 'B.Type'}}
-let test3 : AnyClass = A.self
-let test4 : AnyClass = B.self
+// Deprecated .self
+let test0_self : A.Type = A.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                 // expected-note@-1 {{remove '.self' to silence this warning}}
+let test1_self : A.Type = B.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                 // expected-note@-1 {{remove '.self' to silence this warning}}
+let test2_self : B.Type = A.self // expected-error {{cannot convert value of type 'A.Type' to specified type 'B.Type'}}
+let test3_self : AnyClass = A.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                   // expected-note@-1 {{remove '.self' to silence this warning}}
+let test4_self : AnyClass = B.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                   // expected-note@-1 {{remove '.self' to silence this warning}}
+
+let test0 : A.Type = A
+let test1 : A.Type = B
+let test2 : B.Type = A // expected-error {{cannot convert value of type 'A.Type' to specified type 'B.Type'}}
+let test3 : AnyClass = A
+let test4 : AnyClass = B
 
 struct S {}
 
-let test5 : S.Type = S.self
+let test5 : S.Type = S.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                            // expected-note@-1 {{remove '.self' to silence this warning}}
 let test6 : AnyClass = S.self // expected-error {{cannot convert value of type 'S.Type' to specified type 'AnyClass' (aka 'AnyObject.Type')}}
 
 func acceptMeta<T>(_ meta: T.Type) { }
-acceptMeta(A) // expected-error {{expected member name or constructor call after type name}}
-// expected-note@-1 {{add arguments after the type to construct a value of the type}}
-// expected-note@-2 {{use '.self' to reference the type object}}
+acceptMeta(A) // ok
 
-acceptMeta((A) -> Void) // expected-error {{expected member name or constructor call after type name}}
-// expected-note@-1 {{use '.self' to reference the type object}}
+acceptMeta((A) -> Void) // ok
+
+// Post removed .self on metatypes
+
+// Variables
+let simple = Int // ok
+
+let arraySugar0 = [Int] // expected-error {{type of expression is ambiguous without more context}}
+let arraySugar1: [Int].Type = [Int] // ok
+let arraySugar2: [Int.Type] = [Int] // ok
+
+let dict0 = [Int: String] // expected-error {{type of expression is ambiguous without more context}}
+let dict1: [Int: String].Type = [Int: String] // ok
+let dict2: [Int.Type: String.Type] = [Int: String] // expected-error {{type 'Int.Type' does not conform to protocol 'Hashable'}}
+
+let tuple0 = (Int, Int) // expected-error {{type of expression is ambiguous without more context}}
+let tuple1: (Int, Int).Type = (Int, Int) // ok
+let tuple2: (Int.Type, Int.Type) = (Int, Int) // ok
+let tuple3 = () // expected-warning {{constant 'tuple3' inferred to have type '()', which may be unexpected}}
+                // expected-note@-1 {{add an explicit type annotation to silence this warning}}
+let tuple4 = Void // ok
+
+let generic0 = Array<Int> // ok
+let generic1 = Array<Int.Type> // ok
+let generic2 = Array // expected-error {{generic parameter 'Element' could not be inferred}}
+                     // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -45,25 +45,28 @@ struct Gen<T> {
 }
 
 func unqualifiedType() {
-  _ = Foo.self
-  _ = Foo.self
+  _ = Foo.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+               // expected-note@-1 {{remove '.self' to silence this warning}}
+  _ = Foo.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+               // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = Foo()
   _ = Foo.prop
   _ = Foo.meth
   let _ : () = Foo.meth()
   _ = Foo.instMeth
 
-  _ = Foo // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{10-10=()}} expected-note{{use '.self'}} {{10-10=.self}}
+  _ = Foo // ok
   _ = Foo.dynamicType // expected-error {{type 'Foo' has no member 'dynamicType'}}
                       // expected-error@-1 {{'.dynamicType' is deprecated. Use 'type(of: ...)' instead}} {{7-7=type(of: }} {{10-22=)}}
 
-  _ = Bad // expected-error{{expected member name or constructor call after type name}}
-  // expected-note@-1{{use '.self' to reference the type object}}{{10-10=.self}}
+  _ = Bad // ok
 }
 
 func qualifiedType() {
-  _ = Foo.Bar.self
-  let _ : Foo.Bar.Type = Foo.Bar.self
+  _ = Foo.Bar.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                   // expected-note@-1 {{remove '.self' to silence this warning}}
+  let _ : Foo.Bar.Type = Foo.Bar.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                      // expected-note@-1 {{remove '.self' to silence this warning}}
   let _ : Foo.Protocol = Foo.self // expected-error{{cannot use 'Protocol' with non-protocol type 'Foo'}}
   _ = Foo.Bar()
   _ = Foo.Bar.prop
@@ -71,46 +74,44 @@ func qualifiedType() {
   let _ : () = Foo.Bar.meth()
   _ = Foo.Bar.instMeth
 
-  _ = Foo.Bar // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{14-14=()}} expected-note{{use '.self'}} {{14-14=.self}}
+  _ = Foo.Bar // ok
   _ = Foo.Bar.dynamicType // expected-error {{type 'Foo.Bar' has no member 'dynamicType'}}
                           // expected-error@-1 {{'.dynamicType' is deprecated. Use 'type(of: ...)' instead}} {{7-7=type(of: }} {{14-26=)}}
 }
 
 // We allow '.Type' in expr context
 func metaType() {
-  let _ = Foo.Type.self
-  let _ = Foo.Type.self
+  let _ = Foo.Type.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                        // expected-note@-1 {{remove '.self' to silence this warning}}
+  let _ = Foo.Type.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                        // expected-note@-1 {{remove '.self' to silence this warning}}
 
-  let _ = Foo.Type // expected-error{{expected member name or constructor call after type name}}
-  // expected-note@-1 {{use '.self' to reference the type object}}
+  let _ = Foo.Type // ok
 
-  let _ = type(of: Foo.Type) // expected-error{{expected member name or constructor call after type name}}
-  // expected-note@-1 {{use '.self' to reference the type object}}
+  let _ = type(of: Foo.Type) // ok
 }
 
 func genType() {
-  _ = Gen<Foo>.self
+  _ = Gen<Foo>.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                    // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = Gen<Foo>()
   _ = Gen<Foo>.prop
   _ = Gen<Foo>.meth
   let _ : () = Gen<Foo>.meth()
   _ = Gen<Foo>.instMeth
-  _ = Gen<Foo> // expected-error{{expected member name or constructor call after type name}}
-               // expected-note@-1{{use '.self' to reference the type object}}
-               // expected-note@-2{{add arguments after the type to construct a value of the type}}
+  _ = Gen<Foo> // ok
 }
 
 func genQualifiedType() {
-  _ = Gen<Foo>.Bar.self
+  _ = Gen<Foo>.Bar.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                        // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = Gen<Foo>.Bar()
   _ = Gen<Foo>.Bar.prop
   _ = Gen<Foo>.Bar.meth
   let _ : () = Gen<Foo>.Bar.meth()
   _ = Gen<Foo>.Bar.instMeth
 
-  _ = Gen<Foo>.Bar // expected-error{{expected member name or constructor call after type name}}
-                   // expected-note@-1{{add arguments after the type to construct a value of the type}}
-                   // expected-note@-2{{use '.self' to reference the type object}}
+  _ = Gen<Foo>.Bar // ok
   _ = Gen<Foo>.Bar.dynamicType // expected-error {{type 'Gen<Foo>.Bar' has no member 'dynamicType'}}
                                // expected-error@-1 {{'.dynamicType' is deprecated. Use 'type(of: ...)' instead}} {{7-7=type(of: }} {{19-31=)}}
 }
@@ -136,32 +137,35 @@ func typeOfShadowing() {
   // TODO: Errors need improving here.
   _ = type(of: Gen<Foo>.Bar) // expected-error{{argument labels '(of:)' do not match any available overloads}}
                              // expected-note@-1{{overloads for 'type' exist with these partially matching parameter lists: (T.Type), (fo: T.Type)}}
-  _ = type(Gen<Foo>.Bar) // expected-error{{expected member name or constructor call after type name}}
-  // expected-note@-1{{add arguments after the type to construct a value of the type}}
-  // expected-note@-2{{use '.self' to reference the type object}}
-  _ = type(of: Gen<Foo>.Bar.self, flag: false) // No error here.
-  _ = type(fo: Foo.Bar.self) // No error here.
-  _ = type(of: Foo.Bar.self, [1, 2, 3]) // No error here.
+  _ = type(Gen<Foo>.Bar) // ok
+  _ = type(of: Gen<Foo>.Bar.self, flag: false) // // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                               // expected-note@-1 {{remove '.self' to silence this warning}}
+  _ = type(fo: Foo.Bar.self) // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                             // expected-note@-1 {{remove '.self' to silence this warning}}
+  _ = type(of: Foo.Bar.self, [1, 2, 3]) // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                        // expected-note@-1 {{remove '.self' to silence this warning}}
 }
 
 func archetype<T: Zim>(_: T) {
-  _ = T.self
+  _ = T.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+             // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = T()
   // TODO let prop = T.prop
   _ = T.meth
   let _ : () = T.meth()
 
-  _ = T // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{8-8=()}} expected-note{{use '.self'}} {{8-8=.self}}
+  _ = T // ok
 }
 
 func assocType<T: Zim>(_: T) where T.Zang: Zim {
-  _ = T.Zang.self
+  _ = T.Zang.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                  // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = T.Zang()
   // TODO _ = T.Zang.prop
   _ = T.Zang.meth
   let _ : () = T.Zang.meth()
 
-  _ = T.Zang // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{13-13=()}} expected-note{{use '.self'}} {{13-13=.self}}
+  _ = T.Zang // ok
 }
 
 class B {
@@ -172,16 +176,18 @@ class D: B {
 }
 
 func derivedType() {
-  let _: B.Type = D.self
+  let _: B.Type = D.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                         // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = D.baseMethod
   let _ : () = D.baseMethod()
 
-  let _: D.Type = D.self
+  let _: D.Type = D.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                         // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = D.derivedMethod
   let _ : () = D.derivedMethod()
 
-  let _: B.Type = D // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{20-20=()}} expected-note{{use '.self'}} {{20-20=.self}}
-  let _: D.Type = D // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{20-20=()}} expected-note{{use '.self'}} {{20-20=.self}}
+  let _: B.Type = D // ok
+  let _: D.Type = D // ok
 }
 
 // Referencing a nonexistent member or constructor should not trigger errors
@@ -195,12 +201,17 @@ func nonexistentMember() {
 protocol P {}
 
 func meta_metatypes() {
-  let _: P.Protocol = P.self
-  _ = P.Type.self
-  _ = P.Protocol.self
+  let _: P.Protocol = P.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                             // expected-note@-1 {{remove '.self' to silence this warning}}
+  _ = P.Type.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                  // expected-note@-1 {{remove '.self' to silence this warning}}
+  _ = P.Protocol.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                      // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = P.Protocol.Protocol.self // expected-error{{cannot use 'Protocol' with non-protocol type 'P.Protocol'}}
-  _ = P.Protocol.Type.self
-  _ = B.Type.self
+  _ = P.Protocol.Type.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                           // expected-note@-1 {{remove '.self' to silence this warning}}
+  _ = B.Type.self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                  // expected-note@-1 {{remove '.self' to silence this warning}}
 }
 
 class E {
@@ -208,7 +219,7 @@ class E {
 }
 
 func inAccessibleInit() {
-  _ = E // expected-error {{expected member name or constructor call after type name}} expected-note {{use '.self'}} {{8-8=.self}}
+  _ = E // ok
 }
 
 enum F: Int {
@@ -220,8 +231,8 @@ struct G {
 }
 
 func implicitInit() {
-  _ = F // expected-error {{expected member name or constructor call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
-  _ = G // expected-error {{expected member name or constructor call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
+  _ = F // ok
+  _ = G // ok
 }
 
 // https://bugs.swift.org/browse/SR-502
@@ -246,13 +257,14 @@ func testFunctionCollectionTypes() {
 
   _ = 2 + () -> Int // expected-error {{expected type before '->'}}
   _ = () -> (Int, Int).2 // expected-error {{expected type after '->'}}
-  _ = (Int) -> Int // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
+  _ = (Int) -> Int // ok
 
-  _ = @convention(c) () -> Int // expected-error{{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
+  _ = @convention(c) () -> Int // ok
   _ = 1 + (@convention(c) () -> Int).self // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and '(@convention(c) () -> Int).Type'}} // expected-note {{expected an argument list of type '(Int, Int)'}}
   _ = (@autoclosure () -> Int) -> (Int, Int).2 // expected-error {{expected type after '->'}}
   _ = ((@autoclosure () -> Int) -> (Int, Int)).1 // expected-error {{type '(@autoclosure () -> Int) -> (Int, Int)' has no member '1'}}
-  _ = ((inout Int) -> Void).self
+  _ = ((inout Int) -> Void).self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                 // expected-note@-1 {{remove '.self' to silence this warning}}
 
   _ = [(Int) throws -> Int]()
   _ = [@convention(swift) (Int) throws -> Int]().count
@@ -266,9 +278,10 @@ protocol P1 {}
 protocol P2 {}
 protocol P3 {}
 func compositionType() {
-  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
+  _ = P1 & P2 // ok
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}} expected-note {{overloads}}
-  _ = (P1 & P2).self // Ok.
+  _ = (P1 & P2).self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                     // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
   _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(P2, P3)' cannot be used within a protocol-constrained type}}
   _ = (P1 & Int).self // expected-error {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
@@ -278,18 +291,16 @@ func compositionType() {
 
   _ = P1 & P2 -> P3
   // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
-  // expected-error @-2 {{expected member name or constructor call after type name}}
-  // expected-note @-3 {{use '.self'}} {{7-7=(}} {{20-20=).self}}
 
   _ = P1 & P2 -> P3 & P1 -> Int
   // expected-error @-1 {{single argument function types require parentheses}} {{18-18=(}} {{25-25=)}}
   // expected-error @-2 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
-  // expected-error @-3 {{expected member name or constructor call after type name}}
-  // expected-note @-4 {{use '.self'}} {{7-7=(}} {{32-32=).self}}
 
-  _ = (() -> P1 & P2).self // Ok
+  _ = (() -> P1 & P2).self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                           // expected-note@-1 {{remove '.self' to silence this warning}}
   _ = (P1 & P2 -> P3 & P2).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{15-15=)}}
-  _ = ((P1 & P2) -> (P3 & P2) -> P1 & Any).self // Ok
+  _ = ((P1 & P2) -> (P3 & P2) -> P1 & Any).self // expected-warning {{use of '.self' to reference a type object is deprecated}}
+                                                // expected-note@-1 {{remove '.self' to silence this warning}}
 }
 
 func complexSequence() {
@@ -300,8 +311,6 @@ func complexSequence() {
   _ = try P1 & P2 throws -> P3 & P1
   // expected-warning @-1 {{no calls to throwing functions occur within 'try' expression}}
   // expected-error @-2 {{single argument function types require parentheses}} {{none}} {{11-11=(}} {{18-18=)}}
-  // expected-error @-3 {{expected member name or constructor call after type name}}
-  // expected-note @-4 {{use '.self' to reference the type object}} {{11-11=(}} {{36-36=).self}}
 }
 
 func takesVoid(f: Void -> ()) {} // expected-error {{single argument function types require parentheses}} {{19-23=()}}
@@ -313,33 +322,15 @@ func testMissingSelf() {
   // None of these were not caught in Swift 3.
   // See test/Compatibility/type_expr.swift.
 
-  takesOneArg(Int)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
-  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-  // expected-note@-3 {{use '.self' to reference the type object}}
+  takesOneArg(Int) // ok
 
-  takesOneArg(Swift.Int)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
-  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-  // expected-note@-3 {{use '.self' to reference the type object}}
+  takesOneArg(Swift.Int) // ok
 
-  takesTwoArgs(Int, 0)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
-  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-  // expected-note@-3 {{use '.self' to reference the type object}}
+  takesTwoArgs(Int, 0) // ok
 
-  takesTwoArgs(Swift.Int, 0)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
-  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-  // expected-note@-3 {{use '.self' to reference the type object}}
+  takesTwoArgs(Swift.Int, 0) // ok
 
   Swift.Int // expected-warning {{expression of type 'Int.Type' is unused}}
-  // expected-error@-1 {{expected member name or constructor call after type name}}
-  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-  // expected-note@-3 {{use '.self' to reference the type object}}
 
-  _ = Swift.Int
-  // expected-error@-1 {{expected member name or constructor call after type name}}
-  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-  // expected-note@-3 {{use '.self' to reference the type object}}
+  _ = Swift.Int // ok
 }


### PR DESCRIPTION
This is a rough early attempt at implementing [SE-0090](https://github.com/apple/swift-evolution/blob/master/proposals/0090-remove-dot-self.md).

In no way is this done because there are still a lot of bugs I need to fix and tests to add, but would love to hear feedback regarding this approach and if there are any cleanups you can point out.

The only cases I could find where ambiguity is now found is with arrays, tuples, dictionaries (although they don't work because metatypes aren't hashable), and with protocol composition (not yet implemented).

cc: @DougGregor (thank you for your advice on twitter), @xedin, @slavapestov 