### PR TITLE
SourceKit/InterfaceGen: sanitize Clang-specific doc-comment style when printing headers as Swift interface

### DIFF
--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -32,7 +32,7 @@
 // TAG_DECLS_AND_TYPEDEFS: {{^}}  init(x: Int32, y: Double){{$}}
 // TAG_DECLS_AND_TYPEDEFS: {{^}}}{{$}}
 
-// TAG_DECLS_AND_TYPEDEFS:      /*!
+// TAG_DECLS_AND_TYPEDEFS:      /**
 // TAG_DECLS_AND_TYPEDEFS-NEXT:   @keyword Foo2
 // TAG_DECLS_AND_TYPEDEFS-NEXT: */
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}struct FooStruct2 {{{$}}

--- a/test/SourceKit/InterfaceGen/Inputs/header2.h
+++ b/test/SourceKit/InterfaceGen/Inputs/header2.h
@@ -1,7 +1,12 @@
 
 typedef struct {
+  /*! Some clang-style comments */
   long width;
+  /*!
+   * Some clang-style comments
+   */
   long height;
+
 } NUPixelSize;
 
 #if __swift__ >= 50000

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -136,7 +136,7 @@ public func fooFuncNoreturn2() -> Never
  */
 public func fooFuncWithComment1()
 
-/*!
+/**
   Aaa.  fooFuncWithComment2.  Bbb.
  */
 public func fooFuncWithComment2()
@@ -1695,7 +1695,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 19
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
+    key.kind: source.lang.swift.syntaxtype.doccomment,
     key.offset: 2680,
     key.length: 42
   },
@@ -5457,6 +5457,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 26,
     key.nameoffset: 2735,
     key.namelength: 21,
+    key.docoffset: 2680,
+    key.doclength: 42,
     key.attributes: [
       {
         key.offset: 2723,

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -1,8 +1,12 @@
 
 public struct NUPixelSize {
 
+    /** Some clang-style comments */
     public var width: Int
 
+    /**
+     * Some clang-style comments
+     */
     public var height: Int
 
     public init()
@@ -27,108 +31,118 @@ public struct NUPixelSize {
     key.length: 11
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.doccomment,
     key.offset: 34,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 71,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 41,
+    key.offset: 78,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 45,
+    key.offset: 82,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 52,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 61,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 68,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 72,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 80,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 89,
-    key.length: 6
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 96,
-    key.length: 4
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 98,
+    key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 108,
+    key.offset: 147,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 115,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 120,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 127,
+    key.offset: 154,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 132,
+    key.offset: 158,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 140,
+    key.offset: 166,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 175,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 182,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 194,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 201,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 206,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 213,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 218,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 226,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 52,
+    key.offset: 89,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 80,
+    key.offset: 166,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 127,
+    key.offset: 213,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 140,
+    key.offset: 226,
     key.length: 3,
     key.is_system: 1
   }
@@ -139,11 +153,11 @@ public struct NUPixelSize {
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "NUPixelSize",
     key.offset: 8,
-    key.length: 138,
+    key.length: 224,
     key.nameoffset: 15,
     key.namelength: 11,
     key.bodyoffset: 28,
-    key.bodylength: 117,
+    key.bodylength: 203,
     key.attributes: [
       {
         key.offset: 1,
@@ -157,14 +171,16 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "width",
-        key.offset: 41,
+        key.offset: 78,
         key.length: 14,
         key.typename: "Int",
-        key.nameoffset: 45,
+        key.nameoffset: 82,
         key.namelength: 5,
+        key.docoffset: 34,
+        key.doclength: 32,
         key.attributes: [
           {
-            key.offset: 34,
+            key.offset: 71,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -175,14 +191,16 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "height",
-        key.offset: 68,
+        key.offset: 154,
         key.length: 15,
         key.typename: "Int",
-        key.nameoffset: 72,
+        key.nameoffset: 158,
         key.namelength: 6,
+        key.docoffset: 98,
+        key.doclength: 44,
         key.attributes: [
           {
-            key.offset: 61,
+            key.offset: 147,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -192,13 +210,13 @@ public struct NUPixelSize {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 96,
+        key.offset: 182,
         key.length: 6,
-        key.nameoffset: 96,
+        key.nameoffset: 182,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 89,
+            key.offset: 175,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -208,13 +226,13 @@ public struct NUPixelSize {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(width:height:)",
-        key.offset: 115,
+        key.offset: 201,
         key.length: 29,
-        key.nameoffset: 115,
+        key.nameoffset: 201,
         key.namelength: 29,
         key.attributes: [
           {
-            key.offset: 108,
+            key.offset: 194,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -223,19 +241,19 @@ public struct NUPixelSize {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "width",
-            key.offset: 120,
+            key.offset: 206,
             key.length: 10,
             key.typename: "Int",
-            key.nameoffset: 120,
+            key.nameoffset: 206,
             key.namelength: 5
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "height",
-            key.offset: 132,
+            key.offset: 218,
             key.length: 11,
             key.typename: "Int",
-            key.nameoffset: 132,
+            key.nameoffset: 218,
             key.namelength: 6
           }
         ]


### PR DESCRIPTION
rdar://47985888
