### PR TITLE
Avoid malloc allocations in the runtime, part 2

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -484,11 +484,6 @@ enum class OperatorKind {
   Infix,
 };
 
-/// Mangle an identifier using Swift's mangling rules.
-void mangleIdentifier(const char *data, size_t length,
-                      OperatorKind operatorKind, std::string &out,
-                      bool usePunycode = true);
-
 /// Remangle a demangled parse tree.
 std::string mangleNode(NodePointer root);
 

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -506,9 +506,20 @@ llvm::StringRef mangleNode(NodePointer root, SymbolicResolver resolver,
 /// Remangle in the old mangling scheme.
 ///
 /// This is only used for objc-runtime names.
-/// If \p BorrowFrom is specified, the initial bump pointer memory is
-/// borrowed from the free memory of BorrowFrom.
-std::string mangleNodeOld(NodePointer root, NodeFactory *BorrowFrom = nullptr);
+std::string mangleNodeOld(NodePointer root);
+
+/// Remangle in the old mangling scheme.
+///
+/// This is only used for objc-runtime names.
+/// The returned string is owned by \p Factory. This means \p Factory must stay
+/// alive as long as the returned string is used.
+llvm::StringRef mangleNodeOld(NodePointer node, NodeFactory &Factory);
+
+/// Remangle in the old mangling scheme and embed the name in "_Tt<name>_".
+///
+/// The returned string is null terminated and owned by \p Factory. This means
+/// \p Factory must stay alive as long as the returned string is used.
+const char *mangleNodeAsObjcCString(NodePointer node, NodeFactory &Factory);
 
 /// Transform the node structure to a string.
 ///

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -116,15 +116,6 @@ static void mangleIdentifier(StringRef ident, OperatorKind operatorKind,
   }
 }
 
