### PR TITLE
[5.0] Reduce the time spend in StringMemoryTest

### DIFF
--- a/validation-test/stdlib/StringMemoryTest.swift
+++ b/validation-test/stdlib/StringMemoryTest.swift
@@ -12,6 +12,14 @@ import Foundation
 let str = "abcdefg\u{A758}hijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\u{A759}"
 let str2 = "abcdefg\u{A759}hijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\u{A758}"
 
+
+@inline(never)
+func getMemoryUsage() -> Int {
+  var usage = rusage()
+  getrusage(RUSAGE_SELF, &usage)
+  return usage.ru_maxrss
+}
+
 @inline(never)
 func lookup(_ str: String, _ dict: [String: Int]) -> Bool {
   if let _ = dict[str] {
@@ -30,35 +38,44 @@ func lowercase(_ str: String) -> String {
       return str.lowercased()
 }
 
+@inline(never)
+func runTest() {
+  for _ in 0 ..< 10_0000 {
+    if lookup("\u{1F1E7}\u{1F1E7}", dict) {
+      print("Found?!")
+    }
+    if uppercase(str) == "A" {
+      print("Found?!")
+    }
+    if lowercase(str2) == "A" {
+      print("Found?!")
+    }
+  }
+}
+
+
 /// Make sure the hash function does not leak.
 
 let dict = [ "foo" : 1]
-for _ in 0 ..< 10_000_000 {
-  if lookup("\u{1F1E7}\u{1F1E7}", dict) {
-    print("Found?!")
-  }
-  if uppercase(str) == "A" {
-    print("Found?!")
-  }
-  if lowercase(str2) == "A" {
-    print("Found?!")
-  }
-}
+
+let baseUsage = getMemoryUsage()
+runTest()
+let firstRun = getMemoryUsage () - baseUsage
+runTest()
+runTest()
+let secondRun = getMemoryUsage () - baseUsage
 
 // CHECK-NOT: Found?!
 // CHECK: Not found
 
 print("Not found")
 
-var usage = rusage()
-getrusage(RUSAGE_SELF, &usage)
-
 // CHECK: success
 // CHECK-NOT: failure
 
 // We should not need 50MB for this.
-if usage.ru_maxrss > 50 * 1024 * 1024 {
-  print("failure - should not need 50MB!")
+if firstRun * 2 < secondRun  {
+  print("failure - should not linearly increase")
 } else {
   print("success")
 }


### PR DESCRIPTION
Measure the increase in time.

This adjusts a test to run in a fraction of the time. This test used to run in the order of 10 minutes.

rdar://problem/48658000