### PR TITLE
[silgenpattern] When we switch on an enum with an associated type tha…

### DIFF
--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -1291,3 +1291,15 @@ indirect enum SR6664_Base<Element> {
     }
   }
 }
+
+// Make sure that we properly create switch_enum success arguments if we have an
+// associated type that is a void type.
+func testVoidType() {
+  let x: Optional<()> = ()
+  switch x {
+  case .some(let x):
+    break
+  case .none:
+    break
+  }
+}


### PR DESCRIPTION
…t is empty, create a phi argument for it.

Previously we were handling this like we did not have any associated type. This
caused us to break the requirement in [ossa] that all switch_enum successors
associated with payloaded enums must have arguments. We still emit the empty
tuple value (or an undef tuple) if we do not have any associated type.
