### PR TITLE
Disable key path resilience for protocol extension properties.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3423,6 +3423,10 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
              storage->isResilient(SwiftModule, expansion)) &&
             // Protocol requirements don't have nor need property descriptors.
             !isa<ProtocolDecl>(storage->getDeclContext()) &&
+            // FIXME: The property descriptor for a protocol extension property
+            // doesn't properly accommodate existentials. In principle we
+            // ought to have a separate "open existential" component.
+            !baseTy->isExistentialType() &&
             // Properties that only dispatch via ObjC lookup do not have nor
             // need property descriptors, since the selector identifies the
             // storage.

--- a/test/IRGen/Inputs/keypaths_integration_other.swift
+++ b/test/IRGen/Inputs/keypaths_integration_other.swift
@@ -1,0 +1,5 @@
+public protocol Proto {}
+
+extension Proto {
+  public var foo: Int { return 0 }
+}

--- a/test/IRGen/keypaths_integration.swift
+++ b/test/IRGen/keypaths_integration.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/keypaths_integration_other.swiftmodule -module-name=keypaths_integration_other %S/Inputs/keypaths_integration_other.swift
+// RUN: %target-swift-frontend -emit-ir -verify -I %t %s
+
+import keypaths_integration_other
+
+public func foo() -> KeyPath<Proto, Int> { return \.foo }


### PR DESCRIPTION
Trying to use the resilient property descriptor causes a regression since we don't properly
open the existential beforehand (rdar://problem/48001932).
This could create an API evolution hazard for protocol extension properties that have private
setters; however, none of the standard library or overlays currently use private(set) with any
protocol extension members. Doing the right thing later will be ABI compatible with Swift 5.0
code that does the "wrong" thing with this change. This change now allows existing code to keep
working but doesn't stop us from fixing it properly later.