### PR TITLE
[5.1][Stdlib] Special-case major version 9999 as always available.

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -25,6 +25,9 @@ public func _stdlib_isOSVersionAtLeast(
   _ patch: Builtin.Word
 ) -> Builtin.Int1 {
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  if Int(major) == 9999 {
+    return true._value
+  }
   // The call to _swift_stdlib_operatingSystemVersion is used as an indicator
   // that this function was called by a compiler optimization pass. If it is
   // replaced that pass needs to be updated.

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -766,6 +766,9 @@ AvailabilityVersionsTestSuite.test("_stdlib_isOSVersionAtLeast") {
   expectFalse(isAtLeastOS(1066, 0, 0))
   expectTrue(isAtLeastOS(0, 1066, 0))
   expectTrue(isAtLeastOS(0, 0, 1066))
+  
+  // 9999 is a special version that's always available
+  expectTrue(isAtLeastOS(9999, 0, 0))
 #endif
 }
 


### PR DESCRIPTION
rdar://problem/43776049