### PR TITLE
[TF API] Underscore 'TensorElementLiteral'.

### DIFF
--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -546,9 +546,9 @@ public extension Tensor {
 /// Array literal conversion.
 extension ShapedArray : ExpressibleByArrayLiteral
   where Scalar : TensorFlowScalar {
-  public typealias ArrayLiteralElement = TensorElementLiteral<Scalar>
+  public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
   @inlinable @inline(__always)
-  public init(arrayLiteral elements: TensorElementLiteral<Scalar>...) {
+  public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
     self = Tensor<Scalar>(tensorElementLiterals: elements).array
   }
 }
@@ -888,9 +888,9 @@ public extension ShapedArraySlice where Scalar : TensorFlowScalar {
 /// Array literal conversion.
 extension ShapedArraySlice : ExpressibleByArrayLiteral
   where Scalar : TensorFlowScalar {
-  public typealias ArrayLiteralElement = TensorElementLiteral<Scalar>
+  public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
   @inlinable @inline(__always)
-  public init(arrayLiteral elements: TensorElementLiteral<Scalar>...) {
+  public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
     self.init(base: Tensor(tensorElementLiterals: elements).array)
   }
 }

--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -549,7 +549,7 @@ extension ShapedArray : ExpressibleByArrayLiteral
   public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
   @inlinable @inline(__always)
   public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
-    self = Tensor<Scalar>(tensorElementLiterals: elements).array
+    self = Tensor<Scalar>(_tensorElementLiterals: elements).array
   }
 }
 
@@ -891,7 +891,7 @@ extension ShapedArraySlice : ExpressibleByArrayLiteral
   public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
   @inlinable @inline(__always)
   public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
-    self.init(base: Tensor(tensorElementLiterals: elements).array)
+    self.init(base: Tensor(_tensorElementLiterals: elements).array)
   }
 }
 

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -400,15 +400,15 @@ public extension Tensor {
 // Background story on `TensorElementLiteral` and why it's necessary:
 //
 // Very importantly, we want users to be able to implicitly convert an array
-// literal to a tensor. At a first glance, a straightfoward implementation would
+// literal to a tensor. At first glance, a straightfoward implementation would
 // be conforming `Tensor` to `ExpressibleByArrayLiteral` with
 // `ExpressibleBy(Float|Int|Bool)Literal` as a base case. However, it is not
 // that simple. We have binary operators that take `(Tensor, Scalar)`, `(Scalar,
-// Tensor)` as well as `(Tensor, Tensor)`. When `Tensor` are convertible from
+// Tensor)` as well as `(Tensor, Tensor)`. When `Tensor`s are convertible from
 // both a scalar and an array literal, a scalar-tensor binary operator like `+`
 // will not type check.
 //
-// One way to word around is to define all tensor-tensor operators on a
+// One way to work around it is to define all tensor-tensor operators in a
 // protocol extension, and all tensor-scalar and scalar-tensor operators on
 // concrete `Tensor`. Protocol extensions are less favorable than concrete
 // implementations, so the compiler will prefer the concrete implementation for
@@ -422,16 +422,15 @@ public extension Tensor {
 // `ArrayLiteralElement` be if we want to support both `[1,2,3]` and `[[[1,2],
 // [1,2]]]`? In the first case the array literal element is an interger, while
 // in the second case the array literal itself should be a tensor. Based on this
-// observation, we can come up with an intermediate type: `TensorLiteralElement`
-// as the `ArrayLiteralElement` of `Tensor`. By making `TensorLiteralElement`
+// observation, we come up with an intermediate type: `TensorElementLiteral` as
+// the `ArrayLiteralElement` of `Tensor`. By making `TensorElementLiteral`
 // expressible by both array literal and scalar literal, `Tensor` can now be
 // converted from an arbitrary-dimensional array literal.
 //
 // Due to protocol requirements, `TensorElementLiteral` has to be
 // public. It is never supposed to be used directly by any user, so the library
 // convention is to prepend an underscore to its name, making it
-// `_TensorElementLiteral`. However, we chose not to do that because underscored
-// types are ugly in error messages involving literal conversions to tensors.
+// `_TensorElementLiteral`.
 //
 // It would be nice to be able to remove this type when we can systematically
 // resolve tensor-scalar/scalar-tensor op ambiguity someday, either through an

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -440,10 +440,11 @@ public extension Tensor {
 
 /// Represents a literal element for conversion to a `Tensor`.
 ///
-/// - NOTE: Do not use this API directly. This is implicitly created during the
-/// conversion from an array literal to a `Tensor`.
+/// - Note: Do not ever use this API directly. This is implicitly created
+///   during the conversion from an array literal to a `Tensor`, and is purely
+///   for implementation purposes.
 @_fixed_layout
-public struct TensorElementLiteral<Scalar> : TensorProtocol
+public struct _TensorElementLiteral<Scalar> : TensorProtocol
   where Scalar : TensorFlowScalar {
 
   @usableFromInline let tensor: Tensor<Scalar>
@@ -459,7 +460,7 @@ public struct TensorElementLiteral<Scalar> : TensorProtocol
   }
 }
 
-extension TensorElementLiteral : ExpressibleByBooleanLiteral
+extension _TensorElementLiteral : ExpressibleByBooleanLiteral
   where Scalar : ExpressibleByBooleanLiteral {
   public typealias BooleanLiteralType = Scalar.BooleanLiteralType
   @inlinable @inline(__always)
@@ -468,7 +469,7 @@ extension TensorElementLiteral : ExpressibleByBooleanLiteral
   }
 }
 
-extension TensorElementLiteral : ExpressibleByIntegerLiteral
+extension _TensorElementLiteral : ExpressibleByIntegerLiteral
   where Scalar : ExpressibleByIntegerLiteral {
   public typealias IntegerLiteralType = Scalar.IntegerLiteralType
   @inlinable @inline(__always)
@@ -477,7 +478,7 @@ extension TensorElementLiteral : ExpressibleByIntegerLiteral
   }
 }
 
