### PR TITLE
[DNM, WIP, AST] Double-check factored-out isCascadingUse computation

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -143,6 +143,9 @@ enum class ASTScopeKind : uint8_t {
 /// can be used to fully-expand the tree, constructing all of its nodes, but
 /// should only be used for testing or debugging purposes, e.g., via the
 /// frontend option
+///
+/// "Continuations" are used to lazily expand the next scope in a series.
+///
 /// \code
 /// -dump-scope-maps expanded
 /// \endcode

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -653,6 +653,9 @@ public:
   /// type declarations or extensions thereof, or the source file itself. The
   /// client can perform such lookups using the result of \c getDeclContext().
   SmallVector<ValueDecl *, 4> getLocalBindings() const;
+  
+  /// If \c getLocalBindings needs a baseDC, return it here.
+  DeclContext *getBaseDCForLocalBindings() const;
 
   /// Expand the entire scope map.
   ///

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -642,20 +642,18 @@ public:
   /// \seealso getDeclContext().
   DeclContext *getInnermostEnclosingDeclContext() const;
 
-  /// Call the passed function with the declarations whose names are directly bound by this scope
-  /// and the contexts in which they were found if any.
+  /// Retrieve the declarations whose names are directly bound by this scope.
   ///
   /// The declarations bound in this scope aren't available in the immediate
   /// parent of this scope, but will still be visible in child scopes (unless
   /// shadowed there).
   ///
-  /// This routine does not produce bindings for anything that can
+  /// Note that this routine does not produce bindings for anything that can
   /// be found via qualified name lookup in a \c DeclContext, such as nominal
   /// type declarations or extensions thereof, or the source file itself. The
   /// client can perform such lookups using the result of \c getDeclContext().
-  void forEachLocalBinding(llvm::function_ref<void(ValueDecl*, DeclContext*)>)
-         const;
- 
+  SmallVector<ValueDecl *, 4> getLocalBindings() const;
+
   /// Expand the entire scope map.
   ///
   /// Normally, the scope map will be expanded only as needed by its queries,

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -49,6 +49,7 @@ class SourceFile;
 class Stmt;
 class StmtConditionElement;
 class SwitchStmt;
+class TrailingWhereClause;
 class TopLevelCodeDecl;
 class TypeDecl;
 class WhileStmt;
@@ -197,7 +198,7 @@ class ASTScope {
     
     /// The where clause, for
     /// \c kind == ASTScopeKind::NominalOrExtensionWhereClause
-    TrailingWhereClause *whereClause;
+    const TrailingWhereClause *whereClause;
 
     /// An iterable declaration context, which covers nominal type declarations
     /// and extension bodies.
@@ -354,7 +355,7 @@ class ASTScope {
     this->extension = extension;
   }
 
-  ASTScope(const ASTScope *parent, IterableDeclContext *idc)
+  ASTScope(const char*, const ASTScope *parent, IterableDeclContext *idc)
       : ASTScope(ASTScopeKind::TypeOrExtensionBody, parent) {
     this->iterableDeclContext = idc;
   }
@@ -469,7 +470,7 @@ class ASTScope {
     this->topLevelCode = topLevelCode;
   }
   
-  ASTScope(const ASTScope *parent, TrailingWhereClause *whereClause)
+  ASTScope(const ASTScope *parent, const TrailingWhereClause *const whereClause)
   : ASTScope(ASTScopeKind::NominalOrExtensionWhereClause, parent) {
     this->whereClause = whereClause;
   }
@@ -518,7 +519,8 @@ class ASTScope {
   /// Create a new AST scope if one is needed for the where clause.
   ///
   /// \returns the newly-created AST scope, or \c null if there is no scope
-  static ASTScope *createIfNeeded(const ASTScope *parent, TrailingWhereClause*);
+  static ASTScope *createIfNeeded(const ASTScope *parent,
+                                  const TrailingWhereClause*);
 
   /// Determine whether this scope can steal a continuation from its parent,
   /// because (e.g.) it introduces some name binding that should be visible

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -13,6 +13,26 @@
 // This file defines the ASTScope class and related functionality, which
 // describes the scopes that exist within a Swift AST.
 //
+// What is an ASTScope supposed to be?
+//
+// An ASTScope (hereafter "scope") defines a contiguous region of source code
+// with a uniform context for lookup. In other words, every symbolic reference
+// within a scope will be resolved by examinine the same set of definitions.
+// Each scope "knows" how to look up the symbols mentioned within it.
+//
+// Scopes form an ordered tree that respects source locations:
+// 1. Every descendant of a given scope must have a source range that inclusively
+// nests within the source range of the ancestor.
+// 2. The child scopes of any parent scope must have disjoint source ranges and
+// they must be ordered in source order.
+//
+// The scope tree implies nothing about the locus of name resolution. For
+// example, a child scope may lookup symbols in a completely different place
+// than its parent. Swift is not stricly lexical.
+//
+// Each scope may also have local bindings. These are definitions occuring
+// within that scope.
+//
 //===----------------------------------------------------------------------===//
 #ifndef SWIFT_AST_AST_SCOPE_H
 #define SWIFT_AST_AST_SCOPE_H

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -665,8 +665,8 @@ public:
   void expandAll() const;
   
   /// UnqualifiedLookup often wants to stop looking after finding the first match.
-  /// Some scopes are too soon to stop lookup.
-  bool isTooSoonToStopLookup() const {
+  /// Some scopes are too soon to stop lookup. Don't look here; leave it to the module level.
+  bool isEffectivelyTopLevelCode() const {
     return isCloseToTopLevelCode();
   }
 

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -65,6 +65,8 @@ enum class ASTScopeKind : uint8_t {
   TypeDecl,
   /// The generic parameters of an extension declaration.
   ExtensionGenericParams,
+  /// The where clause (if any) of a nominal or extension declaration.
+  NominalOrExtensionWhereClause,
   /// The body of a type or extension thereof.
   TypeOrExtensionBody,
   /// The generic parameters of a declaration.
@@ -192,6 +194,10 @@ class ASTScope {
     /// An extension declaration, for
     /// \c kind == ASTScopeKind::ExtensionGenericParams.
     ExtensionDecl *extension;
+    
+    /// The where clause, for
+    /// \c kind == ASTScopeKind::NominalOrExtensionWhereClause
+    TrailingWhereClause *whereClause;
 
     /// An iterable declaration context, which covers nominal type declarations
     /// and extension bodies.
@@ -462,6 +468,11 @@ class ASTScope {
       : ASTScope(ASTScopeKind::TopLevelCode, parent) {
     this->topLevelCode = topLevelCode;
   }
+  
+  ASTScope(const ASTScope *parent, TrailingWhereClause *whereClause)
+  : ASTScope(ASTScopeKind::NominalOrExtensionWhereClause, parent) {
+    this->whereClause = whereClause;
+  }
 
   ~ASTScope();
 
@@ -503,6 +514,11 @@ class ASTScope {
   /// \returns the newly-created AST scope, or \c null if there is no scope
   /// introduced by this AST node.
   static ASTScope *createIfNeeded(const ASTScope *parent, ASTNode node);
+  
+  /// Create a new AST scope if one is needed for the where clause.
+  ///
+  /// \returns the newly-created AST scope, or \c null if there is no scope
+  static ASTScope *createIfNeeded(const ASTScope *parent, TrailingWhereClause*);
 
   /// Determine whether this scope can steal a continuation from its parent,
   /// because (e.g.) it introduces some name binding that should be visible

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -202,7 +202,7 @@ class ASTScope {
     
     /// The declaration, for
     /// \c kind == ASTScopeKind::NominalOrExtensionWhereClause
-    llvm::PointerUnion<NominalTypeDecl*, ExtensionDecl*> nominalOrExtensionDecl;
+    llvm::PointerUnion<NominalTypeDecl*, ExtensionDecl*> whereDeclContext;
 
     /// An iterable declaration context, which covers nominal type declarations
     /// and extension bodies.
@@ -476,9 +476,9 @@ class ASTScope {
   
   ASTScope(
     const ASTScope *parent,
-    llvm::PointerUnion<NominalTypeDecl*, ExtensionDecl*> nominalOrExtensionDecl)
+    llvm::PointerUnion<NominalTypeDecl*, ExtensionDecl*> whereDeclContext)
   : ASTScope(ASTScopeKind::NominalOrExtensionWhereClause, parent) {
-    this->nominalOrExtensionDecl = nominalOrExtensionDecl;
+    this->whereDeclContext = whereDeclContext;
   }
 
   ~ASTScope();
@@ -571,10 +571,6 @@ class ASTScope {
   /// Retrieve the \c TrailingWhereClause, if any
   static TrailingWhereClause* getTrailingWhereClause(
            llvm::PointerUnion<NominalTypeDecl*, ExtensionDecl*>);
-  
-  /// Retrieve the \c SelfBounds decls when
-  /// \c getKind() == ASTScopeKind::NominalOrExtensionScope
-  llvm::TinyPtrVector<NominalTypeDecl *> getSelfBoundsDecls() const;
  
 public:
   /// Create the AST scope for a source file, which is the root of the scope

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -573,13 +573,6 @@ public:
            getKind() == ASTScopeKind::AbstractFunctionBody);
     return abstractFunction;
   }
-  
-  /// Retrieve the extension declaration when
-  /// \c getKind() == ASTScopeKind::ExtensionGenericParams;
-  ExtensionDecl *getExtensionDecl() const {
-    assert(getKind() == ASTScopeKind::ExtensionGenericParams);
-    return extension;
-  }
 
   /// Retrieve the abstract storage declaration when
   /// \c getKind() == ASTScopeKind::Accessors;

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -642,21 +642,20 @@ public:
   /// \seealso getDeclContext().
   DeclContext *getInnermostEnclosingDeclContext() const;
 
-  /// Retrieve the declarations whose names are directly bound by this scope.
+  /// Call the passed function with the declarations whose names are directly bound by this scope
+  /// and the contexts in which they were found if any.
   ///
   /// The declarations bound in this scope aren't available in the immediate
   /// parent of this scope, but will still be visible in child scopes (unless
   /// shadowed there).
   ///
-  /// Note that this routine does not produce bindings for anything that can
+  /// This routine does not produce bindings for anything that can
   /// be found via qualified name lookup in a \c DeclContext, such as nominal
   /// type declarations or extensions thereof, or the source file itself. The
   /// client can perform such lookups using the result of \c getDeclContext().
-  SmallVector<ValueDecl *, 4> getLocalBindings() const;
-  
-  /// If \c getLocalBindings needs a baseDC, return it here.
-  DeclContext *getBaseDCForLocalBindings() const;
-
+  void forEachLocalBinding(llvm::function_ref<void(ValueDecl*, DeclContext*)>)
+         const;
+ 
   /// Expand the entire scope map.
   ///
   /// Normally, the scope map will be expanded only as needed by its queries,

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -623,6 +623,9 @@ public:
 
   /// Retrieve the parent scope that encloses this one.
   const ASTScope *getParent() const { return parentAndExpanded.getPointer(); }
+  
+  /// Get parent, w.r.t. lookup rules.
+  const ASTScope *getParentForLookup() const;
 
   /// Retrieve the children of this AST scope, expanding if necessary.
   ArrayRef<ASTScope *> children() const {

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -573,6 +573,13 @@ public:
            getKind() == ASTScopeKind::AbstractFunctionBody);
     return abstractFunction;
   }
+  
+  /// Retrieve the extension declaration when
+  /// \c getKind() == ASTScopeKind::ExtensionGenericParams;
+  ExtensionDecl *getExtensionDecl() const {
+    assert(getKind() == ASTScopeKind::ExtensionGenericParams);
+    return extension;
+  }
 
   /// Retrieve the abstract storage declaration when
   /// \c getKind() == ASTScopeKind::Accessors;

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -571,6 +571,10 @@ class ASTScope {
   /// Retrieve the \c TrailingWhereClause, if any
   static TrailingWhereClause* getTrailingWhereClause(
            llvm::PointerUnion<NominalTypeDecl*, ExtensionDecl*>);
+  
+  /// Is the receiver a close enought descendant of a TopLevelCode scope
+  /// that other matches must be found, even if one is found here?
+  bool isCloseToTopLevelCode() const;
  
 public:
   /// Create the AST scope for a source file, which is the root of the scope
@@ -659,6 +663,12 @@ public:
   /// Normally, the scope map will be expanded only as needed by its queries,
   /// but complete expansion can be useful for debugging.
   void expandAll() const;
+  
+  /// UnqualifiedLookup often wants to stop looking after finding the first match.
+  /// Some scopes are too soon to stop lookup.
+  bool isTooSoonToStopLookup() const {
+    return isCloseToTopLevelCode();
+  }
 
   /// Print out this scope for debugging/reporting purposes.
   void print(llvm::raw_ostream &out, unsigned level = 0,

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -17,7 +17,8 @@
 //
 // An ASTScope (hereafter "scope") defines a contiguous region of source code
 // with a uniform context for lookup. In other words, every symbolic reference
-// within a scope will be resolved by examinine the same set of definitions.
+// within a scope (but not in its children) will be resolved by examinine the
+// same set of definitions.
 // Each scope "knows" how to look up the symbols mentioned within it.
 //
 // Scopes form an ordered tree that respects source locations:
@@ -26,9 +27,10 @@
 // 2. The child scopes of any parent scope must have disjoint source ranges and
 // they must be ordered in source order.
 //
-// The scope tree implies nothing about the locus of name resolution. For
-// example, a child scope may lookup symbols in a completely different place
-// than its parent. Swift is not stricly lexical.
+// In Swift, lookup is a combination of lexical nesting and type-based lookup.
+// For example, an identifier in a method may resolve to either a file-private
+// variable or an instance variable in a superclass. The scope tree
+// attempts to capture the lexical portion of lookup.
 //
 // Each scope may also have local bindings. These are definitions occuring
 // within that scope.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -88,7 +88,7 @@ private:
   /// implicit self, if any.
   /// BaseDC is always one of your outer DCs. if you're inside a type it should
   /// never be an extension of that type. And if you're inside an extension it
-  /// will always be an extension (if it found something at that level)
+  /// will always be an extension (if it found something at that level).
   DeclContext *BaseDC;
 
   /// The declaration corresponds to the given name; i.e. the decl we are

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -288,12 +288,21 @@ public:
     : name(name), results(results), isTypeLookup(isTypeLookup) {}
 
   virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+    if (isVisible(VD))
+      results.push_back(LookupResultEntry(VD));
+  }
+  // All a baseDC to be passed in
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason, DeclContext* BaseDC) {
+    if (isVisible(VD))
+      results.push_back(LookupResultEntry(BaseDC, VD));
+  }
+private:
+  bool isVisible(const ValueDecl *const VD) const {
     // Give clients an opportunity to filter out non-type declarations early,
     // to avoid circular validation.
     if (isTypeLookup && !isa<TypeDecl>(VD))
-      return;
-    if (VD->getFullName().matchesRef(name))
-      results.push_back(LookupResultEntry(VD));
+      return false;
+    return  VD->getFullName().matchesRef(name);
   }
 };
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -63,7 +63,7 @@ private:
   ///
   /// BaseDC will be the method if self is needed for the lookup,
   /// and will be the type if not.
-  /// In other words: Ff baseDC is a method, it means you found an instance
+  /// In other words: If baseDC is a method, it means you found an instance
   /// member and you should add an implicit 'self.' (Each method has its own
   /// implicit self decl.) There's one other kind of non-method context that has
   /// a 'self.' -- a lazy property initializer, which unlike a non-lazy property

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -288,21 +288,12 @@ public:
     : name(name), results(results), isTypeLookup(isTypeLookup) {}
 
   virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
-    if (isVisible(VD))
-      results.push_back(LookupResultEntry(VD));
-  }
-  // All a baseDC to be passed in
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason, DeclContext* BaseDC) {
-    if (isVisible(VD))
-      results.push_back(LookupResultEntry(BaseDC, VD));
-  }
-private:
-  bool isVisible(const ValueDecl *const VD) const {
     // Give clients an opportunity to filter out non-type declarations early,
     // to avoid circular validation.
     if (isTypeLookup && !isa<TypeDecl>(VD))
-      return false;
-    return  VD->getFullName().matchesRef(name);
+      return;
+    if (VD->getFullName().matchesRef(name))
+      results.push_back(LookupResultEntry(VD));
   }
 };
 

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -833,6 +833,13 @@ public:
     return !(left == right);
   }
 };
+  
+/// Cast a pointer to \c U  to a pointer to a supertype \c T.
+/// Example:  Wobulator *w = up_cast<Wobulator>(coloredWobulator)
+/// Useful with ?: where each arm is a different subtype.
+/// If \c U is not a subtype of \c T, the compiler will complain.
+template <typename T, typename U>
+T *up_cast(U *ptr) { return ptr; }
 
 } // end namespace swift
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1852,13 +1852,11 @@ void ASTScope::forEachLocalBinding(
                          );
           return TypeWalker::Action::Continue;
        });
