### PR TITLE
[Python] fix UInt.pythonObject for Python 3.7

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -847,7 +847,7 @@ extension UInt : PythonConvertible {
 
   public var pythonObject: PythonObject {
     _ = Python // Ensure Python is initialized.
-    return PythonObject(owning: PyInt_FromSize_t(Int(self)))
+    return PythonObject(owning: PyInt_FromSize_t(self))
   }
 }
 

--- a/stdlib/public/Python/PythonLibrary+Symbols.swift
+++ b/stdlib/public/Python/PythonLibrary+Symbols.swift
@@ -154,9 +154,9 @@ let PyInt_AsUnsignedLongMask: @convention(c) (PyObjectPointer) -> UInt =
     name: "PyLong_AsUnsignedLongMask",
     legacyName: "PyInt_AsUnsignedLongMask")
 
-let PyInt_FromSize_t: @convention(c) (Int) -> PyObjectPointer =
+let PyInt_FromSize_t: @convention(c) (UInt) -> PyObjectPointer =
   PythonLibrary.loadSymbol(
-    name: "PyInt_FromLong",
+    name: "PyLong_FromUnsignedLong",
     legacyName: "PyInt_FromSize_t")
 
 let PyString_AsString: @convention(c) (PyObjectPointer) -> PyCCharPointer? =


### PR DESCRIPTION
Fix `UInt.pythonObject` for Python 3.7. The existing conversion worked for Python 2.7, but crashed for 3.

cc @pvieito @dan-zheng 