### PR TITLE
Change the algorithm for the AccessEnforcementDom pass.

### DIFF
--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -425,7 +425,7 @@ AccessedStorage swift::findAccessedStorage(SILValue sourceAddr) {
     }
     // `storage` may still be invalid. If both `storage` and `result` are
     // invalid, this check passes, but we return an invalid storage below.
-    if (!accessingIdenticalLocations(storage.getValue(), result.getStorage()))
+    if (!storage.getValue().hasIdenticalBase(result.getStorage()))
       return AccessedStorage();
   }
   return storage.getValueOr(AccessedStorage());

--- a/lib/SILOptimizer/Transforms/AccessEnforcementDom.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementDom.cpp
@@ -1,8 +1,8 @@
-//===--- AccessEnforcementDom.cpp - dominated access removal opt ---===//
+//===------ AccessEnforcementDom.cpp - dominated access removal opt -------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,10 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// This pass contains two optimizations:
+/// This function pass removes dominated accesses in two ways:
 ///
-/// 1) DominatedAccessRemoval:
-/// This function pass removes dynamic access enforcement based on dominance.
+/// 1) Remove accesses dominated by an existing access
 ///
 /// General case:
 /// begin_access A (may or may not have no_nested_conflict)
@@ -26,8 +25,7 @@
 ///
 /// The second access scope does not need to be emitted.
 ///
-/// 2) LoopDominatingAccessAdder:
-/// This function pass adds new dominating accesses to loop's dynamic accesses
+/// 2) Add a new dominating accesses to loop's preheader
 ///
 /// General case:
 /// <loop preheader>
@@ -38,21 +36,15 @@
 /// Adding an empty begin_access A in the preheader would allow us to
 /// turn the loop's access to [static]
 ///
-/// Note 1: This optimization must be aware of all possible access to a Class or
-/// Global address. This includes unpaired access instructions and keypath
-/// entry points. Ignoring any access pattern would weaken enforcement.
+/// Warning: This optimization requires that all points within this function
+/// that begin an access can be identified. Failure to recognize the beginning
+/// of an access scope could weaken dynamic enforcement.
 ///
-/// Note 2: We either need to also flag the dominating access specially, or,
-/// we need to do this in the last-chance pipeline, with a guarantee that no,
-/// access marker removal is done after it.
-///
-/// Note 3: LoopDominatedAccessAdder makes some key assumptions:
-/// 1) Precondition: There are no unpaired accesses (or keypath accesses)
-///    anywhere in the function.
-/// 2) Invariant: An access scope cannot begin outside the loop and end on any
-///    path between the loop header and the original dominated access.
-/// 3) Expectation: Accesses will be hoisted across nested loops during
-///    bottom-up processing.
+/// FIXME: This pass currently only runs in the last-chance pipeline, with a
+/// guarantee that no access marker removal is done after it. This happens to
+/// work but is dangerous and violates SIL semantics. We should instead add a
+/// flag for accesses to give them the semantics that they may guard memory
+/// operations other than those enclosed by the access scope.
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "access-enforcement-dom"
@@ -65,416 +57,548 @@
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/Local.h"
-
-#define _MAX_ACCESS_DOM_OPT_RECURSION_DEPTH 100
-#define _MAX_ACCESS_DOM_OPT_UNIQUE_STORAGE_LOCS 42
+#include "llvm/ADT/DepthFirstIterator.h"
 
 using namespace swift;
 