-extension TensorElementLiteral : ExpressibleByFloatLiteral
+extension _TensorElementLiteral : ExpressibleByFloatLiteral
   where Scalar : ExpressibleByFloatLiteral {
   public typealias FloatLiteralType = Scalar.FloatLiteralType
   @inlinable @inline(__always)
@@ -486,10 +487,10 @@ extension TensorElementLiteral : ExpressibleByFloatLiteral
   }
 }
 
-extension TensorElementLiteral : ExpressibleByArrayLiteral {
-  public typealias ArrayLiteralElement = TensorElementLiteral<Scalar>
+extension _TensorElementLiteral : ExpressibleByArrayLiteral {
+  public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
   @inlinable @inline(__always)
-  public init(arrayLiteral elements: TensorElementLiteral<Scalar>...) {
+  public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
     // Attr T (non-optional in the op definition) need not be specified when we
     // run the op as part of a graph function, but need to be specified when we
     // run it via eager C API.
@@ -501,14 +502,14 @@ extension TensorElementLiteral : ExpressibleByArrayLiteral {
 
 extension Tensor : ExpressibleByArrayLiteral {
   /// The type of the elements of an array literal.
-  public typealias ArrayLiteralElement = TensorElementLiteral<Scalar>
+  public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
 
   /// Creates a tensor initialized with the given elements.
   /// - Note: This is for conversion from tensor element literals. This is a
   /// separate method because `ShapedArray` initializers need to call it.
   @inlinable @inline(__always)
   internal init(
-    tensorElementLiterals elements: [TensorElementLiteral<Scalar>]
+    _tensorElementLiterals elements: [_TensorElementLiteral<Scalar>]
   ) {
     self.init(handle: #tfop("Pack", elements,
                             T$dtype: Scalar.tensorFlowDataType))
@@ -516,8 +517,8 @@ extension Tensor : ExpressibleByArrayLiteral {
 
   /// Creates a tensor initialized with the given elements.
   @inlinable @inline(__always)
-  public init(arrayLiteral elements: TensorElementLiteral<Scalar>...) {
-    self.init(tensorElementLiterals: elements)
+  public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
+    self.init(_tensorElementLiterals: elements)
   }
 }
 

--- a/stdlib/public/TensorFlow/TensorGroup.swift
+++ b/stdlib/public/TensorFlow/TensorGroup.swift
@@ -156,7 +156,7 @@ extension Tensor : TensorGroup {
   }
 }
 
-extension TensorElementLiteral : TensorGroup {
+extension _TensorElementLiteral : TensorGroup {
   @inlinable
   public static var _unknownShapeList: [TensorShape?] {
     return [nil]

--- a/test/TensorFlow/sema_errors.swift
+++ b/test/TensorFlow/sema_errors.swift
@@ -16,7 +16,7 @@ public func testExpressibleByLiteral() {
   let _: Tensor<Int32> = [1, 2, 3, 4] // ok
   let _: Tensor<Float> = [1, 2.0, 3, 4] // ok
   let _: Tensor<Bool> = [[[true, false, false, true]]] // ok
-  let _: Tensor<Float> = [[[true, false, false, true]]] // expected-error {{cannot convert value of type 'Bool' to expected element type 'TensorElementLiteral<Float>'}}
+  let _: Tensor<Float> = [[[true, false, false, true]]] // expected-error {{cannot convert value of type 'Bool' to expected element type '_TensorElementLiteral<Float>'}}
   let _: Tensor<Float> = Tensor([[[true, false, false, true]]]) // ok
 }
 


### PR DESCRIPTION
`TensorElementLiteral` is never ever supposed to be used by the user. Underscore it.

Motivated by the sighting of a `TensorElementLiteral` use in user code. This will make sure `TensorElementLiteral` will not appear in code completion.