### PR TITLE
Fix potential use-after-free in emitFuncToBlock exposed by enabling o…

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -514,7 +514,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   // the block is ultimately destroyed checking that the closure is uniquely
   // referenced.
   bool useWithoutEscapingVerification = false;
-	ManagedValue escaping;
+  ManagedValue escaping;
   if (loweredFuncTy->isNoEscape()) {
     auto escapingTy = loweredFuncTy->getWithExtInfo(
         loweredFuncTy->getExtInfo().withNoEscape(false));
@@ -525,8 +525,11 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
     auto escapingAnyTy =
         funcType.withExtInfo(funcType->getExtInfo().withNoEscape(false));
     funcType = escapingAnyTy;
-    fn = B.createCopyValue(loc, escaping);
+    fn = escaping.copy(*this, loc);
     useWithoutEscapingVerification = true;
+  } else {
+    // Since we are going to be storing this into memory, we need fn at +1.
+    fn = fn.ensurePlusOne(*this, loc);
   }
 
   // Build the invoke function signature. The block will capture the original

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -1,8 +1,8 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/blocks.swiftmodule -typecheck -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-sil-ownership -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-sil-ownership -parse-as-library %t/blocks.swiftmodule -typecheck -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/blocks.h
 // RUN: %check-in-clang %t/blocks.h
 

--- a/test/SILGen/objc_block_to_func_to_block.swift
+++ b/test/SILGen/objc_block_to_func_to_block.swift
@@ -1,8 +1,15 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_block_to_func_to_block.h -emit-silgen -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-sil-ownership -import-objc-header %S/Inputs/objc_block_to_func_to_block.h -emit-silgen -verify %s
 // REQUIRES: objc_interop
 
 import Foundation
 
 func bar<A>(x: Foo<A>) {
   x.blockInception { f in f { _ = $0 } }
+}
+
+typealias MyBlockWithEscapingParam = (@escaping () -> ()) -> Int
+
+// Make sure that we properly create thunks for objc_block_to_func_to_block
+@objc class ObjCClass : NSObject {
+  @objc func blockWithBlockTypealias(_ block: MyBlockWithEscapingParam) {}
 }


### PR DESCRIPTION
…wnership verification on PrintAsObjC/blocks.swift.

If the block is guaranteed, we need to be sure to copy here. This can happen for
instance with arguments (where this was caught). I added a SILGen test that
exposes this failure since this is not an actual bug in PrintAsObjC.
