### PR TITLE
Avoid malloc allocations in the runtime

### DIFF
--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -78,6 +78,14 @@ protected:
     }
   };
 
+  void addSubstWordsInIdent(const WordReplacement &repl) {
+    SubstWordsInIdent.push_back(repl);
+  }
+
+  void addWord(const SubstitutionWord &word) {
+    Words.push_back(word);
+  }
+
   /// Returns the buffer as a StringRef, needed by mangleIdentifier().
   StringRef getBufferStr() const {
     return StringRef(Storage.data(), Storage.size());

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -490,11 +490,7 @@ void mangleIdentifier(const char *data, size_t length,
                       bool usePunycode = true);
 
 /// Remangle a demangled parse tree.
-///
-/// If \p BorrowFrom is specified, the initial bump pointer memory is
-/// borrowed from the free memory of BorrowFrom.
-std::string mangleNode(NodePointer root,
-                       NodeFactory *BorrowFrom = nullptr);
+std::string mangleNode(NodePointer root);
 
 using SymbolicResolver =
   llvm::function_ref<Demangle::NodePointer (SymbolicReferenceKind,
@@ -502,11 +498,15 @@ using SymbolicResolver =
 
 /// Remangle a demangled parse tree, using a callback to resolve
 /// symbolic references.
+std::string mangleNode(NodePointer root, SymbolicResolver resolver);
+
+/// Remangle a demangled parse tree, using a callback to resolve
+/// symbolic references.
 ///
-/// If \p BorrowFrom is specified, the initial bump pointer memory is
-/// borrowed from the free memory of BorrowFrom.
-std::string mangleNode(NodePointer root, SymbolicResolver resolver,
-                       NodeFactory *BorrowFrom = nullptr);
+/// The returned string is owned by \p Factory. This means \p Factory must stay
+/// alive as long as the returned string is used.
+llvm::StringRef mangleNode(NodePointer root, SymbolicResolver resolver,
+                           NodeFactory &Factory);
 
 /// Remangle in the old mangling scheme.
 ///

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -279,7 +279,11 @@ public:
     Capacity = 0;
     Elems = 0;
   }
-  
+
+  void clear() {
+    NumElems = 0;
+  }
+
   iterator begin() { return Elems; }
   iterator end() { return Elems + NumElems; }
   

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -303,6 +303,11 @@ public:
 
   T &back() { return (*this)[NumElems - 1]; }
 
+  void resetSize(size_t toPos) {
+    assert(toPos <= NumElems);
+    NumElems = toPos;
+  }
+
   void push_back(const T &NewElem, NodeFactory &Factory) {
     if (NumElems >= Capacity)
       Factory.Reallocate(Elems, Capacity, /*Growth*/ 1);
@@ -330,6 +335,9 @@ public:
 
   // Append an integer as readable number.
   void append(int Number, NodeFactory &Factory);
+
+  // Append an unsigned 64 bit integer as readable number.
+  void append(unsigned long long Number, NodeFactory &Factory);
 
   StringRef str() const {
     return StringRef(Elems, NumElems);

--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -160,13 +160,13 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
       if (WordIdx >= 0) {
         // We found a word substitution!
         assert(WordIdx < 26);
-        M.SubstWordsInIdent.push_back({wordStartPos, WordIdx});
+        M.addSubstWordsInIdent({wordStartPos, WordIdx});
       } else if (wordLen >= 2 && M.Words.size() < M.MaxNumWords) {
         // It's a new word: remember it.
         // Note: at this time the word's start position is relative to the
         // begin of the identifier. We must update it afterwards so that it is
         // relative to the begin of the whole mangled Buffer.
-        M.Words.push_back({wordStartPos, wordLen});
+        M.addWord({wordStartPos, wordLen});
       }
       wordStartPos = NotInsideWord;
     }
@@ -181,7 +181,7 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
 
   size_t Pos = 0;
   // Add a dummy-word at the end of the list.
-  M.SubstWordsInIdent.push_back({ident.size(), -1});
+  M.addSubstWordsInIdent({ident.size(), -1});
 
   // Mangle a sequence of word substitutions and sub-strings.
   for (size_t Idx = 0, End = M.SubstWordsInIdent.size(); Idx < End; ++Idx) {

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -315,7 +315,7 @@ class TypeDecoder {
       if (Node->getNumChildren() < 2)
         return BuiltType();
 
-      std::vector<BuiltType> args;
+      SmallVector<BuiltType, 8> args;
 
       const auto &genericArgs = Node->getChild(1);
       assert(genericArgs->getKind() == NodeKind::TypeList);
@@ -427,7 +427,7 @@ class TypeDecoder {
         return BuiltType();
 
       // Find the protocol list.
-      std::vector<BuiltProtocolDecl> Protocols;
+      SmallVector<BuiltProtocolDecl, 8> Protocols;
       auto TypeList = Node->getChild(0);
       if (TypeList->getKind() == NodeKind::ProtocolList &&
           TypeList->getNumChildren() >= 1) {
@@ -514,7 +514,7 @@ class TypeDecoder {
         return BuiltType();
 
       bool hasParamFlags = false;
-      std::vector<FunctionParam<BuiltType>> parameters;
+      SmallVector<FunctionParam<BuiltType>, 8> parameters;
       if (!decodeMangledFunctionInputType(Node->getChild(isThrow ? 1 : 0),
                                           parameters, hasParamFlags))
         return BuiltType();
@@ -531,9 +531,9 @@ class TypeDecoder {
     }
     case NodeKind::ImplFunctionType: {
       auto calleeConvention = ImplParameterConvention::Direct_Unowned;
-      std::vector<ImplFunctionParam<BuiltType>> parameters;
-      std::vector<ImplFunctionResult<BuiltType>> results;
-      std::vector<ImplFunctionResult<BuiltType>> errorResults;
+      SmallVector<ImplFunctionParam<BuiltType>, 8> parameters;
+      SmallVector<ImplFunctionResult<BuiltType>, 8> results;
+      SmallVector<ImplFunctionResult<BuiltType>, 8> errorResults;
       ImplFunctionTypeFlags flags;
 
       for (unsigned i = 0; i < Node->getNumChildren(); i++) {
@@ -611,7 +611,7 @@ class TypeDecoder {
       return decodeMangledType(Node->getChild(0));
 
     case NodeKind::Tuple: {
-      std::vector<BuiltType> elements;
+      SmallVector<BuiltType, 8> elements;
       std::string labels;
       bool variadic = false;
       for (auto &element : *Node) {
@@ -785,7 +785,7 @@ class TypeDecoder {
 private:
   template <typename T>
   bool decodeImplFunctionPart(Demangle::NodePointer node,
-                              std::vector<T> &results) {
+                              SmallVectorImpl<T> &results) {
     if (node->getNumChildren() != 2)
       return true;
     
@@ -871,7 +871,7 @@ private:
 
   bool decodeMangledFunctionInputType(
       Demangle::NodePointer node,
-      std::vector<FunctionParam<BuiltType>> &params,
+      SmallVectorImpl<FunctionParam<BuiltType>> &params,
       bool &hasParamFlags) {
     // Look through a couple of sugar nodes.
     if (node->getKind() == NodeKind::Type ||

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -210,12 +210,12 @@ public:
 
   Optional<std::string>
   createTypeDecl(Node *node, bool &typeAlias) {
-    return Demangle::mangleNode(node, &Dem);
+    return Demangle::mangleNode(node);
   }
 
   BuiltProtocolDecl
   createProtocolDecl(Node *node) {
-    return std::make_pair(Demangle::mangleNode(node, &Dem), false);
+    return std::make_pair(Demangle::mangleNode(node), false);
   }
 
   BuiltProtocolDecl

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -274,13 +274,13 @@ public:
 
   const BoundGenericTypeRef *
   createBoundGenericType(const Optional<std::string> &mangledName,
-                         const std::vector<const TypeRef *> &args,
+                         ArrayRef<const TypeRef *> args,
                          const TypeRef *parent) {
     return BoundGenericTypeRef::create(*this, *mangledName, args, parent);
   }
 
   const TupleTypeRef *
-  createTupleType(const std::vector<const TypeRef *> &elements,
+  createTupleType(ArrayRef<const TypeRef *> elements,
                   std::string &&labels, bool isVariadic) {
     // FIXME: Add uniqueness checks in TupleTypeRef::Profile and
     // unittests/Reflection/TypeRef.cpp if using labels for identity.
@@ -288,7 +288,7 @@ public:
   }
 
   const FunctionTypeRef *createFunctionType(
-      const std::vector<remote::FunctionParam<const TypeRef *>> &params,
+      ArrayRef<remote::FunctionParam<const TypeRef *>> params,
       const TypeRef *result, FunctionTypeFlags flags) {
     return FunctionTypeRef::create(*this, params, result, flags);
   }
@@ -406,7 +406,7 @@ public:
 
   const ObjCClassTypeRef *
   createBoundGenericObjCClassType(const std::string &name,
-                                  std::vector<const TypeRef *> &args) {
+                                  ArrayRef<const TypeRef *> args) {
     // Remote reflection just ignores generic arguments for Objective-C
     // lightweight generic types, since they don't affect layout.
     return createObjCClassType(name);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -465,11 +465,20 @@ void CharVector::append(StringRef Rhs, NodeFactory &Factory) {
 }
 
 void CharVector::append(int Number, NodeFactory &Factory) {
-  const int MaxIntPrintSize = 8;
+  const int MaxIntPrintSize = 11;
   if (NumElems + MaxIntPrintSize > Capacity)
     Factory.Reallocate(Elems, Capacity, /*Growth*/ MaxIntPrintSize);
   int Length = snprintf(Elems + NumElems, MaxIntPrintSize, "%d", Number);
   assert(Length > 0 && Length < MaxIntPrintSize);
+  NumElems += Length;
+}
+
+void CharVector::append(unsigned long long Number, NodeFactory &Factory) {
+  const int MaxPrintSize = 21;
+  if (NumElems + MaxPrintSize > Capacity)
+    Factory.Reallocate(Elems, Capacity, /*Growth*/ MaxPrintSize);
+  int Length = snprintf(Elems + NumElems, MaxPrintSize, "%llu", Number);
+  assert(Length > 0 && Length < MaxPrintSize);
   NumElems += Length;
 }
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -155,8 +155,8 @@ class Remangler {
 
   DemanglerPrinter &Buffer;
 
-  std::vector<SubstitutionWord> Words;
-  std::vector<WordReplacement> SubstWordsInIdent;
+  Vector<SubstitutionWord> Words;
+  Vector<WordReplacement> SubstWordsInIdent;
 
   static const size_t MaxNumWords = 26;
 
@@ -171,6 +171,14 @@ class Remangler {
 
   // A callback for resolving symbolic references.
   SymbolicResolver Resolver;
+
+  void addSubstWordsInIdent(const WordReplacement &repl) {
+    SubstWordsInIdent.push_back(repl, Factory);
+  }
+
+  void addWord(const SubstitutionWord &word) {
+    Words.push_back(word, Factory);
+  }
 
   StringRef getBufferStr() const { return Buffer.getStringRef(); }
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -160,8 +160,19 @@ class Remangler {
 
   static const size_t MaxNumWords = 26;
 
+  // An efficient hash-map implementation in the spirit of llvm's SmallPtrSet:
+  // The first 16 substitutions are stored in an inline-allocated array to avoid
+  // malloc calls in the common case.
+  // Lookup is still reasonable fast because there are max 16 elements in the
+  // array.
+  static const size_t InlineSubstCapacity = 16;
+  SubstitutionEntry InlineSubstitutions[InlineSubstCapacity];
+  size_t NumInlineSubsts = 0;
+
+  // The "overflow" for InlineSubstitutions. Only if InlineSubstitutions is
+  // full, new substitutions are stored in OverflowSubstitutions.
   std::unordered_map<SubstitutionEntry, unsigned,
-                     SubstitutionEntry::Hasher> Substitutions;
+                     SubstitutionEntry::Hasher> OverflowSubstitutions;
 
   SubstitutionMerging SubstMerging;
 
@@ -178,6 +189,24 @@ class Remangler {
 
   void addWord(const SubstitutionWord &word) {
     Words.push_back(word, Factory);
+  }
+
+  // Find a substitution and return its index.
+  // Returns -1 if no substitution is found.
+  int findSubstitution(const SubstitutionEntry &entry) {
+    // First search in InlineSubstitutions.
+    SubstitutionEntry *result
+      = std::find(InlineSubstitutions, InlineSubstitutions + NumInlineSubsts,
+                  entry);
+    if (result != InlineSubstitutions + NumInlineSubsts)
+      return result - InlineSubstitutions;
+
+    // Then search in OverflowSubstitutions.
+    auto it = OverflowSubstitutions.find(entry);
+    if (it == OverflowSubstitutions.end())
+      return -1;
+
+    return it->second;
   }
 
   StringRef getBufferStr() const { return Buffer.getStringRef(); }
@@ -343,11 +372,10 @@ bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry,
   // Go ahead and initialize the substitution entry.
   entry.setNode(node, treatAsIdentifier);
 
-  auto it = Substitutions.find(entry);
-  if (it == Substitutions.end())
+  int Idx = findSubstitution(entry);
+  if (Idx < 0)
     return false;
 
-  unsigned Idx = it->second;
   if (Idx >= 26) {
     Buffer << 'A';
     mangleIndex(Idx - 26);
@@ -361,17 +389,16 @@ bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry,
 }
 
 void Remangler::addSubstitution(const SubstitutionEntry &entry) {
-  unsigned Idx = Substitutions.size();
-#if false
-  llvm::outs() << "add subst ";
-  if (Idx < 26) {
-    llvm::outs() << char('A' + Idx);
-  } else {
-    llvm::outs() << Idx;
+  assert(findSubstitution(entry) < 0);
+  if (NumInlineSubsts < InlineSubstCapacity) {
+    // There is still free space in NumInlineSubsts.
+    assert(OverflowSubstitutions.empty());
+    InlineSubstitutions[NumInlineSubsts++] = entry;
+    return;
   }
-  llvm::outs() << " at pos " << getBufferStr().size() << '\n';
-#endif
-  auto result = Substitutions.insert({entry, Idx});
+  // We have to add the entry to OverflowSubstitutions.
+  unsigned Idx = OverflowSubstitutions.size() + InlineSubstCapacity;
+  auto result = OverflowSubstitutions.insert({entry, Idx});
   assert(result.second);
   (void) result;
 }

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -3,6 +3,7 @@ set(swiftReflection_SOURCES
   TypeLowering.cpp
   TypeRef.cpp
   TypeRefBuilder.cpp
+  "${SWIFT_SOURCE_DIR}/stdlib/public/runtime/LLVMSupport.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Context.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
@@ -21,7 +22,7 @@ endif(LLVM_ENABLE_ASSERTIONS)
 if(SWIFT_BUILD_STDLIB)
   add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY
     ${swiftReflection_SOURCES}
-    C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
+    C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftCore_EXPORTS
     LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
     INSTALL_IN_COMPONENT dev)
 endif()

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -56,7 +56,7 @@ static std::string normalizeReflectionName(Demangler &dem, StringRef reflectionN
   
   // Remangle the reflection name to resolve symbolic references.
   if (auto node = dem.demangleType(reflectionName)) {
-    return mangleNode(node, &dem);
+    return mangleNode(node);
   }
 
   // Fall back to the raw string.

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -33,7 +33,7 @@ swift::_buildDemanglingForContext(const ContextDescriptor *context,
   NodePointer node = nullptr;
 
   // Walk up the context tree.
-  std::vector<const ContextDescriptor *> descriptorPath;
+  SmallVector<const ContextDescriptor *, 8> descriptorPath;
   {
     const ContextDescriptor *parent = context;
     while (parent) {
@@ -283,11 +283,11 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
 
   // Gather the complete set of generic arguments that must be written to
   // form this type.
-  std::vector<const Metadata *> allGenericArgs;
+  SmallVector<const Metadata *, 8> allGenericArgs;
   gatherWrittenGenericArgs(type, description, allGenericArgs, Dem);
 
   // Demangle the generic arguments.
-  std::vector<NodePointer> demangledGenerics;
+  SmallVector<NodePointer, 8> demangledGenerics;
   for (auto genericArg : allGenericArgs) {
     // When there is no generic argument, put in a placeholder.
     if (!genericArg) {
@@ -468,7 +468,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
       break;
     }
 
-    std::vector<std::pair<NodePointer, bool>> inputs;
+    SmallVector<std::pair<NodePointer, bool>, 8> inputs;
     for (unsigned i = 0, e = func->getNumParameters(); i < e; ++i) {
       auto param = func->getParameter(i);
       auto flags = func->getParameterFlags(i);

--- a/stdlib/public/runtime/LLVMSupport.cpp
+++ b/stdlib/public/runtime/LLVMSupport.cpp
@@ -10,12 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/SmallVector.h"
+
 // ADT uses report_bad_alloc_error to report an error when it can't allocate
 // elements for a data structure. The swift runtime uses ADT without linking
 // against libSupport, so here we provide a stub to make sure we don't fail
 // to link.
 #if defined(swiftCore_EXPORTS)
 namespace llvm {
+
 #if defined(_WIN32)
 extern void report_bad_alloc_error(const char *Reason, bool GenCrashDiag);
 void _report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
@@ -28,6 +31,42 @@ void _report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
 void __attribute__((__weak__, __visibility__("hidden")))
 report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
 #endif
-} // end namespace llvm
-#endif
 
+// The same for SmallVector: provide the grow_pod implementation (the only
+// SmallVector function which is not inlined) as we don't link LLVM.
+// TODO: This is a hack. This implementaiton is copied from LLVM and has to stay
+// in sync with it.
+
+/// grow_pod - This is an implementation of the grow() method which only works
+/// on POD-like datatypes and is out of line to reduce code duplication.
+void
+#if !defined(_WIN32)
+__attribute__((__weak__, __visibility__("hidden")))
+#endif
+llvm::SmallVectorBase::grow_pod(void *FirstEl, size_t MinCapacity,
+                                size_t TSize) {
+  // Ensure we can fit the new capacity in 32 bits.
+  if (MinCapacity > UINT32_MAX)
+    report_bad_alloc_error("SmallVector capacity overflow during allocation");
+
+  size_t NewCapacity = 2 * capacity() + 1; // Always grow.
+  NewCapacity =
+    std::min(std::max(NewCapacity, MinCapacity), size_t(UINT32_MAX));
+
+  void *NewElts;
+  if (BeginX == FirstEl) {
+    NewElts = safe_malloc(NewCapacity * TSize);
+
+    // Copy the elements over.  No need to run dtors on PODs.
+    memcpy(NewElts, this->BeginX, size() * TSize);
+  } else {
+    // If this wasn't grown from the inline copy, grow the allocated space.
+    NewElts = safe_realloc(this->BeginX, NewCapacity * TSize);
+  }
+
+  this->BeginX = NewElts;
+  this->Capacity = NewCapacity;
+}
+
+} // end namespace llvm
+#endif // defined(swiftCore_EXPORTS)

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -593,8 +593,8 @@ _findNominalTypeDescriptor(Demangle::NodePointer node,
     return cast<TypeContextDescriptor>(
       (const ContextDescriptor *)symbolicNode->getIndex());
 
-  auto mangledName =
-    Demangle::mangleNode(node, ExpandResolvedSymbolicReferences(Dem), &Dem);
+  StringRef mangledName =
+    Demangle::mangleNode(node, ExpandResolvedSymbolicReferences(Dem), Dem);
 
   // Look for an existing entry.
   // Find the bucket for the metadata entry.
@@ -724,7 +724,7 @@ _findProtocolDescriptor(NodePointer node,
       (const ContextDescriptor *)symbolicNode->getIndex());
 
   mangledName =
-    Demangle::mangleNode(node, ExpandResolvedSymbolicReferences(Dem), &Dem);
+    Demangle::mangleNode(node, ExpandResolvedSymbolicReferences(Dem), Dem).str();
 
   // Look for an existing entry.
   // Find the bucket for the metadata entry.

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -821,7 +821,7 @@ Optional<unsigned> swift::_depthIndexToFlatIndex(
 /// \returns true if the innermost descriptor is generic.
 bool swift::_gatherGenericParameterCounts(
                                  const ContextDescriptor *descriptor,
-                                 std::vector<unsigned> &genericParamCounts,
+                                 SmallVectorImpl<unsigned> &genericParamCounts,
                                  Demangler &BorrowFrom) {
   // If we have an extension descriptor, extract the extended type and use
   // that.
@@ -1027,7 +1027,7 @@ public:
 
     // Figure out the various levels of generic parameters we have in
     // this type.
-    std::vector<unsigned> genericParamCounts;
+    SmallVector<unsigned, 8> genericParamCounts;
     (void)_gatherGenericParameterCounts(typeDecl, genericParamCounts, demangler);
     unsigned numTotalGenericParams =
         genericParamCounts.empty() ? 0 : genericParamCounts.back();
@@ -1041,13 +1041,13 @@ public:
       return BuiltType();
     }
 
-    std::vector<const void *> allGenericArgsVec;
+    SmallVector<const void *, 8> allGenericArgsVec;
 
     // If there are generic parameters at any level, check the generic
     // requirements and fill in the generic arguments vector.
     if (!genericParamCounts.empty()) {
       // Compute the set of generic arguments "as written".
-      std::vector<const Metadata *> allGenericArgs;
+      SmallVector<const Metadata *, 8> allGenericArgs;
 
       // If we have a parent, gather it's generic arguments "as written".
       if (parent) {
@@ -1159,8 +1159,8 @@ public:
   BuiltType createFunctionType(
                            ArrayRef<Demangle::FunctionParam<BuiltType>> params,
                            BuiltType result, FunctionTypeFlags flags) const {
-    std::vector<BuiltType> paramTypes;
-    std::vector<uint32_t> paramFlags;
+    SmallVector<BuiltType, 8> paramTypes;
+    SmallVector<uint32_t, 8> paramFlags;
 
     // Fill in the parameters.
     paramTypes.reserve(params.size());
@@ -1625,7 +1625,7 @@ demangleToGenericParamRef(StringRef typeName) {
 void swift::gatherWrittenGenericArgs(
                              const Metadata *metadata,
                              const TypeContextDescriptor *description,
-                             std::vector<const Metadata *> &allGenericArgs,
+                             SmallVectorImpl<const Metadata *> &allGenericArgs,
                              Demangler &BorrowFrom) {
   auto generics = description->getGenericContext();
   if (!generics)
@@ -1679,7 +1679,7 @@ void swift::gatherWrittenGenericArgs(
   // canonicalized away. Use same-type requirements to reconstitute them.
 
   // Retrieve the mapping information needed for depth/index -> flat index.
-  std::vector<unsigned> genericParamCounts;
+  SmallVector<unsigned, 8> genericParamCounts;
   (void)_gatherGenericParameterCounts(description, genericParamCounts,
                                       BorrowFrom);
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1064,7 +1064,10 @@ public:
       auto genericContext = typeDecl->getGenericContext();
       {
         auto genericParams = genericContext->getGenericParams();
-        for (unsigned i = 0, n = genericParams.size(); i != n; ++i) {
+        unsigned n = genericParams.size();
+        if (allGenericArgs.size() != n)
+          return BuiltType();
+        for (unsigned i = 0; i != n; ++i) {
           const auto &param = genericParams[i];
           if (param.getKind() != GenericParamKind::Type)
             return BuiltType();

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -278,7 +278,7 @@ public:
 
     /// Information about the generic context descriptors that make up \c
     /// descriptor, from the outermost to the innermost.
-    mutable std::vector<PathElement> descriptorPath;
+    mutable llvm::SmallVector<PathElement, 8> descriptorPath;
 
     /// The number of key generic parameters.
     mutable unsigned numKeyGenericParameters = 0;
@@ -356,10 +356,10 @@ public:
   /// Use with \c _getTypeByMangledName to decode potentially-generic types.
   class SWIFT_RUNTIME_LIBRARY_VISIBILITY SubstGenericParametersFromWrittenArgs {
     /// The complete set of generic arguments.
-    const std::vector<const Metadata *> &allGenericArgs;
+    const SmallVectorImpl<const Metadata *> &allGenericArgs;
 
     /// The counts of generic parameters at each level.
-    const std::vector<unsigned> &genericParamCounts;
+    const SmallVectorImpl<unsigned> &genericParamCounts;
 
   public:
     /// Initialize a new function object to handle substitutions. Both
@@ -373,8 +373,8 @@ public:
     /// \param genericParamCounts The count of generic parameters at each
     /// generic level, typically gathered by _gatherGenericParameterCounts.
     explicit SubstGenericParametersFromWrittenArgs(
-        const std::vector<const Metadata *> &allGenericArgs,
-        const std::vector<unsigned> &genericParamCounts)
+        const SmallVectorImpl<const Metadata *> &allGenericArgs,
+        const SmallVectorImpl<unsigned> &genericParamCounts)
       : allGenericArgs(allGenericArgs), genericParamCounts(genericParamCounts) {
     }
 
@@ -386,7 +386,7 @@ public:
   ///
   /// \returns true if the innermost descriptor is generic.
   bool _gatherGenericParameterCounts(const ContextDescriptor *descriptor,
-                                     std::vector<unsigned> &genericParamCounts,
+                                     llvm::SmallVectorImpl<unsigned> &genericParamCounts,
                                      Demangler &BorrowFrom);
 
   /// Map depth/index to a flat index.
@@ -407,7 +407,7 @@ public:
   /// \returns true if an error occurred, false otherwise.
   bool _checkGenericRequirements(
                     llvm::ArrayRef<GenericRequirementDescriptor> requirements,
-                    std::vector<const void *> &extraArguments,
+                    llvm::SmallVectorImpl<const void *> &extraArguments,
                     SubstGenericParameterFn substGenericParam,
                     SubstDependentWitnessTableFn substWitnessTable);
 
@@ -452,7 +452,7 @@ public:
   /// \endcode
   void gatherWrittenGenericArgs(const Metadata *metadata,
                                 const TypeContextDescriptor *description,
-                                std::vector<const Metadata *> &allGenericArgs,
+                                llvm::SmallVectorImpl<const Metadata *> &allGenericArgs,
                                 Demangler &BorrowFrom);
 
   Demangle::NodePointer

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -318,8 +318,9 @@ public:
       : sourceIsMetadata(false), environment(environment),
         genericArgs(arguments) { }
 
-    const Metadata *operator()(unsigned depth, unsigned index) const;
-    const WitnessTable *operator()(const Metadata *type, unsigned index) const;
+    const Metadata *getMetadata(unsigned depth, unsigned index) const;
+    const WitnessTable *getWitnessTable(const Metadata *type,
+                                        unsigned index) const;
   };
 
   /// Retrieve the type metadata described by the given demangled type name.
@@ -378,8 +379,9 @@ public:
       : allGenericArgs(allGenericArgs), genericParamCounts(genericParamCounts) {
     }
 
-    const Metadata *operator()(unsigned depth, unsigned index) const;
-    const WitnessTable *operator()(const Metadata *type, unsigned index) const;
+    const Metadata *getMetadata(unsigned depth, unsigned index) const;
+    const WitnessTable *getWitnessTable(const Metadata *type,
+                                        unsigned index) const;
   };
 
   /// Gather generic parameter counts from a context descriptor.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -167,7 +167,12 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
     SubstGenericParametersFromMetadata substitutions(type);
     bool failed =
       _checkGenericRequirements(getConditionalRequirements(), conditionalArgs,
-                                substitutions, substitutions);
+        [&substitutions](unsigned depth, unsigned index) {
+          return substitutions.getMetadata(depth, index);
+        },
+        [&substitutions](const Metadata *type, unsigned index) {
+          return substitutions.getWitnessTable(type, index);
+        });
     if (failed) return nullptr;
   }
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -162,7 +162,7 @@ template<>
 const WitnessTable *
 ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
   // If needed, check the conditional requirements.
-  std::vector<const void *> conditionalArgs;
+  SmallVector<const void *, 8> conditionalArgs;
   if (hasConditionalRequirements()) {
     SubstGenericParametersFromMetadata substitutions(type);
     bool failed =
@@ -626,7 +626,7 @@ swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
 
 bool swift::_checkGenericRequirements(
                       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
-                      std::vector<const void *> &extraArguments,
+                      SmallVectorImpl<const void *> &extraArguments,
                       SubstGenericParameterFn substGenericParam,
                       SubstDependentWitnessTableFn substWitnessTable) {
   for (const auto &req : requirements) {

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -337,8 +337,13 @@ getFieldAt(const Metadata *base, unsigned index) {
 
   SubstGenericParametersFromMetadata substitutions(base);
   auto typeInfo = swift_getTypeByMangledName(MetadataState::Complete,
-                                             typeName, substitutions,
-                                             substitutions);
+   typeName,
+   [&substitutions](unsigned depth, unsigned index) {
+     return substitutions.getMetadata(depth, index);
+   },
+   [&substitutions](const Metadata *type, unsigned index) {
+     return substitutions.getWitnessTable(type, index);
+   });
 
   // If demangling the type failed, pretend it's an empty type instead with
   // a log message.


### PR DESCRIPTION
This PR consists of multiple commits:

* Remangler: use the bump pointer allocator instead of std::vector for internal substitution data structures
* Remangler: Implement the hash map for substitutions in the spirit of llvm's SmallPtrSet.
* Runtime: use SmallVector instead of std::vector to avoid memory allocations in most cases.
* Runtime: use lambdas to avoid allocations in std::function
* Remangler: Use a bump-pointer allocated string instead of std::string

See the commit messages for details.

Fixes https://bugs.swift.org/browse/SR-10028, rdar://problem/48575729
It eliminates all allocations in the cast operation.

to-do: make the old remangler allocation free.