### PR TITLE
[AutoDiff][stdlib] Fix `FloatingPoint.squareRoot()`'s derivative again.

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -2043,7 +2043,7 @@ extension FloatingPoint where Self : Differentiable,
   @inlinable // FIXME(sil-serialize-all)
   func _vjpSquareRoot() -> (Self, (Self) -> Self) {
     let y = squareRoot()
-    return (y, { v in 1 / (2 * y) })
+    return (y, { v in v / (2 * y) })
   }
 }
 


### PR DESCRIPTION
Fix the not-so-correct derivative introduced in #23124. Thanks folks for pointing that out :)