### PR TITLE
[Typechecker] Allow static functions to overload enum cases

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -216,6 +216,9 @@ struct OverloadSignature {
   /// Whether this is a enum element.
   unsigned IsEnumElement : 1;
 
+  /// Whether this is a nominal type.
+  unsigned IsNominal : 1;
+
   /// Whether this signature is part of a protocol extension.
   unsigned InProtocolExtension : 1;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -219,6 +219,9 @@ struct OverloadSignature {
   /// Whether this is a nominal type.
   unsigned IsNominal : 1;
 
+  /// Whether this is a type alias.
+  unsigned IsTypeAlias : 1;
+
   /// Whether this signature is part of a protocol extension.
   unsigned InProtocolExtension : 1;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -213,6 +213,12 @@ struct OverloadSignature {
   /// Whether this is a function.
   unsigned IsFunction : 1;
 
+  /// Whether this is a static function.
+  unsigned IsStaticFunction : 1;
+
+  /// Whether this is a enum element.
+  unsigned IsEnumElement : 1;
+
   /// Whether this signature is part of a protocol extension.
   unsigned InProtocolExtension : 1;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -213,9 +213,6 @@ struct OverloadSignature {
   /// Whether this is a function.
   unsigned IsFunction : 1;
 
-  /// Whether this is a static function.
-  unsigned IsStaticFunction : 1;
-
   /// Whether this is a enum element.
   unsigned IsEnumElement : 1;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2104,6 +2104,12 @@ bool swift::conflicting(ASTContext &ctx,
     return true;
   }
 
+  // Typealiases and enum elements always conflict with each other.
+  if ((sig1.IsTypeAlias && sig2.IsEnumElement) ||
+      (sig1.IsEnumElement && sig2.IsTypeAlias)) {
+    return true;
+  }
+
   // Enum elements always conflict with each other. At this point, they
   // have the same base name but different types.
   if (sig1.IsEnumElement && sig2.IsEnumElement) {
@@ -2270,6 +2276,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   signature.IsFunction = isa<AbstractFunctionDecl>(this);
   signature.IsEnumElement = isa<EnumElementDecl>(this);
   signature.IsNominal = isa<NominalTypeDecl>(this);
+  signature.IsTypeAlias = isa<TypeAliasDecl>(this);
 
   // Unary operators also include prefix/postfix.
   if (auto func = dyn_cast<FuncDecl>(this)) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2090,15 +2090,18 @@ bool swift::conflicting(ASTContext &ctx,
   if (!conflicting(sig1, sig2, skipProtocolExtensionCheck))
     return false;
 
-  // Two enum elements always conflict with each other. At this point, they
+  // Functions and enum elements do not conflict with each other if their types
+  // are different.
+  if ((sig1.IsFunction == sig2.IsEnumElement ||
+       sig1.IsEnumElement == sig2.IsFunction) &&
+      sig1Type != sig2Type) {
+    return false;
+  }
+
+  // Enum elements always conflict with each other. At this point, they
   // have the same base name but different types.
   if (sig1.IsEnumElement == sig2.IsEnumElement) {
     return true;
-  }
-
-  // A function does not conflict with an enum element if their types differ.
-  if (sig1.IsFunction == sig2.IsEnumElement && sig1Type != sig2Type) {
-    return false;
   }
 
   // Functions always conflict with non-functions with the same signature.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2098,6 +2098,12 @@ bool swift::conflicting(ASTContext &ctx,
     return false;
   }
 
+  // Nominal types and enum elements always conflict with each other.
+  if ((sig1.IsNominal && sig2.IsEnumElement) ||
+      (sig1.IsEnumElement && sig2.IsNominal)) {
+    return true;
+  }
+
   // Enum elements always conflict with each other. At this point, they
   // have the same base name but different types.
   if (sig1.IsEnumElement && sig2.IsEnumElement) {
@@ -2263,6 +2269,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   signature.IsVariable = isa<VarDecl>(this);
   signature.IsFunction = isa<AbstractFunctionDecl>(this);
   signature.IsEnumElement = isa<EnumElementDecl>(this);
+  signature.IsNominal = isa<NominalTypeDecl>(this);
 
   // Unary operators also include prefix/postfix.
   if (auto func = dyn_cast<FuncDecl>(this)) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2092,15 +2092,15 @@ bool swift::conflicting(ASTContext &ctx,
 
   // Functions and enum elements do not conflict with each other if their types
   // are different.
-  if ((sig1.IsFunction == sig2.IsEnumElement ||
-       sig1.IsEnumElement == sig2.IsFunction) &&
+  if (((sig1.IsFunction && sig2.IsEnumElement) ||
+       (sig1.IsEnumElement && sig2.IsFunction)) &&
       sig1Type != sig2Type) {
     return false;
   }
 
   // Enum elements always conflict with each other. At this point, they
   // have the same base name but different types.
-  if (sig1.IsEnumElement == sig2.IsEnumElement) {
+  if (sig1.IsEnumElement && sig2.IsEnumElement) {
     return true;
   }
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -476,5 +476,20 @@ extension SR7250 where T : P3 {
   subscript(i: Int) -> String { return "" }
 }
 
+// SR-10084
 
+struct SR_10084_S {
+  let name: String
+}
 
+enum SR_10084_E {
+  case foo(SR_10084_S) // expected-note {{'foo' previously declared here}}
+    
+  static func foo(_ name: String) -> SR_10084_E { // Ok
+    return .foo(SR_10084_S(name: name))
+  }
+
+  static func foo(_ value: SR_10084_S) -> SR_10084_E { // expected-error {{invalid redeclaration of 'foo'}}
+    return .foo(value)
+  }
+}

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -495,15 +495,15 @@ enum SR_10084_E {
 }
 
 enum SR_10084_E_1 {
-  static func foo(_ name: String) -> SR_10084_E_1 { // expected-note {{'foo' previously declared here}}
+  static func foo(_ name: String) -> SR_10084_E_1 {
     return .foo(SR_10084_S(name: name))
   }
 
-  static func foo(_ value: SR_10084_S) -> SR_10084_E_1 { // expected-error {{invalid redeclaration of 'foo'}}
+  static func foo(_ value: SR_10084_S) -> SR_10084_E_1 { // expected-note {{'foo' previously declared here}}
     return .foo(value)
   }
 
-  case foo(SR_10084_S)
+  case foo(SR_10084_S) // expected-error {{invalid redeclaration of 'foo'}}
 }
 
 enum SR_10084_E_2 {

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -568,10 +568,30 @@ enum SR_10084_E_10 {
 
 enum SR_10084_E_11 {
   case A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}}
-  static let A: SR_10084_E_11 = .A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}} // expected-error {{ambiguous use of 'A'}}
+  static var A: SR_10084_E_11 = .A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}} // expected-error {{ambiguous use of 'A'}}
 }
 
 enum SR_10084_E_12 {
-  static let A: SR_10084_E_12 = .A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}} // expected-error {{ambiguous use of 'A'}}
+  static var A: SR_10084_E_12 = .A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}} // expected-error {{ambiguous use of 'A'}}
   case A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}}
+}
+
+enum SR_10084_E_13 {
+  case X // expected-note {{'X' previously declared here}}
+  struct X<T> {} // expected-error {{invalid redeclaration of 'X'}}
+}
+
+enum SR_10084_E_14 {
+  struct X<T> {} // expected-note {{'X' previously declared here}}
+  case X // expected-error {{invalid redeclaration of 'X'}}
+}
+
+enum SR_10084_E_15 {
+  case Y // expected-note {{'Y' previously declared here}}
+  typealias Y = Int // expected-error {{invalid redeclaration of 'Y'}}
+}
+
+enum SR_10084_E_16 {
+  typealias Z = Int // expected-note {{'Z' previously declared here}}
+  case Z // expected-error {{invalid redeclaration of 'Z'}}
 }

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -493,3 +493,27 @@ enum SR_10084_E {
     return .foo(value)
   }
 }
