### PR TITLE
[gardening] Eliminate unneeded public: in TreeScopedHashTable.

### DIFF
--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -332,7 +332,6 @@ public:
     return false;
   }
 
-public:
   V lookup(const ScopeTy &S, const K &Key) {
     const typename ScopeTy::ImplTy *CurrScope = S.getImpl();
     while (CurrScope) {


### PR DESCRIPTION
There is already a public: specifier some lines above this one. It is unneeded.