### PR TITLE
[TF API] Add a setter to ShapedArray's 'scalar' property.

### DIFF
--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -211,8 +211,17 @@ public extension _ShapedArrayProtocol {
   /// Returns the single scalar element if the array has rank 0 and `nil`
   /// otherwise.
   var scalar: Scalar? {
-    guard rank == 0 else { return nil }
-    return scalars.first
+    get {
+      guard rank == 0 else { return nil }
+      return scalars.first
+    }
+    set {
+      precondition(isScalar, "Array does not have shape [].")
+      guard let newValue = newValue else {
+        preconditionFailure("New scalar value cannot be nil.")
+      }
+      scalars[0] = newValue
+    }
   }
 }
 

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -80,6 +80,9 @@ ShapedArrayTests.test("ElementMutation") {
     tensor[0][0][scalarIndex] = ShapedArraySlice<Int>(scalarIndex - 5)
   }
   expectEqual(Array(-5..<10) + Array(15..<60), tensor.scalars)
+
+  tensor[0][1][1].scalar = 100
+  expectEqual(100, tensor[0][1][1].scalar)
 }
 
 ShapedArrayTests.test("ScalarMutation") {


### PR DESCRIPTION
Before:
```swift
array[0][1] = ShapedArraySlice(1)
```

After:
```swift
array[0][1].scalar = 1
```