### PR TITLE
test: disable SILGen test

### DIFF
--- a/test/SILGen/weak_linked_attribute.swift
+++ b/test/SILGen/weak_linked_attribute.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// UNSUPPORTED: OS=windows-msvc
 
 // CHECK-LABEL: sil [_weakLinked] [ossa] @$s21weak_linked_attribute0A8FunctionyyF : $@convention(thin) () -> ()
 @_weakLinked public func weakFunction() {}


### PR DESCRIPTION
This does not make sense on PE/COFF targets where the `_weakLinked`
attribute is unsupported.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
