### PR TITLE
[silgen] Fix a bug where when reabstracting T:P -> P we wrapped a +0 …

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -241,7 +241,11 @@ static ManagedValue emitTransformExistential(SILGenFunction &SGF,
                    [&](SGFContext C) -> ManagedValue {
                      if (openedArchetype)
                        return SGF.manageOpaqueValue(state, loc, C);
-                     return input;
+                     if (input.isPlusOne(SGF))
+                       return input;
+                     if (C.isGuaranteedPlusZeroOk())
+                       return input;
+                     return input.copyUnmanaged(SGF, loc);
                    });
   
   return input;

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir  -module-name outcopyaddr -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership -module-name outcopyaddr -primary-file %s | %FileCheck %s
 
 public protocol BaseProt {
 }


### PR DESCRIPTION
…value in an init_existential_ref.

Found via the ownership verifier running on IRGen/outlined_copy_addr.swift.

We treat initialization of an existential as a +1 operation, so there is the
possibility that we would have double destroyed a value. In fixing this I
followed what manageOpaqueValue did on the first code path, since it is handling
this case correctly (and using the SGFContext to do so to boot!).

To ensure this is tested, I enabled ownership verification on the test and since
it seems to be exposing a SILGen code path that we aren't testing currently,
converted it into a SILGen test.
