### PR TITLE
[Basic] Add FileManager and start caching `stat` calls

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -60,6 +60,7 @@ namespace swift {
   class DeclContext;
   class DefaultArgumentInitializer;
   class ExtensionDecl;
+  class FileManager;
   class ForeignRepresentationInfo;
   class FuncDecl;
   class GenericContext;
@@ -197,7 +198,8 @@ class ASTContext final {
   void operator=(const ASTContext&) = delete;
 
   ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
-             SourceManager &SourceMgr, DiagnosticEngine &Diags);
+             SourceManager &SourceMgr, FileManager &FileMgr,
+             DiagnosticEngine &Diags);
 
 public:
   // Members that should only be used by ASTContext.cpp.
@@ -211,6 +213,7 @@ public:
   static ASTContext *get(LangOptions &langOpts,
                          SearchPathOptions &SearchPathOpts,
                          SourceManager &SourceMgr,
+                         FileManager &FileMgr,
                          DiagnosticEngine &Diags);
   ~ASTContext();
 
@@ -228,6 +231,9 @@ public:
 
   /// The source manager object.
   SourceManager &SourceMgr;
+
+  /// The file manager object.
+  FileManager &FileMgr;
 
   /// Diags - The diagnostics engine.
   DiagnosticEngine &Diags;

--- a/include/swift/Basic/FileManager.h
+++ b/include/swift/Basic/FileManager.h
@@ -24,10 +24,6 @@ class FileSystem;
 }
 }
 
-namespace clang {
-class FileManager;
-}
-
 namespace swift {
 
 /// A file manager that caches file stats, both to avoid re-statting files, but
@@ -42,7 +38,9 @@ private:
   StringRef getCachedFilename(StringRef path);
 public:
   FileManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs =
-              llvm::vfs::getRealFileSystem()) {}
+              llvm::vfs::getRealFileSystem()) {
+    clangManager = new clang::FileManager(FileSystemOpts, fs);
+  }
 
   llvm::vfs::FileSystem &getFileSystem() {
     return *clangManager->getVirtualFileSystem();

--- a/include/swift/Basic/FileManager.h
+++ b/include/swift/Basic/FileManager.h
@@ -1,0 +1,81 @@
+//===----------- FileManager.h - Status-caching file manager ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_FILEMANAGER_H
+#define SWIFT_BASIC_FILEMANAGER_H
+
+#include "swift/Basic/LLVM.h"
+#include "clang/Basic/FileSystemStatCache.h"
+#include "llvm/Support/Errc.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+namespace llvm {
+namespace vfs {
+class FileSystem;
+}
+}
+
+namespace swift {
+
+/// A file manager that caches file stats, both to avoid re-statting files, but
+/// also to ensure we don't accidentally record newer stats than when we first
+/// read the file.
+class FileManager: public llvm::RefCountedBase<FileManager> {
+private:
+  friend class SourceManager;
+  clang::MemorizeStatCalls cachedStats;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fileSystem;
+  StringRef getCachedFilename(StringRef path);
+public:
+  FileManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs =
+              llvm::vfs::getRealFileSystem())
+    : fileSystem(fs) {}
+
+  llvm::vfs::FileSystem &getFileSystem() {
+    return *fileSystem;
+  }
+
+  /// Sets the file system which will be used for file operations.
+  /// Setting this will clear the stat cache.
+  void setFileSystem(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs) {
+    fileSystem = fs;
+    cachedStats = {};
+  }
+
+  /// Gets and caches the filesystem status for the provided path.
+  llvm::ErrorOr<llvm::vfs::Status> status(StringRef path);
+
+  /// Opens the file at the provided path and returns a buffer of that file's
+  /// contents. The file's status will be cached just before reading the file.
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  getBufferForFile(StringRef path, int64_t fileSize = -1,
+                   bool requiresNullTerminator = true,
+                   bool isVolatile = false);
+
+  /// Opens the file at the provided path (or reads from stdin, if the provided
+  /// path is '-') and returns a buffer of that file's contents. The file's
+  /// status will be cached just before reading the file.
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  getBufferForFileOrSTDIN(StringRef path, int64_t fileSize = -1,
+                          bool requiresNullTerminator = true,
+                          bool isVolatile = false);
+
+  /// Removes the file at the provided path and removes the cached status value.
+  std::error_code remove(StringRef path);
+
+  /// Determines if a file exists on disk at the provided path.
+  bool exists(StringRef path);
+};
+
+} // end namespace swift
+
+#endif // !defined(SWIFT_BASIC_FILEMANAGER_H)

--- a/include/swift/Basic/FileSystem.h
+++ b/include/swift/Basic/FileSystem.h
@@ -23,12 +23,6 @@ namespace llvm {
   class Twine;
 }
 
