### PR TITLE
Initial Python 3 compatibility fixes

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -26,6 +26,7 @@ class `BenchmarkDoctor` analyzes performance tests, implements `check` COMMAND.
 """
 
 import argparse
+import functools
 import glob
 import logging
 import math
@@ -36,6 +37,9 @@ import sys
 import time
 
 from compare_perf_tests import LogParser
+
+if not hasattr(sys.modules['__builtin__'], 'reduce'):
+    reduce = functools.reduce
 
 DRIVER_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -178,14 +182,10 @@ class BenchmarkDriver(object):
 
         Returns the aggregated result of independent benchmark invocations.
         """
-        def merge_results(a, b):
-            a.merge(b)
-            return a
-
-        return reduce(merge_results,
-                      [self.run(test, measure_memory=True,
+        result_sets = [self.run(test, measure_memory=True,
                                 num_iters=1, quantile=20)
-                       for _ in range(self.args.independent_samples)])
+                       for _ in range(self.args.independent_samples)]
+        return reduce(lambda m, res: (m.merge(res), m)[1], result_sets)
 
     def log_results(self, output, log_file=None):
         """Log output to `log_file`.
@@ -303,8 +303,12 @@ class MarkdownReportHandler(logging.StreamHandler):
         msg = self.format(record)
         stream = self.stream
         try:
-            if (isinstance(msg, unicode) and
-                    getattr(stream, 'encoding', None)):
+            is_text = isinstance(msg, unicode)
+        except NameError:
+            is_text = isinstance(msg, bytes)
+
+        try:
+            if is_text and getattr(stream, 'encoding', None):
                 stream.write(msg.encode(stream.encoding))
             else:
                 stream.write(msg)
@@ -414,6 +418,7 @@ class BenchmarkDoctor(object):
         name = measurements['name']
         setup, ratio = BenchmarkDoctor._setup_overhead(measurements)
         setup = 0 if ratio < 0.05 else setup
+
         runtime = min(
             [(result.samples.min - correction) for i_series in
              [BenchmarkDoctor._select(measurements, num_iters=i)

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -30,12 +30,15 @@ class `ReportFormatter` creates the test comparison report in specified format.
 from __future__ import print_function
 
 import argparse
+import functools
 import re
 import sys
 from bisect import bisect, bisect_left, bisect_right
 from collections import namedtuple
 from math import ceil, sqrt
 
+if not hasattr(sys.modules['__builtin__'], 'reduce'):
+    reduce = functools.reduce
 
 class Sample(namedtuple('Sample', 'i num_iters runtime')):
     u"""Single benchmark measurement.
@@ -185,13 +188,14 @@ class PerformanceTestSamples(object):
                 sqrt(self.S_runtime / (self.count - 1)))
 
     @staticmethod
-    def running_mean_variance((k, M_, S_), x):
+    def running_mean_variance(kMS, x):
         """Compute running variance, B. P. Welford's method.
 
         See Knuth TAOCP vol 2, 3rd edition, page 232, or
         https://www.johndcook.com/blog/standard_deviation/
         M is mean, Standard Deviation is defined as sqrt(S/k-1)
         """
+        k, M_, S_ = kMS
         k = float(k + 1)
         M = M_ + (x - M_) / k
         S = S_ + (x - M_) * (x - M)

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -18,7 +18,11 @@ import os
 import time
 import unittest
 
-from StringIO import StringIO
+try:
+    from StringIO import StringIO # py2
+except ModuleNotFoundError:
+    from io import StringIO # py3
+
 from imp import load_source
 
 from compare_perf_tests import PerformanceTestResult

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -25,7 +25,11 @@ common unit testing patterns that is used in this project.
 import logging
 import sys
 
-from StringIO import StringIO
+try:
+    from StringIO import StringIO # py2
+except ModuleNotFoundError:
+    from io import StringIO # py3
+
 from contextlib import contextmanager
 
 

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -14,10 +14,10 @@
 # Utility code for later in this template
 #
 
+from __future__ import division
 from SwiftIntTypes import all_integer_types, int_max_bits, should_define_truncating_bit_pattern_init
 from SwiftFloatingPointTypes import getFtoIBounds
 
-from string import maketrans, capitalize
 from itertools import chain
 
 # Number of bits in the Builtin.Word type
