### PR TITLE
[5.1 early] [test] Disable verify_all_overlays.py for watchOS

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -5,8 +5,11 @@
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test
 
-# XFAIL: OS=macosx || OS=ios || OS=tvos || OS=watchos
+# XFAIL: OS=macosx || OS=ios || OS=tvos
 # https://bugs.swift.org/browse/SR-9847
+
+# UNSUPPORTED: OS=watchos
+# watchOS behaves differently when building against the Apple-internal SDK.
 
 from __future__ import print_function
 


### PR DESCRIPTION
watchOS behaves differently when building against the Apple-internal SDK. The differences have been worked out on master, but there have been other changes in the mean time that make cherry-picking more trouble than it's worth. Just disable this test on watchOS until the rebranch.

rdar://problem/48766205