### PR TITLE
Frontend: sketch out a SwiftRuntime infrastructure

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -225,6 +225,8 @@ public:
 
   TypeInfoDumpFilter TypeInfoFilter;
 
+  SwiftRuntime Runtime;
+
   IRGenOptions()
       : DWARFVersion(2), OutputKind(IRGenOutputKind::LLVMAssembly),
         Verify(true), OptMode(OptimizationMode::NotSet),
@@ -246,7 +248,7 @@ public:
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
-        TypeInfoFilter(TypeInfoDumpFilter::All) {}
+        TypeInfoFilter(TypeInfoDumpFilter::All), Runtime() {}
 
   // Get a hash of all options which influence the llvm compilation but are not
   // reflected in the llvm module itself.

--- a/include/swift/Basic/SwiftRuntime.h
+++ b/include/swift/Basic/SwiftRuntime.h
@@ -1,0 +1,54 @@
+//===--- SwiftRuntime.h - Swift Runtime Handling ----------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_SWIFTRUNTIME_H
+#define SWIFT_BASIC_SWIFTRUNTIME_H
+
+#include "llvm/ADT/Triple.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/VersionTuple.h"
+
+namespace swift {
+
+class SwiftRuntime {
+  VersionTuple Version;
+
+public:
+  SwiftRuntime(const VersionTuple &V) : Version(V) {}
+
+  const VersionTuple &getVersion() const { return Version; }
+
+
+  bool hasDefaultForeignClassValueWitnesses() const {
+    return Version >= VersionTuple(5, 1);
+  }
+
+
+  bool tryParse(StringRef S);
+
+  std::string getAsString() const;
+
+  friend bool operator==(const SwiftRuntime &LHS, const SwiftRuntime &RHS) {
+    return LHS.getVersion() == RHS.getVersion();
+  }
+
+  friend bool operator!=(const SwiftRuntime &LHS, const SwiftRuntime &RHS) {
+    return !(LHS == RHS);
+  }
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SwiftRuntime &V);
+
+}
+
+#endif
+

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -187,6 +187,9 @@ def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, Par
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
+def swift_runtime : Separator<["-"], "swift-runtime">, Flags<[FrontendOption]>,
+  HelpText<"Specify the target Swift runtime version">, MetaVarName<"<runtime>">;
+
 def package_description_version: Separate<["-"], "package-description-version">,
   Flags<[FrontendOption, HelpHidden, ParseableInterfaceOption]>,
   HelpText<"The version number to be applied on the input for the PackageDescription availability kind">,

--- a/lib/Basic/SwiftRuntime.cpp
+++ b/lib/Basic/SwiftRuntime.cpp
@@ -1,0 +1,36 @@
+//===--- SwiftRuntime.cpp - Swift Runtime Handling --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Badic/SwiftRuntime.h"
+
+using namespace swift;
+
+bool SwiftRuntime::tryParse(StringRef S) {
+  Version = VersionTuple(0);
+  return !Version.tryParse(S);
+}
+
+std::string SwiftRuntime::getAsString() const {
+  std::string Result;
+  {
+    llvm::raw_string_ostream OS(Result);
+    OS << *this;
+  }
+  return Result;
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS, const SwiftRuntime &V) {
+  if (V.getVersion() > VersionTuple(0))
+    OS << V.getVersion();
+  return OS;
+}
+

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -209,6 +209,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_coverage_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
+  inputArgs.AddLastArg(arguments, options::OPT_swift_runtime);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
   inputArgs.AddLastArg(arguments, options::OPT_trace_stats_events);


### PR DESCRIPTION
Due to the ABI stability, it will become increasingly useful to be able
to query the runtime that we are targeting to take advantage of newer
functionality if possible.  Sketch out a framework for this inspired by
the ObjCRuntime system in clang.  Although there is no reason to assume
that there will be variations of the Kind sort, leave the infrastructure
generic enough to support that.

This addresses some comments on the changes to support lazy registration
of foreign import types.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
