### PR TITLE
[Typechecker] Disallow default argument to inout parameter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -238,6 +238,8 @@ NOTE(inout_change_var_type_if_possible,none,
 ERROR(cannot_pass_rvalue_inout,none,
       "cannot pass immutable value of type %0 as inout argument",
       (Type))
+ERROR(cannot_provide_default_value_inout,none,
+      "cannot provide default value to inout parameter %0", (Identifier))
 
 ERROR(cannot_assign_to_literal,none,
       "cannot assign to a literal value", ())

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -863,6 +863,14 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL,
         param->setSpecifier(VarDecl::Specifier::Owned);
       }
     }
+
+    if (param->isInOut() && param->isDefaultArgument()) {
+      diagnose(param->getDefaultValue()->getLoc(),
+               swift::diag::cannot_provide_default_value_inout,
+               param->getName());
+      param->markInvalid();
+      hadError = true;
+    }
   }
   
   return hadError;

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -122,3 +122,16 @@ struct X<T> {
 
 let testXa: X<Int> = .foo(i: 0)
 let testXb: X<Int> = .bar
+
+// SR-10062
+
+var aLiteral = 1
+let bLiteral = 2
+
+func inoutFuncWithDefaultArg1(x: inout Int = 1) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
+func inoutFuncWithDefaultArg2(x: inout Int = bLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
+func inoutFuncWithDefaultArg3(x: inout Int = aLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
+func inoutFuncWithDefaultArg4(x: inout Int = &aLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
+func inoutFuncWithDefaultArg5(x: inout Int = &bLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
+func inoutFuncWithDefaultArg6(x: inout Int = #file) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
+func inoutFuncWithDefaultArg7(_: inout Int = 1) {} // expected-error {{cannot provide default value to inout parameter '_'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -844,7 +844,7 @@ func inoutTests(_ arr: inout Int) {
 
 // <rdar://problem/20802757> Compiler crash in default argument & inout expr
 var g20802757 = 2
-func r20802757(_ z: inout Int = &g20802757) { // expected-error {{use of extraneous '&'}}
+func r20802757(_ z: inout Int = &g20802757) { // expected-error {{cannot provide default value to inout parameter 'z'}}
   print(z)
 }
 

--- a/validation-test/compiler_crashers_2_fixed/sr10062.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10062.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -emit-silgen %s
+
+// Just make sure we don't crash.
+
+func foo(x: inout Int = 0) {}
+foo()


### PR DESCRIPTION
Don't allow a default argument to be passed to an `inout` parameter. This currently causes a compiler crash and is reproducible on 4.2, 5.0 and 5.1:

```swift
func inoutFuncWithDefaultArg(x: inout Int = 1) {}
inoutFuncWithDefaultArg()
```

Resolves #52464.
Resolves rdar://problem/48703420