-namespace llvm {
-  namespace vfs {
-    class FileSystem;
-  }
-}
-
 namespace swift {
   /// Invokes \p action with a raw_ostream that refers to a temporary file,
   /// which is then renamed into place as \p outputPath when the action
@@ -55,13 +49,6 @@ namespace swift {
   /// the file at \p source will still be present at \p source.
   std::error_code moveFileIfDifferent(const llvm::Twine &source,
                                       const llvm::Twine &destination);
-
-  namespace vfs {
-    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
-    getFileOrSTDIN(llvm::vfs::FileSystem &FS,
-                   const llvm::Twine &Name, int64_t FileSize = -1,
-                   bool RequiresNullTerminator = true, bool IsVolatile = false);
-  } // end namespace vfs
 
 } // end namespace swift
 

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -40,6 +40,7 @@ namespace opt {
 
 namespace swift {
   class DiagnosticEngine;
+  class FileManager;
   namespace sys {
     class TaskQueue;
   }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -431,6 +431,9 @@ public:
   SourceManager &getSourceMgr() { return SourceMgr; }
 
   FileManager &getFileMgr() { return *FileMgr; }
+  void setFileMgr(llvm::IntrusiveRefCntPtr<FileManager> fm) {
+    FileMgr = fm;
+  }
 
   DiagnosticEngine &getDiags() { return Diagnostics; }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -26,6 +26,7 @@
 #include "swift/AST/SILOptions.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/DiagnosticOptions.h"
+#include "swift/Basic/FileManager.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -364,6 +365,7 @@ public:
 class CompilerInstance {
   CompilerInvocation Invocation;
   SourceManager SourceMgr;
+  llvm::IntrusiveRefCntPtr<FileManager> FileMgr;
   DiagnosticEngine Diagnostics{SourceMgr};
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<SILModule> TheSILModule;
@@ -428,9 +430,11 @@ public:
 
   SourceManager &getSourceMgr() { return SourceMgr; }
 
+  FileManager &getFileMgr() { return *FileMgr; }
+
   DiagnosticEngine &getDiags() { return Diagnostics; }
 
-  llvm::vfs::FileSystem &getFileSystem() { return *SourceMgr.getFileSystem(); }
+  llvm::vfs::FileSystem &getFileSystem() { return FileMgr->getFileSystem(); }
 
   ASTContext &getASTContext() {
     return *Context;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -365,7 +365,7 @@ public:
 class CompilerInstance {
   CompilerInvocation Invocation;
   SourceManager SourceMgr;
-  llvm::IntrusiveRefCntPtr<FileManager> FileMgr;
+  llvm::IntrusiveRefCntPtr<FileManager> FileMgr = new FileManager();
   DiagnosticEngine Diagnostics{SourceMgr};
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<SILModule> TheSILModule;

--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -167,10 +167,10 @@ public:
   ///
   /// A simplified version of the core logic in #openModuleFiles.
   static bool buildSwiftModuleFromSwiftInterface(
-    SourceManager &SourceMgr, DiagnosticEngine &Diags,
+    FileManager &FileMgr, DiagnosticEngine &Diags,
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
-    StringRef CacheDir, StringRef PrebuiltCacheDir,
-    StringRef ModuleName, StringRef InPath, StringRef OutPath,
+    StringRef CacheDir, StringRef PrebuiltCacheDir, StringRef ModuleName,
+    StringRef InPath, StringRef OutPath,
     bool SerializeDependencyHashes, bool TrackSystemDependencies,
     bool RemarkOnRebuildFromInterface);
 };

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -47,6 +47,7 @@ namespace swift {
   class DiagnosticConsumer;
   class DiagnosticEngine;
   class Evaluator;
+  class FileManager;
   class FileUnit;
   class GenericEnvironment;
   class GenericParamList;
@@ -357,12 +358,15 @@ namespace swift {
   /// A convenience wrapper for Parser functionality.
   class ParserUnit {
   public:
-    ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
+    ParserUnit(SourceManager &SM, FileManager &FM,
+               SourceFileKind SFKind, unsigned BufferID,
                const LangOptions &LangOpts, StringRef ModuleName,
                std::shared_ptr<SyntaxParseActions> spActions = nullptr,
                SyntaxParsingCache *SyntaxCache = nullptr);
-    ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID);
-    ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
+    ParserUnit(SourceManager &SM, FileManager &FM,
+               SourceFileKind SFKind, unsigned BufferID);
+    ParserUnit(SourceManager &SM, FileManager &FM,
+               SourceFileKind SFKind, unsigned BufferID,
                unsigned Offset, unsigned EndOffset);
 
     ~ParserUnit();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -515,6 +515,7 @@ void ASTContext::operator delete(void *Data) throw() {
 ASTContext *ASTContext::get(LangOptions &langOpts,
                             SearchPathOptions &SearchPathOpts,
                             SourceManager &SourceMgr,
+                            FileManager &FileMgr,
                             DiagnosticEngine &Diags) {
   // If more than two data structures are concatentated, then the aggregate
   // size math needs to become more complicated due to per-struct alignment
@@ -525,14 +526,17 @@ ASTContext *ASTContext::get(LangOptions &langOpts,
   auto impl = reinterpret_cast<void*>((char*)mem + sizeof(ASTContext));
   impl = reinterpret_cast<void*>(llvm::alignAddr(impl,alignof(Implementation)));
   new (impl) Implementation();
-  return new (mem) ASTContext(langOpts, SearchPathOpts, SourceMgr, Diags);
+  return new (mem) ASTContext(langOpts, SearchPathOpts, SourceMgr,
+                              FileMgr, Diags);
 }
 
 ASTContext::ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
-                       SourceManager &SourceMgr, DiagnosticEngine &Diags)
+                       SourceManager &SourceMgr, FileManager &FileMgr,
+                       DiagnosticEngine &Diags)
   : LangOpts(langOpts),
     SearchPathOpts(SearchPathOpts),
     SourceMgr(SourceMgr),
+    FileMgr(FileMgr),
     Diags(Diags),
     evaluator(Diags, langOpts.DebugDumpCycles),
     TheBuiltinModule(createBuiltinModule(*this)),

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -72,6 +72,7 @@ add_swift_host_library(swiftBasic STATIC
   Edit.cpp
   EditorPlaceholder.cpp
   ExponentialGrowthAppendingBinaryByteStream.cpp
+  FileManager.cpp
   FileSystem.cpp
   FileTypes.cpp
   JSONSerialization.cpp

--- a/lib/Basic/FileManager.cpp
+++ b/lib/Basic/FileManager.cpp
@@ -24,7 +24,7 @@ FileManager::status(StringRef path, bool isDirectory) {
 StringRef FileManager::getCachedFilename(StringRef path) {
   auto file = clangManager->getFile(path);
   if (!file) return path;
-  return file->getName();
+  return (*file)->getName();
 }
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
@@ -40,7 +40,7 @@ FileManager::getBufferForFileOrSTDIN(StringRef path, bool isVolatile) {
 }
 
 std::error_code FileManager::remove(StringRef path) {
-  auto file = clangManager->getFileOrError(path);
+  auto file = clangManager->getFile(path);
   if (!file) return file.getError();
   clangManager->invalidateCache(*file);
   return llvm::sys::fs::remove(path);

--- a/lib/Basic/FileManager.cpp
+++ b/lib/Basic/FileManager.cpp
@@ -1,0 +1,78 @@
+//===---------- FileManager.cpp - Status-caching file manager ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+#include "swift/Basic/FileManager.h"
+#include "llvm/Support/xxhash.h"
+
+using namespace swift;
+
+llvm::ErrorOr<llvm::vfs::Status>
+FileManager::status(StringRef path) {
+  llvm::vfs::Status status;
+  bool result = clang::FileSystemStatCache::get(path, status, /*isFile*/true,
+                                                /*File*/nullptr, &cachedStats,
+                                                *fileSystem);
+  if (result)
+    return std::make_error_code(std::errc::no_such_file_or_directory);
+  return status;
+}
+
+StringRef FileManager::getCachedFilename(StringRef path) {
+  llvm::vfs::Status stats;
+  auto stat = status(path);
+  if (!stat)
+    return path;
+  return cachedStats.StatCalls[path].getName();
+}
+
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+FileManager::getBufferForFile(StringRef path, int64_t fileSize,
+                              bool requiresNullTerminator,
+                              bool isVolatile) {
+
+  llvm::vfs::Status status;
+  std::unique_ptr<llvm::vfs::File> file;
+  bool pathDoesNotExist =
+    clang::FileSystemStatCache::get(path, status, /*isFile*/true,
+                                    &file, &cachedStats,
+                                    *fileSystem);
+  if (pathDoesNotExist)
+    return std::make_error_code(std::errc::no_such_file_or_directory);
+  auto buf = file->getBuffer(path, fileSize, requiresNullTerminator,
+                             isVolatile);
+  if (!buf) return buf.getError();
+  return buf;
+}
+
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+FileManager::getBufferForFileOrSTDIN(StringRef path, int64_t fileSize,
+                              bool requiresNullTerminator,
+                              bool isVolatile) {
+  if (path == "-")
+    return llvm::MemoryBuffer::getSTDIN();
+  return getBufferForFile(path, fileSize, requiresNullTerminator,
+                          isVolatile);
+}
+
+std::error_code FileManager::remove(StringRef path) {
+  auto err = llvm::sys::fs::remove(path);
+  if (err) return err;
+  cachedStats.StatCalls.erase(path);
+  return {};
+}
+
+bool FileManager::exists(StringRef path) {
+  // Don't just call into FileSystem::exists, because that'll waste a stat.
+  auto stat = status(path);
+  return stat && stat->exists();
+}

--- a/lib/Basic/FileManager.cpp
+++ b/lib/Basic/FileManager.cpp
@@ -42,7 +42,8 @@ FileManager::getBufferForFileOrSTDIN(StringRef path, bool isVolatile) {
 std::error_code FileManager::remove(StringRef path) {
   auto file = clangManager->getFileOrError(path);
   if (!file) return file.getError();
-  (*file
+  clangManager->invalidateCache(*file);
+  return llvm::sys::fs::remove(path);
 }
 
 bool FileManager::exists(StringRef path) {

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -222,18 +222,3 @@ std::error_code swift::moveFileIfDifferent(const llvm::Twine &source,
   // If we get here, we weren't able to prove that the files are the same.
   return fs::rename(source, destination);
 }
-
-llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
-swift::vfs::getFileOrSTDIN(llvm::vfs::FileSystem &FS,
-                           const llvm::Twine &Filename,
-                           int64_t FileSize,
-                           bool RequiresNullTerminator,
-                           bool IsVolatile) {
-  llvm::SmallString<256> NameBuf;
-  llvm::StringRef NameRef = Filename.toStringRef(NameBuf);
-
-  if (NameRef == "-")
-    return llvm::MemoryBuffer::getSTDIN();
-  return FS.getBufferForFile(Filename, FileSize,
-                             RequiresNullTerminator, IsVolatile);
-}

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -44,20 +44,9 @@ StringRef SourceManager::getDisplayNameForLoc(SourceLoc Loc) const {
   if (auto VFile = getVirtualFile(Loc))
     return VFile->Name;
 
-  // Next, try the stat cache
+  // Otherwise, ask the file manager and cache the result
   auto Ident = getIdentifierForBuffer(findBufferContainingLoc(Loc));
-  auto found = StatusCache.find(Ident);
-  if (found != StatusCache.end()) {
-    return found->second.getName();
-  }
-
-  // Populate the cache with a (virtual) stat.
-  if (auto Status = FileSystem->status(Ident)) {
-    return (StatusCache[Ident] = Status.get()).getName();
-  }
-
-  // Finally, fall back to the buffer identifier.
-  return Ident;
+  return FileMgr->getCachedFilename(Ident);
 }
 
 unsigned

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -44,7 +44,7 @@ StringRef SourceManager::getDisplayNameForLoc(SourceLoc Loc) const {
   if (auto VFile = getVirtualFile(Loc))
     return VFile->Name;
 
-  // Otherwise, ask the file manager and cache the result
+  // Otherwise, ask the file manager which will cache the result
   auto Ident = getIdentifierForBuffer(findBufferContainingLoc(Loc));
   return FileMgr->getCachedFilename(Ident);
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1026,7 +1026,7 @@ ClangImporter::create(ASTContext &ctx,
       if (!instance.getHeaderSearchOpts().VFSOverlayFiles.empty()) {
         ctx.Diags.diagnose(SourceLoc(), diag::clang_vfs_overlay_is_ignored);
       }
-      instance.setVirtualFileSystem(ctx.SourceMgr.getFileSystem());
+      instance.setVirtualFileSystem(&ctx.FileMgr.getFileSystem());
     }
     instance.createFileManager();
   }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -513,11 +513,8 @@ CompilerInstance::getInputBufferAndModuleDocBufferIfPresent(
                               b->getBuffer(), b->getBufferIdentifier()),
                           nullptr);
   }
-  // FIXME: Working with filenames is fragile, maybe use the real path
-  // or have some kind of FileManager.
-  using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
-  FileOrError inputFileOrErr = swift::vfs::getFileOrSTDIN(getFileSystem(),
-                                                          input.file());
+
+  auto inputFileOrErr = FileMgr->getBufferForFileOrSTDIN(input.file());
   if (!inputFileOrErr) {
     Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file, input.file(),
                          inputFileOrErr.getError().message());
@@ -540,9 +537,8 @@ CompilerInstance::openModuleDoc(const InputFile &input) {
   llvm::sys::path::replace_extension(
       moduleDocFilePath,
       file_types::getExtension(file_types::TY_SwiftModuleDocFile));
-  using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
-  FileOrError moduleDocFileOrErr =
-      swift::vfs::getFileOrSTDIN(getFileSystem(), moduleDocFilePath);
+
+  auto moduleDocFileOrErr = FileMgr->getBufferForFileOrSTDIN(moduleDocFilePath);
   if (moduleDocFileOrErr)
     return std::move(*moduleDocFileOrErr);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -275,8 +275,14 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
 
   // If we successfully loaded all the overlays, let the source manager and
   // diagnostic engine take advantage of the overlay file system.
+<<<<<<< HEAD
   if (!hadAnyFailure && hasOverlays) {
     SourceMgr.setFileSystem(OverlayFS);
+=======
+  if (!hadAnyFailure &&
+      (OverlayFS->overlays_begin() != OverlayFS->overlays_end())) {
+    FileMgr->setFileSystem(OverlayFS);
+>>>>>>> [Frontend] Add FileManager to CompilerInstance
   }
 
   return hadAnyFailure;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -204,6 +204,9 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   Invocation = Invok;
 
+  FileMgr = new FileManager();
+  SourceMgr.setFileManager(FileMgr);
+
   // If initializing the overlay file system fails there's no sense in
   // continuing because the compiler will read the wrong files.
   if (setUpVirtualFileSystemOverlays())

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -224,8 +224,7 @@ static bool serializedASTLooksValid(const llvm::MemoryBuffer &buf) {
 
 static std::unique_ptr<llvm::MemoryBuffer> getBufferOfDependency(
   llvm::vfs::FileSystem &fs, StringRef depPath) {
-  auto depBuf = fs.getBufferForFile(depPath, /*FileSize=*/-1,
-                                    /*RequiresNullTerminator=*/false);
+  auto depBuf = fs.getBufferForFile(depPath);
   if (!depBuf) {
     return nullptr;
   }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -677,7 +677,7 @@ static bool buildModuleFromParseableInterface(CompilerInvocation &Invocation,
   StringRef InputPath = FEOpts.InputsAndOutputs.getFilenameOfFirstInput();
   StringRef PrebuiltCachePath = FEOpts.PrebuiltModuleCachePath;
   return ParseableInterfaceModuleLoader::buildSwiftModuleFromSwiftInterface(
-      Instance.getSourceMgr(), Instance.getDiags(),
+      Instance.getFileMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
       Invocation.getClangModuleCachePath(),
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -694,10 +694,10 @@ static bool compileLLVMIR(CompilerInvocation &Invocation,
   // Load in bitcode file.
   assert(Invocation.getFrontendOptions().InputsAndOutputs.hasSingleInput() &&
          "We expect a single input for bitcode input!");
+  auto &FEOpts = Invocation.getFrontendOptions();
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      swift::vfs::getFileOrSTDIN(Instance.getFileSystem(),
-                                 Invocation.getFrontendOptions()
-                                   .InputsAndOutputs.getFilenameOfFirstInput());
+      Instance.getFileMgr().getBufferForFileOrSTDIN(
+        FEOpts.InputsAndOutputs.getFilenameOfFirstInput());
 
   if (!FileBufOrErr) {
     Instance.getASTContext().Diags.diagnose(
@@ -728,8 +728,7 @@ static bool compileLLVMIR(CompilerInvocation &Invocation,
       getOutputKind(Invocation.getFrontendOptions().RequestedAction);
 
   return performLLVM(IRGenOpts, Instance.getASTContext(), Module.get(),
-                     Invocation.getFrontendOptions()
-                         .InputsAndOutputs.getSingleOutputFilename(),
+                     FEOpts.InputsAndOutputs.getSingleOutputFilename(),
                      Stats);
 }
 

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -102,8 +102,9 @@ SourceCompleteResult
 ide::isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
                            SourceFileKind SFKind) {
   SourceManager SM;
+  FileManager FM;
   auto BufferID = SM.addNewSourceBuffer(std::move(MemBuf));
-  ParserUnit Parse(SM, SFKind, BufferID);
+  ParserUnit Parse(SM, FM, SFKind, BufferID);
   Parse.parse();
   SourceCompleteResult SCR;
   SCR.IsComplete = !Parse.getParser().isInputIncomplete();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/USRGeneration.h"
+#include "swift/Basic/FileManager.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/IDE/SourceEntityWalker.h"
@@ -140,6 +141,7 @@ struct IndexedWitness {
 class IndexSwiftASTWalker : public SourceEntityWalker {
   IndexDataConsumer &IdxConsumer;
   SourceManager &SrcMgr;
+  FileManager &FileMgr;
   unsigned BufferID;
   bool enableWarnings;
 
@@ -276,8 +278,8 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
 public:
   IndexSwiftASTWalker(IndexDataConsumer &IdxConsumer, ASTContext &Ctx,
                       unsigned BufferID = -1)
-      : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), BufferID(BufferID),
-        enableWarnings(IdxConsumer.enableWarnings()) {}
+      : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), FileMgr(Ctx.FileMgr),
+        BufferID(BufferID), enableWarnings(IdxConsumer.enableWarnings()) {}
 
   ~IndexSwiftASTWalker() override {
     assert(Cancelled || EntitiesStack.empty());

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -21,7 +21,6 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/USRGeneration.h"
-#include "swift/Basic/FileManager.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/IDE/SourceEntityWalker.h"
@@ -30,7 +29,6 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/FileSystem.h"
 
 using namespace swift;
 using namespace swift::index;
@@ -141,7 +139,6 @@ struct IndexedWitness {
 class IndexSwiftASTWalker : public SourceEntityWalker {
   IndexDataConsumer &IdxConsumer;
   SourceManager &SrcMgr;
-  FileManager &FileMgr;
   unsigned BufferID;
   bool enableWarnings;
 
@@ -278,7 +275,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
 public:
   IndexSwiftASTWalker(IndexDataConsumer &IdxConsumer, ASTContext &Ctx,
                       unsigned BufferID = -1)
-      : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), FileMgr(Ctx.FileMgr),
+      : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr),
         BufferID(BufferID), enableWarnings(IdxConsumer.enableWarnings()) {}
 
   ~IndexSwiftASTWalker() override {

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -405,7 +405,7 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
       case FileUnitKind::DWARFModule:
       case FileUnitKind::ClangModule: {
         auto *LFU = cast<LoadedFile>(FU);
-        if (auto *F = fileMgr.getFile(LFU->getFilename())) {
+        if (auto F = fileMgr.getFile(LFU->getFilename())) {
           std::string moduleName = mod->getNameStr();
           bool withoutUnitName = true;
           if (FU->getKind() == FileUnitKind::ClangModule) {
@@ -434,7 +434,7 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
           }
           clang::index::writer::OpaqueModule opaqMod =
               moduleNameScratch.createString(moduleName);
-          unitWriter.addASTFileDependency(F, mod->isSystemModule(), opaqMod,
+          unitWriter.addASTFileDependency(*F, mod->isSystemModule(), opaqMod,
                                           withoutUnitName);
         }
         break;
@@ -547,7 +547,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
     /*MainFile=*/nullptr, isSystem, /*IsModuleUnit=*/true,
     isDebugCompilation, targetTriple, sysrootPath, getModuleInfoFromOpaqueModule);
 
-  const clang::FileEntry *FE = fileMgr.getFile(filename);
+  auto FE = fileMgr.getFile(filename);
   bool isSystemModule = module->isSystemModule();
   for (auto &pair : records) {
     std::string &recordFile = pair.first;
@@ -555,7 +555,8 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
     if (recordFile.empty())
       continue;
     clang::index::writer::OpaqueModule mod = &groupName;
-    unitWriter.addRecordFile(recordFile, FE, isSystemModule, mod);
+    unitWriter.addRecordFile(recordFile, FE ? *FE : nullptr, isSystemModule,
+                             mod);
   }
 
   ModuleDecl::ImportFilter importFilter;
@@ -585,15 +586,16 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
   auto &fileMgr = clangCI.getFileManager();
   auto *module = primarySourceFile->getParentModule();
   bool isSystem = module->isSystemModule();
-  auto *mainFile = fileMgr.getFile(primarySourceFile->getFilename());
+  auto mainFile = fileMgr.getFile(primarySourceFile->getFilename());
   // FIXME: Get real values for the following.
   StringRef swiftVersion;
   StringRef sysrootPath = clangCI.getHeaderSearchOpts().Sysroot;
 
   IndexUnitWriter unitWriter(fileMgr, indexStorePath,
     "swift", swiftVersion, indexUnitToken, module->getNameStr(),
-    mainFile, isSystem, /*isModuleUnit=*/false, isDebugCompilation,
-    targetTriple, sysrootPath, getModuleInfoFromOpaqueModule);
+    mainFile ? *mainFile : nullptr, isSystem, /*isModuleUnit=*/false,
+    isDebugCompilation, targetTriple, sysrootPath,
+    getModuleInfoFromOpaqueModule);
 
   // Module dependencies.
   ModuleDecl::ImportFilter importFilter;
@@ -612,7 +614,8 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
 
   recordSourceFile(primarySourceFile, indexStorePath, diags,
                    [&](StringRef recordFile, StringRef filename) {
-    unitWriter.addRecordFile(recordFile, fileMgr.getFile(filename),
+    auto file = fileMgr.getFile(filename);
+    unitWriter.addRecordFile(recordFile, file ? *file : nullptr,
                              module->isSystemModule(), /*Module=*/nullptr);
   });
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Module.h"
 #include "swift/Parse/DelayedParsingCallbacks.h"
 #include "swift/Parse/PersistentParserState.h"
+#include "swift/Basic/FileManager.h"
 #include "swift/Basic/SourceManager.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -42,7 +43,7 @@ static FileOrError findModule(ASTContext &ctx, StringRef moduleID,
     llvm::sys::path::append(inputFilename, moduleID);
     inputFilename.append(".swift");
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      ctx.SourceMgr.getFileSystem()->getBufferForFile(inputFilename.str());
+      ctx.FileMgr.getBufferForFile(inputFilename.str());
 
     // Return if we loaded a file
     if (FileBufOrErr)

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -129,7 +129,7 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
     targetFiles.back() += suffix;
   });
 
-  auto &fs = *Ctx.SourceMgr.getFileSystem();
+  auto &fs = Ctx.FileMgr.getFileSystem();
 
   // Apply \p body for each directory entry in \p dirPath.
   auto forEachDirectoryEntryPath =

--- a/test/ParseableInterface/can-import.swift
+++ b/test/ParseableInterface/can-import.swift
@@ -1,4 +1,3 @@
-// RUN: %empty-directory(%t)
 // RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/Library.swiftinterface -
 // RUN: %target-swift-frontend -typecheck %s -I %t
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -950,7 +950,7 @@ ASTUnitRef ASTProducer::createASTUnit(
   Invocation.getLangOptions().CollectParsedToken = true;
 
   if (fileSystem != llvm::vfs::getRealFileSystem()) {
-    CompIns.getSourceMgr().setFileSystem(fileSystem);
+    CompIns.getFileMgr().setFileSystem(fileSystem);
     Invocation.getClangImporterOptions().ForceUseSwiftVirtualFileSystem = true;
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -374,6 +374,7 @@ struct SwiftASTManager::Implementation {
   std::shared_ptr<SwiftStatistics> Stats;
   std::string RuntimeResourcePath;
   SourceManager SourceMgr;
+  FileManager FileMgr;
   Cache<ASTKey, ASTProducerRef> ASTCache{ "sourcekit.swift.ASTCache" };
   llvm::sys::Mutex CacheMtx;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -199,7 +199,7 @@ static bool swiftCodeCompleteImpl(
   // It is not a huge problem in practice because Xcode auto-saves constantly.
 
   if (FileSystem != llvm::vfs::getRealFileSystem()) {
-    CI.getSourceMgr().setFileSystem(FileSystem);
+    CI.getFileMgr().setFileSystem(FileSystem);
     Invocation.getClangImporterOptions().ForceUseSwiftVirtualFileSystem = true;
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -668,6 +668,7 @@ private:
 
 class SwiftDocumentSyntaxInfo {
   SourceManager SM;
+  FileManager FM;
   EditorDiagConsumer DiagConsumer;
   std::shared_ptr<SyntaxTreeCreator> SynTreeCreator;
   std::unique_ptr<ParserUnit> Parser;
@@ -699,7 +700,7 @@ public:
     }
 
     Parser.reset(
-                 new ParserUnit(SM, SourceFileKind::Main, BufferID,
+                 new ParserUnit(SM, FM, SourceFileKind::Main, BufferID,
                      CompInv.getLangOptions(),
                      CompInv.getModuleName(),
                      SynTreeCreator,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1261,6 +1261,7 @@ static void resolveCursor(
       auto &CompIns = AstUnit->getCompilerInstance();
       ModuleDecl *MainModule = CompIns.getMainModule();
       SourceManager &SM = CompIns.getSourceMgr();
+      FileManager &FM = CompIns.getFileMgr();
       unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID().getValue();
       SourceLoc Loc =
         Lexer::getLocForStartOfToken(SM, BufferID, Offset);
@@ -1364,7 +1365,7 @@ static void resolveCursor(
             resolveCursor(Lang, InputFile, Offset, Length, Actionables,
                           ASTInvok,
                           /*TryExistingAST=*/false, CancelOnSubsequentRequest,
-                          SM.getFileSystem(), Receiver);
+                          &FM.getFileSystem(), Receiver);
           } else {
             CursorInfoData Info;
             Info.InternalDiagnostic = Diagnostic;
@@ -1838,7 +1839,7 @@ static void resolveCursorFromUSR(
             resolveCursorFromUSR(
                 Lang, InputFile, USR, ASTInvok,
                 /*TryExistingAST=*/false, CancelOnSubsequentRequest,
-                CompIns.getSourceMgr().getFileSystem(), Receiver);
+                &CompIns.getFileMgr().getFileSystem(), Receiver);
           } else {
             CursorInfoData Info;
             Info.InternalDiagnostic = Diagnostic;

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -167,10 +167,11 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   SearchPathOpts.RuntimeResourcePath = RuntimeResourcePath.str();
 
   SourceManager SrcMgr;
+  FileManager FileMgr;
   LangOptions LangOpts;
   LangOpts.Target = Invocation.getTargetTriple();
   ASTContext &ASTCtx = *ASTContext::get(LangOpts, SearchPathOpts, SrcMgr,
-                                        Instance.getDiags());
+                                        FileMgr, Instance.getDiags());
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
   
   ClangImporterOptions ClangImporterOpts;

--- a/tools/driver/swift_format_main.cpp
+++ b/tools/driver/swift_format_main.cpp
@@ -37,6 +37,7 @@ using namespace llvm::opt;
 class FormatterDocument {
 private:
   SourceManager SM;
+  FileManager FM;
   unsigned BufferID;
   CompilerInvocation CompInv;
   std::unique_ptr<ParserUnit> Parser;
@@ -62,7 +63,7 @@ public:
 
   void updateCode(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
     BufferID = SM.addNewSourceBuffer(std::move(Buffer));
-    Parser.reset(new ParserUnit(SM, SourceFileKind::Main,
+    Parser.reset(new ParserUnit(SM, FM, SourceFileKind::Main,
                                 BufferID, CompInv.getLangOptions(),
                                 CompInv.getModuleName()));
     Parser->getDiagnosticEngine().addConsumer(DiagConsumer);

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -17,6 +17,7 @@
 
 #include "swift-c/SyntaxParser/SwiftSyntaxParser.h"
 #include "swift/AST/Module.h"
+#include "swift/Basic/FileManager.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Parser.h"
@@ -270,6 +271,7 @@ struct SynParserDiagConsumer: public DiagnosticConsumer {
 
 swiftparse_client_node_t SynParser::parse(const char *source) {
   SourceManager SM;
+  FileManager FM;
   unsigned bufID = SM.addNewSourceBuffer(
     llvm::MemoryBuffer::getMemBuffer(source, "syntax_parse_source"));
   LangOptions langOpts;
@@ -283,7 +285,7 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
     std::make_shared<CLibParseActions>(*this, SM, bufID);
   // We have to use SourceFileKind::Main to avoid diagnostics like
   // illegal_top_level_expr
-  ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts,
+  ParserUnit PU(SM, FM, SourceFileKind::Main, bufID, langOpts,
                 "syntax_parse_module", std::move(parseActions),
                 /*SyntaxCache=*/nullptr);
   // Evaluating pound conditions may lead to unknown syntax.

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -2009,7 +2009,7 @@ static parseJsonEmit(SDKContext &Ctx, StringRef FileName) {
 
   // Load the input file.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-    vfs::getFileOrSTDIN(*Ctx.getSourceMgr().getFileSystem(), FileName);
+    Ctx.getFileMgr().getBufferForFileOrSTDIN(FileName);
   if (!FileBufOrErr) {
     llvm_unreachable("Failed to read JSON file");
   }

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -154,6 +154,7 @@ class SDKContext {
   llvm::StringSet<> TextData;
   llvm::BumpPtrAllocator Allocator;
   SourceManager SourceMgr;
+  FileManager FileMgr;
   DiagnosticEngine Diags;
   UpdatedNodesMap UpdateMap;
   NodeMap TypeAliasUpdateMap;
@@ -190,6 +191,9 @@ public:
   }
   SourceManager &getSourceMgr() {
     return SourceMgr;
+  }
+  FileManager &getFileMgr() {
+    return FileMgr;
   }
   DiagnosticEngine &getDiags() {
     return Diags;

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -34,7 +34,8 @@ static void declareOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 }
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
-    : Ctx(*ASTContext::get(LangOpts, SearchPathOpts, SourceMgr, Diags)) {
+    : Ctx(*ASTContext::get(LangOpts, SearchPathOpts, SourceMgr, FileMgr,
+                           Diags)) {
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   auto stdlibID = Ctx.getIdentifier(STDLIB_NAME);
   auto *module = ModuleDecl::create(stdlibID, Ctx);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -13,6 +13,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Module.h"
+#include "swift/Basic/FileManager.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 
@@ -28,6 +29,7 @@ public:
   LangOptions LangOpts;
   SearchPathOptions SearchPathOpts;
   SourceManager SourceMgr;
+  FileManager FileMgr;
   DiagnosticEngine Diags;
 
   TestContextBase() : Diags(SourceMgr) {

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_unittest(SwiftBasicTests
   EditorPlaceholderTest.cpp
   EncodedSequenceTest.cpp
   ExponentialGrowthAppendingBinaryByteStreamTests.cpp
+  FileManagerTest.cpp
   FileSystemTest.cpp
   ImmutablePointerSetTest.cpp
   JSONSerialization.cpp

--- a/unittests/Basic/FileManagerTest.cpp
+++ b/unittests/Basic/FileManagerTest.cpp
@@ -1,0 +1,115 @@
+//===--- FileManagerTest.cpp - for swift/Basic/FileManager.h --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/FileManager.h"
+#include "swift/Basic/LLVM.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+/// An llvm::vfs::FileSystem that tracks the number of times status() and
+/// openFileForRead() are called.
+class StatTrackingFileSystem : public llvm::vfs::ProxyFileSystem {
+  llvm::StringMap<unsigned> statCallCounter;
+  llvm::StringMap<unsigned> openFileCounter;
+public:
+  explicit StatTrackingFileSystem(
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs)
+      : llvm::vfs::ProxyFileSystem(fs) {}
+
+  llvm::ErrorOr<llvm::vfs::Status> status(const llvm::Twine &path) override {
+    statCallCounter[path.str()] += 1;
+    return ProxyFileSystem::status(path);
+  }
+  llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
+  openFileForRead(const llvm::Twine &path) override {
+    openFileCounter[path.str()] += 1;
+    return ProxyFileSystem::openFileForRead(path);
+  }
+
+  unsigned numberOfStatCalls(const StringRef path) {
+    return statCallCounter[path];
+  }
+
+  unsigned numberOfOpens(const StringRef path) {
+    return openFileCounter[path];
+  }
+};
+}
+
+TEST(FileManager, Caching) {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem>
+  inMemoryFS(new llvm::vfs::InMemoryFileSystem());
+
+  llvm::IntrusiveRefCntPtr<StatTrackingFileSystem>
+  statTrackingFS(new StatTrackingFileSystem(inMemoryFS));
+
+  FileManager fileManager(statTrackingFS);
+
+  // Fill the in-memory file system with some files.
+
+  StringRef fileAContent = "contents of fileA";
+  StringRef fileBContent = "contents of fileB";
+  inMemoryFS->addFile("fileA.txt", /*mtime*/42,
+                      llvm::MemoryBuffer::getMemBuffer(fileAContent));
+  inMemoryFS->addFile("fileB.txt", /*mtime*/9001,
+                      llvm::MemoryBuffer::getMemBuffer(fileBContent));
+
+  // Open and stat the files multiple times.
+
+  for (int i = 0; i < 5; ++i) {
+    // Call status() before opening the file, which means we will stat twice.
+
+    auto statA = fileManager.status("fileA.txt");
+    ASSERT_TRUE(statA);
+    EXPECT_EQ(statA->getLastModificationTime().time_since_epoch().count(), 42);
+    EXPECT_EQ(statA->getSize(), fileAContent.size());
+
+    auto openA = fileManager.getBufferForFile("fileA.txt");
+    ASSERT_TRUE(openA);
+    EXPECT_EQ((*openA)->getBuffer(), fileAContent);
+
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    // Open the file and then call status(), which means we should use the
+    // cached status.
+    auto openB = fileManager.getBufferForFile("fileB.txt");
+    ASSERT_TRUE(openB);
+    EXPECT_EQ((*openB)->getBuffer(), fileBContent);
+
+    auto statB = fileManager.status("fileB.txt");
+    ASSERT_TRUE(statB);
+    EXPECT_EQ(statB->getLastModificationTime().time_since_epoch().count(),
+              9001);
+    EXPECT_EQ(statB->getSize(), fileBContent.size());
+  }
+
+  // We called status() once.
+  // FIXME: This test currently fails, because FileManager doesn't keep track
+  //        of llvm::vfs::Status values in its FileEntry struct.
+  EXPECT_EQ(statTrackingFS->numberOfStatCalls("fileA.txt"), 1);
+
+  // We should have retained our status from calling openFileForRead().
+  // FIXME: This test currently fails, because FileManager doesn't keep track
+  //        of llvm::vfs::Status values in its FileEntry struct.
+  EXPECT_EQ(statTrackingFS->numberOfStatCalls("fileB.txt"), 0);
+
+  // We should have only opened fileA once.
+  EXPECT_EQ(statTrackingFS->numberOfOpens("fileA.txt"), 1);
+
+  // We should have only opened fileB once.
+  EXPECT_EQ(statTrackingFS->numberOfOpens("fileB.txt"), 1);
+}

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -72,9 +72,11 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
   swift::SourceManager sourceMgr;
+  llvm::IntrusiveRefCntPtr<FileManager> fileMgr = new FileManager();
+  sourceMgr.setFileManager(fileMgr);
   swift::DiagnosticEngine diags(sourceMgr);
   std::unique_ptr<ASTContext> context(
-      ASTContext::get(langOpts, searchPathOpts, sourceMgr, diags));
+      ASTContext::get(langOpts, searchPathOpts, sourceMgr, *fileMgr, diags));
   auto importer = ClangImporter::create(*context, options);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -1,4 +1,5 @@
 #include "swift/AST/Module.h"
+#include "swift/Basic/FileManager.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Lexer.h"
@@ -15,6 +16,7 @@ class TokenizerTest : public ::testing::Test {
 public:
   LangOptions LangOpts;
   SourceManager SM;
+  FileManager FM;
 
   unsigned makeBuffer(StringRef Source) {
     return SM.addMemBufferCopy(Source);
@@ -82,7 +84,8 @@ public:
   }
   
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
-    swift::ParserUnit PU(SM, SourceFileKind::Main, BufID, LangOpts, "unknown");
+    swift::ParserUnit PU(SM, FM, SourceFileKind::Main, BufID, LangOpts,
+                         "unknown");
 
     bool Done = false;
     while (!Done) {


### PR DESCRIPTION
This is both an optimization -- we avoid `stat`-ing multiple time -- and a mitigation for a correctness issue. We want to keep track of the file stats from the moment we open a file, and we don't want to stat it after we've opened & read it. This avoids racing where a file might change during compilation, and we record the new modification time when we've read the old one.