### PR TITLE
Allow protocols to be nested in non-generic contexts

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1420,8 +1420,8 @@ ERROR(unsupported_type_nested_in_protocol,none,
 ERROR(unsupported_type_nested_in_protocol_extension,none,
       "type %0 cannot be nested in protocol extension of %1",
       (Identifier, Identifier))
-ERROR(unsupported_nested_protocol,none,
-      "protocol %0 cannot be nested inside another declaration",
+ERROR(unsupported_nested_protocol_in_generic,none,
+      "protocol %0 cannot be nested inside a generic context",
       (Identifier))
 
 // Type aliases

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -37,7 +37,6 @@ public:
   }
   BAD_MEMBER(Extension)
   BAD_MEMBER(Import)
-  BAD_MEMBER(Protocol)
   BAD_MEMBER(TopLevelCode)
   BAD_MEMBER(Operator)
   BAD_MEMBER(PrecedenceGroup)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3995,6 +3995,13 @@ public:
   }
 
   void visitProtocolType(ProtocolType *T) {
+    if (auto ParentType = T->getParent()) {
+      visitParentType(ParentType);
+      Printer << ".";
+    } else if (shouldPrintFullyQualified(T)) {
+      printModuleContext(T);
+    }
+
     printTypeDeclName(T);
   }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3650,7 +3650,6 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
     switch (member->getKind()) {
     case DeclKind::Import:
     case DeclKind::TopLevelCode:
-    case DeclKind::Protocol:
     case DeclKind::Extension:
     case DeclKind::InfixOperator:
     case DeclKind::PrefixOperator:
@@ -3694,6 +3693,9 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
       continue;
     case DeclKind::Class:
       emitClassDecl(cast<ClassDecl>(member));
+      continue;
+    case DeclKind::Protocol:
+      emitProtocolDecl(cast<ProtocolDecl>(member));
       continue;
     }
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6222,7 +6222,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   ProtocolDecl *Proto = new (Context)
       ProtocolDecl(CurDeclContext, ProtocolLoc, NameLoc, ProtocolName,
                    Context.AllocateCopy(InheritedProtocols), TrailingWhere);
-  // No need to setLocalDiscriminator: protocols can't appear in local contexts.
+  setLocalDiscriminator(Proto);
 
   Proto->getAttrs() = Attributes;
 

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -187,6 +187,20 @@ extension NSString : A, ZZZ {}
 // CHECK: @interface RootClass4 <A, ZZZ>{{$}}
 @objc class RootClass4 : A, ZZZ {}
 
+// CHECK-LABEL: @interface RootClass4 (SWIFT_EXTENSION(protocols))
+// CHECK-NEXT: @end
+extension RootClass4 {
+
+  // CHECK-LABEL: @protocol DefinedInExtension
+  // CHECK-NEXT: @end
+  @objc protocol DefinedInExtension {}
+
+  // CHECK-LABEL: SWIFT_PROTOCOL_NAMED("DefinedInExtension2")
+  // CHECK-NEXT: @protocol RootClass4Delegate
+  // CHECK-NEXT: @end
+  @objc(RootClass4Delegate) protocol DefinedInExtension2 {}
+}
+
 // CHECK-LABEL: @interface Subclass : RootClass1 <ZZZ>{{$}}
 @objc class Subclass : RootClass1, ZZZ {}
 

--- a/test/decl/nested/type_in_extension.swift
+++ b/test/decl/nested/type_in_extension.swift
@@ -15,7 +15,7 @@ extension { // expected-error {{expected type name in extension declaration}}
 
   class M : S {} // expected-error {{use of undeclared type 'S'}}
 
-  protocol P { // expected-error {{protocol 'P' cannot be nested inside another declaration}}
+  protocol P {
     associatedtype A
   }
 }


### PR DESCRIPTION
I'd like to add more tests. Some guidance would be appreciated.

Does this require swift-evo? I feel that it's an "obvious" feature.