### PR TITLE
build: try to fix swift-reflection-test harder

### DIFF
--- a/stdlib/tools/swift-reflection-test/CMakeLists.txt
+++ b/stdlib/tools/swift-reflection-test/CMakeLists.txt
@@ -4,4 +4,10 @@ add_swift_target_executable(swift-reflection-test BUILD_WITH_STDLIB
   LINK_FAT_LIBRARIES
     swiftRemoteMirror
     swiftReflection)
-
+# NOTE(compnerd) since _WINDLL has no impact on non-Windows targets,
+# we just spam it on all the targets for simplicity due to the build
+# structure of swift.  This will make the global variable imported,
+# which we need.
+set_source_files_properties(swift-reflection-test.c
+                            PROPERTIES
+                              COMPILE_FLAGS -D_WINDLL)


### PR DESCRIPTION
Ensure that the symbol is marked for DLL import rather than just as a local.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
