### PR TITLE
[CodeCompletion] Fixed a crasher regarding malformed operator decl

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -217,6 +217,9 @@ TypeChecker::lookupPrecedenceGroupForInfixOperator(DeclContext *DC, Expr *E) {
 /// 'findLHS(DC, expr, '==')' returns nullptr.
 Expr *TypeChecker::findLHS(DeclContext *DC, Expr *E, Identifier name) {
   auto right = lookupPrecedenceGroupForOperator(*this, DC, name, E->getEndLoc());
+  if (!right)
+    return nullptr;
+
   while (true) {
 
     // Look through implicit conversions.

--- a/validation-test/IDE/crashers_2_fixed/rdar48648877.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar48648877.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%t/main.swift %t/a.swift %t/b.swift %t/c.swift %t/d.swift
+
+// BEGIN main.swift
+func foo(x: Int, y: Int) {
+  x + y #^COMPLETE^#
+}
+
+// BEGIN a.swift
+
+infix operator ***
+
+// BEGIN b.swift
+
+infix operator ***
+
+// BEGIN c.swift
+
+precedencegroup FooPrecedenceGroup {
+  higherThan: MultiplicationPrecedence
+}
+infix operator **** : FooPrecedenceGroup
+
+// BEGIN d.swift
+
+precedencegroup FooPrecedenceGroup {
+  higherThan: MultiplicationPrecedence
+}
+infix operator **** : FooPrecedenceGroup


### PR DESCRIPTION
Infix operator completion used to crash if multiple infix operators with the same name are declared in the module. (Because `precedencegroup` for such operator cannot be resolved).

rdar://problem/48648877
