### PR TITLE
[ConstraintSystem] Prefer a single local choice over outer alternatives

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1519,8 +1519,15 @@ void ConstraintSystem::addOverloadSet(Type boundType,
     recordChoice(overloads, choice);
   }
 
-  for (auto &choice : outerAlternatives)
-    recordChoice(overloads, choice);
+  if (!outerAlternatives.empty()) {
+    // If local scope has a single choice,
+    // it should always be preferred.
+    if (overloads.size() == 1)
+      overloads.front()->setFavored();
+
+    for (auto &choice : outerAlternatives)
+      recordChoice(overloads, choice);
+  }
 
   addDisjunctionConstraint(overloads, locator, ForgetChoice);
 }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -565,3 +565,16 @@ func rdar_48114578() {
     return .valueOf((a, b)) // Ok
   }
 }
+
+struct S_Min {
+  var min: Int = 42
+}
+
+func min(_: Int, _: Float) -> Int { return 0 }
+func min(_: Float, _: Int) -> Int { return 0 }
+
+extension S_Min : CustomStringConvertible {
+  public var description: String {
+    return "\(min)" // Ok
+  }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/23194,
which broke a case were single local overload choice was preferred
over any number of outer alternatives.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
