### PR TITLE
[CursorInfo] Add LSP Refactoring Kinds to action dictionaries

### DIFF
--- a/include/swift/IDE/Refactoring.h
+++ b/include/swift/IDE/Refactoring.h
@@ -28,7 +28,7 @@ namespace ide {
 
 enum class RefactoringKind : int8_t {
   None,
-#define REFACTORING(KIND, NAME, ID) KIND,
+#define REFACTORING(KIND, NAME, ID, LSPKIND) KIND,
 #include "RefactoringKinds.def"
 };
 

--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -1,70 +1,88 @@
+#ifndef LSP_REFACTORING_KIND
+#define LSP_REFACTORING_KIND(KIND, NAME)
+#endif
+
+LSP_REFACTORING_KIND(Refactor, "refactor")
+
+LSP_REFACTORING_KIND(RefactorExtract, "refactor.extract")
+
+LSP_REFACTORING_KIND(RefactorInline, "refactor.inline")
+
+LSP_REFACTORING_KIND(RefactorRewrite, "refactor.rewrite")
+
+LSP_REFACTORING_KIND(Source, "source")
+
+LSP_REFACTORING_KIND(SourceOrganizeImports, "source.organizeImports")
+
+#undef LSP_REFACTORING_KIND
+
 #ifndef REFACTORING
-#define REFACTORING(KIND, NAME, ID)
+#define REFACTORING(KIND, NAME, ID, LSPKIND)
 #endif
 
 #ifndef SEMANTIC_REFACTORING
-#define SEMANTIC_REFACTORING(KIND, NAME, ID) REFACTORING(KIND, NAME, ID)
+#define SEMANTIC_REFACTORING(KIND, NAME, ID, LSPKIND) REFACTORING(KIND, NAME, ID, LSPKIND)
 #endif
 
 #ifndef RANGE_REFACTORING
-#define RANGE_REFACTORING(KIND, NAME, ID) SEMANTIC_REFACTORING(KIND, NAME, ID)
+#define RANGE_REFACTORING(KIND, NAME, ID, LSPKIND) SEMANTIC_REFACTORING(KIND, NAME, ID, LSPKIND)
 #endif
 
 #ifndef INTERNAL_RANGE_REFACTORING
-#define INTERNAL_RANGE_REFACTORING(KIND, NAME, ID) RANGE_REFACTORING(KIND, NAME, ID)
+#define INTERNAL_RANGE_REFACTORING(KIND, NAME, ID, LSPKIND) RANGE_REFACTORING(KIND, NAME, ID, LSPKIND)
 #endif
 
 #ifndef CURSOR_REFACTORING
-#define CURSOR_REFACTORING(KIND, NAME, ID) SEMANTIC_REFACTORING(KIND, NAME, ID)
+#define CURSOR_REFACTORING(KIND, NAME, ID, LSPKIND) SEMANTIC_REFACTORING(KIND, NAME, ID, LSPKIND)
 #endif
 
 /// Rename and categorise the symbol occurrences at provided locations
 /// (syntactically).
-REFACTORING(GlobalRename, "Global Rename", rename.global)
+REFACTORING(GlobalRename, "Global Rename", rename.global, Refactor)
 
 /// Categorize source ranges for symbol occurrences at provided locations
 /// (syntactically).
-REFACTORING(FindGlobalRenameRanges, "Find Global Rename Ranges", rename.global.find-ranges)
+REFACTORING(FindGlobalRenameRanges, "Find Global Rename Ranges", rename.global.find-ranges, Refactor)
 
 /// Find and categorize all occurences of the file-local symbol at a given
 /// location.
-REFACTORING(FindLocalRenameRanges, "Find Local Rename Ranges", rename.local.find-ranges)
+REFACTORING(FindLocalRenameRanges, "Find Local Rename Ranges", rename.local.find-ranges, Refactor)
 
 /// Find and rename all occurences of the file-local symbol at a given
 /// location.
-CURSOR_REFACTORING(LocalRename, "Local Rename", rename.local)
+CURSOR_REFACTORING(LocalRename, "Local Rename", rename.local, Refactor)
 
-CURSOR_REFACTORING(FillProtocolStub, "Add Missing Protocol Requirements", fillstub)
+CURSOR_REFACTORING(FillProtocolStub, "Add Missing Protocol Requirements", fillstub, Refactor)
 
-CURSOR_REFACTORING(ExpandDefault, "Expand Default", expand.default)
+CURSOR_REFACTORING(ExpandDefault, "Expand Default", expand.default, Refactor)
 
-CURSOR_REFACTORING(ExpandSwitchCases, "Expand Switch Cases", expand.switch.cases)
+CURSOR_REFACTORING(ExpandSwitchCases, "Expand Switch Cases", expand.switch.cases, Refactor)
 
-CURSOR_REFACTORING(LocalizeString, "Localize String", localize.string)
+CURSOR_REFACTORING(LocalizeString, "Localize String", localize.string, RefactorRewrite)
 
-CURSOR_REFACTORING(SimplifyNumberLiteral, "Simplify Long Number Literal", simplify.long.number.literal)
+CURSOR_REFACTORING(SimplifyNumberLiteral, "Simplify Long Number Literal", simplify.long.number.literal, RefactorRewrite)
 
-CURSOR_REFACTORING(CollapseNestedIfStmt, "Collapse Nested If Statements", collapse.nested.ifstmt)
+CURSOR_REFACTORING(CollapseNestedIfStmt, "Collapse Nested If Statements", collapse.nested.ifstmt, RefactorRewrite)
 
-CURSOR_REFACTORING(ConvertToDoCatch, "Convert To Do/Catch", convert.do.catch)
+CURSOR_REFACTORING(ConvertToDoCatch, "Convert To Do/Catch", convert.do.catch, RefactorRewrite)
 
-CURSOR_REFACTORING(TrailingClosure, "Convert To Trailing Closure", trailingclosure)
+CURSOR_REFACTORING(TrailingClosure, "Convert To Trailing Closure", trailingclosure, RefactorRewrite)
 
-CURSOR_REFACTORING(MemberwiseInitLocalRefactoring, "Generate Memberwise Initializer", memberwise.init.local.refactoring)
+CURSOR_REFACTORING(MemberwiseInitLocalRefactoring, "Generate Memberwise Initializer", memberwise.init.local.refactoring, Refactor)
 
-RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr)
+RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr, RefactorExtract)
 
