### PR TITLE
SIL: Remove default arguments from resilience expansion parameters

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -198,7 +198,9 @@ public:
   SILModule &getModule() const { return C.Module; }
   ASTContext &getASTContext() const { return getModule().getASTContext(); }
   const Lowering::TypeLowering &getTypeLowering(SILType T) const {
-    return getModule().getTypeLowering(T);
+    // FIXME: Expansion
+    return getModule().Types.getTypeLowering(T,
+                                             ResilienceExpansion::Minimal);
   }
 
   void setOpenedArchetypesTracker(SILOpenedArchetypesTracker *Tracker) {
@@ -2155,13 +2157,15 @@ private:
     if (!SILModuleConventions(M).useLoweredAddresses())
       return true;
 
+    // FIXME: Just call getTypeLowering() here, and move this code there
+
     auto expansion = ResilienceExpansion::Maximal;
     // If there's no current SILFunction, we're inserting into a global
     // variable initializer.
     if (F)
       expansion = F->getResilienceExpansion();
 
-    return M.getTypeLowering(Ty, expansion).isLoadable();
+    return M.Types.getTypeLowering(Ty, expansion).isLoadable();
   }
 
   void appendOperandTypeName(SILType OpdTy, llvm::SmallString<16> &Name) {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -315,13 +315,6 @@ public:
   /// This converts Swift types to SILTypes.
   mutable Lowering::TypeConverter Types;
 
-  /// Look up the TypeLowering for a SILType.
-  const Lowering::TypeLowering &
-  getTypeLowering(SILType t, ResilienceExpansion expansion =
-                               ResilienceExpansion::Minimal) {
-    return Types.getTypeLowering(t, expansion);
-  }
-
   /// Invalidate cached entries in SIL Loader.
   void invalidateSILLoaderCaches();
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -216,26 +216,29 @@ public:
   };
 
 private:
+  friend class TypeConverter;
+
   /// The SIL type of values with this Swift type.
   SILType LoweredType;
 
   RecursiveProperties Properties;
   unsigned ReferenceCounted : 1;
 
-public:
   /// The resilience expansion for this type lowering.
   /// If the type is not resilient at all, this is always Minimal.
-  ResilienceExpansion forExpansion = ResilienceExpansion::Minimal;
+  unsigned ForExpansion : 1;
 
   /// A single linked list of lowerings for different resilience expansions.
   /// The first lowering is always for ResilientExpansion::Minimal.
-  mutable const TypeLowering *nextExpansion = nullptr;
+  mutable const TypeLowering *NextExpansion = nullptr;
 
 protected:
   TypeLowering(SILType type, RecursiveProperties properties,
-               IsReferenceCounted_t isRefCounted)
+               IsReferenceCounted_t isRefCounted,
+               ResilienceExpansion forExpansion)
     : LoweredType(type), Properties(properties),
-      ReferenceCounted(isRefCounted) {}
+      ReferenceCounted(isRefCounted),
+      ForExpansion(unsigned(forExpansion)) {}
 
 public:
   TypeLowering(const TypeLowering &) = delete;
@@ -304,6 +307,10 @@ public:
 
   bool isResilient() const {
     return Properties.isResilient();
+  }
+
+  ResilienceExpansion getResilienceExpansion() const {
+    return ResilienceExpansion(ForExpansion);
   }
 
   /// Produce an exact copy of the value in the given address as a

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -765,8 +765,7 @@ public:
   /// Lowers a Swift type to a SILType, and returns the SIL TypeLowering
   /// for that type.
   const TypeLowering &
-  getTypeLowering(Type t, ResilienceExpansion forExpansion =
-                            ResilienceExpansion::Minimal) {
+  getTypeLowering(Type t, ResilienceExpansion forExpansion) {
     AbstractionPattern pattern(getCurGenericContext(), t->getCanonicalType());
     return getTypeLowering(pattern, t, forExpansion);
   }
@@ -775,33 +774,28 @@ public:
   /// patterns of the given original type.
   const TypeLowering &getTypeLowering(AbstractionPattern origType,
                                       Type substType,
-                                      ResilienceExpansion forExpansion =
-                                        ResilienceExpansion::Minimal);
+                                      ResilienceExpansion forExpansion);
 
   /// Returns the SIL TypeLowering for an already lowered SILType. If the
   /// SILType is an address, returns the TypeLowering for the pointed-to
   /// type.
   const TypeLowering &
