### PR TITLE
Include PR16372 in swift-4.2-branch to support Clang 7.0+ (Ubuntu 18.10)

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -48,12 +48,12 @@ enum class TypeRefKind {
 
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \
   auto ID = Profile(__VA_ARGS__);                                              \
-  const auto Entry = Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.find(ID);       \
-  if (Entry != Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.end())                \
+  const auto Entry = Allocator.TypeRefTy##s.find(ID);                          \
+  if (Entry != Allocator.TypeRefTy##s.end())                                   \
     return Entry->second;                                                      \
   const auto TR =                                                              \
       Allocator.DEPENDENT_TEMPLATE makeTypeRef<TypeRefTy>(__VA_ARGS__);        \
-  Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.insert({ID, TR});                  \
+  Allocator.TypeRefTy##s.insert({ID, TR});                                     \
   return TR;
 
 /// An identifier containing the unique bit pattern made up of all of the


### PR DESCRIPTION
If swift-4.2-branch can still be changed for the 4.2.x linux-only releases, #16372 could be included to be able to compile on systems with clang 7.0 or greater (i.e. Ubuntu 18.10+, so not one of the LTS usually supported).

Since that PR alone doesn't apply cleanly, this new PR contains the result of applying #16212, #16221 and #16372, with some minor formatting updates to align `TypeRef.h` to what we have right now on `master` and the swift-5 branches.
