### PR TITLE
More resilience expansion plumbing for type lowering

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -482,6 +482,8 @@ public:
 
   const Lowering::TypeLowering &getTypeLowering(SILType type) const;
 
+  bool isTypeABIAccessible(SILType type) const;
+
   /// Returns true if this function has a calling convention that has a self
   /// argument.
   bool hasSelfParam() const {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -591,10 +591,8 @@ public:
 
   /// Can value operations (copies and destroys) on the given lowered type
   /// be performed in this module?
-  // FIXME: Expansion
   bool isTypeABIAccessible(SILType type,
-                           ResilienceExpansion forExpansion
-                             = ResilienceExpansion::Minimal);
+                           ResilienceExpansion forExpansion);
 
   /// Can type metadata for the given formal type be fetched in
   /// the given module?

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -237,9 +237,8 @@ public:
   /// This is equivalent to, but possibly faster than, calling
   /// M.Types.getTypeLowering(type).isReturnedIndirectly().
   static bool isFormallyReturnedIndirectly(CanType type, SILModule &M,
-                                           CanGenericSignature Sig,
-                                           ResilienceExpansion Expansion) {
-    return isAddressOnly(type, M, Sig, Expansion);
+                                           CanGenericSignature Sig) {
+    return isAddressOnly(type, M, Sig, ResilienceExpansion::Minimal);
   }
 
   /// Return true if this type must be passed indirectly.
@@ -247,9 +246,8 @@ public:
   /// This is equivalent to, but possibly faster than, calling
   /// M.Types.getTypeLowering(type).isPassedIndirectly().
   static bool isFormallyPassedIndirectly(CanType type, SILModule &M,
-                                         CanGenericSignature Sig,
-                                         ResilienceExpansion Expansion) {
-    return isAddressOnly(type, M, Sig, Expansion);
+                                         CanGenericSignature Sig) {
+    return isAddressOnly(type, M, Sig, ResilienceExpansion::Minimal);
   }
 
   /// True if the type, or the referenced type of an address type, is loadable.
@@ -265,8 +263,8 @@ public:
   /// be loadable inside a resilient function in the module.
   /// In other words: isLoadable(SILModule) is the conservative default, whereas
   /// isLoadable(SILFunction) might give a more optimistic result.
