### PR TITLE
[ownership] Serialize/strip ownership at the beginning of the Onone p…

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -639,24 +639,23 @@ SILPassPipelinePlan
 SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
 
-  // First specialize user-code.
-  P.startPipeline("Prespecialization");
-  P.addUsePrespecialized();
+  // First serialize the SIL if we are asked to.
+  P.startPipeline("Serialization");
+  P.addSerializeSILPass();
 
+  // And then strip ownership...
+  if (!Options.StripOwnershipDuringDiagnosticsPipeline)
+    P.addOwnershipModelEliminator();
+
+  // Finally perform some small transforms.
   P.startPipeline("Rest of Onone");
+  P.addUsePrespecialized();
 
   // Has only an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();
 
   // Has only an effect if the -gsil option is specified.
   P.addSILDebugInfoGenerator();
-
-  // Finally serialize the SIL if we are asked to.
-  P.addSerializeSILPass();
-
-  // And then strip ownership before we IRGen.
-  if (!Options.StripOwnershipDuringDiagnosticsPipeline)
-    P.addOwnershipModelEliminator();
 
   return P;
 }

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -3,12 +3,13 @@
 
 // CHECK: [
 // CHECK:     [
-// CHECK:         "Prespecialization",
-// CHECK-NEXT:         ["UsePrespecialized","use-prespecialized"]
+// CHECK:         "Serialization",
+// CHECK:         ["SerializeSILPass","serialize-sil"]
 // CHECK:     ],
 // CHECK:     [
 // CHECK:         "Rest of Onone",
-// CHECK-NEXT:         ["AssumeSingleThreaded","sil-assume-single-threaded"],
-// CHECK-NEXT:         ["SILDebugInfoGenerator","sil-debuginfo-gen"]
+// CHECK:         ["UsePrespecialized","use-prespecialized"],
+// CHECK:         ["AssumeSingleThreaded","sil-assume-single-threaded"],
+// CHECK:         ["SILDebugInfoGenerator","sil-debuginfo-gen"]
 // CHECK:     ]
 // CHECK: ]


### PR DESCRIPTION
…ass pipeline so we strip ownership before use-prespecialized.

There shouldn't be any performance difference from doing this and it allows me
to avoid updating parts of the generic specializer.
