### PR TITLE
[Foundation] Better error reporting for forced bridging failures

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSDictionary.swift
+++ b/stdlib/public/Darwin/Foundation/NSDictionary.swift
@@ -136,7 +136,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     to: T.Type
   ) {
     for i in (0..<count).reversed() {
-      let bridged = Swift._forceBridgeFromObjectiveC(buffer[i], T.self)
+      let bridged = buffer[i] as! T
       _bridgeInitialize(index: i, of: buffer, to: bridged)
     }
   }
@@ -225,8 +225,8 @@ extension Dictionary : _ObjectiveCBridgeable {
         let anyObjectKey = anyKey as AnyObject
         let anyObjectValue = anyValue as AnyObject
         builder.add(
-            key: Swift._forceBridgeFromObjectiveC(anyObjectKey, Key.self),
-            value: Swift._forceBridgeFromObjectiveC(anyObjectValue, Value.self))
+          key: anyObjectKey as! Key,
+          value: anyObjectValue as! Value)
       })
       result = builder.take()
     } else {

--- a/stdlib/public/Darwin/Foundation/NSDictionary.swift
+++ b/stdlib/public/Darwin/Foundation/NSDictionary.swift
@@ -222,11 +222,9 @@ extension Dictionary : _ObjectiveCBridgeable {
     if keyStride < objectStride || valueStride < objectStride {
       var builder = _DictionaryBuilder<Key, Value>(count: d.count)
       d.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
-        let anyObjectKey = anyKey as AnyObject
-        let anyObjectValue = anyValue as AnyObject
         builder.add(
-          key: anyObjectKey as! Key,
-          value: anyObjectValue as! Value)
+          key: anyKey as! Key,
+          value: anyValue as! Value)
       })
       result = builder.take()
     } else {

--- a/stdlib/public/Darwin/Foundation/NSSet.swift
+++ b/stdlib/public/Darwin/Foundation/NSSet.swift
@@ -77,10 +77,8 @@ extension Set : _ObjectiveCBridgeable {
       // Swift. See rdar://problem/35995647
       var set = Set(minimumCapacity: s.count)
       s.enumerateObjects({ (anyMember: Any, _) in
-        let member = Swift._forceBridgeFromObjectiveC(
-          anyMember as AnyObject, Element.self)
         // FIXME: Log a warning if `member` is already in the set.
-        set.insert(member)
+        set.insert(anyMember as AnyObject as! Element)
       })
       result = set
       return
@@ -90,8 +88,7 @@ extension Set : _ObjectiveCBridgeable {
     // an NSSet.
     var builder = _SetBuilder<Element>(count: s.count)
     s.enumerateObjects({ (anyMember: Any, _) in
-      builder.add(member: Swift._forceBridgeFromObjectiveC(
-        anyMember as AnyObject, Element.self))
+      builder.add(member: anyMember as AnyObject as! Element)
     })
     result = builder.take()
   }

--- a/stdlib/public/Darwin/Foundation/NSSet.swift
+++ b/stdlib/public/Darwin/Foundation/NSSet.swift
@@ -78,7 +78,7 @@ extension Set : _ObjectiveCBridgeable {
       var set = Set(minimumCapacity: s.count)
       s.enumerateObjects({ (anyMember: Any, _) in
         // FIXME: Log a warning if `member` is already in the set.
-        set.insert(anyMember as AnyObject as! Element)
+        set.insert(anyMember as! Element)
       })
       result = set
       return
@@ -88,7 +88,7 @@ extension Set : _ObjectiveCBridgeable {
     // an NSSet.
     var builder = _SetBuilder<Element>(count: s.count)
     s.enumerateObjects({ (anyMember: Any, _) in
-      builder.add(member: anyMember as AnyObject as! Element)
+      builder.add(member: anyMember as! Element)
     })
     result = builder.take()
   }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -3023,14 +3023,17 @@ _bridgeNonVerbatimFromObjectiveC(
         const_cast<void*>(swift_dynamicCastUnknownClass(sourceValue,
                                                         objectiveCType));
       
-    if (sourceValueAsObjectiveCType) {
-      // The type matches.  _forceBridgeFromObjectiveC returns `Self`, so
-      // we can just return it directly.
-      bridgeWitness->forceBridgeFromObjectiveC(
-        static_cast<HeapObject*>(sourceValueAsObjectiveCType),
-        destValue, nativeType, nativeType, bridgeWitness);
-      return;
+    if (!sourceValueAsObjectiveCType) {
+      swift::swift_dynamicCastFailure(_swift_getClass(sourceValue),
+                                      objectiveCType);
     }
+
+    // The type matches.  _forceBridgeFromObjectiveC returns `Self`, so
+    // we can just return it directly.
+    bridgeWitness->forceBridgeFromObjectiveC(
+      static_cast<HeapObject*>(sourceValueAsObjectiveCType),
+      destValue, nativeType, nativeType, bridgeWitness);
+    return;
   }
   
   // Fail.

--- a/validation-test/stdlib/DictionaryTrapsObjC.swift
+++ b/validation-test/stdlib/DictionaryTrapsObjC.swift
@@ -147,6 +147,142 @@ DictionaryTraps.test("BridgedKeyIsNotNSCopyable2")
   nsd.mutableCopy()
 }
 
+DictionaryTraps.test("ForcedNonverbatimBridge.StringKey")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let d1: NSDictionary = [
+    "Gordon" as NSString: NSObject(),
+    "William" as NSString: NSObject(),
+    "Katherine" as NSString: NSObject(),
+    "Lynn" as NSString: NSObject(),
+    "Brian" as NSString: NSObject(),
+    1756 as NSNumber: NSObject()]
+
+  expectCrashLater()
+  _ = d1 as! Dictionary<String, Any>
+}
+
+DictionaryTraps.test("ForcedNonverbatimBridge.IntKey")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let d1: NSDictionary = [
+    4 as NSNumber: NSObject(),
+    8 as NSNumber: NSObject(),
+    15 as NSNumber: NSObject(),
+    16 as NSNumber: NSObject(),
+    23 as NSNumber: NSObject(),
+    42 as NSNumber: NSObject(),
+    "John" as NSString: NSObject()]
+
+  expectCrashLater()
+  _ = d1 as! Dictionary<Int, Any>
+}
+
+DictionaryTraps.test("ForcedNonverbatimBridge.Value")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let d1: NSDictionary = [
+    4 as NSNumber: "Jack" as NSString,
+    8 as NSNumber: "Kate" as NSString,
+    15 as NSNumber: "Hurley" as NSString,
+    16 as NSNumber: "Sawyer" as NSString,
+    23 as NSNumber: "John" as NSString,
+    42 as NSNumber: NSObject()]
+
+  expectCrashLater()
+  _ = d1 as! Dictionary<NSObject, String>
+}
+
+
+DictionaryTraps.test("ForcedVerbatimBridge.StringKey")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let d1: NSDictionary = [
+    "Gordon" as NSString: NSObject(),
+    "William" as NSString: NSObject(),
+    "Katherine" as NSString: NSObject(),
+    "Lynn" as NSString: NSObject(),
+    "Brian" as NSString: NSObject(),
+    1756 as NSNumber: NSObject()]
+
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let d2 = d1 as! Dictionary<NSString, NSObject>
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd numeric value is caught.
+  expectCrashLater()
+  for (key, value) in d2 {
+    _ = (key, value)
+  }
+}
+
+DictionaryTraps.test("ForcedVerbatimBridge.IntKey")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let d1: NSDictionary = [
+    4 as NSNumber: NSObject(),
+    8 as NSNumber: NSObject(),
+    15 as NSNumber: NSObject(),
+    16 as NSNumber: NSObject(),
+    23 as NSNumber: NSObject(),
+    42 as NSNumber: NSObject(),
+    "John" as NSString: NSObject()]
+
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let d2 = d1 as! Dictionary<NSNumber, NSObject>
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd numeric value is caught.
+  expectCrashLater()
+  for (key, value) in d2 {
+    _ = (key, value)
+  }
+}
+
+DictionaryTraps.test("ForcedVerbatimBridge.Value")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let d1: NSDictionary = [
+    4 as NSNumber: "Jack" as NSString,
+    8 as NSNumber: "Kate" as NSString,
+    15 as NSNumber: "Hurley" as NSString,
+    16 as NSNumber: "Sawyer" as NSString,
+    23 as NSNumber: "John" as NSString,
+    42 as NSNumber: NSObject()]
+
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let d2 = d1 as! Dictionary<NSObject, NSString>
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd numeric value is caught.
+  expectCrashLater()
+  for (key, value) in d2 {
+    _ = (key, value)
+  }
+}
+
 DictionaryTraps.test("Downcast1") {
   let d: Dictionary<NSObject, NSObject> = [ TestObjCKeyTy(10): NSObject(),
                                             NSObject() : NSObject() ]

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -4613,4 +4613,102 @@ SetTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
   s.remove(at: i)
 }
 
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let s1: NSSet = [
+    "Gordon" as NSString,
+    "William" as NSString,
+    "Katherine" as NSString,
+    "Lynn" as NSString,
+    "Brian" as NSString,
+    1756 as NSNumber]
+
+  expectCrashLater()
+  _ = s1 as! Set<String>
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let s1: NSSet = [
+    4 as NSNumber,
+    8 as NSNumber,
+    15 as NSNumber,
+    16 as NSNumber,
+    23 as NSNumber,
+    42 as NSNumber,
+    "John" as NSString]
+
+  expectCrashLater()
+  _ = s1 as! Set<Int>
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedVerbatimBridge.Trap.NSString")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+
+  let s1: NSSet = [
+    "Gordon" as NSString,
+    "William" as NSString,
+    "Katherine" as NSString,
+    "Lynn" as NSString,
+    "Brian" as NSString,
+    1756 as NSNumber]
+
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let s2 = s1 as! Set<NSString>
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd numeric value is caught.
+  expectCrashLater()
+  for string in s2 {
+    _ = string
+  }
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedVerbatimBridge.Trap.NSNumber")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let s1: NSSet = [
+    4 as NSNumber,
+    8 as NSNumber,
+    15 as NSNumber,
+    16 as NSNumber,
+    23 as NSNumber,
+    42 as NSNumber,
+    "John" as NSString]
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let s2 = s1 as! Set<NSNumber>
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd numeric value is caught.
+  expectCrashLater()
+  for string in s2 {
+    _ = string
+  }
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
Foundation currently calls `_forceBridgeFromObjectiveC` to force-bridge `NSSet`/`NSDictionary` elements to Swift, which assumes the input is already the expected type and produces a generic trap in an unreachable branch rather than a clear error message.

```swift
// bridging-failure.swift
import Foundation

let s1: NSSet = ["Gordon", "William", "Katherine", "Lynn", "Brian", 1756]
let _ = s1 as! Set<String>
```

```
$ swiftc bridging-failure.swift
$ ./bridging-failure
Illegal instruction: 4
```

Replacing the `_forceBridgeFromObjectiveC` calls with usual everyday `as!`-casts makes these issues easier to debug:

```
$ swiftc bridging-failure.swift
$ ./bridging-failure
Could not cast value of type '__NSCFNumber' (0x7fff868e8200) to 'NSString' (0x7fff86d7cb08).
Abort trap: 6
```

rdar://problem/21556078