-RANGE_REFACTORING(ExtractFunction, "Extract Method", extract.function)
+RANGE_REFACTORING(ExtractFunction, "Extract Method", extract.function, RefactorExtract)
 
-RANGE_REFACTORING(ExtractRepeatedExpr, "Extract Repeated Expression", extract.expr.repeated)
+RANGE_REFACTORING(ExtractRepeatedExpr, "Extract Repeated Expression", extract.expr.repeated, RefactorExtract)
 
-RANGE_REFACTORING(MoveMembersToExtension, "Move To Extension", move.members.to.extension)
+RANGE_REFACTORING(MoveMembersToExtension, "Move To Extension", move.members.to.extension, RefactorRewrite)
 
-RANGE_REFACTORING(ConvertStringsConcatenationToInterpolation, "Convert to String Interpolation", convert.string-concatenation.interpolation)
+RANGE_REFACTORING(ConvertStringsConcatenationToInterpolation, "Convert to String Interpolation", convert.string-concatenation.interpolation, RefactorRewrite)
 
-RANGE_REFACTORING(ExpandTernaryExpr, "Expand Ternary Expression", expand.ternary.expr)
+RANGE_REFACTORING(ExpandTernaryExpr, "Expand Ternary Expression", expand.ternary.expr, Refactor)
 
-RANGE_REFACTORING(ConvertToTernaryExpr, "Convert To Ternary Expression", convert.ternary.expr)
+RANGE_REFACTORING(ConvertToTernaryExpr, "Convert To Ternary Expression", convert.ternary.expr, RefactorRewrite)
 
 RANGE_REFACTORING(ConvertIfLetExprToGuardExpr, "Convert To Guard Expression", convert.iflet.to.guard.expr)
 