@@ -1651,7 +1651,7 @@ extension ${Self} : Hashable {
     return Hasher._hash(
       seed: seed,
       bytes: UInt64(truncatingIfNeeded: ${U}${Self}(_value)),
-      count: ${bits / 8})
+      count: ${bits // 8})
     % end
   }
 }

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -1,4 +1,10 @@
 %{
+from __future__ import division
+try:
+	xrange
+except NameError:
+	xrange = range
+
 from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 storagescalarCounts = [2,4,8,16,32,64]
@@ -46,9 +52,9 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 
   /// Creates a new vector from the given elements.
   @_transparent
-  public init(${', '.join(['_ v' + str(i) + ': Scalar' for i in range(n)])}) {
+  public init(${', '.join(['_ v' + str(i) + ': Scalar' for i in list(range(n))])}) {
     self.init()
-% for i in range(n):
+% for i in list(range(n)):
     self[${i}] = v${i}
 % end
   }
@@ -65,7 +71,7 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
     self.init(${', '.join('xyzw'[:n])})
   }
 
-%  for i in range(n):
+%  for i in list(range(n)):
   /// The ${ordinalPositions[i]} element of the vector.
   @_transparent
   public var ${'xyzw'[i]}: Scalar {
@@ -78,17 +84,17 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 % if n >= 4:
   /// Creates a new vector from two half-length vectors.
   @_transparent
-  public init(lowHalf: SIMD${n/2}<Scalar>, highHalf: SIMD${n/2}<Scalar>) {
+  public init(lowHalf: SIMD${n//2}<Scalar>, highHalf: SIMD${n//2}<Scalar>) {
     self.init()
     self.lowHalf = lowHalf
     self.highHalf = highHalf
   }
 
-%  for (half,indx) in [('low','i'), ('high',str(n/2)+'+i'), ('even','2*i'), ('odd','2*i+1')]:
+%  for (half,indx) in [('low','i'), ('high',str(n//2)+'+i'), ('even','2*i'), ('odd','2*i+1')]:
   /// A half-length vector made up of the ${half} elements of the vector.
-  public var ${half}Half: SIMD${n/2}<Scalar> {
+  public var ${half}Half: SIMD${n//2}<Scalar> {
     @inlinable get {
-      var result = SIMD${n/2}<Scalar>()
+      var result = SIMD${n//2}<Scalar>()
       for i in result.indices { result[i] = self[${indx}] }
       return result
     }
@@ -184,7 +190,7 @@ extension ${Self} : SIMDScalar {
   public typealias SIMDMaskScalar = ${Mask}
 
 % for n in storagescalarCounts:
-%  bytes = n * self_type.bits / 8
+%  bytes = n * self_type.bits // 8
   /// Storage for a vector of ${spelledNumbers[n]} integers.
   @_fixed_layout
   @_alignment(${bytes if bytes <= 16 else 16})
@@ -229,7 +235,7 @@ extension ${Self} : SIMDScalar {
   public typealias SIMDMaskScalar = Int${bits}
 
 % for n in storagescalarCounts:
-%  bytes = n * bits / 8
+%  bytes = n * bits // 8
   /// Storage for a vector of ${spelledNumbers[n]} floating-point values.
   @_fixed_layout
   @_alignment(${bytes if bytes <= 16 else 16})

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -111,7 +111,7 @@ public func >=(lhs: (), rhs: ()) -> Bool {
 %   equatableTypeParams = ", ".join(["{} : Equatable".format(c) for c in typeParams])
 
 %   originalTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity))))
-%   greaterTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity - 1) + [arity])))
+%   greaterTuple = "(\"a\", {})".format(", ".join(map(str, list(range(1, arity - 1)) + [arity])))
 
 /// Returns a Boolean value indicating whether the corresponding components of
 /// two tuples are equal.

--- a/test/Driver/response-file-merge-modules.swift
+++ b/test/Driver/response-file-merge-modules.swift
@@ -1,4 +1,4 @@
-// RUN: %{python} -c 'for i in range(500001): print "-DTEST_" + str(i)' > %t.resp
+// RUN: %{python} -c 'for i in range(500001): print("-DTEST_{}".format(i))' > %t.resp
 // RUN: %swiftc_driver -driver-print-jobs -module-name merge -emit-module %S/Inputs/main.swift %S/Inputs/lib.swift @%t.resp 2>&1 > %t.jobs.txt
 // RUN: %FileCheck %s < %t.jobs.txt -check-prefix=MERGE
 

--- a/test/Driver/response-file.swift
+++ b/test/Driver/response-file.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -typecheck @%t.0.resp %s 2>&1 | %FileCheck %s -check-prefix=SHORT
 // SHORT: warning: result of call to 'abs' is unused
 
-// RUN: %{python} -c 'for a in ["A", "B", "C", "D"]: print "-DTEST1" + a' > %t.1.resp
+// RUN: %{python} -c 'for a in ["A", "B", "C", "D"]: print("-DTEST1{}".format(a))' > %t.1.resp
 // RUN: %target-build-swift -typecheck @%t.1.resp %s 2>&1 | %FileCheck %s -check-prefix=MULTIPLE
 // MULTIPLE: warning: result of call to 'abs' is unused
 
@@ -24,7 +24,7 @@
 // RUN: %target-build-swift -typecheck @%t.4B.resp 2>&1 | %FileCheck %s -check-prefix=RECURSIVE
 // RECURSIVE: warning: result of call to 'abs' is unused
 
-// RUN: %{python} -c 'for i in range(500001): print "-DTEST5_" + str(i)' > %t.5.resp
+// RUN: %{python} -c 'for i in range(500001): print("-DTEST5_{}".format(i))' > %t.5.resp
 // RUN: %target-build-swift -typecheck @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=LONG
 // LONG: warning: result of call to 'abs' is unused
 // RUN: %empty-directory(%t/tmp)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1120,7 +1120,7 @@ source_compiler_rt_libs(compiler_rt_dir)
 
 def check_runtime_libs(features_to_check):
     for lib in config.compiler_rt_libs:
-        for (libname, feature) in features_to_check.iteritems():
+        for (libname, feature) in features_to_check.items():
             if lib.startswith("libclang_rt." + libname + "_"):
                 config.available_features.add(feature)
 

--- a/test/swift_test.py
+++ b/test/swift_test.py
@@ -30,7 +30,7 @@ class SwiftTest(lit.formats.ShTest, object):
             self.coverage_mode = coverage_mode
         self.skipped_tests = set()
 
-    def before_test(self, test, litConfig):
+    def before_test(self, test, litconfig):
         if self.coverage_mode:
             # FIXME: The compiler crashers run so fast they fill up the
             # merger's queue (and therefore the build bot's disk)
@@ -53,12 +53,12 @@ class SwiftTest(lit.formats.ShTest, object):
                     os.path.join(test.config.swift_test_results_dir,
                                  "swift-%4m.profraw")
 
-    def after_test(self, test, litConfig, result):
+    def after_test(self, test, litconfig, result):
         if test.getSourcePath() in self.skipped_tests:
             self.skipped_tests.remove(test.getSourcePath())
         return result
 
-    def execute(self, test, litConfig):
-        self.before_test(test, litConfig)
-        result = super(SwiftTest, self).execute(test, litConfig)
-        return self.after_test(test, litConfig, result)
+    def execute(self, test, litconfig):
+        self.before_test(test, litconfig)
+        result = super(SwiftTest, self).execute(test, litconfig)
+        return self.after_test(test, litconfig, result)

--- a/unittests/Reflection/RemoteMirrorInterop/test.py
+++ b/unittests/Reflection/RemoteMirrorInterop/test.py
@@ -48,15 +48,15 @@ for i, (swiftc, swiftlib) in enumerate(zip(swiftcs, swiftlibs)):
 for i in range(len(swiftcs) + 1):
     for localMirrorlibs in itertools.combinations(mirrorlibs, i):
         for i, arg in enumerate(absoluteArgs):
-            print 'Testing', arg, 'with mirror libs:'
+            print('Testing {} with mirror libs:'.format(arg))
             for l in localMirrorlibs:
                 print '\t', l
             callArgs = ['/tmp/test']
             dylibPath = os.path.join('/tmp', 'libtest' + str(i) + '.dylib')
             callArgs.append(dylibPath)
             callArgs += list(localMirrorlibs)
-            print ' '.join(callArgs)
+            print(' '.join(callArgs))
             subprocess.call(callArgs)
-            print 'DONE'
-            print ''
+            print('DONE')
+            print('')
         print localMirrorlibs

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -51,7 +51,7 @@ constants.""")
 
     p = subprocess.Popen(
         [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)
-    stdout, stderr = p.communicate(stdin)
+    stdout, stderr = p.communicate(stdin.encode('utf-8'))
     if stdout is not None:
         print(stdout)
     if stderr is not None:

--- a/utils/bug_reducer/bug_reducer/swift_tools.py
+++ b/utils/bug_reducer/bug_reducer/swift_tools.py
@@ -3,7 +3,10 @@ from __future__ import print_function
 import os
 import subprocess
 
-import subprocess_utils
+try:
+	from . import subprocess_utils
+except ValueError:
+	import subprocess_utils
 
 DRY_RUN = False
 SQUELCH_STDERR = True

--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -45,7 +45,8 @@ class FuncBugReducerTestCase(unittest.TestCase):
         self.module_cache = os.path.join(self.tmp_dir, 'module_cache')
         self.sdk = subprocess.check_output(['xcrun', '--sdk', 'macosx',
                                             '--toolchain', 'Default',
-                                            '--show-sdk-path']).strip("\n")
+                                            '--show-sdk-path']
+                                          ).decode('utf-8').strip("\n")
         self.tools = swift_tools.SwiftTools(self.build_dir)
         self.passes = ['--pass=-bug-reducer-tester']
 
@@ -111,7 +112,7 @@ class FuncBugReducerTestCase(unittest.TestCase):
             '--extra-silopt-arg=-bug-reducer-tester-failure-kind=opt-crasher'
         ]
         args.extend(self.passes)
-        output = self.run_check_output(args).split("\n")
+        output = self.run_check_output(args).decode('utf-8').split("\n")
         self.assertTrue("*** Successfully Reduced file!" in output)
         self.assertTrue("*** Final Functions: " +
                         "$s9testbasic6foo413yyF" in output)

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -45,7 +45,8 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.module_cache = os.path.join(self.tmp_dir, 'module_cache')
         self.sdk = subprocess.check_output(['xcrun', '--sdk', 'macosx',
                                             '--toolchain', 'Default',
-                                            '--show-sdk-path']).strip("\n")
+                                            '--show-sdk-path']
+                                          ).decode('utf-8').strip("\n")
         self.tools = swift_tools.SwiftTools(self.build_dir)
         json_data = json.loads(subprocess.check_output(
             [self.tools.sil_passpipeline_dumper, '-Performance']))
@@ -54,7 +55,7 @@ class OptBugReducerTestCase(unittest.TestCase):
             for z in y:
                 self.passes.append('--pass=-' + z[1])
         random.seed(0xf487c07f)
-        random.shuffle(self.passes)
+        random.shuffle(self.passes, random=random.random)
         self.passes.insert(random.randint(0, len(self.passes)),
                            '--pass=-bug-reducer-tester')
 
@@ -101,7 +102,7 @@ class OptBugReducerTestCase(unittest.TestCase):
             '--extra-arg=-bug-reducer-tester-failure-kind=opt-crasher'
         ]
         args.extend(self.passes)
-        output = subprocess.check_output(args).split("\n")
+        output = subprocess.check_output(args).decode('utf-8').split("\n")
         self.assertTrue('*** Found miscompiling passes!' in output)
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testbasic_initial'
@@ -130,7 +131,7 @@ class OptBugReducerTestCase(unittest.TestCase):
             '--extra-arg=-bug-reducer-tester-failure-kind=opt-crasher'
         ]
         args.extend(self.passes)
-        output = subprocess.check_output(args).split("\n")
+        output = subprocess.check_output(args).decode('utf-8').split("\n")
         self.assertTrue('*** Found miscompiling passes!' in output)
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testsuffixinneedofprefix_initial'
@@ -160,7 +161,7 @@ class OptBugReducerTestCase(unittest.TestCase):
             '--reduce-sil'
         ]
         args.extend(self.passes)
-        output = subprocess.check_output(args).split("\n")
+        output = subprocess.check_output(args).decode('utf-8').split("\n")
         self.assertTrue('*** Found miscompiling passes!' in output)
         self.assertTrue(
             '*** Final Functions: $s18testreducefunction6foo413yyF' in output)

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -64,7 +64,7 @@ def _repr(cls, args):
     """
 
     _args = []
-    for key, value in args.viewitems():
+    for key, value in args.items():
         _args.append('{}={}'.format(key, repr(value)))
 
     return '{}({})'.format(type(cls).__name__, ', '.join(_args))
@@ -172,7 +172,7 @@ class ClangVersionType(RegexType):
 
     def __call__(self, value):
         matches = super(ClangVersionType, self).__call__(value)
-        components = filter(lambda x: x is not None, matches.group(1, 2, 3, 5))
+        components = list(filter(lambda x: x is not None, matches.group(1, 2, 3, 5)))
 
         return CompilerVersion(components)
 
@@ -192,7 +192,7 @@ class SwiftVersionType(RegexType):
 
     def __call__(self, value):
         matches = super(SwiftVersionType, self).__call__(value)
-        components = filter(lambda x: x is not None, matches.group(1, 2, 4))
+        components = list(filter(lambda x: x is not None, matches.group(1, 2, 4)))
 
         return CompilerVersion(components)
 

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -36,7 +36,7 @@ PRESETS_FILES = [
 ]
 
 
-class ParserError(Exception):
+class ArgParserError(Exception):
     pass
 
 
@@ -114,7 +114,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def generate_default_value_test(cls, dest, default_value):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 parsed_values = self.parse_default_args([])
 
             parsed_value = getattr(parsed_values, dest)
@@ -130,7 +130,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_help_option_test(cls, option):
         def test(self):
-            with redirect_stdout() as output, self.assertRaises(ParserError):
+            with redirect_stdout() as output, self.assertRaises(ArgParserError):
                 self.parse_args([option.option_string])
                 self.assertNotEmpty(output)
 
@@ -139,11 +139,11 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_set_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 namespace = self.parse_args([option.option_string])
                 self.assertEqual(getattr(namespace, option.dest), option.value)
 
-            with self.assertRaises(ParserError):
+            with self.assertRaises(ArgParserError):
                 self.parse_args([option.option_string, 'foo'])
 
         return test
@@ -151,7 +151,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_set_true_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 # TODO: Move to unit-tests for the action class
                 namespace = self.parse_args([])
                 self.assertFalse(getattr(namespace, option.dest))
@@ -164,7 +164,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_set_false_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 # TODO: Move to unit-tests for the action class
                 namespace = self.parse_args([])
                 self.assertTrue(getattr(namespace, option.dest))
@@ -177,7 +177,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_enable_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 # TODO: Move to unit-tests for the action class
                 # Test parsing True values
                 self.parse_args([option.option_string, '1'])
@@ -210,7 +210,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_disable_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 # TODO: Move to unit-tests for the action class
                 # Test parsing True values
                 self.parse_args([option.option_string, '1'])
@@ -243,13 +243,13 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_choices_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 for choice in option.choices:
                     namespace = self.parse_args(
                         [option.option_string, str(choice)])
                     self.assertEqual(getattr(namespace, option.dest), choice)
 
-            with self.assertRaises(ParserError):
+            with self.assertRaises(ArgParserError):
                 self.parse_args([option.option_string, 'INVALID'])
 
         return test
@@ -257,13 +257,13 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_int_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 for i in [0, 1, 42]:
                     namespace = self.parse_args([option.option_string, str(i)])
                     self.assertEqual(int(getattr(namespace, option.dest)), i)
 
             # FIXME: int-type options should not accept non-int strings
-            # with self.assertRaises(ParserError):
+            # with self.assertRaises(ArgParserError):
             #     self.parse_args([option.option_string, str(0.0)])
             #     self.parse_args([option.option_string, str(1.0)])
             #     self.parse_args([option.option_string, str(3.14)])
@@ -274,7 +274,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_str_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 self.parse_args([option.option_string, 'foo'])
 
         return test
@@ -282,11 +282,11 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_path_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 self.parse_args([option.option_string, sys.executable])
 
             # FIXME: path-type options should not accept non-path inputs
-            # with self.assertRaises(ParserError):
+            # with self.assertRaises(ArgParserError):
             #     self.parse_args([option.option_string, 'foo'])
 
         return test
@@ -294,7 +294,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_append_option_test(cls, option):
         def test(self):
-            with self.assertNotRaises(ParserError):
+            with self.assertNotRaises(ArgParserError):
                 # Range size is arbitrary, just needs to be more than once
                 for i in range(1, 4):
                     namespace = self.parse_args(
@@ -307,7 +307,7 @@ class TestDriverArgumentParserMeta(type):
     @classmethod
     def _generate_unsupported_option_test(cls, option):
         def test(self):
-            with self.assertRaises(ParserError):
+            with self.assertRaises(ArgParserError):
                 self.parse_args([option.option_string])
 
         return test
@@ -345,16 +345,18 @@ class TestDriverArgumentParserMeta(type):
         def test(self):
             try:
                 self.parse_default_args(preset_args, check_impl_args=True)
-            except ParserError as e:
+            except ArgParserError as e:
                 self.fail('failed to parse preset "{}": {}'.format(
                     preset_name, e))
 
         return test
 
 
-class TestDriverArgumentParser(unittest.TestCase):
-
-    __metaclass__ = TestDriverArgumentParserMeta
+# This unusual declaration replaces the usage of Python 2's __metaclass__ and
+# Python 3's metaclass= with a construct which works correctly in both.
+class TestDriverArgumentParser(type.__new__(
+    TestDriverArgumentParserMeta, TestDriverArgumentParserMeta.__name__,
+    (unittest.TestCase,), {})):
 
     @contextmanager
     def _quiet_output(self):
@@ -366,7 +368,7 @@ class TestDriverArgumentParser(unittest.TestCase):
         try:
             return migration.parse_args(self.parser, args)
         except (SystemExit, ValueError) as e:
-            raise ParserError('failed to parse arguments: ' +
+            raise ArgParserError('failed to parse arguments: ' +
                               str(args), e)
 
     def _check_impl_args(self, namespace):
@@ -376,7 +378,7 @@ class TestDriverArgumentParser(unittest.TestCase):
             migration.check_impl_args(BUILD_SCRIPT_IMPL,
                                       namespace.build_script_impl_args)
         except (SystemExit, ValueError) as e:
-            raise ParserError('failed to parse impl arguments: ' +
+            raise ArgParserError('failed to parse impl arguments: ' +
                               str(namespace.build_script_impl_args), e)
 
     def parse_args(self, args, namespace=None):
@@ -389,10 +391,10 @@ class TestDriverArgumentParser(unittest.TestCase):
                     super(self.parser.__class__, self.parser)\
                     .parse_known_args(args, namespace)
             except (SystemExit, argparse.ArgumentError) as e:
-                raise ParserError('failed to parse arguments: ' + str(args), e)
+                raise ArgParserError('failed to parse arguments: ' + str(args), e)
 
         if unknown_args:
-            raise ParserError('unknown arguments: ' + str(unknown_args))
+            raise ArgParserError('unknown arguments: ' + str(unknown_args))
 
         return namespace
 
@@ -468,12 +470,12 @@ class TestDriverArgumentParser(unittest.TestCase):
     def test_option_clang_compiler_version(self):
         option_string = '--clang-compiler-version'
 
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             self.parse_default_args([option_string, '5.0.0'])
             self.parse_default_args([option_string, '5.0.1'])
             self.parse_default_args([option_string, '5.0.0.1'])
 
-        with self.assertRaises(ParserError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args([option_string, '1'])
             self.parse_default_args([option_string, '1.2'])
             self.parse_default_args([option_string, '0.0.0.0.1'])
@@ -481,12 +483,12 @@ class TestDriverArgumentParser(unittest.TestCase):
     def test_option_clang_user_visible_version(self):
         option_string = '--clang-user-visible-version'
 
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             self.parse_default_args([option_string, '5.0.0'])
             self.parse_default_args([option_string, '5.0.1'])
             self.parse_default_args([option_string, '5.0.0.1'])
 
-        with self.assertRaises(ParserError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args([option_string, '1'])
             self.parse_default_args([option_string, '1.2'])
             self.parse_default_args([option_string, '0.0.0.0.1'])
@@ -494,48 +496,48 @@ class TestDriverArgumentParser(unittest.TestCase):
     def test_option_swift_compiler_version(self):
         option_string = '--swift-compiler-version'
 
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             self.parse_default_args([option_string, '4.1'])
             self.parse_default_args([option_string, '4.0.1'])
             self.parse_default_args([option_string, '200.99.1'])
 
-        with self.assertRaises(ParserError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args([option_string, '1'])
             self.parse_default_args([option_string, '0.0.0.1'])
 
     def test_option_swift_user_visible_version(self):
         option_string = '--swift-user-visible-version'
 
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             self.parse_default_args([option_string, '4.1'])
             self.parse_default_args([option_string, '4.0.1'])
             self.parse_default_args([option_string, '200.99.1'])
 
-        with self.assertRaises(ParserError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args([option_string, '1'])
             self.parse_default_args([option_string, '0.0.0.1'])
 
     def test_option_I(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args(['-I'])
 
     def test_option_ios_all(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args(['--ios-all'])
 
     def test_option_tvos_all(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args(['--tvos-all'])
 
     def test_option_watchos_all(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ArgParserError):
             self.parse_default_args(['--watchos-all'])
 
     # -------------------------------------------------------------------------
     # Implied defaults tests
 
     def test_implied_defaults_assertions(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--assertions'])
 
             self.assertTrue(namespace.cmark_assertions)
@@ -544,21 +546,21 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertTrue(namespace.swift_stdlib_assertions)
 
     def test_implied_defaults_cmark_build_variant(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--debug-cmark'])
             self.assertTrue(namespace.build_cmark)
 
     def test_implied_defaults_lldb_build_variant(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--debug-lldb'])
             self.assertTrue(namespace.build_lldb)
 
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--lldb-assertions'])
             self.assertTrue(namespace.build_lldb)
 
     def test_implied_defaults_build_variant(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--debug'])
 
             self.assertEqual(namespace.cmark_build_variant, 'Debug')
@@ -571,7 +573,7 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertEqual(namespace.swift_stdlib_build_variant, 'Debug')
 
     def test_implied_defaults_skip_build(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-build'])
 
             self.assertFalse(namespace.build_benchmarks)
@@ -596,7 +598,7 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertFalse(namespace.build_xctest)
 
     def test_implied_defaults_skip_build_ios(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-build-ios'])
             self.assertFalse(namespace.build_ios_device)
             self.assertFalse(namespace.build_ios_simulator)
@@ -606,7 +608,7 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertFalse(namespace.test_ios_simulator)
 
     def test_implied_defaults_skip_build_tvos(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-build-tvos'])
             self.assertFalse(namespace.build_tvos_device)
             self.assertFalse(namespace.build_tvos_simulator)
@@ -616,7 +618,7 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertFalse(namespace.test_tvos_simulator)
 
     def test_implied_defaults_skip_build_watchos(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-build-watchos'])
             self.assertFalse(namespace.build_watchos_device)
             self.assertFalse(namespace.build_watchos_simulator)
@@ -626,22 +628,22 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertFalse(namespace.test_watchos_simulator)
 
     def test_implied_defaults_validation_test(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--validation-test'])
             self.assertTrue(namespace.test)
 
     def test_implied_defaults_test_optimized(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--test-optimized'])
             self.assertTrue(namespace.test)
 
     def test_implied_defaults_test_optimize_for_size(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--test-optimize-for-size'])
             self.assertTrue(namespace.test)
 
     def test_implied_defaults_skip_all_tests(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args([
                 '--test', '0',
                 '--validation-test', '0',
@@ -658,34 +660,34 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertFalse(namespace.test_watchos)
 
     def test_implied_defaults_skip_test_ios(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-test-ios'])
             self.assertFalse(namespace.test_ios_host)
             self.assertFalse(namespace.test_ios_simulator)
 
     def test_implied_defaults_skip_test_tvos(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-test-tvos'])
             self.assertFalse(namespace.test_tvos_host)
             self.assertFalse(namespace.test_tvos_simulator)
 
     def test_implied_defaults_skip_test_watchos(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-test-watchos'])
             self.assertFalse(namespace.test_watchos_host)
             self.assertFalse(namespace.test_watchos_simulator)
 
     def test_implied_defaults_skip_build_android(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--android', '0'])
             self.assertFalse(namespace.test_android_host)
 
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--skip-build-android'])
             self.assertFalse(namespace.test_android_host)
 
     def test_implied_defaults_host_test(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--host-test', '0'])
             self.assertFalse(namespace.test_ios_host)
             self.assertFalse(namespace.test_tvos_host)
@@ -694,7 +696,7 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.assertFalse(namespace.build_libparser_only)
 
     def test_build_lib_swiftsyntaxparser_only(self):
-        with self.assertNotRaises(ParserError):
+        with self.assertNotRaises(ArgParserError):
             namespace = self.parse_default_args(['--build-libparser-only'])
             self.assertTrue(namespace.build_libparser_only)
 

--- a/utils/chex.py
+++ b/utils/chex.py
@@ -12,7 +12,7 @@ import sys
 hex = re.compile(r"""<(i([0-9]+)\s+)0x([0-9A-Fa-f_]+)>""")
 
 
-def hexReplace(match):
+def hex_replace(match):
     # Integer type is match group 1
     ty = match.group(1)
     # Integer bit width is match group 2
@@ -28,4 +28,4 @@ def hexReplace(match):
 
 
 for line in sys.stdin:
-    print(re.sub(hex, hexReplace, line), end="")
+    print(re.sub(hex, hex_replace, line), end="")

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -760,8 +760,8 @@ def expand(filename, line_directive=_default_line_directive, **local_bindings):
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> f = NamedTemporaryFile(delete=False)
-    >>> f.write(
-    ... r'''---
+    >>> _ = f.write(
+    ... br'''---
     ... % for i in range(int(x)):
     ... a pox on ${i} for epoxy
     ... % end

--- a/utils/gyb_sourcekit_support/__init__.py
+++ b/utils/gyb_sourcekit_support/__init__.py
@@ -14,9 +14,9 @@
 # utils/gyb_sourcekit_support/ directory as a module.
 #
 # ----------------------------------------------------------------------------
-from UIDs import UID_KEYS
-from UIDs import UID_KINDS
-from UIDs import UID_REQUESTS
+from .UIDs import UID_KEYS
+from .UIDs import UID_KINDS
+from .UIDs import UID_REQUESTS
 
 
 def check_uid_duplication():

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 ATTRIBUTE_NODES = [
     # token-list -> token? token-list?

--- a/utils/gyb_syntax_support/AvailabilityNodes.py
+++ b/utils/gyb_syntax_support/AvailabilityNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 AVAILABILITY_NODES = [
     # availability-spec-list -> availability-entry availability-spec-list?

--- a/utils/gyb_syntax_support/Child.py
+++ b/utils/gyb_syntax_support/Child.py
@@ -1,7 +1,7 @@
 # flake8: noqa I201
-from Classification import classification_by_name
-from Token import SYNTAX_TOKEN_MAP
-from kinds import SYNTAX_BASE_KINDS, kind_to_type, lowercase_first_word
+from .Classification import classification_by_name
+from .Token import SYNTAX_TOKEN_MAP
+from .kinds import SYNTAX_BASE_KINDS, kind_to_type, lowercase_first_word
 
 
 class Child(object):

--- a/utils/gyb_syntax_support/Classification.py
+++ b/utils/gyb_syntax_support/Classification.py
@@ -1,5 +1,5 @@
-from Node import error
-from kinds import lowercase_first_word  # noqa: I201
+from .Node import error
+from .kinds import lowercase_first_word  # noqa: I201
 
 
 class SyntaxClassification(object):

--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 COMMON_NODES = [
     Node('Decl', kind='Syntax'),

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -1,6 +1,6 @@
 # flake8: noqa I201
-from Child import Child
-from Node import Node
+from .Child import Child
+from .Node import Node
 
 
 DECL_NODES = [

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 EXPR_NODES = [
     # An inout expression.

--- a/utils/gyb_syntax_support/GenericNodes.py
+++ b/utils/gyb_syntax_support/GenericNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 GENERIC_NODES = [
     # generic-where-clause -> 'where' requirement-list

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys  # noqa: I201
-from kinds import SYNTAX_BASE_KINDS, kind_to_type, lowercase_first_word
+from .kinds import SYNTAX_BASE_KINDS, kind_to_type, lowercase_first_word
 
 
 def error(msg):

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -1,4 +1,4 @@
-from Node import error
+from .Node import error
 
 
 SYNTAX_NODE_SERIALIZATION_CODES = {

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 PATTERN_NODES = [
 

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 STMT_NODES = [
     # continue-stmt -> 'continue' label? ';'?

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -1,6 +1,6 @@
-from Classification import classification_by_name
-from Node import error  # noqa: I201
-from kinds import lowercase_first_word  # noqa: I201
+from .Classification import classification_by_name
+from .Node import error  # noqa: I201
+from .kinds import lowercase_first_word  # noqa: I201
 
 
 class Token(object):

--- a/utils/gyb_syntax_support/Traits.py
+++ b/utils/gyb_syntax_support/Traits.py
@@ -1,4 +1,4 @@
-from Child import Child
+from .Child import Child
 
 
 class Trait(object):

--- a/utils/gyb_syntax_support/Trivia.py
+++ b/utils/gyb_syntax_support/Trivia.py
@@ -1,5 +1,5 @@
-from Node import error
-from kinds import lowercase_first_word  # noqa: I201
+from .Node import error
+from .kinds import lowercase_first_word  # noqa: I201
 
 
 class Trivia(object):

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -1,5 +1,5 @@
-from Child import Child
-from Node import Node  # noqa: I201
+from .Child import Child
+from .Node import Node  # noqa: I201
 
 TYPE_NODES = [
     # simple-type-identifier -> identifier generic-argument-clause?

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -1,19 +1,19 @@
 import textwrap
-from AttributeNodes import ATTRIBUTE_NODES  # noqa: I201
-from AvailabilityNodes import AVAILABILITY_NODES  # noqa: I201
-import Classification  # noqa: I201
-from CommonNodes import COMMON_NODES  # noqa: I201
-from DeclNodes import DECL_NODES  # noqa: I201
-from ExprNodes import EXPR_NODES  # noqa: I201
-from GenericNodes import GENERIC_NODES  # noqa: I201
-from NodeSerializationCodes import SYNTAX_NODE_SERIALIZATION_CODES, \
+from .AttributeNodes import ATTRIBUTE_NODES  # noqa: I201
+from .AvailabilityNodes import AVAILABILITY_NODES  # noqa: I201
+from . import Classification  # noqa: I201
+from .CommonNodes import COMMON_NODES  # noqa: I201
+from .DeclNodes import DECL_NODES  # noqa: I201
+from .ExprNodes import EXPR_NODES  # noqa: I201
+from .GenericNodes import GENERIC_NODES  # noqa: I201
+from .NodeSerializationCodes import SYNTAX_NODE_SERIALIZATION_CODES, \
     get_serialization_code, \
     verify_syntax_node_serialization_codes
 
-from PatternNodes import PATTERN_NODES  # noqa: I201
-from StmtNodes import STMT_NODES  # noqa: I201
-import Token
-from TypeNodes import TYPE_NODES  # noqa: I201
+from .PatternNodes import PATTERN_NODES  # noqa: I201
+from .StmtNodes import STMT_NODES  # noqa: I201
+from . import Token
+from .TypeNodes import TYPE_NODES  # noqa: I201
 
 
 # Re-export global constants

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -60,7 +60,10 @@ line_pattern = re.compile(
 
 def _make_line_map(target_filename, stream=None):
     """
-    >>> from StringIO import StringIO
+    >>> try:
+    ...     from StringIO import StringIO # py2
+    ... except ModuleNotFoundError:
+    ...     from io import StringIO # py3
     >>> _make_line_map('box',
     ... StringIO('''// ###sourceLocation(file: "foo.bar", line: 3)
     ... line 2
@@ -100,7 +103,7 @@ def map_line_to_source_file(target_filename, target_line_num):
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> t = NamedTemporaryFile(delete=False)
-    >>> t.write('''line 1
+    >>> _ = t.write(b'''line 1
     ... line 2
     ... // ###sourceLocation(file: "foo.bar", line: 20)
     ... line 4
@@ -150,7 +153,7 @@ def map_line_from_source_file(source_filename, source_line_num,
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> t = NamedTemporaryFile(delete=False)
-    >>> t.write('''line 1
+    >>> _ = t.write(b'''line 1
     ... line 2
     ... // ###sourceLocation(file: "foo.bar", line: 20)
     ... line 4
@@ -236,7 +239,7 @@ def run():
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> target1 = NamedTemporaryFile(delete=False)
-    >>> target1.write('''line 1
+    >>> _ = target1.write(b'''line 1
     ... line 2
     ... // ###sourceLocation(file: "foo.bar", line: 20)
     ... line 4
@@ -251,7 +254,7 @@ def run():
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> target2 = NamedTemporaryFile(delete=False)
-    >>> target2.write('''// ###sourceLocation(file: "foo.bar", line: 7)
+    >>> _ = target2.write(b'''// ###sourceLocation(file: "foo.bar", line: 7)
     ... line 2
     ... line 3
     ... // ###sourceLocation(file: "fox.box", line: 11)
@@ -268,21 +271,21 @@ def run():
     >>> # the file by its name across all platforms.
     >>> raw_output = NamedTemporaryFile(delete=False)
     >>> target1_name, target2_name = target1.name, target2.name
-    >>> raw_output.write('''A
-    ... %(target1_name)s:2:111: error one
+    >>> _ = raw_output.write('''A
+    ... {target1_name}:2:111: error one
     ... B
-    ... %(target1_name)s:4:222: error two
+    ... {target1_name}:4:222: error two
     ... C
-    ... %(target1_name)s:8:333: error three
+    ... {target1_name}:8:333: error three
     ... D
-    ... glitch in file %(target2_name)s:1 assert one
+    ... glitch in file {target2_name}:1 assert one
     ... E
-    ... glitch in file %(target2_name)s, line 2 assert two
-    ... glitch at %(target2_name)s, line 3 assert three
-    ... glitch at %(target2_name)s:4 assert four
-    ... glitch in [%(target2_name)s, line 5 assert five
-    ... glitch in [%(target2_name)s:22 assert six
-    ... ''' % locals())
+    ... glitch in file {target2_name}, line 2 assert two
+    ... glitch at {target2_name}, line 3 assert three
+    ... glitch at {target2_name}:4 assert four
+    ... glitch in [{target2_name}, line 5 assert five
+    ... glitch in [{target2_name}:22 assert six
+    ... '''.format(**locals()).encode('utf-8'))
     >>> raw_output.flush()
 
     Run this tool on the two targets, using a portable version of Unix 'cat' to
@@ -329,7 +332,7 @@ def run():
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> long_output = NamedTemporaryFile(delete=False)
-    >>> long_output.write('''
+    >>> _ = long_output.write(b'''
     ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 1)
     ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 1)
     ... //===--- Map.swift.gyb - Lazily map over a Sequence -----------*- swif
@@ -649,7 +652,7 @@ def run():
     >>> long_output_result = subprocess.check_output(sys.executable + ' ' +
     ...    __file__ + ' ' + long_output.name + ' -- ' + "echo '" +
     ...    long_output.name + ":112:27: error:'",
-    ...    shell=True).rstrip()
+    ...    shell=True).rstrip().decode('ascii')
     >>> print(long_output_result)
     /public/core/Map.swift.gyb:117:27: error:
     >>> target1.close()
@@ -704,7 +707,7 @@ def run():
             ':(?P<line>[0-9]+):(?P<column>[0-9]+):(?P<tail>.*?)\n?$')
 
         assertion_pattern = re.compile(
-            '^(?P<head>.*( file | at |#[0-9]+: |[[]))' +
+            '^(?P<head>.*( file | at |#[0-9]+: |[\\[]))' +
             sources +
             '(?P<middle>, line |:)(?P<line>[0-9]+)(?P<tail>.*?)\n?$')
 

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -105,18 +105,18 @@ def write_lnt_values(args):
             json.dump(j, args.output, indent=4)
         else:
             url = args.lnt_submit
-            print "\nsubmitting to LNT server: " + url
+            print("\nsubmitting to LNT server: {}".format(url))
             json_report = {'input_data': json.dumps(j), 'commit': '1'}
             data = urllib.urlencode(json_report)
             response_str = urllib2.urlopen(urllib2.Request(url, data))
             response = json.loads(response_str.read())
-            print "### response:"
-            print response
+            print("### response:")
+            print(response)
             if 'success' in response:
-                print "server response:\tSuccess"
+                print("server response:\tSuccess")
             else:
-                print "server response:\tError"
-                print "error:\t", response['error']
+                print("server response:\tError")
+                print("error:\t{}".format(response['error']))
                 sys.exit(1)
 
 
@@ -239,7 +239,7 @@ def set_csv_baseline(args):
             print ("updating %d baseline entries in %s" %
                    (len(existing), args.set_csv_baseline))
     else:
-        print "making new baseline " + args.set_csv_baseline
+        print("making new baseline {}".format(args.set_csv_baseline))
     fieldnames = ["epoch", "name", "value"]
     with open(args.set_csv_baseline, "wb") as f:
         out = csv.DictWriter(f, fieldnames, dialect='excel-tab',
@@ -248,7 +248,7 @@ def set_csv_baseline(args):
                                 for s in load_stats_dir(d, **vargs)),
                                **vargs)
         if m is None:
-            print "no stats found"
+            print("no stats found")
             return 1
         changed = 0
         newepoch = int(time.time())
@@ -265,7 +265,7 @@ def set_csv_baseline(args):
                               name=name,
                               value=int(value)))
         if existing is not None:
-            print "changed %d entries in baseline" % changed
+            print("changed %d entries in baseline" % changed)
     return 0
 
 

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -45,7 +45,7 @@ class CommandRunner(object):
         self.run_remote(['/bin/mkdir', '-p'] + dirs_to_make)
 
         # Send the local files.
-        sftp_commands = ("-put {0} {1}".format(quote(local_file), 
+        sftp_commands = ("-put {0} {1}".format(quote(local_file),
                                                quote(remote_file))
                          for local_file, remote_file
                          in local_to_remote_files.viewitems())
@@ -61,14 +61,14 @@ class CommandRunner(object):
             subprocess.check_call(mkdir_command)
 
         # Fetch the remote files.
-        sftp_commands = ("-get {0} {1}".format(quote(remote_file), 
+        sftp_commands = ("-get {0} {1}".format(quote(remote_file),
                                                quote(local_file))
                          for local_file, remote_file
                          in local_to_remote_files.viewitems())
         self.run_sftp(sftp_commands)
 
     def run_remote(self, command, remote_env={}):
-        env_strings = ['{0}={1}'.format(k,v) for k,v in remote_env.viewitems()]
+        env_strings = ['{0}={1}'.format(k,v) for k,v in remote_env.items()]
         remote_invocation = self.remote_invocation(
             ['/usr/bin/env'] + env_strings + command)
         remote_proc = self.popen(remote_invocation, stdin=subprocess.PIPE,
@@ -80,7 +80,7 @@ class CommandRunner(object):
             # FIXME: We may still want to fetch the output files to see what
             # went wrong.
             sys.exit(remote_proc.returncode)
-    
+
     def run_sftp(self, commands):
         sftp_proc = self.popen(self.sftp_invocation(), stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE, stderr=None)
@@ -204,18 +204,18 @@ def main():
     if args.input_prefix:
         assert not args.remote_input_prefix.startswith("..")
         remote_dir = posixpath.join(args.remote_dir, args.remote_input_prefix)
-        input_files = find_transfers(args.command, args.input_prefix, 
+        input_files = find_transfers(args.command, args.input_prefix,
                                      remote_dir)
-        assert not any(upload_files.has_key(f) for f in input_files)
+        assert not any(f in upload_files for f in input_files)
         upload_files.update(input_files)
     if args.output_prefix:
         assert not args.remote_output_prefix.startswith("..")
         remote_dir = posixpath.join(args.remote_dir, args.remote_output_prefix)
-        test_files = find_transfers(args.command, args.output_prefix, 
+        test_files = find_transfers(args.command, args.output_prefix,
                                     remote_dir)
-        assert not any(upload_files.has_key(f) for f in test_files)
+        assert not any(f in upload_files for f in test_files)
         upload_files.update(test_files)
-        assert not any(download_files.has_key(f) for f in test_files)
+        assert not any(f in download_files for f in test_files)
         download_files.update(test_files)
         remote_test_specific_dir = remote_dir
 

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -92,7 +92,7 @@ def swift_files_in_dir(d):
     swift_files = []
     for root, dirs, files in os.walk(d):
         for basename in files:
-            if not basename.decode('utf-8').endswith('.swift'):
+            if not basename.endswith('.swift'):
                 continue
             abs_file = os.path.abspath(os.path.join(root, basename))
             swift_files.append(abs_file)

--- a/utils/run-test
+++ b/utils/run-test
@@ -21,10 +21,8 @@ from swift_build_support.swift_build_support import (
     arguments,
     shell
 )
-
 from swift_build_support.swift_build_support.SwiftBuildSupport import \
     SWIFT_SOURCE_ROOT
-
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
 

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -69,7 +69,7 @@ def write_input_file(args, ast, d, n):
 
 def ensure_tmpdir(d):
     if d is not None and not os.path.exists(d):
-        os.makedirs(d, 0700)
+        os.makedirs(d, 0o700)
     return tempfile.mkdtemp(dir=d)
 
 

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -161,8 +161,7 @@ def print_command(cmd, outfile=""):
 # Dump the API for the given module.
 
 
-def dump_module_api((cmd, extra_dump_args, output_dir, module, quiet,
-                     verbose)):
+def dump_module_api(cmd, extra_dump_args, output_dir, module, quiet, verbose):
     # Collect the submodules
     submodules = collect_submodules(cmd, module)
 

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -73,7 +73,7 @@ class ShellTestCase(unittest.TestCase):
 
         self.assertEqual(
             shell.capture(["sh", "-c", "echo foo && false"],
-                          allow_non_zero_exit=True), "foo\n")
+                          allow_non_zero_exit=True).decode('ascii'), "foo\n")
 
         with self.assertRaises(SystemExit):
             shell.capture(["**not-a-command**"], optional=False)

--- a/utils/update_checkout/__init__.py
+++ b/utils/update_checkout/__init__.py
@@ -1,4 +1,3 @@
-
-from update_checkout import main
+from update_checkout.update_checkout import main
 
 __all__ = ["main"]

--- a/utils/update_checkout/update_checkout/__init__.py
+++ b/utils/update_checkout/update_checkout/__init__.py
@@ -1,4 +1,3 @@
-
-from update_checkout import main
+from .update_checkout import main
 
 __all__ = ["main"]

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -18,16 +18,17 @@ import re
 import sys
 import traceback
 
+
+SCRIPT_FILE = os.path.abspath(__file__)
+SCRIPT_DIR = os.path.dirname(SCRIPT_FILE)
+sys.path.append(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+
 from functools import reduce
 from multiprocessing import freeze_support
 
 from swift_build_support.swift_build_support import shell
 from swift_build_support.swift_build_support.SwiftBuildSupport import \
     SWIFT_SOURCE_ROOT
-
-
-SCRIPT_FILE = os.path.abspath(__file__)
-SCRIPT_DIR = os.path.dirname(SCRIPT_FILE)
 
 
 def confirm_tag_in_repo(tag, repo_name):

--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -8,6 +8,7 @@ var FixedPoint = TestSuite("FixedPoint")
 
 %{
 
+from __future__ import division
 import gyb
 from SwiftIntTypes import all_integer_types
 
@@ -248,7 +249,7 @@ FixedPoint.test("${Self}.hash(into:)") {
 %     if self_ty.bits == 64:
     let expected = Hasher._hash(seed: 0, ${reference} as UInt64)
 %     else:
-    let expected = Hasher._hash(seed: 0, bytes: ${reference}, count: ${self_ty.bits / 8})
+    let expected = Hasher._hash(seed: 0, bytes: ${reference}, count: ${self_ty.bits // 8})
 %     end
     expectEqual(expected, output, "input: \(input)")
   }


### PR DESCRIPTION
This PR adds compatibility with Python versions 2 and 3 for the following parts of Swift:
- Various `.gyb` files in the stdlib
- `gyb`
- `gyb_sourcekit_support`
- `gyb_syntax_support`
- `line-directive`
- `update_checkout`
- `build_swift`
- `swift_build_support`
- `bug_reducer`
- Several additional miscellaneous utilities
- Initial support for the primary test driver
- A few bits and pieces in the test suite, validation test suite, unit tests, and benchmarks.

_Note: All of `llvm` and `clang`, as well as `build-script`, are already fully compatible with Python 3._

_Note: An upstream issue with `lit.py`'s Windows support is blocking Python 3 compatibility for the test suites at this time._

This PR does _NOT_ provide complete Python 3 support; considerable further work is needed. Thoughts on whether this PR should be broken into multiple pieces and if so in what way would be most appreciated.