-void Demangle::mangleIdentifier(const char *data, size_t length,
-                                OperatorKind operatorKind,
-                                std::string &out, bool usePunycode) {
-  DemanglerPrinter printer;
-  ::mangleIdentifier(StringRef(data, length), operatorKind,
-                     usePunycode, printer);
-  out = std::move(printer).str();
-}
-
 namespace {
   struct DeepHasher {
     size_t value = 0;

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -306,7 +306,6 @@ namespace {
     bool trySubstitution(Node *node, SubstitutionEntry &entry);
     bool mangleStandardSubstitution(Node *node);
     void addSubstitution(const SubstitutionEntry &entry);
-    void resetSubstitutions();
 
     void mangleDependentGenericParamIndex(Node *node);
     void mangleConstrainedType(Node *node);
@@ -387,13 +386,6 @@ static NodePointer applyParamLabels(NodePointer LabelList, NodePointer OrigType,
     Type->addChild(visitTypeChild(Child), Factory);
 
   return Type;
-}
-
-/// Reset the currently-active set of substitutions.  This is useful
-/// when part of the mangling is done independently, e.g. when an
-/// optimization pass modifies a pass.
-void Remangler::resetSubstitutions() {
-  Substitutions.clear();
 }
 
 bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry) {
@@ -520,65 +512,35 @@ void Remangler::mangleSuffix(Node *node) {
 }
 
 void Remangler::mangleGenericSpecialization(Node *node) {
-  Out << "TSg";
-  mangleChildNodes(node); // GenericSpecializationParams
-
-  // Specializations are just prepended to already-mangled names.
-  resetSubstitutions();
-
-  // Start another mangled name.
-  Out << "__T";
+  unreachable("unsupported");
 }
 
 void Remangler::mangleGenericSpecializationNotReAbstracted(Node *node) {
-  Out << "TSr";
-  mangleChildNodes(node); // GenericSpecializationParams
-
-  // Specializations are just prepended to already-mangled names.
-  resetSubstitutions();
-
-  // Start another mangled name.
-  Out << "__T";
+  unreachable("unsupported");
 }
 
 void Remangler::mangleInlinedGenericFunction(Node *node) {
-  Out << "TSi";
-  mangleChildNodes(node); // GenericSpecializationParams
-
-  // Specializations are just prepended to already-mangled names.
-  resetSubstitutions();
-
-  // Start another mangled name.
-  Out << "__T";
+  unreachable("unsupported");
 }
 
 void Remangler::mangleGenericPartialSpecialization(Node *node) {
-  unreachable("todo");
+  unreachable("unsupported");
 }
 
 void Remangler::mangleGenericPartialSpecializationNotReAbstracted(Node *node) {
-  unreachable("todo");
+  unreachable("unsupported");
 }
 
 void Remangler::mangleGenericSpecializationParam(Node *node) {
-  // Should be a type followed by a series of protocol conformances.
-  mangleChildNodes(node);
-  Out << '_';
+  unreachable("unsupported");
 }
 
 void Remangler::mangleFunctionSignatureSpecialization(Node *node) {
-  Out << "TSf";
-  mangleChildNodes(node); // FunctionSignatureSpecializationParams
-
-  // Specializations are just prepended to already-mangled names.
-  resetSubstitutions();
-
-  // Start another mangled name.
-  Out << "__T";
+  unreachable("unsupported");
 }
 
 void Remangler::mangleSpecializationPassID(Node *node) {
-  Out << node->getIndex();
+  unreachable("unsupported");
 }
 
 void Remangler::mangleIsSerialized(Node *node) {
@@ -586,81 +548,11 @@ void Remangler::mangleIsSerialized(Node *node) {
 }
 
 void Remangler::mangleFunctionSignatureSpecializationReturn(Node *node) {
-  mangleFunctionSignatureSpecializationParam(node);
+  unreachable("unsupported");
 }
 
 void Remangler::mangleFunctionSignatureSpecializationParam(Node *node) {
-  if (!node->hasChildren()) {
-    Out << "n_";
-    return;
-  }
-
-  // The first child is always a kind that specifies the type of param that we
-  // have.
-  NodePointer firstChild = node->getChild(0);
-  unsigned kindValue = firstChild->getIndex();
-  auto kind = FunctionSigSpecializationParamKind(kindValue);
-
-  switch (kind) {
-  case FunctionSigSpecializationParamKind::ConstantPropFunction:
-    Out << "cpfr";
-    mangleIdentifier(node->getChild(1));
-    Out << '_';
-    return;
-  case FunctionSigSpecializationParamKind::ConstantPropGlobal:
-    Out << "cpg";
-    mangleIdentifier(node->getChild(1));
-    Out << '_';
-    return;
-  case FunctionSigSpecializationParamKind::ConstantPropInteger:
-    Out << "cpi" << node->getChild(1)->getText() << '_';
-    return;
-  case FunctionSigSpecializationParamKind::ConstantPropFloat:
-    Out << "cpfl" << node->getChild(1)->getText() << '_';
-    return;
-  case FunctionSigSpecializationParamKind::ConstantPropString: {
-    Out << "cpse";
-    StringRef encodingStr = node->getChild(1)->getText();
-    if (encodingStr == "u8")
-      Out << '0';
-    else if (encodingStr == "u16")
-      Out << '1';
-    else
-      unreachable("Unknown encoding");
-    Out << 'v';
-    mangleIdentifier(node->getChild(2));
-    Out << '_';
-    return;
-  }
-  case FunctionSigSpecializationParamKind::ClosureProp:
-    Out << "cl";
-    mangleIdentifier(node->getChild(1));
-    for (unsigned i = 2, e = node->getNumChildren(); i != e; ++i) {
-      mangleType(node->getChild(i));
-    }
-    Out << '_';
-    return;
-  case FunctionSigSpecializationParamKind::BoxToValue:
-    Out << "i_";
-    return;
-  case FunctionSigSpecializationParamKind::BoxToStack:
-    Out << "k_";
-    return;
-  default:
-    if (kindValue &
-        unsigned(FunctionSigSpecializationParamKind::Dead))
-      Out << 'd';
-    if (kindValue &
-        unsigned(FunctionSigSpecializationParamKind::OwnedToGuaranteed))
-      Out << 'g';
-    if (kindValue &
-        unsigned(FunctionSigSpecializationParamKind::GuaranteedToOwned))
-      Out << 'o';
-    if (kindValue & unsigned(FunctionSigSpecializationParamKind::SROA))
-      Out << 's';
-    Out << '_';
-    return;
-  }
+  unreachable("unsupported");
 }
 
 void Remangler::mangleFunctionSignatureSpecializationParamPayload(Node *node) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -24,10 +24,9 @@
 #include "swift/Strings.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
-#include <vector>
+#include "RemanglerBase.h"
 #include <cstdio>
 #include <cstdlib>
-#include <unordered_map>
 
 using namespace swift;
 using namespace Demangle;
@@ -39,7 +38,25 @@ static void unreachable(const char *Message) {
   std::abort();
 }
 
-static StringRef getTextForSubstitution(Node *node, std::string &tmp) {
+void SubstitutionEntry::deepHash(Node *node) {
+  if (treatAsIdentifier) {
+    combineHash((size_t) Node::Kind::Identifier);
+    std::string tmp;
+    combineHash(getTextForSubstitution(node, tmp));
+    return;
+  }
+  combineHash((size_t) node->getKind());
+  if (node->hasIndex()) {
+    combineHash(node->getIndex());
+  } else if (node->hasText()) {
+    combineHash(node->getText());
+  }
+  for (Node *child : *node) {
+    deepHash(child);
+  }
+}
+
+StringRef SubstitutionEntry::getTextForSubstitution(Node *node, std::string &tmp) {
   switch (node->getKind()) {
     case Node::Kind::InfixOperator:
     case Node::Kind::PrefixOperator:
@@ -50,72 +67,6 @@ static StringRef getTextForSubstitution(Node *node, std::string &tmp) {
       return node->getText();
   }
 }
-
-namespace {
-
-class SubstitutionEntry {
-  Node *TheNode = nullptr;
-  size_t StoredHash = 0;
-  bool treatAsIdentifier = false;
-
-public:
-  void setNode(Node *node, bool treatAsIdentifier) {
-    this->treatAsIdentifier = treatAsIdentifier;
-    TheNode = node;
-    deepHash(node);
-  }
-
-  struct Hasher {
-    size_t operator()(const SubstitutionEntry &entry) const {
-      return entry.StoredHash;
-    }
-  };
-
-private:
-  friend bool operator==(const SubstitutionEntry &lhs,
-                         const SubstitutionEntry &rhs) {
-    if (lhs.StoredHash != rhs.StoredHash)
-      return false;
-    if (lhs.treatAsIdentifier != rhs.treatAsIdentifier)
-      return false;
-    if (lhs.treatAsIdentifier) {
-      std::string tmp1, tmp2;
-      return (getTextForSubstitution(lhs.TheNode, tmp1) ==
-              getTextForSubstitution(rhs.TheNode, tmp2));
-    }
-    return lhs.deepEquals(lhs.TheNode, rhs.TheNode);
-  }
-
-  void combineHash(size_t newValue) {
-    StoredHash = 33 * StoredHash + newValue;
-  }
-
-  void combineHash(StringRef Text) {
-    for (char c : Text) {
-      combineHash((unsigned char) c);
-    }
-  }
-
-  void deepHash(Node *node) {
-    if (treatAsIdentifier) {
-      combineHash((size_t) Node::Kind::Identifier);
-      std::string tmp;
-      combineHash(getTextForSubstitution(node, tmp));
-      return;
-    }
-    combineHash((size_t) node->getKind());
-    if (node->hasIndex()) {
-      combineHash(node->getIndex());
-    } else if (node->hasText()) {
-      combineHash(node->getText());
-    }
-    for (Node *child : *node) {
-      deepHash(child);
-    }
-  }
-
-  bool deepEquals(Node *lhs, Node *rhs) const;
-};
 
 bool SubstitutionEntry::deepEquals(Node *lhs, Node *rhs) const {
   if (lhs->getKind() != rhs->getKind())
@@ -146,49 +97,42 @@ bool SubstitutionEntry::deepEquals(Node *lhs, Node *rhs) const {
   return true;
 }
 
-/// The output string of the Demangler.
-///
-/// It's allocating the string with the provided Factory.
-struct RemanglerBuffer {
-  CharVector Stream;
-  NodeFactory &Factory;
+// Find a substitution and return its index.
+// Returns -1 if no substitution is found.
+int RemanglerBase::findSubstitution(const SubstitutionEntry &entry) {
+  // First search in InlineSubstitutions.
+  SubstitutionEntry *result
+  = std::find(InlineSubstitutions, InlineSubstitutions + NumInlineSubsts,
+              entry);
+  if (result != InlineSubstitutions + NumInlineSubsts)
+    return result - InlineSubstitutions;
 
-  RemanglerBuffer(NodeFactory &Factory) : Factory(Factory) {
-    Stream.init(Factory, 32);
+  // Then search in OverflowSubstitutions.
+  auto it = OverflowSubstitutions.find(entry);
+  if (it == OverflowSubstitutions.end())
+    return -1;
+
+  return it->second;
+}
+
+void RemanglerBase::addSubstitution(const SubstitutionEntry &entry) {
+  assert(findSubstitution(entry) < 0);
+  if (NumInlineSubsts < InlineSubstCapacity) {
+    // There is still free space in NumInlineSubsts.
+    assert(OverflowSubstitutions.empty());
+    InlineSubstitutions[NumInlineSubsts++] = entry;
+    return;
   }
+  // We have to add the entry to OverflowSubstitutions.
+  unsigned Idx = OverflowSubstitutions.size() + InlineSubstCapacity;
+  auto result = OverflowSubstitutions.insert({entry, Idx});
+  assert(result.second);
+  (void) result;
+}
 
-  RemanglerBuffer &operator<<(char c) & {
-    Stream.push_back(c, Factory);
-    return *this;
-  }
+namespace {
 
-  RemanglerBuffer &operator<<(llvm::StringRef Value) & {
-    Stream.append(Value, Factory);
-    return *this;
-  }
-
-  RemanglerBuffer &operator<<(int n) & {
-    Stream.append(n, Factory);
-    return *this;
-  }
-
-  RemanglerBuffer &operator<<(unsigned n) & {
-    Stream.append((unsigned long long)n, Factory);
-    return *this;
-  }
-
-  RemanglerBuffer &operator<<(unsigned long n) & {
-    Stream.append((unsigned long long)n, Factory);
-    return *this;
-  }
-
-  RemanglerBuffer &operator<<(unsigned long long n) & {
-    Stream.append(n, Factory);
-    return *this;
-  }
-};
-
-class Remangler {
+class Remangler : public RemanglerBase {
   template <typename Mangler>
   friend void Mangle::mangleIdentifier(Mangler &M, StringRef ident);
   friend class Mangle::SubstitutionMerging;
@@ -200,27 +144,7 @@ class Remangler {
 
   static const size_t MaxNumWords = 26;
 
-  // An efficient hash-map implementation in the spirit of llvm's SmallPtrSet:
-  // The first 16 substitutions are stored in an inline-allocated array to avoid
-  // malloc calls in the common case.
-  // Lookup is still reasonable fast because there are max 16 elements in the
-  // array.
-  static const size_t InlineSubstCapacity = 16;
-  SubstitutionEntry InlineSubstitutions[InlineSubstCapacity];
-  size_t NumInlineSubsts = 0;
-
-  // The "overflow" for InlineSubstitutions. Only if InlineSubstitutions is
-  // full, new substitutions are stored in OverflowSubstitutions.
-  std::unordered_map<SubstitutionEntry, unsigned,
-                     SubstitutionEntry::Hasher> OverflowSubstitutions;
-
   SubstitutionMerging SubstMerging;
-
-  // We have to cons up temporary nodes sometimes when remangling
-  // nested generics. This factory owns them.
-  NodeFactory &Factory;
-
-  RemanglerBuffer Buffer;
 
   // A callback for resolving symbolic references.
   SymbolicResolver Resolver;
@@ -232,28 +156,6 @@ class Remangler {
   void addWord(const SubstitutionWord &word) {
     Words.push_back(word, Factory);
   }
-
-  // Find a substitution and return its index.
-  // Returns -1 if no substitution is found.
-  int findSubstitution(const SubstitutionEntry &entry) {
-    // First search in InlineSubstitutions.
-    SubstitutionEntry *result
-      = std::find(InlineSubstitutions, InlineSubstitutions + NumInlineSubsts,
-                  entry);
-    if (result != InlineSubstitutions + NumInlineSubsts)
-      return result - InlineSubstitutions;
-
-    // Then search in OverflowSubstitutions.
-    auto it = OverflowSubstitutions.find(entry);
-    if (it == OverflowSubstitutions.end())
-      return -1;
-
-    return it->second;
-  }
-
-  StringRef getBufferStr() const { return Buffer.Stream.str(); }
-
-  void resetBuffer(size_t toPos) { Buffer.Stream.resetSize(toPos); }
 
   template <typename Mangler>
   friend void mangleIdentifier(Mangler &M, StringRef ident);
@@ -356,7 +258,6 @@ class Remangler {
 
   bool trySubstitution(Node *node, SubstitutionEntry &entry,
                        bool treatAsIdentifier = false);
-  void addSubstitution(const SubstitutionEntry &entry);
 
   void mangleIdentifierImpl(Node *node, bool isOperator);
 
@@ -391,7 +292,7 @@ class Remangler {
 
 public:
   Remangler(SymbolicResolver Resolver, NodeFactory &Factory)
-       : Factory(Factory), Buffer(Factory), Resolver(Resolver) { }
+       : RemanglerBase(Factory), Resolver(Resolver) { }
 
   void mangle(Node *node) {
     switch (node->getKind()) {
@@ -399,14 +300,6 @@ public:
 #include "swift/Demangling/DemangleNodes.def"
     }
     unreachable("bad demangling tree node");
-  }
-
-  StringRef strRef() {
-    return Buffer.Stream.str();
-  }
-
-  std::string str() {
-    return strRef().str();
   }
 };
 
@@ -432,21 +325,6 @@ bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry,
     Buffer << 'A' << Subst;
   }
   return true;
-}
-
-void Remangler::addSubstitution(const SubstitutionEntry &entry) {
-  assert(findSubstitution(entry) < 0);
-  if (NumInlineSubsts < InlineSubstCapacity) {
-    // There is still free space in NumInlineSubsts.
-    assert(OverflowSubstitutions.empty());
-    InlineSubstitutions[NumInlineSubsts++] = entry;
-    return;
-  }
-  // We have to add the entry to OverflowSubstitutions.
-  unsigned Idx = OverflowSubstitutions.size() + InlineSubstCapacity;
-  auto result = OverflowSubstitutions.insert({entry, Idx});
-  assert(result.second);
-  (void) result;
 }
 
 void Remangler::mangleIdentifierImpl(Node *node, bool isOperator) {
@@ -514,9 +392,9 @@ std::pair<int, Node *> Remangler::mangleConstrainedType(Node *node) {
   if (trySubstitution(node, entry))
     return {-1, nullptr};
 
-  std::vector<Node *> Chain;
+  Vector<Node *> Chain;
   while (node->getKind() == Node::Kind::DependentMemberType) {
-    Chain.push_back(node->getChild(1));
+    Chain.push_back(node->getChild(1), Factory);
     node = getChildOfType(node->getFirstChild());
   }
   assert(node->getKind() == Node::Kind::DependentGenericParamType);
@@ -2446,7 +2324,7 @@ Demangle::mangleNode(NodePointer node, SymbolicResolver resolver,
   Remangler remangler(resolver, Factory);
   remangler.mangle(node);
 
-  return remangler.strRef();
+  return remangler.getBufferStr();
 }
 
 bool Demangle::isSpecialized(Node *node) {

--- a/lib/Demangling/RemanglerBase.h
+++ b/lib/Demangling/RemanglerBase.h
@@ -1,0 +1,177 @@
+//===--- Demangler.h - String to Node-Tree Demangling -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains shared code between the old and new remanglers.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DEMANGLING_BASEREMANGLER_H
+#define SWIFT_DEMANGLING_BASEREMANGLER_H
+
+#include "swift/Demangling/Demangler.h"
+#include <unordered_map>
+
+using namespace swift::Demangle;
+using llvm::StringRef;
+
+namespace swift {
+namespace Demangle {
+
+// An entry in the remangler's substitution map.
+class SubstitutionEntry {
+  Node *TheNode = nullptr;
+  size_t StoredHash = 0;
+  bool treatAsIdentifier = false;
+
+public:
+  void setNode(Node *node, bool treatAsIdentifier) {
+    this->treatAsIdentifier = treatAsIdentifier;
+    TheNode = node;
+    deepHash(node);
+  }
+
+  struct Hasher {
+    size_t operator()(const SubstitutionEntry &entry) const {
+      return entry.StoredHash;
+    }
+  };
+
+private:
+  friend bool operator==(const SubstitutionEntry &lhs,
+                         const SubstitutionEntry &rhs) {
+    if (lhs.StoredHash != rhs.StoredHash)
+      return false;
+    if (lhs.treatAsIdentifier != rhs.treatAsIdentifier)
+      return false;
+    if (lhs.treatAsIdentifier) {
+      std::string tmp1, tmp2;
+      return (getTextForSubstitution(lhs.TheNode, tmp1) ==
+              getTextForSubstitution(rhs.TheNode, tmp2));
+    }
+    return lhs.deepEquals(lhs.TheNode, rhs.TheNode);
+  }
+
+  void combineHash(size_t newValue) {
+    StoredHash = 33 * StoredHash + newValue;
+  }
+
+  void combineHash(StringRef Text) {
+    for (char c : Text) {
+      combineHash((unsigned char) c);
+    }
+  }
+
+  void deepHash(Node *node);
+
+  static StringRef getTextForSubstitution(Node *node, std::string &tmp);
+
+  bool deepEquals(Node *lhs, Node *rhs) const;
+};
+
+/// The output string for the Remangler.
+///
+/// It's allocating the string with the provided Factory.
+class RemanglerBuffer {
+  CharVector Stream;
+  NodeFactory &Factory;
+
+public:
+  RemanglerBuffer(NodeFactory &Factory) : Factory(Factory) {
+    Stream.init(Factory, 32);
+  }
+
+  void reset(size_t toPos) { Stream.resetSize(toPos); }
+
+  StringRef strRef() const { return Stream.str(); }
+
+  RemanglerBuffer &operator<<(char c) & {
+    Stream.push_back(c, Factory);
+    return *this;
+  }
+
+  RemanglerBuffer &operator<<(llvm::StringRef Value) & {
+    Stream.append(Value, Factory);
+    return *this;
+  }
+
+  RemanglerBuffer &operator<<(int n) & {
+    Stream.append(n, Factory);
+    return *this;
+  }
+
+  RemanglerBuffer &operator<<(unsigned n) & {
+    Stream.append((unsigned long long)n, Factory);
+    return *this;
+  }
+
+  RemanglerBuffer &operator<<(unsigned long n) & {
+    Stream.append((unsigned long long)n, Factory);
+    return *this;
+  }
+
+  RemanglerBuffer &operator<<(unsigned long long n) & {
+    Stream.append(n, Factory);
+    return *this;
+  }
+};
+
+/// The base class for the old and new remangler.
+class RemanglerBase {
+protected:
+  // Used to allocate temporary nodes and the output string (in Buffer).
+  NodeFactory &Factory;
+
+  // An efficient hash-map implementation in the spirit of llvm's SmallPtrSet:
+  // The first 16 substitutions are stored in an inline-allocated array to avoid
+  // malloc calls in the common case.
+  // Lookup is still reasonable fast because there are max 16 elements in the
+  // array.
+  static const size_t InlineSubstCapacity = 16;
+  SubstitutionEntry InlineSubstitutions[InlineSubstCapacity];
+  size_t NumInlineSubsts = 0;
+
+  // The "overflow" for InlineSubstitutions. Only if InlineSubstitutions is
+  // full, new substitutions are stored in OverflowSubstitutions.
+  std::unordered_map<SubstitutionEntry, unsigned, SubstitutionEntry::Hasher>
+    OverflowSubstitutions;
+
+  RemanglerBuffer Buffer;
+
+protected:
+  RemanglerBase(NodeFactory &Factory) : Factory(Factory), Buffer(Factory) { }
+
+  /// Find a substitution and return its index.
+  /// Returns -1 if no substitution is found.
+  int findSubstitution(const SubstitutionEntry &entry);
+
+  /// Adds a substitution.
+  void addSubstitution(const SubstitutionEntry &entry);
+
+  /// Resets the output string buffer to \p toPos.
+  void resetBuffer(size_t toPos) { Buffer.reset(toPos); }
+
+public:
+
+  /// Append a custom string to the output buffer.
+  void append(StringRef str) { Buffer << str; }
+
+  StringRef getBufferStr() const { return Buffer.strRef(); }
+
+  std::string str() {
+    return getBufferStr().str();
+  }
+};
+
+} // end namespace Demangle
+} // end namespace swift
+
+#endif // SWIFT_DEMANGLING_BASEREMANGLER_H

--- a/lib/Demangling/RemanglerBase.h
+++ b/lib/Demangling/RemanglerBase.h
@@ -53,26 +53,18 @@ private:
     if (lhs.treatAsIdentifier != rhs.treatAsIdentifier)
       return false;
     if (lhs.treatAsIdentifier) {
-      std::string tmp1, tmp2;
-      return (getTextForSubstitution(lhs.TheNode, tmp1) ==
-              getTextForSubstitution(rhs.TheNode, tmp2));
+      return identifierEquals(lhs.TheNode, rhs.TheNode);
     }
     return lhs.deepEquals(lhs.TheNode, rhs.TheNode);
   }
+
+  static bool identifierEquals(Node *lhs, Node *rhs);
 
   void combineHash(size_t newValue) {
     StoredHash = 33 * StoredHash + newValue;
   }
 
-  void combineHash(StringRef Text) {
-    for (char c : Text) {
-      combineHash((unsigned char) c);
-    }
-  }
-
   void deepHash(Node *node);
-
-  static StringRef getTextForSubstitution(Node *node, std::string &tmp);
 
   bool deepEquals(Node *lhs, Node *rhs) const;
 };

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4740,19 +4740,37 @@ areAllTransitiveMetadataComplete_cheap(const Metadata *type) {
 /// dependencies actually hold, and we can keep going.
 static MetadataDependency
 checkTransitiveCompleteness(const Metadata *initialType) {
-  // TODO: it would nice to avoid allocating memory in common cases here.
-  // In particular, we don't usually add *anything* to the worklist, and we
-  // usually only add a handful of types to the map.
-  std::vector<const Metadata *> worklist;
-  std::unordered_set<const Metadata *> presumedCompleteTypes;
+  llvm::SmallVector<const Metadata *, 8> worklist;
+  
+  // An efficient hash-set implementation in the spirit of llvm's SmallPtrSet:
+  // The first 8 elements are stored in an inline-allocated array to avoid
+  // malloc calls in the common case. Lookup is still reasonable fast because
+  // there are max 8 elements in the array.
+  const int InlineCapacity = 8;
+  const Metadata *inlinedPresumedCompleteTypes[InlineCapacity];
+  int numInlinedTypes = 0;
+  std::unordered_set<const Metadata *> overflowPresumedCompleteTypes;
 
   MetadataDependency dependency;
   auto isIncomplete = [&](const Metadata *type) -> bool {
     // Add the type to the presumed-complete-types set.  If this doesn't
     // succeed, we've already inserted it, which means we must have already
     // decided it was complete.
-    if (!presumedCompleteTypes.insert(type).second)
+    // First, try to find the type in the inline-storage of the set.
+    const Metadata **end = inlinedPresumedCompleteTypes + numInlinedTypes;
+    if (std::find(inlinedPresumedCompleteTypes, end, type) != end)
       return false;
+
+    // We didn't find the type in the inline-storage.
+    if (numInlinedTypes < InlineCapacity) {
+      assert(overflowPresumedCompleteTypes.size() == 0);
+      inlinedPresumedCompleteTypes[numInlinedTypes++] = type;
+    } else {
+      // The inline-storage is full. So try to insert the type into the
+      // overflow set.
+      if (!overflowPresumedCompleteTypes.insert(type).second)
+        return false;
+    }
 
     // Check the metadata's current state with a non-blocking request.
     auto request = MetadataRequest(MetadataState::Complete,
@@ -4780,7 +4798,9 @@ checkTransitiveCompleteness(const Metadata *initialType) {
 
   // Consider the type itself to be presumed-complete.  We're looking for
   // a greatest fixed point.
-  presumedCompleteTypes.insert(initialType);
+  assert(numInlinedTypes == 0 && overflowPresumedCompleteTypes.size() == 0);
+  inlinedPresumedCompleteTypes[0] = initialType;
+  numInlinedTypes = 1;
   if (findAnyTransitiveMetadata(initialType, isIncomplete))
     return dependency;
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -601,11 +601,9 @@ MetadataResponse
 swift::swift_getGenericMetadata(MetadataRequest request,
                                 const void * const *arguments,
                                 const TypeContextDescriptor *description) {
-  auto &generics = description->getFullGenericContextHeader();
-  size_t numGenericArgs = generics.Base.NumKeyArguments;
-
   auto &cache = getCache(*description);
-  assert(numGenericArgs == cache.NumKeyParameters + cache.NumWitnessTables);
+  assert(description->getFullGenericContextHeader().Base.NumKeyArguments ==
+         cache.NumKeyParameters + cache.NumWitnessTables);
   auto key = MetadataCacheKey(cache.NumKeyParameters, cache.NumWitnessTables,
                               arguments);
   auto result = cache.getOrInsert(key, request, description, arguments);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -965,8 +965,8 @@ public:
 #if SWIFT_OBJC_INTEROP
     // Look for a Swift-defined @objc protocol with the Swift 3 mangling that
     // is used for Objective-C entities.
-    std::string objcMangledName = "_Tt" + mangleNodeOld(node, &demangler) + "_";
-    if (auto protocol = objc_getProtocol(objcMangledName.c_str()))
+    const char *objcMangledName = mangleNodeAsObjcCString(node, demangler);
+    if (auto protocol = objc_getProtocol(objcMangledName))
       return ProtocolDescriptorRef::forObjC(protocol);
 #endif
 


### PR DESCRIPTION
This is a followup on https://github.com/apple/swift/pull/23131.

Removes even more memory allocations in the runtime. The most significant changes are:
* making the old remangler allocation-free
*  avoid memory allocations in checkTransitiveCompleteness

See the commit messages for details.
