### PR TITLE
Changes needed to build Swift toolchain with --test option in release mode.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -779,6 +779,7 @@ lit-args=-v --time-tests
 
 dash-dash
 
+skip-test-lldb
 # rdar://problem/31454823
 lldb-test-swift-only
 


### PR DESCRIPTION
Invoking the toolchain and the tests using the following default command:-
	./swift/utils/build-toolchain mybundle --test 
This creates a release build by default using the defaults in 'utils/build-presets.ini' file , where source files are compiled without any debug information.
So in that case the binaries(test binaries 'a.out' and others) are not really helpful in debugging with lldb debugger which needs debugging information. Hence the lldb suite tests which involve debugging with lldb debugger, fail.