### PR TITLE
Add availability annotations to NWConnection.maximumDatagramSize

### DIFF
--- a/stdlib/public/Darwin/Network/NWConnection.swift
+++ b/stdlib/public/Darwin/Network/NWConnection.swift
@@ -110,6 +110,7 @@ public final class NWConnection : CustomDebugStringConvertible {
 	/// Retrieve the maximum datagram size that can be sent
 	/// on the connection. Any datagrams sent should be less
 	/// than or equal to this size.
+	@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 	public var maximumDatagramSize: Int {
 		get {
 			return Int(nw_connection_get_maximum_datagram_size(self.nw))


### PR DESCRIPTION
Since it did not exist pre-ABI.

 <rdar://problem/48314607>