### PR TITLE
[5.1] IRGen: Move coroutine passes to be scheduled before tsan

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -200,6 +200,9 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
                            addSwiftContractPass);
   }
 
+  if (RunSwiftSpecificLLVMOptzns)
+    addCoroutinePassesToExtensionPoints(PMBuilder);
+
   if (Opts.Sanitizers & SanitizerKind::Address) {
     PMBuilder.addExtension(PassManagerBuilder::EP_OptimizerLast,
                            addAddressSanitizerPasses);
@@ -222,10 +225,6 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
     PMBuilder.addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0,
                            addSanitizerCoveragePass);
   }
-
-  if (RunSwiftSpecificLLVMOptzns)
-    addCoroutinePassesToExtensionPoints(PMBuilder);
-
   if (RunSwiftSpecificLLVMOptzns)
     PMBuilder.addExtension(PassManagerBuilder::EP_OptimizerLast,
                            addSwiftMergeFunctionsPass);

--- a/test/IRGen/tsan_coroutines.swift
+++ b/test/IRGen/tsan_coroutines.swift
@@ -1,0 +1,27 @@
+// This test case used to crash when tsan ran before co-routine lowering.
+// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s
+
+public class C { }
+
+public struct Foobar {
+  var things: [String: C] = [:]
+}
+
+extension Foobar {
+    public struct Index {
+        fileprivate typealias MyIndex = Dictionary<String, C>.Values.Index
+
+        fileprivate let myIndex: MyIndex
+
+        fileprivate init(_ index: MyIndex) {
+            self.myIndex = index
+        }
+    }
+
+    // We used to crash emitting the subscript function.
+    // CHECK: define swiftcc { i8*, %T15tsan_coroutines1CC* } @"$s15tsan_coroutines6FoobarVyAA1CCAC5IndexVcir"
+    @_borrowed
+    public subscript(position: Index) -> C {
+        return things.values[position.myIndex]
+    }
+}

--- a/test/IRGen/tsan_coroutines.swift
+++ b/test/IRGen/tsan_coroutines.swift
@@ -1,6 +1,10 @@
 // This test case used to crash when tsan ran before co-routine lowering.
 // RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s
 
+// TSan is currently only supported on 64 bit mac and simulators.
+// (We do not test the simulators here.)
+// REQUIRES: CPU=x86_64, OS=macosx
+
 public class C { }
 
 public struct Foobar {


### PR DESCRIPTION
The coroutine transformation passes can't seem to handle tsan'ified
code.

My attempt at reducing a test case failed.

rdar://48719789