### PR TITLE
[5.1][Reflection] Fail gracefully when objc_debug_taggedpointer_obfuscator isn't present.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2471,8 +2471,13 @@ private:
     TaggedPointerExtendedClasses =
         TaggedPointerExtendedClassesAddr.getAddressData();
 
-    tryFindAndReadSymbol(TaggedPointerObfuscator,
-                         "objc_debug_taggedpointer_obfuscator");
+    // The tagged pointer obfuscator is not present on older OSes, in
+    // which case we can treat it as zero.
+    TaggedPointerObfuscator = 0;
+    auto TaggedPointerObfuscatorAddr = Reader->getSymbolAddress(
+      "objc_debug_taggedpointer_obfuscator");
+    if (TaggedPointerObfuscatorAddr)
+      tryReadSymbol(TaggedPointerObfuscatorAddr, TaggedPointerObfuscator);
 
 #   undef tryFindSymbol
 #   undef tryReadSymbol

--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -66,6 +66,14 @@ static void errnoAndExit(const char *message) {
   abort();
 }
 
+#if 0
+#include <inttypes.h>
+#define DEBUG_LOG(fmt, ...) fprintf(stderr, "%s: " fmt "\n",\
+                                    __func__, __VA_ARGS__)
+#else
+#define DEBUG_LOG(fmt, ...) (void)0
+#endif
+
 static const size_t ReadEnd = 0;
 static const size_t WriteEnd = 1;
 
@@ -143,6 +151,8 @@ const void *PipeMemoryReader_readBytes(void *Context, swift_addr_t Address,
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;
   uintptr_t TargetAddress = Address;
   size_t TargetSize = (size_t)Size;
+  DEBUG_LOG("Requesting read of %zu bytes from 0x%" PRIxPTR,
+            TargetSize, TargetAddress);
   int WriteFD = PipeMemoryReader_getParentWriteFD(Reader);
   write(WriteFD, REQUEST_READ_BYTES, 2);
   write(WriteFD, &TargetAddress, sizeof(TargetAddress));
@@ -162,12 +172,14 @@ swift_addr_t PipeMemoryReader_getSymbolAddress(void *Context,
                                                uint64_t Length) {
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;
   uintptr_t Address = 0;
+  DEBUG_LOG("Requesting address of symbol %s", SymbolName);
   int WriteFD = PipeMemoryReader_getParentWriteFD(Reader);
   write(WriteFD, REQUEST_SYMBOL_ADDRESS, 2);
   write(WriteFD, SymbolName, Length);
   write(WriteFD, "\n", 1);
   PipeMemoryReader_collectBytesFromPipe(Reader, (uint8_t*)&Address,
                                         sizeof(Address));
+  DEBUG_LOG("Address of %s is 0x%" PRIxPTR, SymbolName, Address);
   return (uintptr_t)Address;
 }
 
@@ -177,6 +189,7 @@ PipeMemoryReader_receiveInstanceKind(const PipeMemoryReader *Reader) {
   write(WriteFD, REQUEST_INSTANCE_KIND, 2);
   uint8_t KindValue = 0;
   PipeMemoryReader_collectBytesFromPipe(Reader, &KindValue, sizeof(KindValue));
+  DEBUG_LOG("Requested instance kind is %u", KindValue);
   return KindValue;
 }
 
@@ -187,6 +200,7 @@ PipeMemoryReader_receiveInstanceAddress(const PipeMemoryReader *Reader) {
   uintptr_t InstanceAddress = 0;
   PipeMemoryReader_collectBytesFromPipe(Reader, (uint8_t *)&InstanceAddress,
                                         sizeof(InstanceAddress));
+  DEBUG_LOG("Requested instance address is 0x%" PRIxPTR, InstanceAddress);
   return InstanceAddress;
 }
 
@@ -222,6 +236,7 @@ PipeMemoryReader_receiveImages(SwiftReflectionContextRef RC,
   size_t NumReflectionInfos;
   PipeMemoryReader_collectBytesFromPipe(Reader, &NumReflectionInfos,
                                         sizeof(NumReflectionInfos));
+  DEBUG_LOG("Receiving %z images from child", NumReflectionInfos);
 
   if (NumReflectionInfos == 0)
     return;
@@ -232,6 +247,7 @@ PipeMemoryReader_receiveImages(SwiftReflectionContextRef RC,
                                         NumReflectionInfos * sizeof(*Images));
   
   for (size_t i = 0; i < NumReflectionInfos; ++i) {
+    DEBUG_LOG("Adding image at 0x%" PRIxPTR, Images[i].Start);
     swift_reflection_addImage(RC, Images[i].Start);
   }
   


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/22956 to 5.1.

Older OSes don't have this variable. We can treat it as 0 when it's not present.

Also add some (disabled by default) debug logging in swift-reflection-test.c

rdar://problem/48411483