-  getTypeLowering(SILType t, ResilienceExpansion forExpansion =
-                               ResilienceExpansion::Minimal);
+  getTypeLowering(SILType t, ResilienceExpansion forExpansion);
 
   // Returns the lowered SIL type for a Swift type.
-  SILType getLoweredType(Type t, ResilienceExpansion forExpansion
-                           = ResilienceExpansion::Minimal) {
+  SILType getLoweredType(Type t, ResilienceExpansion forExpansion) {
     return getTypeLowering(t, forExpansion).getLoweredType();
   }
 
   // Returns the lowered SIL type for a Swift type.
   SILType getLoweredType(AbstractionPattern origType, Type substType,
-                         ResilienceExpansion forExpansion =
-                           ResilienceExpansion::Minimal) {
+                         ResilienceExpansion forExpansion) {
     return getTypeLowering(origType, substType, forExpansion)
       .getLoweredType();
   }
 
   SILType getLoweredLoadableType(Type t,
-                                 ResilienceExpansion forExpansion =
-                                   ResilienceExpansion::Minimal) {
+                                 ResilienceExpansion forExpansion) {
     const TypeLowering &ti = getTypeLowering(t, forExpansion);
     assert(
         (ti.isLoadable() || !SILModuleConventions(M).useLoweredAddresses()) &&
@@ -810,11 +804,16 @@ public:
   }
 
   CanType getLoweredRValueType(Type t) {
-    return getLoweredType(t).getASTType();
+    // We're ignoring the category (object vs address), so the resilience
+    // expansion does not matter.
+    return getLoweredType(t, ResilienceExpansion::Minimal).getASTType();
   }
 
   CanType getLoweredRValueType(AbstractionPattern origType, Type substType) {
-    return getLoweredType(origType, substType).getASTType();
+    // We're ignoring the category (object vs address), so the resilience
+    // expansion does not matter.
+    return getLoweredType(origType, substType,
+                          ResilienceExpansion::Minimal).getASTType();
   }
 
   AbstractionPattern getAbstractionPattern(AbstractStorageDecl *storage,

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -250,12 +250,22 @@ public:
   /// convention?
   ///
   /// This is independent of whether the SIL argument is address type.
-  bool isFormallyPassedIndirectly() const { return isAddressOnly(); }
+  bool isFormallyPassedIndirectly() const {
+    assert(!isResilient() ||
+           getResilienceExpansion() == ResilienceExpansion::Minimal &&
+           "calling convention uses minimal resilience expansion");
+    return isAddressOnly();
+  }
 
   /// Are r-values of this type returned indirectly by formal convention?
   ///
   /// This is independent of whether the SIL result is address type.
-  bool isFormallyReturnedIndirectly() const { return isAddressOnly(); }
+  bool isFormallyReturnedIndirectly() const {
+    assert(!isResilient() ||
+           getResilienceExpansion() == ResilienceExpansion::Minimal &&
+           "calling convention uses minimal resilience expansion");
+    return isAddressOnly();
+  }
 
   RecursiveProperties getRecursiveProperties() const {
     return Properties;

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1150,7 +1150,7 @@ emitKeyPathComponent(IRGenModule &IGM,
   case KeyPathPatternComponent::Kind::TupleElement:
     assert(baseTy->is<TupleType>() && "not a tuple");
 
-    SILType loweredTy = IGM.getSILTypes().getLoweredType(baseTy);
+    SILType loweredTy = IGM.getLoweredType(baseTy);
 
     // Tuple with fixed layout
     //

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1434,12 +1434,16 @@ const TypeInfo &IRGenFunction::getTypeInfo(SILType T) {
 
 /// Return the SIL-lowering of the given type.
 SILType IRGenModule::getLoweredType(AbstractionPattern orig, Type subst) {
-  return getSILTypes().getLoweredType(orig, subst);
+  // FIXME: Expansion
+  return getSILTypes().getLoweredType(orig, subst,
+                                      ResilienceExpansion::Minimal);
 }
 
 /// Return the SIL-lowering of the given type.
 SILType IRGenModule::getLoweredType(Type subst) {
-  return getSILTypes().getLoweredType(subst);
+  // FIXME: Expansion
+  return getSILTypes().getLoweredType(subst,
+                                      ResilienceExpansion::Minimal);
 }
 
 /// Get a pointer to the storage type for the given type.  Note that,

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -315,7 +315,8 @@ public:
       return;
     }
 
-    auto &substResultTL = M.Types.getTypeLowering(origType, substType);
+    auto &substResultTL = M.Types.getTypeLowering(origType, substType,
+                                                  ResilienceExpansion::Minimal);
 
     // Determine the result convention.
     ResultConvention convention;
@@ -590,7 +591,8 @@ private:
 
     unsigned origParamIndex = NextOrigParamIndex++;
 
-    auto &substTL = M.Types.getTypeLowering(origType, substType);
+    auto &substTL = M.Types.getTypeLowering(origType, substType,
+                                            ResilienceExpansion::Minimal);
     ParameterConvention convention;
     if (ownership == ValueOwnership::InOut) {
       convention = ParameterConvention::Indirect_Inout;
@@ -748,8 +750,11 @@ lowerCaptureContextParameters(SILModule &M, AnyFunctionRef function,
     auto type = VD->getInterfaceType();
     auto canType = type->getCanonicalType(origGenericSig);
 
+    // FIXME: Could be changed to Maximal at some point without impacting ABI,
+    // as long as we make sure all call sites are non inlinable.
     auto &loweredTL =
-        Types.getTypeLowering(AbstractionPattern(genericSig, canType), canType);
+        Types.getTypeLowering(AbstractionPattern(genericSig, canType), canType,
+                              ResilienceExpansion::Minimal);
     auto loweredTy = loweredTL.getLoweredType();
     switch (Types.getDeclCaptureKind(capture)) {
     case CaptureKind::None:
@@ -806,7 +811,8 @@ static void destructureYieldsForReadAccessor(SILModule &M,
     return;
   }
 
-  auto &tl = M.Types.getTypeLowering(origType, valueType);
+  auto &tl = M.Types.getTypeLowering(origType, valueType,
+                                     ResilienceExpansion::Minimal);
   auto convention = [&] {
     if (isFormallyPassedIndirectly(M, origType, valueType, tl))
       return ParameterConvention::Indirect_In_Guaranteed;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -627,10 +627,10 @@ private:
       return false;
 
     auto foreignErrorTy =
-      M.Types.getLoweredType(Foreign.Error->getErrorParameterType());
+      M.Types.getLoweredRValueType(Foreign.Error->getErrorParameterType());
 
     // Assume the error parameter doesn't have interesting lowering.
-    Inputs.push_back(SILParameterInfo(foreignErrorTy.getASTType(),
+    Inputs.push_back(SILParameterInfo(foreignErrorTy,
                                       ParameterConvention::Direct_Unowned));
     NextOrigParamIndex++;
     return true;

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -81,11 +81,15 @@ SILType SILType::getSILTokenType(const ASTContext &C) {
 }
 
 bool SILType::isTrivial(SILModule &M) const {
-  return M.getTypeLowering(*this).isTrivial();
+  return M.Types.getTypeLowering(*this,
+                                 ResilienceExpansion::Minimal)
+    .isTrivial();
 }
 
 bool SILType::isReferenceCounted(SILModule &M) const {
-  return M.getTypeLowering(*this).isReferenceCounted();
+  return M.Types.getTypeLowering(*this,
+                                 ResilienceExpansion::Minimal)
+    .isReferenceCounted();
 }
 
 bool SILType::isNoReturnFunction() const {
@@ -187,11 +191,12 @@ bool SILType::isLoadableOrOpaque(SILFunction *inFunction) const {
 /// address-only. For example, it could be a resilient struct or something of
 /// unknown size.
 bool SILType::isAddressOnly(SILModule &M) const {
-  return M.getTypeLowering(*this).isAddressOnly();
+  return M.Types.getTypeLowering(*this, ResilienceExpansion::Minimal)
+    .isAddressOnly();
 }
 
 bool SILType::isAddressOnly(SILFunction *inFunction) const {
-  return inFunction->getModule().getTypeLowering(*this,
+  return inFunction->getModule().Types.getTypeLowering(*this,
                         inFunction->getResilienceExpansion()).isAddressOnly();
 }
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -854,8 +854,8 @@ namespace {
       unsigned index = 0;
       for (auto elt : tupleTy.getElementTypes()) {
         auto silElt = SILType::getPrimitiveType(elt, silTy.getCategory());
-        // FIXME: Expansion
-        children.push_back(Child{index, M.Types.getTypeLowering(silElt)});
+        auto &eltTL = M.Types.getTypeLowering(silElt, getResilienceExpansion());
+        children.push_back(Child{index, eltTL});
         ++index;
       }
     }
@@ -888,9 +888,9 @@ namespace {
       assert(structDecl);
       
       for (auto prop : structDecl->getStoredProperties()) {
-        SILType propTy = silTy.getFieldType(prop, M);        
-        // FIXME: Expansion
-        children.push_back(Child{prop, M.Types.getTypeLowering(propTy)});
+        SILType propTy = silTy.getFieldType(prop, M);
+        auto &propTL = M.Types.getTypeLowering(propTy, getResilienceExpansion());
+        children.push_back(Child{prop, propTL});
       }
     }
   };

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -98,7 +98,8 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture) {
     if (var->isImmutable() &&
         (!SILModuleConventions(M).useLoweredAddresses() ||
          // FIXME: Expansion
-         !getTypeLowering(var->getType()).isAddressOnly()))
+         !getTypeLowering(var->getType(),
+                          ResilienceExpansion::Minimal).isAddressOnly()))
       return CaptureKind::Constant;
 
     // In-out parameters are captured by address.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -166,11 +166,6 @@ public:
 
   /// True if a function has been emitted for a given SILDeclRef.
   bool hasFunction(SILDeclRef constant);
-  
-  /// Get the lowered type for a Swift type.
-  SILType getLoweredType(Type t) {
-    return Types.getTypeLowering(t).getLoweredType();
-  }
 
   /// Get or create the declaration of a reabstraction thunk with the
   /// given signature.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5995,7 +5995,8 @@ static void collectFakeIndexParameters(SILGenModule &SGM,
   }
 
   // Use conventions that will produce a +1 value.
-  auto &tl = SGM.Types.getTypeLowering(substType);
+  auto &tl = SGM.Types.getTypeLowering(substType,
+                                       ResilienceExpansion::Minimal);
   ParameterConvention convention;
   if (tl.isFormallyPassedIndirectly()) {
     convention = ParameterConvention::Indirect_In;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3336,9 +3336,12 @@ lowerKeyPathSubscriptIndexTypes(
     if (sig) {
       indexTy = indexTy.subst(subscriptSubs);
     }
+
+    // FIXME: Expansion
     auto indexLoweredTy = SGM.Types.getLoweredType(
                                                 AbstractionPattern::getOpaque(),
-                                                indexTy);
+                                                indexTy,
+                                                ResilienceExpansion::Minimal);
     indexLoweredTy = indexLoweredTy.mapTypeOutOfContext();
     indexPatterns.push_back({indexTy->mapTypeOutOfContext()
                                     ->getCanonicalType(),

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -694,7 +694,7 @@ bool swift::ArraySemanticsCall::replaceByValue(SILValue V) {
     return false;
 
   SILBuilderWithScope Builder(SemanticsCall);
-  auto &ValLowering = Builder.getModule().getTypeLowering(V->getType());
+  auto &ValLowering = Builder.getTypeLowering(V->getType());
   if (hasGetElementDirectResult()) {
     ValLowering.emitCopyValue(Builder, SemanticsCall->getLoc(), V);
     SemanticsCall->replaceAllUsesWith(V);
@@ -756,7 +756,7 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
 
   for (SILValue V : Vals) {
     auto SubTy = V->getType();
-    auto &ValLowering = Builder.getModule().getTypeLowering(SubTy);
+    auto &ValLowering = Builder.getTypeLowering(SubTy);
     auto CopiedVal = ValLowering.emitCopyValue(Builder, Loc, V);
     auto *AllocStackInst = Builder.createAllocStack(Loc, SubTy);
 

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -365,7 +365,8 @@ computeNewArgInterfaceTypes(SILFunction *F,
     assert(paramBoxTy->getLayout()->getFields().size() == 1
            && "promoting compound box not implemented yet");
     auto paramBoxedTy = paramBoxTy->getFieldType(F->getModule(), 0);
-    auto &paramTL = Types.getTypeLowering(paramBoxedTy);
+    auto &paramTL = Types.getTypeLowering(paramBoxedTy,
+                                          ResilienceExpansion::Minimal);
     ParameterConvention convention;
     if (paramTL.isFormallyPassedIndirectly()) {
       convention = ParameterConvention::Indirect_In;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -544,8 +544,7 @@ ClosureCloner::visitStrongReleaseInst(StrongReleaseInst *Inst) {
     if (I != BoxArgumentMap.end()) {
       // Releases of the box arguments get replaced with ReleaseValue of the new
       // object type argument.
-      SILFunction &F = getBuilder().getFunction();
-      auto &typeLowering = F.getModule().getTypeLowering(I->second->getType());
+      auto &typeLowering = getBuilder().getTypeLowering(I->second->getType());
       SILBuilderWithPostProcess<ClosureCloner, 1> B(this, Inst);
       typeLowering.emitDestroyValue(B, Inst->getLoc(), I->second);
       return;
@@ -567,7 +566,7 @@ void ClosureCloner::visitDestroyValueInst(DestroyValueInst *Inst) {
       // Releases of the box arguments get replaced with an end_borrow,
       // destroy_value of the new object type argument.
       SILFunction &F = getBuilder().getFunction();
-      auto &typeLowering = F.getModule().getTypeLowering(I->second->getType());
+      auto &typeLowering = F.getTypeLowering(I->second->getType());
       SILBuilderWithPostProcess<ClosureCloner, 1> B(this, Inst);
 
       SILValue Value = I->second;
@@ -1240,6 +1239,7 @@ static SILFunction *
 processPartialApplyInst(SILOptFunctionBuilder &FuncBuilder,
                         PartialApplyInst *PAI, IndicesSet &PromotableIndices,
                         SmallVectorImpl<SILFunction*> &Worklist) {
+  SILFunction *F = PAI->getFunction();
   SILModule &M = PAI->getModule();
 
   auto *FRI = dyn_cast<FunctionRefInst>(PAI->getCallee());
@@ -1284,7 +1284,7 @@ processPartialApplyInst(SILOptFunctionBuilder &FuncBuilder,
     SILValue Box = PAI->getOperand(OpNo);
     SILValue Addr = getOrCreateProjectBoxHelper(Box);
 
-    auto &typeLowering = M.getTypeLowering(Addr->getType());
+    auto &typeLowering = F->getTypeLowering(Addr->getType());
     auto newCaptured =
         typeLowering.emitLoadOfCopy(B, PAI->getLoc(), Addr, IsNotTake);
     Args.push_back(newCaptured);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -841,7 +841,7 @@ void ApplyRewriter::canonicalizeResults(
       }
       SILBuilder B(destroyInst);
       B.setSILConventions(SILModuleConventions::getLoweredAddressConventions());
-      auto &TL = pass.F->getModule().getTypeLowering(result->getType());
+      auto &TL = pass.F->getTypeLowering(result->getType());
       TL.emitDestroyValue(B, destroyInst->getLoc(), result);
     }
     destroyInst->eraseFromParent();

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1154,7 +1154,9 @@ void AvailableValueDataflowContext::explodeCopyAddr(CopyAddrInst *CAI) {
   LLVM_DEBUG(llvm::dbgs() << "  -- Exploding copy_addr: " << *CAI << "\n");
 
   SILType ValTy = CAI->getDest()->getType().getObjectType();
-  auto &TL = getModule().getTypeLowering(ValTy);
+
+  SILFunction *F = CAI->getFunction();
+  auto &TL = F->getTypeLowering(ValTy);
 
   // Keep track of the new instructions emitted.
   SmallVector<SILInstruction *, 4> NewInsts;

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -452,8 +452,8 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
 
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "promoting multi-field box not implemented");
-  auto &Lowering = ABI->getModule()
-    .getTypeLowering(ABI->getBoxType()->getFieldType(ABI->getModule(), 0));
+  auto &Lowering = ABI->getFunction()
+    ->getTypeLowering(ABI->getBoxType()->getFieldType(ABI->getModule(), 0));
   auto Loc = CleanupLocation::get(ABI->getLoc());
 
   for (auto LastRelease : FinalReleases) {

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -72,6 +72,7 @@ STATISTIC(NumExpand, "Number of instructions expanded");
 ///     store %new to %1 : $*T
 static bool expandCopyAddr(CopyAddrInst *CA) {
   SILModule &M = CA->getModule();
+  SILFunction *F = CA->getFunction();
   SILValue Source = CA->getSrc();
 
   // If we have an address only type don't do anything.
@@ -95,7 +96,7 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
   // If our object type is not trivial, we may need to release the old value and
   // retain the new one.
 
-  auto &TL = M.getTypeLowering(SrcType);
+  auto &TL = F->getTypeLowering(SrcType);
 
   // If we have a non-trivial type...
   if (!TL.isTrivial()) {
@@ -136,6 +137,7 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
 }
 
 static bool expandDestroyAddr(DestroyAddrInst *DA) {
+  SILFunction *F = DA->getFunction();
   SILModule &Module = DA->getModule();
   SILBuilderWithScope Builder(DA);
 
@@ -155,7 +157,7 @@ static bool expandDestroyAddr(DestroyAddrInst *DA) {
     // If we have a type with reference semantics, emit a load/strong release.
     LoadInst *LI = Builder.createLoad(DA->getLoc(), Addr,
                                       LoadOwnershipQualifier::Unqualified);
-    auto &TL = Module.getTypeLowering(Type);
+    auto &TL = F->getTypeLowering(Type);
     using TypeExpansionKind = Lowering::TypeLowering::TypeExpansionKind;
     auto expansionKind = expand ? TypeExpansionKind::MostDerivedDescendents
                                 : TypeExpansionKind::None;
@@ -167,6 +169,7 @@ static bool expandDestroyAddr(DestroyAddrInst *DA) {
 }
 
 static bool expandReleaseValue(ReleaseValueInst *DV) {
+  SILFunction *F = DV->getFunction();
   SILModule &Module = DV->getModule();
   SILBuilderWithScope Builder(DV);
 
@@ -183,7 +186,7 @@ static bool expandReleaseValue(ReleaseValueInst *DV) {
   if (!shouldExpand(Module, Type.getObjectType()))
     return false;
 
-  auto &TL = Module.getTypeLowering(Type);
+  auto &TL = F->getTypeLowering(Type);
   TL.emitLoweredDestroyValueMostDerivedDescendents(Builder, DV->getLoc(),
                                                    Value);
 
@@ -194,6 +197,7 @@ static bool expandReleaseValue(ReleaseValueInst *DV) {
 }
 
 static bool expandRetainValue(RetainValueInst *CV) {
+  SILFunction *F = CV->getFunction();
   SILModule &Module = CV->getModule();
   SILBuilderWithScope Builder(CV);
 
@@ -210,7 +214,7 @@ static bool expandRetainValue(RetainValueInst *CV) {
   if (!shouldExpand(Module, Type.getObjectType()))
     return false;
 
-  auto &TL = Module.getTypeLowering(Type);
+  auto &TL = F->getTypeLowering(Type);
   TL.emitLoweredCopyValueMostDerivedDescendents(Builder, CV->getLoc(), Value);
 
   LLVM_DEBUG(llvm::dbgs() << "    Expanding Copy Value: " << *CV);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -376,7 +376,8 @@ static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
   SILBuilderWithScope Builder(DAI);
 
   auto Ty = DAI->getOperand()->getType();
-  auto &TL = DAI->getModule().getTypeLowering(Ty);
+  SILFunction *F = DAI->getFunction();
+  auto &TL = F->getTypeLowering(Ty);
 
   bool expand = shouldExpand(DAI->getModule(),
                              DAI->getOperand()->getType().getObjectType());

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -705,7 +705,7 @@ SILInstruction *CastOptimizer::simplifyCheckedCastAddrBranchInst(
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     if (shouldDestroyOnFailure(Inst->getConsumptionKind())) {
-      auto &srcTL = Builder.getModule().getTypeLowering(Src->getType());
+      auto &srcTL = Builder.getTypeLowering(Src->getType());
       srcTL.emitDestroyAddress(Builder, Loc, Src);
     }
     auto NewI = Builder.createBranch(Loc, FailureBB);
@@ -748,7 +748,7 @@ SILInstruction *CastOptimizer::simplifyCheckedCastAddrBranchInst(
     // is not used afterwards.
     if (ResultNotUsed) {
       if (shouldTakeOnSuccess(Inst->getConsumptionKind())) {
-        auto &srcTL = Builder.getModule().getTypeLowering(Src->getType());
+        auto &srcTL = Builder.getTypeLowering(Src->getType());
         srcTL.emitDestroyAddress(Builder, Loc, Src);
       }
       EraseInstAction(Inst);


### PR DESCRIPTION
This concludes the first phase of a refactoring. Previous PRs include:
- https://github.com/apple/swift/pull/22803
- https://github.com/apple/swift/pull/23004
- https://github.com/apple/swift/pull/23082

The next step is to look at each occurrence of `FIXME: Expansion` and pass in the right expansion.

https://bugs.swift.org/browse/SR-261, rdar://24057844