### PR TITLE
[cast-opt] Fix obvious bug.

### DIFF
--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -654,7 +654,7 @@ CastOptimizer::optimizeBridgedCasts(SILDynamicCastInst dynamicCast) {
 
   if ((CanBridgedSourceTy && CanBridgedSourceTy->getAnyNominal() ==
                                  M.getASTContext().getNSErrorDecl()) ||
-      (CanBridgedTargetTy && CanBridgedSourceTy->getAnyNominal() ==
+      (CanBridgedTargetTy && CanBridgedTargetTy->getAnyNominal() ==
                                  M.getASTContext().getNSErrorDecl())) {
     // FIXME: Can't optimize bridging with NSError.
     return nullptr;


### PR DESCRIPTION
Found via inspection. The code is supposed to check if either the source or the
target is NSError and in such a case bail.
