### PR TITLE
Fix document for AdditiveArithmetic

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -36,7 +36,7 @@ extension ExpressibleByIntegerLiteral
 /// generic constraint.
 ///
 /// The following code declares a method that calculates the total of any
-/// sequence with `Numeric` elements.
+/// sequence with `AdditiveArithmetic` elements.
 ///
 ///     extension Sequence where Element: AdditiveArithmetic {
 ///         func sum() -> Element {


### PR DESCRIPTION
In the sentence describing the code of Sequence with AdditiveArithmetic, the word Numeric is used. I think this is a mistake.