### PR TITLE
build: introduce and switch to GYB_SOURCES

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -721,6 +721,7 @@ function(_add_swift_library_single target name)
         FILE_DEPENDS
         FRAMEWORK_DEPENDS
         FRAMEWORK_DEPENDS_WEAK
+        GYB_SOURCES
         INCORPORATE_OBJECT_LIBRARIES
         INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY
         INTERFACE_LINK_LIBRARIES
@@ -810,10 +811,14 @@ function(_add_swift_library_single target name)
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
   endif()
 
-  handle_gyb_sources(
-      gyb_dependency_targets
-      SWIFTLIB_SINGLE_SOURCES
-      "${SWIFTLIB_SINGLE_ARCHITECTURE}")
+  if(SWIFTLIB_SINGLE_GYB_SOURCES)
+    handle_gyb_sources(
+        gyb_dependency_targets
+        SWIFTLIB_SINGLE_GYB_SOURCES
+        "${SWIFTLIB_SINGLE_ARCHITECTURE}")
+    set(SWIFTLIB_SINGLE_SOURCES ${SWIFTLIB_SINGLE_SOURCES}
+      ${SWIFTLIB_SINGLE_GYB_SOURCES})
+  endif()
 
   # Remove the "swift" prefix from the name to determine the module name.
   if(SWIFTLIB_IS_STDLIB_CORE)
@@ -1620,6 +1625,7 @@ function(add_swift_target_library name)
         FRAMEWORK_DEPENDS_IOS_TVOS
         FRAMEWORK_DEPENDS_OSX
         FRAMEWORK_DEPENDS_WEAK
+        GYB_SOURCES
         INCORPORATE_OBJECT_LIBRARIES
         INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY
         INTERFACE_LINK_LIBRARIES
@@ -1914,6 +1920,7 @@ function(add_swift_target_library name)
         DEPLOYMENT_VERSION_IOS "${SWIFTLIB_DEPLOYMENT_VERSION_IOS}"
         DEPLOYMENT_VERSION_TVOS "${SWIFTLIB_DEPLOYMENT_VERSION_TVOS}"
         DEPLOYMENT_VERSION_WATCHOS "${SWIFTLIB_DEPLOYMENT_VERSION_WATCHOS}"
+        GYB_SOURCES ${SWIFTLIB_GYB_SOURCES}
       )
 
       if(NOT SWIFTLIB_OBJECT_LIBRARY)

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -131,35 +131,31 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name arch)
       "${SWIFT_SOURCE_DIR}/utils/gyb_sourcekit_support/UIDs.py")
 
   foreach (src ${${sources_var_name}})
-    string(REGEX REPLACE "[.]gyb$" "" src_sans_gyb "${src}")
-    if(src STREQUAL src_sans_gyb)
-      list(APPEND de_gybbed_sources "${src}")
+    # On Windows (using Visual Studio), the generated project files assume that the
+    # generated GYB files will be in the source, not binary directory.
+    # We can work around this by modifying the root directory when generating VS projects.
+    if ("${CMAKE_GENERATOR_PLATFORM}" MATCHES "Visual Studio")
+      set(dir_root ${CMAKE_CURRENT_SOURCE_DIR})
     else()
-
-      # On Windows (using Visual Studio), the generated project files assume that the
-      # generated GYB files will be in the source, not binary directory.
-      # We can work around this by modifying the root directory when generating VS projects.
-      if ("${CMAKE_GENERATOR_PLATFORM}" MATCHES "Visual Studio")
-        set(dir_root ${CMAKE_CURRENT_SOURCE_DIR})
-      else()
-        set(dir_root ${CMAKE_CURRENT_BINARY_DIR})
-      endif()
-      
-      if (arch)
-        set(dir "${dir_root}/${ptr_size}")
-      else()
-        set(dir "${dir_root}")
-      endif()
-      set(output_file_name "${dir}/${src_sans_gyb}")
-      list(APPEND de_gybbed_sources "${output_file_name}")
-      handle_gyb_source_single(dependency_target
-          SOURCE "${src}"
-          OUTPUT "${output_file_name}"
-          FLAGS ${extra_gyb_flags}
-          DEPENDS "${gyb_extra_sources}"
-          COMMENT "with ptr size = ${ptr_size}")
-      list(APPEND dependency_targets "${dependency_target}")
+      set(dir_root ${CMAKE_CURRENT_BINARY_DIR})
     endif()
