### PR TITLE
build: specify vendor for Darwin benchmarks

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -77,6 +77,11 @@ macro(configure_sdks_darwin)
   set(appletvos_ver "9.1")
   set(watchos_ver "2.0")
 
+  set(macosx_vendor "apple")
+  set(iphoneos_vendor "apple")
+  set(appletvos_vendor "apple")
+  set(watchos_vendor "apple")
+
   set(macosx_triple_platform "macosx")
   set(iphoneos_triple_platform "ios")
   set(appletvos_triple_platform "tvos")


### PR DESCRIPTION
The build was not specifying the vendor when building the Darwin
benchmarks.  Parts of the SDK rely on the vendor macro (`__APPLE__`) to
be defined which requires that the vendor is specified properly.  Ensure
that we do so.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
