### PR TITLE
[Constraint solver] Generalize disjunction favoring

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4404,7 +4404,6 @@ ConstraintSystem::simplifyEscapableFunctionOfConstraint(
     return SolutionKind::Unsolved;
   };
 
-
   type2 = getFixedTypeRecursive(type2, flags, /*wantRValue=*/true);
   if (auto fn2 = type2->getAs<FunctionType>()) {
     // Solve forward by binding the other type variable to the escapable
@@ -4901,6 +4900,34 @@ retry_after_fail:
 
   case SolutionKind::Unsolved:
     break;
+  }
+
+  // Collect the active overload choices.
+  SmallVector<OverloadChoice, 4> choices;
+  for (auto constraint : disjunction->getNestedConstraints()) {
+    if (constraint->isDisabled())
+      continue;
+    choices.push_back(constraint->getOverloadChoice());
+  }
+
+  // If we can favor one generic result over another, do so.
+  if (auto favoredChoice = tryOptimizeGenericDisjunction(choices)) {
+    unsigned favoredIndex = favoredChoice - choices.data();
+    for (auto constraint : disjunction->getNestedConstraints()) {
+      if (constraint->isDisabled())
+        continue;
+
+      if (favoredIndex == 0) {
+        if (solverState)
+          solverState->favorConstraint(constraint);
+        else
+          constraint->setFavored();
+
+        break;
+      } else {
+        --favoredIndex;
+      }
+    }
   }
 
   // If there was a constraint that we couldn't reason about, don't use the

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4903,7 +4903,6 @@ retry_after_fail:
     break;
   }
 
-
   // If there was a constraint that we couldn't reason about, don't use the
   // results of any common-type computations.
   if (hasUnhandledConstraints)

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -424,6 +424,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numCheckedConformances = cs.CheckedConformances.size();
   numMissingMembers = cs.MissingMembers.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
+  numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
 
   PreviousScore = cs.CurrentScore;
 

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -444,7 +444,7 @@ public:
   }
 
   /// Mark or retrieve whether this constraint should be favored in the system.
-  void setFavored() { IsFavored = true; }
+  void setFavored(bool favored = true) { IsFavored = favored; }
   bool isFavored() const { return IsFavored; }
 
   /// Whether the solver should remember which choice was taken for

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3122,12 +3122,14 @@ private:
                                   bool restoreOnFail,
                                   llvm::function_ref<bool(Constraint *)> pred);
 
+public:
   // Given a type variable, attempt to find the disjunction of
   // bind overloads associated with it. This may return null in cases where
   // the disjunction has either not been created or binds the type variable
   // in some manner other than by binding overloads.
   Constraint *getUnboundBindOverloadDisjunction(TypeVariableType *tyvar);
 
+private:
   /// Given a type variable that might represent an overload set, retrieve
   ///
   /// \returns the set of overload choices to which this type variable
@@ -3748,7 +3750,7 @@ private:
 /// easy to work with disjunction and encapsulates
 /// some other important information such as locator.
 class DisjunctionChoiceProducer : public BindingProducer<DisjunctionChoice> {
-  // The disjunciton choices that this producer will iterate through.
+  // The disjunction choices that this producer will iterate through.
   ArrayRef<Constraint *> Choices;
 
   // The ordering of disjunction choices. We index into Choices

--- a/validation-test/Sema/type_checker_perf/fast/sr139.swift
+++ b/validation-test/Sema/type_checker_perf/fast/sr139.swift
@@ -3,5 +3,5 @@
 
 // SR-139:
 // Infinite recursion parsing bitwise operators
-let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);  // expected-error {{reasonable time}}
+let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF)
 


### PR DESCRIPTION
Clean up the disjunction favoring code to enable favoring of disjunction terms during constraint solving, unifying some of the code around existing utility functions in the constraint solver (`getUnboundBindOverload()`, `getEffectiveOverloadType()`) rather than hand-rolled versions.