-   else {
-     GenericParamList *gps = whereDeclContext.is<NominalTypeDecl*>()
-     ? whereDeclContext.get<NominalTypeDecl*>()->getGenericParams()
-     : whereDeclContext.get<ExtensionDecl*>()->getGenericParams();
-      for (GenericTypeParamDecl* gp: *gps)
-          processBinding(gp, nullptr);
-    }
+   GenericParamList *gps = whereDeclContext.is<NominalTypeDecl*>()
+   ? whereDeclContext.get<NominalTypeDecl*>()->getGenericParams()
+   : whereDeclContext.get<ExtensionDecl*>()->getGenericParams();
+    for (GenericTypeParamDecl* gp: *gps)
+        processBinding(gp, nullptr);
     }
     break;
       

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -2195,10 +2195,12 @@ bool ASTScope::isCloseToTopLevelCode() const {
       case ASTScopeKind::TypeOrExtensionBody:
       case ASTScopeKind::AbstractFunctionBody:
       case ASTScopeKind::Closure:
+      // Need to get generic parameters
+      // for ClangImporter/MixedSource/can_import_objc_idempotent.swift
+      case ASTScopeKind::NominalOrExtensionWhereClause:
         return false;
       case ASTScopeKind::Preexpanded:
       case ASTScopeKind::ExtensionGenericParams:
-      case ASTScopeKind::NominalOrExtensionWhereClause:
       case ASTScopeKind::GenericParams:
       case ASTScopeKind::TypeDecl:
       case ASTScopeKind::AbstractFunctionDecl:

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1843,15 +1843,15 @@ void ASTScope::forEachLocalBinding(
       : whereDeclContext.get<NominalTypeDecl*>();
     auto *baseProtocol = dyn_cast<ProtocolDecl>(baseNominal);
     
-   if (baseProtocol)
-     baseProtocol->walkInheritedProtocols([&](ProtocolDecl *p) {
-       for (auto *atm: p->getAssociatedTypeMembers())
-         processBinding(atm,
-                        extensionDecl ? cast<DeclContext>(extensionDecl)
-                                      : cast<DeclContext>(baseProtocol)
-                        );
-       return TypeWalker::Action::Continue;
-     });
+    if (baseProtocol)
+      baseProtocol->walkInheritedProtocols([&](ProtocolDecl *p) {
+        for (auto *atm: p->getAssociatedTypeMembers())
+          processBinding(atm,
+                         extensionDecl ? cast<DeclContext>(extensionDecl)
+                                       : cast<DeclContext>(baseProtocol)
+                         );
+          return TypeWalker::Action::Continue;
+       });
    else {
      GenericParamList *gps = whereDeclContext.is<NominalTypeDecl*>()
      ? whereDeclContext.get<NominalTypeDecl*>()->getGenericParams()

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -590,10 +590,8 @@ bool ASTScope::addChild(ASTScope *const child) const {
 
 void ASTScope::addNextGenericParamOrWhereAndBody(Decl *const decl) const {
   if (auto child = createIfNeeded(this, decl)) {
-    if (child->getKind() != ASTScopeKind::GenericParams) {
-      assert(child->getKind() == ASTScopeKind::TypeOrExtensionBody &&
-             "unexpected scope kind");
-      if (NominalTypeDecl *n = dyn_cast<NominalTypeDecl>(decl))
+    if (child->getKind() == ASTScopeKind::TypeOrExtensionBody) {
+      if (auto *n = dyn_cast<NominalTypeDecl>(decl))
         addNominalOrExtensionWhereClause(n);
     }
     addChild(child);

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -2249,6 +2249,7 @@ bool ASTScope::isCloseToTopLevelCode() const {
     switch (s->getKind()) {
       case ASTScopeKind::TopLevelCode:
         return true;
+        
       case ASTScopeKind::SourceFile:
       case ASTScopeKind::TypeOrExtensionBody:
       case ASTScopeKind::AbstractFunctionBody:
@@ -2258,6 +2259,12 @@ bool ASTScope::isCloseToTopLevelCode() const {
       // for ClangImporter/MixedSource/can_import_objc_idempotent.swift
       case ASTScopeKind::NominalOrExtensionWhereClause:
         return false;
+        
+      case ASTScopeKind::BraceStmt:
+        if (getParent()->getKind() != ASTScopeKind::TopLevelCode)
+          return false;
+        break;
+
       case ASTScopeKind::Preexpanded:
       case ASTScopeKind::ExtensionGenericParams:
       case ASTScopeKind::TypeDecl:
@@ -2268,7 +2275,6 @@ bool ASTScope::isCloseToTopLevelCode() const {
       case ASTScopeKind::PatternBinding:
       case ASTScopeKind::PatternInitializer:
       case ASTScopeKind::AfterPatternBinding:
-      case ASTScopeKind::BraceStmt:
       case ASTScopeKind::IfStmt:
       case ASTScopeKind::ConditionalClause:
       case ASTScopeKind::GuardStmt:

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1694,8 +1694,6 @@ DeclContext *ASTScope::getDeclContext() const {
     return topLevelCode;
 
   case ASTScopeKind::ExtensionGenericParams:
-    return extension;
-      
   case ASTScopeKind::GenericParams:
   case ASTScopeKind::AbstractFunctionParams:
   case ASTScopeKind::PatternBinding:

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1694,6 +1694,8 @@ DeclContext *ASTScope::getDeclContext() const {
     return topLevelCode;
 
   case ASTScopeKind::ExtensionGenericParams:
+    return extension;
+      
   case ASTScopeKind::GenericParams:
   case ASTScopeKind::AbstractFunctionParams:
   case ASTScopeKind::PatternBinding:

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1909,6 +1909,47 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
   return result;
 }
 
+DeclContext* ASTScope::getBaseDCForLocalBindings() const {
+  switch (getKind()) {
+    // HACK for compatibility
+    case ASTScopeKind::NominalOrExtensionWhereClause:
+      if (auto *ed = whereDeclContext.dyn_cast<ExtensionDecl*>()) {
+        if (isa<ProtocolDecl>(ed->getExtendedNominal()))
+          return ed;
+      }
+      return nullptr;
+      
+    case ASTScopeKind::Preexpanded:
+    case ASTScopeKind::SourceFile:
+    case ASTScopeKind::TypeDecl:
+    case ASTScopeKind::ExtensionGenericParams:
+    case ASTScopeKind::TypeOrExtensionBody:
+    case ASTScopeKind::GenericParams:
+    case ASTScopeKind::AbstractFunctionDecl:
+    case ASTScopeKind::AbstractFunctionParams:
+    case ASTScopeKind::DefaultArgument:
+    case ASTScopeKind::AbstractFunctionBody:
+    case ASTScopeKind::PatternBinding:
+    case ASTScopeKind::PatternInitializer:
+    case ASTScopeKind::AfterPatternBinding:
+    case ASTScopeKind::BraceStmt:
+    case ASTScopeKind::IfStmt:
+    case ASTScopeKind::ConditionalClause:
+    case ASTScopeKind::GuardStmt:
+    case ASTScopeKind::RepeatWhileStmt:
+    case ASTScopeKind::ForEachStmt:
+    case ASTScopeKind::ForEachPattern:
+    case ASTScopeKind::DoCatchStmt:
+    case ASTScopeKind::CatchStmt:
+    case ASTScopeKind::SwitchStmt:
+    case ASTScopeKind::CaseStmt:
+    case ASTScopeKind::Accessors:
+    case ASTScopeKind::Closure:
+    case ASTScopeKind::TopLevelCode:
+      return nullptr;
+  }
+}
+
 void ASTScope::expandAll() const {
   if (!isExpanded())
     expand();

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -2287,7 +2287,7 @@ bool ASTScope::isCloseToTopLevelCode() const {
         return false;
         
       case ASTScopeKind::BraceStmt:
-        if (getParent()->getKind() != ASTScopeKind::TopLevelCode)
+        if (s->getParent()->getKind() != ASTScopeKind::TopLevelCode)
           return false;
         break;
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -2196,12 +2196,12 @@ bool ASTScope::isCloseToTopLevelCode() const {
       case ASTScopeKind::AbstractFunctionBody:
       case ASTScopeKind::Closure:
       // Need to get generic parameters
+      case ASTScopeKind::GenericParams: // attr/attr_override.swift
       // for ClangImporter/MixedSource/can_import_objc_idempotent.swift
       case ASTScopeKind::NominalOrExtensionWhereClause:
         return false;
       case ASTScopeKind::Preexpanded:
       case ASTScopeKind::ExtensionGenericParams:
-      case ASTScopeKind::GenericParams:
       case ASTScopeKind::TypeDecl:
       case ASTScopeKind::AbstractFunctionDecl:
       case ASTScopeKind::AbstractFunctionParams:

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1811,6 +1811,7 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
   case ASTScopeKind::DoCatchStmt:
   case ASTScopeKind::SwitchStmt:
   case ASTScopeKind::Accessors:
+  case ASTScopeKind::TopLevelCode:
   case ASTScopeKind::NominalOrExtensionWhereClause:
     // No local declarations.
     break;
@@ -1862,28 +1863,6 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
       }
     }
     break;
-      
-  case ASTScopeKind::TopLevelCode:
-//qqq    for (auto *child: children()) {
-//      assert(child->getKind() == ASTScopeKind::BraceStmt);
-//      for (auto &element: child->braceStmt.stmt->getElements()) {
-//        if (auto *d = element.dyn_cast<Decl *>())
-//          if (auto *vd = dyn_cast<ValueDecl>(d))
-//            result.push_back(vd);
-//      }
-//    }
-    // TODO: factor with above
-    // All types and functions are visible anywhere within the brace
-    // statement. It's up to capture analysis to determine what is usable.
-    // TODO: Just types and functions???
-//    for (auto element : topLevelCode->getBody()->getElements()) {
-//      if (auto decl = element.dyn_cast<Decl *>()) {
-//        if (auto *vd = dyn_cast<ValueDecl>(decl))
-//          result.push_back(vd);
-//      }
-//    }
-    break;
-
 
   case ASTScopeKind::ForEachPattern:
     handlePattern(forEach->getPattern());

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1423,7 +1423,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
                        sourceFile.file->Decls.back()->getEndLoc());
 
   case ASTScopeKind::TypeDecl:
-    return typeDecl->getSourceRange();
+    return typeDecl->getSourceRangeIncludingAttrs();
 
   case ASTScopeKind::ExtensionGenericParams: {
     // The generic parameters of an extension are available from the ':' of
@@ -1472,7 +1472,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
       return SourceRange(abstractFunction->getLoc(),
                          abstractFunction->getEndLoc());
 
-    return abstractFunction->getSourceRange();
+    return abstractFunction->getSourceRangeIncludingAttrs();
   }
 
   case ASTScopeKind::AbstractFunctionParams: {

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1746,6 +1746,7 @@ DeclContext *ASTScope::getDeclContext() const {
     // own nodes. Maybe they should.
     if (auto subscript = dyn_cast<SubscriptDecl>(abstractStorageDecl))
       return subscript;
+    return nullptr;
 
   case ASTScopeKind::NominalOrExtensionWhereClause:
       return whereDeclContext.is<NominalTypeDecl*>()

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1842,7 +1842,7 @@ void ASTScope::forEachLocalBinding(
        for (auto *atm: p->getAssociatedTypeMembers())
          processBinding(atm,
                         extensionDecl ? cast<DeclContext>(extensionDecl)
-                                      : cast<DeclContext>(p)
+                                      : cast<DeclContext>(baseProtocol)
                         );
        return TypeWalker::Action::Continue;
      });

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -216,18 +216,18 @@ public:
                            Options options,
                            SmallVectorImpl<LookupResultEntry> &Results,
                            size_t &IndexOfFirstOuterResult);
-  // clang-format on
+    // clang-format on
 
-  void performUnqualifiedLookup();
+    void performUnqualifiedLookup();
 
-private:
-  struct ContextAndUnresolvedIsCascadingUse {
-    DeclContext *whereToLook;
-    Optional<bool> isCascadingUse;
-    ContextAndResolvedIsCascadingUse resolve(const bool resolution) const {
-      return ContextAndResolvedIsCascadingUse{
-          whereToLook, isCascadingUse.getValueOr(resolution)};
-    }
+  private:
+    struct ContextAndUnresolvedIsCascadingUse {
+      DeclContext *whereToLook;
+      Optional<bool> isCascadingUse;
+      ContextAndResolvedIsCascadingUse resolve(const bool resolution) const {
+        return ContextAndResolvedIsCascadingUse{
+            whereToLook, isCascadingUse.getValueOr(resolution)};
+      }
   };
 
   bool useASTScopesForExperimentalLookup() const;
@@ -467,8 +467,9 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
     lookupNamesIntroducedBy(contextAndIsCascadingUse);
     if (useASTScopesForExperimentalLookupIfEnabled()) {
       SmallVector<LookupResultEntry, 4> results;
-      size_t indexOfFirstOuterResult;
-      UnqualifiedLookupFactory scopeLookup(Name, DC, TypeResolver, Loc, options, results, indexOfFirstOuterResult);
+      size_t indexOfFirstOuterResult = 0;
+      UnqualifiedLookupFactory scopeLookup(Name, DC, TypeResolver, Loc, options,
+                                           results, indexOfFirstOuterResult);
       scopeLookup.experimentallyLookInASTScopes(contextAndIsCascadingUse);
       assert(verifyEqualTo(std::move(scopeLookup)));
     }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -501,6 +501,11 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
     lookupOperatorInDeclContexts(contextAndIsCascadingUse);
   else {
     const bool isCascadingUse = computeIsCascadingUse();
+    
+    llvm::errs() << "WARNING: TRYING Scope exclusively";
+    experimentallyLookInASTScopes(contextAndIsCascadingUse);
+    return;
+    
     lookupNamesIntroducedBy(contextAndIsCascadingUse);
     assert(!recordedSF || isCascadingUse == recordedIsCascadingUse);
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -634,6 +634,11 @@ void UnqualifiedLookupFactory::lookInASTScope(
   
   involvedANominalOrExtensionWhereClause |=
     state.scope->getKind() == ASTScopeKind::NominalOrExtensionWhereClause;
+  
+  if (state.scope->isEffectivelyTopLevelCode()) {
+    lookInASTScope(state.withParentScope());
+    return;
+  }
 
   // Perform local lookup within this scope.
   auto localBindings = state.scope->getLocalBindings();

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -1082,8 +1082,9 @@ void UnqualifiedLookupFactory::setAsideUnavailableResults(
 void UnqualifiedLookupFactory::recordDependencyOnTopLevelNameIfNeeded() {
   for (const auto &result : Results) {
     auto *const resultContext = result.getValueDecl()->getDeclContext();
-    if (isa<SourceFile>(resultContext))
-      recordDependencyOnTopLevelName(resultContext, Name, computeIsCascadingUse());
+    if (resultContext->isModuleScopeContext())
+      recordDependencyOnTopLevelName(DC->getParentSourceFile(), Name,
+                                     computeIsCascadingUse());
   }
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -65,6 +65,7 @@ static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
   case ASTScopeKind::ExtensionGenericParams:
   case ASTScopeKind::GenericParams:
   case ASTScopeKind::NominalOrExtensionWhereClause:
+  case swift::ASTScopeKind::SpecializeAttribute:
     return DeclVisibilityKind::GenericParameter;
 
   case ASTScopeKind::AbstractFunctionParams:

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -1389,8 +1389,11 @@ bool UnqualifiedLookupFactory::verifyEqualTo(
     // unsigned printContext(llvm::raw_ostream &OS, unsigned indent = 0,
     // bool onlyAPartialLine = false) const;
   }
-
-  llvm::errs() << "WARNING NOT TESTING DEPS\n";
+  static bool haveWarned = false;
+  if (!haveWarned) {
+    haveWarned = true;
+    llvm::errs() << "WARNING NOT TESTING DEPS\n";
+  }
 //  if (recordedSF != other.recordedSF) {
 //    llvm::errs() << "\n\nrecordedSFs differ: "
 //    << recordedSF

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -626,6 +626,7 @@ void UnqualifiedLookupFactory::lookInASTScope(
           state.withParentScope().withSelfDC(state.scope->getAbstractFunctionDecl()));
     // If there is a declaration context associated with this scope, we might
     // want to look in it.
+#error need to go into lookInASTScopeContext with scopeDC the extensionDecl even though this is the ExtensionGenericParams so that finder can find the name
     else if (auto *const scopeDC = state.scope->getDeclContext())
       lookInASTScopeContext(state, scopeDC);
     else

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -624,7 +624,10 @@ void UnqualifiedLookupFactory::lookIntoDeclarationContextForASTScopeLookup(
   // We have a nominal type or an extension thereof. Perform lookup into
   // the nominal type.
   auto nominal = scopeDC->getSelfNominalTypeDecl();
-  assert(nominal && "case should have been handled above");
+  if (!nominal) {
+    lookInParentScopeForASTScopeLookup(defaultNextState);
+    return;
+  }
   // Dig out the type we're looking into.
   // Perform lookup into the type
   auto resultFinder = ResultFinderForTypeContext(
@@ -653,7 +656,7 @@ bool UnqualifiedLookupFactory::nothingToSeeHere(
          // Top-level declarations have no lookup of their own.
          isa<TopLevelCodeDecl>(scopeDC) ||
          // Typealiases have no lookup of their own.
-         isa<TypeAliasDecl>(scopeDC) || !scopeDC->getSelfNominalTypeDecl();
+         isa<TypeAliasDecl>(scopeDC);
 }
 
 #pragma mark context-based lookup definitions

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -277,7 +277,8 @@ public:
       return ASTScopeLookupState{scope, selfDC, startingDC, isCascadingUse};
     }
   private:
-    static DeclContext *selfDCIfValidForScope(const ASTScope *scope, DeclContext *selfDC) {
+    static DeclContext *selfDCIfValidForScope(const ASTScope *scope,
+                                              DeclContext *selfDC) {
       return selfDC; // disable this fix
       // TODO: See if something like below is needed
       // return scope && !isExtension(*scope) ? selfDC : nullptr;
@@ -446,24 +447,26 @@ public:
 
 // clang-format off
 UnqualifiedLookupFactory::UnqualifiedLookupFactory(
-                                                   DeclName Name,
-                                                   DeclContext *const DC,
-                                                   LazyResolver *TypeResolver,
-                                                   SourceLoc Loc,
-                                                   Options options,
-                                                   UnqualifiedLookup &lookupToBeCreated)
-: UnqualifiedLookupFactory(Name, DC, TypeResolver, Loc, options, lookupToBeCreated.Results, lookupToBeCreated.IndexOfFirstOuterResult)
+                            DeclName Name,
+                            DeclContext *const DC,
+                            LazyResolver *TypeResolver,
+                            SourceLoc Loc,
+                            Options options,
+                            UnqualifiedLookup &lookupToBeCreated)
+: UnqualifiedLookupFactory(Name, DC, TypeResolver, Loc, options,
+    lookupToBeCreated.Results,
+    lookupToBeCreated.IndexOfFirstOuterResult)
 
 {}
 
 UnqualifiedLookupFactory::UnqualifiedLookupFactory(
-                                                   DeclName Name,
-                                                   DeclContext *const DC,
-                                                   LazyResolver *TypeResolver,
-                                                   SourceLoc Loc,
-                                                   Options options,
-                                                   SmallVectorImpl<LookupResultEntry> &Results,
-                                                   size_t &IndexOfFirstOuterResult)
+                            DeclName Name,
+                            DeclContext *const DC,
+                            LazyResolver *TypeResolver,
+                            SourceLoc Loc,
+                            Options options,
+                            SmallVectorImpl<LookupResultEntry> &Results,
+                            size_t &IndexOfFirstOuterResult)
 :
   Name(Name),
   DC(DC),
@@ -623,10 +626,10 @@ void UnqualifiedLookupFactory::lookInASTScope(
             ->isTypeContext();
     if (inMethodBody)
       lookInASTScope(
-          state.withParentScope().withSelfDC(state.scope->getAbstractFunctionDecl()));
+          state.withParentScope()
+               .withSelfDC(state.scope->getAbstractFunctionDecl()));
     // If there is a declaration context associated with this scope, we might
     // want to look in it.
-#error need to go into lookInASTScopeContext with scopeDC the extensionDecl even though this is the ExtensionGenericParams so that finder can find the name
     else if (auto *const scopeDC = state.scope->getDeclContext())
       lookInASTScopeContext(state, scopeDC);
     else
@@ -642,7 +645,8 @@ void UnqualifiedLookupFactory::lookInASTScopeContext(
       scopeDC, stateArg.isCascadingUse, /*onlyCareAboutFunctionBody=*/false);
 
   const ASTScopeLookupState defaultNextState =
-      stateArg.withParentScope().withResolvedIsCascadingUse(isCascadingUseResult);
+      stateArg.withParentScope()
+              .withResolvedIsCascadingUse(isCascadingUseResult);
 
   // Lookup in the source file's scope marks the end.
   if (isa<SourceFile>(scopeDC)) {
@@ -955,10 +959,10 @@ void UnqualifiedLookupFactory::lookupNamesIntroducedByMiscContext(
 
 
 void UnqualifiedLookupFactory::finishLookingInContext(
-                                                      const AddGenericParameters addGenericParameters,
-                                                      DeclContext *const lookupContextForThisContext,
-                                                      Optional<ResultFinderForTypeContext> &&resultFinderForTypeContext,
-                                                      const Optional<bool> isCascadingUse) {
+       const AddGenericParameters addGenericParameters,
+       DeclContext *const lookupContextForThisContext,
+       Optional<ResultFinderForTypeContext> &&resultFinderForTypeContext,
+       const Optional<bool> isCascadingUse) {
   
   // When a generic has the same name as a member, Swift prioritizes the generic
   // because the member could still be named by qualifying it. But there is no
@@ -968,17 +972,17 @@ void UnqualifiedLookupFactory::finishLookingInContext(
     addGenericParametersHereAndInEnclosingScopes(lookupContextForThisContext);
   
   ifNotDoneYet(
-               [&] {
-                 if (resultFinderForTypeContext)
-                   findResultsAndSaveUnavailables(lookupContextForThisContext,
-                                                  std::move(*resultFinderForTypeContext),
-                                                  *isCascadingUse, baseNLOptions);
-               },
-               // Recurse into the next context.
-               [&] {
-                 lookupNamesIntroducedBy(ContextAndUnresolvedIsCascadingUse{
-                   lookupContextForThisContext->getParentForLookup(), isCascadingUse});
-               });
+    [&] {
+      if (resultFinderForTypeContext)
+        findResultsAndSaveUnavailables(lookupContextForThisContext,
+                                      std::move(*resultFinderForTypeContext),
+                                      *isCascadingUse, baseNLOptions);
+    },
+    // Recurse into the next context.
+    [&] {
+      lookupNamesIntroducedBy(ContextAndUnresolvedIsCascadingUse{
+        lookupContextForThisContext->getParentForLookup(), isCascadingUse});
+    });
 }
 
 
@@ -1209,9 +1213,9 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
 
 
 void UnqualifiedLookupFactory::findResultsAndSaveUnavailables(
-                                                              DeclContext *lookupContextForThisContext,
-                                                              ResultFinderForTypeContext &&resultFinderForTypeContext,
-                                                              bool isCascadingUse, NLOptions baseNLOptions) {
+       DeclContext *lookupContextForThisContext,
+       ResultFinderForTypeContext &&resultFinderForTypeContext,
+       bool isCascadingUse, NLOptions baseNLOptions) {
   auto firstPossiblyUnavailableResult = Results.size();
   resultFinderForTypeContext.findResults(Name, isCascadingUse, baseNLOptions,
                                          lookupContextForThisContext, Results);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -617,10 +617,12 @@ void UnqualifiedLookupFactory::lookInASTScope(
     const ASTScopeLookupState state) {
 
   // Perform local lookup within this scope.
-  auto localBindings = state.scope->getLocalBindings();
-  for (auto local : localBindings)
-    Consumer.foundDecl(local, getLocalDeclVisibilityKind(state.scope),
-                       state.scope->getBaseDCForLocalBindings());
+  state.scope->forEachLocalBinding(
+    [&](ValueDecl *local, DeclContext *context) {
+    Consumer.foundDecl(local,
+                       getLocalDeclVisibilityKind(state.scope),
+                       context);
+    });
 
   ifNotDoneYet([&] {
     // When we are in the body of a method, get the 'self' declaration.

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -785,13 +785,14 @@ bool UnqualifiedLookupFactory::nothingToSeeHere(
 }
 
 void UnqualifiedLookupFactory::
-    lookForGenericsBeforeMembersInViolationOfLexicalOrdering(
-        DeclContext *const scopeDC) {
-  auto *params = getGenericParams(scopeDC);
-  if (params)
-    for (auto *param : params->getParams()) {
+lookForGenericsBeforeMembersInViolationOfLexicalOrdering(
+  DeclContext *const scopeDC) {
+  for (auto *params = getGenericParams(scopeDC);
+       params;
+       params = params->getOuterParameters()) {
+    for (auto *param : params->getParams())
       Consumer.foundDecl(param, DeclVisibilityKind::GenericParameter);
-    }
+  }
 }
 
 #pragma mark context-based lookup definitions

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -616,7 +616,8 @@ void UnqualifiedLookupFactory::lookInASTScope(
   // Perform local lookup within this scope.
   auto localBindings = state.scope->getLocalBindings();
   for (auto local : localBindings)
-    Consumer.foundDecl(local, getLocalDeclVisibilityKind(state.scope));
+    Consumer.foundDecl(local, getLocalDeclVisibilityKind(state.scope),
+                       state.scope->getBaseDCForLocalBindings());
 
   ifNotDoneYet([&] {
     // When we are in the body of a method, get the 'self' declaration.

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -538,7 +538,7 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
     lookupOperatorInDeclContexts(contextAndIsCascadingUse);
   else {
     const bool isCascadingUse = computeIsCascadingUse();
-    const bool useOnlyScopeLookupWhenPossible = false;
+    const bool useOnlyScopeLookupWhenPossible = true;
     if (useOnlyScopeLookupWhenPossible && Loc.isValid()) {
       static bool haveWarned = false;
       if (!haveWarned) {
@@ -1490,7 +1490,7 @@ void UnqualifiedLookupFactory::dump() const {
 }
 
 void UnqualifiedLookupFactory::print(raw_ostream &OS) const {
-  OS << "Look up (" << lookupCounter << ") '" << Name << " at: ";
+  OS << "Look up (" << lookupCounter << ") '" << Name << "' at: ";
   Loc.print(OS, DC->getASTContext().SourceMgr);
   OS << "\nStarting in: ";
   DC->printContext(OS);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -44,6 +44,7 @@ using namespace swift::namelookup;
 /// name lookup successfully resolved.
 static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
   switch (scope->getKind()) {
+       case ASTScopeKind::NominalOrExtensionWhereClause: abort();
   case ASTScopeKind::Preexpanded:
   case ASTScopeKind::SourceFile:
   case ASTScopeKind::TypeDecl:

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -643,8 +643,6 @@ UnqualifiedLookupFactory::nonoperatorScopeForASTScopeLookup(
   // Find the source file in which we are performing the lookup.
   SourceFile &sourceFile =
       *contextAndIsCascadingUseArg.whereToLook->getParentSourceFile();
-      
-  stopIfTargetLookup();
 
   // Find the scope from which we will initiate unqualified name lookup.
   const ASTScope *innermostScope =
@@ -660,6 +658,8 @@ UnqualifiedLookupFactory::nonoperatorScopeForASTScopeLookup(
   }
   if (!startingScope)
     startingScope = innermostScope;
+      
+    stopIfTargetLookup();
 
   return std::make_pair(startingScope,
                         contextAndIsCascadingUseArg.isCascadingUse);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -403,7 +403,7 @@ public:
     return resolveIsCascadingUse(x.whereToLook, x.isCascadingUse,
                                  onlyCareAboutFunctionBody);
   }
-  
+
   bool computeIsCascadingUse() const;
 
   void findResultsAndSaveUnavailables(
@@ -471,15 +471,17 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
     const bool isCascadingUse = computeIsCascadingUse();
     lookupNamesIntroducedBy(contextAndIsCascadingUse);
     assert(!recordedSF || isCascadingUse == recordedIsCascadingUse);
-    
-//    if (useASTScopesForExperimentalLookupIfEnabled()) {
-//      SmallVector<LookupResultEntry, 4> results;
-//      size_t indexOfFirstOuterResult = 0;
-//      UnqualifiedLookupFactory scopeLookup(Name, DC, TypeResolver, Loc, options,
-//                                           results, indexOfFirstOuterResult);
-//      scopeLookup.experimentallyLookInASTScopes(contextAndIsCascadingUse);
-//      assert(verifyEqualTo(std::move(scopeLookup)));
-//    }
+
+    //    if (useASTScopesForExperimentalLookupIfEnabled()) {
+    //      SmallVector<LookupResultEntry, 4> results;
+    //      size_t indexOfFirstOuterResult = 0;
+    //      UnqualifiedLookupFactory scopeLookup(Name, DC, TypeResolver, Loc,
+    //      options,
+    //                                           results,
+    //                                           indexOfFirstOuterResult);
+    //      scopeLookup.experimentallyLookInASTScopes(contextAndIsCascadingUse);
+    //      assert(verifyEqualTo(std::move(scopeLookup)));
+    //    }
   }
 }
 
@@ -1219,13 +1221,15 @@ bool UnqualifiedLookupFactory::computeIsCascadingUse() const {
     return true;
   if (auto I = dyn_cast<DefaultArgumentInitializer>(dc))
     return false;
-  
+
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(dc)) {
-    if (!Loc.isInvalid() && AFD->getBody() && SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc))
+    if (!Loc.isInvalid() && AFD->getBody() &&
+        SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc))
       return false;
-  }
-  else if (auto *PBI = dyn_cast<PatternBindingInitializer>(dc)) {
-    if (PBI->getBinding()->getDeclContext()->isTypeContext()) //lookupNamesIntroducedByInitializerOfStoredPropertyOfAType
+  } else if (auto *PBI = dyn_cast<PatternBindingInitializer>(dc)) {
+    if (PBI->getBinding()
+            ->getDeclContext()
+            ->isTypeContext()) // InitializerOfStoredPropertyOfAType
       dc = PBI->getParent();
   }
   // clang-format off
@@ -1238,7 +1242,7 @@ bool UnqualifiedLookupFactory::computeIsCascadingUse() const {
            isa<TypeAliasDecl>(dc) ||
            isa<SubscriptDecl>(dc));
   // clang-format on
-  return dc->isCascadingContextForLookup(/*onlyCareAboutFunctionBody*/false);
+  return dc->isCascadingContextForLookup(/*onlyCareAboutFunctionBody*/ false);
 }
 
 void UnqualifiedLookupFactory::ResultFinderForTypeContext::dump() const {

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -441,6 +441,9 @@ public:
   void dumpBreadcrumbs() const;
 
   bool verifyEqualTo(const UnqualifiedLookupFactory &&) const;
+  
+  /// Legacy lookup is wrong here; we should NOT find this symbol.
+  bool shouldDiffer() const;
 };
 } // namespace
 
@@ -1343,6 +1346,9 @@ TypeDecl *UnqualifiedLookup::getSingleTypeResult() const {
 
 bool UnqualifiedLookupFactory::verifyEqualTo(
     const UnqualifiedLookupFactory &&other) const {
+  if (shouldDiffer()) {
+     return true;
+  }
   assert(Results.size() == other.Results.size());
   for (size_t i : indices(Results)) {
     const auto &e = Results[i];
@@ -1362,4 +1368,13 @@ bool UnqualifiedLookupFactory::verifyEqualTo(
 //  else
 //    assert(!other.recordedIsCascadingUse);
   return true;
+}
+
+bool UnqualifiedLookupFactory::shouldDiffer() const {
+  auto *SF = dyn_cast<SourceFile>(DC->getModuleScopeContext());
+  if (!SF)
+    return false;
+  return SF->getFilename() == "/Volumes/AS/s/exp-dep/swift/test/NameBinding/name-binding.swift" &&
+  isa<AbstractFunctionDecl>(DC) &&
+  (Name.getBaseName() == "v" || Name.getBaseName() == "x");
 }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -617,12 +617,9 @@ void UnqualifiedLookupFactory::lookInASTScope(
     const ASTScopeLookupState state) {
 
   // Perform local lookup within this scope.
-  state.scope->forEachLocalBinding(
-    [&](ValueDecl *local, DeclContext *context) {
-    Consumer.foundDecl(local,
-                       getLocalDeclVisibilityKind(state.scope),
-                       context);
-    });
+  auto localBindings = state.scope->getLocalBindings();
+  for (auto local : localBindings)
+    Consumer.foundDecl(local, getLocalDeclVisibilityKind(state.scope));
 
   ifNotDoneYet([&] {
     // When we are in the body of a method, get the 'self' declaration.

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -292,7 +292,7 @@ public:
     Optional<bool> isCascadingUse;
     
     ASTScopeLookupState withParentScope() const {
-      auto *const parent = scope->getParent();
+      auto *const parent = scope->getParentForLookup();
       return ASTScopeLookupState{
         parent,
         selfDCIfValidForScope(parent, selfDC),

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -506,9 +506,13 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
     lookupOperatorInDeclContexts(contextAndIsCascadingUse);
   else {
     const bool isCascadingUse = computeIsCascadingUse();
-    const bool useOnlyScopeLookupWhenPossible = false;
+    const bool useOnlyScopeLookupWhenPossible = true;
     if (useOnlyScopeLookupWhenPossible && Loc.isValid()) {
-      llvm::errs() << "WARNING: TRYING Scope exclusively";
+      static bool haveWarned = false;
+      if (!haveWarned) {
+        haveWarned = true;
+        llvm::errs() << "WARNING: TRYING Scope exclusively\n";
+      }
       experimentallyLookInASTScopes(contextAndIsCascadingUse);
       return;
     }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -266,9 +266,9 @@ private:
 
   void lookIntoDeclarationContextForASTScopeLookup(ASTScopeLookupState,
                                                    DeclContext *const);
-  
-  static bool nothingToSeeHere(const DeclContext*);
-  
+
+  static bool nothingToSeeHere(const DeclContext *);
+
   /// Can lookup stop searching for results, assuming hasn't looked for outer
   /// results yet?
   bool isFirstResultEnough() const;
@@ -381,7 +381,8 @@ private:
   static bool resolveIsCascadingUse(const DeclContext *const dc,
                                     Optional<bool> isCascadingUse,
                                     bool onlyCareAboutFunctionBody) {
-    return isCascadingUse.getValueOr(dc->isCascadingContextForLookup(/*functionsAreNonCascading=*/onlyCareAboutFunctionBody));
+    return isCascadingUse.getValueOr(dc->isCascadingContextForLookup(
+        /*functionsAreNonCascading=*/onlyCareAboutFunctionBody));
   }
   static bool resolveIsCascadingUse(ContextAndUnresolvedIsCascadingUse x,
                                     bool onlyCareAboutFunctionBody) {
@@ -564,15 +565,15 @@ void UnqualifiedLookupFactory::lookIntoDeclarationContextForASTScopeLookup(
   const ASTScopeLookupState defaultNextState =
       stateArg.withResolvedIsCascadingUse(isCascadingUseResult)
           .withParentScope();
-  
+
   // Lookup in the source file's scope marks the end.
   if (isa<SourceFile>(scopeDC)) {
     recordDependencyOnTopLevelName(scopeDC, Name, isCascadingUseResult);
     lookUpTopLevelNamesInModuleScopeContext(scopeDC);
     return;
   }
-  
-  if (nothingToSeeHere(scopeDC))  {
+
+  if (nothingToSeeHere(scopeDC)) {
     lookInScopeForASTScopeLookup(defaultNextState);
     return;
   }
@@ -595,32 +596,32 @@ void UnqualifiedLookupFactory::lookIntoDeclarationContextForASTScopeLookup(
   // Dig out the type we're looking into.
   // Perform lookup into the type
   auto resultFinder = ResultFinderForTypeContext(
-                                                 defaultNextState.selfDC ? defaultNextState.selfDC : scopeDC, scopeDC);
-  findResultsAndSaveUnavailables( std::move(resultFinder), isCascadingUseResult,
+      defaultNextState.selfDC ? defaultNextState.selfDC : scopeDC, scopeDC);
+  findResultsAndSaveUnavailables(std::move(resultFinder), isCascadingUseResult,
                                  baseNLOptions, scopeDC);
   ifNotDoneYet([&] {
     // Forget the 'self' declaration.
-   lookInScopeForASTScopeLookup(defaultNextState.withSelfDC(nullptr));
+    lookInScopeForASTScopeLookup(defaultNextState.withSelfDC(nullptr));
   });
 }
 
-bool UnqualifiedLookupFactory::nothingToSeeHere(const DeclContext *const scopeDC) {
+bool UnqualifiedLookupFactory::nothingToSeeHere(
+    const DeclContext *const scopeDC) {
   // Default arguments only have 'static' access to the members of the
   // enclosing type, if there is one.
-  return
-    isa<DefaultArgumentInitializer>(scopeDC) ||
-    // Functions/initializers/deinitializers are only interesting insofar as
-    // they affect lookup in an enclosing nominal type or extension thereof.
-    isa<AbstractFunctionDecl>(scopeDC) ||
-    // Subscripts have no lookup of their own.
-    isa<SubscriptDecl>(scopeDC) ||
-    // Closures have no lookup of their own.
-    isa<AbstractClosureExpr>(scopeDC) ||
-    // Top-level declarations have no lookup of their own.
-    isa<TopLevelCodeDecl>(scopeDC) ||
-    // Typealiases have no lookup of their own.
-    isa<TypeAliasDecl>(scopeDC) ||
-    !scopeDC->getSelfNominalTypeDecl();
+  return isa<DefaultArgumentInitializer>(scopeDC) ||
+         // Functions/initializers/deinitializers are only interesting insofar
+         // as they affect lookup in an enclosing nominal type or extension
+         // thereof.
+         isa<AbstractFunctionDecl>(scopeDC) ||
+         // Subscripts have no lookup of their own.
+         isa<SubscriptDecl>(scopeDC) ||
+         // Closures have no lookup of their own.
+         isa<AbstractClosureExpr>(scopeDC) ||
+         // Top-level declarations have no lookup of their own.
+         isa<TopLevelCodeDecl>(scopeDC) ||
+         // Typealiases have no lookup of their own.
+         isa<TypeAliasDecl>(scopeDC) || !scopeDC->getSelfNominalTypeDecl();
 }
 
 #pragma mark context-based lookup definitions

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -272,7 +272,7 @@ public:
 
   void lookInScopeForASTScopeLookup(const ASTScopeLookupState);
 
-  void lookInParentScopeForASCScopeLookup(const ASTScopeLookupState state) {
+  void lookInParentScopeForASTScopeLookup(const ASTScopeLookupState state) {
     lookInScopeForASTScopeLookup(state.withParentScope());
   }
 
@@ -576,14 +576,14 @@ void UnqualifiedLookupFactory::lookInScopeForASTScopeLookup(
             ->getDeclContext()
             ->isTypeContext();
     if (inBody)
-      lookInParentScopeForASCScopeLookup(
+      lookInParentScopeForASTScopeLookup(
           state.withSelfDC(state.scope->getAbstractFunctionDecl()));
     // If there is a declaration context associated with this scope, we might
     // want to look in it.
     else if (auto *const scopeDC = state.scope->getDeclContext())
       lookIntoDeclarationContextForASTScopeLookup(state, scopeDC);
     else
-      lookInParentScopeForASCScopeLookup(state);
+      lookInParentScopeForASTScopeLookup(state);
   });
 }
 
@@ -605,7 +605,7 @@ void UnqualifiedLookupFactory::lookIntoDeclarationContextForASTScopeLookup(
   }
 
   if (nothingToSeeHere(scopeDC)) {
-    lookInParentScopeForASCScopeLookup(defaultNextState);
+    lookInParentScopeForASTScopeLookup(defaultNextState);
     return;
   }
 
@@ -614,7 +614,7 @@ void UnqualifiedLookupFactory::lookIntoDeclarationContextForASTScopeLookup(
   if (auto *bindingInit = dyn_cast<PatternBindingInitializer>(scopeDC)) {
     // Lazy variable initializer contexts have a 'self' parameter for
     // instance member lookup.
-    lookInParentScopeForASCScopeLookup(
+    lookInParentScopeForASTScopeLookup(
         bindingInit->getImplicitSelfDecl()
             ? defaultNextState.withSelfDC(bindingInit)
             : defaultNextState);
@@ -633,7 +633,7 @@ void UnqualifiedLookupFactory::lookIntoDeclarationContextForASTScopeLookup(
                                  baseNLOptions, scopeDC);
   ifNotDoneYet([&] {
     // Forget the 'self' declaration.
-    lookInParentScopeForASCScopeLookup(defaultNextState.withSelfDC(nullptr));
+    lookInParentScopeForASTScopeLookup(defaultNextState.withSelfDC(nullptr));
   });
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -664,14 +664,19 @@ static void dumpOneScopeMapLocation(unsigned bufferID,
   }
 
   // Grab the local bindings introduced by this scope.
-  auto localBindings = locScope->getLocalBindings();
-  if (!localBindings.empty()) {
-    llvm::errs() << "Local bindings: ";
-    interleave(localBindings.begin(), localBindings.end(),
-               [&](ValueDecl *value) { llvm::errs() << value->getFullName(); },
-               [&]() { llvm::errs() << " "; });
+  // TODO: move this code into ASTScope
+  bool firstBinding = true;
+  locScope->forEachLocalBinding([&](ValueDecl *value, DeclContext *) {
+    if (firstBinding) {
+      firstBinding = false;
+      llvm::errs() << "Local bindings: ";
+    }
+    else
+      llvm::errs() << " ";
+    llvm::errs() << value->getFullName();
+  });
+  if (firstBinding)
     llvm::errs() << "\n";
-  }
 }
 
 static void dumpAndPrintScopeMap(CompilerInvocation &Invocation,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -664,19 +664,14 @@ static void dumpOneScopeMapLocation(unsigned bufferID,
   }
 
   // Grab the local bindings introduced by this scope.
-  // TODO: move this code into ASTScope
-  bool firstBinding = true;
-  locScope->forEachLocalBinding([&](ValueDecl *value, DeclContext *) {
-    if (firstBinding) {
-      firstBinding = false;
-      llvm::errs() << "Local bindings: ";
-    }
-    else
-      llvm::errs() << " ";
-    llvm::errs() << value->getFullName();
-  });
-  if (firstBinding)
+  auto localBindings = locScope->getLocalBindings();
+  if (!localBindings.empty()) {
+    llvm::errs() << "Local bindings: ";
+    interleave(localBindings.begin(), localBindings.end(),
+               [&](ValueDecl *value) { llvm::errs() << value->getFullName(); },
+               [&]() { llvm::errs() << " "; });
     llvm::errs() << "\n";
+  }
 }
 
 static void dumpAndPrintScopeMap(CompilerInvocation &Invocation,

--- a/test/NameBinding/name-binding.swift
+++ b/test/NameBinding/name-binding.swift
@@ -64,7 +64,7 @@ func test_varname_binding() {
 
 // We don't allow namebinding to look forward past a var declaration in the
 // main module
-var x : x_ty  // expected-error {{use of undeclared type 'x_ty'}}
+var x : x_ty  // expected-error {{use of undeclared type 'x_ty'}} expected-note {{did you mean 'x'?}}
 typealias x_ty = Int
 
 // We allow namebinding to look forward past a function declaration (and other
@@ -77,7 +77,7 @@ typealias y_ty = Int
 
 // FIXME: Should reject this (has infinite size or is tautological depend on
 // how you look at it).
-enum y {
+enum y { // expected-note {{did you mean 'y'?}}
   case y
   case Int
 }
@@ -195,8 +195,8 @@ test+++
 //===----------------------------------------------------------------------===//
 
 func forwardReference() {
-  v = 0 // expected-error{{use of local variable 'v' before its declaration}}
-  var v: Float = 0.0 // expected-note{{'v' declared here}}
+  v = 0 // expected-error{{use of unresolved identifier 'v'}}
+  var v: Float = 0.0
 }
 
 class ForwardReference {

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -467,7 +467,6 @@ class LazyProperties {
 // CHECK-SEARCHES-NEXT: SourceFile {{.*}} '{{.*}}scope_map.swift' [1:1 - [[EOF:[0-9]+:[0-9]+]]] unexpanded
 // CHECK-SEARCHES: TypeOrExtensionBody {{.*}} 'S0' [4:11 - 6:1] expanded
 // CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded
-// CHECK-SEARCHES-NOT: {{ expanded}}
 // CHECK-SEARCHES: -TypeDecl {{.*}} ContainsGenerics0 [25:1 - 31:1] expanded
 // CHECK-SEARCHES-NEXT: `-TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
 // CHECK-SEARCHES-NEXT:   |-AbstractFunctionDecl {{.*}} init(t:u:) [26:3 - 27:3] expanded
@@ -482,19 +481,17 @@ class LazyProperties {
 // CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} throwing() [102:1 - 102:26] unexpanded
 // CHECK-SEARCHES: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - 175:1] expanded
 // CHECK-SEARCHES: DefaultArgument {{.*}} [166:32 - 166:32] expanded
-// CHECK-SEARCHES-NOT: {{ expanded}}
 // CHECK-SEARCHES: |-TypeDecl {{.*}} PatternInitializers [177:1 - 180:1] expanded
 // CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'PatternInitializers' [177:28 - 180:1] expanded
 // CHECK-SEARCHES:    |-PatternBinding {{.*}} entry 0 [178:7 - 178:21] unexpanded
 // CHECK-SEARCHES:    `-PatternBinding {{.*}} entry 1 [179:7 - 179:25] expanded
 // CHECK-SEARCHES:      `-PatternInitializer {{.*}} entry 1 [179:16 - 179:25] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
-// CHECK-SEARCHES:    |-TypeDecl {{.*}} ProtoWithSubscript [182:1 - 184:1] unexpanded
-// CHECK-SEARCHES-NOT: {{ expanded}}
-// CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] unexpanded
+// CHECK-SEARCHES:    |-TypeDecl {{.*}} ProtoWithSubscript [182:1 - 184:1] expanded
+// CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] expanded
 // CHECK-SEARCHES: `-TypeDecl {{.*}} LazyProperties [190:1 - 194:1] expanded
 // CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'LazyProperties' [190:22 - 194:1] expanded
-// CHECK-SEARCHES-NEXT:   |-PatternBinding {{.*}} entry 0 [191:7 - 191:20] unexpanded
-// CHECK-SEARCHES-NEXT:   `-PatternBinding {{.*}} entry 0 [193:12 - 193:29] expanded
+// CHECK-SEARCHES-NEXT:   |-PatternBinding {{.*}} entry 0 [191:7 - 191:20] expanded
+// CHECK-SEARCHES:   `-PatternBinding {{.*}} entry 0 [193:12 - 193:29] expanded
 // CHECK-SEARCHES-NEXT:     `-PatternInitializer {{.*}} entry 0 [193:24 - 193:29] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In preparation for converting UnqualifiedLookup to ASTScope-based lookup, factor out the isCascadingUse computation and cross-check it with the existing code. Run all the tests to insure it is correct.