### PR TITLE
[NFC][testsuite] Add lit 'libdispatch' feature

### DIFF
--- a/test/ClangImporter/Dispatch_test.swift
+++ b/test/ClangImporter/Dispatch_test.swift
@@ -1,9 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
 import Dispatch
-import Foundation
 
 func test1(_ queue: dispatch_queue_t) {} // expected-error {{'dispatch_queue_t' is unavailable}}
 func test2(_ queue: DispatchQueue) {

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -632,7 +632,10 @@ if run_vendor == 'apple':
         { 'macosx': 'macos', 'darwin': 'macos' }.get(run_os, run_os)
     )
 
+    config.available_features.add('libdispatch')
+    config.available_features.add('foundation')
     config.available_features.add('objc_interop')
+
     config.target_object_format = "macho"
     config.target_shared_library_prefix = 'lib'
     config.target_shared_library_suffix = ".dylib"

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -1,14 +1,8 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/a.out
-// RUN: %target-codesign %t/a.out
-//
-// RUN: %target-run %t/a.out
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
 import Dispatch
-import Foundation
 import StdlibUnittest
 
 
@@ -126,18 +120,6 @@ DispatchAPI.test("DispatchTime.addSubtract") {
 
 	then = DispatchTime.now() - Double.nan
 	expectEqual(DispatchTime.distantFuture, then)
-
-	then = DispatchTime.now() + Date.distantFuture.timeIntervalSinceNow
-	expectEqual(DispatchTime(uptimeNanoseconds: UInt64.max), then)
-
-	then = DispatchTime.now() + Date.distantPast.timeIntervalSinceNow
-	expectEqual(DispatchTime(uptimeNanoseconds: 1), then)
-
-	then = DispatchTime.now() - Date.distantFuture.timeIntervalSinceNow
-	expectEqual(DispatchTime(uptimeNanoseconds: 1), then)
-
-	then = DispatchTime.now() - Date.distantPast.timeIntervalSinceNow
-	expectEqual(DispatchTime(uptimeNanoseconds: UInt64.max), then)
 }
 
 DispatchAPI.test("DispatchWallTime.addSubtract") {
@@ -153,18 +135,6 @@ DispatchAPI.test("DispatchWallTime.addSubtract") {
 	expectEqual(distantPastRawValue, then.rawValue)
 
 	then = DispatchWallTime.now() - Double.nan
-	expectEqual(DispatchWallTime.distantFuture, then)
-
-	then = DispatchWallTime.now() + Date.distantFuture.timeIntervalSinceNow
-	expectEqual(DispatchWallTime.distantFuture, then)
-
-	then = DispatchWallTime.now() + Date.distantPast.timeIntervalSinceNow
-	expectEqual(distantPastRawValue, then.rawValue)
-
-	then = DispatchWallTime.now() - Date.distantFuture.timeIntervalSinceNow
-	expectEqual(distantPastRawValue, then.rawValue)
-
-	then = DispatchWallTime.now() - Date.distantPast.timeIntervalSinceNow
 	expectEqual(DispatchWallTime.distantFuture, then)
 }
 

--- a/test/stdlib/DispatchData.swift
+++ b/test/stdlib/DispatchData.swift
@@ -2,10 +2,9 @@
 // RUN: %target-build-swift -swift-version 4 %s -o %t/a.out-4 && %target-codesign %t/a.out-4 && %target-run %t/a.out-4
 // RUN: %target-build-swift -swift-version 4.2 %s -o %t/a.out-4.2 && %target-codesign %t/a.out-4.2 && %target-run %t/a.out-4.2
 // REQUIRES: executable_test
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
 import Dispatch
-import Foundation
 import StdlibUnittest
 
 defer { runAllTests() }

--- a/test/stdlib/DispatchDate.swift
+++ b/test/stdlib/DispatchDate.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: libdispatch
+// REQUIRES: foundation
+
+import Dispatch
+import Foundation
+import StdlibUnittest
+
+var DispatchAPI = TestSuite("DispatchAPI")
+
+DispatchAPI.test("DispatchTime.addSubtractDateConstants") {
+	var then = DispatchTime.now() + Date.distantFuture.timeIntervalSinceNow
+	expectEqual(DispatchTime(uptimeNanoseconds: UInt64.max), then)
+
+	then = DispatchTime.now() + Date.distantPast.timeIntervalSinceNow
+	expectEqual(DispatchTime(uptimeNanoseconds: 1), then)
+
+	then = DispatchTime.now() - Date.distantFuture.timeIntervalSinceNow
+	expectEqual(DispatchTime(uptimeNanoseconds: 1), then)
+
+	then = DispatchTime.now() - Date.distantPast.timeIntervalSinceNow
+	expectEqual(DispatchTime(uptimeNanoseconds: UInt64.max), then)
+}
+
+DispatchAPI.test("DispatchWallTime.addSubtractDateConstants") {
+	let distantPastRawValue = DispatchWallTime.distantFuture.rawValue - UInt64(1)
+
+	var then = DispatchWallTime.now() + Date.distantFuture.timeIntervalSinceNow
+	expectEqual(DispatchWallTime.distantFuture, then)
+
+	then = DispatchWallTime.now() + Date.distantPast.timeIntervalSinceNow
+	expectEqual(distantPastRawValue, then.rawValue)
+
+	then = DispatchWallTime.now() - Date.distantFuture.timeIntervalSinceNow
+	expectEqual(distantPastRawValue, then.rawValue)
+
+	then = DispatchWallTime.now() - Date.distantPast.timeIntervalSinceNow
+	expectEqual(DispatchWallTime.distantFuture, then)
+}
+
+runAllTests()

--- a/test/stdlib/DispatchRenames.swift
+++ b/test/stdlib/DispatchRenames.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
 import Dispatch
 

--- a/test/stdlib/DispatchTypes.swift
+++ b/test/stdlib/DispatchTypes.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s
 
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
 import Dispatch
 

--- a/validation-test/Runtime/weak-reference-racetests-dispatch.swift
+++ b/validation-test/Runtime/weak-reference-racetests-dispatch.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: stress_test
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
 import StdlibUnittest
 import Dispatch


### PR DESCRIPTION
I am picking up the effort to make TSan work (better) with Swift on Linux. Currently landing upstream patches for supporting interception of libdispatch on Linux.

The goal of this PR is to identify tests of the dispatch functionality. I am assuming that `REQUIRES: objc_interop` is used as a proxy for libdispatch availability.

The following tests also `import Foundation`. My understanding is that Foundation is not available on Linux. Can you go through the tests and mark the ones which could be modified to work without Foundation, i.e., tests in which Foundation is just used as a utility/helper, but we are not actually testing Dispatch<>Foundation interaction.

- [x] test/ClangImporter/Dispatch_test.swift: YES, removed unnecessary `import Foundation`
- [x] test/PrintAsObjC/dispatch.swift: NO, seems to be real objc_interop test
- [x] test/stdlib/Dispatch.swift: YES, broke out parts that depend on Foundation (`Date`)
- [x] test/stdlib/DispatchData.swift: YES, removed unnecessary `import Foundation`
- [x] test/stdlib/DispatchDeprecationMacOS.swift: NO, deprecation test
- [x] test/stdlib/DispatchDeprecationWatchOS.swift: NO, deprecation test

The list was compiled by searching for the content `objc_interop` in files with name containing `dispatch`. Are there any other tests we should consider here?

I will follow up with PRs to make those tests work without Foundation, actually work on Linux, and then also enable the lit feature flag on Linux. Any help or feedback greatly appreciated!

Previous effort: https://github.com/apple/swift/pull/19836