-  bool isLoadable(SILFunction *inFunction) const {
-    return !isAddressOnly(inFunction);
+  bool isLoadable(const SILFunction &F) const {
+    return !isAddressOnly(F);
   }
 
   /// True if either:
@@ -275,19 +273,23 @@ public:
   bool isLoadableOrOpaque(SILModule &M) const;
 
   /// Like isLoadableOrOpaque(SILModule), but takes the resilience expansion of
-  /// \p inFunction into account (see isLoadable(SILFunction)).
-  bool isLoadableOrOpaque(SILFunction *inFunction) const;
+  /// \p F into account (see isLoadable(SILFunction)).
+  bool isLoadableOrOpaque(const SILFunction &F) const;
 
   /// True if the type, or the referenced type of an address type, is
   /// address-only. This is the opposite of isLoadable.
   bool isAddressOnly(SILModule &M) const;
 
   /// Like isAddressOnly(SILModule), but takes the resilience expansion of
-  /// \p inFunction into account (see isLoadable(SILFunction)).
-  bool isAddressOnly(SILFunction *inFunction) const;
+  /// \p F into account (see isLoadable(SILFunction)).
+  bool isAddressOnly(const SILFunction &F) const;
 
   /// True if the type, or the referenced type of an address type, is trivial.
   bool isTrivial(SILModule &M) const;
+
+  /// Like isTrivial(SILModule), but takes the resilience expansion of
+  /// \p F into account (see isLoadable(SILFunction)).
+  bool isTrivial(const SILFunction &F) const;
 
   /// True if the type, or the referenced type of an address type, is known to
   /// be a scalar reference-counted type. If this is false, then some part of

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -683,7 +683,9 @@ class TypeConverter {
   llvm::DenseMap<AnyFunctionRef, CaptureInfo> LoweredCaptures;
 
   /// Cache of loadable SILType to number of (estimated) fields
-  llvm::DenseMap<SILType, unsigned> TypeFields;
+  ///
+  /// Second element is a ResilienceExpansion.
+  llvm::DenseMap<std::pair<SILType, unsigned>, unsigned> TypeFields;
 
   CanAnyFunctionType makeConstantInterfaceType(SILDeclRef constant);
   
@@ -739,7 +741,7 @@ public:
   static ProtocolDispatchStrategy getProtocolDispatchStrategy(ProtocolDecl *P);
 
   /// Count the total number of fields inside the given SIL Type
-  unsigned countNumberOfFields(SILType Ty);
+  unsigned countNumberOfFields(SILType Ty, ResilienceExpansion expansion);
 
   /// True if a protocol uses witness tables for dynamic dispatch.
   static bool protocolRequiresWitnessTable(ProtocolDecl *P) {

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -697,11 +697,8 @@ class TypeConverter {
   const TypeLowering &
   getTypeLoweringForLoweredType(TypeKey key,
                                 ResilienceExpansion forExpansion);
-  const TypeLowering &
-  getTypeLoweringForUncachedLoweredType(TypeKey key,
-                                        ResilienceExpansion forExpansion);
 
-  const TypeLowering &
+  const TypeLowering *
   getTypeLoweringForExpansion(TypeKey key,
                               ResilienceExpansion forExpansion,
                               const TypeLowering *lowering);

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -175,11 +175,15 @@ public:
     constexpr RecursiveProperties(IsTrivial_t isTrivial,
                                   IsFixedABI_t isFixedABI,
                                   IsAddressOnly_t isAddressOnly,
-                                  IsResilient_t isResilient = IsNotResilient)
+                                  IsResilient_t isResilient)
       : Flags((isTrivial ? 0U : NonTrivialFlag) | 
-              (isAddressOnly ? AddressOnlyFlag : 0U) |
               (isFixedABI ? 0U : NonFixedABIFlag) |
+              (isAddressOnly ? AddressOnlyFlag : 0U) |
               (isResilient ? ResilientFlag : 0U)) {}
+
+    static constexpr RecursiveProperties forTrivial() {
+      return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient};
+    }
 
     static constexpr RecursiveProperties forReference() {
       return {IsNotTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient };
@@ -190,7 +194,7 @@ public:
     }
 
     static constexpr RecursiveProperties forResilient() {
-      return {IsNotTrivial, IsNotFixedABI, IsAddressOnly, IsResilient};
+      return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsResilient};
     }
 
     void addSubobject(RecursiveProperties other) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6202,8 +6202,7 @@ SingletonEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
     if (TIK <= Opaque) {
       auto alignment = eltTI.getBestKnownAlignment();
       applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/false, alignment);
-      auto enumAccessible =
-        IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
+      auto enumAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
       return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
                              alignment,
                              eltTI.isPOD(ResilienceExpansion::Maximal),
@@ -6389,8 +6388,7 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeDynamicLayout(
   
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/false, alignment);
   
-  auto enumAccessible =
-    IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
+  auto enumAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
 
   return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
          alignment,
@@ -6590,8 +6588,7 @@ TypeInfo *MultiPayloadEnumImplStrategy::completeDynamicLayout(
   
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/false, alignment);
 
-  auto enumAccessible =
-    IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
+  auto enumAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
   
   return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
                                                        alignment, pod, bt,
@@ -6614,8 +6611,7 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                   SILType Type,
                                                   EnumDecl *theEnum,
                                                   llvm::StructType *enumTy) {
-  auto abiAccessible =
-    IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
+  auto abiAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
   return registerEnumTypeInfo(
                        new ResilientEnumTypeInfo(*this, enumTy, abiAccessible));
 }

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -355,7 +355,7 @@ namespace {
                                      FieldsAreABIAccessible_t fieldsAccessible,
                                           StructLayout &&layout) {
       auto tupleAccessible = IsABIAccessible_t(
-        IGM.getSILModule().isTypeABIAccessible(TheTuple));
+        IGM.isTypeABIAccessible(TheTuple));
       return NonFixedTupleTypeInfo::create(fields, fieldsAccessible,
                                            layout.getType(),
                                            layout.getAlignment(),

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1433,17 +1433,23 @@ const TypeInfo &IRGenFunction::getTypeInfo(SILType T) {
 }
 
 /// Return the SIL-lowering of the given type.
-SILType IRGenModule::getLoweredType(AbstractionPattern orig, Type subst) {
+SILType IRGenModule::getLoweredType(AbstractionPattern orig, Type subst) const {
   // FIXME: Expansion
   return getSILTypes().getLoweredType(orig, subst,
                                       ResilienceExpansion::Minimal);
 }
 
 /// Return the SIL-lowering of the given type.
-SILType IRGenModule::getLoweredType(Type subst) {
+SILType IRGenModule::getLoweredType(Type subst) const {
   // FIXME: Expansion
   return getSILTypes().getLoweredType(subst,
                                       ResilienceExpansion::Minimal);
+}
+
+bool IRGenModule::isTypeABIAccessible(SILType type) const {
+  // FIXME: Expansion
+  return getSILModule().isTypeABIAccessible(type,
+                                            ResilienceExpansion::Minimal);
 }
 
 /// Get a pointer to the storage type for the given type.  Note that,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -747,8 +747,10 @@ public:
   getConformanceInfo(const ProtocolDecl *protocol,
                      const ProtocolConformance *conformance);
 
-  SILType getLoweredType(AbstractionPattern orig, Type subst);
-  SILType getLoweredType(Type subst);
+  SILType getLoweredType(AbstractionPattern orig, Type subst) const;
+  SILType getLoweredType(Type subst) const;
+  bool isTypeABIAccessible(SILType type) const;
+
   const TypeInfo &getTypeInfoForUnlowered(AbstractionPattern orig,
                                           CanType subst);
   const TypeInfo &getTypeInfoForUnlowered(AbstractionPattern orig,

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -263,6 +263,12 @@ const TypeLowering &SILFunction::getTypeLowering(SILType type) const {
                                            ResilienceExpansion::Minimal);
 }
 
+bool SILFunction::isTypeABIAccessible(SILType type) const {
+  // FIXME: Expansion
+  return getModule().isTypeABIAccessible(type,
+                                         ResilienceExpansion::Minimal);
+}
+
 SILBasicBlock *SILFunction::createBasicBlock() {
   return new (getModule()) SILBasicBlock(this, nullptr, false);
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -370,10 +370,8 @@ public:
 
     // Otherwise, query specifically for the original type.
     } else {
-      // FIXME: Get expansion from SILDeclRef
       return SILType::isFormallyReturnedIndirectly(
-          origType.getType(), M, origType.getGenericSignature(),
-          ResilienceExpansion::Minimal);
+          origType.getType(), M, origType.getGenericSignature());
     }
   }
 };