@@ -78,7 +96,7 @@ RANGE_REFACTORING(ConvertToSwitchStmt, "Convert To Switch Statement", convert.sw
 // the compiler/standard library, etc., but are likely to be just confusing and
 // noise for general development.
 
-INTERNAL_RANGE_REFACTORING(ReplaceBodiesWithFatalError, "Replace Function Bodies With 'fatalError()'", replace.bodies.with.fatalError)
+INTERNAL_RANGE_REFACTORING(ReplaceBodiesWithFatalError, "Replace Function Bodies With 'fatalError()'", replace.bodies.with.fatalError, RefactorRewrite)
 
 #undef CURSOR_REFACTORING
 #undef INTERNAL_RANGE_REFACTORING

--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -84,13 +84,13 @@ RANGE_REFACTORING(ExpandTernaryExpr, "Expand Ternary Expression", expand.ternary
 
 RANGE_REFACTORING(ConvertToTernaryExpr, "Convert To Ternary Expression", convert.ternary.expr, RefactorRewrite)
 
-RANGE_REFACTORING(ConvertIfLetExprToGuardExpr, "Convert To Guard Expression", convert.iflet.to.guard.expr)
+RANGE_REFACTORING(ConvertIfLetExprToGuardExpr, "Convert To Guard Expression", convert.iflet.to.guard.expr, RefactorRewrite)
 
-RANGE_REFACTORING(ConvertGuardExprToIfLetExpr, "Convert To IfLet Expression", convert.to.iflet.expr)
+RANGE_REFACTORING(ConvertGuardExprToIfLetExpr, "Convert To IfLet Expression", convert.to.iflet.expr, RefactorRewrite)
 
-RANGE_REFACTORING(ConvertToComputedProperty, "Convert To Computed Property", convert.to.computed.property)
+RANGE_REFACTORING(ConvertToComputedProperty, "Convert To Computed Property", convert.to.computed.property, RefactorRewrite)
 
-RANGE_REFACTORING(ConvertToSwitchStmt, "Convert To Switch Statement", convert.switch.stmt)
+RANGE_REFACTORING(ConvertToSwitchStmt, "Convert To Switch Statement", convert.switch.stmt, RefactorRewrite)
 
 // These internal refactorings are designed to be helpful for working on
 // the compiler/standard library, etc., but are likely to be just confusing and

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -713,7 +713,7 @@ public:
   }
 };
 
-#define CURSOR_REFACTORING(KIND, NAME, ID)                                    \
+#define CURSOR_REFACTORING(KIND, NAME, ID, LSPKIND)                           \
 class RefactoringAction##KIND: public TokenBasedRefactoringAction {           \
   public:                                                                     \
   RefactoringAction##KIND(ModuleDecl *MD, RefactoringOptions &Opts,           \
@@ -741,7 +741,7 @@ public:
                               ResolvedRangeInfo())) {}
 };
 
-#define RANGE_REFACTORING(KIND, NAME, ID)                                     \
+#define RANGE_REFACTORING(KIND, NAME, ID, LSPKIND)                            \
 class RefactoringAction##KIND: public RangeBasedRefactoringAction {           \
   public:                                                                     \
   RefactoringAction##KIND(ModuleDecl *MD, RefactoringOptions &Opts,           \
@@ -3561,7 +3561,8 @@ getDescriptiveRefactoringKindName(RefactoringKind Kind) {
     switch(Kind) {
       case RefactoringKind::None:
         llvm_unreachable("Should be a valid refactoring kind");
-#define REFACTORING(KIND, NAME, ID) case RefactoringKind::KIND: return NAME;
+#define REFACTORING(KIND, NAME, ID, LSPKIND) case RefactoringKind::KIND:       \
+        return NAME;
 #include "swift/IDE/RefactoringKinds.def"
     }
     llvm_unreachable("unhandled kind");
@@ -3745,7 +3746,7 @@ collectAvailableRefactorings(SourceFile *SF,
     }
   }
   DiagnosticEngine DiagEngine(SF->getASTContext().SourceMgr);
