### PR TITLE
[SourceKit] Add generic requirements to doc structure

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -145,6 +145,7 @@ struct SyntaxStructureNode {
   CharSourceRange TypeRange;
   CharSourceRange DocRange;
   std::vector<CharSourceRange> InheritedTypeRanges;
+  std::vector<CharSourceRange> GenericRequirementRanges;
   std::vector<SyntaxStructureElement> Elements;
 
   bool hasSubstructure() const {

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -46,10 +46,10 @@ struct MyStruc {
 // CHECK:   <ifunc>func <name>foo()</name></ifunc>
 // CHECK:   <ifunc>func <name>foo2()</name> throws</ifunc>
 // CHECK:   <ifunc>func <name>foo3()</name> throws -> <type>Int</type></ifunc>
-// CHECK:   <ifunc>func <name>foo4<<generic-param><name>T</name></generic-param>>()</name> where T: MyProt</ifunc>
+// CHECK:   <ifunc>func <name>foo4<<generic-param><name>T</name></generic-param>>()</name> where <generic-req>T: MyProt</generic-req></ifunc>
 // CHECK:   <ifunc><name>init()</name></ifunc>
 // CHECK:   <ifunc><name>init(<param><name>a</name>: <type>Int</type></param>)</name> throws</ifunc>
-// CHECK:   <ifunc><name>init<<generic-param><name>T</name></generic-param>>(<param><name>a</name>: <type>T</type></param>)</name> where T: MyProt</ifunc>
+// CHECK:   <ifunc><name>init<<generic-param><name>T</name></generic-param>>(<param><name>a</name>: <type>T</type></param>)</name> where <generic-req>T: MyProt</generic-req></ifunc>
 // CHECK: }</protocol>
 protocol MyProt {
   func foo()
@@ -197,7 +197,7 @@ class A {
 // CHECK: <typealias>typealias <name>OtherA</name> = A</typealias>
 typealias OtherA = A
 
-// CHECK: <typealias>typealias <name>EqBox</name><<generic-param><name>Boxed</name></generic-param>> = Box<Boxed> where Boxed: Equatable</typealias>
+// CHECK: <typealias>typealias <name>EqBox</name><<generic-param><name>Boxed</name></generic-param>> = Box<Boxed> where <generic-req>Boxed: Equatable</generic-req></typealias>
 typealias EqBox<Boxed> = Box<Boxed> where Boxed: Equatable
 
 class SubscriptTest {
@@ -244,13 +244,13 @@ protocol FooProtocol {
   associatedtype Baz: Equatable
   // CHECK:  <associatedtype>associatedtype <name>Baz</name>: Equatable</associatedtype>
   associatedtype Qux where Qux: Equatable
-  // CHECK:  <associatedtype>associatedtype <name>Qux</name> where Qux: Equatable</associatedtype>
+  // CHECK:  <associatedtype>associatedtype <name>Qux</name> where <generic-req>Qux: Equatable</generic-req></associatedtype>
   associatedtype Bar2 = Int
   // CHECK:  <associatedtype>associatedtype <name>Bar2</name> = Int</associatedtype>
   associatedtype Baz2: Equatable = Int
   // CHECK:  <associatedtype>associatedtype <name>Baz2</name>: Equatable = Int</associatedtype>
   associatedtype Qux2 = Int where Qux2: Equatable
-  // CHECK:  <associatedtype>associatedtype <name>Qux2</name> = Int where Qux2: Equatable</associatedtype>
+  // CHECK:  <associatedtype>associatedtype <name>Qux2</name> = Int where <generic-req>Qux2: Equatable</generic-req></associatedtype>
 }
 
 // CHECK: <struct>struct <name>Generic</name><<generic-param><name>T</name>: <inherited><elem-typeref>Comparable</elem-typeref></inherited></generic-param>, <generic-param><name>X</name></generic-param>> {

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -129,3 +129,16 @@ enum MySecondEnum {
 }
 
 func someFunc(input :Int?, completion: () throws -> Void) rethrows {}
+
+class GenReqClass<T> where T: MyProt
+{}
+
+extension GenReqClass where T: Equatable
+{}
+
+protocol GenReqProt where Self: Foo {
+    associatedtype GenReqAssocType where GenReqAssocType: Foo
+}
+
+func genReqFunc<A, B>(a: A, b: B) where A: GenReqProt, B == A.GenReqAssocType
+{}

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2136,
+  key.length: 2407,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1324,6 +1324,136 @@
           key.typename: "() throws -> Void",
           key.nameoffset: 2093,
           key.namelength: 10
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqClass",
+      key.generic_requirements: [
+        {
+          key.description: "T: MyProt"
+        }
+      ],
+      key.offset: 2137,
+      key.length: 39,
+      key.nameoffset: 2143,
+      key.namelength: 11,
+      key.bodyoffset: 2175,
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.offset: 2155,
+          key.length: 1,
+          key.nameoffset: 2155,
+          key.namelength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqClass",
+      key.generic_requirements: [
+        {
+          key.description: "T: Equatable"
+        }
+      ],
+      key.offset: 2178,
+      key.length: 43,
+      key.nameoffset: 2188,
+      key.namelength: 11,
+      key.bodyoffset: 2220,
+      key.bodylength: 0
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqProt",
+      key.generic_requirements: [
+        {
+          key.description: "Self: Foo"
+        }
+      ],
+      key.offset: 2223,
+      key.length: 101,
+      key.runtime_name: "_TtP4main10GenReqProt_",
+      key.nameoffset: 2232,
+      key.namelength: 10,
+      key.bodyoffset: 2260,
+      key.bodylength: 63,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.associatedtype,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "GenReqAssocType",
+          key.generic_requirements: [
+            {
+              key.description: "GenReqAssocType: Foo"
+            }
+          ],
+          key.offset: 2265,
+          key.length: 57,
+          key.nameoffset: 2280,
+          key.namelength: 15
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "genReqFunc(a:b:)",
+      key.generic_requirements: [
+        {
+          key.description: "A: GenReqProt"
+        },
+        {
+          key.description: "B == A.GenReqAssocType"
+        }
+      ],
+      key.offset: 2326,
+      key.length: 80,
+      key.nameoffset: 2331,
+      key.namelength: 28,
+      key.bodyoffset: 2405,
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "A",
+          key.offset: 2342,
+          key.length: 1,
+          key.nameoffset: 2342,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "B",
+          key.offset: 2345,
+          key.length: 1,
+          key.nameoffset: 2345,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "a",
+          key.offset: 2348,
+          key.length: 4,
+          key.typename: "A",
+          key.nameoffset: 2348,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "b",
+          key.offset: 2354,
+          key.length: 4,
+          key.typename: "B",
+          key.nameoffset: 2354,
+          key.namelength: 1
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2136,
+  key.length: 2407,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1324,6 +1324,136 @@
           key.typename: "() throws -> Void",
           key.nameoffset: 2093,
           key.namelength: 10
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqClass",
+      key.generic_requirements: [
+        {
+          key.description: "T: MyProt"
+        }
+      ],
+      key.offset: 2137,
+      key.length: 39,
+      key.nameoffset: 2143,
+      key.namelength: 11,
+      key.bodyoffset: 2175,
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.offset: 2155,
+          key.length: 1,
+          key.nameoffset: 2155,
+          key.namelength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqClass",
+      key.generic_requirements: [
+        {
+          key.description: "T: Equatable"
+        }
+      ],
+      key.offset: 2178,
+      key.length: 43,
+      key.nameoffset: 2188,
+      key.namelength: 11,
+      key.bodyoffset: 2220,
+      key.bodylength: 0
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqProt",
+      key.generic_requirements: [
+        {
+          key.description: "Self: Foo"
+        }
+      ],
+      key.offset: 2223,
+      key.length: 101,
+      key.runtime_name: "_TtP4main10GenReqProt_",
+      key.nameoffset: 2232,
+      key.namelength: 10,
+      key.bodyoffset: 2260,
+      key.bodylength: 63,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.associatedtype,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "GenReqAssocType",
+          key.generic_requirements: [
+            {
+              key.description: "GenReqAssocType: Foo"
+            }
+          ],
+          key.offset: 2265,
+          key.length: 57,
+          key.nameoffset: 2280,
+          key.namelength: 15
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "genReqFunc(a:b:)",
+      key.generic_requirements: [
+        {
+          key.description: "A: GenReqProt"
+        },
+        {
+          key.description: "B == A.GenReqAssocType"
+        }
+      ],
+      key.offset: 2326,
+      key.length: 80,
+      key.nameoffset: 2331,
+      key.namelength: 28,
+      key.bodyoffset: 2405,
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "A",
+          key.offset: 2342,
+          key.length: 1,
+          key.nameoffset: 2342,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "B",
+          key.offset: 2345,
+          key.length: 1,
+          key.nameoffset: 2345,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "a",
+          key.offset: 2348,
+          key.length: 4,
+          key.typename: "A",
+          key.nameoffset: 2348,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "b",
+          key.offset: 2354,
+          key.length: 4,
+          key.typename: "B",
+          key.nameoffset: 2354,
+          key.namelength: 1
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2136,
+  key.length: 2407,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1324,6 +1324,136 @@
           key.typename: "() throws -> Void",
           key.nameoffset: 2093,
           key.namelength: 10
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqClass",
+      key.generic_requirements: [
+        {
+          key.description: "T: MyProt"
+        }
+      ],
+      key.offset: 2137,
+      key.length: 39,
+      key.nameoffset: 2143,
+      key.namelength: 11,
+      key.bodyoffset: 2175,
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.offset: 2155,
+          key.length: 1,
+          key.nameoffset: 2155,
+          key.namelength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqClass",
+      key.generic_requirements: [
+        {
+          key.description: "T: Equatable"
+        }
+      ],
+      key.offset: 2178,
+      key.length: 43,
+      key.nameoffset: 2188,
+      key.namelength: 11,
+      key.bodyoffset: 2220,
+      key.bodylength: 0
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "GenReqProt",
+      key.generic_requirements: [
+        {
+          key.description: "Self: Foo"
+        }
+      ],
+      key.offset: 2223,
+      key.length: 101,
+      key.runtime_name: "_TtP13StructureTest10GenReqProt_",
+      key.nameoffset: 2232,
+      key.namelength: 10,
+      key.bodyoffset: 2260,
+      key.bodylength: 63,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.associatedtype,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "GenReqAssocType",
+          key.generic_requirements: [
+            {
+              key.description: "GenReqAssocType: Foo"
+            }
+          ],
+          key.offset: 2265,
+          key.length: 57,
+          key.nameoffset: 2280,
+          key.namelength: 15
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "genReqFunc(a:b:)",
+      key.generic_requirements: [
+        {
+          key.description: "A: GenReqProt"
+        },
+        {
+          key.description: "B == A.GenReqAssocType"
+        }
+      ],
+      key.offset: 2326,
+      key.length: 80,
+      key.nameoffset: 2331,
+      key.namelength: 28,
+      key.bodyoffset: 2405,
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "A",
+          key.offset: 2342,
+          key.length: 1,
+          key.nameoffset: 2342,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "B",
+          key.offset: 2345,
+          key.length: 1,
+          key.nameoffset: 2345,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "a",
+          key.offset: 2348,
+          key.length: 4,
+          key.typename: "A",
+          key.nameoffset: 2348,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "b",
+          key.offset: 2354,
+          key.length: 4,
+          key.typename: "B",
+          key.nameoffset: 2354,
+          key.namelength: 1
         }
       ]
     }

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -259,7 +259,8 @@ public:
                                          StringRef RuntimeName,
                                          StringRef SelectorName,
                                          ArrayRef<StringRef> InheritedTypes,
-                                         ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) = 0;
+                                         ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs,
+                                         ArrayRef<StringRef> GenericRequirements) = 0;
 
   virtual void endDocumentSubStructure() = 0;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1175,6 +1175,11 @@ public:
       }
     }
 