@@ -453,10 +451,8 @@ static bool isFormallyPassedIndirectly(SILModule &M,
 
   // Otherwise, query specifically for the original type.
   } else {
-    // FIXME: Get expansion from SILDeclRef
     return SILType::isFormallyPassedIndirectly(
-        origType.getType(), M, origType.getGenericSignature(),
-        ResilienceExpansion::Minimal);
+        origType.getType(), M, origType.getGenericSignature());
   }
 }
 

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -86,6 +86,12 @@ bool SILType::isTrivial(SILModule &M) const {
     .isTrivial();
 }
 
+bool SILType::isTrivial(const SILFunction &F) const {
+  // FIXME: Should just call F.getTypeLowering()
+  return F.getModule().Types.getTypeLowering(*this,
+                                       F.getResilienceExpansion()).isTrivial();
+}
+
 bool SILType::isReferenceCounted(SILModule &M) const {
   return M.Types.getTypeLowering(*this,
                                  ResilienceExpansion::Minimal)
@@ -181,9 +187,9 @@ bool SILType::isLoadableOrOpaque(SILModule &M) const {
   return isLoadable(M) || !SILModuleConventions(M).useLoweredAddresses();
 }
 
-bool SILType::isLoadableOrOpaque(SILFunction *inFunction) const {
-  SILModule &M = inFunction->getModule();
-  return isLoadable(inFunction) ||
+bool SILType::isLoadableOrOpaque(const SILFunction &F) const {
+  SILModule &M = F.getModule();
+  return isLoadable(F) ||
          !SILModuleConventions(M).useLoweredAddresses();
 }
 
@@ -195,9 +201,10 @@ bool SILType::isAddressOnly(SILModule &M) const {
     .isAddressOnly();
 }
 
-bool SILType::isAddressOnly(SILFunction *inFunction) const {
-  return inFunction->getModule().Types.getTypeLowering(*this,
-                        inFunction->getResilienceExpansion()).isAddressOnly();
+bool SILType::isAddressOnly(const SILFunction &F) const {
+  // FIXME: Should just call F.getTypeLowering()
+  return F.getModule().Types.getTypeLowering(*this,
+                                   F.getResilienceExpansion()).isAddressOnly();
 }
 
 SILType SILType::substGenericArgs(SILModule &M,
@@ -414,6 +421,7 @@ SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
   return fieldTy;
 }
 
+// FIXME: This should take a SILFunction, or a SILModule + ResilienceExpansion
 ValueOwnershipKind
 SILResultInfo::getOwnershipKind(SILModule &M,
                                 CanGenericSignature signature) const {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1913,7 +1913,7 @@ public:
             "Dest address should be lvalue");
     require(SI->getDest()->getType() == SI->getSrc()->getType(),
             "Store operand type and dest type mismatch");
-    require(F.getModule().isTypeABIAccessible(SI->getDest()->getType()),
+    require(F.isTypeABIAccessible(SI->getDest()->getType()),
             "cannot directly copy type with inaccessible ABI");
   }
 
@@ -2328,7 +2328,7 @@ public:
   void checkDestroyAddrInst(DestroyAddrInst *DI) {
     require(DI->getOperand()->getType().isAddress(),
             "Operand of destroy_addr must be address");
-    require(F.getModule().isTypeABIAccessible(DI->getOperand()->getType()),
+    require(F.isTypeABIAccessible(DI->getOperand()->getType()),
             "cannot directly destroy type with inaccessible ABI");
   }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1551,7 +1551,7 @@ public:
   void checkLoadInst(LoadInst *LI) {
     require(LI->getType().isObject(), "Result of load must be an object");
     require(!fnConv.useLoweredAddresses()
-                || LI->getType().isLoadable(LI->getFunction()),
+                || LI->getType().isLoadable(*LI->getFunction()),
             "Load must have a loadable type");
     require(LI->getOperand()->getType().isAddress(),
             "Load operand must be an address");
@@ -1571,14 +1571,14 @@ public:
       require(F.hasOwnership(),
               "Load with qualified ownership in an unqualified function");
       // TODO: Could probably make this a bit stricter.
-      require(!LI->getType().isTrivial(LI->getModule()),
+      require(!LI->getType().isTrivial(*LI->getFunction()),
               "load [copy] or load [take] can only be applied to non-trivial "
               "types");
       break;
     case LoadOwnershipQualifier::Trivial:
       require(F.hasOwnership(),
               "Load with qualified ownership in an unqualified function");
-      require(LI->getType().isTrivial(LI->getModule()),
+      require(LI->getType().isTrivial(*LI->getFunction()),
               "A load with trivial ownership must load a trivial type");
       break;
     }
@@ -1590,7 +1590,7 @@ public:
         "Inst with qualified ownership in a function that is not qualified");
     require(LBI->getType().isObject(), "Result of load must be an object");
     require(!fnConv.useLoweredAddresses()
-            || LBI->getType().isLoadable(LBI->getFunction()),
+            || LBI->getType().isLoadable(*LBI->getFunction()),
             "Load must have a loadable type");
     require(LBI->getOperand()->getType().isAddress(),
             "Load operand must be an address");
@@ -1708,7 +1708,7 @@ public:
     require(SI->getSrc()->getType().isObject(),
             "Can't store from an address source");
     require(!fnConv.useLoweredAddresses()
-                || SI->getSrc()->getType().isLoadable(SI->getFunction()),
+                || SI->getSrc()->getType().isLoadable(*SI->getFunction()),
             "Can't store a non loadable type");
     require(SI->getDest()->getType().isAddress(),
             "Must store to an address dest");
@@ -1729,7 +1729,7 @@ public:
           F.hasOwnership(),
           "Inst with qualified ownership in a function that is not qualified");
       // TODO: Could probably make this a bit stricter.
-      require(!SI->getSrc()->getType().isTrivial(SI->getModule()),
+      require(!SI->getSrc()->getType().isTrivial(*SI->getFunction()),
               "store [init] or store [assign] can only be applied to "
               "non-trivial types");
       break;
@@ -1738,7 +1738,7 @@ public:
           F.hasOwnership(),
           "Inst with qualified ownership in a function that is not qualified");
       SILValue Src = SI->getSrc();
-      require(Src->getType().isTrivial(SI->getModule()) ||
+      require(Src->getType().isTrivial(*SI->getFunction()) ||
               Src.getOwnershipKind() == ValueOwnershipKind::Any,
               "A store with trivial ownership must store a type with trivial "
               "ownership");
@@ -1934,7 +1934,7 @@ public:
   void checkCopyValueInst(CopyValueInst *I) {
     require(I->getOperand()->getType().isObject(),
             "Source value should be an object value");
-    require(!I->getOperand()->getType().isTrivial(I->getModule()),
+    require(!I->getOperand()->getType().isTrivial(*I->getFunction()),
             "Source value should be non-trivial");
     require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
             "copy_value is only valid in functions with qualified "
@@ -1944,7 +1944,7 @@ public:
   void checkDestroyValueInst(DestroyValueInst *I) {
     require(I->getOperand()->getType().isObject(),
             "Source value should be an object value");
-    require(!I->getOperand()->getType().isTrivial(I->getModule()),
+    require(!I->getOperand()->getType().isTrivial(*I->getFunction()),
             "Source value should be non-trivial");
     require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
             "destroy_value is only valid in functions with qualified "
@@ -3585,7 +3585,7 @@ public:
             "unchecked_trivial_bit_cast must operate on a value");
     require(BI->getType().isObject(),
             "unchecked_trivial_bit_cast must produce a value");
-    require(BI->getType().isTrivial(F.getModule()),
+    require(BI->getType().isTrivial(F),
             "unchecked_trivial_bit_cast must produce a value of trivial type");
   }
 

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1509,7 +1509,10 @@ bool swift::shouldExpand(SILModule &Module, SILType Ty) {
   if (EnableExpandAll) {
     return true;
   }
-  unsigned numFields = Module.Types.countNumberOfFields(Ty);
+
+  // FIXME: Expansion
+  unsigned numFields =
+    Module.Types.countNumberOfFields(Ty, ResilienceExpansion::Minimal);
   if (numFields > 6) {
     return false;
   }


### PR DESCRIPTION
As promised in https://github.com/apple/swift/pull/23110, I've started fixing the call sites annotated with `// FIXME: Expansion`. This uncovered some more type lowering bugs and missing APIs.

rdar://problem/24057844, https://bugs.swift.org/browse/SR-261.