### PR TITLE
[Typechecker] Remove useless null check

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3909,7 +3909,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   auto toConstrainedArchetype = false;
   if (toArchetypeType) {
     auto archetype = toType->castTo<ArchetypeType>();
-    toConstrainedArchetype = archetype && !archetype->getConformsTo().empty();
+    toConstrainedArchetype = !archetype->getConformsTo().empty();
   }
 
   if (fromFunctionType &&


### PR DESCRIPTION
Follow-up from #22822. Removing a useless null check as it's not needed because `archetype` is guaranteed to be not null due to the preceding `is` check. 