### PR TITLE
[WIP] Shared string APIs

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -132,6 +132,7 @@ set(SWIFTLIB_ESSENTIAL
   SetStorage.swift
   SetVariant.swift
   ShadowProtocols.swift
+  SharedString.swift
   Shims.swift
   Slice.swift
   SmallBuffer.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -10,6 +10,7 @@
     "CharacterProperties.swift",
     "ICU.swift",
     "NormalizedCodeUnitIterator.swift",
+    "SharedString.swift",
     "SmallString.swift",
     "StaticString.swift",
     "String.swift",

--- a/stdlib/public/core/SharedString.swift
+++ b/stdlib/public/core/SharedString.swift
@@ -11,88 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 extension String {
-  /// Calls the given closure with a `String` whose backing store is shared with
-  /// the UTF-8 data referenced by the given buffer pointer.
-  ///
-  /// This method does not try to repair ill-formed UTF-8 code unit sequences.
-  /// If any are found, the closure parameter is `nil`.
-  ///
-  /// - Parameters:
-  ///   - buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes that
-  ///     should be shared with the created `String`.
-  ///   - body: A closure with an optional `String` parameter that shares the
-  ///     memory pointed to by `buffer`. The string argument is valid only for
-  ///     the duration of the method's execution, and it may be nil if the
-  ///     `String` could not be created (for example, if the bytes were not
-  ///     valid UTF-8).
-  /// - Returns: The return value, if any, of the `body` closure parameter.
-  public static func withSharedUTF8<Result>(
-    _ buffer: UnsafeBufferPointer<UInt8>,
-    _ body: (String?) throws -> Result
-  ) rethrows -> Result {
-    return try body(String(sharingUTF8: buffer, deallocator: { _ in }))
-  }
-
-  /// Calls the given closure with a `String` whose backing store is shared with
-  /// the null-terminated UTF-8 data referenced by the given pointer.
-  ///
-  /// This method does not try to repair ill-formed UTF-8 code unit sequences.
-  /// If any are found, the closure parameter is `nil`.
-  ///
-  /// - Parameters:
-  ///   - cString: An `UnsafePointer` containing the null-terminated UTF-8 bytes
-  ///     that should be shared with the created `String`.
-  ///   - body: A closure with an optional `String` parameter that shares the
-  ///     memory pointed to by `buffer`. The string argument is valid only for
-  ///     the duration of the method's execution, and it may be nil if the
-  ///     `String` could not be created (for example, if the bytes were not
-  ///     valid UTF-8).
-  /// - Returns: The return value, if any, of the `body` closure parameter.
-  public static func withSharedNullTerminatedUTF8<Result>(
-    _ cString: UnsafePointer<UInt8>,
-    _ body: (String?) throws -> Result
-  ) rethrows -> Result {
-    let len = UTF8._nullCodeUnitOffset(in: cString)
-    let buf = UnsafeBufferPointer<UInt8>(start: cString, count: len)
-    return try withSharedUTF8(buf, body)
-  }
-}
-
-extension String {
-  internal class SharedDeallocatingOwner {
-    internal let pointer: UnsafePointer<UInt8>
-    internal let deallocator: (UnsafePointer<UInt8>) -> Void
-
-    internal init(
-      pointer: UnsafePointer<UInt8>,
-      deallocator: @escaping (UnsafePointer<UInt8>) -> Void
-    ) {
-      self.pointer = pointer
-      self.deallocator = deallocator
-    }
-
-    deinit {
-      deallocator(pointer)
-    }
-  }
-
   /// Creates a `String` whose backing store is shared with the UTF-8 data
-  /// referenced by the given buffer pointer, which will be released by calling
-  /// `deallocate`.
+  /// referenced by the given buffer pointer.
   ///
-  /// This initializer does not try to repair ill-formed UTF-8 code unit
-  /// sequences. If any are found, the result of the initializer is `nil`.
-  ///
-  /// - Parameter buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes
-  ///   that should be shared with the created `String`.
-  public init?(sharingUTF8 buffer: UnsafeBufferPointer<UInt8>) {
-    self.init(
-      sharingUTF8: buffer, deallocator: { ptr in ptr.deallocate() })
-  }
-
-  /// Creates a `String` whose backing store is shared with the UTF-8 data
-  /// referenced by the given buffer pointer, which will be released by calling
-  /// the `deallocator` closure.
+  /// The `owner` argument should manage the lifetime of the shared buffer and
+  /// its deinitializer is responsible for deallocating `buffer`. The `String`
+  /// instance created by this initializer retains `owner` so that deallocation
+  /// occurs after the string is no longer in use. The buffer _must not_ be
+  /// deallocated while there are any strings sharing it.
   ///
   /// This initializer does not try to repair ill-formed UTF-8 code unit
   /// sequences. If any are found, the result of the initializer is `nil`.
@@ -100,14 +26,13 @@ extension String {
   /// - Parameters:
   ///   - buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes that
   ///     should be shared with the created `String`.
-  ///   - deallocator: A closure called to free the backing store at the end of
-  ///     the string's lifetime.
+  ///   - owner: An optional object that owns the memory referenced by `buffer`
+  ///     and is responsible for deallocating it.
   public init?(
-    sharingUTF8 buffer: UnsafeBufferPointer<UInt8>,
-    deallocator: @escaping (UnsafePointer<UInt8>) -> Void
+    sharingContent buffer: UnsafeBufferPointer<UInt8>,
+    owner: AnyObject?
   ) {
-    guard
-      let baseAddress = buffer.baseAddress,
+    guard let baseAddress = buffer.baseAddress,
       case .success(let extraInfo) = validateUTF8(buffer)
     else {
       return nil
@@ -117,44 +42,11 @@ extension String {
       countAndFlags: _StringObject.CountAndFlags(
         sharedCount: buffer.count,
         isASCII: extraInfo.isASCII))
-    storage._owner = SharedDeallocatingOwner(
-      pointer: baseAddress, deallocator: deallocator)
+    storage._owner = owner
     self.init(String(_StringGuts(storage)))
   }
+}
 
-  /// Creates a `String` whose backing store is shared with the null-terminated
-  /// UTF-8 data referenced by the given buffer pointer, which will be released
-  /// by calling `deallocate`.
-  ///
-  /// This initializer does not try to repair ill-formed UTF-8 code unit
-  /// sequences. If any are found, the result of the initializer is `nil`.
-  ///
-  /// - Parameter cString: An `UnsafePointer` containing the null-terminated
-  ///   UTF-8 bytes that should be shared with the created `String`.
-  public init?(sharingNullTerminatedUTF8 cString: UnsafePointer<UInt8>) {
-    self.init(
-      sharingNullTerminatedUTF8: cString,
-      deallocator: { ptr in ptr.deallocate() })
-  }
+extension Substring {
 
-  /// Creates a `String` whose backing store is shared with the null-terminated
-  /// UTF-8 data referenced by the given pointer, which will be released by
-  /// calling the `deallocator` closure.
-  ///
-  /// This initializer does not try to repair ill-formed UTF-8 code unit
-  /// sequences. If any are found, the result of the initializer is `nil`.
-  ///
-  /// - Parameters:
-  ///   - cString: An `UnsafePointer` containing the null-terminated UTF-8 bytes
-  ///     that should be shared with the created `String`.
-  ///   - deallocator: A closure called to free the backing store at the end of
-  ///     the string's lifetime.
-  public init?(
-    sharingNullTerminatedUTF8 cString: UnsafePointer<UInt8>,
-    deallocator: @escaping (UnsafePointer<UInt8>) -> Void
-  ) {
-    let len = UTF8._nullCodeUnitOffset(in: cString)
-    let buf = UnsafeBufferPointer<UInt8>(start: cString, count: len)
-    self.init(sharingUTF8: buf, deallocator: deallocator)
-  }
 }

--- a/stdlib/public/core/SharedString.swift
+++ b/stdlib/public/core/SharedString.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+  /// Calls the given closure with a `String` whose backing store is shared with
+  /// the UTF-8 data referenced by the given buffer pointer.
+  ///
+  /// This method does not try to repair ill-formed UTF-8 code unit sequences.
+  /// If any are found, the closure parameter is `nil`.
+  ///
+  /// - Parameters:
+  ///   - buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes that
+  ///     should be shared with the created `String`.
+  ///   - body: A closure with an optional `String` parameter that shares the
+  ///     memory pointed to by `buffer`. The string argument is valid only for
+  ///     the duration of the method's execution, and it may be nil if the
+  ///     `String` could not be created (for example, if the bytes were not
+  ///     valid UTF-8).
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  public static func withSharedUTF8<Result>(
+    _ buffer: UnsafeBufferPointer<UInt8>,
+    _ body: (String?) throws -> Result
+  ) rethrows -> Result {
+    return try body(String(sharingUTF8: buffer, deallocator: .none))
+  }
+
+  /// Calls the given closure with a `String` whose backing store is shared with
+  /// the null-terminated UTF-8 data referenced by the given pointer.
+  ///
+  /// This method does not try to repair ill-formed UTF-8 code unit sequences.
+  /// If any are found, the closure parameter is `nil`.
+  ///
+  /// - Parameters:
+  ///   - cString: An `UnsafePointer` containing the null-terminated UTF-8 bytes
+  ///     that should be shared with the created `String`.
+  ///   - body: A closure with an optional `String` parameter that shares the
+  ///     memory pointed to by `buffer`. The string argument is valid only for
+  ///     the duration of the method's execution, and it may be nil if the
+  ///     `String` could not be created (for example, if the bytes were not
+  ///     valid UTF-8).
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  public static func withSharedNullTerminatedUTF8<Result>(
+    _ cString: UnsafePointer<UInt8>,
+    _ body: (String?) throws -> Result
+  ) rethrows -> Result {
+    let len = UTF8._nullCodeUnitOffset(in: cString)
+    let buf = UnsafeBufferPointer<UInt8>(start: cString, count: len)
+    return try withSharedUTF8(buf, body)
+  }
+}
+
+extension String {
+  /// Creates a `String` whose backing store is shared with the UTF-8 data
+  /// referenced by the given buffer pointer.
+  ///
+  /// This initializer does not try to repair ill-formed UTF-8 code unit
+  /// sequences. If any are found, the result of the initializer is `nil`.
+  ///
+  /// - Parameters:
+  ///   - buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes that
+  ///     should be shared with the created `String`.
+  ///   - deallocator: The strategy used to free the buffer, or `.none`.
+  public init?(
+    sharingUTF8 buffer: UnsafeBufferPointer<UInt8>,
+    deallocator: Deallocator
+  ) {
+    guard
+      let baseAddress = buffer.baseAddress,
+      case .success(let extraInfo) = validateUTF8(buffer)
+    else {
+      return nil
+    }
+    let storage = __SharedStringStorage(
+      immortal: baseAddress,
+      countAndFlags: _StringObject.CountAndFlags(
+        sharedCount: buffer.count,
+        isASCII: extraInfo.isASCII),
+      deallocator: deallocator)
+    self.init(String(_StringGuts(storage)))
+  }
+
+  /// Creates a `String` whose backing store is shared with the null-terminated
+  /// UTF-8 data referenced by the given buffer pointer.
+  ///
+  /// This initializer does not try to repair ill-formed UTF-8 code unit
+  /// sequences. If any are found, the result of the initializer is `nil`.
+  ///
+  /// - Parameters:
+  ///   - cString: An `UnsafePointer` containing the null-terminated UTF-8 bytes
+  ///     that should be shared with the created `String`.
+  ///   - deallocator: The strategy used to free the buffer, or `.none`.
+  public init?(
+    sharingNullTerminatedUTF8 cString: UnsafePointer<UInt8>,
+    deallocator: Deallocator
+  ) {
+    let len = UTF8._nullCodeUnitOffset(in: cString)
+    let buf = UnsafeBufferPointer<UInt8>(start: cString, count: len)
+    self.init(sharingUTF8: buf, deallocator: deallocator)
+  }
+}

--- a/stdlib/public/core/SharedString.swift
+++ b/stdlib/public/core/SharedString.swift
@@ -45,6 +45,28 @@ extension String {
     storage._owner = owner
     self.init(String(_StringGuts(storage)))
   }
+
+  /// Creates a `String` whose backing store is shared with the UTF-8 data in
+  /// the given array.
+  ///
+  /// The new `String` instance shares ownership of the array's underlying
+  /// storage, guaranteeing that the `String` remains valid even if the `array`
+  /// is released.
+  ///
+  /// This initializer does not try to repair ill-formed UTF-8 code unit
+  /// sequences. If any are found, the result of the initializer is `nil`.
+  ///
+  /// - Parameter array: An `Array` containing the UTF-8 bytes that should be
+  ///   shared with the created `String`.
+  public init?(sharing array: [UInt8]) {
+    guard case (let owner, let rawPtr?) = array._cPointerArgs() else {
+      self = ""
+      return
+    }
+    let baseAddress = rawPtr.assumingMemoryBound(to: UInt8.self)
+    let buffer = UnsafeBufferPointer(start: baseAddress, count: array.count)
+    self.init(sharingContent: buffer, owner: owner)
+  }
 }
 
 extension Substring {

--- a/stdlib/public/core/SharedString.swift
+++ b/stdlib/public/core/SharedString.swift
@@ -30,7 +30,7 @@ extension String {
     _ buffer: UnsafeBufferPointer<UInt8>,
     _ body: (String?) throws -> Result
   ) rethrows -> Result {
-    return try body(String(sharingUTF8: buffer, deallocator: .none))
+    return try body(String(sharingUTF8: buffer, deallocator: { _ in }))
   }
 
   /// Calls the given closure with a `String` whose backing store is shared with
@@ -59,8 +59,40 @@ extension String {
 }
 
 extension String {
+  internal class SharedDeallocatingOwner {
+    internal let pointer: UnsafePointer<UInt8>
+    internal let deallocator: (UnsafePointer<UInt8>) -> Void
+
+    internal init(
+      pointer: UnsafePointer<UInt8>,
+      deallocator: @escaping (UnsafePointer<UInt8>) -> Void
+    ) {
+      self.pointer = pointer
+      self.deallocator = deallocator
+    }
+
+    deinit {
+      deallocator(pointer)
+    }
+  }
+
   /// Creates a `String` whose backing store is shared with the UTF-8 data
-  /// referenced by the given buffer pointer.
+  /// referenced by the given buffer pointer, which will be released by calling
+  /// `deallocate`.
+  ///
+  /// This initializer does not try to repair ill-formed UTF-8 code unit
+  /// sequences. If any are found, the result of the initializer is `nil`.
+  ///
+  /// - Parameter buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes
+  ///   that should be shared with the created `String`.
+  public init?(sharingUTF8 buffer: UnsafeBufferPointer<UInt8>) {
+    self.init(
+      sharingUTF8: buffer, deallocator: { ptr in ptr.deallocate() })
+  }
+
+  /// Creates a `String` whose backing store is shared with the UTF-8 data
+  /// referenced by the given buffer pointer, which will be released by calling
+  /// the `deallocator` closure.
   ///
   /// This initializer does not try to repair ill-formed UTF-8 code unit
   /// sequences. If any are found, the result of the initializer is `nil`.
@@ -68,10 +100,11 @@ extension String {
   /// - Parameters:
   ///   - buffer: An `UnsafeBufferPointer` containing the UTF-8 bytes that
   ///     should be shared with the created `String`.
-  ///   - deallocator: The strategy used to free the buffer, or `.none`.
+  ///   - deallocator: A closure called to free the backing store at the end of
+  ///     the string's lifetime.
   public init?(
     sharingUTF8 buffer: UnsafeBufferPointer<UInt8>,
-    deallocator: Deallocator
+    deallocator: @escaping (UnsafePointer<UInt8>) -> Void
   ) {
     guard
       let baseAddress = buffer.baseAddress,
@@ -83,13 +116,30 @@ extension String {
       immortal: baseAddress,
       countAndFlags: _StringObject.CountAndFlags(
         sharedCount: buffer.count,
-        isASCII: extraInfo.isASCII),
-      deallocator: deallocator)
+        isASCII: extraInfo.isASCII))
+    storage._owner = SharedDeallocatingOwner(
+      pointer: baseAddress, deallocator: deallocator)
     self.init(String(_StringGuts(storage)))
   }
 
   /// Creates a `String` whose backing store is shared with the null-terminated
-  /// UTF-8 data referenced by the given buffer pointer.
+  /// UTF-8 data referenced by the given buffer pointer, which will be released
+  /// by calling `deallocate`.
+  ///
+  /// This initializer does not try to repair ill-formed UTF-8 code unit
+  /// sequences. If any are found, the result of the initializer is `nil`.
+  ///
+  /// - Parameter cString: An `UnsafePointer` containing the null-terminated
+  ///   UTF-8 bytes that should be shared with the created `String`.
+  public init?(sharingNullTerminatedUTF8 cString: UnsafePointer<UInt8>) {
+    self.init(
+      sharingNullTerminatedUTF8: cString,
+      deallocator: { ptr in ptr.deallocate() })
+  }
+
+  /// Creates a `String` whose backing store is shared with the null-terminated
+  /// UTF-8 data referenced by the given pointer, which will be released by
+  /// calling the `deallocator` closure.
   ///
   /// This initializer does not try to repair ill-formed UTF-8 code unit
   /// sequences. If any are found, the result of the initializer is `nil`.
@@ -97,10 +147,11 @@ extension String {
   /// - Parameters:
   ///   - cString: An `UnsafePointer` containing the null-terminated UTF-8 bytes
   ///     that should be shared with the created `String`.
-  ///   - deallocator: The strategy used to free the buffer, or `.none`.
+  ///   - deallocator: A closure called to free the backing store at the end of
+  ///     the string's lifetime.
   public init?(
     sharingNullTerminatedUTF8 cString: UnsafePointer<UInt8>,
-    deallocator: Deallocator
+    deallocator: @escaping (UnsafePointer<UInt8>) -> Void
   ) {
     let len = UTF8._nullCodeUnitOffset(in: cString)
     let buf = UnsafeBufferPointer<UInt8>(start: cString, count: len)

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -647,33 +647,6 @@ extension __StringStorage {
   }
 }
 
-extension String {
-
-  /// Customizes how the backing store of a shared `String` is deallocated.
-  public enum Deallocator {
-    /// No action is taken on the backing store.
-    case none
-
-    /// Call `free` on the backing store.
-    case free
-
-    /// A custom deallocation action is taken.
-    case custom((UnsafePointer<UInt8>, Int) -> Void)
-
-    internal func apply(to ptr: UnsafePointer<UInt8>, count: Int) {
-      switch self {
-      case .none:
-        // Intentionally do nothing.
-        break
-      case .free:
-        _swift_stdlib_free(UnsafeMutableRawPointer(mutating: ptr))
-      case .custom(let deleter):
-        deleter(ptr, count)
-      }
-    }
-  }
-}
-
 // For shared storage and bridging literals
 // NOTE: older runtimes called this class _SharedStringStorage. The two
 // must coexist without conflicting ObjC class names, so it was
@@ -682,7 +655,6 @@ final internal class __SharedStringStorage
   : __SwiftNativeNSString, _AbstractStringStorage {
   internal var _owner: AnyObject?
   internal var start: UnsafePointer<UInt8>
-  internal let deallocator: String.Deallocator
 
 #if arch(i386) || arch(arm)
   internal var _count: Int
@@ -702,8 +674,7 @@ final internal class __SharedStringStorage
 
   internal init(
     immortal ptr: UnsafePointer<UInt8>,
-    countAndFlags: _StringObject.CountAndFlags,
-    deallocator: String.Deallocator = .none
+    countAndFlags: _StringObject.CountAndFlags
   ) {
     self._owner = nil
     self.start = ptr
@@ -713,13 +684,8 @@ final internal class __SharedStringStorage
 #else
     self._countAndFlags = countAndFlags
 #endif
-    self.deallocator = deallocator
     super.init()
     self._invariantCheck()
-  }
-
-  deinit {
-    deallocator.apply(to: start, count: count)
   }
 
   @inline(__always)

--- a/test/stdlib/SharedString.swift
+++ b/test/stdlib/SharedString.swift
@@ -66,9 +66,7 @@ SharedStringTests.test("String.init(sharedUTF8:deallocator:)") {
   ptr.initialize(repeating: UInt8(ascii: "a"), count: 4)
   let buf = UnsafeBufferPointer<UInt8>(start: ptr, count: 4)
 
-  let str = String(sharingUTF8: buf, deallocator: .custom({ ptr, _ in
-    ptr.deallocate()
-  }))
+  let str = String(sharingUTF8: buf)
   expectNotNil(str)
   expectEqual(str!, "aaaa")
 
@@ -87,7 +85,7 @@ SharedStringTests.test("String.withSharedUTF8 invalid UTF8") {
   ptr.pointee = 0x80  // orphaned continuation byte
   let buf = UnsafeBufferPointer<UInt8>(start: ptr, count: 1)
 
-  expectNil(String(sharingUTF8: buf, deallocator: .none))
+  expectNil(String(sharingUTF8: buf))
 }
 
 SharedStringTests.test("String.init(sharingNullTerminatedUTF8:deallocator:)") {
@@ -95,9 +93,7 @@ SharedStringTests.test("String.init(sharingNullTerminatedUTF8:deallocator:)") {
   ptr.initialize(repeating: UInt8(ascii: "a"), count: 4)
   ptr[4] = 0
 
-  let str = String(sharingNullTerminatedUTF8: ptr, deallocator: .custom({ ptr, _ in
-    ptr.deallocate()
-  }))
+  let str = String(sharingNullTerminatedUTF8: ptr)
   expectNotNil(str)
   expectEqual(str!, "aaaa")
 
@@ -116,7 +112,7 @@ SharedStringTests.test("String.init(sharingNullTerminatedUTF8:deallocator:) inva
   ptr[0] = 0x80  // orphaned continuation byte
   ptr[1] = 0
 
-  expectNil(String(sharingNullTerminatedUTF8: ptr, deallocator: .none))
+  expectNil(String(sharingNullTerminatedUTF8: ptr))
 }
 
 runAllTests()

--- a/test/stdlib/SharedString.swift
+++ b/test/stdlib/SharedString.swift
@@ -38,17 +38,17 @@ SharedStringTests.test("String.init(sharingContent:owner:)") {
   let str = String(sharingContent: buf, owner: BufferDeallocator(buf))
 
   expectNotNil(str)
-  expectEqual(str!, "aaaa")
+  expectEqual("aaaa", str!)
 
   // Show that the string didn't copy the buffer by modifying it in-place.
   UnsafeMutableBufferPointer(mutating: buf)[0] = UInt8(ascii: "b")
-  expectEqual(str!, "baaa")
+  expectEqual("baaa", str!)
 
   // Show that mutating a copy works as expected.
   var copy = str!
   copy.append("c")
-  expectEqual(copy, "baaac")
-  expectEqual(str!, "baaa")
+  expectEqual("baaac", copy)
+  expectEqual("baaa", str!)
 }
 
 SharedStringTests.test("String.init(sharingContent:owner:) invalid UTF8") {
@@ -63,7 +63,7 @@ SharedStringTests.test("Substring.withSharedString(_:)") {
   let substr = original.dropFirst().dropLast()
 
   substr.withSharedString { shared in
-    expectEqual(shared, "bcd")
+    expectEqual("bcd", shared)
   }
 }
 
@@ -72,12 +72,12 @@ SharedStringTests.test("String.init(sharing:)") {
   let str = String(sharing: array)
 
   expectNotNil(str)
-  expectEqual(str!, "aaaa")
+  expectEqual("aaaa", str!)
 
   // Show that mutating the array causes CoW and the original string isn't
   // modified.
   array[0] = UInt8(ascii: "b")
-  expectEqual(str!, "aaaa")
+  expectEqual("aaaa", str!)
 }
 
 SharedStringTests.test("String.init(sharing:) invalid UTF8") {

--- a/test/stdlib/SharedString.swift
+++ b/test/stdlib/SharedString.swift
@@ -33,7 +33,7 @@ class BufferDeallocator {
   }
 }
 
-SharedStringTests.test("String.init(sharing:owner:)") {
+SharedStringTests.test("String.init(sharingContent:owner:)") {
   let buf = makeValidUTF8Buffer()
   let str = String(sharingContent: buf, owner: BufferDeallocator(buf))
 
@@ -51,7 +51,7 @@ SharedStringTests.test("String.init(sharing:owner:)") {
   expectEqual(str!, "baaa")
 }
 
-SharedStringTests.test("String.init(sharing:owner:) invalid UTF8") {
+SharedStringTests.test("String.init(sharingContent:owner:) invalid UTF8") {
   let buf = makeInvalidUTF8Buffer()
   let str = String(sharingContent: buf, owner: BufferDeallocator(buf))
 
@@ -65,6 +65,26 @@ SharedStringTests.test("Substring.withSharedString(_:)") {
   substr.withSharedString { shared in
     expectEqual(shared, "bcd")
   }
+}
+
+SharedStringTests.test("String.init(sharing:)") {
+  var array = [UInt8](repeating: UInt8(ascii: "a"), count: 4)
+  let str = String(sharing: array)
+
+  expectNotNil(str)
+  expectEqual(str!, "aaaa")
+
+  // Show that mutating the array causes CoW and the original string isn't
+  // modified.
+  array[0] = UInt8(ascii: "b")
+  expectEqual(str!, "aaaa")
+}
+
+SharedStringTests.test("String.init(sharing:) invalid UTF8") {
+  let array: [UInt8] = [0x80]  // orphaned continuation byte
+  let str = String(sharing: array)
+
+  expectNil(str)
 }
 
 runAllTests()

--- a/test/stdlib/SharedString.swift
+++ b/test/stdlib/SharedString.swift
@@ -1,0 +1,122 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+//
+// Tests for shared string APIs
+//
+
+import StdlibUnittest
+
+var SharedStringTests = TestSuite("SharedStringTests")
+
+SharedStringTests.test("String.withSharedUTF8") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 4)
+  defer { ptr.deallocate() }
+  ptr.initialize(repeating: UInt8(ascii: "a"), count: 4)
+  let buf = UnsafeBufferPointer<UInt8>(start: ptr, count: 4)
+
+  String.withSharedUTF8(buf) { str in
+    expectNotNil(str)
+    expectEqual(str!, "aaaa")
+
+    ptr.pointee = UInt8(ascii: "b")
+    expectEqual(str!, "baaa")
+  }
+}
+
+SharedStringTests.test("String.withSharedUTF8 invalid UTF8") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
+  defer { ptr.deallocate() }
+  ptr.pointee = 0x80  // orphaned continuation byte
+  let buf = UnsafeBufferPointer<UInt8>(start: ptr, count: 1)
+
+  String.withSharedUTF8(buf) { str in
+    expectNil(str)
+  }
+}
+
+SharedStringTests.test("String.withSharedNullTerminatedUTF8") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 5)
+  defer { ptr.deallocate() }
+  ptr.initialize(repeating: UInt8(ascii: "a"), count: 4)
+  ptr[4] = 0
+
+  String.withSharedNullTerminatedUTF8(ptr) { str in
+    expectNotNil(str)
+    expectEqual(str!, "aaaa")
+
+    ptr.pointee = UInt8(ascii: "b")
+    expectEqual(str!, "baaa")
+  }
+}
+
+SharedStringTests.test("String.withSharedNullTerminatedUTF8 invalid UTF8") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 2)
+  defer { ptr.deallocate() }
+  ptr[0] = 0x80  // orphaned continuation byte
+  ptr[1] = 0
+
+  String.withSharedNullTerminatedUTF8(ptr) { str in
+    expectNil(str)
+  }
+}
+
+SharedStringTests.test("String.init(sharedUTF8:deallocator:)") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 4)
+  ptr.initialize(repeating: UInt8(ascii: "a"), count: 4)
+  let buf = UnsafeBufferPointer<UInt8>(start: ptr, count: 4)
+
+  let str = String(sharingUTF8: buf, deallocator: .custom({ ptr, _ in
+    ptr.deallocate()
+  }))
+  expectNotNil(str)
+  expectEqual(str!, "aaaa")
+
+  ptr.pointee = UInt8(ascii: "b")
+  expectEqual(str!, "baaa")
+
+  // Verify that the deallocator was called by trying to free the memory again.
+  // If a crash occurs, that means the deallocator already did it.
+  expectCrashLater()
+  ptr.deallocate()
+}
+
+SharedStringTests.test("String.withSharedUTF8 invalid UTF8") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
+  defer { ptr.deallocate() }
+  ptr.pointee = 0x80  // orphaned continuation byte
+  let buf = UnsafeBufferPointer<UInt8>(start: ptr, count: 1)
+
+  expectNil(String(sharingUTF8: buf, deallocator: .none))
+}
+
+SharedStringTests.test("String.init(sharingNullTerminatedUTF8:deallocator:)") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 5)
+  ptr.initialize(repeating: UInt8(ascii: "a"), count: 4)
+  ptr[4] = 0
+
+  let str = String(sharingNullTerminatedUTF8: ptr, deallocator: .custom({ ptr, _ in
+    ptr.deallocate()
+  }))
+  expectNotNil(str)
+  expectEqual(str!, "aaaa")
+
+  ptr.pointee = UInt8(ascii: "b")
+  expectEqual(str!, "baaa")
+
+  // Verify that the deallocator was called by trying to free the memory again.
+  // If a crash occurs, that means the deallocator already did it.
+  expectCrashLater()
+  ptr.deallocate()
+}
+
+SharedStringTests.test("String.init(sharingNullTerminatedUTF8:deallocator:) invalid UTF8") {
+  let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 2)
+  defer { ptr.deallocate() }
+  ptr[0] = 0x80  // orphaned continuation byte
+  ptr[1] = 0
+
+  expectNil(String(sharingNullTerminatedUTF8: ptr, deallocator: .none))
+}
+
+runAllTests()

--- a/test/stdlib/SharedString.swift
+++ b/test/stdlib/SharedString.swift
@@ -58,4 +58,13 @@ SharedStringTests.test("String.init(sharing:owner:) invalid UTF8") {
   expectNil(str)
 }
 
+SharedStringTests.test("Substring.withSharedString(_:)") {
+  let original = "abcde"
+  let substr = original.dropFirst().dropLast()
+
+  substr.withSharedString { shared in
+    expectEqual(shared, "bcd")
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
Floating an early sketch of some shared `String` APIs to improve interop code.

Still some open questions, like:
* Should this take advantage of `ContiguousCollection` instead of taking pointers directly (probably)
* Do we need a method to force a shared string into a native one, thus copying it (probably)

cc @milseman