### PR TITLE
[Sema] QoI: Report all tuple type resolution errors

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3045,14 +3045,19 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
     complained = true;
   }
 
+  bool hadError = false;
   for (unsigned i = 0, end = repr->getNumElements(); i != end; ++i) {
     auto *tyR = repr->getElementType(i);
 
     Type ty = resolveType(tyR, elementOptions);
-    if (!ty || ty->hasError()) return ty;
+    if (!ty || ty->hasError())
+      hadError = true;
 
     elements.emplace_back(ty, repr->getElementName(i), ParameterTypeFlags());
   }
+
+  if (hadError)
+    return ErrorType::get(Context);
 
   // Single-element labeled tuples are not permitted outside of declarations
   // or SIL, either.

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1464,7 +1464,9 @@ let _ = sr4745.enumerated().map { (count, element) in "\(count): \(element)" }
 // SR-4738
 
 let sr4738 = (1, (2, 3))
-[sr4738].map { (x, (y, z)) -> Int in x + y + z } // expected-error {{use of undeclared type 'y'}}
+// expected-error @+2{{use of undeclared type 'y'}}
+// expected-error @+1{{use of undeclared type 'z'}}
+[sr4738].map { (x, (y, z)) -> Int in x + y + z }
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{20-26=arg1}} {{38-38=let (y, z) = arg1; }}
 
 // rdar://problem/31892961
@@ -1472,6 +1474,7 @@ let r31892961_1 = [1: 1, 2: 2]
 r31892961_1.forEach { (k, v) in print(k + v) }
 
 let r31892961_2 = [1, 2, 3]
+// expected-error @+1{{use of undeclared type 'val'}}
 let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
   // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
   // expected-error@-2 {{use of undeclared type 'index'}}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1467,7 +1467,9 @@ let _ = sr4745.enumerated().map { (count, element) in "\(count): \(element)" }
 // SR-4738
 
 let sr4738 = (1, (2, 3))
-[sr4738].map { (x, (y, z)) -> Int in x + y + z } // expected-error {{use of undeclared type 'y'}}
+// expected-error@+2{{use of undeclared type 'y'}}
+// expected-error@+1{{use of undeclared type 'z'}}
+[sr4738].map { (x, (y, z)) -> Int in x + y + z }
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{20-26=arg1}} {{38-38=let (y, z) = arg1; }}
 
 // rdar://problem/31892961
@@ -1475,6 +1477,7 @@ let r31892961_1 = [1: 1, 2: 2]
 r31892961_1.forEach { (k, v) in print(k + v) }
 
 let r31892961_2 = [1, 2, 3]
+// expected-error@+1{{use of undeclared type 'val'}}
 let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
   // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
   // expected-error@-2 {{use of undeclared type 'index'}}

--- a/test/attr/attr_inout.swift
+++ b/test/attr/attr_inout.swift
@@ -4,7 +4,7 @@ func f(x : inout Int) { } // okay
 
 func h(_ : inout Int) -> (inout Int) -> (inout Int) -> Int { }
 
-func ff(x: (inout Int, inout Float)) { } //  expected-error {{'inout' may only be used on parameters}}
+func ff(x: (inout Int, inout Float)) { } //  expected-error 2{{'inout' may only be used on parameters}}
 
 enum inout_carrier {
   case carry(inout Int) // expected-error {{'inout' may only be used on parameters}}

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -88,7 +88,7 @@ func parseError6(_ a: unknown_type, b: ) {} // expected-error {{use of undeclare
 
 func parseError7(_ a: Int, goo b: unknown_type) {} // expected-error {{use of undeclared type 'unknown_type'}}
 
-public func foo(_ a: Bool = true) -> (b: Bar, c: Bar) {} // expected-error {{use of undeclared type 'Bar'}}
+public func foo(_ a: Bool = true) -> (b: Bar, c: Bar) {} // expected-error 2{{use of undeclared type 'Bar'}}
 
 func parenPatternInArg((a): Int) -> Int { // expected-error {{expected parameter name followed by ':'}}
   return a  // expected-error {{use of unresolved identifier 'a'}}


### PR DESCRIPTION
This improves single pass diagnostics when more than one tuple type element has problems.