+    SmallVector<StringRef, 4> GenericRequirements;
+    for (auto &TR : Node.GenericRequirementRanges) {
+      GenericRequirements.push_back(SrcManager.extractText(TR));
+    }
+
     StringRef TypeName;
     if (Node.TypeRange.isValid()) {
       TypeName = SrcManager.extractText(Node.TypeRange);
@@ -1227,7 +1232,8 @@ public:
                                        DisplayName,
                                        TypeName, RuntimeName,
                                        SelectorName,
-                                       InheritedNames, Attrs);
+                                       InheritedNames, Attrs,
+                                       GenericRequirements);
 
     for (const auto &Elem : Node.Elements) {
       if (Elem.Range.isInvalid())
@@ -1299,7 +1305,7 @@ public:
                                        StringRef(),
                                        StringRef(), StringRef(),
                                        StringRef(),
-                                       {}, {});
+                                       {}, {}, {});
     return true;
   }
 

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
@@ -22,6 +22,7 @@ VariantFunctions *getVariantFunctionsForDocStructureArray();
 VariantFunctions *getVariantFunctionsForDocStructureElementArray();
 VariantFunctions *getVariantFunctionsForInheritedTypesArray();
 VariantFunctions *getVariantFunctionsForAttributesArray();
+VariantFunctions *getVariantFunctionsForGenericRequirementsArray();
 
 class DocStructureArrayBuilder {
 public:
@@ -38,7 +39,8 @@ public:
                          llvm::StringRef RuntimeName,
                          llvm::StringRef SelectorName,
                          llvm::ArrayRef<llvm::StringRef> InheritedTypes,
-                         llvm::ArrayRef<std::tuple<SourceKit::UIdent, unsigned, unsigned>> Attrs);
+                         llvm::ArrayRef<std::tuple<SourceKit::UIdent, unsigned, unsigned>> Attrs,
+                         llvm::ArrayRef<llvm::StringRef> GenericRequirements);
 
   void addElement(SourceKit::UIdent Kind, unsigned Offset, unsigned Length);
 

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -60,6 +60,7 @@ enum class CustomBufferKind {
   DocStructureElementArray,
   AttributesArray,
   ExpressionTypeArray,
+  GenericRequirementsArray,
   RawData
 };
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2275,7 +2275,8 @@ public:
                                  StringRef RuntimeName,
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override;
+                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs,
+                                 ArrayRef<StringRef> GenericRequirements) override;
 
   void endDocumentSubStructure() override;
 
