### PR TITLE
[parse] Implement a dump method on Scope using a new debugVisit metho…

### DIFF
--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -357,6 +357,16 @@ public:
     return iterator(I->second);
   }
 
+  using DebugVisitValueTy = TreeScopedHashTableVal<K, V> *;
+
+  /// Visit each entry in the map without regard to order. Meant to be used with
+  /// in the debugger in coordination with other dumpers that can dump whatever
+  /// is stored in the map. No-op when asserts are disabled.
+  LLVM_ATTRIBUTE_DEPRECATED(
+      void debugVisit(std::function<void(const DebugVisitValueTy &)> &&func)
+          const LLVM_ATTRIBUTE_USED,
+      "Only for use in the debugger");
+
   /// This inserts the specified key/value at the specified
   /// (possibly not the current) scope.  While it is ok to insert into a scope
   /// that isn't the current one, it isn't ok to insert *underneath* an existing
@@ -382,6 +392,16 @@ public:
     S.getImpl()->LastValInScope = KeyEntry;
   }
 };
+
+template <typename K, typename V, typename Allocator>
+void TreeScopedHashTable<K, V, Allocator>::debugVisit(
+    std::function<void(const DebugVisitValueTy &)> &&func) const {
+#ifndef NDEBUG
+  for (auto entry : TopLevelMap) {
+    func(entry.second);
+  }
+#endif
+}
 
 template <typename K, typename V, typename Allocator>
 TreeScopedHashTableScopeImpl<K, V, Allocator>::~TreeScopedHashTableScopeImpl() {

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -57,6 +57,9 @@ public:
   bool isInactiveConfigBlock() const;
   
   SavedScope saveCurrentScope();
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "Only for use in the debugger");
 };
 
 enum class ScopeKind {

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -139,3 +139,26 @@ void ScopeInfo::addToScope(ValueDecl *D, Parser &TheParser) {
                      D->getFullName(),
                      std::make_pair(CurScope->getDepth(), D));
 }
+
+void ScopeInfo::dump() const {
+#ifndef NDEBUG
+  // Dump out the current list of scopes.
+  if (!CurScope->isResolvable())
+    return;
+
+  assert(CurScope->getDepth() >= ResolvableDepth &&
+         "Attempting to dump a non-resolvable scope?!");
+
+  llvm::dbgs() << "--- Dumping ScopeInfo ---\n";
+  std::function<void(decltype(HT)::DebugVisitValueTy)> func =
+      [&](const decltype(HT)::DebugVisitValueTy &iter) -> void {
+    llvm::dbgs() << "DeclName: " << iter->getKey() << "\n"
+                 << "KeyScopeID: " << iter->getValue().first << "\n"
+                 << "Decl: ";
+    iter->getValue().second->dumpRef(llvm::dbgs());
+    llvm::dbgs() << "\n";
+  };
+  HT.debugVisit(std::move(func));
+  llvm::dbgs() << "\n";
+#endif
+}


### PR DESCRIPTION
…d on TreeScopedHashTable.

This is just for use in the debugger when one may want to know what is in the
current scope. The order is not guaranteed but at least it can provide /some/
info ignoring that property. These are no-ops when not in asserts and I put in a
compile time warnign to make sure it is not used in the actual code base.
