### PR TITLE
[preset] Add sourcekit-lsp to swiftpm PR presets

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -262,7 +262,7 @@ function(_compile_swift_files
   if (SWIFTFILE_IS_STDLIB)
     list(APPEND swift_flags "-swift-version" "5")
   endif()
-  
+
   # Force swift 4 compatibility mode for overlays.
   if (SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-swift-version" "4")
@@ -344,16 +344,11 @@ function(_compile_swift_files
     list(APPEND module_outputs "${interface_file}")
   endif()
 
-  set(optional_arg)
-  if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
-    # Allow installation of stdlib without building all variants on Darwin.
-    set(optional_arg "OPTIONAL")
-  endif()
-
   if(SWIFTFILE_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
     swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
       DIRECTORY "${specific_module_dir}"
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}"
+      OPTIONAL)
   else()
     swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
       FILES ${module_outputs}
@@ -439,7 +434,7 @@ function(_compile_swift_files
   set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
   string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
   file(WRITE "${file_path}" "'${source_files_quoted}'")
-  
+
   # If this platform/architecture combo supports backward deployment to old
   # Objective-C runtimes, we need to copy a YAML file with legacy type layout
   # information to the build directory so that the compiler can find it.

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1416,6 +1416,9 @@ sourcekit-lsp
 install-swift
 install-llbuild
 install-swiftpm
+install-foundation
+install-libdispatch
+install-xctest
 
 skip-test-swift
 skip-test-cmark

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1380,6 +1380,12 @@ assertions
 llbuild
 swiftpm
 
+sourcekit-lsp
+
+install-swift
+install-llbuild
+install-swiftpm
+
 dash-dash
 
 skip-test-swift
@@ -1405,6 +1411,11 @@ xctest
 foundation
 libdispatch
 llbuild
+sourcekit-lsp
+
+install-swift
+install-llbuild
+install-swiftpm
 
 skip-test-swift
 skip-test-cmark


### PR DESCRIPTION
In anticipation of moving sourcekit-lsp to build with swiftpm master
without using a Package.resolved pin, add sourcekit-lsp to the PR tests
for swiftpm.