### PR TITLE
 [Constraint solver] Favor constraints with param/arg matches during solving

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -542,13 +542,10 @@ namespace {
   /// \param expr The application.
   /// \param isFavored Determine whether the given overload is favored, passing
   /// it the "effective" overload type when it's being called.
-  /// \param mustConsider If provided, a function to detect the presence of
-  /// overloads which inhibit any overload from being favored.
-  void favorCallOverloads(ApplyExpr *expr,
-                          ConstraintSystem &CS,
-                          llvm::function_ref<bool(ValueDecl *, Type)> isFavored,
-                          std::function<bool(ValueDecl *)>
-                              mustConsider = nullptr) {
+  void favorCallOverloads(
+      ApplyExpr *expr,
+      ConstraintSystem &CS,
+      llvm::function_ref<bool(ValueDecl *, Type)> isFavored) {
     // Find the type variable associated with the function, if any.
     auto tyvarType = CS.getType(expr->getFn())->getAs<TypeVariableType>();
     if (!tyvarType || CS.getFixedType(tyvarType))
@@ -562,21 +559,12 @@ namespace {
       return;
     
     // Find the favored constraints and mark them.
-    SmallVector<Constraint *, 4> newlyFavoredConstraints;
     unsigned numFavoredConstraints = 0;
     Constraint *firstFavored = nullptr;
     for (auto constraint : disjunction->getNestedConstraints()) {
       if (!constraint->getOverloadChoice().isDecl())
         continue;
       auto decl = constraint->getOverloadChoice().getDecl();
-
-      if (mustConsider && mustConsider(decl)) {
-        // Roll back any constraints we favored.
-        for (auto favored : newlyFavoredConstraints)
-          favored->setFavored(false);
-
-        return;
-      }
 
       Type overloadType =
           CS.getEffectiveOverloadType(constraint->getOverloadChoice(),
@@ -586,11 +574,6 @@ namespace {
 
       if (!decl->getAttrs().isUnavailable(CS.getASTContext()) &&
           isFavored(decl, overloadType)) {
-        // If we might need to roll back the favored constraints, keep
-        // track of those we are favoring.
-        if (mustConsider && !constraint->isFavored())
-          newlyFavoredConstraints.push_back(constraint);
-
         constraint->setFavored();
         ++numFavoredConstraints;
         if (!firstFavored)
@@ -609,40 +592,6 @@ namespace {
       if (!resultType->hasTypeParameter())
         CS.setFavoredType(expr, resultType.getPointer());
     }
-  }
-  
-  size_t getOperandCount(Type t) {
-    size_t nOperands = 0;
-    
-    if (auto parenTy = dyn_cast<ParenType>(t.getPointer())) {
-      if (parenTy->getDesugaredType())
-        nOperands = 1;
-    } else if (auto tupleTy = t->getAs<TupleType>()) {
-      nOperands = tupleTy->getElementTypes().size();
-    }
-    
-    return nOperands;
-  }
-  
-  /// Return a pair, containing the total parameter count of a function, coupled
-  /// with the number of non-default parameters.
-  std::pair<size_t, size_t> getParamCount(ValueDecl *VD) {
-    auto fTy = VD->getInterfaceType()->castTo<AnyFunctionType>();
-    
-    size_t nOperands = fTy->getParams().size();
-    size_t nNoDefault = 0;
-    
-    if (auto AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
-      assert(!AFD->hasImplicitSelfDecl());
-      for (auto param : *AFD->getParameters()) {
-        if (!param->isDefaultArgument())
-          nNoDefault++;
-      }
-    } else {
-      nNoDefault = nOperands;
-    }
-    
-    return { nOperands, nNoDefault };
   }
   
   /// Favor unary operator constraints where we have exact matches
@@ -667,75 +616,6 @@ namespace {
     };
     
     favorCallOverloads(expr, CS, isFavoredDecl);
-  }
-  
-  void favorMatchingOverloadExprs(ApplyExpr *expr,
-                                  ConstraintSystem &CS) {
-    // Find the argument type.
-    size_t nArgs = getOperandCount(CS.getType(expr->getArg()));
-    auto fnExpr = expr->getFn();
-    
-    // Check to ensure that we have an OverloadedDeclRef, and that we're not
-    // favoring multiple overload constraints. (Otherwise, in this case
-    // favoring is useless.
-    if (auto ODR = dyn_cast<OverloadedDeclRefExpr>(fnExpr)) {
-      bool haveMultipleApplicableOverloads = false;
-      
-      for (auto VD : ODR->getDecls()) {
-        if (VD->getInterfaceType()->is<AnyFunctionType>()) {
-          auto nParams = getParamCount(VD);
-          
-          if (nArgs == nParams.first) {
-            if (haveMultipleApplicableOverloads) {
-              return;
-            } else {
-              haveMultipleApplicableOverloads = true;
-            }
-          }
-        }
-      }
-      
-      // Determine whether the given declaration is favored.
-      auto isFavoredDecl = [&](ValueDecl *value, Type type) -> bool {
-        if (!type->is<AnyFunctionType>())
-          return false;
-
-        auto paramCount = getParamCount(value);
-        
-        return nArgs == paramCount.first ||
-               nArgs == paramCount.second;
-      };
-      
-      favorCallOverloads(expr, CS, isFavoredDecl);
-      
-    }
-    
-    if (auto favoredTy = CS.getFavoredType(expr->getArg())) {
-      // Determine whether the given declaration is favored.
-      auto isFavoredDecl = [&](ValueDecl *value, Type type) -> bool {
-        auto fnTy = type->getAs<AnyFunctionType>();
-        if (!fnTy)
-          return false;
-
-        auto paramTy =
-            AnyFunctionType::composeInput(CS.getASTContext(), fnTy->getParams(),
-                                          /*canonicalVararg*/ false);
-        return favoredTy->isEqual(paramTy);
-      };
-
-      // This is a hack to ensure we always consider the protocol requirement
-      // itself when calling something that has a default implementation in an
-      // extension. Otherwise, the extension method might be favored if we're
-      // inside an extension context, since any archetypes in the parameter
-      // list could match exactly.
-      auto mustConsider = [&](ValueDecl *value) -> bool {
-        return isa<ProtocolDecl>(value->getDeclContext());
-      };
-
-      favorCallOverloads(expr, CS,
-                         isFavoredDecl,
-                         mustConsider);
-    }
   }
   
   /// Favor binary operator constraints where we have exact matches
@@ -843,8 +723,6 @@ namespace {
           favorMatchingUnaryOperators(applyExpr, CS);
         } else if (isa<BinaryExpr>(applyExpr)) {
           favorMatchingBinaryOperators(applyExpr, CS);
-        } else {
-          favorMatchingOverloadExprs(applyExpr, CS);
         }
       }
       

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3425,7 +3425,12 @@ public:
 
   /// Determine whether the given parameter type and argument should be
   /// "favored" because they match exactly.
-  bool isFavoredParamAndArg(Type paramTy, Type argTy);
+  ///
+  /// \param genericSig When provided, the generic signature will be
+  /// used to extract more information about \c paramTy when it is a
+  /// type parameter.
+  bool isFavoredParamAndArg(Type paramTy, Type argTy,
+                            GenericSignature *genericSig = nullptr);
 
   typedef std::function<bool(unsigned index, Constraint *)> ConstraintMatcher;
   typedef std::function<void(ArrayRef<Constraint *>, ConstraintMatcher)>
@@ -3588,9 +3593,9 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// Attempt to prove that arguments with the given labels at the
 /// given parameter depth cannot be used with the given value.
 /// If this cannot be proven, conservatively returns true.
-bool areConservativelyCompatibleArgumentLabels(OverloadChoice choice,
-                                               ArrayRef<Identifier> labels,
-                                               bool hasTrailingClosure);
+bool areConservativelyCompatibleArgumentLabels(
+    OverloadChoice choice, ArrayRef<Identifier> labels,
+    bool hasTrailingClosure, SmallVectorImpl<ParamBinding> *bindings = nullptr);
 
 /// Simplify the given locator by zeroing in on the most specific
 /// subexpression described by the locator.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3423,6 +3423,10 @@ public:
 
   bool haveTypeInformationForAllArguments(FunctionType *fnType);
 
+  /// Determine whether the given parameter type and argument should be
+  /// "favored" because they match exactly.
+  bool isFavoredParamAndArg(Type paramTy, Type argTy);
+
   typedef std::function<bool(unsigned index, Constraint *)> ConstraintMatcher;
   typedef std::function<void(ArrayRef<Constraint *>, ConstraintMatcher)>
       ConstraintMatchLoop;

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -2,49 +2,55 @@
 // RUN: %FileCheck %s < %t.err
 
 struct X {
-  func g(_: Int) -> Int { return 0 }
-  func g(_: Double) -> Int { return 0 }
+  func g(_: Inting) -> Int { return 0 }
+  func g(_: Doubling) -> Int { return 0 }
 
-  subscript(_: Int) -> String { return "" }
-  subscript(_: Double) -> String { return "" }
+  subscript(_: Inting) -> String { return "" }
+  subscript(_: Doubling) -> String { return "" }
 
-  func iuo(_: Int) -> Int! { return 0 }
-  func iuo(_: Double) -> Int! { return 0 }
+  func iuo(_: Inting) -> Int! { return 0 }
+  func iuo(_: Doubling) -> Int! { return 0 }
 }
 
 struct Y {
-  func g(_: Int) -> Double { return 0 }
-  func g(_: Double) -> Double { return 0 }
+  func g(_: Inting) -> Double { return 0 }
+  func g(_: Doubling) -> Double { return 0 }
 
-  subscript(_: Int) -> Substring { return "" }
-  subscript(_: Double) -> Substring { return "" }
+  subscript(_: Inting) -> Substring { return "" }
+  subscript(_: Doubling) -> Substring { return "" }
 
-  func iuo(_: Int) -> Double! { return 0 }
-  func iuo(_: Double) -> Double! { return 0 }
+  func iuo(_: Inting) -> Double! { return 0 }
+  func iuo(_: Doubling) -> Double! { return 0 }
 }
 
-func f(_: Int) -> X { return X() }
-func f(_: Double) -> Y { return Y() }
+protocol Inting { }
+extension Int: Inting { }
+
+protocol Doubling { }
+extension Double: Doubling { }
+
+func f(_: Inting) -> X { return X() }
+func f(_: Doubling) -> Y { return Y() }
 
 func testCallCommonType() {
-  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK: overload set choice binding $T{{[0-9]+}} := (Inting) -> X
   // CHECK-NEXT: (common result type for $T{{[0-9]+}} is Int)
-  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
+  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Doubling) -> Y)
   // CHECK-NEXT: (common result type for $T{{[0-9]+}} is Double)
   _ = f(0).g(0)
 }
 
 func testSubscriptCommonType() {
   // CHECK: subscript_expr
-  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK: overload set choice binding $T{{[0-9]+}} := (Inting) -> X
   // CHECK: (common result type for $T{{[0-9]+}} is String)
-  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
+  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Doubling) -> Y)
   // CHECK: (common result type for $T{{[0-9]+}} is Substring)
   _ = f(0)[0]
 }
 
 func testCommonTypeIUO() {
-  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK: overload set choice binding $T{{[0-9]+}} := (Inting) -> X
   // CHECK-NOT: common result type
     _ = f(0).iuo(0)
 }

--- a/test/Constraints/favoring.swift
+++ b/test/Constraints/favoring.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+func f(_: Int) { }
+func f(_: Double) { }
+
+func g(i: Int) {
+  // CHECK: favoring overloads for
+  // CHECK-NEXT: bound to decl{{.*}} : (Int) -> ()
+  f(i)
+
+  // CHECK: favoring overloads for
+  // CHECK-NEXT: bound to decl{{.*}} : (Int) -> ()
+  f(0)
+
+  // CHECK: favoring overloads for
+  // CHECK-NEXT: bound to decl{{.*}} : (Double) -> ()
+  // CHECK-NOT: bound
+  // CHECK: Initial
+  f(3.14159)
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -553,8 +553,8 @@ struct SpecialPi {} // Type with no implicit construction.
 
 var pi_s: SpecialPi
 
-func getPi() -> Float {}
-func getPi() -> Double {}
+func getPi() -> Float {}  // expected-note 3 {{found this candidate}}
+func getPi() -> Double {}  // expected-note 3 {{found this candidate}}
 func getPi() -> SpecialPi {}
 
 enum Empty { }
@@ -576,12 +576,12 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var pi_d1 = Double(pi_d)
   var pi_s1 = SpecialPi(pi_s) // expected-error {{argument passed to call that takes no arguments}}
 
-  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
-  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
+  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
   var pi_s2: SpecialPi = getPi() // no-warning
   
   var float = Float.self
-  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
   var pi_f4 = float.init(pi_f)
 
   var e = Empty(f) // expected-warning {{variable 'e' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s
+// RUN: %target-typecheck-verify-swift -DBREAKING_POINT
 
 func wrap<T>(_ key: String, _ value: T) -> T { return value }
 func wrap<T: ExpressibleByIntegerLiteral>(_ key: String, _ value: T) -> T { return value }
@@ -6,8 +7,12 @@ func wrap<T: ExpressibleByFloatLiteral>(_ key: String, _ value: T) -> T { return
 func wrap<T: ExpressibleByStringLiteral>(_ key: String, _ value: T) -> T { return value }
 
 func wrapped(i: Int) -> Int {
-  // FIXME: When this stops being "too complex", turn the integer value into
-  // an integer literal.
-  // expected-error@+1{{reasonable time}}
-  return wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i)
+  return wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i)
 }
+
+#if BREAKING_POINT
+func wrapped2(i: Int) -> Int {
+  // expected-error@+1{{reasonable time}}
+  return wrap("1", 0) + wrap("1", 0) + wrap("1", 0) + wrap("1", 0)
+}
+#endif


### PR DESCRIPTION
Use the parameter/argument matching logic while simplifying an applicable-
function constraint, to favor any constraints that now have argument
matches. This is a step toward eliminating the favoring code from
earlier phases (e.g., constraint generation), but also should help us
discover more favored overloads to improve solving as it goes.

Slightly improves type checker performance for the slow test in
rdar://problem/46713933, so update the test to both lock in the gains
and still show where we can improve things.