### PR TITLE
[cmake] Fix link pool and allow overriding from command line.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,17 @@ endif()
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-# Make a job pool for things that can't yet be distributed
-cmake_host_system_information(
-  RESULT localhost_logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
-set_property(GLOBAL PROPERTY JOB_POOLS local_jobs=${localhost_logical_cores})
-# Put linking in that category
-set_property(GLOBAL PROPERTY JOB_POOL_LINK local_jobs)
+if(DEFINED CMAKE_JOB_POOLS)
+  # CMake < 3.11 doesn't support CMAKE_JOB_POOLS. Manually set the property.
+  set_property(GLOBAL PROPERTY JOB_POOLS "${CMAKE_JOB_POOLS}")
+else()
+  # Make a job pool for things that can't yet be distributed
+  cmake_host_system_information(
+    RESULT localhost_logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
+  set_property(GLOBAL PROPERTY JOB_POOLS local_jobs=${localhost_logical_cores})
+  # Put linking in that category
+  set(CMAKE_JOB_POOL_LINK local_jobs)
+endif()
 
 ENABLE_LANGUAGE(C)
 


### PR DESCRIPTION
Fix the usage of JOB_POOL_LINK. JOB_POOL_LINK is not global property,
only a target property. To set in all the targets, one has to set
CMAKE_JOB_POOL_LINK.

Also, allow overriding JOB_POOLS from the command line with
CMAKE_JOB_POOLS. There's a workaround for old versions of CMake which do
not have automatic support for that override.

