### PR TITLE
Fix for rdar://48526524 - wrong module file output when given by two -o's; cherry-pick to 5.1

### DIFF
--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -401,7 +401,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   ID emitModuleOption;
   std::string moduleExtension;
   std::string mainOutputIfUsableForModule;
-  deriveModulePathParameters(emitModuleOption, moduleExtension,
+  deriveModulePathParameters(outputFile, emitModuleOption, moduleExtension,
                              mainOutputIfUsableForModule);
 
   auto moduleOutputPath = determineSupplementaryOutputFilename(
@@ -458,7 +458,7 @@ SupplementaryOutputPathsComputer::determineSupplementaryOutputFilename(
 };
 
 void SupplementaryOutputPathsComputer::deriveModulePathParameters(
-    options::ID &emitOption, std::string &extension,
+    StringRef mainOutputFile, options::ID &emitOption, std::string &extension,
     std::string &mainOutputIfUsable) const {
 
   bool isSIB = RequestedAction == FrontendOptions::ActionType::EmitSIB ||
@@ -477,7 +477,7 @@ void SupplementaryOutputPathsComputer::deriveModulePathParameters(
       isSIB ? file_types::TY_SIB : file_types::TY_SwiftModuleFile);
 
   mainOutputIfUsable =
-      canUseMainOutputForModule && !OutputFiles.empty() ? OutputFiles[0] : "";
+      canUseMainOutputForModule && !OutputFiles.empty() ? mainOutputFile : "";
 }
 
 static SupplementaryOutputPaths

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.h
@@ -167,7 +167,8 @@ private:
       file_types::ID type, StringRef mainOutputIfUsable,
       StringRef defaultSupplementaryOutputPathExcludingExtension) const;
 
-  void deriveModulePathParameters(options::ID &emitOption,
+  void deriveModulePathParameters(StringRef mainOutputFile,
+                                  options::ID &emitOption,
                                   std::string &extension,
                                   std::string &mainOutputIfUsable) const;
 };

--- a/test/Frontend/batch_mode_module_file_names_as_main_output.swift
+++ b/test/Frontend/batch_mode_module_file_names_as_main_output.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift
+// RUN: touch %t/file-02.swift
+// RUN: cd %t
+// RUN: %target-swift-frontend -emit-module -primary-file file-01.swift -primary-file file-02.swift -o file-01.swiftmodule -o file-02.swiftmodule -module-name foo
+// RUN: test -e file-01.swiftmodule -a -e file-02.swiftmodule


### PR DESCRIPTION
Fixes rdar://48526524.
When no -c and there are >1 -o's each giving the module output file, the compiler would just use the first output file name for all primaries. This fixes that.