### PR TITLE
[5.1] Serialization: Also serialize the filename for storage decls with private accessors

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4621,6 +4621,9 @@ public:
   /// other modules.
   bool exportsPropertyDescriptor() const;
 
+  /// True if any of the accessors to the storage is private or fileprivate.
+  bool hasPrivateAccessor() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_AbstractStorageDecl &&

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4435,6 +4435,14 @@ void AbstractStorageDecl::overwriteImplInfo(StorageImplInfo implInfo) {
   Accessors.getPointer()->overwriteImplInfo(implInfo);
 }
 
+bool AbstractStorageDecl::hasPrivateAccessor() const {
+  for (auto accessor : getAllAccessors()) {
+    if (hasPrivateOrFilePrivateFormalAccess(accessor))
+      return true;
+  }
+  return false;
+}
+
 void AbstractStorageDecl::setAccessors(StorageImplInfo implInfo,
                                        SourceLoc lbraceLoc,
                                        ArrayRef<AccessorDecl *> accessors,

--- a/test/Serialization/Inputs/private_import_other.swift
+++ b/test/Serialization/Inputs/private_import_other.swift
@@ -8,3 +8,10 @@ struct Value {
 extension Value {
   fileprivate func foo() {}
 }
+
+struct Internal {
+    private(set) var internalVarWithPrivateSetter : Int = 0
+    fileprivate(set) var internalVarWithFilePrivateSetter : Int = 0
+    public private(set) var publicVarWithPrivateSetter : Int = 0
+    public fileprivate(set) var publicVarWithFilePrivateSetter : Int = 0
+}

--- a/test/Serialization/private_import.swift
+++ b/test/Serialization/private_import.swift
@@ -41,6 +41,15 @@
   @_private(sourceFile: "private_import_other.swift") import private_import
   @_private(sourceFile: "private_import.swift") import client
 
+  extension Internal {
+    mutating func set() {
+      self.internalVarWithPrivateSetter = 1
+      self.internalVarWithFilePrivateSetter = 1
+      self.publicVarWithPrivateSetter = 1
+      self.publicVarWithFilePrivateSetter = 1
+    }
+  }
+
   Base().foo()
   // This should not be ambigious.
   Base().bar()


### PR DESCRIPTION
If a value decl is internal hasTestableOrPrivateImport will succeed (or
fail) without looking at the filename. However this breaks when we query
an internal storage decl with private formal access for a private
setter: the query would fail because no filename was serialized for the
decl (we only serialize filenames for private decls). So in the special
case of storage with private accessor also serialize the
filename.

rdar://48516545