### PR TITLE
master-next: Update call to setSuppressAfterFatalError for Clang r355586

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1011,8 +1011,7 @@ ClangImporter::create(ASTContext &ctx,
   clangDiags.setSeverity(clang::diag::err_module_not_built,
                          clang::diag::Severity::Error,
                          clang::SourceLocation());
-  clangDiags.setSuppressAfterFatalError(
-      !ctx.Diags.getShowDiagnosticsAfterFatalError());
+  clangDiags.setFatalsAsError(ctx.Diags.getShowDiagnosticsAfterFatalError());
 
 
   // Create the associated action.


### PR DESCRIPTION
This function was renamed to setFatalsAsError, with an inverted sense of
the argument value.