### PR TITLE
[AST] Don't return inapplicable decls in lookupVisibleDecls

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -81,9 +81,15 @@ namespace swift {
   /// decide if the extension has been applied, i.e. if the requirements of the
   /// extension have been fulfilled.
   /// \returns True on applied, false on not applied.
-  bool isExtensionApplied(DeclContext &DC, Type Ty, const ExtensionDecl *ED);
+  bool isExtensionApplied(const DeclContext *DC, Type Ty,
+                          const ExtensionDecl *ED);
 
-/// The kind of type checking to perform for code completion.
+  /// Given a type and an member value decl , decide if the decl is applied,
+  /// i.e. if the \c where requirements of the decl have been fulfilled.
+  /// \returns True on applied, false on not applied.
+  bool isMemberDeclApplied(const DeclContext *DC, Type Ty, const ValueDecl *VD);
+
+  /// The kind of type checking to perform for code completion.
   enum class CompletionTypeCheckKind {
     /// Type check the expression as normal.
     Normal,

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -62,8 +62,8 @@ PrintOptions PrintOptions::printTypeInterface(Type T) {
   result.PrintExtensionFromConformingProtocols = true;
   result.TransformContext = TypeTransformContext(T);
   result.printExtensionContentAsMembers = [T](const ExtensionDecl *ED) {
-    return isExtensionApplied(*T->getNominalOrBoundGenericNominal()->
-                              getDeclContext(), T, ED);
+    return isExtensionApplied(
+        T->getNominalOrBoundGenericNominal()->getDeclContext(), T, ED);
   };
   result.CurrentPrintabilityChecker.reset(new ModulePrinterPrintableChecker());
   return result;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -3607,39 +3608,68 @@ void ConstraintSystem::optimizeConstraints(Expr *e) {
   e->walk(optimizer);
 }
 
-bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
-                               const ExtensionDecl *ED) {
-  if (!ED->isConstrainedExtension() ||
-      // We'll crash if we leak type variables from one constraint
-      // system into the new one created below.
-      BaseTy->hasTypeVariable() ||
-      // We can't do anything if the base type has unbound generic
-      // parameters either.
-      BaseTy->hasUnboundGenericType())
-    return true;
+static bool areGenericRequirementsSatisfied(
+    const DeclContext *DC, const GenericSignature *sig,
+    const SubstitutionMap &Substitutions, bool isExtension) {
 
-  TypeChecker *TC = &createTypeChecker(DC.getASTContext());
-  TC->validateExtension(const_cast<ExtensionDecl *>(ED));
-
+  TypeChecker &TC = createTypeChecker(DC->getASTContext());
   ConstraintSystemOptions Options;
-  ConstraintSystem CS(*TC, &DC, Options);
+  ConstraintSystem CS(TC, const_cast<DeclContext *>(DC), Options);
   auto Loc = CS.getConstraintLocator(nullptr);
 
-  // Prepare type substitution map.
-  SubstitutionMap Substitutions = BaseTy->getContextSubstitutionMap(
-    DC.getParentModule(), ED);
-
   // For every requirement, add a constraint.
-  for (auto Req : ED->getGenericRequirements()) {
+  for (auto Req : sig->getRequirements()) {
     if (auto resolved = Req.subst(Substitutions)) {
       CS.addConstraint(*resolved, Loc);
-    } else {
+    } else if (isExtension) {
       return false;
     }
+    // Unresolved requirements are requirements of the function itself. This
+    // does not prevent it from being applied. E.g. func foo<T: Sequence>(x: T).
   }
 
-  // Having a solution implies the extension's requirements have been fulfilled.
+  // Having a solution implies the requirements have been fulfilled.
   return CS.solveSingle().hasValue();
+}
+
+bool swift::isExtensionApplied(const DeclContext *DC, Type BaseTy,
+                               const ExtensionDecl *ED) {
+  // We can't do anything if the base type has unbound generic parameters.
+  // We can't leak type variables into another constraint system.
+  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType())
+    return true;
+
+  if (!ED->isConstrainedExtension())
+    return true;
+
+  TypeChecker *TC = &createTypeChecker(DC->getASTContext());
+  TC->validateExtension(const_cast<ExtensionDecl *>(ED));
+
+  GenericSignature *genericSig = ED->getGenericSignature();
+  SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
+      DC->getParentModule(), ED->getExtendedNominal());
+  return areGenericRequirementsSatisfied(DC, genericSig, substMap,
+                                         /*isExtension=*/true);
+}
+
+bool swift::isMemberDeclApplied(const DeclContext *DC, Type BaseTy,
+                                const ValueDecl *VD) {
+  // We can't leak type variables into another constraint system.
+  // We can't do anything if the base type has unbound generic parameters.
+  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType())
+    return true;
+
+  const GenericContext *genericDecl = VD->getAsGenericContext();
+  if (!genericDecl)
+    return true;
+  const GenericSignature *genericSig = genericDecl->getGenericSignature();
+  if (!genericSig)
+    return true;
+
+  SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
+      DC->getParentModule(), VD->getDeclContext());
+  return areGenericRequirementsSatisfied(DC, genericSig, substMap,
+                                         /*isExtension=*/false);
 }
 
 static bool canSatisfy(Type type1, Type type2, bool openArchetypes,

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -174,6 +174,24 @@ static bool isDeclVisibleInLookupMode(ValueDecl *Member, LookupState LS,
   return true;
 }
 
+/// Collect visble members from \p Parent into \p FoundDecls .
+static void collectVisibleMemberDecls(const DeclContext *CurrDC, LookupState LS,
+                                      Type BaseType,
+                                      IterableDeclContext *Parent,
+                                      SmallVectorImpl<ValueDecl *> &FoundDecls,
+                                      LazyResolver *TypeResolver) {
+  for (auto Member : Parent->getMembers()) {
+    auto *VD = dyn_cast<ValueDecl>(Member);
+    if (!VD)
+      continue;
+    if (!isDeclVisibleInLookupMode(VD, LS, CurrDC, TypeResolver))
+      continue;
+    if (!isMemberDeclApplied(CurrDC, BaseType, VD))
+      continue;
+    FoundDecls.push_back(VD);
+  }
+}
+
 /// Lookup members in extensions of \p LookupType, using \p BaseType as the
 /// underlying type when checking any constraints on the extensions.
 static void doGlobalExtensionLookup(Type BaseType,
@@ -187,15 +205,12 @@ static void doGlobalExtensionLookup(Type BaseType,
 
   // Look in each extension of this type.
   for (auto extension : nominal->getExtensions()) {
-    if (!isExtensionApplied(*const_cast<DeclContext*>(CurrDC), BaseType,
+    if (!isExtensionApplied(const_cast<DeclContext *>(CurrDC), BaseType,
                             extension))
       continue;
 
-    for (auto Member : extension->getMembers()) {
-      if (auto VD = dyn_cast<ValueDecl>(Member))
-        if (isDeclVisibleInLookupMode(VD, LS, CurrDC, TypeResolver))
-          FoundDecls.push_back(VD);
-    }
+    collectVisibleMemberDecls(CurrDC, LS, BaseType, extension, FoundDecls,
+                              TypeResolver);
   }
 
   // Handle shadowing.
@@ -217,12 +232,8 @@ static void lookupTypeMembers(Type BaseType, Type LookupType,
   assert(D && "should have a nominal type");
 
   SmallVector<ValueDecl*, 2> FoundDecls;
+  collectVisibleMemberDecls(CurrDC, LS, BaseType, D, FoundDecls, TypeResolver);
 
-  for (Decl *Member : D->getMembers()) {
-    if (auto *VD = dyn_cast<ValueDecl>(Member))
-      if (isDeclVisibleInLookupMode(VD, LS, CurrDC, TypeResolver))
-        FoundDecls.push_back(VD);
-  }
   doGlobalExtensionLookup(BaseType, LookupType, FoundDecls, CurrDC, LS, Reason,
                           TypeResolver);
 

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -1,0 +1,72 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MYSTRUCT_INT_DOT | %FileCheck %s -check-prefix=MYSTRUCT_INT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=META_MYSTRUCT_INT_DOT | %FileCheck %s -check-prefix=META_MYSTRUCT_INT_DOT
+
+protocol SomeProto {
+  associatedtype Assoc
+}
+
+extension SomeProto where Assoc == String {
+  func protoExt_AssocEqString_None() -> Int { return 1 }
+}
+extension SomeProto where Assoc == Int {
+  func protoExt_AssocEqInt_None() -> Int { return 1 }
+}
+extension SomeProto where Assoc: SomeProto {
+  func protoExt_AssocConformsToSomeProto_None() -> Int { return 1 }
+}
+
+extension SomeProto {
+  func protoExt_None_AssocEqString<U>(_ x: U) -> Int where Assoc == String { return 1 }
+  func protoExt_None_AssocEqInt<U>(_ x: U) -> Int where Assoc == Int { return 1 }
+  func protoExt_None_AssocConformsToSomeProto<U>(_ x: U) -> Int where Assoc: SomeProto { return 1 }
+}
+
+struct MyStruct<T> : SomeProto {
+  typealias Assoc = T
+  init<U>(int: U) where T == Int {}
+  init<U>(str: U) where T == String {}
+  init<U: SomeProto>(withConstrainedGenericParam: U) {}
+  func methodWithConstrainedGenericParam<U: SomeProto>(x: U) -> Int { return 1 }
+}
+
+extension MyStruct where T == String {
+  func concreteExt_TEqString_None() -> Int { return 1 }
+}
+extension MyStruct where T == Int {
+  func concreteExt_TEqInt_None() -> Int { return 1 }
+}
+extension MyStruct where T: SomeProto {
+  func concreteExt_TConformsToSomeProto_None() -> Int { return 1 }
+}
+
+extension MyStruct {
+  func concreteExt_None_TEqString<U>(_ x: U) -> Int where T == String { return 1 }
+  func concreteExt_None_TEqInt<U>(_ x: U) -> Int where T == Int { return 1 }
+  func concreteExt_None_TConformsToSomeProto<U>(_ x: U) -> Int where T: SomeProto { return 1 }
+}
+
+func foo(s: MyStruct<Int>) {
+  let _ = s.#^MYSTRUCT_INT_DOT^#
+// MYSTRUCT_INT_DOT: Begin completions, 6 items
+// MYSTRUCT_INT_DOT-DAG: Keyword[self]/CurrNominal:          self[#MyStruct<Int>#]; name=self
+// MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   methodWithConstrainedGenericParam({#x: SomeProto#})[#Int#]; name=methodWithConstrainedGenericParam(x: SomeProto)
+// MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   concreteExt_TEqInt_None()[#Int#]; name=concreteExt_TEqInt_None()
+// MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   concreteExt_None_TEqInt({#(x): U#})[#Int#]; name=concreteExt_None_TEqInt(x: U)
+// MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/Super:         protoExt_AssocEqInt_None()[#Int#]; name=protoExt_AssocEqInt_None()
+// MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/Super:         protoExt_None_AssocEqInt({#(x): U#})[#Int#]; name=protoExt_None_AssocEqInt(x: U)
+// MYSTRUCT_INT_DOT: End completions
+
+  let _ = MyStruct<Int>.#^META_MYSTRUCT_INT_DOT^#
+// META_MYSTRUCT_INT_DOT: Begin completions, 10 items
+// META_MYSTRUCT_INT_DOT-DAG: Keyword[self]/CurrNominal:          self[#MyStruct<Int>.Type#]; name=self
+// META_MYSTRUCT_INT_DOT-DAG: Keyword/CurrNominal:                Type[#MyStruct<Int>.Type#]; name=Type
+// META_MYSTRUCT_INT_DOT-DAG: Decl[TypeAlias]/CurrNominal:        Assoc[#T#]; name=Assoc
+// META_MYSTRUCT_INT_DOT-DAG: Decl[Constructor]/CurrNominal:      init({#int: U#})[#MyStruct<Int>#]; name=init(int: U)
+// META_MYSTRUCT_INT_DOT-DAG: Decl[Constructor]/CurrNominal:      init({#withConstrainedGenericParam: SomeProto#})[#MyStruct<Int>#]; name=init(withConstrainedGenericParam: SomeProto)
+// META_MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   methodWithConstrainedGenericParam({#(self): MyStruct<Int>#})[#(x: SomeProto) -> Int#]; name=methodWithConstrainedGenericParam(self: MyStruct<Int>)
+// META_MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   concreteExt_TEqInt_None({#(self): MyStruct<Int>#})[#() -> Int#]; name=concreteExt_TEqInt_None(self: MyStruct<Int>)
+// META_MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   concreteExt_None_TEqInt({#(self): MyStruct<Int>#})[#(U) -> Int#]; name=concreteExt_None_TEqInt(self: MyStruct<Int>)
+// META_MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/Super:         protoExt_AssocEqInt_None({#(self): MyStruct<Int>#})[#() -> Int#]; name=protoExt_AssocEqInt_None(self: MyStruct<Int>)
+// META_MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/Super:         protoExt_None_AssocEqInt({#(self): MyStruct<Int>#})[#(U) -> Int#]; name=protoExt_None_AssocEqInt(self: MyStruct<Int>)
+// META_MYSTRUCT_INT_DOT: End completions
+}

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -262,9 +262,8 @@ func testInfix11() {
 func testInfix12() {
   P#^INFIX_12^#
 }
-// INFIX_12: Begin completions, 5 items
+// INFIX_12: Begin completions, 4 items
 // INFIX_12-NEXT: Decl[AssociatedType]/CurrNominal:   .T; name=T
-// INFIX_12-NEXT: Decl[InstanceMethod]/CurrNominal:   .foo({#(self): P#})[#() -> P.T#]; name=foo(self: P)
 // INFIX_12-NEXT: Keyword[self]/CurrNominal:          .self[#P.Protocol#]; name=self
 // INFIX_12-NEXT: Keyword/CurrNominal:                .Protocol[#P.Protocol#]; name=Protocol
 // INFIX_12-NEXT: Keyword/CurrNominal:                .Type[#P.Type#]; name=Type

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -493,11 +493,7 @@ func testSubType() {
 func testMemberTypealias() {
   var _: MyProtocol = .#^SUBTYPE_2^#
 }
-// SUBTYPE_2: Begin completions, 2 items
-// SUBTYPE_1-NOT: Concrete1(failable:
-// SUBTYPE_2-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: Concrete1()[#BaseClass#];
-// SUBTYPE_2-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: Concrete2()[#AnotherTy#];
-// SUBTYPE_2: End completions
+// SUBTYPE_2-NOT: Begin completions
 
 enum Generic<T> {
   case contains(content: T)

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -2074,14 +2074,10 @@ protocol ExistentialProto {
 
 func testExistential() {
   let _ = ExistentialProto.#^PROTOCOLTYPE_DOT_1^#
-// PROTOCOLTYPE_DOT_1: Begin completions, 5 items
+// PROTOCOLTYPE_DOT_1: Begin completions, 3 items
 // PROTOCOLTYPE_DOT_1-DAG: Keyword[self]/CurrNominal:          self[#ExistentialProto.Protocol#]; name=self
 // PROTOCOLTYPE_DOT_1-DAG: Keyword/CurrNominal:                Protocol[#ExistentialProto.Protocol#]; name=Protocol
 // PROTOCOLTYPE_DOT_1-DAG: Keyword/CurrNominal:                Type[#ExistentialProto.Type#]; name=Type
-// FIXME(SR-75, rdar://problem/21289579): These 2 are invalid: {
-// PROTOCOLTYPE_DOT_1-DAG: Decl[StaticMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: staticMethod()[#Void#]; name=staticMethod()
-// PROTOCOLTYPE_DOT_1-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: instanceMethod({#(self): ExistentialProto#})[#() -> Void#]; name=instanceMethod(self: ExistentialProto)
-// }
 // PROTOCOLTYPE_DOT_1: End completions
 
   let _ = ExistentialProto.Type.#^PROTOCOLTYPE_DOT_2^#

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -145,7 +145,6 @@ protocol P3 {
 // Test for not crashing on recursive aliases
 protocol Circular {
   typealias Y = Self.Y // expected-error {{'Y' is not a member type of 'Self'}}
-  // expected-note@-1 {{did you mean 'Y'?}}
 
   typealias Y2 = Y2 // expected-error {{type alias 'Y2' references itself}}
   // expected-note@-1 {{type declared here}}


### PR DESCRIPTION
We used to return decls from extension with non-matching same type requirements. e.g.
```swift
struct S<T> { }
extension S where T == String {
  func foo() {}
}
S<Int>().#HERE# // shows foo()
```

Also, we used to not take requirements for decl itself into account. e.g.
```swift
struct S<T> {
  func foo<U>(x: U) where T : Error {}
}
S<Int>().#HERE# // shows foo(x: U)
```

rdar://problem/45340583 / https://bugs.swift.org/browse/SR-9027
rdar://problem/36594731
