### PR TITLE
[stdlib][Semantics annotation] Add ".empty" suffix to the semantics attribute of  array.init()  and add semantics annotation to the compiler intrinsic: Array._allocateUninitializedArray

### DIFF
--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -168,7 +168,7 @@ ArrayCallKind swift::ArraySemanticsCall::getKind() const {
         llvm::StringSwitch<ArrayCallKind>(Attrs)
             .Case("array.props.isNativeTypeChecked",
                   ArrayCallKind::kArrayPropsIsNativeTypeChecked)
-            .Case("array.init", ArrayCallKind::kArrayInit)
+            .StartsWith("array.init", ArrayCallKind::kArrayInit)
             .Case("array.uninitialized", ArrayCallKind::kArrayUninitialized)
             .Case("array.check_subscript", ArrayCallKind::kCheckSubscript)
             .Case("array.check_index", ArrayCallKind::kCheckIndex)

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -102,7 +102,7 @@ bool ArrayAllocation::isInitializationWithKnownCount() {
       (ArrayValue = Uninitialized.getArrayValue()))
     return true;
 
-  ArraySemanticsCall Init(Alloc, "array.init");
+  ArraySemanticsCall Init(Alloc, "array.init", /*matchPartialName*/true);
   if (Init &&
       (ArrayCount = Init.getInitializationCount()) &&
       (ArrayValue = Init.getArrayValue()))

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -802,7 +802,7 @@ extension Array: RangeReplaceableCollection {
   ///     print(emptyArray.isEmpty)
   ///     // Prints "true"
   @inlinable
-  @_semantics("array.init")
+  @_semantics("array.init.empty")
   public init() {
     _buffer = _Buffer()
   }

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -27,6 +27,7 @@ public struct _DependenceToken {
 /// - Precondition: `storage` is `_ContiguousArrayStorage`.
 @inlinable // FIXME(inline-always)
 @inline(__always)
+@_semantics("array.uninitialized_intrinsic")
 public // COMPILER_INTRINSIC
 func _allocateUninitializedArray<Element>(_  builtinCount: Builtin.Word)
     -> (Array<Element>, Builtin.RawPointer) {


### PR DESCRIPTION
These semantics attribute allow the constant interpreter to distinguish between an empty array initializer and the compiler intrinsic: _allocateUninitializerArray