### PR TITLE
 [Constraint solver] Look through optional binding for overload sets.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5036,34 +5036,6 @@ retry_after_fail:
     break;
   }
 
-  // Collect the active overload choices.
-  SmallVector<OverloadChoice, 4> choices;
-  for (auto constraint : disjunction->getNestedConstraints()) {
-    if (constraint->isDisabled())
-      continue;
-    choices.push_back(constraint->getOverloadChoice());
-  }
-
-  // If we can favor one generic result over another, do so.
-  if (auto favoredChoice = tryOptimizeGenericDisjunction(choices)) {
-    unsigned favoredIndex = favoredChoice - choices.data();
-    for (auto constraint : disjunction->getNestedConstraints()) {
-      if (constraint->isDisabled())
-        continue;
-
-      if (favoredIndex == 0) {
-        if (solverState)
-          solverState->favorConstraint(constraint);
-        else
-          constraint->setFavored();
-
-        break;
-      } else {
-        --favoredIndex;
-      }
-    }
-  }
-
   // If there was a constraint that we couldn't reason about, don't use the
   // results of any common-type computations.
   if (hasUnhandledConstraints)

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1944,7 +1944,7 @@ static Constraint *tryOptimizeGenericDisjunction(
       return type->isAny();
     });
 
-    // If function declaration references `Any` or `Any?` type
+    // If function declaration references `Any` or an optional type,
     // let's not attempt it, because it's unclear
     // without solving which overload is going to be better.
     return !hasAnyOrOptional;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1713,38 +1713,6 @@ Constraint *ConstraintSystem::getUnboundBindOverloadDisjunction(
   return nullptr;
 }
 
-/// solely resolved by an overload set.
-SmallVector<OverloadChoice, 2> ConstraintSystem::getUnboundBindOverloads(
-                                                     TypeVariableType *tyvar) {
-  // Always work on the representation.
-  tyvar = getRepresentative(tyvar);
-
-  SmallVector<OverloadChoice, 2> choices;
-
-  auto disjunction = getUnboundBindOverloadDisjunction(tyvar);
-  if (!disjunction) return choices;
-
-  for (auto constraint : disjunction->getNestedConstraints()) {
-    // We must have bind-overload constraints.
-    if (constraint->getKind() != ConstraintKind::BindOverload) {
-      choices.clear();
-      return choices;
-    }
-
-    // We must be binding the type variable (or a type variable equivalent to
-    // it).
-    auto boundTypeVar = constraint->getFirstType()->getAs<TypeVariableType>();
-    if (!boundTypeVar || getRepresentative(boundTypeVar) != tyvar) {
-      choices.clear();
-      return choices;
-    }
-
-    choices.push_back(constraint->getOverloadChoice());
-  }
-
-  return choices;
-}
-
 // Find a disjunction associated with an ApplicableFunction constraint
 // where we have some information about all of the types of in the
 // function application (even if we only know something about what the

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3166,7 +3166,14 @@ public:
   // bind overloads associated with it. This may return null in cases where
   // the disjunction has either not been created or binds the type variable
   // in some manner other than by binding overloads.
-  Constraint *getUnboundBindOverloadDisjunction(TypeVariableType *tyvar);
+  ///
+  /// \param numOptionalUnwraps If non-null, this will receive the number
+  /// of "optional object of" constraints that this function looked through
+  /// to uncover the disjunction. The actual overloads will have this number
+  /// of optionals wrapping the type.
+  Constraint *getUnboundBindOverloadDisjunction(
+    TypeVariableType *tyvar,
+    unsigned *numOptionalUnwraps = nullptr);
 
 private:
   /// Given a type variable that might represent an overload set, retrieve

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3176,14 +3176,6 @@ public:
     unsigned *numOptionalUnwraps = nullptr);
 
 private:
-  /// Given a type variable that might represent an overload set, retrieve
-  ///
-  /// \returns the set of overload choices to which this type variable
-  /// could be bound, or an empty vector if the type variable is not
-  /// solely resolved by an overload set.
-  SmallVector<OverloadChoice, 2> getUnboundBindOverloads(
-                                                  TypeVariableType *tyvar);
-
   /// Solve the system of constraints after it has already been
   /// simplified.
   ///

--- a/test/Constraints/common_type_objc.swift
+++ b/test/Constraints/common_type_objc.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol P {
+  func foo(_ i: Int) -> Double
+  func foo(_ d: Double) -> Double
+
+  @objc optional func opt(_ i: Int) -> Int
+  @objc optional func opt(_ d: Double) -> Int
+}
+
+func testOptional(obj: P) {
+  // CHECK: common result type for {{.*}} is Int
+  _ = obj.opt?(1)
+
+  // CHECK: common result type for {{.*}} is Int
+  _ = obj.opt!(1)
+}


### PR DESCRIPTION
When we’re trying to find the overload set corresponding to a particular
type variable, look through “optional object of” constraints that represent
the use of ? binding or ! forcing. This allows us to find overload sets
when referring to, e.g., @objc optional protocol requirements.