### PR TITLE
[SourceKit][Refactor] Inject indentation when extracting methods

### DIFF
--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift.expected
@@ -1,6 +1,6 @@
 source.edit.kind.active:
   1:1-1:1 "fileprivate func extractedFunc() -> Int {
-var a = 3
+  var a = 3
   a = a + 1
   return 1
 }

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-indented.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-indented.swift
@@ -1,0 +1,14 @@
+func foo2() -> Int {
+  func foo3() -> Int {
+    var a = 3
+    a = a + 1
+    return 1
+  }
+}
+
+// RUN: %empty-directory(%t.result)
+// RUN: %sourcekitd-test -req=extract-func -pos=3:1 -end-pos 5:13 -name new_name %s -- %s > %t.result/extract-func-idented.swift.expected
+// RUN: diff -u %S/extract-func-idented.swift.expected %t.result/extract-func-idented.swift.expected
+
+// FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed
+// REQUIRES-ANY: OS=macosx

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-indented.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-indented.swift.expected
@@ -1,0 +1,12 @@
+source.edit.kind.active:
+  2:3-2:3 "func new_name() -> Int {
+    var a = 3
+    a = a + 1
+    return 1
+  }
+
+  "
+  <note>source.refactoring.range.kind.basename 1:6-1:14 "new_name"</note>
+source.edit.kind.active:
+  3:5-5:13 "return new_name()"
+  <note>source.refactoring.range.kind.basename 1:8-1:16 "new_name"</note>

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift.expected
@@ -1,6 +1,6 @@
 source.edit.kind.active:
   1:1-1:1 "fileprivate func new_name(_ a: inout Int) {
-a = a + 1
+  a = a + 1
 }
 
 "

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift.expected
@@ -1,6 +1,6 @@
 source.edit.kind.active:
   1:1-1:1 "fileprivate func new_name() -> Int {
-var a = 3
+  var a = 3
   a = a + 1
   return 1
 }


### PR DESCRIPTION
The method extraction refactoring is not taking the original range's indentation in consideration when generating the new strings. This has no effect on Xcode, but unformatted environments like SourceKit-LSP are affected:

<img width="137" alt="screen shot 2019-03-04 at 2 08 26 pm" src="https://user-images.githubusercontent.com/11647449/53752979-dd43d880-3e8e-11e9-9c7c-461f931012c4.png">

<img width="219" alt="screen shot 2019-03-04 at 2 08 39 pm" src="https://user-images.githubusercontent.com/11647449/53752985-e2088c80-3e8e-11e9-8276-1aadcf7213df.png">

These changes injects spaces to achieve the following result:

<img width="219" alt="screen shot 2019-03-04 at 2 09 14 pm" src="https://user-images.githubusercontent.com/11647449/53753003-ecc32180-3e8e-11e9-8f26-5ae469968726.png">

Note that this does not take tabs in consideration - I was unsure if that would be a problem or not given that this is supposed to assist environments that can't format input, but If that's important and there's no way to generate the "true" indentation string from SourceKit, then it's probably better to leave this unchanged.