+// =============================================================================
+// DominatedAccessAnalysis
+
+namespace swift {
+/// Information about each dynamic access with valid storage.
+///
+/// This is a pass-specific subclass of AccessedStorage with identical layout.
+/// An instance is created for each BeginAccess in the current function. In
+/// additional to identifying the access' storage location, it associates that
+/// access with pass-specific data in reserved bits. The reserved bits do not
+/// participate in equality or hash lookup.
+class DomAccessedStorage : public AccessedStorage {
+public:
+  DomAccessedStorage() {}
+
+  explicit DomAccessedStorage(const AccessedStorage &storage)
+      : AccessedStorage(storage) {
+    Bits.DomAccessedStorage.isInner = false;
+    Bits.DomAccessedStorage.containsRead = false;
+  }
+
+  // Is this dynamic, identifiable access scope potentially contained within any
+  // kind of outer scope. The outer scope may be static and/or have unidentified
+  // storage. For example:
+  //
+  // A1: [static] [read]
+  // A2: [dynamic] [read]
+  // A3: [dynamic] [modify]
+  //
+  // A2 cannot be promoted to modify if its scope overlaps with A1.
+  bool isInner() const { return Bits.DomAccessedStorage.isInner; }
+
+  void setIsInner() { Bits.DomAccessedStorage.isInner = true; }
+
+  /// Is this dynamic, identifiable access scope a [read], and does it
+  /// potentially contain another non-distinct [read] access of any kind?
+  bool containsRead() const { return Bits.DomAccessedStorage.containsRead; }
+
+  void setContainsRead() { Bits.DomAccessedStorage.containsRead = true; }
+
+  void dump() const {
+    AccessedStorage::dump();
+    llvm::dbgs() << "<" << (isInner() ? "" : "inner")
+                 << (containsRead() ? "" : "containsRead") << ">\n";
+  }
+};
+} // namespace swift
+
 namespace {
-class DominatedAccessRemoval {
+// An analysis that maps each valid dynamic BeginAccess to
+// DomAccessedStorage. Performs a trivial data flow analysis to populate the map
+// with information about nested accesses. Data flow is needed to track open
+// access scopes, but only flow-insensitive information is recorded in the
+// result.
+//
+// Note that all access scopes are tracked during data flow, but only valid
+// dynamic are mapped to results.
+//
+// TODO: Separate this into a shared analysis and factor it with
+// AccessEnforcementOpts. The optimization that merges accesses would also
+// benefit.
+//
+// TODO: This could be made more precise by querying AccessedStorageAnalysis.
+class DominatedAccessAnalysis {
 public:
-  using AccessedStoragePair = std::pair<BeginAccessInst *, AccessedStorage>;
-  using AccessedStorageInfo = llvm::SmallVector<AccessedStoragePair, 32>;
-  using DominatedInstVec = llvm::SmallVector<BeginAccessInst *, 32>;
-  using KeyPathEntryPointsSet = llvm::SmallSet<SILInstruction *, 8>;
-
-public:
-  DominatedAccessRemoval(SILFunction &func, DominanceInfo *domInfo)
-      : func(func), domInfo(domInfo) {}
-
-  bool perform();
-
-protected:
-  bool visitInstruction(SILInstruction *instr,
-                        AccessedStorageInfo &visitedDomAccessesToStorageInfo);
-  void visitBeginAccess(BeginAccessInst *beginAccess, AccessedStorage storage,
-                        AccessedStorageInfo &visitedDomAccessesToStorageInfo);
-  bool analyzeDomSubTree(SILBasicBlock *block,
-                         AccessedStorageInfo &visitedDomAccessesToStorageInfo,
-                         size_t recursionDepth);
-
-  bool analyze();
-  void optimize();
+  // The result records information for all dynamic accesses in this
+  // function. If an UnpairedAccess exists, then the result will be
+  // consevatively empty.
+  struct Result {
+    llvm::SmallDenseMap<BeginAccessInst *, DomAccessedStorage, 32> accessMap;
+  };
 
 private:
-  SILFunction &func;
-  DominanceInfo *domInfo;
-  // domInstrs is a vector of Dominated begin_access instructions.
-  // the accesses are dynamic, and the Dominated one has no nested conflict
-  // we can turn the dominated to static during the optimize() phase
-  DominatedInstVec domInstrs;
-};
-} // namespace
+  // The data flow state for each block. It is only valid between the time at
+  // least one predecesor block has been finished and before its own block
+  // has been finished.
+  //
+  // The isBottom flag allows the analysis to avoid quadratic behavior where
+  // each open access must be updated at each conservatively handled
+  // instruction. Instead, the accesses are only conservatively updated once
+  // until the next scope is entered. So the complexity is (#OpenScopes)^2
+  // instead of (#OpenScopes)*(#Applies).
+  struct BBState {
+    using DenseAccessSet = llvm::SmallDenseSet<BeginAccessInst *, 4>;
+    using DenseCoroutineSet = llvm::SmallDenseSet<BeginApplyInst *, 4>;
 
-// Returns a bool: If we should bail on this function
-// we return false - else true
-// See the discussion in DominatedAccessRemoval::analyze() below
-//
-// FIXME: Handle KeyPath access.
-bool DominatedAccessRemoval::visitInstruction(
-    SILInstruction *instr,
-    AccessedStorageInfo &visitedDomAccessesToStorageInfo) {
-  if (auto *BAI = dyn_cast<BeginAccessInst>(instr)) {
-    if (BAI->getEnforcement() != SILAccessEnforcement::Dynamic) {
-      return true;
-    }
-    AccessedStorage storage = findAccessedStorageNonNested(BAI->getSource());
-    if (!storage) {
-      return true;
-    }
-
-    visitBeginAccess(BAI, storage, visitedDomAccessesToStorageInfo);
-  } else if (auto *BUAI = dyn_cast<BeginUnpairedAccessInst>(instr)) {
-    // We have an Implementation that handles this in the analyzer
-    // and optimizer in a previous commit, However,
-    // In order to simplify the code, at least in the initial version,
-    // We decided to just bail on these extremely rare cases
-    return false;
-  }
-  return true;
-}
-
-static EndAccessInst *getSingleEndAccess(BeginAccessInst *inst) {
-  EndAccessInst *end = nullptr;
-  for (auto *currEnd : inst->getEndAccesses()) {
-    if (end == nullptr)
-      end = currEnd;
-    else
-      return nullptr;
-  }
-  return end;
-}
-
-void DominatedAccessRemoval::visitBeginAccess(
-    BeginAccessInst *beginAccess, AccessedStorage storage,
-    AccessedStorageInfo &visitedDomAccessesToStorageInfo) {
-  if (!storage.isUniquelyIdentifiedOrClass()) {
-    // No cannot do anything about this location -
-    // bail on trying to turn it to static
-    return;
-  }
-
-  // checks if the current storage has never been seen before
-  auto predNewStorageLoc = [&](AccessedStoragePair it) {
-    auto currStorage = it.second;
-    return !currStorage.isDistinctFrom(storage);
+    DenseAccessSet inScopeAccesses;
+    DenseCoroutineSet inScopeCoroutines;
+    bool isBottom = false;
   };
-  // The size of this list should be tiny: number of storage locations
-  auto visitedAccessesIt =
-      std::find_if(visitedDomAccessesToStorageInfo.begin(),
-                   visitedDomAccessesToStorageInfo.end(), predNewStorageLoc);
+  using BlockStateMap = llvm::DenseMap<SILBasicBlock *, BBState>;
 
-  if (visitedAccessesIt == visitedDomAccessesToStorageInfo.end()) {
-    // We've never seen this one before - just add it and return
-    visitedDomAccessesToStorageInfo.push_back(
-        std::make_pair(beginAccess, storage));
-    return;
-  }
+  PostOrderFunctionInfo *PO;
 
-  // If the currnet access has nested conflict,
-  // we can't remove it by finding a dominating access
-  if (!beginAccess->hasNoNestedConflict()) {
-    return;
-  }
+  Result result; // Flow-insensitive analysis result.
 
-  // check that the storage we found is identical to the
-  // one we found in order to enable optimization
-  auto parentStorage = visitedAccessesIt->second;
-  if (!parentStorage.hasIdenticalBase(storage)) {
-    return;
-  }
-
-  auto *parentBegin = visitedAccessesIt->first;
-
-  // If this beginAccess is a modify, and is nested inside parent
-  // then we have to bail: can't change it to static
-  // If, on the other hand, it is a read, we can continue.
-  if (beginAccess->getAccessKind() >= SILAccessKind::Modify) {
-    auto *endP = getSingleEndAccess(parentBegin);
-    if (!endP) {
-      return;
-    }
-    if (!domInfo->properlyDominates(endP, beginAccess)) {
-      return;
-    }
-  }
-
-  if (beginAccess->getAccessKind() > parentBegin->getAccessKind()) {
-    // we can't change to static: dominating access has a > access kind
-    // change parent's access kind so we would be able to do so
-    parentBegin->setAccessKind(beginAccess->getAccessKind());
-  }
-
-  domInstrs.push_back(beginAccess);
-}
-
-bool DominatedAccessRemoval::analyzeDomSubTree(
-    SILBasicBlock *block, AccessedStorageInfo &visitedDomAccessesToStorageInfo,
-    size_t recursionDepth) {
-  if (recursionDepth > _MAX_ACCESS_DOM_OPT_RECURSION_DEPTH) {
-    return false;
-  }
-  // We will modify the incoming visitedDomAccessesToStorageInfo,
-  // after finishing with the sub-tree,
-  // we need to restore it to its previous state.
-  // the state should be small because the number of unique storage
-  // locations, which is the size of the data structure,
-  // should be quite small. a handful at most.
-  auto numOfElems = visitedDomAccessesToStorageInfo.size();
-  if (numOfElems > _MAX_ACCESS_DOM_OPT_UNIQUE_STORAGE_LOCS) {
-    return false;
-  }
-
-  // analyze the current block:
-  for (auto &instr : *block) {
-    if (!visitInstruction(&instr, visitedDomAccessesToStorageInfo))
-      return false;
-  }
-  // do the same for each child:
-  auto *domNode = domInfo->getNode(block);
-  for (auto *child : *domNode) {
-    if (!analyzeDomSubTree(child->getBlock(), visitedDomAccessesToStorageInfo,
-                           recursionDepth + 1))
-      return false;
-  }
-
-  // Restore the sets to their previous state as described above,
-  // removing all "new" elements
-  assert(visitedDomAccessesToStorageInfo.size() >= numOfElems &&
-         "Expected the size of visitedStorageLocs to be the same or higher");
-  auto rmInfoStart = visitedDomAccessesToStorageInfo.begin() + numOfElems;
-  visitedDomAccessesToStorageInfo.erase(rmInfoStart,
-                                        visitedDomAccessesToStorageInfo.end());
-  assert(visitedDomAccessesToStorageInfo.size() == numOfElems &&
-         "Number of elems should stay the same");
-  return true;
-}
-
-// Finds domPairs for which we can change the dominated instruction to static
-// NOTE: We might not be able to optimize some the pairs due to other
-// restrictions Such as key-path or unpaired begin access. We only traverse the
-// function once, if we find a pattern that *might* prevent optimization, we
-// just add it to appropriate data structures which will be analyzed later.
-// If we should bail on this function we return false - else true
-// we bail to simplify the code instead of handling unpaired accesses
-// in the optimize phase
-bool DominatedAccessRemoval::analyze() {
-  SILBasicBlock *entry = &func.front();
-  AccessedStorageInfo visitedDomAccessesToStorageInfo;
-
-  return analyzeDomSubTree(entry, visitedDomAccessesToStorageInfo,
-                           0 /*recursion-depth*/);
-}
-
-// Sets the dominated instruction to static.
-// Goes through the data structures initialized by the analysis method
-// and makes sure we are not Weakening enforcement
-void DominatedAccessRemoval::optimize() {
-  for (BeginAccessInst *dominatedInstr : domInstrs) {
-    LLVM_DEBUG(llvm::dbgs() << "Processing optimizable dominated instruction: "
-                            << dominatedInstr << "\n");
-    LLVM_DEBUG(llvm::dbgs() << "Setting " << *dominatedInstr
-                            << " access enforcement to static\n");
-    dominatedInstr->setEnforcement(SILAccessEnforcement::Static);
-  }
-}
-
-// Returns a bool: If we should bail on this function
-// we return false - else true
-bool DominatedAccessRemoval::perform() {
-  if (func.empty())
-    return false;
-
-  if (!analyze()) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Bailed on function: " << func.getName() << "\n");
-    return false;
-  }
-  optimize();
-  return true;
-}
-
-namespace {
-class LoopDominatingAccessAdder {
-  SmallVector<SILLoop *, 8> bottomUpWorkList;
-  DominanceInfo *domInfo;
+  BlockStateMap blockStateMap; // Data flow state.
 
 public:
-  LoopDominatingAccessAdder(SILLoop *topLevelLoop, DominanceInfo *domInfo)
-      : domInfo(domInfo) {
-    // Collect loops for a recursive bottom-up traversal in the loop tree.
-    bottomUpWorkList.push_back(topLevelLoop);
-    for (unsigned i = 0; i < bottomUpWorkList.size(); ++i) {
-      auto *loop = bottomUpWorkList[i];
-      for (auto *subLoop : *loop) {
-        bottomUpWorkList.push_back(subLoop);
-      }
-    }
-  }
+  DominatedAccessAnalysis(PostOrderFunctionInfo *PO) : PO(PO) {}
 
-  void perform();
+  Result analyze() &&;
 
 protected:
-  /// Collect a set of instructions that can be dominated
-  void
-  analyzeCurrentLoop(SILLoop *currentLoop,
-                     SmallVectorImpl<BeginAccessInst *> &dominatableInstrVec);
-
-  /// Optimize the current loop nest.
-  void optimizeLoop(SILLoop *currnetLoop,
-                    SmallVectorImpl<BeginAccessInst *> &dominatableInstrVec);
+  void setBottom(BBState &state);
+  void analyzeAccess(BeginAccessInst *BAI, BBState &state);
 };
 } // namespace
 
-void LoopDominatingAccessAdder::analyzeCurrentLoop(
-    SILLoop *currentLoop,
-    SmallVectorImpl<BeginAccessInst *> &dominatableInstrVec) {
-  auto *preheader = currentLoop->getLoopPreheader();
-  if (!preheader) {
-    // Can't dominate this loop - bail
+// Set information for all in-scope accesses to the worst case "bottom".
+// The isInner flag is not affected because it only applies to scopes inside the
+// currently open scopes, not the currently open scopes themselves.
+void DominatedAccessAnalysis::setBottom(BBState &state) {
+  if (state.isBottom)
     return;
-  }
-  for (auto *block : currentLoop->getBlocks()) {
-    for (auto &instr : *block) {
-      auto *beginAccess = dyn_cast<BeginAccessInst>(&instr);
-      if (!beginAccess) {
-        continue;
-      }
-      if (beginAccess->getEnforcement() != SILAccessEnforcement::Dynamic) {
-        continue;
-      }
-      if (!beginAccess->hasNoNestedConflict()) {
-        continue;
-      }
-      auto operand = beginAccess->getOperand();
-      auto *parentBB = operand->getParentBlock();
-      if (currentLoop->contains(parentBB)) {
-        // Loop varaint argument
-        continue;
-      }
-      if (!domInfo->properlyDominates(parentBB, preheader) &&
-          parentBB != preheader) {
-        // Argument not dominated by the preheader
-        // TODO: Should this be a fatal error? Invalid control flow?
-        continue;
-      }
-      dominatableInstrVec.push_back(beginAccess);
-    }
-  }
+
+  // Unordered iteration over the in-access scopes.
+  llvm::for_each(state.inScopeAccesses, [this](BeginAccessInst *BAI) {
+    if (auto &domStorage = result.accessMap[BAI])
+      domStorage.setContainsRead();
+  });
 }
 
-void LoopDominatingAccessAdder::optimizeLoop(
-    SILLoop *currnetLoop,
-    SmallVectorImpl<BeginAccessInst *> &dominatableInstrVec) {
-  auto *preheader = currnetLoop->getLoopPreheader();
-  if (!preheader) {
-    // Can't dominate this loop - bail
-    return;
-  }
-  // Get the last instruction in the pre-header, this is
-  // We insert new access scopes before it.
-  // We also use it for our currently-optimizeable begin_access:
-  // We can only create a dominating scope if the
-  // dominatableInstr's operand dominates this instruction:
-  TermInst *preheaderTerm = preheader->getTerminator();
-
-  // Same operand may appear more than once in dominatableInstrVec
-  // No reason to create multiple dominating instructions
-  // The following set keeps track of operands we can safely skip
-  // i.e. we already created a dominating begin_access for
-  // We also need to keep track of the new dominating begin_access:
-  // First inner loop access might be [read] while a second one
-  // Might be [modify], the dominating access should be [modify]
-  // in that case
-  llvm::SmallDenseMap<SILValue, BeginAccessInst *> domOpToBeginAccess;
-
-  while (!dominatableInstrVec.empty()) {
-    BeginAccessInst *beginAccess = dominatableInstrVec.pop_back_val();
-    auto operand = beginAccess->getOperand();
-    auto domIt = domOpToBeginAccess.find(operand);
-    if (domIt != domOpToBeginAccess.end()) {
-      BeginAccessInst *domBegin = domIt->getSecond();
-      if (domBegin->getAccessKind() < beginAccess->getAccessKind()) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "Changing " << *domBegin << " access kind to "
-                   << *beginAccess << " access kind\n");
-        domBegin->setAccessKind(beginAccess->getAccessKind());
+// Perform the analysis and return the Result, relinquishing internal state.
+DominatedAccessAnalysis::Result DominatedAccessAnalysis::analyze() && {
+  // A single RPO traversal is sufficient to visit access scopes in order. The
+  // set of open accesses entering a block cannot grow as a result of loops, and
+  // within an open scope the results are flow-insensitive.
+  for (auto *BB : PO->getReversePostOrder()) {
+    BBState state = blockStateMap[BB];
+    for (auto &I : *BB) {
+      if (auto *BAI = dyn_cast<BeginAccessInst>(&I)) {
+        analyzeAccess(BAI, state);
+        continue;
       }
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Already have a dominating access scope for: "
-                 << *beginAccess
-                 << ", settting the inner access' enforcement to static\n");
-      beginAccess->setEnforcement(SILAccessEnforcement::Static);
-      continue;
+      if (auto *EAI = dyn_cast<EndAccessInst>(&I)) {
+        bool erased = state.inScopeAccesses.erase(EAI->getBeginAccess());
+        (void)erased;
+        assert(erased);
+        continue;
+      }
+      // Check for BeginApply before checking FullApplySite below.
+      if (auto *beginApply = dyn_cast<BeginApplyInst>(&I)) {
+        auto iterAndInserted = state.inScopeCoroutines.insert(beginApply);
+        (void)iterAndInserted;
+        assert(iterAndInserted.second);
+        continue;
+      }
+      if (auto *endApply = dyn_cast<EndApplyInst>(&I)) {
+        bool erased = state.inScopeCoroutines.erase(endApply->getBeginApply());
+        (void)erased;
+        assert(erased);
+        continue;
+      }
+      if (FullApplySite::isa(&I)) {
+        setBottom(state);
+        continue;
+      }
+      if (isa<BeginUnpairedAccessInst>(&I)) {
+        // Unpaired accesses could be tracked, but are ignored because they are
+        // mostly irrelevant and hard to test. Rather than making the results
+        // conservative, we return an empty result.
+        result.accessMap.clear();
+        return std::move(result);
+      }
     }
-    // We can go ahead with the optimization - do so:
-    SILBuilderWithScope scopeBuilder(preheaderTerm);
-    BeginAccessInst *newBegin = scopeBuilder.createBeginAccess(
-        beginAccess->getLoc(), operand, beginAccess->getAccessKind(),
-        SILAccessEnforcement::Dynamic, true /*no nested conflict*/,
-        beginAccess->isFromBuiltin());
-    scopeBuilder.createEndAccess(beginAccess->getLoc(), newBegin, false);
-    domOpToBeginAccess.insert(std::make_pair(operand, newBegin));
+    auto successors = BB->getTerminator()->getSuccessors();
+    unsigned numSucc = successors.size();
+    for (unsigned succIdx : indices(successors)) {
+      SILBasicBlock *succBB = successors[succIdx].getBB();
+      if (succBB == BB)
+        continue;
+
+      if (succIdx != numSucc - 1)
+        blockStateMap.try_emplace(succBB, state);
+      else
+        // Move the state into the last successor to avoid copying sets.
+        blockStateMap.try_emplace(succBB, std::move(state));
+    }
+  }
+  return std::move(result);
+}
+
+// The data flow transfer function for BeginAccess. Creates the
+// DomAccessedStorage for this access and inserts it in the result.
+void DominatedAccessAnalysis::analyzeAccess(BeginAccessInst *BAI,
+                                            BBState &state) {
+  DomAccessedStorage domStorage;
+  // Only track dynamic access in the result. Static accesses still need to be
+  // tracked by data flow, but they can't be optimized as "dominating".
+  if (BAI->getEnforcement() == SILAccessEnforcement::Dynamic) {
+    AccessedStorage storage = findAccessedStorageNonNested(BAI->getSource());
+    // Copy the AccessStorage into DomAccessedStorage. All pass-specific bits
+    // are initialized to zero.
+    domStorage = DomAccessedStorage(storage);
+  }
+  // Continue to handle both untracked access and invalid domStorage
+  // conservatively below...
+
+  // unordered set iteration...
+  llvm::for_each(state.inScopeAccesses, [&](BeginAccessInst *outerBegin) {
+    auto &outerInfo = result.accessMap[outerBegin];
+    // If the current access is mapped, set its isInner flag.
+    if (domStorage && !domStorage.isInner()) {
+      if (domStorage.isDistinctFrom(outerInfo))
+        return;
+
+      domStorage.setIsInner();
+    }
+    // The results for tracked in-scope accesses still need to be
+    // updated even if the current access is not be tracked.
+    if (outerInfo && BAI->getAccessKind() == SILAccessKind::Read
+        && outerBegin->getAccessKind() == SILAccessKind::Read) {
+      outerInfo.setContainsRead();
+    }
+  });
+  // Track this access even if it is invalid or unmapped.
+  {
+    auto iterAndInserted = state.inScopeAccesses.insert(BAI);
+    (void)iterAndInserted;
+    assert(iterAndInserted.second);
+  }
+  // Update the results if this access will be mapped.
+  if (!domStorage)
+    return;
+
+  // Set the current accesss isInner flag if it's inside a coroutine scope.
+  if (!state.inScopeCoroutines.empty())
+    domStorage.setIsInner();
+
+  // Map the current access.
+  {
+    auto iterAndInserted = result.accessMap.try_emplace(BAI, domStorage);
+    (void)iterAndInserted;
+    assert(iterAndInserted.second);
+  }
+  state.isBottom = false;
+}
+
+// =============================================================================
+// DominatedAccessRemoval optimization.
+
+namespace {
+using DomTreeNode = llvm::DomTreeNodeBase<SILBasicBlock>;
+
+// Visit the dominator tree top down, tracking the current set of dominating
+// dynamic accesses. Dominated dynamic accesses with identical storage are
+// marked static during traversal. If a dynamic access inside a loop has no
+// dominating access, insert a new access in the preheader.
+class DominatedAccessRemoval {
+  // Record the first access of a given storage location and the dominator node
+  // in which the access occurred.
+  struct DominatingAccess {
+    BeginAccessInst *beginAccess;
+    DomTreeNode *domNode;
+
+    DominatingAccess(BeginAccessInst *beginAccess, DomTreeNode *domNode)
+        : beginAccess(beginAccess), domNode(domNode) {}
+  };
+  using StorageToDomMap = llvm::DenseMap<AccessedStorage, DominatingAccess>;
+
+  SILFunction &func;
+  DominanceInfo *domInfo;
+  SILLoopInfo *loopInfo;
+  DominatedAccessAnalysis::Result &DAA;
+
+  // Hash map from each storage location to the dominating access.
+  StorageToDomMap storageToDomMap;
+
+  DomTreeNode *currDomNode = nullptr;
+
+  bool hasChanged = false;
+
+public:
+  DominatedAccessRemoval(SILFunction &func, DominanceInfo *domInfo,
+                         SILLoopInfo *loopInfo,
+                         DominatedAccessAnalysis::Result &DAA)
+      : func(func), domInfo(domInfo), loopInfo(loopInfo), DAA(DAA) {}
+
+  bool optimize();
+
+protected:
+  void visitBeginAccess(BeginAccessInst *BAI);
+  bool checkDominatedAccess(BeginAccessInst *BAI,
+                            DomAccessedStorage currDomStorage);
+  bool optimizeDominatedAccess(BeginAccessInst *currBegin,
+                               DomAccessedStorage currDomStorage,
+                               const DominatingAccess &domAccess);
+  void tryInsertLoopPreheaderAccess(BeginAccessInst *BAI,
+                                    DomAccessedStorage currDomStorage);
+};
+} // namespace
+
+// Optimize the current function, and return true if any optimization was
+// performed.
+bool DominatedAccessRemoval::optimize() {
+  DomTreeNode *entryNode = domInfo->getNode(func.getEntryBlock());
+  for (DomTreeNode *domNode : llvm::depth_first(entryNode)) {
+    currDomNode = domNode;
+
+    // Optimize dominated accesses in this block.
+    for (auto &instr : *domNode->getBlock()) {
+      if (auto *BAI = dyn_cast<BeginAccessInst>(&instr))
+        visitBeginAccess(BAI);
+    }
+  }
+  return hasChanged;
+}
+
+// Visit a BeginAccessInst once-and-only-once in domtree order.
+// Attempt to find a dominating access with identical storage.
+// If that fails, attempt to insert a new dominating access in the preheader.
+void DominatedAccessRemoval::visitBeginAccess(BeginAccessInst *BAI) {
+  if (BAI->getEnforcement() != SILAccessEnforcement::Dynamic)
+    return;
+
+  DomAccessedStorage currDomStorage = DAA.accessMap.lookup(BAI);
+  if (!currDomStorage)
+    return;
+
+  // Only track "identifiable" storage.
+  if (currDomStorage.isUniquelyIdentifiedOrClass()) {
+    if (checkDominatedAccess(BAI, currDomStorage))
+      return;
+  }
+  tryInsertLoopPreheaderAccess(BAI, currDomStorage);
+}
+
+// Track this identifiable dynamic access in storageToDomMap, and optimize it if
+// possible. Return true if the optimization suceeds.
+bool DominatedAccessRemoval::checkDominatedAccess(
+    BeginAccessInst *BAI, DomAccessedStorage currDomStorage) {
+  // Attempt to add this access to storageToDomMap using its base storage
+  // location as the key.
+  //
+  // Cast this DomAccessedStorage back to a plain storage location. The
+  // pass-specific bits will be ignored, but reset them anyway for sanity.
+  AccessedStorage storage = static_cast<AccessedStorage>(currDomStorage);
+  storage.resetSubclassData();
+  auto iterAndInserted =
+      storageToDomMap.try_emplace(storage, DominatingAccess(BAI, currDomNode));
+  if (iterAndInserted.second)
+    return false;
+
+  // An access has already been recorded for this storage.
+  // If the previous domNode does not dominate currDomNode, then replace it.
+  DominatingAccess &domAccess = iterAndInserted.first->second;
+  if (!domInfo->dominates(domAccess.domNode, currDomNode)) {
+    domAccess = DominatingAccess(BAI, currDomNode);
+    return false;
+  }
+  // The previously mapped access still dominates this block, so the current
+  // access can potentially be optimized.
+  return optimizeDominatedAccess(BAI, currDomStorage, domAccess);
+}
+
+// If possible, optimize the current access by converting it to [static]. Return
+// true if the optimization succeeds.
+//
+// This function is not allowed to add or erase instructions, only change
+// instruction flags.
+//
+// The four required conditions for converting this access to static are:
+//
+// 1. A closed dominating access has identical storage.
+//
+// The caller looked up this access' storage in storageToDomMap and checked
+// that the previously seen access dominates this block. As long as this access'
+// isInner flag from DominatedAccessAnalysis is not set, the dominating access
+// must be closed.
+//
+// 2. There is no open (overlapping) access with nondistinct storage (that isn't
+// also open at the dominating access).
+//
+// The isInner flag from DominatedAccessAnalysis indicates no enclosing
+// nondistinct scopes within this function. Any outer scope would enclose the
+// whole function, thereby also enclosing the dominating scope.
+//
+// 3. This access has no_nested_conflict.
+//
+// This is a direct check on this BeginAccessInst flag.
+//
+// 4. The current and dominating access kinds are compatible:
+//
+// read -> read: OK
+//
+// modify -> read: OK
+//
+// modify -> modify: OK
+//
+// read -> modify: Requires promoting the dominating access to a modify. This
+// can be done as long as the dominating access does not contain another
+// non-distinct read and isn't contained by another non-distinct read. The
+// containsRead and isInner flags from in DominatedAccessAnalysis answer this
+// conservatively.
+bool DominatedAccessRemoval::optimizeDominatedAccess(
+    BeginAccessInst *BAI, DomAccessedStorage currAccessInfo,
+    const DominatingAccess &domAccess) {
+  // 1. and 2. If any nondistinct scopes are open, it must remain dynamic.
+  if (currAccessInfo.isInner())
+    return false;
+
+  // 3. If BAI may have a nested conflict, it must remain dynamic.
+  if (!BAI->hasNoNestedConflict())
+    return false;
+
+  // 4. Promoting a read to a modify is only safe with no nested reads.
+  if (domAccess.beginAccess->getAccessKind() == SILAccessKind::Read
+      && BAI->getAccessKind() == SILAccessKind::Modify) {
+    DomAccessedStorage domStorage = DAA.accessMap[domAccess.beginAccess];
+    if (domStorage.containsRead() || domStorage.isInner())
+      return false;
+
     LLVM_DEBUG(llvm::dbgs()
-               << "Created a dominating access scope for: " << *beginAccess
-               << ", settting the inner access' enforcement to static\n");
-    beginAccess->setEnforcement(SILAccessEnforcement::Static);
+               << "Promoting to modify: " << *domAccess.beginAccess << "\n");
+    domAccess.beginAccess->setAccessKind(SILAccessKind::Modify);
   }
+  LLVM_DEBUG(llvm::dbgs() << "Setting static enforcement: " << *BAI << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "Dominated by: " << *domAccess.beginAccess
+                          << "\n");
+  BAI->setEnforcement(SILAccessEnforcement::Static);
+
+  hasChanged = true;
+  return true;
 }
 
-void LoopDominatingAccessAdder::perform() {
-  // Process loops bottom up in the loop tree.
-  while (!bottomUpWorkList.empty()) {
-    SILLoop *currnetLoop = bottomUpWorkList.pop_back_val();
-    LLVM_DEBUG(llvm::dbgs() << "Processing loop " << *currnetLoop);
+// Attempt to insert a new access in the loop preheader. If successful, insert
+// the new access in DominatedAccessAnalysis so it can be used to dominate other
+// accesses. Also convert the current access to static and update the current
+// storageToDomMap since the access may already have been recorded (when it was
+// still dynamic).
+//
+// This function cannot add or remove instructions in the current block, but
+// may add instructions to the current loop's preheader.
+//
+// The required conditions for inserting a new dominating access are:
+//
+// 1. The new preheader access is not enclosed in another scope that doesn't
+// also enclose the current scope.
+//
+// This is inferred from the loop structure; any scope that encloses the
+// preheader must also enclose the entire loop.
+//
+// 2. The current access is not enclosed in another scope that doesn't also
+// enclose the preheader.
+//
+// As before, it is sufficient to check this access' isInner flags in
+// DominatedAccessAnalysis; if this access isn't enclosed by any scope within
+// the function, then it can't be enclosed within a scope inside the loop.
+//
+// 3. The current header has no nested conflict within its scope.
+//
+// 4. The access' source operand is available in the loop preheader.
+void DominatedAccessRemoval::tryInsertLoopPreheaderAccess(
+    BeginAccessInst *BAI, DomAccessedStorage currAccessInfo) {
+  // 2. the current access may be enclosed.
+  if (currAccessInfo.isInner())
+    return;
 
-    llvm::SmallVector<BeginAccessInst *, 8> dominatableInstrVec;
-    analyzeCurrentLoop(currnetLoop, dominatableInstrVec);
-    optimizeLoop(currnetLoop, dominatableInstrVec);
+  // 3. the current access must be instantaneous.
+  if (!BAI->hasNoNestedConflict())
+    return;
+
+  SILLoop *currLoop = loopInfo->getLoopFor(BAI->getParent());
+  if (!currLoop)
+    return;
+  SILBasicBlock *preheader = currLoop->getLoopPreheader();
+  if (!preheader)
+    return;
+
+  // 4. The source operand must be available in the preheader.
+  auto sourceOperand = BAI->getOperand();
+  auto *sourceBB = sourceOperand->getParentBlock();
+  if (!domInfo->dominates(sourceBB, preheader))
+    return;
+
+  // Insert a new access scope immediately before the
+  // preheader's terminator.
+  TermInst *preheaderTerm = preheader->getTerminator();
+  SILBuilderWithScope scopeBuilder(preheaderTerm);
+  BeginAccessInst *newBegin = scopeBuilder.createBeginAccess(
+      preheaderTerm->getLoc(), sourceOperand, BAI->getAccessKind(),
+      SILAccessEnforcement::Dynamic, true /*no nested conflict*/,
+      BAI->isFromBuiltin());
+  scopeBuilder.createEndAccess(preheaderTerm->getLoc(), newBegin, false);
+  LLVM_DEBUG(llvm::dbgs() << "Created loop preheader access: " << *newBegin
+                          << "\n"
+                          << "dominating: " << *BAI << "\n");
+  BAI->setEnforcement(SILAccessEnforcement::Static);
+
+  hasChanged = true;
+
+  // Insert the new dominating instruction in both DominatedAccessAnalysis and
+  // storageToDomMap if it has uniquely identifiable storage.
+  if (!currAccessInfo.isUniquelyIdentifiedOrClass())
+    return;
+
+  AccessedStorage storage = static_cast<AccessedStorage>(currAccessInfo);
+  storage.resetSubclassData();
+
+  // Create a DomAccessedStorage for the new access with no flags set.
+  DAA.accessMap.try_emplace(newBegin, DomAccessedStorage(storage));
+
+  // Track the new access as long as no other accesses from the same storage are
+  // already tracked. This also necessarily replaces the current access, which
+  // was just made static.
+  DominatingAccess newDomAccess(newBegin, domInfo->getNode(preheader));
+  auto iterAndInserted = storageToDomMap.try_emplace(storage, newDomAccess);
+  if (!iterAndInserted.second) {
+    DominatingAccess &curDomAccess = iterAndInserted.first->second;
+    if (curDomAccess.beginAccess == BAI)
+      curDomAccess = newDomAccess;
   }
 }
 
 namespace {
 struct AccessEnforcementDom : public SILFunctionTransform {
-  void run() override {
-    SILFunction *func = getFunction();
-
-    DominanceAnalysis *domAnalysis = getAnalysis<DominanceAnalysis>();
-    DominanceInfo *domInfo = domAnalysis->get(func);
-    DominatedAccessRemoval eliminationPass(*func, domInfo);
-    if (!eliminationPass.perform()) {
-      // Bailed on the function due to key-path and/or other reasons
-      // Too risky to do anything else, don't repeat
-      // the analysis in subsequent optimizations
-      return;
-    }
-
-    SILLoopAnalysis *loopAnalysis = PM->getAnalysis<SILLoopAnalysis>();
-    SILLoopInfo *loopInfo = loopAnalysis->get(func);
-    if (loopInfo->empty()) {
-      LLVM_DEBUG(llvm::dbgs() << "No loops in " << func->getName() << "\n");
-      return;
-    }
-
-    LLVM_DEBUG(llvm::dbgs() << "LoopDominatingAccessAdder: Processing loops in "
-                            << func->getName() << "\n");
-
-    for (auto *topLevelLoop : *loopInfo) {
-      LoopDominatingAccessAdder additionPass(topLevelLoop, domInfo);
-      additionPass.perform();
-    }
-
-    // TODO: Do we need to rerun the normal dominated check removal here?
-    // I don’t think we need to do so: there shouldn’t be any redundant
-    // accesses in the preheader that we can eliminate:
-    // We only create a single access no matter how many accesses to
-    // the same storage are inside the loop.
-    // If there was an access outside of the loop then no new potential
-    // would have been exposed by LoopDominatingAccessAdder?
-  }
+  void run() override;
 };
 } // namespace
+
+void AccessEnforcementDom::run() {
+  SILFunction *func = getFunction();
+  if (func->empty())
+    return;
+
+  PostOrderFunctionInfo *PO = getAnalysis<PostOrderAnalysis>()->get(func);
+  auto DAA = DominatedAccessAnalysis(PO).analyze();
+
+  DominanceAnalysis *domAnalysis = getAnalysis<DominanceAnalysis>();
+  DominanceInfo *domInfo = domAnalysis->get(func);
+  SILLoopAnalysis *loopAnalysis = PM->getAnalysis<SILLoopAnalysis>();
+  SILLoopInfo *loopInfo = loopAnalysis->get(func);
+
+  DominatedAccessRemoval eliminationPass(*func, domInfo, loopInfo, DAA);
+  if (eliminationPass.optimize())
+    invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+}
 
 SILTransform *swift::createAccessEnforcementDom() {
   return new AccessEnforcementDom();

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -1020,12 +1020,6 @@ static void mergeEndAccesses(BeginAccessInst *parentIns,
 }
 
 static bool canMergeEnd(BeginAccessInst *parentIns, BeginAccessInst *childIns) {
-  // A [read] access cannot be converted to a [modify] without potentially
-  // introducing new conflicts that were previously ignored. Merging read/modify
-  // will require additional data flow information.
-  if (childIns->getAccessKind() != parentIns->getAccessKind())
-    return false;
-
   auto *endP = getSingleEndAccess(parentIns);
   if (!endP)
     return false;
@@ -1067,6 +1061,12 @@ static bool
 canMerge(PostDominanceInfo *postDomTree,
          const llvm::DenseMap<SILBasicBlock *, SCCInfo> &blockToSCCMap,
          BeginAccessInst *parentIns, BeginAccessInst *childIns) {
+  // A [read] access cannot be converted to a [modify] without potentially
+  // introducing new conflicts that were previously ignored. Merging read/modify
+  // will require additional data flow information.
+  if (childIns->getAccessKind() != parentIns->getAccessKind())
+    return false;
+
   if (!canMergeBegin(postDomTree, blockToSCCMap, parentIns, childIns))
     return false;
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1771,6 +1771,9 @@ func _getAtKeyPath<Root, Value>(
   return keyPath._projectReadOnly(from: root)
 }
 
+// The release that ends the access scope is guaranteed to happen
+// immediate at the end_apply call because the continuation is a
+// runtime call with a manual release (access scopes cannot be extended).
 @_silgen_name("_swift_modifyAtWritableKeyPath_impl")
 public // runtime entrypoint
 func _modifyAtWritableKeyPath_impl<Root, Value>(
@@ -1780,6 +1783,9 @@ func _modifyAtWritableKeyPath_impl<Root, Value>(
   return keyPath._projectMutableAddress(from: &root)
 }
 
+// The release that ends the access scope is guaranteed to happen
+// immediate at the end_apply call because the continuation is a
+// runtime call with a manual release (access scopes cannot be extended).
 @_silgen_name("_swift_modifyAtReferenceWritableKeyPath_impl")
 public // runtime entrypoint
 func _modifyAtReferenceWritableKeyPath_impl<Root, Value>(
@@ -1800,6 +1806,8 @@ func _setAtWritableKeyPath<Root, Value>(
   let (addr, owner) = keyPath._projectMutableAddress(from: &root)
   addr.pointee = value
   _fixLifetime(owner)
+  // FIXME: this needs a deallocation barrier to ensure that the
+  // release isn't extended, along with the access scope.
 }
 
 @_silgen_name("swift_setAtReferenceWritableKeyPath")
@@ -1813,6 +1821,8 @@ func _setAtReferenceWritableKeyPath<Root, Value>(
   let (addr, owner) = keyPath._projectMutableAddress(from: root)
   addr.pointee = value
   _fixLifetime(owner)
+  // FIXME: this needs a deallocation barrier to ensure that the
+  // release isn't extended, along with the access scope.
 }
 
 // MARK: Appending type system

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1772,7 +1772,7 @@ func _getAtKeyPath<Root, Value>(
 }
 
 // The release that ends the access scope is guaranteed to happen
-// immediate at the end_apply call because the continuation is a
+// immediately at the end_apply call because the continuation is a
 // runtime call with a manual release (access scopes cannot be extended).
 @_silgen_name("_swift_modifyAtWritableKeyPath_impl")
 public // runtime entrypoint
@@ -1784,7 +1784,7 @@ func _modifyAtWritableKeyPath_impl<Root, Value>(
 }
 
 // The release that ends the access scope is guaranteed to happen
-// immediate at the end_apply call because the continuation is a
+// immediately at the end_apply call because the continuation is a
 // runtime call with a manual release (access scopes cannot be extended).
 @_silgen_name("_swift_modifyAtReferenceWritableKeyPath_impl")
 public // runtime entrypoint

--- a/test/SILOptimizer/access_dom.sil
+++ b/test/SILOptimizer/access_dom.sil
@@ -460,7 +460,7 @@ bb4:
 // CHECK-NEXT: [[BEGIN:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
 // CHECK: bb3:
-// CHECK: [[BEGIN2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK: [[BEGIN2:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
 // CHECK: [[BEGIN3:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBAL]] : $*X
@@ -523,13 +523,24 @@ bb0:
 }
 
 // public func testOptOnNestedDomRead() {
-// Checks that we bail when the dominated begin comes before the dominating begin
+//
+// Bail on a nested access. The dominator-based algorithm does not
+// remove nested access scopes because those could generally be
+// conflicts. This one just happens to be a read-read, so it isn't a real
+// conflict.
+//
+// FIXME: simple nested dynamic reads to identical storage could very
+// easily be removed via separate logic, but it does not fit with the
+// dominator-based algorithm. For example, during the analysis phase, we
+// could simply mark the "fully nested" read scopes, then convert them to
+// [static] right after the analysis, removing them from the result
+// map. I didn't do this because I don't know if it happens in practice.
 //
 // CHECK-LABEL: sil @testOptOnNestedDomRead : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
 // CHECK: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
-// CHECK: [[BEGIN2:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-LABEL: } // end sil function 'testOptOnNestedDomRead'
 sil @testOptOnNestedDomRead : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/access_dom_call.sil
+++ b/test/SILOptimizer/access_dom_call.sil
@@ -1,0 +1,213 @@
+// RUN: %target-sil-opt -access-enforcement-dom %s -enable-sil-verify-all | %FileCheck %s
+//
+// Test AccessEnforcementDom in the presence of calls.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+@_hasInitialValue @_hasStorage var globalInt: Int64 { get set }
+
+// globalInt
+sil_global hidden @globalInt : $Int64
+
+// readGlobal
+sil hidden [noinline] @readGlobal : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = global_addr @globalInt : $*Int64
+  %1 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*Int64
+  %2 = struct_element_addr %1 : $*Int64, #Int64._value
+  %3 = load %2 : $*Builtin.Int64
+  end_access %1 : $*Int64
+  return %3 : $Builtin.Int64
+}
+
+// writeGlobal
+sil hidden [noinline] @writeGlobal : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalInt : $*Int64
+  %1 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*Int64
+  %2 = integer_literal $Builtin.Int64, 3
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  end_access %1 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// (read, read-call), read
+// Yes, can optimize when the dominating access has a nested call.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingRDRC_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingRDRC_RD'
+sil hidden [noinline] @testDominatingRDRC_RD : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalInt : $*Int64
+  %1 = begin_access [read] [dynamic] %0 : $*Int64
+  %4 = function_ref @readGlobal : $@convention(thin) () -> Builtin.Int64
+  %5 = apply %4() : $@convention(thin) () -> Builtin.Int64
+  end_access %1 : $*Int64
+  %13 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*Int64
+  end_access %13 : $*Int64
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// (read, read-call), modify
+// No, cannot promote a read with a nested call.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingRDRC_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingRDRC_MD'
+sil hidden [noinline] @testDominatingRDRC_MD : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalInt : $*Int64
+  %1 = begin_access [read] [dynamic] %0 : $*Int64
+  %4 = function_ref @readGlobal : $@convention(thin) () -> Builtin.Int64
+  %5 = apply %4() : $@convention(thin) () -> Builtin.Int64
+  end_access %1 : $*Int64
+  %13 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*Int64
+  end_access %13 : $*Int64
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// (modify, read-call), read
+// Yes, can optimize when the dominating access has a nested call.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingMDRC_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingMDRC_RD'
+sil hidden [noinline] @testDominatingMDRC_RD : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalInt : $*Int64
+  %1 = begin_access [modify] [dynamic] %0 : $*Int64
+  %4 = function_ref @readGlobal : $@convention(thin) () -> Builtin.Int64
+  %5 = apply %4() : $@convention(thin) () -> Builtin.Int64
+  end_access %1 : $*Int64
+  %13 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*Int64
+  end_access %13 : $*Int64
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// -----------------------------------------------------------------------------
+// Accessors
+
+public class C {
+  @_hasStorage @_hasInitialValue public var field: Int64 { get set }
+}
+
+sil_property #C.field ()
+
+sil hidden [transparent] @CFieldModify : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64 {
+bb0(%0 : $C):
+  debug_value %0 : $C, let, name "self", argno 1  // id: %1
+  %2 = ref_element_addr %0 : $C, #C.field         // user: %3
+  %3 = begin_access [modify] [dynamic] %2 : $*Int64 // users: %5, %8, %4
+  yield %3 : $*Int64, resume bb1, unwind bb2      // id: %4
+
+bb1:                                              // Preds: bb0
+  end_access %3 : $*Int64                         // id: %5
+  %6 = tuple ()                                   // user: %7
+  return %6 : $()                                 // id: %7
+
+bb2:                                              // Preds: bb0
+  end_access %3 : $*Int64                         // id: %8
+  unwind                                          // id: %9
+} // end sil function '$s1t1CC5fields5Int64VvM'
+
+sil_vtable C {
+  #C.field!modify.1: (C) -> () -> () : @CFieldModify
+}
+
+// No, cannot optimize an access within a coroutine.
+// CHECK-LABEL: sil @testDominatingRD_ARD : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: begin_access [read] [dynamic]
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'testDominatingRD_ARD'
+sil @testDominatingRD_ARD : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : $C):
+  %ra = ref_element_addr %0 : $C, #C.field         // user: %3
+  %a1 = begin_access [read] [dynamic] %ra : $*Int64
+  end_access %a1 : $*Int64
+  %m = class_method %0 : $C, #C.field!modify.1 : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  (%3, %4) = begin_apply %m(%0) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  %a2 = begin_access [read] [dynamic] [no_nested_conflict] %ra : $*Int64
+  end_access %a2 : $*Int64
+  end_apply %4
+  %v = tuple ()
+  return %v : $()
+}
+
+// Yes, can optimize when the dominating access is inside a coroutine.
+// CHECK-LABEL: sil @testDominatingRDA_RD : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: begin_access [read] [dynamic]
+// CHECK: begin_access [read] [static] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'testDominatingRDA_RD'
+sil @testDominatingRDA_RD : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : $C):
+  %m = class_method %0 : $C, #C.field!modify.1 : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  (%3, %4) = begin_apply %m(%0) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  %ra = ref_element_addr %0 : $C, #C.field         // user: %3
+  %a1 = begin_access [read] [dynamic] %ra : $*Int64
+  end_access %a1 : $*Int64
+  end_apply %4
+  %a2 = begin_access [read] [dynamic] [no_nested_conflict] %ra : $*Int64
+  end_access %a2 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// No, cannot promote an access within a coroutine.
+// CHECK-LABEL: sil @testDominatingRDA_MD : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: begin_access [read] [dynamic]
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'testDominatingRDA_MD'
+sil @testDominatingRDA_MD : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : $C):
+  %m = class_method %0 : $C, #C.field!modify.1 : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  (%3, %4) = begin_apply %m(%0) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  %ra = ref_element_addr %0 : $C, #C.field         // user: %3
+  %a1 = begin_access [read] [dynamic] %ra : $*Int64
+  end_access %a1 : $*Int64
+  end_apply %4
+  %a2 = begin_access [modify] [dynamic] [no_nested_conflict] %ra : $*Int64
+  end_access %a2 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// No, cannot guard an access inside a coroutine with a preheader check.
+// CHECK-LABEL: sil @testDomLoopAMD : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: begin_apply
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict]
+// CHECK: end_apply
+// CHECK-LABEL: } // end sil function 'testDomLoopAMD'
+sil @testDomLoopAMD : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : $C):
+  br bb1
+  
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+  
+bb3:
+  %m = class_method %0 : $C, #C.field!modify.1 : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  (%3, %4) = begin_apply %m(%0) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
+  %ra = ref_element_addr %0 : $C, #C.field         // user: %3
+  %a1 = begin_access [modify] [dynamic] [no_nested_conflict] %ra : $*Int64
+  end_access %a1 : $*Int64
+  end_apply %4
+  %cond = integer_literal $Builtin.Int1, 1
+  cond_br %cond, bb2, bb4
+
+bb4:
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/access_dom_loop.sil
+++ b/test/SILOptimizer/access_dom_loop.sil
@@ -1,0 +1,111 @@
+// RUN: %target-sil-opt -access-enforcement-dom %s -enable-sil-verify-all | %FileCheck %s
+//
+// Test AccessEnforcementDom in the presence of loops.
+// For loops with accessors, see also access_dom_call.sil.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct X {
+  @_hasStorage var i: Int64 { get set }
+  init(i: Int64)
+  init()
+}
+
+var globalX: X
+
+sil_global hidden @globalX : $X
+
+// Insert one preheader check for the outer access only.
+// CHECK-LABEL: sil @testDomLoopRDMD : $@convention(thin) () -> () {
+// CHECK: [[A:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GA:%.*]] : $*X
+// CHECK: end_access [[A]]
+// CHECK: bb3:
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*X
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*X
+// CHECK-LABEL: } // end sil function 'testDomLoopRDMD'
+sil @testDomLoopRDMD : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalX: $*X
+  br bb1
+  
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+  
+bb3:
+  %4 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*X
+  %6 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*X
+  end_access %6 : $*X
+  end_access %4 : $*X
+  %cond = integer_literal $Builtin.Int1, 1
+  cond_br %cond, bb2, bb4
+
+bb4:
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// No, do cannot optimize a nested loop access.
+// CHECK-LABEL: sil @testDomLoopRSMD : $@convention(thin) () -> () {
+// CHECK-NOT: begin_access
+// CHECK: bb3:
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA:%.*]] : $*X
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*X
+// CHECK-LABEL: } // end sil function 'testDomLoopRSMD'
+sil @testDomLoopRSMD : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalX: $*X
+  br bb1
+  
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+  
+bb3:
+  %4 = begin_access [read] [static] [no_nested_conflict] %0 : $*X
+  %6 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*X
+  end_access %6 : $*X
+  end_access %4 : $*X
+  %cond = integer_literal $Builtin.Int1, 1
+  cond_br %cond, bb2, bb4
+
+bb4:
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// Yes, insert a preheader check for unidentifiable access (address argument).
+// CHECK-LABEL: sil @testDomLoopUnidentified : $@convention(thin) (@inout Int64) -> () {
+// CHECK: [[A:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GA:%.*]] : $*Int64
+// CHECK: end_access [[A]]
+// CHECK: bb3:
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDomLoopUnidentified'
+sil @testDomLoopUnidentified : $@convention(thin) (@inout Int64) -> () {
+bb0(%0 : $*Int64):
+  br bb1
+  
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+  
+bb3:
+  %6 = begin_access [modify] [dynamic] [no_nested_conflict] %0 : $*Int64
+  end_access %6 : $*Int64
+  %cond = integer_literal $Builtin.Int1, 1
+  cond_br %cond, bb2, bb4
+
+bb4:
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/access_dom_overlap.sil
+++ b/test/SILOptimizer/access_dom_overlap.sil
@@ -1,0 +1,523 @@
+// RUN: %target-sil-opt -access-enforcement-dom %s -enable-sil-verify-all | %FileCheck %s
+//
+// Test AccessEnforcementDom in the presence of overlapping access scopes.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+@_hasInitialValue @_hasStorage var globalInt: Int64 { get set }
+
+// globalInt
+sil_global hidden @globalInt : $Int64
+
+
+// -----------------------------------------------------------------------------
+// (read, read), read
+
+// Yes, can optimize if the dominating access is nested outside another dynamic.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDRD_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDRD_RD'
+sil hidden [noinline] @testDominatingOverlapRDRD_RD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// Yes, can optimize if the dominating access is nested inside.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRSRD_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [static] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRSRD_RD'
+sil hidden [noinline] @testDominatingOverlapRSRD_RD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [static] %ga : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// Yes, can optimize if the dominating access is nested outside.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDRS_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [[GA]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDRS_RD'
+sil hidden [noinline] @testDominatingOverlapRDRS_RD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [read] [static] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// (read, read), modify
+
+// No, cannot promote nested read to write.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDRD_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDRD_MD'
+sil hidden [noinline] @testDominatingOverlapRDRD_MD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot promote nested read to write.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRSRD_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [static] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRSRD_MD'
+sil hidden [noinline] @testDominatingOverlapRSRD_MD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [static] %ga : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot promote nested read to write.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDRS_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDRS_MD'
+sil hidden [noinline] @testDominatingOverlapRDRS_MD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [read] [static] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// (read, modify), read
+
+// Yes, can optimize if the dominating access is nested outside.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDMD_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDMD_RD'
+sil hidden [noinline] @testDominatingOverlapRDMD_RD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// Yes, can optimize if the dominating access is nested inside.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRSMD_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [static] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRSMD_RD'
+sil hidden [noinline] @testDominatingOverlapRSMD_RD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [static] %ga : $*Int64
+  %a2 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// Yes, can optimize if the dominating access is nested outside.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDMS_RD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [static] [[GA]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDMS_RD'
+sil hidden [noinline] @testDominatingOverlapRDMS_RD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [modify] [static] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// (read, modify), modify
+
+// Yes, can promote if the nested access is a modify.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDMD_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDMD_MD'
+sil hidden [noinline] @testDominatingOverlapRDMD_MD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// Yes, can optimize if the dominating access is nested inside.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRSMD_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [static] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRSMD_MD'
+sil hidden [noinline] @testDominatingOverlapRSMD_MD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [static] %ga : $*Int64
+  %a2 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// Yes, can promote if the nested access is a modify.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRDMS_MD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [static] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRDMS_MD'
+sil hidden [noinline] @testDominatingOverlapRDMS_MD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  %a2 = begin_access [modify] [static] %ga : $*Int64
+  end_access %a2 : $*Int64
+  end_access %a1 : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// read, (read, read)
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_RDRD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_RDRD'
+sil hidden [noinline] @testDominatingOverlapRD_RDRD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_RSRD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [[GA]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_RSRD'
+sil hidden [noinline] @testDominatingOverlapRD_RSRD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [static] %ga : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// read, (read, modify)
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_RDMD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_RDMD'
+sil hidden [noinline] @testDominatingOverlapRD_RDMD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_RSMD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_RSMD'
+sil hidden [noinline] @testDominatingOverlapRD_RSMD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [static] %ga : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// read, (modify, read)
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_MDRD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_MDRD'
+sil hidden [noinline] @testDominatingOverlapRD_MDRD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [modify] [dynamic] %ga : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_MSRD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [static] [[GA]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_MSRD'
+sil hidden [noinline] @testDominatingOverlapRD_MSRD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [modify] [static] %ga : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// read, (modify, modify)
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_MDMD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_MDMD'
+sil hidden [noinline] @testDominatingOverlapRD_MDMD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [modify] [dynamic] %ga : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapRD_MSMD : $@convention(thin) () -> () {
+// CHECK: begin_access [read] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [modify] [static] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapRD_MSMD'
+sil hidden [noinline] @testDominatingOverlapRD_MSMD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [read] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [modify] [static] %ga : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// modify, (read, read)
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapMD_RDRD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapMD_RDRD'
+sil hidden [noinline] @testDominatingOverlapMD_RDRD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapMD_RSRD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [[GA]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapMD_RSRD'
+sil hidden [noinline] @testDominatingOverlapMD_RSRD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [static] %ga : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// modify, (read, modify)
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapMD_RDMD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [dynamic] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapMD_RDMD'
+sil hidden [noinline] @testDominatingOverlapMD_RDMD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [dynamic] %ga : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// No, cannot optimize a nested access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapMD_RSMD : $@convention(thin) () -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] [[GA]] : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapMD_RSMD'
+sil hidden [noinline] @testDominatingOverlapMD_RSMD : $@convention(thin) () -> () {
+bb0:
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [static] %ga : $*Int64
+  %a3 = begin_access [modify] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}
+
+// -----------------------------------------------------------------------------
+// Unidentifiable access
+
+// No, cannot optimized nest access inside an non-uniquely identified access.
+// CHECK-LABEL: sil hidden [noinline] @testDominatingOverlapUnidentifiable : $@convention(thin) (@inout Int64) -> () {
+// CHECK: begin_access [modify] [dynamic] [[GA:%.*]] : $*Int64
+// CHECK: begin_access [read] [static] %0 : $*Int64
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[GA]] : $*Int64
+// CHECK-LABEL: } // end sil function 'testDominatingOverlapUnidentifiable'
+sil hidden [noinline] @testDominatingOverlapUnidentifiable : $@convention(thin) (@inout Int64) -> () {
+bb0(%0 : $*Int64):
+  %ga = global_addr @globalInt : $*Int64
+  %a1 = begin_access [modify] [dynamic] %ga : $*Int64
+  end_access %a1 : $*Int64
+  %a2 = begin_access [read] [static] %0 : $*Int64
+  %a3 = begin_access [read] [dynamic] [no_nested_conflict] %ga : $*Int64
+  end_access %a3 : $*Int64
+  end_access %a2 : $*Int64
+  %z = tuple ()
+  return %z : $()
+}

--- a/test/SILOptimizer/access_wmo.swift
+++ b/test/SILOptimizer/access_wmo.swift
@@ -99,7 +99,7 @@ func setKeyPath(_ c: C, _ kp: ReferenceWritableKeyPath<C, Int>, _ v: Int) {
 // testAccessProp: Access a class property defined in another file.
 //
 // In -primary-file mode, all nonfinal access is behind
-// getter, setter, or materializeForSet calls. The final access remains
+// getter, setter, or begin/end_apply calls. The final access remains
 // dynamic because the property is "visibleExternally". i.e. the compiler can't
 // see how other files are using it.
 // 


### PR DESCRIPTION
This adds a mostly flow-insensitive analysis that runs before the
dominator-based transformations. The analysis is simple and efficient
because it only needs to track data flow of currently in-scope
accesses. The original dominator tree walk remains simple, but it now
checks the flow insensitive analysis information to determine general
correctness. This is now correct in the presence of all kinds of nested
static and dynamic nested accesses, call sites, coroutines, etc.

This is a better compromise than:

(a) disabling the pass and taking a major performance loss.

(b) converting the pass itself to full-fledged data flow driven
optimization, which would be more optimal because it could remove
accesses when nesting is involved, but would be much more expensive
and complicated, and there's no indication that it's useful.

The new approach is also simpler than adding more complexity to
independently handle to each of many issues:

- Nested reads followed by a modify without a false conflict.
- Reads nested within a function call without a false conflict.
- Conflicts nested within a function call without dropping enforcement.
- Accesses within a generalized accessor.
- Conservative treatment of invalid storage locations.
- Conservative treatment of unknown apply callee.
- General analysis invalidation.

Some of these issues also needed to be considered in the
LoopDominatingAccess sub-pass. Rather than fix that sub-pass, I just
integrated it into the main pass. This is a simplification, is more
efficient, and also handles nested loops without creating more
redundant accesses. It is also generalized to:
- hoist non-uniquely identified accesses.
- Avoid unnecessarily promoting accesses inside the loop.

With this approach we can remove the scary warnings and caveats in the
comments.

While doing this I also took the opportunity to eliminate quadratic
behavior, make the domtree walk non-recursive, and eliminate cutoff
thresholds.

Note that simple nested dynamic reads to identical storage could very
easily be removed via separate logic, but it does not fit with the
dominator-based algorithm. For example, during the analysis phase, we
could simply mark the "fully nested" read scopes, then convert them to
[static] right after the analysis, removing them from the result
map. I didn't do this because I don't know if it happens in practice.