### PR TITLE
IRGen: Move coroutine passes to be scheduled before tsan

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -200,6 +200,9 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
                            addSwiftContractPass);
   }
 
+  if (RunSwiftSpecificLLVMOptzns)
+    addCoroutinePassesToExtensionPoints(PMBuilder);
+
   if (Opts.Sanitizers & SanitizerKind::Address) {
     PMBuilder.addExtension(PassManagerBuilder::EP_OptimizerLast,
                            addAddressSanitizerPasses);
@@ -222,10 +225,6 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
     PMBuilder.addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0,
                            addSanitizerCoveragePass);
   }
-
-  if (RunSwiftSpecificLLVMOptzns)
-    addCoroutinePassesToExtensionPoints(PMBuilder);
-
   if (RunSwiftSpecificLLVMOptzns)
     PMBuilder.addExtension(PassManagerBuilder::EP_OptimizerLast,
                            addSwiftMergeFunctionsPass);


### PR DESCRIPTION
The coroutine transformation passes can't seem to handle tsan'ified
code.

My attempt at reducing a test case failed.

rdar://48719789