### PR TITLE
[cast-opt] Change optimize{Swift,ObjC}to{ObjC,Swift} to use SILDynami…

### DIFF
--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_SIL_DYNAMICCASTS_H
 #define SWIFT_SIL_DYNAMICCASTS_H
 
+#include "swift/AST/Module.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
@@ -420,8 +421,31 @@ public:
     // Bridging casts cannot be further simplified.
     auto TargetIsBridgeable = getTargetType()->isBridgeableObjectType();
     auto SourceIsBridgeable = getSourceType()->isBridgeableObjectType();
-
     return TargetIsBridgeable != SourceIsBridgeable;
+  }
+
+  /// If getSourceType() is a Swift type that can bridge to an ObjC type, return
+  /// the ObjC type it bridges to. If the source type is an objc type, an empty
+  /// CanType() is returned.
+  CanType getBridgedSourceType() const {
+    SILModule &mod = getModule();
+    Type t = mod.getASTContext().getBridgedToObjC(mod.getSwiftModule(),
+                                                  getSourceType());
+    if (!t)
+      return CanType();
+    return t->getCanonicalType();
+  }
+
+  /// If getTargetType() is a Swift type that can bridge to an ObjC type, return
+  /// the ObjC type it bridges to. If the target type is an objc type, an empty
+  /// CanType() is returned.
+  CanType getBridgedTargetType() const {
+    SILModule &mod = getModule();
+    Type t = mod.getASTContext().getBridgedToObjC(mod.getSwiftModule(),
+                                                  getTargetType());
+    if (!t)
+      return CanType();
+    return t->getCanonicalType();
   }
 
   bool isConditional() const {

--- a/include/swift/SILOptimizer/Utils/CastOptimizer.h
+++ b/include/swift/SILOptimizer/Utils/CastOptimizer.h
@@ -63,24 +63,6 @@ class CastOptimizer {
   /// that a cast will fail.
   std::function<void()> WillFailAction;
 
-  /// Optimize a cast from a bridged ObjC type into
-  /// a corresponding Swift type implementing _ObjectiveCBridgeable.
-  SILInstruction *optimizeBridgedObjCToSwiftCast(
-      SILInstruction *Inst, bool isConditional, SILValue Src, SILValue Dest,
-      CanType Source, CanType Target, Type BridgedSourceTy,
-      Type BridgedTargetTy, SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB);
-
-  /// Optimize a cast from a Swift type implementing _ObjectiveCBridgeable
-  /// into a bridged ObjC type.
-  SILInstruction *optimizeBridgedSwiftToObjCCast(
-      SILInstruction *Inst, CastConsumptionKind ConsumptionKind,
-      bool isConditional, SILValue Src, SILValue Dest, CanType Source,
-      CanType Target, Type BridgedSourceTy, Type BridgedTargetTy,
-      SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB);
-
-  void deleteInstructionsAfterUnreachable(SILInstruction *UnreachableInst,
-                                          SILInstruction *TrapInst);
-
 public:
   CastOptimizer(SILOptFunctionBuilder &FunctionBuilder,
                 SILBuilderContext *BuilderContext,
@@ -148,6 +130,19 @@ public:
   ///
   /// May change the control flow.
   SILInstruction *optimizeBridgedCasts(SILDynamicCastInst cast);
+
+  /// Optimize a cast from a bridged ObjC type into
+  /// a corresponding Swift type implementing _ObjectiveCBridgeable.
+  SILInstruction *
+  optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast);
+
+  /// Optimize a cast from a Swift type implementing _ObjectiveCBridgeable
+  /// into a bridged ObjC type.
+  SILInstruction *
+  optimizeBridgedSwiftToObjCCast(SILDynamicCastInst dynamicCast);
+
+  void deleteInstructionsAfterUnreachable(SILInstruction *UnreachableInst,
+                                          SILInstruction *TrapInst);
 
   SILValue optimizeMetatypeConversion(ConversionInst *mci,
                                       MetatypeRepresentation representation);

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -45,21 +45,21 @@
 
 using namespace swift;
 
-/// If target is a Swift type bridging to an ObjC type,
-/// return the ObjC type it bridges to.
-/// If target is an ObjC type, return this type.
-static Type getCastFromObjC(SILModule &M, CanType source, CanType target) {
-  return M.getASTContext().getBridgedToObjC(M.getSwiftModule(), target);
-}
-
 /// Create a call of _forceBridgeFromObjectiveC_bridgeable or
 /// _conditionallyBridgeFromObjectiveC_bridgeable which converts an ObjC
 /// instance into a corresponding Swift type, conforming to
 /// _ObjectiveCBridgeable.
-SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
-    SILInstruction *Inst, bool isConditional, SILValue Src, SILValue Dest,
-    CanType Source, CanType Target, Type BridgedSourceTy, Type BridgedTargetTy,
-    SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB) {
+SILInstruction *
+CastOptimizer::optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast) {
+
+  SILInstruction *Inst = dynamicCast.getInstruction();
+  bool isConditional = dynamicCast.isConditional();
+  SILValue Src = dynamicCast.getSource();
+  SILValue Dest = dynamicCast.getDest();
+  CanType Target = dynamicCast.getTargetType();
+  CanType BridgedTargetTy = dynamicCast.getBridgedTargetType();
+  SILBasicBlock *SuccessBB = dynamicCast.getSuccessBlock();
+  SILBasicBlock *FailureBB = dynamicCast.getFailureBlock();
   auto *F = Inst->getFunction();
   auto &M = Inst->getModule();
   auto Loc = Inst->getLoc();
@@ -313,12 +313,17 @@ static bool canOptimizeCast(const swift::Type &BridgedTargetTy,
 
 /// Create a call of _bridgeToObjectiveC which converts an _ObjectiveCBridgeable
 /// instance into a bridged ObjC type.
-SILInstruction *CastOptimizer::optimizeBridgedSwiftToObjCCast(
-    SILInstruction *Inst, CastConsumptionKind ConsumptionKind,
-    bool isConditional, SILValue Src, SILValue Dest, CanType Source,
-    CanType Target, Type BridgedSourceTy, Type BridgedTargetTy,
-    SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB) {
-
+SILInstruction *
+CastOptimizer::optimizeBridgedSwiftToObjCCast(SILDynamicCastInst dynamicCast) {
+  SILInstruction *Inst = dynamicCast.getInstruction();
+  CastConsumptionKind ConsumptionKind = dynamicCast.getBridgedConsumptionKind();
+  bool isConditional = dynamicCast.isConditional();
+  SILValue Src = dynamicCast.getSource();
+  SILValue Dest = dynamicCast.getDest();
+  CanType Source = dynamicCast.getSourceType();
+  CanType BridgedTargetTy = dynamicCast.getBridgedTargetType();
+  SILBasicBlock *SuccessBB = dynamicCast.getSuccessBlock();
+  SILBasicBlock *FailureBB = dynamicCast.getFailureBlock();
   auto &M = Inst->getModule();
   auto Loc = Inst->getLoc();
 
@@ -596,24 +601,17 @@ SILInstruction *CastOptimizer::optimizeBridgedSwiftToObjCCast(
   return NewI;
 }
 
-/// Make use of the fact that some of these casts cannot fail.  For example, if
-/// the ObjC type is exactly the expected _ObjectiveCType type, then it would
-/// always succeed for NSString, NSNumber, etc.  Casts from NSArray,
-/// NSDictionary and NSSet may fail.
+/// Make use of the fact that some of these casts cannot fail.  For
+/// example, if the ObjC type is exactly the expected _ObjectiveCType
+/// type, then it would always succeed for NSString, NSNumber, etc.
+/// Casts from NSArray, NSDictionary and NSSet may fail.
 ///
-/// If ObjC class is not exactly _ObjectiveCType, then its conversion to a
-/// required _ObjectiveCType may fail.
+/// If ObjC class is not exactly _ObjectiveCType, then its conversion
+/// to a required _ObjectiveCType may fail.
 SILInstruction *
 CastOptimizer::optimizeBridgedCasts(SILDynamicCastInst dynamicCast) {
-  SILInstruction *Inst = dynamicCast.getInstruction();
-  CastConsumptionKind ConsumptionKind = dynamicCast.getBridgedConsumptionKind();
-  bool isConditional = dynamicCast.isConditional();
-  SILValue Src = dynamicCast.getSource();
-  SILValue Dest = dynamicCast.getDest();
   CanType source = dynamicCast.getSourceType();
   CanType target = dynamicCast.getTargetType();
-  SILBasicBlock *SuccessBB = dynamicCast.getSuccessBlock();
-  SILBasicBlock *FailureBB = dynamicCast.getFailureBlock();
   auto &M = dynamicCast.getModule();
 
   // To apply the bridged optimizations, we should ensure that types are not
@@ -631,16 +629,13 @@ CastOptimizer::optimizeBridgedCasts(SILDynamicCastInst dynamicCast) {
   if (source->hasArchetype() || target->hasArchetype())
     return nullptr;
 
-  auto BridgedTargetTy = getCastFromObjC(M, source, target);
-  if (!BridgedTargetTy)
-    return nullptr;
+  CanType CanBridgedSourceTy = dynamicCast.getBridgedSourceType();
+  CanType CanBridgedTargetTy = dynamicCast.getBridgedTargetType();
 
-  auto BridgedSourceTy = getCastFromObjC(M, target, source);
-  if (!BridgedSourceTy)
+  // If we were unable to bridge either of our source/target types, return
+  // nullptr.
+  if (!CanBridgedSourceTy || !CanBridgedTargetTy)
     return nullptr;
-
-  CanType CanBridgedTargetTy = BridgedTargetTy->getCanonicalType();
-  CanType CanBridgedSourceTy = BridgedSourceTy->getCanonicalType();
 
   if (CanBridgedSourceTy == source && CanBridgedTargetTy == target) {
     // Both source and target type are ObjC types.
@@ -660,19 +655,13 @@ CastOptimizer::optimizeBridgedCasts(SILDynamicCastInst dynamicCast) {
     return nullptr;
   }
 
-  if (CanBridgedSourceTy || CanBridgedTargetTy) {
-    // Check what kind of conversion it is? ObjC->Swift or Swift-ObjC?
-    if (CanBridgedTargetTy != target) {
-      // This is an ObjC to Swift cast.
-      return optimizeBridgedObjCToSwiftCast(
-          Inst, isConditional, Src, Dest, source, target, BridgedSourceTy,
-          BridgedTargetTy, SuccessBB, FailureBB);
-    } else {
-      // This is a Swift to ObjC cast
-      return optimizeBridgedSwiftToObjCCast(
-          Inst, ConsumptionKind, isConditional, Src, Dest, source, target,
-          BridgedSourceTy, BridgedTargetTy, SuccessBB, FailureBB);
-    }
+  // Check what kind of conversion it is? ObjC->Swift or Swift-ObjC?
+  if (CanBridgedTargetTy != target) {
+    // This is an ObjC to Swift cast.
+    return optimizeBridgedObjCToSwiftCast(dynamicCast);
+  } else {
+    // This is a Swift to ObjC cast
+    return optimizeBridgedSwiftToObjCCast(dynamicCast);
   }
 
   llvm_unreachable("Unknown kind of bridging");


### PR DESCRIPTION
…cCastInst.

I also debrided dead variables that resulted from eliminating the trampoline
argument code in optimizeBridgedCasts().

----

Andy, take a look at optimizeBridgedFunctions... its really clean now since we do not need to marshall any data.