+
+    if (arch)
+      set(dir "${dir_root}/${ptr_size}")
+    else()
+      set(dir "${dir_root}")
+    endif()
+    # get_filename_component(src_sans_gyb ${src} NAME_WLE)
+    string(REGEX REPLACE "\.gyb$" "" src_sans_gyb ${src})
+    set(output_file_name "${dir}/${src_sans_gyb}")
+    list(APPEND de_gybbed_sources "${output_file_name}")
+    handle_gyb_source_single(dependency_target
+        SOURCE "${src}"
+        OUTPUT "${output_file_name}"
+        FLAGS ${extra_gyb_flags}
+        DEPENDS "${gyb_extra_sources}"
+        COMMENT "with ptr size = ${ptr_size}")
+    list(APPEND dependency_targets "${dependency_target}")
   endforeach()
   set("${dependency_out_var_name}" "${dependency_targets}" PARENT_SCOPE)
   set("${sources_var_name}" "${de_gybbed_sources}" PARENT_SCOPE)

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -102,7 +102,8 @@ add_swift_host_library(swiftBasic STATIC
   # Platform-agnostic fallback TaskQueue implementation
   Default/TaskQueue.inc
 
-  UnicodeExtendedGraphemeClusters.cpp.gyb
+  GYB_SOURCES
+    UnicodeExtendedGraphemeClusters.cpp.gyb
 
   C_COMPILE_FLAGS ${UUID_INCLUDE}
   LLVM_COMPONENT_DEPENDS support)

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -10,9 +10,6 @@ add_swift_host_library(swiftParse STATIC
   ParseDecl.cpp
   ParsedRawSyntaxNode.cpp
   ParsedRawSyntaxRecorder.cpp
-  ParsedSyntaxBuilders.cpp.gyb
-  ParsedSyntaxNodes.cpp.gyb
-  ParsedSyntaxRecorder.cpp.gyb
   ParsedTrivia.cpp
   ParseExpr.cpp
   ParseGeneric.cpp
@@ -24,7 +21,12 @@ add_swift_host_library(swiftParse STATIC
   PersistentParserState.cpp
   Scope.cpp
   SyntaxParsingCache.cpp
-  SyntaxParsingContext.cpp)
+  SyntaxParsingContext.cpp
+
+  GYB_SOURCES
+    ParsedSyntaxBuilders.cpp.gyb
+    ParsedSyntaxNodes.cpp.gyb
+    ParsedSyntaxRecorder.cpp.gyb)
 target_link_libraries(swiftParse PRIVATE
   swiftAST
   swiftSyntax)

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -5,14 +5,16 @@ else()
 endif()
 
 add_swift_host_library(swiftSyntax STATIC
-  SyntaxNodes.cpp.gyb
-  SyntaxBuilders.cpp.gyb
-  SyntaxKind.cpp.gyb
-  SyntaxFactory.cpp.gyb
-  SyntaxVisitor.cpp.gyb
-  Trivia.cpp.gyb
   RawSyntax.cpp
   Syntax.cpp
   SyntaxData.cpp
-  SyntaxSerialization.cpp.gyb
-  UnknownSyntax.cpp)
+  UnknownSyntax.cpp
+
+  GYB_SOURCES
+    SyntaxNodes.cpp.gyb
+    SyntaxBuilders.cpp.gyb
+    SyntaxKind.cpp.gyb
+    SyntaxFactory.cpp.gyb
+    SyntaxVisitor.cpp.gyb
+    Trivia.cpp.gyb
+    SyntaxSerialization.cpp.gyb)

--- a/stdlib/private/SwiftPrivate/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivate/CMakeLists.txt
@@ -7,9 +7,11 @@ add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   # filename.
   SwiftPrivate.swift
 
-  AtomicInt.swift.gyb
   IO.swift
   ShardedAtomicCounter.swift
+
+  GYB_SOURCES
+    AtomicInt.swift.gyb
 
   SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT WinSDK
   SWIFT_COMPILE_FLAGS ${swift_swiftprivate_compile_flags}

