### PR TITLE
[cast-opt] Eliminate always true if statement.

### DIFF
--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -111,55 +111,53 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
     Builder.setInsertionPoint(CurrInsPoint);
   }
 
-  if (SILBridgedTy != Src->getType()) {
-    // Check if we can simplify a cast into:
-    // - ObjCTy to _ObjectiveCBridgeable._ObjectiveCType.
-    // - then convert _ObjectiveCBridgeable._ObjectiveCType to
-    // a Swift type using _forceBridgeFromObjectiveC.
+  // We know this is always true since SILBridgedTy is an object and Src is an
+  // address.
+  assert(SILBridgedTy != Src->getType());
 
-    if (!Src->getType().isLoadable(M)) {
-      // This code path is never reached in current test cases
-      // If reached, we'd have to convert from an ObjC Any* to a loadable type
-      // Should use check_addr / make a source we can actually load
-      return nullptr;
-    }
+  // Check if we can simplify a cast into:
+  // - ObjCTy to _ObjectiveCBridgeable._ObjectiveCType.
+  // - then convert _ObjectiveCBridgeable._ObjectiveCType to
+  // a Swift type using _forceBridgeFromObjectiveC.
 
-    // Generate a load for the source argument.
-    auto *Load =
-        Builder.createLoad(Loc, Src, LoadOwnershipQualifier::Unqualified);
-    // Try to convert the source into the expected ObjC type first.
+  if (!Src->getType().isLoadable(M)) {
+    // This code path is never reached in current test cases
+    // If reached, we'd have to convert from an ObjC Any* to a loadable type
+    // Should use check_addr / make a source we can actually load
+    return nullptr;
+  }
 
-    if (Load->getType() == SILBridgedTy) {
-      // If type of the source and the expected ObjC type are
-      // equal, there is no need to generate the conversion
-      // from ObjCTy to _ObjectiveCBridgeable._ObjectiveCType.
-      if (isConditional) {
-        SILBasicBlock *CastSuccessBB = F->createBasicBlock();
-        CastSuccessBB->createPhiArgument(SILBridgedTy,
-                                         ValueOwnershipKind::Owned);
-        Builder.createBranch(Loc, CastSuccessBB, SILValue(Load));
-        Builder.setInsertionPoint(CastSuccessBB);
-        SrcOp = CastSuccessBB->getArgument(0);
-      } else {
-        SrcOp = Load;
-      }
-    } else if (isConditional) {
+  // Generate a load for the source argument.
+  auto *Load =
+      Builder.createLoad(Loc, Src, LoadOwnershipQualifier::Unqualified);
+  // Try to convert the source into the expected ObjC type first.
+
+  if (Load->getType() == SILBridgedTy) {
+    // If type of the source and the expected ObjC type are
+    // equal, there is no need to generate the conversion
+    // from ObjCTy to _ObjectiveCBridgeable._ObjectiveCType.
+    if (isConditional) {
       SILBasicBlock *CastSuccessBB = F->createBasicBlock();
       CastSuccessBB->createPhiArgument(SILBridgedTy, ValueOwnershipKind::Owned);
-      auto *CCBI = Builder.createCheckedCastBranch(Loc, false, Load,
-                                      SILBridgedTy, CastSuccessBB, ConvFailBB);
-      NewI = CCBI;
-      splitEdge(CCBI, /* EdgeIdx to ConvFailBB */ 1);
+      Builder.createBranch(Loc, CastSuccessBB, SILValue(Load));
       Builder.setInsertionPoint(CastSuccessBB);
       SrcOp = CastSuccessBB->getArgument(0);
     } else {
-      auto cast =
-          Builder.createUnconditionalCheckedCast(Loc, Load, SILBridgedTy);
-      NewI = cast;
-      SrcOp = cast;
+      SrcOp = Load;
     }
+  } else if (isConditional) {
+    SILBasicBlock *CastSuccessBB = F->createBasicBlock();
+    CastSuccessBB->createPhiArgument(SILBridgedTy, ValueOwnershipKind::Owned);
+    auto *CCBI = Builder.createCheckedCastBranch(Loc, false, Load, SILBridgedTy,
+                                                 CastSuccessBB, ConvFailBB);
+    NewI = CCBI;
+    splitEdge(CCBI, /* EdgeIdx to ConvFailBB */ 1);
+    Builder.setInsertionPoint(CastSuccessBB);
+    SrcOp = CastSuccessBB->getArgument(0);
   } else {
-    SrcOp = Src;
+    auto cast = Builder.createUnconditionalCheckedCast(Loc, Load, SILBridgedTy);
+    NewI = cast;
+    SrcOp = cast;
   }
 
   // Now emit the a cast from the casted ObjC object into a target type.


### PR DESCRIPTION
I think that this is a result of previous refactorings. This code has a long
time assert in it that Src (since 2016) is an object and for a long time the bridged type has
always been an object (since 2015). So, thus we know that the following is always true.

  SILBridgedTy != Src->getType()

I also removed a level of indentation. NFC.

The 2015 commit hash is: 2dd38eee0ede4a51f4e7d1bf9272ae91b3a8a1ff (the original commit).
The 2016 commit hash is: 506ab9809f0187c5242d57cadd80e9c07286329e
