### PR TITLE
[5.1] [CMake] Set -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1 for runtime/overlays

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1195,6 +1195,15 @@ function(_add_swift_library_single target name)
     "${SWIFTLIB_SINGLE_FORCE_BUILD_OPTIMIZED_keyword}"
     RESULT_VAR_NAME c_compile_flags
     )
+
+  if(SWIFTLIB_IS_STDLIB)
+    # We don't ever want to link against the ABI-breakage checking symbols
+    # in the standard library, runtime, or overlays because they only rely
+    # on the header parts of LLVM's ADT.
+    list(APPEND c_compile_flags
+      "-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1")
+  endif()
+
   _add_variant_link_flags(
     SDK "${SWIFTLIB_SINGLE_SDK}"
     ARCH "${SWIFTLIB_SINGLE_ARCHITECTURE}"


### PR DESCRIPTION
Whenever we're building C++ code as part of the Swift runtime or overlays,
disable the ABI-breaking checks. We are only using header content from
LLVM's ADT library.

Fixes rdar://problem/48618250.