+
+enum SR_10084_E_1 {
+  static func foo(_ name: String) -> SR_10084_E_1 { // expected-note {{'foo' previously declared here}}
+    return .foo(SR_10084_S(name: name))
+  }
+
+  static func foo(_ value: SR_10084_S) -> SR_10084_E_1 { // expected-error {{invalid redeclaration of 'foo'}}
+    return .foo(value)
+  }
+
+  case foo(SR_10084_S)
+}
+
+enum SR_10084_E_2 {
+  case fn(() -> Void) // expected-note {{'fn' previously declared here}}
+
+  static func fn(_ x: @escaping () -> Void) -> SR_10084_E_2 { // expected-error {{invalid redeclaration of 'fn'}}
+    fatalError()
+  }
+
+  static func fn(_ x: @escaping () -> Int) -> SR_10084_E_2 { // Ok
+    fatalError()
+  }
+}

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -485,8 +485,12 @@ struct SR_10084_S {
 enum SR_10084_E {
   case foo(SR_10084_S) // expected-note {{'foo' previously declared here}}
     
-  static func foo(_ name: String) -> SR_10084_E { // Ok
+  static func foo(_ name: String) -> SR_10084_E { // Okay
     return .foo(SR_10084_S(name: name))
+  }
+
+  func foo(_ name: Bool) -> SR_10084_E { // Okay
+    return .foo(SR_10084_S(name: "Test"))
   }
 
   static func foo(_ value: SR_10084_S) -> SR_10084_E { // expected-error {{invalid redeclaration of 'foo'}}
@@ -495,7 +499,7 @@ enum SR_10084_E {
 }
 
 enum SR_10084_E_1 {
-  static func foo(_ name: String) -> SR_10084_E_1 {
+  static func foo(_ name: String) -> SR_10084_E_1 { // Okay
     return .foo(SR_10084_S(name: name))
   }
 
@@ -513,7 +517,61 @@ enum SR_10084_E_2 {
     fatalError()
   }
 
-  static func fn(_ x: @escaping () -> Int) -> SR_10084_E_2 { // Ok
+  static func fn(_ x: @escaping () -> Int) -> SR_10084_E_2 { // Okay
     fatalError()
   }
+
+  static func fn(_ x: @escaping () -> Bool) -> SR_10084_E_2 { // Okay
+    fatalError()
+  }
+}
+
+enum SR_10084_E_3 {
+  protocol A {} //expected-error {{protocol 'A' cannot be nested inside another declaration}} // expected-note {{'A' previously declared here}}
+  case A // expected-error {{invalid redeclaration of 'A'}}
+}
+
+enum SR_10084_E_4 {
+  class B {} // expected-note {{'B' previously declared here}}
+  case B // expected-error {{invalid redeclaration of 'B'}}
+}
+
+enum SR_10084_E_5 {
+  struct C {} // expected-note {{'C' previously declared here}}
+  case C // expected-error {{invalid redeclaration of 'C'}}
+}
+
+enum SR_10084_E_6 {
+  case D // expected-note {{'D' previously declared here}}
+  protocol D {} //expected-error {{protocol 'D' cannot be nested inside another declaration}} // expected-error {{invalid redeclaration of 'D'}}
+}
+
+enum SR_10084_E_7 {
+  case E // expected-note {{'E' previously declared here}}
+  class E {} // expected-error {{invalid redeclaration of 'E'}} 
+}
+
+enum SR_10084_E_8 {
+  case F // expected-note {{'F' previously declared here}}
+  struct F {} // expected-error {{invalid redeclaration of 'F'}} 
+}
+
+enum SR_10084_E_9 {
+  case A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}}
+  static let A: SR_10084_E_9 = .A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}} // expected-error {{ambiguous use of 'A'}}
+}
+
+enum SR_10084_E_10 {
+  static let A: SR_10084_E_10 = .A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}} // expected-error {{ambiguous use of 'A'}}
+  case A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}}
+}
+
+enum SR_10084_E_11 {
+  case A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}}
+  static let A: SR_10084_E_11 = .A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}} // expected-error {{ambiguous use of 'A'}}
+}
+
+enum SR_10084_E_12 {
+  static let A: SR_10084_E_12 = .A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}} // expected-error {{ambiguous use of 'A'}}
+  case A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}}
 }


### PR DESCRIPTION
Fixes an issue with redeclaration checking where a static function would incorrectly get marked as a redeclaration of an enum element declaration, even if their types were different. See https://twitter.com/an0/status/1105187953834369025

Resolves [SR-10084](https://bugs.swift.org/browse/SR-10084).
