### PR TITLE
SourceKit: allow expression type request to specify a list of protocol USRs for filtering

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_SEMA_IDETYPECHECKING_H
 #define SWIFT_SEMA_IDETYPECHECKING_H
 
+#include "llvm/ADT/MapVector.h"
 #include "swift/Basic/SourceLoc.h"
 #include <memory>
 
@@ -177,12 +178,21 @@ namespace swift {
 
     /// The length of the printed type
     uint32_t typeLength;
+
+    /// The offsets and lengths of all protocols the type conforms to
+    std::vector<std::pair<uint32_t, uint32_t>> protocols;
   };
 
   /// Collect type information for every expression in \c SF; all types will
   /// be printed to \c OS.
   ArrayRef<ExpressionTypeInfo> collectExpressionType(SourceFile &SF,
+    ArrayRef<const char *> ExpectedProtocols,
     std::vector<ExpressionTypeInfo> &scratch, llvm::raw_ostream &OS);
+
+  /// Resolve a list of mangled names to accessible protocol decls from
+  /// the decl context.
+  bool resolveProtocolNames(DeclContext *DC, ArrayRef<const char *> names,
+                            llvm::MapVector<ProtocolDecl*, StringRef> &result);
 }
 
 #endif

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -32,9 +32,8 @@ class ConformingMethodListCallbacks : public CodeCompletionCallbacks {
   Expr *ParsedExpr = nullptr;
   DeclContext *CurDeclContext = nullptr;
 
-  void resolveExpectedTypes(ArrayRef<const char *> names, SourceLoc loc,
-                            SmallVectorImpl<ProtocolDecl *> &result);
-  void getMatchingMethods(Type T, ArrayRef<ProtocolDecl *> expectedTypes,
+  void getMatchingMethods(Type T,
+                          llvm::MapVector<ProtocolDecl*, StringRef> &expectedTypes,
                           SmallVectorImpl<ValueDecl *> &result);
 
 public:
@@ -89,9 +88,8 @@ void ConformingMethodListCallbacks::doneParsing() {
   if (!T || T->is<ErrorType>() || T->is<UnresolvedType>())
     return;
 
-  SmallVector<ProtocolDecl *, 4> expectedProtocols;
-  resolveExpectedTypes(ExpectedTypeNames, ParsedExpr->getLoc(),
-                       expectedProtocols);
+  llvm::MapVector<ProtocolDecl*, StringRef> expectedProtocols;
+  resolveProtocolNames(CurDeclContext, ExpectedTypeNames, expectedProtocols);
 
   // Collect the matching methods.
   ConformingMethodListResult result(CurDeclContext, T);
@@ -100,21 +98,8 @@ void ConformingMethodListCallbacks::doneParsing() {
   Consumer.handleResult(result);
 }
 
-void ConformingMethodListCallbacks::resolveExpectedTypes(
-    ArrayRef<const char *> names, SourceLoc loc,
-    SmallVectorImpl<ProtocolDecl *> &result) {
-  auto &ctx = CurDeclContext->getASTContext();
-
-  for (auto name : names) {
-    if (auto ty = Demangle::getTypeForMangling(ctx, name)) {
-      if (auto Proto = dyn_cast_or_null<ProtocolDecl>(ty->getAnyGeneric()))
-        result.push_back(Proto);
-    }
-  }
-}
-
 void ConformingMethodListCallbacks::getMatchingMethods(
-    Type T, ArrayRef<ProtocolDecl *> expectedTypes,
+    Type T, llvm::MapVector<ProtocolDecl*, StringRef> &expectedTypes,
     SmallVectorImpl<ValueDecl *> &result) {
   if (!T->mayHaveMembers())
     return;
@@ -126,7 +111,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
     Type T;
 
     /// The list of expected types.
-    ArrayRef<ProtocolDecl *> ExpectedTypes;
+    llvm::MapVector<ProtocolDecl*, StringRef> &ExpectedTypes;
 
     /// Result sink to populate.
     SmallVectorImpl<ValueDecl *> &Result;
@@ -149,7 +134,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
 
       // The return type conforms to any of the requested protocols.
       for (auto Proto : ExpectedTypes) {
-        if (CurModule->conformsToProtocol(declTy, Proto))
+        if (CurModule->conformsToProtocol(declTy, Proto.first))
           return true;
       }
 
@@ -158,7 +143,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
 
   public:
     LocalConsumer(DeclContext *DC, Type T,
-                  ArrayRef<ProtocolDecl *> expectedTypes,
+                  llvm::MapVector<ProtocolDecl*, StringRef> &expectedTypes,
                   SmallVectorImpl<ValueDecl *> &result)
         : CurModule(DC->getParentModule()), T(T), ExpectedTypes(expectedTypes),
           Result(result) {}

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
+#include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/IDE/SourceEntityWalker.h"
@@ -582,6 +583,7 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
 
 /// This walker will traverse the AST and report types for every expression.
 class ExpressionTypeCollector: public SourceEntityWalker {
+  ModuleDecl &Module;
   SourceManager &SM;
   unsigned int BufferId;
   std::vector<ExpressionTypeInfo> &Results;
@@ -596,7 +598,13 @@ class ExpressionTypeCollector: public SourceEntityWalker {
   // [offset, length].
   llvm::DenseMap<unsigned, llvm::DenseSet<unsigned>> AllPrintedTypes;
 
-  bool shouldReport(unsigned Offset, unsigned Length, Expr *E) {
+  // When non empty, we only print expression types that conform to any of
+  // these protocols.
+  llvm::MapVector<ProtocolDecl*, StringRef> &InterestedProtocols;
+
+  bool shouldReport(unsigned Offset, unsigned Length, Expr *E,
+                    std::vector<StringRef> &Conformances) {
+    assert(Conformances.empty());
     // We shouldn't report null types.
     if (E->getType().isNull())
       return false;
@@ -605,25 +613,46 @@ class ExpressionTypeCollector: public SourceEntityWalker {
     // report again. This makes sure we always report the outtermost type of
     // several overlapping expressions.
     auto &Bucket = AllPrintedTypes[Offset];
-    return Bucket.find(Length) == Bucket.end();
+    if (Bucket.find(Length) != Bucket.end())
+      return false;
+
+    // We print every expression if the interested protocols are empty.
+    if (InterestedProtocols.empty())
+      return true;
+
+    // Collecting protocols conformed by this expressions that are in the list.
+    for (auto Proto: InterestedProtocols) {
+      if (Module.conformsToProtocol(E->getType(), Proto.first)) {
+        Conformances.push_back(Proto.second);
+      }
+    }
+
+    // We only print the type of the expression if it conforms to any of the
+    // interested protocols.
+    return !Conformances.empty();
   }
 
   // Find an existing offset in the type buffer otherwise print the type to
   // the buffer.
-  uint32_t getTypeOffsets(StringRef PrintedType) {
+  std::pair<uint32_t, uint32_t> getTypeOffsets(StringRef PrintedType) {
     auto It = TypeOffsets.find(PrintedType);
     if (It == TypeOffsets.end()) {
       TypeOffsets[PrintedType] = OS.tell();
-      OS << PrintedType;
+      OS << PrintedType << '\0';
     }
-    return TypeOffsets[PrintedType];
+    return {TypeOffsets[PrintedType], PrintedType.size()};
   }
 
+
 public:
-  ExpressionTypeCollector(SourceFile &SF, std::vector<ExpressionTypeInfo> &Results,
-    llvm::raw_ostream &OS): SM(SF.getASTContext().SourceMgr),
+  ExpressionTypeCollector(SourceFile &SF,
+              llvm::MapVector<ProtocolDecl*, StringRef> &InterestedProtocols,
+                          std::vector<ExpressionTypeInfo> &Results,
+                          llvm::raw_ostream &OS): Module(*SF.getParentModule()),
+                            SM(SF.getASTContext().SourceMgr),
                             BufferId(*SF.getBufferID()),
-                            Results(Results), OS(OS) {}
+                            Results(Results), OS(OS),
+                            InterestedProtocols(InterestedProtocols) {}
   bool walkToExprPre(Expr *E) override {
     if (E->getSourceRange().isInvalid())
       return true;
@@ -631,20 +660,24 @@ public:
       Lexer::getCharSourceRangeFromSourceRange(SM, E->getSourceRange());
     unsigned Offset = SM.getLocOffsetInBuffer(Range.getStart(), BufferId);
     unsigned Length = Range.getByteLength();
-    if (!shouldReport(Offset, Length, E))
+    std::vector<StringRef> Conformances;
+    if (!shouldReport(Offset, Length, E, Conformances))
       return true;
     // Print the type to a temporary buffer.
     SmallString<64> Buffer;
     {
       llvm::raw_svector_ostream OS(Buffer);
       E->getType()->getRValueType()->reconstituteSugar(true)->print(OS);
-      // Ensure the end user can directly use the char*
-      OS << '\0';
     }
-
+    auto Ty = getTypeOffsets(Buffer.str());
     // Add the type information to the result list.
-    Results.push_back({Offset, Length, getTypeOffsets(Buffer.str()),
-      static_cast<uint32_t>(Buffer.size()) - 1});
+    Results.push_back({Offset, Length, Ty.first, Ty.second, {}});
+
+    // Adding all protocol names to the result.
+    for(auto Con: Conformances) {
+      auto Ty = getTypeOffsets(Con);
+      Results.back().protocols.push_back({Ty.first, Ty.second});
+    }
 
     // Keep track of that we have a type reported for this range.
     AllPrintedTypes[Offset].insert(Length);
@@ -652,11 +685,44 @@ public:
   }
 };
 
+bool swift::resolveProtocolNames(DeclContext *DC,
+                                 ArrayRef<const char *> names,
+                          llvm::MapVector<ProtocolDecl*, StringRef> &result) {
+  assert(result.empty());
+  auto &ctx = DC->getASTContext();
+  for (auto name : names) {
+    // First try to solve by usr
+    ProtocolDecl *pd = dyn_cast_or_null<ProtocolDecl>(Demangle::
+      getTypeDeclForUSR(ctx, name));
+    if (!pd) {
+      // Second try to solve by mangled symbol name
+      pd = dyn_cast_or_null<ProtocolDecl>(Demangle::getTypeDeclForMangling(ctx, name));
+    }
+    if (!pd) {
+      // Thirdly try to solve by mangled type name
+      if (auto ty = Demangle::getTypeForMangling(ctx, name)) {
+        pd = dyn_cast_or_null<ProtocolDecl>(ty->getAnyGeneric());
+      }
+    }
+    if (pd) {
+      result.insert({pd, name});
+    }
+  }
+  if (names.size() == result.size())
+    return false;
+  // If we resolved none but the given names are not empty, return true for failure.
+  return result.size() == 0;
+}
+
 ArrayRef<ExpressionTypeInfo>
 swift::collectExpressionType(SourceFile &SF,
+                             ArrayRef<const char *> ExpectedProtocols,
                              std::vector<ExpressionTypeInfo> &Scratch,
                              llvm::raw_ostream &OS) {
-  ExpressionTypeCollector Walker(SF, Scratch, OS);
+  llvm::MapVector<ProtocolDecl*, StringRef> InterestedProtocols;
+  if (resolveProtocolNames(&SF, ExpectedProtocols, InterestedProtocols))
+    return {};
+  ExpressionTypeCollector Walker(SF, InterestedProtocols, Scratch, OS);
   Walker.walk(SF);
   return Scratch;
 }

--- a/test/IDE/Inputs/ExprTypeFiltered.swift
+++ b/test/IDE/Inputs/ExprTypeFiltered.swift
@@ -1,0 +1,31 @@
+protocol ProtEmpty {}
+
+protocol Prot {}
+
+protocol Prot1 {}
+
+class Clas: Prot {
+  var value: Clas { return self }
+  func getValue() -> Clas { return self }
+}
+
+struct Stru: Prot, Prot1 {
+  var value: Stru { return self }
+  func getValue() -> Stru { return self }
+}
+
+class C {}
+
+func ArrayC(_ a: [C]) {
+	_ = a.count
+	_ = a.description.count.advanced(by: 1).description
+	_ = a[0]
+}
+
+func ArrayClas(_ a: [Clas]) {
+	_ = a[0].value.getValue().value
+}
+
+func ArrayClas(_ a: [Stru]) {
+	_ = a[0].value.getValue().value
+}

--- a/test/IDE/expr_type_filtered.swift
+++ b/test/IDE/expr_type_filtered.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-ide-test -print-expr-type -source-filename %S/Inputs/ExprTypeFiltered.swift -swift-version 5 -module-name filtered -usr-filter 's:8filtered9ProtEmptyP' | %FileCheck %s -check-prefix=EMPTY
+// RUN: %target-swift-ide-test -print-expr-type -source-filename %S/Inputs/ExprTypeFiltered.swift -swift-version 5 -module-name filtered -usr-filter 's:8filtered4ProtP' | %FileCheck %s -check-prefix=PROTO
+// RUN: %target-swift-ide-test -print-expr-type -source-filename %S/Inputs/ExprTypeFiltered.swift -swift-version 5 -module-name filtered -usr-filter 's:8filtered5Prot1P' | %FileCheck %s -check-prefix=PROTO1
+
+// EMPTY: class Clas: Prot {
+// EMPTY:   var value: Clas { return self }
+// EMPTY:   func getValue() -> Clas { return self }
+// EMPTY: }
+// EMPTY: struct Stru: Prot, Prot1 {
+// EMPTY:   var value: Stru { return self }
+// EMPTY:   func getValue() -> Stru { return self }
+// EMPTY: }
+
+// PROTO: class Clas: Prot {
+// PROTO:   var value: Clas { return <expr type:"Clas">self</expr> }
+// PROTO:   func getValue() -> Clas { return <expr type:"Clas">self</expr> }
+// PROTO: }
+// PROTO: struct Stru: Prot, Prot1 {
+// PROTO:   var value: Stru { return <expr type:"Stru">self</expr> }
+// PROTO:   func getValue() -> Stru { return <expr type:"Stru">self</expr> }
+// PROTO: }
+
+// PROTO1: class Clas: Prot {
+// PROTO1:   var value: Clas { return self }
+// PROTO1:   func getValue() -> Clas { return self }
+// PROTO1: }
+// PROTO1: struct Stru: Prot, Prot1 {
+// PROTO1:   var value: Stru { return <expr type:"Stru">self</expr> }
+// PROTO1:   func getValue() -> Stru { return <expr type:"Stru">self</expr> }
+// PROTO1: }

--- a/test/SourceKit/ExpressionType/filtered.swift
+++ b/test/SourceKit/ExpressionType/filtered.swift
@@ -1,0 +1,92 @@
+// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='s:8filtered4ProtP;s:8filtered5Prot1P' -- %s | %FileCheck %s -check-prefix=BOTH
+// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='s:8filtered5Prot1P' -- %s | %FileCheck %s -check-prefix=PROTO1
+// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='s:8filtered6Proto2P' -- %s | %FileCheck %s -check-prefix=PROTO2
+
+protocol Prot {}
+
+protocol Prot1 {}
+
+class Clas: Prot {
+  var value: Clas { return self }
+  func getValue() -> Clas { return self }
+}
+
+struct Stru: Prot, Prot1 {
+  var value: Stru { return self }
+  func getValue() -> Stru { return self }
+}
+
+class C {}
+
+func ArrayC(_ a: [C]) {
+	_ = a.count
+	_ = a.description.count.advanced(by: 1).description
+	_ = a[0]
+}
+
+func ArrayClas(_ a: [Clas]) {
+	_ = a[0].value.getValue().value
+}
+
+func ArrayClas(_ a: [Stru]) {
+	_ = a[0].value.getValue().value
+}
+
+protocol Proto2 {}
+
+class Proto2Conformer: Proto2 {}
+
+func foo(_ c: Proto2Conformer) { _ = c }
+
+// BOTH: <ExpressionTypes>
+// BOTH: (503, 507): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (545, 549): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (609, 613): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: (651, 655): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: (811, 838): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (811, 832): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (811, 821): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (811, 815): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (877, 904): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: (877, 898): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: (877, 887): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: (877, 881): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: </ExpressionTypes>
+
+// PROTO1: <ExpressionTypes>
+// PROTO1: (609, 613): Stru
+// PROTO1: conforming to: s:8filtered5Prot1P
+// PROTO1: (651, 655): Stru
+// PROTO1: conforming to: s:8filtered5Prot1P
+// PROTO1: (877, 904): Stru
+// PROTO1: conforming to: s:8filtered5Prot1P
+// PROTO1: (877, 898): Stru
+// PROTO1: conforming to: s:8filtered5Prot1P
+// PROTO1: (877, 887): Stru
+// PROTO1: conforming to: s:8filtered5Prot1P
+// PROTO1: (877, 881): Stru
+// PROTO1: conforming to: s:8filtered5Prot1P
+// PROTO1: </ExpressionTypes>
+
+// PROTO2: <ExpressionTypes>
+// PROTO2: (999, 1000): Proto2Conformer
+// PROTO2: conforming to: s:8filtered6Proto2P
+// PROTO2: </ExpressionTypes>

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -751,6 +751,9 @@ type checking and the necessary compiler arguments to help resolve all dependenc
     <key.compilerargs>:       [string*] // Array of zero or more strings for the compiler arguments,
                                         // e.g ["-sdk", "/path/to/sdk"]. If key.sourcefile is provided,
                                         // these must include the path to that file.
+    <key.expectedtypes>:      [string*] // A list of interested protocol USRs.
+                                        // When empty, we report all expressions in the file.
+                                        // When non-empty, we report expressions whose types conform to any of the give protocols.
 }
 ```
 
@@ -767,6 +770,7 @@ expr-type-info ::=
   <key.expression_offset>:    (int64)    // Offset of an expression in the source file
   <key.expression_length>:    (int64)    // Length of an expression in the source file
   <key.expression_type>:      (string)   // Printed type of this expression
+  <key.expectedtypes>:        [string*]  // A list of interested protocol USRs this expression conforms to
 }
 ```
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -128,6 +128,7 @@ struct ExpressionType {
   unsigned ExprOffset;
   unsigned ExprLength;
   unsigned TypeOffset;
+  std::vector<unsigned> ProtocolOffsets;
 };
 
 struct ExpressionTypesInFile {
@@ -722,6 +723,7 @@ public:
 
   virtual void collectExpressionTypes(StringRef FileName,
                                       ArrayRef<const char *> Args,
+                                      ArrayRef<const char *> ExpectedProtocols,
                                       std::function<void(const ExpressionTypesInFile&)> Receiver) = 0;
 
   virtual void getDocInfo(llvm::MemoryBuffer *InputBuf,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -523,6 +523,7 @@ public:
                              CategorizedRenameRangesReceiver Receiver) override;
 
   void collectExpressionTypes(StringRef FileName, ArrayRef<const char *> Args,
+                              ArrayRef<const char *> ExpectedProtocols,
                               std::function<void(const ExpressionTypesInFile&)> Receiver) override;
 
   void semanticRefactoring(StringRef Filename, SemanticRefactoringInfo Info,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -398,6 +398,28 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
   return 0;
 }
 
+static int setExpectedTypes(const sourcekitd_test::TestOptions &Opts,
+                            sourcekitd_object_t Req) {
+  for (auto &Opt : Opts.RequestOptions) {
+    auto KeyValue = StringRef(Opt).split('=');
+    if (KeyValue.first == "expectedtypes") {
+      SmallVector<StringRef, 4> expectedTypeNames;
+      KeyValue.second.split(expectedTypeNames, ';');
+
+      auto typenames = sourcekitd_request_array_create(nullptr, 0);
+      for (auto &name : expectedTypeNames) {
+        std::string n = name;
+        sourcekitd_request_array_set_string(typenames, SOURCEKITD_ARRAY_APPEND, n.c_str());
+      }
+      sourcekitd_request_dictionary_set_value(Req, KeyExpectedTypes, typenames);
+    } else {
+      llvm::errs() << "invalid key '" << KeyValue.first << "' in -req-opts\n";
+      return 1;
+    }
+  }
+  return 0;
+}
+
 static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
 
   if (!Opts.JsonRequestPath.empty())
@@ -569,24 +591,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                           RequestConformingMethodList);
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
-    for (auto &Opt : Opts.RequestOptions) {
-      auto KeyValue = StringRef(Opt).split('=');
-      if (KeyValue.first == "expectedtypes") {
-        SmallVector<StringRef, 4> expectedTypeNames;
-        KeyValue.second.split(expectedTypeNames, ';');
-
-        auto typenames = sourcekitd_request_array_create(nullptr, 0);
-        for (auto &name : expectedTypeNames) {
-          std::string n = name;
-          sourcekitd_request_array_set_string(typenames, SOURCEKITD_ARRAY_APPEND, n.c_str());
-        }
-
-        sourcekitd_request_dictionary_set_value(Req, KeyExpectedTypes, typenames);
-      } else {
-        llvm::errs() << "invalid key '" << KeyValue.first << "' in -req-opts\n";
-        return 1;
-      }
-    }
+    setExpectedTypes(Opts, Req);
     break;
 
   case SourceKitRequest::CursorInfo:
@@ -617,6 +622,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
 
   case SourceKitRequest::CollectExpresstionType: {
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestCollectExpressionType);
+    setExpectedTypes(Opts, Req);
     break;
   }
 
@@ -1543,13 +1549,21 @@ static void printExpressionType(sourcekitd_variant_t Info, llvm::raw_ostream &OS
     OS << "cannot find expression types in the file\n";
     return;
   }
+  OS << "<ExpressionTypes>\n";
   for (unsigned i = 0; i != Count; ++i) {
     sourcekitd_variant_t Item = sourcekitd_variant_array_get_value(TypeBuffer, i);
     unsigned Offset = sourcekitd_variant_dictionary_get_int64(Item, KeyExpressionOffset);
     unsigned Length = sourcekitd_variant_dictionary_get_int64(Item, KeyExpressionLength);
     OS << "(" << Offset << ", " << Offset + Length << "): " <<
       sourcekitd_variant_dictionary_get_string(Item, KeyExpressionType) << "\n";
+    sourcekitd_variant_t protocols = sourcekitd_variant_dictionary_get_value(Item,
+      KeyExpectedTypes);
+    unsigned Count = sourcekitd_variant_array_get_count(protocols);
+    for (unsigned i = 0; i != Count; i ++) {
+      OS << "conforming to: " << sourcekitd_variant_array_get_string(protocols, i) << "\n";
+    }
   }
+  OS << "</ExpressionTypes>\n";
 }
 
 static void printFoundInterface(sourcekitd_variant_t Info,

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/ExpressionTypeArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/ExpressionTypeArray.h
@@ -21,6 +21,7 @@ namespace SourceKit {
 
 namespace sourcekitd {
 VariantFunctions *getVariantFunctionsForExpressionTypeArray();
+VariantFunctions *getVariantFunctionsForProtocolNameArray();
 
 class ExpressionTypeArrayBuilder {
 public:

--- a/tools/SourceKit/tools/sourcekitd/lib/API/ExpressionTypeArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/ExpressionTypeArray.cpp
@@ -22,9 +22,19 @@
 using namespace SourceKit;
 using namespace sourcekitd;
 
+namespace {
 class ExpressionTypeReader {
   const char *printedType;
-  CompactArrayReader<unsigned, unsigned, unsigned> entryReader;
+  // Five unsigned integers for:
+  //  - Expression offset in the source buffer
+  //  - Expression length in the source buffer
+  //  - Offset of printed expression type inside printedType
+  //  - Offset of the first conforming protocol in the protocol buffer
+  //  - Number of conforming protocols
+  CompactArrayReader<unsigned, unsigned, unsigned, unsigned, unsigned> entryReader;
+
+  // Offsets inside printedType where a protocol name starts.
+  CompactArrayReader<unsigned> protoReader;
 
   static uint64_t getHeaderValue(char *buffer, unsigned index) {
     uint64_t headerField;
@@ -34,7 +44,8 @@ class ExpressionTypeReader {
 
 public:
   ExpressionTypeReader(char *buffer):
-      entryReader(buffer + getHeaderValue(buffer, 0)) {
+      entryReader(buffer + getHeaderValue(buffer, 0)),
+      protoReader(buffer + getHeaderValue(buffer, 2)) {
     // Read the printed type string buffer here.
     CompactArrayReader<const char*> reader(buffer + getHeaderValue(buffer, 1));
     reader.readEntries(0, printedType);
@@ -42,12 +53,20 @@ public:
 
   uint64_t count() const { return entryReader.getCount(); }
 
-  std::pair<std::pair<unsigned, unsigned>, const char*> getExpression(uint64_t idx) {
+  ExpressionType getExpression(uint64_t idx) {
     ExpressionType result;
+    unsigned protoStart, protoCount;
     entryReader.readEntries(idx, result.ExprOffset, result.ExprLength,
-                            result.TypeOffset);
-    return {std::make_pair(result.ExprOffset, result.ExprLength),
-      printedType + result.TypeOffset};
+                            result.TypeOffset, protoStart, protoCount);
+    for (unsigned i = protoStart, n = protoStart + protoCount; i < n; i ++) {
+      result.ProtocolOffsets.emplace_back();
+      protoReader.readEntries(i, result.ProtocolOffsets.back());
+    }
+    return result;
+  }
+
+  const char* readPrintedType(unsigned offset) {
+    return printedType + offset;
   }
 
   static bool
@@ -62,18 +81,82 @@ public:
     sourcekitd_variant_t var = make##Ty##Variant(Field); \
     if (!applier(key, var)) return false;                \
   } while (0)
-    APPLY(KeyExpressionOffset, Int, result.first.first);
-    APPLY(KeyExpressionLength, Int, result.first.second);
-    APPLY(KeyExpressionType, String, result.second);
+
+#define APPLY_ARRAY(Kind, Key)                                                 \
+  do {                                                                         \
+    sourcekitd_uid_t key = SKDUIDFromUIdent(Key);                              \
+    sourcekitd_variant_t var = {                                               \
+        {(uintptr_t)getVariantFunctionsFor##Kind##Array(), (uintptr_t)buffer,  \
+                     index}};                                                  \
+    if (!applier(key, var)) return false;                                      \
+  } while (0)
+
+    APPLY(KeyExpressionOffset, Int, result.ExprOffset);
+    APPLY(KeyExpressionLength, Int, result.ExprLength);
+    APPLY(KeyExpressionType, String, reader.readPrintedType(result.TypeOffset));
+    APPLY_ARRAY(ProtocolName, KeyExpectedTypes);
     return true;
   }
+};
+
+// data[0] = ProtocolListFuncs::funcs
+// data[1] = custum buffer
+// data[2] = offset for the element in ExpressionTypeArray
+struct ProtocolListFuncs {
+  static sourcekitd_variant_type_t get_type(sourcekitd_variant_t var) {
+    return SOURCEKITD_VARIANT_TYPE_ARRAY;
+  }
+
+  static size_t array_get_count(sourcekitd_variant_t array) {
+    char *buffer = (char*)array.data[1];
+    size_t offset = array.data[2];
+    return ExpressionTypeReader(buffer).getExpression(offset).
+      ProtocolOffsets.size();
+  }
+
+  static sourcekitd_variant_t array_get_value(sourcekitd_variant_t array,
+                                              size_t index) {
+    char *buffer = (char*)array.data[1];
+    size_t offset = array.data[2];
+    ExpressionTypeReader reader(buffer);
+    return makeStringVariant(reader.readPrintedType((reader.getExpression(offset).
+      ProtocolOffsets[index])));
+  }
+
+  static VariantFunctions Funcs;
+};
+}// end of anonymous namespace
+
+VariantFunctions ProtocolListFuncs::Funcs = {
+  get_type,
+  nullptr /*AnnotArray_array_apply*/,
+  nullptr /*AnnotArray_array_get_bool*/,
+  array_get_count,
+  nullptr /*AnnotArray_array_get_int64*/,
+  nullptr /*AnnotArray_array_get_string*/,
+  nullptr /*AnnotArray_array_get_uid*/,
+  array_get_value,
+  nullptr /*AnnotArray_bool_get_value*/,
+  nullptr /*AnnotArray_dictionary_apply*/,
+  nullptr /*AnnotArray_dictionary_get_bool*/,
+  nullptr /*AnnotArray_dictionary_get_int64*/,
+  nullptr /*AnnotArray_dictionary_get_string*/,
+  nullptr /*AnnotArray_dictionary_get_value*/,
+  nullptr /*AnnotArray_dictionary_get_uid*/,
+  nullptr /*AnnotArray_string_get_length*/,
+  nullptr /*AnnotArray_string_get_ptr*/,
+  nullptr /*AnnotArray_int64_get_value*/,
+  nullptr /*AnnotArray_uid_get_value*/,
+  nullptr /*Annot_data_get_size*/,
+  nullptr /*Annot_data_get_ptr*/,
 };
 
 struct ExpressionTypeArrayBuilder::Implementation {
   StringRef printedType;
   SmallVector<char, 256> buffer;
-  CompactArrayBuilder<unsigned, unsigned, unsigned> builder;
+  CompactArrayBuilder<unsigned, unsigned, unsigned, unsigned, unsigned> builder;
   CompactArrayBuilder<StringRef> strBuilder;
+  CompactArrayBuilder<unsigned> protoBuilder;
 
   Implementation(StringRef PrintedType) { strBuilder.addEntry(PrintedType); }
   static sourcekitd_variant_type_t get_type(sourcekitd_variant_t var) {
@@ -94,9 +177,13 @@ struct ExpressionTypeArrayBuilder::Implementation {
   }
 
   std::unique_ptr<llvm::MemoryBuffer> createBuffer() {
-    size_t headerSize = sizeof(uint64_t) * 2;
-    auto result = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
-      headerSize + builder.sizeInBytes() + strBuilder.sizeInBytes());
+    std::array<CompactArrayBuilderImpl*, 3> builders =
+      {&builder, &strBuilder, &protoBuilder};
+    size_t headerSize = sizeof(uint64_t) * builders.size();
+    auto allSize = headerSize;
+    for (auto *b: builders)
+      allSize += b->sizeInBytes();
+    auto result = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(allSize);
     char *start = result->getBufferStart();
     char *headerPtr = start;
     char *ptr = start + headerSize;
@@ -106,9 +193,9 @@ struct ExpressionTypeArrayBuilder::Implementation {
       headerPtr += sizeof(offset);
       ptr += buffer.copyInto(ptr);
     };
-
-    addBuilder(builder);
-    addBuilder(strBuilder);
+    for (auto *b: builders) {
+      addBuilder(*b);
+    }
     assert(ptr == result->getBufferEnd());
     return std::move(result);
   }
@@ -122,8 +209,16 @@ ExpressionTypeArrayBuilder::~ExpressionTypeArrayBuilder() {
 }
 
 void ExpressionTypeArrayBuilder::add(const ExpressionType &expType) {
+  auto protoStart = Impl.protoBuilder.size();
+  // Add protocol name starts and length to the protocol buffer.
+  for (auto off: expType.ProtocolOffsets) {
+    Impl.protoBuilder.addEntry(off);
+  }
+  auto protoCount = Impl.protoBuilder.size() - protoStart;
   Impl.builder.addEntry(expType.ExprOffset, expType.ExprLength,
-                        expType.TypeOffset/*Printed type is null ended*/);
+                        expType.TypeOffset/*Printed type is null ended*/,
+                        protoStart/*Index of first protocol in the protocol buffer*/,
+                        protoCount/*Number of conforming protocols*/);
 }
 
 std::unique_ptr<llvm::MemoryBuffer>
@@ -158,4 +253,9 @@ VariantFunctions ExpressionTypeArrayBuilder::Funcs = {
 VariantFunctions *
 sourcekitd::getVariantFunctionsForExpressionTypeArray() {
  return &ExpressionTypeArrayBuilder::Funcs;
+}
+
+VariantFunctions *
+sourcekitd::getVariantFunctionsForProtocolNameArray() {
+  return &ProtocolListFuncs::Funcs;
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1005,7 +1005,11 @@ handleSemanticRequest(RequestDict Req,
 
   if (ReqUID == RequestCollectExpressionType) {
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-    return Lang.collectExpressionTypes(*SourceFile, Args,
+
+    SmallVector<const char *, 8> ExpectedProtocols;
+    if (Req.getStringArray(KeyExpectedTypes, ExpectedProtocols, true))
+      return Rec(createErrorRequestInvalid("invalid 'key.interested_protocols'"));
+    return Lang.collectExpressionTypes(*SourceFile, Args, ExpectedProtocols,
       [Rec](const ExpressionTypesInFile &Info) {
         reportExpressionTypeInfo(Info, Rec);
       });

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -642,6 +642,11 @@ HeaderToPrint("header-to-print",
               llvm::cl::cat(Category));
 
 static llvm::cl::list<std::string>
+UsrFilter("usr-filter",
+          llvm::cl::desc("Filter results by the given usrs"),
+          llvm::cl::cat(Category));
+
+static llvm::cl::list<std::string>
 DeclToPrint("decl-to-print",
             llvm::cl::desc("Decl name to print swift interface for"),
             llvm::cl::cat(Category));
@@ -1734,8 +1739,11 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
   auto Source = SF.getASTContext().SourceMgr.getRangeForBuffer(*SF.getBufferID()).str();
   std::vector<std::pair<unsigned, std::string>> SortedTags;
 
+  std::vector<const char*> Usrs;
+  for (auto &u: options::UsrFilter)
+    Usrs.push_back(u.c_str());
   // Collect all tags of expressions.
-  for (auto R: collectExpressionType(*CI.getPrimarySourceFile(), Scratch, OS)) {
+  for (auto R: collectExpressionType(*CI.getPrimarySourceFile(), Usrs, Scratch, OS)) {
     SortedTags.push_back({R.offset,
       (llvm::Twine("<expr type:\"") + TypeBuffer.str().substr(R.typeOffset,
                                                   R.typeLength) + "\">").str()});


### PR DESCRIPTION
The client usually cares about a subset of all expressions. A way to differentiate
them is by the protocols these expressions' types conform to. This patch allows
the request to add a list of protocol USRs so that the response only includes those
interested expressions that conform to any of the input protocols.

We also add a field to the response for each expression type to indicate the
conforming protocols names that were originally in the input list.

When an empty list of protocol USRs are given, we report all expressions' types
in the file like the old behavior.

rdar://35199889