### PR TITLE
[AST] NFC: Generalize no-escape tracking

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3056,15 +3056,24 @@ ERROR(closure_noescape_use,none,
 ERROR(decl_closure_noescape_use,none,
       "declaration closing over non-escaping parameter %0 may allow it to escape",
       (Identifier))
-ERROR(passing_noescape_to_escaping,none,
+ERROR(passing_noescape_declref_to_escaping,none,
       "passing non-escaping parameter %0 to function expecting an @escaping closure",
       (Identifier))
-ERROR(assigning_noescape_to_escaping,none,
+ERROR(assigning_noescape_declref_to_escaping,none,
       "assigning non-escaping parameter %0 to an @escaping closure",
       (Identifier))
-ERROR(general_noescape_to_escaping,none,
+ERROR(general_noescape_declref_to_escaping,none,
       "using non-escaping parameter %0 in a context expecting an @escaping closure",
       (Identifier))
+ERROR(passing_noescape_to_escaping,none,
+      "passing non-escaping value to function expecting an escaping %0",
+      (Type))
+ERROR(assigning_noescape_to_escaping,none,
+      "assigning non-escaping value to an escaping %0",
+      (Type))
+ERROR(general_noescape_to_escaping,none,
+      "using non-escaping value in a context expecting an escaping %0",
+      (Type))
 ERROR(converting_noescape_to_type,none,
       "converting non-escaping value to %0 may allow it to escape",
       (Type))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -126,7 +126,11 @@ public:
     /// This type contains a DependentMemberType.
     HasDependentMember   = 0x200,
 
-    Last_Property = HasDependentMember
+    /// This type expression contains a borrowed reference and therefore
+    /// cannot escape to the heap or be returned to a caller.
+    HasNoEscape       = 0x400,
+
+    Last_Property = HasNoEscape
   };
   enum { BitWidth = countBitsUsed(Property::Last_Property) };
 
@@ -157,6 +161,9 @@ public:
   
   /// Is a type with these properties an lvalue?
   bool isLValue() const { return Bits & IsLValue; }
+
+  /// Does this type contain a non-escaping reference?
+  bool hasNoEscape() const { return Bits & HasNoEscape; }
 
   /// Does this type contain an error?
   bool hasError() const { return Bits & HasError; }
@@ -621,7 +628,12 @@ public:
   bool hasLValueType() {
     return getRecursiveProperties().isLValue();
   }
-  
+
+  /// Determines whether this type contains a non-escaping reference.
+  bool hasNoEscape() const {
+    return getRecursiveProperties().hasNoEscape();
+  }
+
   /// Is a type with these properties materializable: that is, is it a
   /// first-class value type?
   bool isMaterializable();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -391,7 +391,7 @@ bool LabelingFailure::diagnoseAsError() {
                                     isa<SubscriptExpr>(anchor));
 }
 
-bool NoEscapeFuncToTypeConversionFailure::diagnoseAsError() {
+bool NoEscapeConversionFailure::diagnoseAsError() {
   auto *anchor = getAnchor();
 
   if (ConvertTo) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -454,15 +454,14 @@ public:
   bool diagnoseAsError() override;
 };
 
-/// Diagnose errors related to converting function type which
-/// isn't explicitly '@escaping' to some other type.
-class NoEscapeFuncToTypeConversionFailure final : public FailureDiagnostic {
+/// Diagnose errors related to converting to type which is potentially escaping.
+class NoEscapeConversionFailure final : public FailureDiagnostic {
   Type ConvertTo;
 
 public:
-  NoEscapeFuncToTypeConversionFailure(Expr *expr, ConstraintSystem &cs,
-                                      ConstraintLocator *locator,
-                                      Type toType = Type())
+  NoEscapeConversionFailure(Expr *expr, ConstraintSystem &cs,
+                            ConstraintLocator *locator,
+                            Type toType = Type())
       : FailureDiagnostic(expr, cs, locator), ConvertTo(toType) {}
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -132,8 +132,8 @@ CoerceToCheckedCast *CoerceToCheckedCast::create(ConstraintSystem &cs,
 }
 
 bool MarkExplicitlyEscaping::diagnose(Expr *root, bool asNote) const {
-  NoEscapeFuncToTypeConversionFailure failure(root, getConstraintSystem(),
-                                              getLocator(), ConvertTo);
+  NoEscapeConversionFailure failure(root, getConstraintSystem(),
+                                    getLocator(), ConvertTo);
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1634,11 +1634,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
   // we need to disallow conversions from @noescape functions to Any.
 
   // Conformance to 'Any' always holds.
-  if (type2->isAny()) {
-    auto *fnTy = type1->getAs<FunctionType>();
-    if (!fnTy || !fnTy->isNoEscape())
-      return getTypeMatchSuccess();
-
+  if (type2->isAny() && type1->hasNoEscape()) {
     if (shouldAttemptFixes()) {
       auto &ctx = getASTContext();
       auto *fix = MarkExplicitlyEscaping::create(
@@ -1825,21 +1821,19 @@ ConstraintSystem::matchTypesBindTypeVar(
     return getTypeMatchFailure(locator);
   }
 
-  // Disallow bindings of noescape functions to type variables that
+  // Disallow bindings of borrowed references to type variables that
   // represent an opened archetype. If we allowed this it would allow
-  // the noescape function to potentially escape.
-  if (auto *fnTy = type->getAs<FunctionType>()) {
-    if (fnTy->isNoEscape() && typeVar->getImpl().getGenericParameter()) {
-      if (shouldAttemptFixes()) {
-        auto *fix = MarkExplicitlyEscaping::create(
-            *this, getConstraintLocator(locator));
-        if (recordFix(fix))
-          return getTypeMatchFailure(locator);
-
-        // Allow no-escape function to be bound with recorded fix.
-      } else {
+  // the value to potentially escape.
+  if (type->hasNoEscape() && typeVar->getImpl().getGenericParameter()) {
+    if (shouldAttemptFixes()) {
+      auto *fix = MarkExplicitlyEscaping::create(
+          *this, getConstraintLocator(locator));
+      if (recordFix(fix))
         return getTypeMatchFailure(locator);
-      }
+
+      // Allow no-escape function to be bound with recorded fix.
+    } else {
+      return getTypeMatchFailure(locator);
     }
   }
 
@@ -2380,24 +2374,22 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     if (!type1->is<LValueType>() &&
         type2->isExistentialType()) {
 
-      // Penalize conversions to Any, and disallow conversions of
-      // noescape functions to Any.
+      // Penalize conversions to Any, and disallow conversions of noescape types
+      // to Any.
       if (kind >= ConstraintKind::Conversion && type2->isAny()) {
-        if (auto *fnTy = type1->getAs<FunctionType>()) {
-          if (fnTy->isNoEscape()) {
-            if (shouldAttemptFixes()) {
-              auto &ctx = getASTContext();
-              auto *fix = MarkExplicitlyEscaping::create(
-                  *this, getConstraintLocator(locator), ctx.TheAnyType);
-              if (recordFix(fix))
-                return getTypeMatchFailure(locator);
-
-              // Allow 'no-escape' functions to be converted to 'Any'
-              // with a recorded fix that helps us to properly diagnose
-              // such situations.
-            } else {
+        if (type1->hasNoEscape()) {
+          if (shouldAttemptFixes()) {
+            auto &ctx = getASTContext();
+            auto *fix = MarkExplicitlyEscaping::create(
+                *this, getConstraintLocator(locator), ctx.TheAnyType);
+            if (recordFix(fix))
               return getTypeMatchFailure(locator);
-            }
+
+            // Allow 'no-escape' functions to be converted to 'Any'
+            // with a recorded fix that helps us to properly diagnose
+            // such situations.
+          } else {
+            return getTypeMatchFailure(locator);
           }
         }
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -205,8 +205,7 @@ public:
     if (AFR.hasType() &&
         !AFR.getType()->hasError() &&
         VD->hasInterfaceType() &&
-        VD->getInterfaceType()->is<AnyFunctionType>() &&
-        VD->getInterfaceType()->castTo<AnyFunctionType>()->isNoEscape() &&
+        VD->getInterfaceType()->hasNoEscape() &&
         !capture.isNoEscape() &&
         // Don't repeatedly diagnose the same thing.
         Diagnosed.insert(VD).second) {


### PR DESCRIPTION
This patch generalizes the existing "no-escape" semantic analysis and makes future features possible. In my case, I have a research branch with a couple new types that need no-escape behavior. As for Swift in general, this opens the door to things like "no-escape array of no-escape functions".