-#define CURSOR_REFACTORING(KIND, NAME, ID)                                     \
+#define CURSOR_REFACTORING(KIND, NAME, ID, LSPKIND)                            \
   if (RefactoringAction##KIND::isApplicable(CursorInfo, DiagEngine))           \
     AllKinds.push_back(RefactoringKind::KIND);
 #include "swift/IDE/RefactoringKinds.def"
@@ -3792,12 +3793,12 @@ collectAvailableRefactorings(SourceFile *SF, RangeConfig Range,
 
   bool enableInternalRefactoring = getenv("SWIFT_ENABLE_INTERNAL_REFACTORING_ACTIONS");
 
-#define RANGE_REFACTORING(KIND, NAME, ID)                                     \
+#define RANGE_REFACTORING(KIND, NAME, ID, LSPKIND)                            \
   if (RefactoringAction##KIND::isApplicable(Result, DiagEngine))              \
     Scratch.push_back(RefactoringKind::KIND);
-#define INTERNAL_RANGE_REFACTORING(KIND, NAME, ID)                            \
+#define INTERNAL_RANGE_REFACTORING(KIND, NAME, ID, LSPKIND)                   \
   if (enableInternalRefactoring)                                              \
-    RANGE_REFACTORING(KIND, NAME, ID)
+    RANGE_REFACTORING(KIND, NAME, ID, LSPKIND)
 #include "swift/IDE/RefactoringKinds.def"
 
   RangeStartMayNeedRename = rangeStartMayNeedRename(Result);
@@ -3816,7 +3817,7 @@ refactorSwiftModule(ModuleDecl *M, RefactoringOptions Opts,
   }
 
   switch (Opts.Kind) {
-#define SEMANTIC_REFACTORING(KIND, NAME, ID)                                   \
+#define SEMANTIC_REFACTORING(KIND, NAME, ID, LSPKIND)                          \
 case RefactoringKind::KIND: {                                                  \
       RefactoringAction##KIND Action(M, Opts, EditConsumer, DiagConsumer);     \
       if (RefactoringKind::KIND == RefactoringKind::LocalRename ||             \

--- a/test/SourceKit/CursorInfo/cursor_info_lsp_kinds.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_lsp_kinds.swift
@@ -1,0 +1,44 @@
+enum E1 {
+  case e1
+  case e2
+  case e3
+  case e4
+}
+
+func foo1(_ e : E1) -> Int {
+  switch e {
+  }
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=9:5 -end-pos=9:5 -cursor-action %s -- %s | %FileCheck %s
+
+// CHECK: ACTIONS BEGIN
+// CHECK: source.refactoring.kind.expand.switch.cases
+// CHECK-NEXT: LSP KIND "refactor"
+// CHECK: ACTIONS END
+
+func foo() -> String {
+  return bar()
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=21:10 -end-pos=21:15 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK2
+
+// CHECK2: ACTIONS BEGIN
+// CHECK2: source.refactoring.kind.extract.expr
+// CHECK2-NEXT: LSP KIND "refactor.extract"
+// CHECK2: source.refactoring.kind.extract.function
+// CHECK2-NEXT: LSP KIND "refactor.extract"
+// CHECK2: source.refactoring.kind.extract.expr.repeated
+// CHECK2-NEXT: LSP KIND "refactor.extract"
+// CHECK2: ACTIONS END
+
+func bar() -> String {
+  return "bar"
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=36:10 -end-pos=36:15 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK3
+
+// CHECK3: ACTIONS BEGIN
+// CHECK3: source.refactoring.kind.localize.string
+// CHECK3-NEXT: LSP KIND "refactor.rewrite"
+// CHECK3: ACTIONS END

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -306,6 +306,12 @@ public:
 struct Statistic;
 typedef std::function<void(ArrayRef<Statistic *> stats)> StatisticsReceiver;
 
+enum class LSPRefactoringKind {
+  None,
+#define LSP_REFACTORING_KIND(KIND, NAME) KIND,
+#include "swift/IDE/RefactoringKinds.def"
+};
+
 /// Options for configuring a virtual file system provider.
 struct VFSOptions {
   /// The name of the virtual file system to use.
@@ -373,6 +379,7 @@ struct RefactoringInfo {
   UIdent Kind;
   StringRef KindName;
   StringRef UnavailableReason;
+  LSPRefactoringKind LSPKind;
 };
 
 struct CursorInfoData {
@@ -440,7 +447,7 @@ struct NameTranslatingInfo {
 
 enum class SemanticRefactoringKind {
   None,
-#define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
+#define SEMANTIC_REFACTORING(KIND, NAME, ID, LSPKIND) KIND,
 #include "swift/IDE/RefactoringKinds.def"
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -62,7 +62,7 @@ using swift::index::SymbolRoleSet;
 #define KIND(NAME, CONTENT) static UIdent Kind##NAME(CONTENT);
 #include "SourceKit/Core/ProtocolUIDs.def"
 
-#define REFACTORING(KIND, NAME, ID) static UIdent Kind##Refactoring##KIND("source.refactoring.kind."#ID);
+#define REFACTORING(KIND, NAME, ID, LSPKIND) static UIdent Kind##Refactoring##KIND("source.refactoring.kind."#ID);
 #include "swift/IDE/RefactoringKinds.def"
 
 static UIdent Attr_IBAction("source.decl.attribute.ibaction");
@@ -342,8 +342,18 @@ SourceKit::UIdent SwiftLangSupport::getUIDForObjCAttr() {
 UIdent SwiftLangSupport::getUIDForRefactoringKind(ide::RefactoringKind Kind){
   switch(Kind) {
   case ide::RefactoringKind::None: llvm_unreachable("cannot end up here.");
-#define REFACTORING(KIND, NAME, ID)                                            \
+#define REFACTORING(KIND, NAME, ID, LSPKIND)                                \
   case ide::RefactoringKind::KIND: return KindRefactoring##KIND;
+#include "swift/IDE/RefactoringKinds.def"
+  }
+}
+
+LSPRefactoringKind 
+SwiftLangSupport::getLSPKindForRefactoringKind(ide::RefactoringKind Kind) {
+  switch(Kind) {
+  case ide::RefactoringKind::None: llvm_unreachable("cannot end up here.");
+#define REFACTORING(KIND, NAME, ID, LSPKIND)                                   \
+  case ide::RefactoringKind::KIND: return LSPRefactoringKind::LSPKIND; 
 #include "swift/IDE/RefactoringKinds.def"
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -354,6 +354,8 @@ public:
   static SourceKit::UIdent getUIDForLocalVar(bool IsRef = false);
   static SourceKit::UIdent getUIDForRefactoringKind(
       swift::ide::RefactoringKind Kind);
+  static SourceKit::LSPRefactoringKind getLSPKindForRefactoringKind(
+      swift::ide::RefactoringKind Kind);
   static SourceKit::UIdent getUIDForCodeCompletionDeclKind(
       swift::ide::CodeCompletionDeclKind Kind, bool IsRef = false);
   static SourceKit::UIdent getUIDForAccessor(const swift::ValueDecl *D,

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -65,7 +65,7 @@ enum class SourceKitRequest {
   EnableCompileNotifications,
   CollectExpresstionType,
   GlobalConfiguration,
-#define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
+#define SEMANTIC_REFACTORING(KIND, NAME, ID, LSPKIND) KIND,
 #include "swift/IDE/RefactoringKinds.def"
 };
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -171,6 +171,7 @@ UID_KEYS = [
     KEY('ExpressionOffset', 'key.expression_offset'),
     KEY('ExpressionLength', 'key.expression_length'),
     KEY('ExpressionType', 'key.expression_type'),
+    KEY('LSPRefactoringKind', 'key.lsp_refactoring_kind'),
     KEY('CanonicalizeType', 'key.canonicalize_type'),
     KEY('InternalDiagnostic', "key.internal_diagnostic"),
     KEY('VFSName', 'key.vfs.name'),


### PR DESCRIPTION
The LSP allows the server to attribute [kinds to CodeActions](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction). Clients can use these kinds to categorize them in the UI, and also a filter condition when asking the server for the available CodeActions of a range.

To allow SourceKit-LSP to determine the kind of a CodeAction, I thought it would be interesting to add a new `key.lsp_refactoring_kind` entry to CursorInfo's actions dictionary and attribute a kind to each supported refactoring action.

CC: @benlangmuir @akyrtzi 