### PR TITLE
Cleanup/fix AccessEnforcementOpts

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
@@ -122,8 +122,6 @@ template <> struct DenseMapInfo<swift::StorageAccessInfo> {
 }
 
 namespace swift {
-/// The per-function result of AccessedStorageAnalysis.
-///
 /// Records each unique AccessedStorage in a set of StorageAccessInfo
 /// objects. Hashing and equality only sees the AccesedStorage data. The
 /// additional StorageAccessInfo bits are recorded as results of this analysis.
@@ -133,28 +131,32 @@ namespace swift {
 /// results, either because the call graph is unknown or the access sets are too
 /// large. It does not imply that all accesses have Unidentified
 /// AccessedStorage, which is never allowed for class or global access.
-class FunctionAccessedStorage {
+class AccessedStorageResult {
+
   using AccessedStorageSet = llvm::SmallDenseSet<StorageAccessInfo, 8>;
 
   AccessedStorageSet storageAccessSet;
   Optional<SILAccessKind> unidentifiedAccess;
-
 public:
-  FunctionAccessedStorage() {}
+  AccessedStorageResult() {}
 
   // ---------------------------------------------------------------------------
   // Accessing the results.
+
+  bool isEmpty() const {
+    return storageAccessSet.empty() && !unidentifiedAccess;
+  }
 
   bool hasUnidentifiedAccess() const { return unidentifiedAccess != None; }
 
   /// Return true if the analysis has determined all accesses of otherStorage
   /// have the [no_nested_conflict] flag set.
   ///
-  /// Only call this if there is no unidentifiedAccess in the function and the
+  /// Only call this if there is no unidentifiedAccess in the region and the
   /// given storage is uniquely identified.
   bool hasNoNestedConflict(const AccessedStorage &otherStorage) const;
 
-  /// Does any of the accesses represented by this FunctionAccessedStorage
+  /// Does any of the accesses represented by this AccessedStorageResult
   /// object conflict with the given access kind and storage.
   bool mayConflictWith(SILAccessKind otherAccessKind,
                        const AccessedStorage &otherStorage) const;
@@ -181,6 +183,97 @@ public:
     unidentifiedAccess = SILAccessKind::Modify;
   }
 
+  void setUnidentifiedAccess(SILAccessKind kind) { unidentifiedAccess = kind; }
+
+  /// Merge effects directly from \p RHS.
+  bool mergeFrom(const AccessedStorageResult &other);
+
+  /// Merge the effects represented in calleeAccess into this
+  /// FunctionAccessedStorage object. calleeAccess must correspond to at least
+  /// one callee at the apply site `fullApply`. Merging drops any local effects,
+  /// and translates parameter effects into effects on the caller-side
+  /// arguments.
+  ///
+  /// The full caller-side effects at a call site can be obtained with
+  /// AccessedStorageAnalysis::getCallSiteEffects().
+  bool mergeFromApply(const AccessedStorageResult &calleeAccess,
+                      FullApplySite fullApply);
+
+  /// Record any access scopes entered by the given single SIL instruction. 'I'
+  /// must not be a FullApply; use mergeFromApply instead.
+  void analyzeInstruction(SILInstruction *I);
+
+  void print(raw_ostream &os) const;
+  void dump() const;
+
+protected:
+  std::pair<AccessedStorageSet::iterator, bool>
+  insertStorageAccess(StorageAccessInfo storageAccess) {
+    storageAccess.setStorageIndex(storageAccessSet.size());
+    return storageAccessSet.insert(storageAccess);
+  }
+
+  bool updateUnidentifiedAccess(SILAccessKind accessKind);
+
+  bool mergeAccesses(const AccessedStorageResult &other,
+                     std::function<StorageAccessInfo(const StorageAccessInfo &)>
+                         transformStorage);
+
+  template <typename B> void visitBeginAccess(B *beginAccess);
+};
+} // namespace swift
+
+namespace swift {
+/// The per-function result of AccessedStorageAnalysis.
+class FunctionAccessedStorage {
+  AccessedStorageResult accessResult;
+
+public:
+  FunctionAccessedStorage() {}
+
+  // ---------------------------------------------------------------------------
+  // Accessing the results.
+
+  const AccessedStorageResult &getResult() const { return accessResult; }
+
+  bool hasUnidentifiedAccess() const {
+    return accessResult.hasUnidentifiedAccess();
+  }
+
+  /// Return true if the analysis has determined all accesses of otherStorage
+  /// have the [no_nested_conflict] flag set.
+  ///
+  /// Only call this if there is no unidentifiedAccess in the function and the
+  /// given storage is uniquely identified.
+  bool hasNoNestedConflict(const AccessedStorage &otherStorage) const {
+    return accessResult.hasNoNestedConflict(otherStorage);
+  }
+
+  /// Does any of the accesses represented by this FunctionAccessedStorage
+  /// object conflict with the given access kind and storage.
+  bool mayConflictWith(SILAccessKind otherAccessKind,
+                       const AccessedStorage &otherStorage) const {
+    return accessResult.mayConflictWith(otherAccessKind, otherStorage);
+  }
+
+  /// Raw access to the result for a given AccessedStorage location.
+  StorageAccessInfo
+  getStorageAccessInfo(const AccessedStorage &otherStorage) const {
+    return accessResult.getStorageAccessInfo(otherStorage);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Constructing the results.
+
+  void clear() { accessResult.clear(); }
+
+  /// Return true if these effects are fully conservative.
+  bool hasWorstEffects() { return accessResult.hasWorstEffects(); }
+
+  /// Sets the most conservative effects, if we don't know anything about the
+  /// function.
+  void setWorstEffects() { accessResult.setWorstEffects(); }
+
   /// Summarize the given function's effects using this FunctionAccessedStorage
   /// object.
   //
@@ -201,12 +294,14 @@ public:
   ///
   /// TODO: Summarize ArraySemanticsCall accesses.
   bool summarizeCall(FullApplySite fullApply) {
-    assert(storageAccessSet.empty() && "expected uninitialized results.");
+    assert(accessResult.isEmpty() && "expected uninitialized results.");
     return false;
   }
 
   /// Merge effects directly from \p RHS.
-  bool mergeFrom(const FunctionAccessedStorage &RHS);
+  bool mergeFrom(const FunctionAccessedStorage &RHS) {
+    return accessResult.mergeFrom(RHS.accessResult);
+  }
 
   /// Merge the effects represented in calleeAccess into this
   /// FunctionAccessedStorage object. calleeAccess must correspond to at least
@@ -217,31 +312,19 @@ public:
   /// The full caller-side effects at a call site can be obtained with
   /// AccessedStorageAnalysis::getCallSiteEffects().
   bool mergeFromApply(const FunctionAccessedStorage &calleeAccess,
-                      FullApplySite fullApply);
+                      FullApplySite fullApply) {
+    return accessResult.mergeFromApply(calleeAccess.accessResult, fullApply);
+  }
 
   /// Analyze the side-effects of a single SIL instruction \p I.
   /// Visited callees are added to \p BottomUpOrder until \p RecursionDepth
   /// reaches MaxRecursionDepth.
-  void analyzeInstruction(SILInstruction *I);
-
-  void print(raw_ostream &os) const;
-  void dump() const;
-
-protected:
-  std::pair<AccessedStorageSet::iterator, bool>
-  insertStorageAccess(StorageAccessInfo storageAccess) {
-    storageAccess.setStorageIndex(storageAccessSet.size());
-    return storageAccessSet.insert(storageAccess);
+  void analyzeInstruction(SILInstruction *I) {
+    accessResult.analyzeInstruction(I);
   }
 
-  bool updateUnidentifiedAccess(SILAccessKind accessKind);
-
-  bool mergeAccesses(
-      const FunctionAccessedStorage &other,
-      std::function<StorageAccessInfo(const StorageAccessInfo &)>
-          transformStorage);
-
-  template <typename B> void visitBeginAccess(B *beginAccess);
+  void print(raw_ostream &os) const { accessResult.print(os); }
+  void dump() const { accessResult.dump(); }
 };
 
 /// Summarizes the dynamic accesses performed within a function and its

--- a/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
@@ -122,6 +122,8 @@ template <> struct DenseMapInfo<swift::StorageAccessInfo> {
 }
 
 namespace swift {
+using AccessedStorageSet = llvm::SmallDenseSet<StorageAccessInfo, 8>;
+
 /// Records each unique AccessedStorage in a set of StorageAccessInfo
 /// objects. Hashing and equality only sees the AccesedStorage data. The
 /// additional StorageAccessInfo bits are recorded as results of this analysis.
@@ -132,16 +134,16 @@ namespace swift {
 /// large. It does not imply that all accesses have Unidentified
 /// AccessedStorage, which is never allowed for class or global access.
 class AccessedStorageResult {
-
-  using AccessedStorageSet = llvm::SmallDenseSet<StorageAccessInfo, 8>;
-
   AccessedStorageSet storageAccessSet;
   Optional<SILAccessKind> unidentifiedAccess;
+
 public:
   AccessedStorageResult() {}
 
   // ---------------------------------------------------------------------------
   // Accessing the results.
+
+  const AccessedStorageSet &getStorageSet() const { return storageAccessSet; }
 
   bool isEmpty() const {
     return storageAccessSet.empty() && !unidentifiedAccess;

--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -258,9 +258,16 @@ transformCalleeStorage(const StorageAccessInfo &storage,
     }
     // If the argument can't be transformed, demote it to an unidentified
     // access.
+    //
+    // This is an untested bailout. It is only reachable if the call graph
+    // contains an edge that getCallerArg is unable to analyze OR if
+    // findAccessedStorageNonNested returns an invalid SILValue, which won't
+    // pass SIL verification.
+    //
+    // FIXME: In case argVal is invalid, support Unidentified access for invalid
+    // values. This would also be useful for partially invalidating results.
     return StorageAccessInfo(
-      AccessedStorage(storage.getValue(), AccessedStorage::Unidentified),
-      storage);
+        AccessedStorage(argVal, AccessedStorage::Unidentified), storage);
   }
   case AccessedStorage::Nested:
     llvm_unreachable("Unexpected nested access");

--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -23,7 +23,7 @@ using namespace swift;
 // MARK: Accessing the results.
 // -----------------------------------------------------------------------------
 
-bool FunctionAccessedStorage::hasNoNestedConflict(
+bool AccessedStorageResult::hasNoNestedConflict(
     const AccessedStorage &otherStorage) const {
   assert(otherStorage.isUniquelyIdentified());
   assert(!hasUnidentifiedAccess());
@@ -31,7 +31,7 @@ bool FunctionAccessedStorage::hasNoNestedConflict(
   return getStorageAccessInfo(otherStorage).hasNoNestedConflict();
 }
 
-bool FunctionAccessedStorage::mayConflictWith(
+bool AccessedStorageResult::mayConflictWith(
     SILAccessKind otherAccessKind, const AccessedStorage &otherStorage) const {
   if (hasUnidentifiedAccess()
       && accessKindMayConflict(otherAccessKind,
@@ -50,7 +50,7 @@ bool FunctionAccessedStorage::mayConflictWith(
   return false;
 }
 
-StorageAccessInfo FunctionAccessedStorage::getStorageAccessInfo(
+StorageAccessInfo AccessedStorageResult::getStorageAccessInfo(
     const AccessedStorage &otherStorage) const {
   // Construct a fake StorageAccessInfo to do a hash lookup for the real
   // StorageAccessInfo. The DenseSet key is limited to the AccessedStorage base
@@ -103,41 +103,7 @@ bool StorageAccessInfo::mergeFrom(const StorageAccessInfo &RHS) {
   return changed;
 }
 
-bool FunctionAccessedStorage::summarizeFunction(SILFunction *F) {
-  assert(storageAccessSet.empty() && "expected uninitialized results.");
-
-  if (F->isDefinition())
-    return false;
-
-  // If the function definition is unavailable, set unidentifiedAccess to a
-  // conservative value, since analyzeInstruction will never be called.
-  //
-  // If FunctionSideEffects can be summarized, use that information.
-  FunctionSideEffects functionSideEffects;
-  if (!functionSideEffects.summarizeFunction(F)) {
-    setWorstEffects();
-    // May as well consider this a successful summary since there are no
-    // instructions to visit anyway.
-    return true;
-  }
-  bool mayRead = functionSideEffects.getGlobalEffects().mayRead();
-  bool mayWrite = functionSideEffects.getGlobalEffects().mayWrite();
-  for (auto &paramEffects : functionSideEffects.getParameterEffects()) {
-    mayRead |= paramEffects.mayRead();
-    mayWrite |= paramEffects.mayWrite();
-  }
-  if (mayWrite)
-    unidentifiedAccess = SILAccessKind::Modify;
-  else if (mayRead)
-    unidentifiedAccess = SILAccessKind::Read;
-
-  // If function side effects is "readnone" then this result will have an empty
-  // storageAccessSet and unidentifiedAccess == None.
-  return true;
-}
-
-bool FunctionAccessedStorage::updateUnidentifiedAccess(
-    SILAccessKind accessKind) {
+bool AccessedStorageResult::updateUnidentifiedAccess(SILAccessKind accessKind) {
   if (unidentifiedAccess == None) {
     unidentifiedAccess = accessKind;
     return true;
@@ -145,18 +111,18 @@ bool FunctionAccessedStorage::updateUnidentifiedAccess(
   return updateAccessKind(unidentifiedAccess.getValue(), accessKind);
 }
 
-// Merge the given FunctionAccessedStorage in `other` into this
-// FunctionAccessedStorage. Use the given `transformStorage` to map `other`
+// Merge the given AccessedStorageResult in `other` into this
+// AccessedStorageResult. Use the given `transformStorage` to map `other`
 // AccessedStorage into this context. If `other` is from a callee, argument
 // substitution will be performed if possible. However, there's no guarantee
-// that the merged access values will belong to this function.
+// that the merged access values will belong to this region.
 //
 // Return true if these results changed, requiring further propagation through
 // the call graph.
-bool FunctionAccessedStorage::mergeAccesses(
-    const FunctionAccessedStorage &other,
+bool AccessedStorageResult::mergeAccesses(
+    const AccessedStorageResult &other,
     std::function<StorageAccessInfo(const StorageAccessInfo &)>
-      transformStorage) {
+        transformStorage) {
 
   // The cost of BottomUpIPAnalysis can be quadratic for large recursive call
   // graphs. That cost is multiplied by the size of storageAccessSet. Slowdowns
@@ -176,16 +142,16 @@ bool FunctionAccessedStorage::mergeAccesses(
   // invalidates the iterator. We still need to propagate and merge in that case
   // because arguments can be recursively dependent. The alternative would be
   // treating all self-recursion conservatively.
-  const FunctionAccessedStorage *otherFunctionAccesses = &other;
-  FunctionAccessedStorage functionAccessCopy;
+  const AccessedStorageResult *otherRegionAccesses = &other;
+  AccessedStorageResult regionAccessCopy;
   if (this == &other) {
-    functionAccessCopy = other;
-    otherFunctionAccesses = &functionAccessCopy;
+    regionAccessCopy = other;
+    otherRegionAccesses = &regionAccessCopy;
   }
   bool changed = false;
   // Nondeterminstically iterate for the sole purpose of inserting into another
   // unordered set.
-  for (auto &rawStorageInfo : otherFunctionAccesses->storageAccessSet) {
+  for (auto &rawStorageInfo : otherRegionAccesses->storageAccessSet) {
     const StorageAccessInfo &otherStorageInfo =
         transformStorage(rawStorageInfo);
     // If transformStorage() returns invalid storage object for local storage,
@@ -213,7 +179,7 @@ bool FunctionAccessedStorage::mergeAccesses(
   return changed;
 }
 
-bool FunctionAccessedStorage::mergeFrom(const FunctionAccessedStorage &other) {
+bool AccessedStorageResult::mergeFrom(const AccessedStorageResult &other) {
   // Merge accesses from other. Both `this` and `other` are either from the same
   // function or are both callees of the same call site, so their parameters
   // indices coincide. transformStorage is the identity function.
@@ -310,8 +276,8 @@ transformCalleeStorage(const StorageAccessInfo &storage,
   llvm_unreachable("unhandled kind");
 }
 
-bool FunctionAccessedStorage::mergeFromApply(
-    const FunctionAccessedStorage &calleeAccess, FullApplySite fullApply) {
+bool AccessedStorageResult::mergeFromApply(
+    const AccessedStorageResult &calleeAccess, FullApplySite fullApply) {
   // Merge accesses from calleeAccess. Transform any Argument type
   // AccessedStorage into the caller context to be added to `this` storage map.
   return mergeAccesses(calleeAccess, [&fullApply](const StorageAccessInfo &s) {
@@ -320,7 +286,7 @@ bool FunctionAccessedStorage::mergeFromApply(
 }
 
 template <typename B>
-void FunctionAccessedStorage::visitBeginAccess(B *beginAccess) {
+void AccessedStorageResult::visitBeginAccess(B *beginAccess) {
   if (beginAccess->getEnforcement() != SILAccessEnforcement::Dynamic)
     return;
 
@@ -338,7 +304,9 @@ void FunctionAccessedStorage::visitBeginAccess(B *beginAccess) {
     result.first->mergeFrom(storageAccess);
 }
 
-void FunctionAccessedStorage::analyzeInstruction(SILInstruction *I) {
+void AccessedStorageResult::analyzeInstruction(SILInstruction *I) {
+  assert(!FullApplySite::isa(I) && "caller should merge");
+
   if (auto *BAI = dyn_cast<BeginAccessInst>(I))
     visitBeginAccess(BAI);
   else if (auto *BUAI = dyn_cast<BeginUnpairedAccessInst>(I))
@@ -354,7 +322,7 @@ void StorageAccessInfo::print(raw_ostream &os) const {
 
 void StorageAccessInfo::dump() const { print(llvm::dbgs()); }
 
-void FunctionAccessedStorage::print(raw_ostream &os) const {
+void AccessedStorageResult::print(raw_ostream &os) const {
   for (auto &storageAccess : storageAccessSet)
     storageAccess.print(os);
 
@@ -364,7 +332,45 @@ void FunctionAccessedStorage::print(raw_ostream &os) const {
   }
 }
 
-void FunctionAccessedStorage::dump() const { print(llvm::dbgs()); }
+void AccessedStorageResult::dump() const { print(llvm::dbgs()); }
+
+// -----------------------------------------------------------------------------
+// MARK: FunctionAccessedStorage, implementation of
+// GenericFunctionEffectAnalysis.
+// -----------------------------------------------------------------------------
+
+bool FunctionAccessedStorage::summarizeFunction(SILFunction *F) {
+  assert(accessResult.isEmpty() && "expected uninitialized results.");
+
+  if (F->isDefinition())
+    return false;
+
+  // If the function definition is unavailable, set unidentifiedAccess to a
+  // conservative value, since analyzeInstruction will never be called.
+  //
+  // If FunctionSideEffects can be summarized, use that information.
+  FunctionSideEffects functionSideEffects;
+  if (!functionSideEffects.summarizeFunction(F)) {
+    setWorstEffects();
+    // May as well consider this a successful summary since there are no
+    // instructions to visit anyway.
+    return true;
+  }
+  bool mayRead = functionSideEffects.getGlobalEffects().mayRead();
+  bool mayWrite = functionSideEffects.getGlobalEffects().mayWrite();
+  for (auto &paramEffects : functionSideEffects.getParameterEffects()) {
+    mayRead |= paramEffects.mayRead();
+    mayWrite |= paramEffects.mayWrite();
+  }
+  if (mayWrite)
+    accessResult.setUnidentifiedAccess(SILAccessKind::Modify);
+  else if (mayRead)
+    accessResult.setUnidentifiedAccess(SILAccessKind::Read);
+
+  // If function side effects is "readnone" then this result will have an empty
+  // storageAccessSet and unidentifiedAccess == None.
+  return true;
+}
 
 SILAnalysis *swift::createAccessedStorageAnalysis(SILModule *) {
   return new AccessedStorageAnalysis();

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -1089,11 +1089,10 @@ static bool mergeAccesses(
     LLVM_DEBUG(llvm::dbgs()
                << "Merging: " << *childIns << " into " << *parentIns << "\n");
 
-    // Change the no nested conflict of parent:
-    // should be the worst case scenario: we might merge to non-conflicting
-    // scopes to a conflicting one. f the new result does not conflict,
-    // a later on pass will remove the flag
-    parentIns->setNoNestedConflict(false);
+    // Change the no nested conflict of parent if the child has a nested
+    // conflict.
+    if (!childIns->hasNoNestedConflict())
+      parentIns->setNoNestedConflict(false);
 
     // remove end accesses and create new ones that cover bigger scope:
     mergeEndAccesses(parentIns, childIns);

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -91,15 +91,16 @@
 using namespace swift;
 
 namespace swift {
-/// Represents the identity of a storage location being accessed.
+/// Information about each dynamic access with valid storage.
 ///
-/// A value-based subclass of AccessedStorage with identical layout. This
-/// provides access to pass-specific data in reserved bits.
+/// This is a pass-specific subclass of AccessedStorage with identical layout.
+/// An instance is created for each BeginAccess in the current function. In
+/// additional to identifying the access' storage location, it associates that
+/// access with pass-specific data in reserved bits. The reserved bits do not
+/// participate in equality or hash lookup.
 ///
-/// The fully descriptive class name allows forward declaration in order to
-/// define bitfields in AccessedStorage.
-///
-/// Aliased to AccessInfo in this file.
+/// Aliased to AccessInfo in this file; the fully descriptive class name allows
+/// forward declaration in order to define bitfields in AccessedStorage.
 class AccessEnforcementOptsInfo : public AccessedStorage {
 public:
   AccessEnforcementOptsInfo(const AccessedStorage &storage)

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1709,3 +1709,32 @@ bb0:
   %10 = tuple ()
   return %10 : $()
 }
+
+// Test transformCalleeStorage when the callee storage is an Argument
+// and the caller storage is an Argument at a different position.
+//
+// CHECK-LABEL: sil @testTransformArgumentCaller : $@convention(thin) (Int64, @guaranteed { var Int64 }, @guaranteed { var Int64 }) -> Int64 {
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'testTransformArgumentCaller'
+sil @testTransformArgumentCaller : $@convention(thin) (Int64, @guaranteed { var Int64 }, @guaranteed { var Int64 }) -> Int64 {
+bb0(%0 : $Int64, %1 : ${ var Int64 }, %2 : ${ var Int64 }):
+  %boxadr = project_box %1 : $ { var Int64 }, 0
+  %access = begin_access [read] [dynamic] [no_nested_conflict] %boxadr : $*Int64
+  %f = function_ref @testTransformArgumentCallee : $@convention(thin) (@guaranteed { var Int64 }) -> Int64
+  %call = apply %f(%2) : $@convention(thin) (@guaranteed { var Int64 }) -> Int64
+  store %0 to %access : $*Int64
+  end_access %access : $*Int64
+  return %call : $Int64
+}
+
+// CHECK-LABEL: sil @testTransformArgumentCallee : $@convention(thin) (@guaranteed { var Int64 }) -> Int64 {
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'testTransformArgumentCallee'
+sil @testTransformArgumentCallee : $@convention(thin) (@guaranteed { var Int64 }) -> Int64 {
+bb0(%0 : ${ var Int64 }):
+  %boxadr = project_box %0 : $ { var Int64 }, 0
+  %access = begin_access [read] [dynamic] [no_nested_conflict] %boxadr : $*Int64
+  %val = load %access : $*Int64
+  end_access %access : $*Int64
+  return %val : $Int64
+}

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1293,13 +1293,11 @@ bb4:
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
 // CHECK-NEXT: br bb3
-// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
+// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
-// CHECK-NEXT: end_access [[BEGIN3]] : $*X
 // CHECK: br bb4
-// CHECK: [[BEGIN4:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
-// CHECK-NEXT: load [[BEGIN4]] : $*X
-// CHECK-NEXT: end_access [[BEGIN4]] : $*X
+// CHECK: load [[BEGIN3]] : $*X
+// CHECK-NEXT: end_access [[BEGIN3]] : $*X
 // CHECK: cond_br {{.*}}, bb2, bb5
 // CHECK: [[BEGIN5:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN5]] : $*X

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -382,7 +382,7 @@ bb0(%0 : $*Int64):
 // CHECK-LABEL: sil @testInoutReadEscapeRead : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ var Int64 }, var, name "x"
 // CHECK: [[BOXADR:%.*]] = project_box [[BOX]] : ${ var Int64 }, 0
-// CHECK: begin_access [read] [static] [[BOXADR]] : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[BOXADR]] : $*Int64
 // CHECK-NOT: begin_access
 // CHECK-LABEL: } // end sil function 'testInoutReadEscapeRead'
 sil @testInoutReadEscapeRead : $@convention(thin) () -> () {
@@ -951,7 +951,7 @@ bb0(%0 : $*Int64, %1 : $@callee_guaranteed () -> ()):
 //
 // CHECK-LABEL: sil @testOldToNewMapRead : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
@@ -981,7 +981,7 @@ bb0:
 //
 // CHECK-LABEL: sil @testOldToNewMapReadMayRelease : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
@@ -1293,7 +1293,7 @@ bb4:
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
 // CHECK-NEXT: br bb3
-// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK: br bb4
 // CHECK: load [[BEGIN3]] : $*X
@@ -1439,7 +1439,7 @@ bb0(%0 : $RefElemNoConflictClass):
 // CHECK-NEXT: load [[BEGIN2]] : $*X
 // CHECK-NEXT: end_access [[BEGIN2]] : $*X
 // CHECK-NEXT: br bb3
-// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK: [[BEGIN3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN3]] : $*X
 // CHECK: br bb4
 // CHECK: load [[BEGIN3]] : $*X
@@ -1563,7 +1563,7 @@ bb0:
 // CHECK: bb2
 // CHECK: br bb3([[GLOBAL]] : $*X)
 // CHECK: bb3([[GLOBALPHI:%.*]] : $*X):
-// CHECK: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBALPHI]] : $*X
+// CHECK: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBALPHI]] : $*X
 // CHECK-NEXT: load
 // CHECK-NEXT: load
 // CHECK-NEXT: end_access [[BEGIN]] : $*X
@@ -1655,7 +1655,7 @@ bb0(%0 : $TestClass):
 //
 // CHECK-LABEL: sil @testNestedReadMerging : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
-// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: load [[BEGIN]] : $*X
 // CHECK-NEXT: [[BEGIN2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1352,8 +1352,9 @@ class RefElemClass {
   init()
 }
 
-// Checks that we don't crash when unable to create projection paths
-// we can't merge anything here because of that
+// Merge access overlapping scopes. Scope nesting does not need to be
+// preserved unless the nested accesses are to identical storage.
+//
 // CHECK-LABEL: sil @ref_elem_c : $@convention(thin) (RefElemClass) -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
 // CHECK-NEXT: [[BEGIN:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[GLOBAL]] : $*X
@@ -1362,10 +1363,8 @@ class RefElemClass {
 // CHECK-NEXT: [[REFX:%.*]] = ref_element_addr %0 : $RefElemClass, #RefElemClass.x
 // CHECK-NEXT: [[REFY:%.*]] = ref_element_addr %0 : $RefElemClass, #RefElemClass.y
 // CHECK-NEXT: [[BEGINX:%.*]] = begin_access [modify] [dynamic] [[REFX]] : $*BitfieldOne
-// CHECK: end_access [[BEGINX]] : $*BitfieldOne
 // CHECK: [[BEGINY:%.*]] = begin_access [modify] [dynamic] [[REFY]] : $*Int32
-// CHECK: [[BEGINX2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[REFX]] : $*BitfieldOne
-// CHECK-NEXT: end_access [[BEGINX2]] : $*BitfieldOne
+// CHECK: end_access [[BEGINX]] : $*BitfieldOne
 // CHECK-NEXT: end_access [[BEGINY]] : $*Int32
 // CHECK-LABEL: } // end sil function 'ref_elem_c'
 


### PR DESCRIPTION
Simplify the analysis and dataflow to make the pass faster eliminate bugs as a side effect.

This is broken into a series of commits. The commit called "Redo the data flow" can't be reviewed as a diff. It's best just to read the new code, referencing the old code if it's helpful.

I'm posting this somewhat prematurely (I haven't done self-review or looked into adding more tests) so there is plenty of time for review. I don't plan on checking in until a week from now.