### PR TITLE
[DO NOT MERGE] Revert the revert of enabling FPElim

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -228,7 +228,7 @@ public:
         DebugInfoFormat(IRGenDebugInfoFormat::None),
         UseJIT(false), IntegratedREPL(false),
         DisableLLVMOptzns(false), DisableSwiftSpecificLLVMOptzns(false),
-        DisableLLVMSLPVectorizer(false), DisableFPElim(true), Playground(false),
+        DisableLLVMSLPVectorizer(false), DisableFPElim(false), Playground(false),
         EmitStackPromotionChecks(false), PrintInlineTree(false),
         EmbedMode(IRGenEmbedMode::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),


### PR DESCRIPTION
Purely to see what this does to the benchmarks and identify issues that may have arisen since this was last disabled about 5 years ago.