### PR TITLE
SwiftRemoteMirror: repair the windows build

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -37,6 +37,7 @@
 extern "C" {
 #endif
 
+SWIFT_REMOTE_MIRROR_LINKAGE
 extern unsigned long long swift_reflection_classIsSwiftMask;
 
 /// Get the metadata version supported by the Remote Mirror library.

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SwiftRemoteMirror/Platform.h"
+
 #define SWIFT_CLASS_IS_SWIFT_MASK swift_reflection_classIsSwiftMask
-extern "C" unsigned long long swift_reflection_classIsSwiftMask = 2;
+extern "C" {
+SWIFT_REMOTE_MIRROR_LINKAGE
+unsigned long long swift_reflection_classIsSwiftMask = 2;
+}
 
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeLowering.h"


### PR DESCRIPTION
This symbol is meant to be exposed to users of the SwiftRemoteMirror
library which requires that it is explicitly marked with the appropriate
DLL storage on Windows.  This should repair the Windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
