### PR TITLE
[5.1 ]Parser: properly handle token receiver in back tracking scope

### DIFF
--- a/test/IDE/coloring_string_interpolation.swift
+++ b/test/IDE/coloring_string_interpolation.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
+
+// CHECK: <kw>_</kw> = <str>"</str>\<anchor>(</anchor><anchor>)</anchor><str>"</str>
+// CHECK: <kw>if</kw> <kw>true</kw> { <kw>_</kw> = <str>"</str>\<anchor>(</anchor><anchor>)</anchor><str>"</str> }
+
+if true {
+    _ = "\()"
+}
+
+if true { _ = "\()" }


### PR DESCRIPTION
Back tracking scope may lead to a same token to be consumed/received twice.
This patch introduces a DelayedTokenReceiver to temporarily store received
tokens during a back tracking scope. After the scope ends, the stored tokens
will be either transferred to the original token receiver in the parser or
be discarded, depending on whether the scope will actually back-track.

Fixing: rdar://42547871