### PR TITLE
Build script builders

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -41,6 +41,8 @@ from swift_build_support.swift_build_support.SwiftBuildSupport import (
     SWIFT_SOURCE_ROOT,
 )
 from swift_build_support.swift_build_support.cmake import CMake
+from swift_build_support.swift_build_support.host_specific_configuration \
+    import HostSpecificConfiguration
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
 from swift_build_support.swift_build_support.toolchain import host_toolchain
@@ -54,143 +56,6 @@ def exit_rejecting_arguments(message, parser=None):
     if parser:
         parser.print_usage(sys.stderr)
     sys.exit(2)  # 2 is the same as `argparse` error exit code.
-
-
-class HostSpecificConfiguration(object):
-
-    """Configuration information for an individual host."""
-
-    def __init__(self, host_target, invocation):
-        """Initialize for the given `host_target`."""
-
-        # Compute the set of deployment targets to configure/build.
-        args = invocation.args
-        if host_target == args.host_target:
-            # This host is the user's desired product, so honor the requested
-            # set of targets to configure/build.
-            stdlib_targets_to_configure = args.stdlib_deployment_targets
-            if "all" in args.build_stdlib_deployment_targets:
-                stdlib_targets_to_build = set(stdlib_targets_to_configure)
-            else:
-                stdlib_targets_to_build = set(
-                    args.build_stdlib_deployment_targets).intersection(
-                    set(args.stdlib_deployment_targets))
-        else:
-            # Otherwise, this is a host we are building as part of
-            # cross-compiling, so we only need the target itself.
-            stdlib_targets_to_configure = [host_target]
-            stdlib_targets_to_build = set(stdlib_targets_to_configure)
-
-        # Compute the lists of **CMake** targets for each use case (configure
-        # vs. build vs. run) and the SDKs to configure with.
-        self.sdks_to_configure = set()
-        self.swift_stdlib_build_targets = []
-        self.swift_test_run_targets = []
-        self.swift_benchmark_build_targets = []
-        self.swift_benchmark_run_targets = []
-        for deployment_target_name in stdlib_targets_to_configure:
-            # Get the target object.
-            deployment_target = StdlibDeploymentTarget.get_target_for_name(
-                deployment_target_name)
-            if deployment_target is None:
-                diagnostics.fatal("unknown target: %r" % (
-                    deployment_target_name,))
-
-            # Add the SDK to use.
-            deployment_platform = deployment_target.platform
-            self.sdks_to_configure.add(deployment_platform.sdk_name)
-
-            # If we aren't actually building this target (only configuring
-            # it), do nothing else.
-            if deployment_target_name not in stdlib_targets_to_build:
-                continue
-
-            # Compute which actions are desired.
-            build = (
-                deployment_platform not in invocation.platforms_to_skip_build)
-            test = (
-                deployment_platform not in invocation.platforms_to_skip_test)
-            test_host_only = None
-            dt_supports_benchmark = deployment_target.supports_benchmark
-            build_benchmarks = build and dt_supports_benchmark
-            build_external_benchmarks = all([build, dt_supports_benchmark,
-                                             args.build_external_benchmarks])
-
-            # FIXME: Note, `build-script-impl` computed a property here
-            # w.r.t. testing, but it was actually unused.
-
-            # For platforms which normally require a connected device to
-            # test, the default behavior is to run tests that only require
-            # the host (i.e., they do not attempt to execute).
-            if deployment_platform.uses_host_tests and \
-                    deployment_platform not in \
-                    invocation.platforms_to_skip_test_host:
-                test_host_only = True
-
-            name = deployment_target.name
-
-            for skip_test_arch in invocation.platforms_archs_to_skip_test:
-                if deployment_target.name == skip_test_arch.name:
-                    test = False
-
-            if build:
-                # Validation, long, and stress tests require building the full
-                # standard library, whereas the other targets can build a
-                # slightly smaller subset which is faster to build.
-                if args.build_swift_stdlib_unittest_extra or \
-                        args.validation_test or args.long_test or \
-                        args.stress_test:
-                    self.swift_stdlib_build_targets.append(
-                        "swift-stdlib-" + name)
-                else:
-                    self.swift_stdlib_build_targets.append(
-                        "swift-test-stdlib-" + name)
-            if build_benchmarks:
-                self.swift_benchmark_build_targets.append(
-                    "swift-benchmark-" + name)
-                if args.benchmark:
-                    self.swift_benchmark_run_targets.append(
-                        "check-swift-benchmark-" + name)
-
-            if build_external_benchmarks:
-                # Add support for the external benchmarks.
-                self.swift_benchmark_build_targets.append(
-                    "swift-benchmark-{}-external".format(name))
-                if args.benchmark:
-                    self.swift_benchmark_run_targets.append(
-                        "check-swift-benchmark-{}-external".format(name))
-            if test:
-                if test_host_only:
-                    suffix = "-only_non_executable"
-                else:
-                    suffix = ""
-                subset_suffix = ""
-                if args.validation_test and args.long_test and \
-                        args.stress_test:
-                    subset_suffix = "-all"
-                elif args.validation_test:
-                    subset_suffix = "-validation"
-                elif args.long_test:
-                    subset_suffix = "-only_long"
-                elif args.stress_test:
-                    subset_suffix = "-only_stress"
-                else:
-                    subset_suffix = ""
-                self.swift_test_run_targets.append("check-swift{}{}-{}".format(
-                    subset_suffix, suffix, name))
-                if args.test_optimized and not test_host_only:
-                    self.swift_test_run_targets.append(
-                        "check-swift{}-optimize-{}".format(
-                            subset_suffix, name))
-                if args.test_optimize_for_size and not test_host_only:
-                    self.swift_test_run_targets.append(
-                        "check-swift{}-optimize_size-{}".format(
-                            subset_suffix, name))
-                if args.test_optimize_none_implicit_dynamic and \
-                        not test_host_only:
-                    self.swift_test_run_targets.append(
-                        "check-swift{}-optimize_none_implicit_dynamic-{}"
-                        .format(subset_suffix, name))
 
 
 class BuildScriptInvocation(object):
@@ -317,91 +182,6 @@ class BuildScriptInvocation(object):
             source_root=SWIFT_SOURCE_ROOT,
             build_root=os.path.join(SWIFT_BUILD_ROOT, args.build_subdir))
 
-        # Compute derived information from the arguments.
-        #
-        # FIXME: We should move the platform-derived arguments to be entirely
-        # data driven, so that we can eliminate this code duplication and just
-        # iterate over all supported platforms.
-
-        self.platforms_to_skip_build = set()
-        if not args.build_linux:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
-        if not args.build_freebsd:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
-        if not args.build_cygwin:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
-        if not args.build_osx:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
-        if not args.build_ios_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
-        if not args.build_ios_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.iOSSimulator)
-        if not args.build_tvos_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
-        if not args.build_tvos_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.AppleTVSimulator)
-        if not args.build_watchos_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
-        if not args.build_watchos_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.AppleWatchSimulator)
-        if not args.build_android:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
-
-        self.platforms_to_skip_test = set()
-        self.platforms_archs_to_skip_test = set()
-        if not args.test_linux:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
-        if not args.test_freebsd:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
-        if not args.test_cygwin:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
-        if not args.test_osx:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
-        if not args.test_ios_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
-        else:
-            exit_rejecting_arguments("error: iOS device tests are not " +
-                                     "supported in open-source Swift.")
-        if not args.test_ios_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.iOSSimulator)
-        if not args.test_ios_32bit_simulator:
-            self.platforms_archs_to_skip_test.add(
-                StdlibDeploymentTarget.iOSSimulator.i386)
-        if not args.test_tvos_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
-        else:
-            exit_rejecting_arguments("error: tvOS device tests are not " +
-                                     "supported in open-source Swift.")
-        if not args.test_tvos_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.AppleTVSimulator)
-        if not args.test_watchos_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
-        else:
-            exit_rejecting_arguments("error: watchOS device tests are not " +
-                                     "supported in open-source Swift.")
-        if not args.test_watchos_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.AppleWatchSimulator)
-        if not args.test_android:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
-
-        self.platforms_to_skip_test_host = set()
-        if not args.test_android_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.Android)
-        if not args.test_ios_host:
-            self.platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
-        if not args.test_tvos_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.AppleTV)
-        if not args.test_watchos_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.AppleWatch)
         self.build_libparser_only = args.build_libparser_only
 
     def initialize_runtime_environment(self):
@@ -821,7 +601,10 @@ class BuildScriptInvocation(object):
         options = {}
         for host_target in [args.host_target] + args.cross_compile_hosts:
             # Compute the host specific configuration.