@@ -2501,12 +2502,14 @@ SKEditorConsumer::beginDocumentSubStructure(unsigned Offset,
                                             StringRef RuntimeName,
                                             StringRef SelectorName,
                                             ArrayRef<StringRef> InheritedTypes,
-                                            ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) {
+                                            ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs,
+                                            ArrayRef<StringRef> GenericRequirements) {
   if (Opts.EnableStructure) {
     DocStructure.beginSubStructure(
         Offset, Length, Kind, AccessLevel, SetterAccessLevel, NameOffset,
         NameLength, BodyOffset, BodyLength, DocOffset, DocLength, DisplayName,
-        TypeName, RuntimeName, SelectorName, InheritedTypes, Attrs);
+        TypeName, RuntimeName, SelectorName, InheritedTypes, Attrs,
+        GenericRequirements);
   }
 }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -258,6 +258,7 @@ public:
       case CustomBufferKind::DocStructureElementArray:
       case CustomBufferKind::AttributesArray:
       case CustomBufferKind::ExpressionTypeArray:
+      case CustomBufferKind::GenericRequirementsArray:
         return SOURCEKITD_VARIANT_TYPE_ARRAY;
       case CustomBufferKind::RawData:
         return SOURCEKITD_VARIANT_TYPE_DATA;
@@ -986,6 +987,8 @@ static sourcekitd_variant_t variantFromSKDObject(SKDObjectRef Object) {
           (uintptr_t)DataObject->getDataPtr(), 0 }};
       case CustomBufferKind::ExpressionTypeArray:
         return {{ (uintptr_t)getVariantFunctionsForExpressionTypeArray(),
+      case CustomBufferKind::GenericRequirementsArray:
+        return {{ (uintptr_t)getVariantFunctionsForGenericRequirementsArray(),
           (uintptr_t)DataObject->getDataPtr(), 0 }};
       case CustomBufferKind::RawData:
         return {{ (uintptr_t)getVariantFunctionsForRawData(),

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -623,6 +623,7 @@ static sourcekitd_variant_type_t XPCVar_get_type(sourcekitd_variant_t var) {
     case CustomBufferKind::DocStructureElementArray:
     case CustomBufferKind::AttributesArray:
     case CustomBufferKind::ExpressionTypeArray:
+    case CustomBufferKind::GenericRequirementsArray:
       return SOURCEKITD_VARIANT_TYPE_ARRAY;
     case CustomBufferKind::RawData:
       return SOURCEKITD_VARIANT_TYPE_DATA;
@@ -785,6 +786,9 @@ static sourcekitd_variant_t variantFromXPCObject(xpc_object_t obj) {
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
     case CustomBufferKind::ExpressionTypeArray:
       return {{ (uintptr_t)getVariantFunctionsForExpressionTypeArray(),
+                (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
+    case CustomBufferKind::GenericRequirementsArray:
+      return {{ (uintptr_t)getVariantFunctionsForGenericRequirementsArray(),
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
     case sourcekitd::CustomBufferKind::RawData:
       return {{ (uintptr_t)getVariantFunctionsForRawData(),

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1220,6 +1220,9 @@ private:
     for (auto &TyRange : Node.InheritedTypeRanges) {
       tagRange(TyRange, "inherited", Node);
     }
+    for (auto &TyRange : Node.GenericRequirementRanges) {
+      tagRange(TyRange, "generic-req", Node);
+    }
     for (auto &Elem : Node.Elements) {
       tagRange(Elem.Range, getTagName(Elem.Kind), Node);
     }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -60,7 +60,8 @@ class NullEditorConsumer : public EditorConsumer {
                                  StringRef RuntimeName,
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
+                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs,
+                                 ArrayRef<StringRef> GenericRequirements) override {
   }
 
   void endDocumentSubStructure() override {}

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -68,7 +68,8 @@ private:
                                  StringRef RuntimeName,
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
+                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs,
+                                 ArrayRef<StringRef> GenericRequirements) override {
   }
 
   void endDocumentSubStructure() override {}


### PR DESCRIPTION
This adds requirements from 'where' clauses to doc structure, following the model of `inherited types` and the format from `doc-info`.  This is useful for tools to understand constraints on extensions in particular.

Resolves [SR-5474](https://bugs.swift.org/browse/SR-5474).

@nkcsgexi would you mind looking at this one?  There are a lot of changed lines in the patch but most are tests and boiler-plate in SourceKit.