--- a/stdlib/public/Darwin/AVFoundation/CMakeLists.txt
+++ b/stdlib/public/Darwin/AVFoundation/CMakeLists.txt
@@ -8,7 +8,9 @@ add_swift_target_library(swiftAVFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
   AVCaptureVideoDataOutput.swift
   AVError.swift
   AVMetadataObject.swift
-  NSValue.swift.gyb
+
+  GYB_SOURCES
+    NSValue.swift.gyb
 
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"

--- a/stdlib/public/Darwin/Accelerate/CMakeLists.txt
+++ b/stdlib/public/Darwin/Accelerate/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftAccelerate ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-  BNNS.swift.gyb
+
+  GYB_SOURCES
+    BNNS.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/CoreGraphics/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreGraphics/CMakeLists.txt
@@ -3,8 +3,10 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftCoreGraphics ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreGraphics.swift
-  CGFloat.swift.gyb
   Private.swift
+
+  GYB_SOURCES
+    CGFloat.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/CoreLocation/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreLocation/CMakeLists.txt
@@ -3,7 +3,9 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftCoreLocation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CLError.swift
-  NSValue.swift.gyb
+
+  GYB_SOURCES
+    NSValue.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/Foundation/CMakeLists.txt
+++ b/stdlib/public/Darwin/Foundation/CMakeLists.txt
@@ -51,7 +51,6 @@ add_swift_target_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   NSTextCheckingResult.swift
   NSUndoManager.swift
   NSURL.swift
-  NSValue.swift.gyb
   PersonNameComponents.swift
   PlistEncoder.swift
   Progress.swift
@@ -63,6 +62,9 @@ add_swift_target_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   URLRequest.swift
   UUID.swift
   CheckClass.mm
+
+  GYB_SOURCES
+    NSValue.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization" "-swift-version" "5"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/GLKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/GLKit/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftGLKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-  GLKMath.swift.gyb
+
+  GYB_SOURCES
+    GLKMath.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/MapKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/MapKit/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftMapKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-  NSValue.swift.gyb
+
+  GYB_SOURCES
+    NSValue.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/QuartzCore/CMakeLists.txt
+++ b/stdlib/public/Darwin/QuartzCore/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftQuartzCore ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-  NSValue.swift.gyb
+
+  GYB_SOURCES
+    NSValue.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/SceneKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/SceneKit/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-  SceneKit.swift.gyb
+
+  GYB_SOURCES
+    SceneKit.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/SpriteKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/SpriteKit/CMakeLists.txt
@@ -3,7 +3,9 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftSpriteKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   SpriteKit.swift
-  SpriteKitQuickLooks.swift.gyb
+
+  GYB_SOURCES
+    SpriteKitQuickLooks.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/UIKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/UIKit/CMakeLists.txt
@@ -4,7 +4,9 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_target_library(swiftUIKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   DesignatedInitializers.mm
   UIKit.swift
-  UIKit_FoundationExtensions.swift.gyb
+
+  GYB_SOURCES
+    UIKit_FoundationExtensions.swift.gyb
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} -swift-version 4.2
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Darwin/simd/CMakeLists.txt
+++ b/stdlib/public/Darwin/simd/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_target_library(swiftsimd ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-  simd.swift.gyb
-  Quaternion.swift.gyb
+
+  GYB_SOURCES
+    simd.swift.gyb
+    Quaternion.swift.gyb
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -1,13 +1,17 @@
 set(swift_platform_sources
     Platform.swift
-    TiocConstants.swift
+    TiocConstants.swift)
+set(swift_platform_gyb_sources
     tgmath.swift.gyb)
 
 add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-    Darwin.swift.gyb
     ${swift_platform_sources}
     POSIXError.swift
     MachError.swift
+
+    GYB_SOURCES
+      ${swift_platform_gyb_sources}
+      Darwin.swift.gyb
 
     SWIFT_COMPILE_FLAGS -Xfrontend -disable-objc-attr-requires-foundation-module "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
@@ -18,8 +22,11 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_
     DEPENDS copy_apinotes)
 
 add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-    Glibc.swift.gyb
     ${swift_platform_sources}
+
+    GYB_SOURCES
+      ${swift_platform_gyb_sources}
+      Glibc.swift.gyb
 
     SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
@@ -29,6 +36,9 @@ add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_O
 add_swift_target_library(swiftMSVCRT ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     msvcrt.swift
     ${swift_platform_sources}
+
+    GYB_SOURCES
+      ${swift_platform_gyb_sources}
 
     SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -30,7 +30,6 @@ set(SWIFTLIB_ESSENTIAL
   ASCII.swift
   Assert.swift
   AssertCommon.swift
-  AtomicInt.swift.gyb
   BidirectionalCollection.swift
   Bitset.swift
   Bool.swift
@@ -38,10 +37,8 @@ set(SWIFTLIB_ESSENTIAL
   BridgeStorage.swift
   BridgingBuffer.swift
   Builtin.swift
-  BuiltinMath.swift.gyb
   Character.swift
   CocoaArray.swift
-  Codable.swift.gyb
   Collection.swift
   CollectionAlgorithms.swift
   Comparable.swift
@@ -65,12 +62,9 @@ set(SWIFTLIB_ESSENTIAL
   Equatable.swift
   ErrorType.swift
   Filter.swift
-  FixedArray.swift.gyb
   FlatMap.swift
   Flatten.swift
   FloatingPoint.swift
-  FloatingPointParsing.swift.gyb
-  FloatingPointTypes.swift.gyb
   Hashable.swift
   # WORKAROUND: This file name is not sorted alphabetically in the list because
   # if we do so, the compiler crashes.
@@ -84,7 +78,6 @@ set(SWIFTLIB_ESSENTIAL
   InputStream.swift
   IntegerParsing.swift
   Integers.swift
-  IntegerTypes.swift.gyb
   Join.swift
   KeyPath.swift
   KeyValuePairs.swift
@@ -95,7 +88,6 @@ set(SWIFTLIB_ESSENTIAL
   Map.swift
   MemoryLayout.swift
   UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
-  Mirrors.swift.gyb
   Misc.swift
   MutableCollection.swift
   NativeDictionary.swift
@@ -118,7 +110,6 @@ set(SWIFTLIB_ESSENTIAL
   REPL.swift
   Result.swift
   Reverse.swift
-  Runtime.swift.gyb
   RuntimeFunctionCounters.swift
   SipHash.swift
   Sequence.swift
@@ -170,7 +161,6 @@ set(SWIFTLIB_ESSENTIAL
   SwiftNativeNSArray.swift
   ThreadLocalStorage.swift
   UIntBuffer.swift
-  UnavailableStringAPIs.swift.gyb
   UnicodeEncoding.swift
   UnicodeHelpers.swift
   UnicodeParser.swift
@@ -179,8 +169,6 @@ set(SWIFTLIB_ESSENTIAL
   Unmanaged.swift
   UnmanagedOpaqueString.swift
   UnmanagedString.swift
-  UnsafeBufferPointer.swift.gyb
-  UnsafeRawBufferPointer.swift.gyb
   UnsafePointer.swift
   UnsafeRawPointer.swift
   UTFEncoding.swift
@@ -191,7 +179,21 @@ set(SWIFTLIB_ESSENTIAL
   StringGraphemeBreaking.swift # ORDER DEPENDENCY: Must follow UTF16.swift
   ValidUTF8Buffer.swift
   WriteBackMutableSlice.swift
-  MigrationSupport.swift
+  MigrationSupport.swift)
+
+set(SWIFTLIB_ESSENTIAL_GYB_SOURCES
+  AtomicInt.swift.gyb
+  BuiltinMath.swift.gyb
+  Codable.swift.gyb
+  FixedArray.swift.gyb
+  FloatingPointParsing.swift.gyb
+  FloatingPointTypes.swift.gyb
+  IntegerTypes.swift.gyb
+  Mirrors.swift.gyb
+  Runtime.swift.gyb
+  UnavailableStringAPIs.swift.gyb
+  UnsafeBufferPointer.swift.gyb
+  UnsafeRawBufferPointer.swift.gyb
   )
 
 # The complete list of sources in the core standard library.  Includes
@@ -203,17 +205,20 @@ set(SWIFTLIB_SOURCES
   CollectionDifference.swift
   CollectionOfOne.swift
   Diffing.swift
-  ExistentialCollection.swift.gyb
   Mirror.swift
   PlaygroundDisplay.swift
   CommandLine.swift
   SliceBuffer.swift
   SIMDVector.swift
-  SIMDVectorTypes.swift.gyb
-  Tuple.swift.gyb
   UnfoldSequence.swift
   VarArgs.swift
-  Zip.swift
+  Zip.swift)
+
+set(SWIFTLIB_GYB_SOURCES
+    ${SWIFTLIB_ESSENTIAL_GYB_SOURCES}
+    ExistentialCollection.swift.gyb
+    SIMDVectorTypes.swift.gyb
+    Tuple.swift.gyb
   )
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)
 set(swift_core_link_flags "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
@@ -283,13 +288,17 @@ endif()
 
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_target_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
-      ${SWIFTLIB_ESSENTIAL})
+      ${SWIFTLIB_ESSENTIAL}
+      GYB_SOURCES
+        ${SWIFTLIB_ESSENTIAL_GYB_SOURCES})
   target_link_libraries(swift_stdlib_essential ${RUNTIME_DEPENDENCY})
 endif()
 
 add_swift_target_library(swiftCore
                   ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
                     ${SWIFTLIB_SOURCES}
+                  GYB_SOURCES
+                    ${SWIFTLIB_GYB_SOURCES}
                   # The copy_shim_headers target dependency is required to let the
                   # build system know that there's a rule to produce the shims
                   # directory, but is not sufficient to cause the object file to be rebuilt

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -13,13 +13,15 @@ set(swift_stubs_objc_sources
     FoundationHelpers.mm
     OptionalBridgingHelper.mm
     Reflection.mm
-    SwiftNativeNSXXXBaseARC.m
+    SwiftNativeNSXXXBaseARC.m)
+set(swift_stubs_gyb_sources
     SwiftNativeNSXXXBase.mm.gyb)
 set(swift_stubs_unicode_normalization_sources
     UnicodeNormalization.cpp)
 set(LLVM_OPTIONAL_SOURCES
     ${swift_stubs_objc_sources}
-    ${swift_stubs_unicode_normalization_sources})
+    ${swift_stubs_unicode_normalization_sources}
+    ${swift_stubs_gyb_sources})
 
 set(swift_stubs_c_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 list(APPEND swift_stubs_c_compile_flags -DswiftCore_EXPORTS)
@@ -30,6 +32,8 @@ add_swift_target_library(swiftStdlibStubs
                     ${swift_stubs_sources}
                     ${swift_stubs_objc_sources}
                     ${swift_stubs_unicode_normalization_sources}
+                  GYB_SOURCES
+                    ${swift_stubs_gyb_sources}
                   C_COMPILE_FLAGS
                     ${swift_stubs_c_compile_flags}
                   LINK_FLAGS

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1328,6 +1328,16 @@
         },
         {
           "kind": "Conformance",
+          "name": "MirrorPath",
+          "printedName": "MirrorPath"
+        },
+        {
+          "kind": "Conformance",
+          "name": "CVarArg",
+          "printedName": "CVarArg"
+        },
+        {
+          "kind": "Conformance",
           "name": "Encodable",
           "printedName": "Encodable"
         },
@@ -1360,11 +1370,6 @@
           "kind": "Conformance",
           "name": "_CustomPlaygroundQuickLookable",
           "printedName": "_CustomPlaygroundQuickLookable"
-        },
-        {
-          "kind": "Conformance",
-          "name": "MirrorPath",
-          "printedName": "MirrorPath"
         },
         {
           "kind": "Conformance",
@@ -1463,11 +1468,6 @@
               ]
             }
           ]
-        },
-        {
-          "kind": "Conformance",
-          "name": "CVarArg",
-          "printedName": "CVarArg"
         }
       ]
     }

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1226,6 +1226,16 @@
         },
         {
           "kind": "Conformance",
+          "name": "MirrorPath",
+          "printedName": "MirrorPath"
+        },
+        {
+          "kind": "Conformance",
+          "name": "CVarArg",
+          "printedName": "CVarArg"
+        },
+        {
+          "kind": "Conformance",
           "name": "Encodable",
           "printedName": "Encodable"
         },
@@ -1248,11 +1258,6 @@
           "kind": "Conformance",
           "name": "CustomReflectable",
           "printedName": "CustomReflectable"
-        },
-        {
-          "kind": "Conformance",
-          "name": "MirrorPath",
-          "printedName": "MirrorPath"
         },
         {
           "kind": "Conformance",
@@ -1358,11 +1363,6 @@
               ]
             }
           ]
-        },
-        {
-          "kind": "Conformance",
-          "name": "CVarArg",
-          "printedName": "CVarArg"
         }
       ]
     }

--- a/tools/SourceKit/tools/swift-lang/CMakeLists.txt
+++ b/tools/SourceKit/tools/swift-lang/CMakeLists.txt
@@ -21,7 +21,9 @@ if(NOT SWIFT_SOURCEKIT_USE_INPROC_LIBRARY AND SWIFT_BUILD_STDLIB AND SWIFT_BUILD
     SourceKitdRequest.swift
     SourceKitdResponse.swift
     SourceKitdUID.swift
-    UIDs.swift.gyb
+
+    GYB_SOURCES
+      UIDs.swift.gyb
 
     DEPENDS ${DEPENDS_LIST}
     SWIFT_MODULE_DEPENDS_OSX Darwin Foundation


### PR DESCRIPTION
This avoids us having to pattern match every source file which should
help speed up the CMake generation.  A secondary optimization is
possible with CMake 3.14 which has the ability to remove the last
extension component without having to resort to regular expressions.  It
also helps easily identify the GYB'ed sources.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