-            config = HostSpecificConfiguration(host_target, self)
+            try:
+                config = HostSpecificConfiguration(self.args, host_target)
+            except argparse.ArgumentError as e:
+                exit_rejecting_arguments(e.message)
 
             # Convert into `build-script-impl` style variables.
             options[host_target] = {
@@ -934,7 +717,10 @@ class BuildScriptInvocation(object):
         # Build...
         for host_target in all_hosts:
             # FIXME: We should only compute these once.
-            config = HostSpecificConfiguration(host_target.name, self)
+            try:
+                config = HostSpecificConfiguration(self.args, host_target.name)
+            except argparse.ArgumentError as e:
+                exit_rejecting_arguments(e.message)
             print("Building the standard library for: {}".format(
                 " ".join(config.swift_stdlib_build_targets)))
             if config.swift_test_run_targets and (

--- a/utils/build-script
+++ b/utils/build-script
@@ -43,12 +43,11 @@ from swift_build_support.swift_build_support.SwiftBuildSupport import (
 from swift_build_support.swift_build_support.cmake import CMake
 from swift_build_support.swift_build_support.host_specific_configuration \
     import HostSpecificConfiguration
+from swift_build_support.swift_build_support.products \
+    import BuildScriptImplHelper
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
 from swift_build_support.swift_build_support.toolchain import host_toolchain
-
-build_script_impl = os.path.join(
-    SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME, "utils", "build-script-impl")
 
 
 def exit_rejecting_arguments(message, parser=None):
@@ -172,8 +171,6 @@ class BuildScriptInvocation(object):
             args.android = True
             args.build_android = False
 
-# ---
-
     def __init__(self, toolchain, args):
         self.toolchain = toolchain
         self.args = args
@@ -217,411 +214,6 @@ class BuildScriptInvocation(object):
                 self.args.host_target))
         ninja_build.do_build()
         self.toolchain.ninja = ninja_build.ninja_bin_path
-
-    def convert_to_impl_arguments(self):
-        """convert_to_impl_arguments() -> (env, args)
-
-        Convert the invocation to an environment and list of arguments suitable
-        for invoking `build-script-impl`.
-        """
-
-        # Create local shadows, for convenience.
-        args = self.args
-        toolchain = self.toolchain
-
-        cmake = CMake(args=args,
-                      toolchain=self.toolchain)
-
-        impl_args = [
-            "--workspace", self.workspace.source_root,
-            "--build-dir", self.workspace.build_root,
-            "--install-prefix", args.install_prefix,
-            "--host-target", args.host_target,
-            "--stdlib-deployment-targets",
-            " ".join(args.stdlib_deployment_targets),
-            "--host-cc", toolchain.cc,
-            "--host-cxx", toolchain.cxx,
-            "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
-            "--darwin-deployment-version-osx=%s" % (
-                args.darwin_deployment_version_osx),
-            "--darwin-deployment-version-ios=%s" % (
-                args.darwin_deployment_version_ios),
-            "--darwin-deployment-version-tvos=%s" % (
-                args.darwin_deployment_version_tvos),
-            "--darwin-deployment-version-watchos=%s" % (
-                args.darwin_deployment_version_watchos),
-            "--cmake", toolchain.cmake,
-            "--cmark-build-type", args.cmark_build_variant,
-            "--llvm-build-type", args.llvm_build_variant,
-            "--swift-build-type", args.swift_build_variant,
-            "--swift-stdlib-build-type", args.swift_stdlib_build_variant,
-            "--lldb-build-type", args.lldb_build_variant,
-            "--lldb-build-with-xcode", args.lldb_build_with_xcode,
-            "--foundation-build-type", args.foundation_build_variant,
-            "--libdispatch-build-type", args.libdispatch_build_variant,
-            "--libicu-build-type", args.libicu_build_variant,
-            "--xctest-build-type", args.build_variant,
-            "--swiftpm-build-type", args.build_variant,
-            "--swiftsyntax-build-type", args.build_variant,
-            "--skstresstester-build-type", args.build_variant,
-            "--swiftevolve-build-type", args.build_variant,
-            "--llbuild-build-type", args.build_variant,
-            "--swift-enable-assertions", str(args.swift_assertions).lower(),
-            "--swift-stdlib-enable-assertions", str(
-                args.swift_stdlib_assertions).lower(),
-            "--swift-analyze-code-coverage", str(
-                args.swift_analyze_code_coverage).lower(),
-            "--llbuild-enable-assertions", str(
-                args.llbuild_assertions).lower(),
-            "--lldb-assertions", str(
-                args.lldb_assertions).lower(),
-            "--cmake-generator", args.cmake_generator,
-            "--build-jobs", str(args.build_jobs),
-            "--common-cmake-options=%s" % ' '.join(
-                pipes.quote(opt) for opt in cmake.common_options()),
-            "--build-args=%s" % ' '.join(
-                pipes.quote(arg) for arg in cmake.build_args()),
-        ]
-
-        # Compute any product specific cmake arguments.
-        for product_class in self.compute_product_classes():
-            if not product_class.is_build_script_impl_product():
-                continue
-
-            product_name = product_class.product_name()
-            product_source_name = product_class.product_source_name()
-            source_dir = self.workspace.source_dir(product_source_name)
-
-            if not os.path.exists(source_dir):
-                diagnostics.fatal(
-                    "can't find source directory for %s "
-                    "(tried %s)" % (product_name, source_dir))
-
-            product = product_class(
-                args=args,
-                toolchain=self.toolchain,
-                source_dir=source_dir,
-                # FIXME: This is incorrect since it always assumes the host
-                # target I think?
-                build_dir=self.workspace.build_dir(
-                    args.host_target, product_name))
-            cmake_opts = product.cmake_options
-
-            # FIXME: We should be using pipes.quote here but we run into issues
-            # with build-script-impl/cmake not being happy with all of the
-            # extra "'" in the strings. To fix this easily, we really need to
-            # just invoke cmake from build-script directly rather than futzing
-            # with build-script-impl. This makes even more sense since there
-            # really isn't a security issue here.
-            if cmake_opts:
-                impl_args += [
-                    "--{}-cmake-options={}".format(
-                        product_name, ' '.join(cmake_opts))
-                ]
-
-        if args.build_stdlib_deployment_targets:
-            impl_args += [
-                "--build-stdlib-deployment-targets", " ".join(
-                    args.build_stdlib_deployment_targets)]
-        if args.cross_compile_hosts:
-            impl_args += [
-                "--cross-compile-hosts", " ".join(args.cross_compile_hosts)]
-
-        if args.test_paths:
-            impl_args += ["--test-paths", " ".join(args.test_paths)]
-
-        if toolchain.ninja:
-            impl_args += ["--ninja-bin=%s" % toolchain.ninja]
-        if args.distcc:
-            impl_args += [
-                "--distcc",
-                "--distcc-pump=%s" % toolchain.distcc_pump
-            ]
-
-        # *NOTE* We use normal cmake to pass through tsan/ubsan options. We do
-        # NOT pass them to build-script-impl.
-        if args.enable_asan:
-            impl_args += ["--enable-asan"]
-            # If we are on linux, disable leak detection when running ASAN. We
-            # have a separate bot that checks for leaks.
-            if platform.system() == 'Linux':
-                os.environ['ASAN_OPTIONS'] = 'detect_leaks=0'
-        if args.enable_ubsan:
-            impl_args += ["--enable-ubsan"]
-
-        # If we have lsan, we need to export our suppression list. The actual
-        # passing in of the LSAN flag is done via the normal cmake method. We
-        # do not pass the flag to build-script-impl.
-        if args.enable_lsan:
-            supp_file = os.path.join(SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME,
-                                     "utils",
-                                     "lsan_leaks_suppression_list.txt")
-            os.environ['LSAN_OPTIONS'] = 'suppressions={}'.format(supp_file)
-        if args.verbose_build:
-            impl_args += ["--verbose-build"]
-        if args.install_symroot:
-            impl_args += [
-                "--install-symroot", os.path.abspath(args.install_symroot)
-            ]
-        if args.install_destdir:
-            impl_args += [
-                "--install-destdir", os.path.abspath(args.install_destdir)
-            ]
-
-        if args.skip_build:
-            impl_args += ["--skip-build-cmark",
-                          "--skip-build-llvm",
-                          "--skip-build-swift"]
-        if not args.build_benchmarks:
-            impl_args += ["--skip-build-benchmarks"]
-        # Currently we do not build external benchmarks by default.
-        if args.build_external_benchmarks:
-            impl_args += ["--skip-build-external-benchmarks=0"]
-        if not args.build_foundation:
-            impl_args += ["--skip-build-foundation"]
-        if not args.build_xctest:
-            impl_args += ["--skip-build-xctest"]
-        if not args.build_lldb:
-            impl_args += ["--skip-build-lldb"]
-        if not args.build_llbuild:
-            impl_args += ["--skip-build-llbuild"]
-        if not args.build_libcxx:
-            impl_args += ["--skip-build-libcxx"]
-        if not args.build_libdispatch:
-            impl_args += ["--skip-build-libdispatch"]
-        if not args.build_libicu:
-            impl_args += ["--skip-build-libicu"]
-        if not args.build_swiftpm:
-            impl_args += ["--skip-build-swiftpm"]
-        if not args.build_swiftsyntax:
-            impl_args += ["--skip-build-swiftsyntax"]
-        if not args.build_skstresstester:
-            impl_args += ["--skip-build-skstresstester"]
-        if not args.build_swiftevolve:
-            impl_args += ["--skip-build-swiftevolve"]
-        if not args.build_playgroundsupport:
-            impl_args += ["--skip-build-playgroundsupport"]
-        if args.build_swift_dynamic_stdlib:
-            impl_args += ["--build-swift-dynamic-stdlib"]
-        if args.build_swift_static_stdlib:
-            impl_args += ["--build-swift-static-stdlib"]
-        if args.build_swift_stdlib_unittest_extra:
-            impl_args += ["--build-swift-stdlib-unittest-extra"]
-        if args.build_swift_dynamic_sdk_overlay:
-            impl_args += ["--build-swift-dynamic-sdk-overlay"]
-        if args.build_swift_static_sdk_overlay:
-            impl_args += ["--build-swift-static-sdk-overlay"]
-
-        if not args.build_linux:
-            impl_args += ["--skip-build-linux"]
-        if not args.build_freebsd:
-            impl_args += ["--skip-build-freebsd"]
-        if not args.build_cygwin:
-            impl_args += ["--skip-build-cygwin"]
-        if not args.build_osx:
-            impl_args += ["--skip-build-osx"]
-        if not args.build_ios_device:
-            impl_args += ["--skip-build-ios-device"]
-        if not args.build_ios_simulator:
-            impl_args += ["--skip-build-ios-simulator"]
-        if not args.build_tvos_device:
-            impl_args += ["--skip-build-tvos-device"]
-        if not args.build_tvos_simulator:
-            impl_args += ["--skip-build-tvos-simulator"]
-        if not args.build_watchos_device:
-            impl_args += ["--skip-build-watchos-device"]
-        if not args.build_watchos_simulator:
-            impl_args += ["--skip-build-watchos-simulator"]
-        if not args.build_android:
-            impl_args += ["--skip-build-android"]
-
-        if not args.test and not args.long_test and not args.stress_test:
-            impl_args += ["--skip-test-swift"]
-        if not args.test:
-            impl_args += ["--skip-test-cmark",
-                          "--skip-test-lldb",
-                          "--skip-test-llbuild",
-                          "--skip-test-swiftpm",
-                          "--skip-test-swiftsyntax",
-                          "--skip-test-skstresstester",
-                          "--skip-test-swiftevolve",
-                          "--skip-test-xctest",
-                          "--skip-test-foundation",
-                          "--skip-test-libdispatch",
-                          "--skip-test-libicu",
-                          "--skip-test-playgroundsupport"]
-        if not args.test_linux:
-            impl_args += ["--skip-test-linux"]
-        if not args.test_freebsd:
-            impl_args += ["--skip-test-freebsd"]
-        if not args.test_cygwin:
-            impl_args += ["--skip-test-cygwin"]
-        if not args.test_osx:
-            impl_args += ["--skip-test-osx"]
-        if not args.test_ios_host:
-            impl_args += ["--skip-test-ios-host"]
-        if not args.test_ios_simulator:
-            impl_args += ["--skip-test-ios-simulator"]
-        if not args.test_ios_32bit_simulator:
-            impl_args += ["--skip-test-ios-32bit-simulator"]
-        if not args.test_tvos_host:
-            impl_args += ["--skip-test-tvos-host"]
-        if not args.test_tvos_simulator:
-            impl_args += ["--skip-test-tvos-simulator"]
-        if not args.test_watchos_host:
-            impl_args += ["--skip-test-watchos-host"]
-        if not args.test_watchos_simulator:
-            impl_args += ["--skip-test-watchos-simulator"]
-        if not args.test_android:
-            impl_args += ["--skip-test-android"]
-        if not args.test_android_host:
-            impl_args += ["--skip-test-android-host"]
-        if args.build_runtime_with_host_compiler:
-            impl_args += ["--build-runtime-with-host-compiler"]
-        if args.validation_test:
-            impl_args += ["--validation-test"]
-        if args.long_test:
-            impl_args += ["--long-test"]
-        if args.stress_test:
-            impl_args += ["--stress-test"]
-        if not args.benchmark:
-            impl_args += ["--skip-test-benchmarks"]
-        if not args.test_optimized:
-            impl_args += ["--skip-test-optimized"]
-        if not args.test_optimize_for_size:
-            impl_args += ["--skip-test-optimize-for-size"]
-        if not args.test_optimize_none_implicit_dynamic:
-            impl_args += ["--skip-test-optimize-none-implicit-dynamic"]
-        if args.build_libparser_only:
-            impl_args += ["--build-libparser-only"]
-        if args.android:
-            impl_args += [
-                "--android-arch", args.android_arch,
-                "--android-ndk", args.android_ndk,
-                "--android-api-level", args.android_api_level,
-                "--android-ndk-gcc-version", args.android_ndk_gcc_version,
-                "--android-icu-uc", args.android_icu_uc,
-                "--android-icu-uc-include", args.android_icu_uc_include,
-                "--android-icu-i18n", args.android_icu_i18n,
-                "--android-icu-i18n-include", args.android_icu_i18n_include,
-                "--android-icu-data", args.android_icu_data,
-            ]
-        if args.android_deploy_device_path:
-            impl_args += [
-                "--android-deploy-device-path",
-                args.android_deploy_device_path,
-            ]
-
-        if platform.system() == 'Darwin':
-            impl_args += [
-                "--toolchain-prefix",
-                targets.darwin_toolchain_prefix(
-                    args.install_prefix),
-                "--host-lipo", toolchain.lipo,
-            ]
-
-        if toolchain.libtool is not None:
-            impl_args += [
-                "--host-libtool", toolchain.libtool,
-            ]
-
-        # If we have extra_swift_args, combine all of them together and then
-        # add them as one command.
-        if args.extra_swift_args:
-            impl_args += [
-                "--extra-swift-args=%s" % ';'.join(args.extra_swift_args)
-            ]
-
-        # If we have extra_cmake_options, combine all of them together and then
-        # add them as one command.
-        if args.extra_cmake_options:
-            impl_args += [
-                "--extra-cmake-options=%s" % ' '.join(
-                    pipes.quote(opt) for opt in args.extra_cmake_options)
-            ]
-
-        if args.lto_type is not None:
-            impl_args += [
-                "--llvm-enable-lto=%s" % args.lto_type,
-                "--swift-tools-enable-lto=%s" % args.lto_type
-            ]
-            if args.llvm_max_parallel_lto_link_jobs is not None:
-                impl_args += [
-                    "--llvm-num-parallel-lto-link-jobs=%s" %
-                    min(args.llvm_max_parallel_lto_link_jobs, args.build_jobs)
-                ]
-            if args.swift_tools_max_parallel_lto_link_jobs is not None:
-                impl_args += [
-                    "--swift-tools-num-parallel-lto-link-jobs=%s" %
-                    min(args.swift_tools_max_parallel_lto_link_jobs,
-                        args.build_jobs)
-                ]
-
-        impl_args += args.build_script_impl_args
-
-        if args.dry_run:
-            impl_args += ["--dry-run"]
-
-        if args.clang_profile_instr_use:
-            impl_args += [
-                "--clang-profile-instr-use=%s" %
-                os.path.abspath(args.clang_profile_instr_use)
-            ]
-
-        if args.lit_args:
-            impl_args += ["--llvm-lit-args=%s" % args.lit_args]
-
-        if args.coverage_db:
-            impl_args += [
-                "--coverage-db=%s" %
-                os.path.abspath(args.coverage_db)
-            ]
-
-        # Compute the set of host-specific variables, which we pass through to
-        # the build script via environment variables.
-        host_specific_variables = self.compute_host_specific_variables()
-        impl_env = {}
-        for (host_target, options) in host_specific_variables.items():
-            for (name, value) in options.items():
-                # We mangle into an environment variable we can easily evaluate
-                # from the `build-script-impl`.
-                impl_env["HOST_VARIABLE_{}__{}".format(
-                    host_target.replace("-", "_"), name)] = value
-
-        return (impl_env, impl_args)
-
-    def compute_host_specific_variables(self):
-        """compute_host_specific_variables(args) -> dict
-
-        Compute the host-specific options, organized as a dictionary keyed by
-        host of options.
-        """
-
-        args = self.args
-
-        options = {}
-        for host_target in [args.host_target] + args.cross_compile_hosts:
-            # Compute the host specific configuration.
-            try:
-                config = HostSpecificConfiguration(self.args, host_target)
-            except argparse.ArgumentError as e:
-                exit_rejecting_arguments(e.message)
-
-            # Convert into `build-script-impl` style variables.
-            options[host_target] = {
-                "SWIFT_SDKS": " ".join(sorted(
-                    config.sdks_to_configure)),
-                "SWIFT_STDLIB_TARGETS": " ".join(
-                    config.swift_stdlib_build_targets),
-                "SWIFT_BENCHMARK_TARGETS": " ".join(
-                    config.swift_benchmark_build_targets),
-                "SWIFT_RUN_BENCHMARK_TARGETS": " ".join(
-                    config.swift_benchmark_run_targets),
-                "SWIFT_TEST_TARGETS": " ".join(
-                    config.swift_test_run_targets),
-            }
-
-        return options
 
     def compute_product_classes(self):
         """compute_product_classes() -> list
@@ -668,35 +260,17 @@ class BuildScriptInvocation(object):
     def execute(self):
         """Execute the invocation with the configured arguments."""
 
-        # Convert to a build-script-impl invocation.
-        (impl_env, impl_args) = self.convert_to_impl_arguments()
-
         # If using the legacy implementation, delegate all behavior to
         # `build-script-impl`.
         if self.args.legacy_impl:
             # Execute the underlying build script implementation.
-            shell.call_without_sleeping([build_script_impl] + impl_args,
-                                        env=impl_env, echo=True)
+            helper = BuildScriptImplHelper(self.args, self.toolchain,
+                                           self.workspace,
+                                           self.compute_product_classes())
+            helper.execute(echo=True)
             return
 
         # Otherwise, we compute and execute the individual actions ourselves.
-
-        def execute_one_impl_action(host=None, product_class=None, name=None):
-            if host is None:
-                assert (product_class is None and
-                        name == "merged-hosts-lipo"), "invalid action"
-                action_name = name
-            elif product_class is None:
-                assert name in ("package", "extractsymbols"), "invalid action"
-                action_name = "{}-{}".format(host.name, name)
-            else:
-                assert name is not None, "invalid action"
-                action_name = "{}-{}-{}".format(
-                    host.name, product_class.product_name(), name)
-            shell.call_without_sleeping(
-                [build_script_impl] + impl_args + [
-                    "--only-execute", action_name],
-                env=impl_env, echo=self.args.verbose_build)
 
         # Compute the list of hosts to operate on.
         all_host_names = [
@@ -733,17 +307,17 @@ class BuildScriptInvocation(object):
                     " ".join(config.swift_benchmark_run_targets)))
 
             for product_class in impl_product_classes:
-                execute_one_impl_action(host_target, product_class, "build")
+                self.__execute_build_action(host_target, product_class)
 
         # Test...
         for host_target in all_hosts:
             for product_class in impl_product_classes:
-                execute_one_impl_action(host_target, product_class, "test")
+                self.__execute_test_action(host_target, product_class)
 
         # Install...
         for host_target in all_hosts:
             for product_class in impl_product_classes:
-                execute_one_impl_action(host_target, product_class, "install")
+                self.__execute_install_action(host_target, product_class)
 
         # Non-build-script-impl products...
         # Note: currently only supports building for the host.
@@ -764,14 +338,47 @@ class BuildScriptInvocation(object):
 
         # Extract symbols...
         for host_target in all_hosts:
-            execute_one_impl_action(host_target, name="extractsymbols")
+            self.__execute_extract_symbols_action(host_target)
 
         # Package...
         for host_target in all_hosts:
-            execute_one_impl_action(host_target, name="package")
+            self.__execute_package_action(host_target)
 
         # Lipo...
-        execute_one_impl_action(name="merged-hosts-lipo")
+        self.__execute_lipo_action()
+
+    def __execute_build_action(self, host, product_class):
+        builder = product_class.make_builder(self.args, self.toolchain,
+                                             self.workspace, host)
+        builder.do_build()
+
+    def __execute_test_action(self, host, product_class):
+        builder = product_class.make_builder(self.args, self.toolchain,
+                                             self.workspace, host)
+        builder.do_test()
+
+    def __execute_install_action(self, host, product_class):
+        builder = product_class.make_builder(self.args, self.toolchain,
+                                             self.workspace, host)
+        builder.do_install()
+
+    def __execute_extract_symbols_action(self, host):
+        helper = BuildScriptImplHelper(self.args, self.toolchain,
+                                       self.workspace,
+                                       self.compute_product_classes())
+        helper.do_extract_symbols(host)
+
+    def __execute_package_action(self, host):
+        helper = BuildScriptImplHelper(self.args, self.toolchain,
+                                       self.workspace,
+                                       self.compute_product_classes())
+        helper.do_package(host)
+
+    def __execute_lipo_action(self):
+        helper = BuildScriptImplHelper(self.args, self.toolchain,
+                                       self.workspace,
+                                       self.compute_product_classes())
+        helper.do_lipo()
 
 
 # Provide a short delay so accidentally invoked clean builds can be canceled.
@@ -929,8 +536,9 @@ def main_normal():
         # If we received any impl args, check if `build-script-impl` would
         # accept them or not before any further processing.
         try:
-            migration.check_impl_args(build_script_impl,
-                                      args.build_script_impl_args)
+            migration.check_impl_args(
+                products.BUILD_SCRIPT_IMPL_PATH,
+                args.build_script_impl_args)
         except ValueError as e:
             exit_rejecting_arguments(e, parser)
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -56,21 +56,6 @@ def exit_rejecting_arguments(message, parser=None):
     sys.exit(2)  # 2 is the same as `argparse` error exit code.
 
 
-def call_without_sleeping(command, env=None, dry_run=False, echo=False):
-    """
-    Execute a command during which system sleep is disabled.
-
-    By default, this ignores the state of the `shell.dry_run` flag.
-    """
-
-    # Disable system sleep, if possible.
-    if platform.system() == 'Darwin':
-        # Don't mutate the caller's copy of the arguments.
-        command = ["caffeinate"] + list(command)
-
-    shell.call(command, env=env, dry_run=dry_run, echo=echo)
-
-
 class HostSpecificConfiguration(object):
 
     """Configuration information for an individual host."""
@@ -906,8 +891,8 @@ class BuildScriptInvocation(object):
         # `build-script-impl`.
         if self.args.legacy_impl:
             # Execute the underlying build script implementation.
-            call_without_sleeping([build_script_impl] + impl_args,
-                                  env=impl_env, echo=True)
+            shell.call_without_sleeping([build_script_impl] + impl_args,
+                                        env=impl_env, echo=True)
             return
 
         # Otherwise, we compute and execute the individual actions ourselves.
@@ -924,7 +909,7 @@ class BuildScriptInvocation(object):
                 assert name is not None, "invalid action"
                 action_name = "{}-{}-{}".format(
                     host.name, product_class.product_name(), name)
-            call_without_sleeping(
+            shell.call_without_sleeping(
                 [build_script_impl] + impl_args + [
                     "--only-execute", action_name],
                 env=impl_env, echo=self.args.verbose_build)
@@ -1143,7 +1128,7 @@ def main_preset():
     if args.expand_build_script_invocation:
         return 0
 
-    call_without_sleeping(build_script_args)
+    shell.call_without_sleeping(build_script_args)
     return 0
 
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -321,20 +321,14 @@ class BuildScriptInvocation(object):
 
         # Non-build-script-impl products...
         # Note: currently only supports building for the host.
-        for host_target in [self.args.host_target]:
+        for host_target in [
+                StdlibDeploymentTarget.get_target_for_name(
+                    self.args.host_target)]:
             for product_class in product_classes:
                 if product_class.is_build_script_impl_product():
                     continue
-                product_source = product_class.product_source_name()
-                product_name = product_class.product_name()
-                product = product_class(
-                    args=self.args,
-                    toolchain=self.toolchain,
-                    source_dir=self.workspace.source_dir(product_source),
-                    build_dir=self.workspace.build_dir(
-                        host_target, product_name))
-                product.do_build(host_target)
-                product.do_test(host_target)
+                self.__execute_build_action(host_target, product_class)
+                self.__execute_test_action(host_target, product_class)
 
         # Extract symbols...
         for host_target in all_hosts:

--- a/utils/build-script
+++ b/utils/build-script
@@ -209,11 +209,12 @@ class BuildScriptInvocation(object):
                 "can't find source directory for ninja "
                 "(tried %s)" % (self.workspace.source_dir("ninja")))
 
-        ninja_build = products.Ninja(
+        ninja_build = products.Ninja.make_builder(
             args=self.args,
             toolchain=self.toolchain,
-            source_dir=self.workspace.source_dir("ninja"),
-            build_dir=self.workspace.build_dir("build", "ninja"))
+            workspace=self.workspace,
+            host=StdlibDeploymentTarget.get_target_for_name(
+                self.args.host_target))
         ninja_build.do_build()
         self.toolchain.ninja = ninja_build.ninja_bin_path
 

--- a/utils/swift_build_support/swift_build_support/__init__.py
+++ b/utils/swift_build_support/swift_build_support/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "cmake",
     "debug",
     "diagnostics",
+    "host_specific_configuration",
     "migration",
     "tar",
     "targets",

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -1,0 +1,248 @@
+# swift_build_support/host_configuration_support.py -------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from .targets import StdlibDeploymentTarget
+import diagnostics
+
+from argparse import ArgumentError
+
+
+class HostSpecificConfiguration(object):
+
+    """Configuration information for an individual host."""
+
+    def __init__(self, args, host_target):
+        """Initialize for the given `host_target`."""
+
+        # Compute the set of deployment targets to configure/build.
+        if host_target == args.host_target:
+            # This host is the user's desired product, so honor the requested
+            # set of targets to configure/build.
+            stdlib_targets_to_configure = args.stdlib_deployment_targets
+            if "all" in args.build_stdlib_deployment_targets:
+                stdlib_targets_to_build = set(stdlib_targets_to_configure)
+            else:
+                stdlib_targets_to_build = set(
+                    args.build_stdlib_deployment_targets).intersection(
+                    set(args.stdlib_deployment_targets))
+        else:
+            # Otherwise, this is a host we are building as part of
+            # cross-compiling, so we only need the target itself.
+            stdlib_targets_to_configure = [host_target]
+            stdlib_targets_to_build = set(stdlib_targets_to_configure)
+
+        # Compute derived information from the arguments.
+        #
+        # FIXME: We should move the platform-derived arguments to be entirely
+        # data driven, so that we can eliminate this code duplication and just
+        # iterate over all supported platforms.
+        platforms_to_skip_build = self.__platforms_to_skip_build(args)
+        platforms_to_skip_test = self.__platforms_to_skip_test(args)
+        platforms_archs_to_skip_test = self.__platforms_archs_to_skip_test(args)
+        platforms_to_skip_test_host = self.__platforms_to_skip_test_host(args)
+
+        # Compute the lists of **CMake** targets for each use case (configure
+        # vs. build vs. run) and the SDKs to configure with.
+        self.sdks_to_configure = set()
+        self.swift_stdlib_build_targets = []
+        self.swift_test_run_targets = []
+        self.swift_benchmark_build_targets = []
+        self.swift_benchmark_run_targets = []
+        for deployment_target_name in stdlib_targets_to_configure:
+            # Get the target object.
+            deployment_target = StdlibDeploymentTarget.get_target_for_name(
+                deployment_target_name)
+            if deployment_target is None:
+                diagnostics.fatal("unknown target: %r" % (
+                    deployment_target_name,))
+
+            # Add the SDK to use.
+            deployment_platform = deployment_target.platform
+            self.sdks_to_configure.add(deployment_platform.sdk_name)
+
+            # If we aren't actually building this target (only configuring
+            # it), do nothing else.
+            if deployment_target_name not in stdlib_targets_to_build:
+                continue
+
+            # Compute which actions are desired.
+            build = (
+                deployment_platform not in platforms_to_skip_build)
+            test = (
+                deployment_platform not in platforms_to_skip_test)
+            test_host_only = None
+            dt_supports_benchmark = deployment_target.supports_benchmark
+            build_benchmarks = build and dt_supports_benchmark
+            build_external_benchmarks = all([build, dt_supports_benchmark,
+                                             args.build_external_benchmarks])
+
+            # FIXME: Note, `build-script-impl` computed a property here
+            # w.r.t. testing, but it was actually unused.
+
+            # For platforms which normally require a connected device to
+            # test, the default behavior is to run tests that only require
+            # the host (i.e., they do not attempt to execute).
+            if deployment_platform.uses_host_tests and \
+                    deployment_platform not in platforms_to_skip_test_host:
+                test_host_only = True
+
+            name = deployment_target.name
+
+            for skip_test_arch in platforms_archs_to_skip_test:
+                if deployment_target.name == skip_test_arch.name:
+                    test = False
+
+            if build:
+                # Validation, long, and stress tests require building the full
+                # standard library, whereas the other targets can build a
+                # slightly smaller subset which is faster to build.
+                if args.build_swift_stdlib_unittest_extra or \
+                        args.validation_test or args.long_test or \
+                        args.stress_test:
+                    self.swift_stdlib_build_targets.append(
+                        "swift-stdlib-" + name)
+                else:
+                    self.swift_stdlib_build_targets.append(
+                        "swift-test-stdlib-" + name)
+            if build_benchmarks:
+                self.swift_benchmark_build_targets.append(
+                    "swift-benchmark-" + name)
+                if args.benchmark:
+                    self.swift_benchmark_run_targets.append(
+                        "check-swift-benchmark-" + name)
+
+            if build_external_benchmarks:
+                # Add support for the external benchmarks.
+                self.swift_benchmark_build_targets.append(
+                    "swift-benchmark-{}-external".format(name))
+                if args.benchmark:
+                    self.swift_benchmark_run_targets.append(
+                        "check-swift-benchmark-{}-external".format(name))
+            if test:
+                if test_host_only:
+                    suffix = "-only_non_executable"
+                else:
+                    suffix = ""
+                subset_suffix = ""
+                if args.validation_test and args.long_test and \
+                        args.stress_test:
+                    subset_suffix = "-all"
+                elif args.validation_test:
+                    subset_suffix = "-validation"
+                elif args.long_test:
+                    subset_suffix = "-only_long"
+                elif args.stress_test:
+                    subset_suffix = "-only_stress"
+                else:
+                    subset_suffix = ""
+                self.swift_test_run_targets.append("check-swift{}{}-{}".format(
+                    subset_suffix, suffix, name))
+                if args.test_optimized and not test_host_only:
+                    self.swift_test_run_targets.append(
+                        "check-swift{}-optimize-{}".format(
+                            subset_suffix, name))
+                if args.test_optimize_for_size and not test_host_only:
+                    self.swift_test_run_targets.append(
+                        "check-swift{}-optimize_size-{}".format(
+                            subset_suffix, name))
+                if args.test_optimize_none_implicit_dynamic and \
+                        not test_host_only:
+                    self.swift_test_run_targets.append(
+                        "check-swift{}-optimize_none_implicit_dynamic-{}"
+                        .format(subset_suffix, name))
+
+    def __platforms_to_skip_build(self, args):
+        platforms_to_skip_build = set()
+        if not args.build_linux:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
+        if not args.build_freebsd:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
+        if not args.build_cygwin:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
+        if not args.build_osx:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
+        if not args.build_ios_device:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
+        if not args.build_ios_simulator:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.iOSSimulator)
+        if not args.build_tvos_device:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
+        if not args.build_tvos_simulator:
+            platforms_to_skip_build.add(
+                StdlibDeploymentTarget.AppleTVSimulator)
+        if not args.build_watchos_device:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
+        if not args.build_watchos_simulator:
+            platforms_to_skip_build.add(
+                StdlibDeploymentTarget.AppleWatchSimulator)
+        if not args.build_android:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
+        return platforms_to_skip_build
+
+    def __platforms_to_skip_test(self, args):
+        platforms_to_skip_test = set()
+        if not args.test_linux:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
+        if not args.test_freebsd:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
+        if not args.test_cygwin:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
+        if not args.test_osx:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
+        if not args.test_ios_host:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
+        else:
+            raise ArgumentError(None,
+                                "error: iOS device tests are not " +
+                                "supported in open-source Swift.")
+        if not args.test_ios_simulator:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.iOSSimulator)
+        if not args.test_tvos_host:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
+        else:
+            raise ArgumentError(None,
+                                "error: tvOS device tests are not " +
+                                "supported in open-source Swift.")
+        if not args.test_tvos_simulator:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTVSimulator)
+        if not args.test_watchos_host:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
+        else:
+            raise ArgumentError(None,
+                                "error: watchOS device tests are not " +
+                                "supported in open-source Swift.")
+        if not args.test_watchos_simulator:
+            platforms_to_skip_test.add(
+                StdlibDeploymentTarget.AppleWatchSimulator)
+        if not args.test_android:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
+
+        return platforms_to_skip_test
+
+    def __platforms_archs_to_skip_test(self, args):
+        platforms_archs_to_skip_test = set()
+        if not args.test_ios_32bit_simulator:
+            platforms_archs_to_skip_test.add(
+                StdlibDeploymentTarget.iOSSimulator.i386)
+        return platforms_archs_to_skip_test
+
+    def __platforms_to_skip_test_host(self, args):
+        platforms_to_skip_test_host = set()
+        if not args.test_android_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.Android)
+        if not args.test_ios_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
+        if not args.test_tvos_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleTV)
+        if not args.test_watchos_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleWatch)
+        return platforms_to_skip_test_host

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -10,6 +10,9 @@
 #
 # ----------------------------------------------------------------------------
 
+from .build_script_impl_builder import (
+    BuildScriptImplHelper,
+    BUILD_SCRIPT_IMPL_PATH)
 from .cmark import CMark
 from .foundation import Foundation
 from .indexstoredb import IndexStoreDB
@@ -29,6 +32,8 @@ from .swiftsyntax import SwiftSyntax
 from .xctest import XCTest
 
 __all__ = [
+    'BUILD_SCRIPT_IMPL_PATH'
+    'BuildScriptImplHelper',
     'CMark',
     'Ninja',
     'Foundation',

--- a/utils/swift_build_support/swift_build_support/products/build_script_helper_builder.py
+++ b/utils/swift_build_support/swift_build_support/products/build_script_helper_builder.py
@@ -1,0 +1,60 @@
+# swift_build_support/product_builders/build_script_helper_b... -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from . import product_builder
+from .. import shell, targets
+
+import os
+import platform
+
+
+class BuildScriptHelperBuilder(product_builder.ProductBuilder):
+    def __init__(self, product_class, args, toolchain, workspace, host):
+        self.__source_dir = workspace.source_dir(
+            product_class.product_source_name())
+        self.__build_dir = workspace.build_dir(host.name,
+                                               product_class.product_name())
+        self.__args = args
+
+    def do_build(self):
+        self.__run_build_script_helper('build')
+
+    def do_test(self):
+        if self._should_test():
+            self.__run_build_script_helper('test')
+
+    def _should_test(self):
+        raise NotImplementedError("_should_test should be overriden by "
+                                  "subclass {}.".format(self.__class__))
+
+    def __run_build_script_helper(self, action):
+        script_path = os.path.join(
+            self.__source_dir, 'Utilities', 'build-script-helper.py')
+        toolchain_path = self.__args.install_destdir
+        if platform.system() == 'Darwin':
+            # The prefix is an absolute path, so concatenate without os.path.
+            toolchain_path += \
+                targets.darwin_toolchain_prefix(self.__args.install_prefix)
+        if self.__args.build_variant == 'Debug':
+            configuration = 'debug'
+        else:
+            configuration = 'release'
+        helper_cmd = [
+            script_path,
+            action,
+            '--verbose',
+            '--package-path', self.__source_dir,
+            '--build-path', self.__build_dir,
+            '--configuration', configuration,
+            '--toolchain', toolchain_path,
+        ]
+        shell.call(helper_cmd)

--- a/utils/swift_build_support/swift_build_support/products/build_script_impl_builder.py
+++ b/utils/swift_build_support/swift_build_support/products/build_script_impl_builder.py
@@ -1,0 +1,478 @@
+# swift_build_support/product_builders/build_script_impl_buil... -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from . import product_builder
+from .. import diagnostics, targets, shell
+from ..cmake import CMake
+from ..host_specific_configuration import HostSpecificConfiguration
+from ..SwiftBuildSupport import (
+    SWIFT_REPO_NAME,
+    SWIFT_SOURCE_ROOT,
+)
+
+import os
+import os.path
+import pipes
+import platform
+
+
+BUILD_SCRIPT_IMPL_PATH = os.path.join(
+    SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME, "utils", "build-script-impl")
+
+
+class BuildScriptImplBuilder(product_builder.ProductBuilder):
+    def __init__(self, product_class, args, toolchain, workspace, host):
+        self.__product_class = product_class
+        self.__helper = BuildScriptImplHelper(args, toolchain, workspace,
+                                              [product_class])
+        self.__host = host
+
+    def do_build(self):
+        self.__helper.execute(self.__action_name('build'))
+
+    def do_test(self):
+        self.__helper.execute(self.__action_name('test'))
+
+    def do_install(self):
+        self.__helper.execute(self.__action_name('install'))
+
+    def __action_name(self, action_name):
+        return '{}-{}-{}'.format(self.__host.name,
+                                 self.__product_class.product_name(),
+                                 action_name)
+
+
+class BuildScriptImplHelper(object):
+    def __init__(self, args, toolchain, workspace, product_classes):
+        self.__args = args
+        self.__toolchain = toolchain
+        self.__workspace = workspace
+        self.__product_classes = product_classes
+
+    def do_extract_symbols(self, host):
+        self.execute('{}-extractsymbols'.format(host.name))
+
+    def do_package(self, host):
+        self.execute('{}-package'.format(host.name))
+
+    def do_lipo(self):
+        self.execute('merged-hosts-lipo')
+
+    def execute(self, action=None, echo=None):
+        (impl_env, impl_args) = self.__convert_to_impl_arguments()
+        command = [BUILD_SCRIPT_IMPL_PATH] + impl_args
+        if action is not None:
+            command += ['--only-execute', action]
+        if echo is None:
+            echo = self.__args.verbose_build
+        shell.call_without_sleeping(command, env=impl_env, echo=echo)
+
+    def __convert_to_impl_arguments(self):
+        """convert_to_impl_arguments() -> (env, args)
+
+        Convert the invocation to an environment and list of arguments suitable
+        for invoking `build-script-impl`.
+        """
+
+        # Create local shadows, for convenience.
+        args = self.__args
+        toolchain = self.__toolchain
+        workspace = self.__workspace
+
+        cmake = CMake(args=args, toolchain=toolchain)
+
+        impl_args = [
+            "--workspace", workspace.source_root,
+            "--build-dir", workspace.build_root,
+            "--install-prefix", args.install_prefix,
+            "--host-target", args.host_target,
+            "--stdlib-deployment-targets",
+            " ".join(args.stdlib_deployment_targets),
+            "--host-cc", toolchain.cc,
+            "--host-cxx", toolchain.cxx,
+            "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
+            "--darwin-deployment-version-osx=%s" % (
+                args.darwin_deployment_version_osx),
+            "--darwin-deployment-version-ios=%s" % (
+                args.darwin_deployment_version_ios),
+            "--darwin-deployment-version-tvos=%s" % (
+                args.darwin_deployment_version_tvos),
+            "--darwin-deployment-version-watchos=%s" % (
+                args.darwin_deployment_version_watchos),
+            "--cmake", toolchain.cmake,
+            "--cmark-build-type", args.cmark_build_variant,
+            "--llvm-build-type", args.llvm_build_variant,
+            "--swift-build-type", args.swift_build_variant,
+            "--swift-stdlib-build-type", args.swift_stdlib_build_variant,
+            "--lldb-build-type", args.lldb_build_variant,
+            "--lldb-build-with-xcode", args.lldb_build_with_xcode,
+            "--foundation-build-type", args.foundation_build_variant,
+            "--libdispatch-build-type", args.libdispatch_build_variant,
+            "--libicu-build-type", args.libicu_build_variant,
+            "--xctest-build-type", args.build_variant,
+            "--swiftpm-build-type", args.build_variant,
+            "--swiftsyntax-build-type", args.build_variant,
+            "--skstresstester-build-type", args.build_variant,
+            "--swiftevolve-build-type", args.build_variant,
+            "--llbuild-build-type", args.build_variant,
+            "--swift-enable-assertions", str(args.swift_assertions).lower(),
+            "--swift-stdlib-enable-assertions", str(
+                args.swift_stdlib_assertions).lower(),
+            "--swift-analyze-code-coverage", str(
+                args.swift_analyze_code_coverage).lower(),
+            "--llbuild-enable-assertions", str(
+                args.llbuild_assertions).lower(),
+            "--lldb-assertions", str(
+                args.lldb_assertions).lower(),
+            "--cmake-generator", args.cmake_generator,
+            "--build-jobs", str(args.build_jobs),
+            "--common-cmake-options=%s" % ' '.join(
+                pipes.quote(opt) for opt in cmake.common_options()),
+            "--build-args=%s" % ' '.join(
+                pipes.quote(arg) for arg in cmake.build_args()),
+        ]
+
+        # Compute any product specific cmake arguments.
+        for product_class in self.__product_classes:
+            if not product_class.is_build_script_impl_product():
+                continue
+
+            product_name = product_class.product_name()
+            product_source_name = product_class.product_source_name()
+            source_dir = workspace.source_dir(product_source_name)
+
+            if not os.path.exists(source_dir):
+                diagnostics.fatal(
+                    "can't find source directory for %s "
+                    "(tried %s)" % (product_name, source_dir))
+
+            product = product_class(
+                args=args,
+                toolchain=toolchain,
+                source_dir=source_dir,
+                # FIXME: This is incorrect since it always assumes the host
+                # target I think?
+                build_dir=workspace.build_dir(args.host_target, product_name))
+            cmake_opts = product.cmake_options
+
+            # FIXME: We should be using pipes.quote here but we run into issues
+            # with build-script-impl/cmake not being happy with all of the
+            # extra "'" in the strings. To fix this easily, we really need to
+            # just invoke cmake from build-script directly rather than futzing
+            # with build-script-impl. This makes even more sense since there
+            # really isn't a security issue here.
+            if cmake_opts:
+                impl_args += [
+                    "--{}-cmake-options={}".format(
+                        product_name, ' '.join(cmake_opts))
+                ]
+
+        if args.build_stdlib_deployment_targets:
+            impl_args += [
+                "--build-stdlib-deployment-targets", " ".join(
+                    args.build_stdlib_deployment_targets)]
+        if args.cross_compile_hosts:
+            impl_args += [
+                "--cross-compile-hosts", " ".join(args.cross_compile_hosts)]
+
+        if args.test_paths:
+            impl_args += ["--test-paths", " ".join(args.test_paths)]
+
+        if toolchain.ninja:
+            impl_args += ["--ninja-bin=%s" % toolchain.ninja]
+        if args.distcc:
+            impl_args += [
+                "--distcc",
+                "--distcc-pump=%s" % toolchain.distcc_pump
+            ]
+
+        # *NOTE* We use normal cmake to pass through tsan/ubsan options. We do
+        # NOT pass them to build-script-impl.
+        if args.enable_asan:
+            impl_args += ["--enable-asan"]
+            # If we are on linux, disable leak detection when running ASAN. We
+            # have a separate bot that checks for leaks.
+            if platform.system() == 'Linux':
+                os.environ['ASAN_OPTIONS'] = 'detect_leaks=0'
+        if args.enable_ubsan:
+            impl_args += ["--enable-ubsan"]
+
+        # If we have lsan, we need to export our suppression list. The actual
+        # passing in of the LSAN flag is done via the normal cmake method. We
+        # do not pass the flag to build-script-impl.
+        if args.enable_lsan:
+            supp_file = os.path.join(SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME,
+                                     "utils",
+                                     "lsan_leaks_suppression_list.txt")
+            os.environ['LSAN_OPTIONS'] = 'suppressions={}'.format(supp_file)
+        if args.verbose_build:
+            impl_args += ["--verbose-build"]
+        if args.install_symroot:
+            impl_args += [
+                "--install-symroot", os.path.abspath(args.install_symroot)
+            ]
+        if args.install_destdir:
+            impl_args += [
+                "--install-destdir", os.path.abspath(args.install_destdir)
+            ]
+
+        if args.skip_build:
+            impl_args += ["--skip-build-cmark",
+                          "--skip-build-llvm",
+                          "--skip-build-swift"]
+        if not args.build_benchmarks:
+            impl_args += ["--skip-build-benchmarks"]
+        # Currently we do not build external benchmarks by default.
+        if args.build_external_benchmarks:
+            impl_args += ["--skip-build-external-benchmarks=0"]
+        if not args.build_foundation:
+            impl_args += ["--skip-build-foundation"]
+        if not args.build_xctest:
+            impl_args += ["--skip-build-xctest"]
+        if not args.build_lldb:
+            impl_args += ["--skip-build-lldb"]
+        if not args.build_llbuild:
+            impl_args += ["--skip-build-llbuild"]
+        if not args.build_libcxx:
+            impl_args += ["--skip-build-libcxx"]
+        if not args.build_libdispatch:
+            impl_args += ["--skip-build-libdispatch"]
+        if not args.build_libicu:
+            impl_args += ["--skip-build-libicu"]
+        if not args.build_swiftpm:
+            impl_args += ["--skip-build-swiftpm"]
+        if not args.build_swiftsyntax:
+            impl_args += ["--skip-build-swiftsyntax"]
+        if not args.build_skstresstester:
+            impl_args += ["--skip-build-skstresstester"]
+        if not args.build_swiftevolve:
+            impl_args += ["--skip-build-swiftevolve"]
+        if not args.build_playgroundsupport:
+            impl_args += ["--skip-build-playgroundsupport"]
+        if args.build_swift_dynamic_stdlib:
+            impl_args += ["--build-swift-dynamic-stdlib"]
+        if args.build_swift_static_stdlib:
+            impl_args += ["--build-swift-static-stdlib"]
+        if args.build_swift_stdlib_unittest_extra:
+            impl_args += ["--build-swift-stdlib-unittest-extra"]
+        if args.build_swift_dynamic_sdk_overlay:
+            impl_args += ["--build-swift-dynamic-sdk-overlay"]
+        if args.build_swift_static_sdk_overlay:
+            impl_args += ["--build-swift-static-sdk-overlay"]
+
+        if not args.build_linux:
+            impl_args += ["--skip-build-linux"]
+        if not args.build_freebsd:
+            impl_args += ["--skip-build-freebsd"]
+        if not args.build_cygwin:
+            impl_args += ["--skip-build-cygwin"]
+        if not args.build_osx:
+            impl_args += ["--skip-build-osx"]
+        if not args.build_ios_device:
+            impl_args += ["--skip-build-ios-device"]
+        if not args.build_ios_simulator:
+            impl_args += ["--skip-build-ios-simulator"]
+        if not args.build_tvos_device:
+            impl_args += ["--skip-build-tvos-device"]
+        if not args.build_tvos_simulator:
+            impl_args += ["--skip-build-tvos-simulator"]
+        if not args.build_watchos_device:
+            impl_args += ["--skip-build-watchos-device"]
+        if not args.build_watchos_simulator:
+            impl_args += ["--skip-build-watchos-simulator"]
+        if not args.build_android:
+            impl_args += ["--skip-build-android"]
+
+        if not args.test and not args.long_test and not args.stress_test:
+            impl_args += ["--skip-test-swift"]
+        if not args.test:
+            impl_args += ["--skip-test-cmark",
+                          "--skip-test-lldb",
+                          "--skip-test-llbuild",
+                          "--skip-test-swiftpm",
+                          "--skip-test-swiftsyntax",
+                          "--skip-test-skstresstester",
+                          "--skip-test-swiftevolve",
+                          "--skip-test-xctest",
+                          "--skip-test-foundation",
+                          "--skip-test-libdispatch",
+                          "--skip-test-libicu",
+                          "--skip-test-playgroundsupport"]
+        if not args.test_linux:
+            impl_args += ["--skip-test-linux"]
+        if not args.test_freebsd:
+            impl_args += ["--skip-test-freebsd"]
+        if not args.test_cygwin:
+            impl_args += ["--skip-test-cygwin"]
+        if not args.test_osx:
+            impl_args += ["--skip-test-osx"]
+        if not args.test_ios_host:
+            impl_args += ["--skip-test-ios-host"]
+        if not args.test_ios_simulator:
+            impl_args += ["--skip-test-ios-simulator"]
+        if not args.test_ios_32bit_simulator:
+            impl_args += ["--skip-test-ios-32bit-simulator"]
+        if not args.test_tvos_host:
+            impl_args += ["--skip-test-tvos-host"]
+        if not args.test_tvos_simulator:
+            impl_args += ["--skip-test-tvos-simulator"]
+        if not args.test_watchos_host:
+            impl_args += ["--skip-test-watchos-host"]
+        if not args.test_watchos_simulator:
+            impl_args += ["--skip-test-watchos-simulator"]
+        if not args.test_android:
+            impl_args += ["--skip-test-android"]
+        if not args.test_android_host:
+            impl_args += ["--skip-test-android-host"]
+        if args.build_runtime_with_host_compiler:
+            impl_args += ["--build-runtime-with-host-compiler"]
+        if args.validation_test:
+            impl_args += ["--validation-test"]
+        if args.long_test:
+            impl_args += ["--long-test"]
+        if args.stress_test:
+            impl_args += ["--stress-test"]
+        if not args.benchmark:
+            impl_args += ["--skip-test-benchmarks"]
+        if not args.test_optimized:
+            impl_args += ["--skip-test-optimized"]
+        if not args.test_optimize_for_size:
+            impl_args += ["--skip-test-optimize-for-size"]
+        if not args.test_optimize_none_implicit_dynamic:
+            impl_args += ["--skip-test-optimize-none-implicit-dynamic"]
+        if args.build_libparser_only:
+            impl_args += ["--build-libparser-only"]
+        if args.android:
+            impl_args += [
+                "--android-arch", args.android_arch,
+                "--android-ndk", args.android_ndk,
+                "--android-api-level", args.android_api_level,
+                "--android-ndk-gcc-version", args.android_ndk_gcc_version,
+                "--android-icu-uc", args.android_icu_uc,
+                "--android-icu-uc-include", args.android_icu_uc_include,
+                "--android-icu-i18n", args.android_icu_i18n,
+                "--android-icu-i18n-include", args.android_icu_i18n_include,
+                "--android-icu-data", args.android_icu_data,
+            ]
+        if args.android_deploy_device_path:
+            impl_args += [
+                "--android-deploy-device-path",
+                args.android_deploy_device_path,
+            ]
+
+        if platform.system() == 'Darwin':
+            impl_args += [
+                "--toolchain-prefix",
+                targets.darwin_toolchain_prefix(
+                    args.install_prefix),
+                "--host-lipo", toolchain.lipo,
+            ]
+
+        if toolchain.libtool is not None:
+            impl_args += [
+                "--host-libtool", toolchain.libtool,
+            ]
+
+        # If we have extra_swift_args, combine all of them together and then
+        # add them as one command.
+        if args.extra_swift_args:
+            impl_args += [
+                "--extra-swift-args=%s" % ';'.join(args.extra_swift_args)
+            ]
+
+        # If we have extra_cmake_options, combine all of them together and then
+        # add them as one command.
+        if args.extra_cmake_options:
+            impl_args += [
+                "--extra-cmake-options=%s" % ' '.join(
+                    pipes.quote(opt) for opt in args.extra_cmake_options)
+            ]
+
+        if args.lto_type is not None:
+            impl_args += [
+                "--llvm-enable-lto=%s" % args.lto_type,
+                "--swift-tools-enable-lto=%s" % args.lto_type
+            ]
+            if args.llvm_max_parallel_lto_link_jobs is not None:
+                impl_args += [
+                    "--llvm-num-parallel-lto-link-jobs=%s" %
+                    min(args.llvm_max_parallel_lto_link_jobs, args.build_jobs)
+                ]
+            if args.swift_tools_max_parallel_lto_link_jobs is not None:
+                impl_args += [
+                    "--swift-tools-num-parallel-lto-link-jobs=%s" %
+                    min(args.swift_tools_max_parallel_lto_link_jobs,
+                        args.build_jobs)
+                ]
+
+        impl_args += args.build_script_impl_args
+
+        if args.dry_run:
+            impl_args += ["--dry-run"]
+
+        if args.clang_profile_instr_use:
+            impl_args += [
+                "--clang-profile-instr-use=%s" %
+                os.path.abspath(args.clang_profile_instr_use)
+            ]
+
+        if args.lit_args:
+            impl_args += ["--llvm-lit-args=%s" % args.lit_args]
+
+        if args.coverage_db:
+            impl_args += [
+                "--coverage-db=%s" %
+                os.path.abspath(args.coverage_db)
+            ]
+
+        # Compute the set of host-specific variables, which we pass through to
+        # the build script via environment variables.
+        host_specific_variables = self.__compute_host_specific_variables()
+        impl_env = {}
+        for (host_target, options) in host_specific_variables.items():
+            for (name, value) in options.items():
+                # We mangle into an environment variable we can easily evaluate
+                # from the `build-script-impl`.
+                impl_env["HOST_VARIABLE_{}__{}".format(
+                    host_target.replace("-", "_"), name)] = value
+
+        return (impl_env, impl_args)
+
+    def __compute_host_specific_variables(self):
+        """compute_host_specific_variables(args) -> dict
+
+        Compute the host-specific options, organized as a dictionary keyed by
+        host of options.
+        """
+
+        args = self.__args
+
+        options = {}
+        for host_target in [args.host_target] + args.cross_compile_hosts:
+            # Compute the host specific configuration.
+            config = HostSpecificConfiguration(args, host_target)
+
+            # Convert into `build-script-impl` style variables.
+            options[host_target] = {
+                "SWIFT_SDKS": " ".join(sorted(
+                    config.sdks_to_configure)),
+                "SWIFT_STDLIB_TARGETS": " ".join(
+                    config.swift_stdlib_build_targets),
+                "SWIFT_BENCHMARK_TARGETS": " ".join(
+                    config.swift_benchmark_build_targets),
+                "SWIFT_RUN_BENCHMARK_TARGETS": " ".join(
+                    config.swift_benchmark_run_targets),
+                "SWIFT_TEST_TARGETS": " ".join(
+                    config.swift_test_run_targets),
+            }
+
+        return options

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -10,12 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
-import os
-import platform
-
 from . import product
-from .. import shell
-from .. import targets
+from .build_script_helper_builder import BuildScriptHelperBuilder
 
 
 class IndexStoreDB(product.Product):
@@ -27,30 +23,16 @@ class IndexStoreDB(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def do_build(self, host_target):
-        run_build_script_helper('build', host_target, self, self.args)
-
-    def do_test(self, host_target):
-        if self.args.test and self.args.test_indexstoredb:
-            run_build_script_helper('test', host_target, self, self.args)
+    @classmethod
+    def make_builder(cls, args, toolchain, workspace, host):
+        return IndexStoreDBBuilder(args, toolchain, workspace, host)
 
 
-def run_build_script_helper(action, host_target, product, args):
-    script_path = os.path.join(
-        product.source_dir, 'Utilities', 'build-script-helper.py')
-    toolchain_path = args.install_destdir
-    if platform.system() == 'Darwin':
-        # The prefix is an absolute path, so concatenate without os.path.
-        toolchain_path += \
-            targets.darwin_toolchain_prefix(args.install_prefix)
-    configuration = 'debug' if args.build_variant == 'Debug' else 'release'
-    helper_cmd = [
-        script_path,
-        action,
-        '--verbose',
-        '--package-path', product.source_dir,
-        '--build-path', product.build_dir,
-        '--configuration', configuration,
-        '--toolchain', toolchain_path,
-    ]
-    shell.call(helper_cmd)
+class IndexStoreDBBuilder(BuildScriptHelperBuilder):
+    def __init__(self, args, toolchain, workspace, host):
+        BuildScriptHelperBuilder.__init__(self, IndexStoreDB, args, toolchain,
+                                          workspace, host)
+        self.__args = args
+
+    def _should_test(self):
+        return self.__args.test and self.__args.test_indexstoredb

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -10,6 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
+from .build_script_impl_builder import BuildScriptImplBuilder
+
 
 class Product(object):
     @classmethod
@@ -29,11 +31,6 @@ class Product(object):
         the value of product_name() by default for this reason.
         """
         return cls.product_name()
-
-    @classmethod
-    def get_build_directory_name(cls, host_target):
-        return "{}-{}".format(cls.product_name(),
-                              host_target.name)
 
     @classmethod
     def is_build_script_impl_product(cls):
@@ -56,6 +53,10 @@ class Product(object):
         Run the tests, for a non-build-script-impl product.
         """
         raise NotImplementedError
+
+    @classmethod
+    def make_builder(cls, args, toolchain, workspace, host):
+        return BuildScriptImplBuilder(cls, args, toolchain, workspace, host)
 
     def __init__(self, args, toolchain, source_dir, build_dir):
         self.args = args

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -40,20 +40,6 @@ class Product(object):
         """
         return True
 
-    def do_build(self, host_target):
-        """do_build() -> void
-
-        Perform the build, for a non-build-script-impl product.
-        """
-        raise NotImplementedError
-
-    def do_test(self, host_target):
-        """do_build() -> void
-
-        Run the tests, for a non-build-script-impl product.
-        """
-        raise NotImplementedError
-
     @classmethod
     def make_builder(cls, args, toolchain, workspace, host):
         return BuildScriptImplBuilder(cls, args, toolchain, workspace, host)

--- a/utils/swift_build_support/swift_build_support/products/product_builder.py
+++ b/utils/swift_build_support/swift_build_support/products/product_builder.py
@@ -1,0 +1,61 @@
+# swift_build_support/product_builders/product_builder.py -------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import abc
+
+
+class ProductBuilder(object):
+    """
+    Abstract base class for all ProductBuilders.
+
+    An specific ProductBuilder will implement the interface methods depending
+    how the product want to be build. Multiple products can use the same
+    product builder if parametrized right (for example all the products build
+    using CMake).
+
+    Ideally a ProductBuilder will be initialized with references to the
+    invocation arguments, the calculated toolchain, the calculated workspace,
+    and the target host, but the base class doesn't impose those requirements
+    in order to be flexible.
+
+    NOTE: Python doesn't need an explicit abstract base class, but it helps
+    documenting the interface.
+    """
+
+    @abc.abstractmethod
+    def do_build(self):
+        """
+        Perform the build phase for the product.
+
+        This phase might also imply a configuration phase, but each product
+        builder is free to determine how to do it.
+        """
+        pass
+
+    @abc.abstractmethod
+    def do_test(self):
+        """
+        Perform the test phase for the product.
+
+        This phase might build and execute the product tests.
+        """
+        pass
+
+    @abc.abstractmethod
+    def do_install(self):
+        """
+        Perform the install phase for the product.
+
+        This phase might copy the artifacts from the previous phases into a
+        destination directory.
+        """
+        pass

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -10,8 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
-from . import indexstoredb
 from . import product
+from .build_script_helper_builder import BuildScriptHelperBuilder
 
 
 class SourceKitLSP(product.Product):
@@ -23,11 +23,16 @@ class SourceKitLSP(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def do_build(self, host_target):
-        indexstoredb.run_build_script_helper(
-            'build', host_target, self, self.args)
+    @classmethod
+    def make_builder(cls, args, toolchain, workspace, host):
+        return SourceKitLSPBuilder(args, toolchain, workspace, host)
 
-    def do_test(self, host_target):
-        if self.args.test and self.args.test_sourcekitlsp:
-            indexstoredb.run_build_script_helper(
-                'test', host_target, self, self.args)
+
+class SourceKitLSPBuilder(BuildScriptHelperBuilder):
+    def __init__(self, args, toolchain, workspace, host):
+        BuildScriptHelperBuilder.__init__(self, SourceKitLSP, args, toolchain,
+                                          workspace, host)
+        self.__args = args
+
+    def _should_test(self):
+        return self.__args.test and self.__args.test_sourcekitlsp

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 import os
 import pipes
+import platform
 import shutil
 import subprocess
 import sys
@@ -92,6 +93,19 @@ def call(command, stderr=None, env=None, dry_run=None, echo=True):
             "could not execute '" + quote_command(command) +
             "': " + e.strerror)
 
+def call_without_sleeping(command, env=None, dry_run=False, echo=False):
+    """
+    Execute a command during which system sleep is disabled.
+
+    By default, this ignores the state of the `shell.dry_run` flag.
+    """
+
+    # Disable system sleep, if possible.
+    if platform.system() == 'Darwin':
+        # Don't mutate the caller's copy of the arguments.
+        command = ["caffeinate"] + list(command)
+
+    call(command, env=env, dry_run=dry_run, echo=echo)
 
 def capture(command, stderr=None, env=None, dry_run=None, echo=True,
             optional=False, allow_non_zero_exit=False):

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -83,7 +83,7 @@ class NinjaTestCase(unittest.TestCase):
 
         self.assertEqual(ninja_build.ninja_bin_path,
                          os.path.join(
-                            self.workspace.build_dir(self.host.name, 'ninja'),
+                            self.workspace.build_dir('build', 'ninja'),
                             'ninja'))
 
     def test_do_build(self):
@@ -122,6 +122,6 @@ class NinjaTestCase(unittest.TestCase):
 + popd
 """.format(
             source_dir=self.workspace.source_dir('ninja'),
-            build_dir=self.workspace.build_dir(self.host.name, 'ninja'),
+            build_dir=self.workspace.build_dir('build', 'ninja'),
             expect_env=expect_env,
             python=sys.executable))


### PR DESCRIPTION
Applies to SR-237

This is a transition version of #23038. I tried to reduce the code to only the essential to show the idea behind the “product builders”. This version hides the invocations to `build-script-impl` in a builder, and that way, one can replace each product builder one by one, which should make reviews easier.

This is probably easier to look at commit by commit, because the code movements are clearer. There are three commits that mostly move code from one file to another:
- Moving a small utility method into `shell`.
- Moving `HostSpecificConfiguration` from the main script into its own file, and also bring parts of `BuildScriptInvocation` with it.
- Moving large parts of `BuildScriptInvocation` that dealt with transforming the Python arguments into `build-script-impl` arguments into `BuildScriptImplBuilder`.
- The rest of the movements are mostly inside the files themselves.

The final intention of this changes is replacing `build-script-impl` to allow the build script to not depend on Bash, and be compatible with Windows.

/cc @Rostepher, @benlangmuir, @compnerd 
