### PR TITLE
[GSB] NFC: delete dead code

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2940,11 +2940,7 @@ Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
     if (parentType->hasError())
       return parentType;
 
-    // If we've resolved to an associated type, use it.
-    if (auto assocType = getResolvedType())
-      return getResolvedDependentMemberType(parentType);
-
-    return DependentMemberType::get(parentType, getNestedName());
+    return getResolvedDependentMemberType(parentType);
   }
   
   assert(isGenericParam() && "Not a generic parameter?");


### PR DESCRIPTION
Potential archetypes with parents always have AssociatedTypeDecls.

@DougGregor agreed that this was dead code here:

https://github.com/apple/swift/pull/23025/files#r261920455