### PR TITLE
RFC: [Sema] Remove no-escape "must call" rule

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1390,9 +1390,6 @@ ERROR(attr_noescape_implied_by_autoclosure,none,
 ERROR(attr_autoclosure_escaping_deprecated,none,
       "@autoclosure(escaping) has been removed; use @autoclosure @escaping instead",
       ())
-ERROR(attr_noescape_deprecated,none,
-      "@noescape is the default and has been removed",
-      ())
 
 // convention
 ERROR(convention_attribute_expected_lparen,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2513,6 +2513,9 @@ ERROR(autoclosure_function_input_nonunit,none,
 ERROR(escaping_non_function_parameter,none,
       "@escaping attribute may only be used in function parameter position", ())
 
+ERROR(non_local_noescape,none,
+      "@noescape attribute may only be used in local function contexts", ())
+
 NOTE(escaping_optional_type_argument, none,
      "closure is already escaping in optional type argument", ())
 
@@ -3043,9 +3046,6 @@ WARNING(debug_description_in_string_interpolation_segment,none,
 NOTE(silence_debug_description_in_interpolation_segment_call,none,
      "use 'String(describing:)' to silence this warning", ())
 
-ERROR(invalid_noescape_use,none,
-      "non-escaping %select{value|parameter}1 %0 may only be called",
-      (Identifier, bool))
 NOTE(noescape_parameter,none,
     "parameter %0 is implicitly non-escaping",
      (Identifier))

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -127,7 +127,6 @@ struct FixitFilter {
         Info.ID == diag::where_inside_brackets.ID ||
         Info.ID == diag::selector_construction_suggest.ID ||
         Info.ID == diag::selector_literal_deprecated_suggest.ID ||
-        Info.ID == diag::attr_noescape_deprecated.ID ||
         Info.ID == diag::attr_autoclosure_escaping_deprecated.ID ||
         Info.ID == diag::attr_warn_unused_result_removed.ID ||
         Info.ID == diag::any_as_anyobject_fixit.ID ||

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2053,14 +2053,6 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
     if (Attributes.has(TAK_autoclosure) && !isInSILMode()) {
       diagnose(Loc, diag::attr_noescape_implied_by_autoclosure);
     }
-
-    // @noescape is deprecated and no longer used
-    // In SIL, the polarity of @escaping is reversed.
-    // @escaping is the default and @noescape is explicit.
-    if (!isInSILMode()) {
-      diagnose(Loc, diag::attr_noescape_deprecated)
-        .fixItRemove({Attributes.AtLoc, Loc});
-    }
     break;
   case TAK_escaping:
     // You can't specify @noescape and @escaping together.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2194,7 +2194,13 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
 
   // Handle @escaping
   if (hasFunctionAttr && ty->is<FunctionType>()) {
-    if (attrs.has(TAK_escaping)) {
+    if (attrs.has(TAK_noescape)) {
+      auto loc = attrs.getLoc(TAK_noescape);
+      if (!DC->isLocalContext() ||
+          options.getBaseContext() == TypeResolverContext::FunctionResult) {
+        diagnose(loc, diag::non_local_noescape);
+      }
+    } else if (attrs.has(TAK_escaping)) {
       // The attribute is meaningless except on non-variadic parameter types.
       if (!isParam || options.getBaseContext() == TypeResolverContext::EnumElementDecl) {
         auto loc = attrs.getLoc(TAK_escaping);

--- a/test/Parse/swift3_warnings_swift4_errors_version_4.swift
+++ b/test/Parse/swift3_warnings_swift4_errors_version_4.swift
@@ -13,8 +13,6 @@ let x: protocol<> // expected-error {{'protocol<>' syntax has been removed; use 
 let y: protocol<P1> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}}}
 let z: protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
 
-func bar(f: @noescape () -> ()) {} // expected-error {{@noescape is the default and has been removed}}
-
 func baz(f: @autoclosure(escaping) () -> ()) {} // expected-error {{@autoclosure(escaping) has been removed; use @autoclosure @escaping instead}}
 
 prefix operator +++ {} // expected-error {{operator should no longer be declared with body}}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -210,10 +210,9 @@ func rdar_20591571() {
   func same<T>(_: T, _: T) {}
 
   func takesAnAutoclosure(_ fn: @autoclosure () -> Int, _ efn: @escaping @autoclosure () -> Int) {
-  // expected-note@-1 2{{parameter 'fn' is implicitly non-escaping}}
 
-    var _ = fn // expected-error {{non-escaping parameter 'fn' may only be called}}
-    let _ = fn // expected-error {{non-escaping parameter 'fn' may only be called}}
+    var _ = fn
+    let _ = fn
 
     var _ = efn
     let _ = efn

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -6,16 +6,15 @@ func paramDeclEscaping(@escaping fn: (Int) -> Void) {} // expected-error {{attri
 func wrongParamType(a: @escaping Int) {} // expected-error {{@escaping attribute only applies to function types}}
 
 func conflictingAttrs(_ fn: @noescape @escaping () -> Int) {} // expected-error {{@escaping conflicts with @noescape}}
- // expected-error@-1{{@noescape is the default and has been removed}} {{29-39=}}
 
 func takesEscaping(_ fn: @escaping () -> Int) {} // ok
 
 func callEscapingWithNoEscape(_ fn: () -> Int) {
   // expected-note@-1{{parameter 'fn' is implicitly non-escaping}} {{37-37=@escaping }}
-  // expected-note@-2{{parameter 'fn' is implicitly non-escaping}} {{37-37=@escaping }}
 
   takesEscaping(fn) // expected-error{{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
-  let _ = fn // expected-error{{non-escaping parameter 'fn' may only be called}}
+  let fn2 = fn // okay
+  let _ = fn2()
 }
 
 typealias IntSugar = Int


### PR DESCRIPTION
***As a preface, does this need to go through Swift Evolution? The change seems very minor and is source compatible.***

The Swift compiler currently "requires" that no-escape closures be called, but this rule isn't actually true (they may be passed for example) and this rule doesn't actually solve any no-escape problems
that aren't solved elsewhere in the compiler. By removing the "must call" rule, one can now write natural looking code with no-escape closures. For example:

Before (workaround the must call-or-pass rule where `x` and `y` are no-escape closures):

```
let r : Int
if b {
    r = f(x)
} else {
    r = f(y)
}
```

After:

```
let r = f(b ? x : y)
```
Admittedly, this problem rarely comes up because there are rarely more than one no-escape closure in play. Nevertheless, this restriction is more than what is necessary for correctness.