### PR TITLE
[AutoDiff] [stdlib] Fix derivative of square root.

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -2042,7 +2042,8 @@ extension FloatingPoint where Self : Differentiable,
   /// result and pullback of `squareRoot` with respect to `self`.
   @inlinable // FIXME(sil-serialize-all)
   func _vjpSquareRoot() -> (Self, (Self) -> Self) {
-    return (squareRoot(), { v in 2 * self * v })
+    let y = squareRoot()
+    return (y, { v in 1 / (2 * y) })
   }
 }
 


### PR DESCRIPTION
No, `dsqrt(x)/dx` is not `2x` :)

Resolves [TF-343](https://bugs.swift.org/browse/TF-343).