### PR TITLE
[Runtime] NFC: Move LLVM_ATTRIBUTE_USED from declaration to definition

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -706,7 +706,7 @@ public:
 #endif
 
 #ifndef NDEBUG
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
                             "Only meant for use in the debugger");
 #endif
 
@@ -2404,7 +2404,7 @@ public:
   ///
   /// 1. Has a valid TypeReferenceKind.
   /// 2. Has a valid conformance kind.
-  void verify() const LLVM_ATTRIBUTE_USED;
+  void verify() const;
 #endif
 
 private:
@@ -2997,7 +2997,7 @@ public:
   }
 
 #ifndef NDEBUG
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
                             "only for use in the debugger");
 #endif
 

--- a/include/swift/Runtime/ExistentialContainer.h
+++ b/include/swift/Runtime/ExistentialContainer.h
@@ -64,11 +64,11 @@ struct TargetOpaqueExistentialContainer {
   ///
   /// The intention is that this is used in combination with ASAN or Guard
   /// Malloc to catch use-after-frees.
-  void verify() const LLVM_ATTRIBUTE_USED;
+  void verify() const;
 
   /// Dump information about this specific box and its contents. Only intended
   /// for use in the debugger.
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
                             "Only meant for use in the debugger");
 #endif
 };

--- a/stdlib/public/runtime/ExistentialContainer.cpp
+++ b/stdlib/public/runtime/ExistentialContainer.cpp
@@ -57,6 +57,7 @@ void OpaqueExistentialContainer::deinit() {
 // *NOTE* This routine performs unused memory reads on purpose to try to catch
 // use-after-frees in conjunction with ASAN or Guard Malloc.
 template <>
+LLVM_ATTRIBUTE_USED
 void OpaqueExistentialContainer::verify() const {
   // We do not actually care about value. We just want to see if the
   // memory is valid or not. So convert to a uint8_t and try to
@@ -70,6 +71,7 @@ void OpaqueExistentialContainer::verify() const {
 
 /// Dump information about this specific container and its contents.
 template <>
+LLVM_ATTRIBUTE_USED
 void OpaqueExistentialContainer::dump() const {
   // Quickly verify to make sure we are well formed.
   verify();

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3913,7 +3913,9 @@ StringRef swift::getStringForMetadataKind(MetadataKind kind) {
 }
 
 #ifndef NDEBUG
-template <> void Metadata::dump() const {
+template <>
+LLVM_ATTRIBUTE_USED
+void Metadata::dump() const {
   printf("TargetMetadata.\n");
   printf("Kind: %s.\n", getStringForMetadataKind(getKind()).data());
   printf("Value Witnesses: %p.\n", getValueWitnesses());

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -31,7 +31,9 @@
 using namespace swift;
 
 #ifndef NDEBUG
-template <> void ProtocolDescriptor::dump() const {
+template <>
+LLVM_ATTRIBUTE_USED
+void ProtocolDescriptor::dump() const {
   printf("TargetProtocolDescriptor.\n"
          "Name: \"%s\".\n",
          Name.get());
@@ -93,7 +95,9 @@ template<> void ProtocolConformanceDescriptor::dump() const {
 #endif
 
 #ifndef NDEBUG
-template<> void ProtocolConformanceDescriptor::verify() const {
+template<>
+LLVM_ATTRIBUTE_USED
+void ProtocolConformanceDescriptor::verify() const {
   auto typeKind = unsigned(getTypeKind());
   assert(((unsigned(TypeReferenceKind::First_Kind) <= typeKind) &&
           (unsigned(TypeReferenceKind::Last_Kind) >= typeKind)) &&


### PR DESCRIPTION
This is both more correct and now required to keep building with top-of-tree clang.

CC: @bob-wilson