### PR TITLE
[ConstraintSystem] Move "outer" candidates handling to `simplifyMembe…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4020,9 +4020,21 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
   // If we found viable candidates, then we're done!
   if (!result.ViableCandidates.empty()) {
-    addOverloadSet(memberTy, result.ViableCandidates, useDC, locator,
-                   result.getFavoredChoice(), outerAlternatives);
+    llvm::SmallVector<Constraint *, 8> candidates;
+    generateConstraints(candidates, memberTy, result.ViableCandidates,
+                        useDC, locator, result.getFavoredChoice());
 
+    if (!outerAlternatives.empty()) {
+      // If local scope has a single choice,
+      // it should always be preferred.
+      if (candidates.size() == 1)
+        candidates.front()->setFavored();
+
+      generateConstraints(candidates, memberTy, outerAlternatives,
+                          useDC, locator);
+    }
+
+    addOverloadSet(candidates, locator);
     return SolutionKind::Solved;
   }
   

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2417,8 +2417,10 @@ public:
   /// sets.
   void addOverloadSet(Type boundType, ArrayRef<OverloadChoice> choices,
                       DeclContext *useDC, ConstraintLocator *locator,
-                      OverloadChoice *favored = nullptr,
-                      ArrayRef<OverloadChoice> outerAlternatives = {});
+                      OverloadChoice *favored = nullptr);
+
+  void addOverloadSet(ArrayRef<Constraint *> choices,
+                      ConstraintLocator *locator);
 
   /// Retrieve the allocator used by this constraint system.
   llvm::BumpPtrAllocator &getAllocator() { return Allocator; }
@@ -2454,6 +2456,12 @@ public:
   ///
   /// \returns a possibly-sanitized initializer, or null if an error occurred.
   Type generateConstraints(Pattern *P, ConstraintLocatorBuilder locator);
+
+  /// Generate constraints for a given set of overload choices.
+  void generateConstraints(SmallVectorImpl<Constraint *> &constraints,
+                           Type type, ArrayRef<OverloadChoice> choices,
+                           DeclContext *useDC, ConstraintLocator *locator,
+                           OverloadChoice *favoredChoice = nullptr);
 
   /// Propagate constraints in an effort to enforce local
   /// consistency to reduce the time to solve the system.


### PR DESCRIPTION
…rConstraint`

Further simplify `addOverloadSet` and move "outer" candidate handling
to the only place where it comes up - `simplifyMemberConstraint`.
Also move constraint generation for choices into a separate method.

This is a stepping stone on the path to enable attaching fixes to
the overload choices.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
