### PR TITLE
WinSDK: add some constants from CommCtrl

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -96,6 +96,11 @@ module WinSDK [system] [extern_c] {
     }
   }
 
+  module CommCtrl {
+    header "CommCtrl.h"
+    export *
+  }
+
   // FIXME(compnerd) this is a hack for the HWND typedef for DbgHelp
   module __DirectX {
     header "directmanipulation.h"

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -51,3 +51,23 @@ public let WS_POPUPWINDOW: UINT =
 // fileapi.h
 public let INVALID_FILE_ATTRIBUTES: DWORD = DWORD(bitPattern: -1)
 
+// CommCtrl.h
+public let WC_BUTTONW: [WCHAR] = Array<WCHAR>("Button".utf16)
+public let WC_COMBOBOXW: [WCHAR] = Array<WCHAR>("ComboBox".utf16)
+public let WC_EDITW: [WCHAR] = Array<WCHAR>("Edit".utf16)
+public let WC_HEADERW: [WCHAR] = Array<WCHAR>("SysHeader32".utf16)
+public let WC_LISTBOXW: [WCHAR] = Array<WCHAR>("ListBox".utf16)
+public let WC_LISTVIEWW: [WCHAR] = Array<WCHAR>("SysListView32".utf16)
+public let WC_SCROLLBARW: [WCHAR] = Array<WCHAR>("ScrollBar".utf16)
+public let WC_STATICW: [WCHAR] = Array<WCHAR>("Static".utf16)
+public let WC_TABCONTROLW: [WCHAR] = Array<WCHAR>("SysTabControl32".utf16)
+public let WC_TREEVIEWW: [WCHAR] = Array<WCHAR>("SysTreeView32".utf16)
+
+public let ANIMATE_CLASSW: [WCHAR] = Array<WCHAR>("SysAnimate32".utf16)
+public let HOTKEY_CLASSW: [WCHAR] = Array<WCHAR>("msctls_hotkey32".utf16)
+public let PROGRESS_CLASSW: [WCHAR] = Array<WCHAR>("msctls_progress32".utf16)
+public let STATUSCLASSNAMEW: [WCHAR] = Array<WCHAR>("msctls_statusbar32".utf16)
+public let TOOLBARW_CLASSW: [WCHAR] = Array<WCHAR>("ToolbarWindow32".utf16)
+public let TRACKBAR_CLASSW: [WCHAR] = Array<WCHAR>("msctls_trackbar32".utf16)
+public let UPDOWN_CLASSW: [WCHAR] = Array<WCHAR>("msctls_updown32".utf16)
+


### PR DESCRIPTION
This exposes the common control window class name constants to the Swift
side enabling the use of these constants to create Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
