### PR TITLE
Changes for test failures on PowerPC64LE when running as non-root user

### DIFF
--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -3,7 +3,6 @@
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s
 // REQUIRES: executable_test
-// XFAIL: CPU=powerpc64le
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
 


### PR DESCRIPTION
This test case was earlier marked as XFAIL since it was failing when run as root users( #21541 ). However, this test case now passes successfully when run as non-root(normal) user. Submitting this changeset/pull request since the test suite proceeds ahead to other test suites like those for TestFoundation, etc as non-root(normal) user successfully. Please review and approve.