### PR TITLE
Introduce TypeConverter::getLoweredRValueType() and use it in various places

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -808,7 +808,7 @@ public:
                                            bool isNonObjC = false);
   AbstractionPattern getAbstractionPattern(EnumElementDecl *element);
 
-  SILType getLoweredTypeOfGlobal(VarDecl *var);
+  CanType getLoweredTypeOfGlobal(VarDecl *var);
 
   /// Return the SILFunctionType for a native function value of the
   /// given type.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -792,6 +792,14 @@ public:
     return ti.getLoweredType();
   }
 
+  CanType getLoweredRValueType(Type t) {
+    return getLoweredType(t).getASTType();
+  }
+
+  CanType getLoweredRValueType(AbstractionPattern origType, Type substType) {
+    return getLoweredType(origType, substType).getASTType();
+  }
+
   AbstractionPattern getAbstractionPattern(AbstractStorageDecl *storage,
                                            bool isNonObjC = false);
   AbstractionPattern getAbstractionPattern(VarDecl *var,

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1001,7 +1001,8 @@ public:
                                          EnumElementDecl *elt);
 
 private:
-  CanType getLoweredRValueType(AbstractionPattern origType, CanType substType);
+  CanType computeLoweredRValueType(AbstractionPattern origType,
+                                   CanType substType);
 
   Type getLoweredCBridgedType(AbstractionPattern pattern, Type t,
                               Bridgeability bridging,

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -224,7 +224,7 @@ private:
   getOffsetOfFieldFromIRGen(irgen::IRGenModule &IGM, Type type,
                             NominalTypeDecl *typeDecl,
                             RemoteAddress optMetadata, VarDecl *member) {
-    SILType loweredTy = IGM.getSILTypes().getLoweredType(type);
+    SILType loweredTy = IGM.getLoweredType(type);
 
     MemberAccessStrategy strategy =
       (isa<StructDecl>(typeDecl)
@@ -334,7 +334,7 @@ private:
     if (!irgen) return Result<uint64_t>::emplaceFailure(Failure::Unknown);
     auto &IGM = irgen->IGM;
 
-    SILType loweredTy = IGM.getSILTypes().getLoweredType(type);
+    SILType loweredTy = IGM.getLoweredType(type);
 
     // If the type has a statically fixed offset, return that.
     if (auto offset =

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -29,10 +29,10 @@ using namespace swift;
 using namespace swift::Lowering;
 
 
-SILType TypeConverter::getLoweredTypeOfGlobal(VarDecl *var) {
+CanType TypeConverter::getLoweredTypeOfGlobal(VarDecl *var) {
   AbstractionPattern origType = getAbstractionPattern(var);
   assert(!origType.isTypeParameter());
-  return getLoweredType(origType, origType.getType()).getObjectType();
+  return getLoweredRValueType(origType, origType.getType());
 }
 
 AnyFunctionType::Param

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -857,8 +857,8 @@ static void destructureYieldsForCoroutine(SILModule &M,
 
   // 'modify' yields an inout of the target type.
   if (accessor->getAccessorKind() == AccessorKind::Modify) {
-    auto loweredValueTy = M.Types.getLoweredType(origType, canValueType);
-    yields.push_back(SILYieldInfo(loweredValueTy.getASTType(),
+    auto loweredValueTy = M.Types.getLoweredRValueType(origType, canValueType);
+    yields.push_back(SILYieldInfo(loweredValueTy,
                                   ParameterConvention::Indirect_Inout));
     return;
   }
@@ -2411,8 +2411,7 @@ public:
     }
 
     AbstractionPattern abstraction(Sig, origType);
-    return TheSILModule.Types.getLoweredType(abstraction, substType)
-             .getASTType();
+    return TheSILModule.Types.getLoweredRValueType(abstraction, substType);
   }
 };
 

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -138,11 +138,12 @@ SILType SILType::getFieldType(VarDecl *field, SILModule &M) const {
       baseTy->getTypeOfMember(M.getSwiftModule(),
                               field, nullptr)->getCanonicalType();
   }
-  auto loweredTy = M.Types.getLoweredType(origFieldTy, substFieldTy);
+
+  auto loweredTy = M.Types.getLoweredRValueType(origFieldTy, substFieldTy);
   if (isAddress() || getClassOrBoundGenericClass() != nullptr) {
-    return loweredTy.getAddressType();
+    return SILType::getPrimitiveAddressType(loweredTy);
   } else {
-    return loweredTy.getObjectType();
+    return SILType::getPrimitiveObjectType(loweredTy);
   }
 }
 
@@ -166,9 +167,10 @@ SILType SILType::getEnumElementType(EnumElementDecl *elt, SILModule &M) const {
     getASTType()->getTypeOfMember(M.getSwiftModule(), elt,
                                           elt->getArgumentInterfaceType());
   auto loweredTy =
-    M.Types.getLoweredType(M.Types.getAbstractionPattern(elt), substEltTy);
+    M.Types.getLoweredRValueType(M.Types.getAbstractionPattern(elt),
+                                 substEltTy);
 
-  return SILType(loweredTy.getASTType(), getCategory());
+  return SILType(loweredTy, getCategory());
 }
 
 bool SILType::isLoadableOrOpaque(SILModule &M) const {

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -51,22 +51,20 @@ struct LValueTypeData {
   CanType SubstFormalType;
 
   /// The lowered type of value that should be stored in the l-value.
-  /// Always an object type.
   ///
   /// On physical path components, projection yields an address of
   /// this type.  On logical path components, materialize yields an
   /// address of this type, set expects a value of this type, and
-  /// get yields a value of this type.
-  SILType TypeOfRValue;
+  /// get yields an object of this type.
+  CanType TypeOfRValue;
 
   SGFAccessKind AccessKind;
 
   LValueTypeData() = default;
   LValueTypeData(SGFAccessKind accessKind, AbstractionPattern origFormalType,
-                 CanType substFormalType, SILType typeOfRValue)
+                 CanType substFormalType, CanType typeOfRValue)
     : OrigFormalType(origFormalType), SubstFormalType(substFormalType),
       TypeOfRValue(typeOfRValue), AccessKind(accessKind) {
-    assert(typeOfRValue.isObject());
     assert(substFormalType->isMaterializable());
   }
 
@@ -185,7 +183,9 @@ public:
 
   /// Returns the logical type-as-rvalue of the value addressed by the
   /// component.  This is always an object type, never an address.
-  SILType getTypeOfRValue() const { return TypeData.TypeOfRValue; }
+  SILType getTypeOfRValue() const {
+    return SILType::getPrimitiveObjectType(TypeData.TypeOfRValue);
+  }
   AbstractionPattern getOrigFormalType() const {
     return TypeData.OrigFormalType;
   }
@@ -485,7 +485,9 @@ public:
   /// Returns the type-of-rvalue of the logical object referenced by
   /// this l-value.  Note that this may differ significantly from the
   /// type of l-value.
-  SILType getTypeOfRValue() const { return getTypeData().TypeOfRValue; }
+  SILType getTypeOfRValue() const {
+    return SILType::getPrimitiveObjectType(getTypeData().TypeOfRValue);
+  }
   CanType getSubstFormalType() const { return getTypeData().SubstFormalType; }
   AbstractionPattern getOrigFormalType() const {
     return getTypeData().OrigFormalType;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1123,7 +1123,8 @@ SILFunction *SILGenModule::emitLazyGlobalInitializer(StringRef funcName,
   auto *type = blockParam->getType()->castTo<FunctionType>();
   Type initType = FunctionType::get({}, TupleType::getEmpty(C),
                                     type->getExtInfo());
-  auto initSILType = getLoweredType(initType).castTo<SILFunctionType>();
+  auto initSILType = cast<SILFunctionType>(
+      Types.getLoweredRValueType(initType));
 
   SILGenFunctionBuilder builder(*this);
   auto *f = builder.createFunction(
@@ -1337,9 +1338,10 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
       componentObjTy = genericEnv->mapTypeIntoContext(componentObjTy);
     auto storageTy = M.Types.getSubstitutedStorageType(decl, componentObjTy);
     auto opaqueTy =
-      M.Types.getLoweredType(AbstractionPattern::getOpaque(), componentObjTy);
+      M.Types.getLoweredRValueType(AbstractionPattern::getOpaque(),
+                                   componentObjTy);
     
-    return storageTy.getAddressType() == opaqueTy.getAddressType();
+    return storageTy.getASTType() == opaqueTy;
   }
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5159,8 +5159,7 @@ ManagedValue SILGenFunction::emitLValueToPointer(SILLocation loc, LValue &&lv,
   case PTK_AutoreleasingUnsafeMutablePointer: {
     // Set up a writeback through a +0 buffer.
     LValueTypeData typeData = lv.getTypeData();
-    SILType rvalueType = SILType::getPrimitiveObjectType(
-      CanUnmanagedStorageType::get(typeData.TypeOfRValue.getASTType()));
+    auto rvalueType = CanUnmanagedStorageType::get(typeData.TypeOfRValue);
 
     LValueTypeData unownedTypeData(
       lv.getAccessKind(),

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -54,7 +54,8 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
     return gv;
   }
 
-  SILType silTy = M.Types.getLoweredTypeOfGlobal(gDecl);
+  SILType silTy = SILType::getPrimitiveObjectType(
+    M.Types.getLoweredTypeOfGlobal(gDecl));
 
   auto *silGlobal = SILGlobalVariable::create(M, silLinkage, IsNotSerialized,
                                               mangledName, silTy,

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -262,10 +262,10 @@ static SILFunction *getGlobalGetterFunction(SILOptFunctionBuilder &FunctionBuild
     Serialized = IsSerialized;
   }
 
-  auto refType = M.Types.getLoweredType(varDecl->getInterfaceType());
+  auto refType = M.Types.getLoweredRValueType(varDecl->getInterfaceType());
 
   // Function takes no arguments and returns refType
-  SILResultInfo Results[] = { SILResultInfo(refType.getASTType(),
+  SILResultInfo Results[] = { SILResultInfo(refType,
                                             ResultConvention::Owned) };
   SILFunctionType::ExtInfo EInfo;
   EInfo = EInfo.withRepresentation(SILFunctionType::Representation::Thin);


### PR DESCRIPTION
This is for when you don't care about the category (object vs address), which will soon require a ResilienceExpansion to compute.

https://bugs.swift.org/browse/SR-261, rdar://24057844