### PR TITLE
[gardening] Remove unnecessary -enable-sil-ownership from tests that …

### DIFF
--- a/test/ClangImporter/serialization-sil.swift
+++ b/test/ClangImporter/serialization-sil.swift
@@ -1,6 +1,5 @@
-
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h -enable-sil-ownership
+// RUN: %target-swift-frontend -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h
 // RUN: %target-sil-func-extractor %t/Test.swiftmodule -sil-print-debuginfo  -func='$s4Test16testPartialApplyyySoAA_pF' -o - | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/IRGen/keypath_witness_overrides.swift
+++ b/test/IRGen/keypath_witness_overrides.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name protocol_overrides -emit-module -enable-sil-ownership -enable-resilience -emit-module-path=%t/protocol_overrides.swiftmodule %S/../SILGen/Inputs/protocol_overrides.swift
+// RUN: %target-swift-frontend -module-name protocol_overrides -emit-module -enable-resilience -emit-module-path=%t/protocol_overrides.swiftmodule %S/../SILGen/Inputs/protocol_overrides.swift
 // RUN: %target-swift-frontend -module-name keypath_witness_overrides -emit-ir %s -I %t | %FileCheck %s
 
 import protocol_overrides

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership -module-name outcopyaddr -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -module-name outcopyaddr -primary-file %s | %FileCheck %s
 
 public protocol BaseProt {
 }

--- a/test/Profiler/instrprof_basic.swift
+++ b/test/Profiler/instrprof_basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -enable-sil-ownership -emit-silgen -profile-generate %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -emit-silgen -profile-generate %s | %FileCheck %s
 
 // CHECK: sil hidden [ossa] @[[F_EMPTY:.*empty.*]] :
 // CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_basic.swift:[[F_EMPTY]]"

--- a/test/Profiler/instrprof_operators.swift
+++ b/test/Profiler/instrprof_operators.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -emit-silgen -enable-sil-ownership -profile-generate %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -emit-silgen -profile-generate %s | %FileCheck %s
 
 // CHECK: sil hidden [ossa] @[[F_OPERATORS:.*operators.*]] :
 // CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"

--- a/test/Profiler/pgo_switchenum.swift
+++ b/test/Profiler/pgo_switchenum.swift
@@ -8,13 +8,13 @@
 
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // need to move counts attached to expr for this
-// RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -enable-sil-ownership -emit-sorted-sil -emit-sil -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=SIL
 // need to lower switch_enum(addr) into IR for this
-// %target-swift-frontend %s -enable-sil-ownership -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-ir -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=IR
+// %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-ir -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=IR
 // need to check Opt support
-// %target-swift-frontend %s -enable-sil-ownership -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-sorted-sil -emit-sil -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=SIL-OPT
+// %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-sorted-sil -emit-sil -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=SIL-OPT
 // need to lower switch_enum(addr) into IR for this
-// %target-swift-frontend -enable-sil-ownership %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=IR-OPT
+// %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
 // REQUIRES: executable_test

--- a/test/SILGen/apply_abstraction_nested.swift
+++ b/test/SILGen/apply_abstraction_nested.swift
@@ -1,5 +1,4 @@
-
-// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-silgen %s | %FileCheck %s
 
 infix operator ~>
 

--- a/test/SILGen/codable/struct_codable_member_type_lookup.swift
+++ b/test/SILGen/codable/struct_codable_member_type_lookup.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 // Make sure we have an int, not a float.
 //

--- a/test/SILGen/global_init_attribute.swift
+++ b/test/SILGen/global_init_attribute.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-module -o %t %S/Inputs/def_global.swift -enable-sil-ownership
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-module -o %t %S/Inputs/def_global.swift
 // RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -parse-as-library -I %t %s | %FileCheck %s
 //
 // Test that SILGen uses the "global_init" attribute for all global

--- a/test/SILGen/global_resilience.swift
+++ b/test/SILGen/global_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-sil-ownership -enable-resilience -emit-module-path=%t/resilient_global.swiftmodule -module-name=resilient_global %S/../Inputs/resilient_global.swift
-// RUN: %target-swift-emit-silgen -I %t -enable-resilience -enable-sil-ownership -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_global.swiftmodule -module-name=resilient_global %S/../Inputs/resilient_global.swift
+// RUN: %target-swift-emit-silgen -I %t -enable-resilience -parse-as-library %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -I %t -O -enable-resilience -parse-as-library %s | %FileCheck --check-prefix=CHECK-OPT %s
 
 import resilient_global

--- a/test/SILGen/keypath_covariant_override.swift
+++ b/test/SILGen/keypath_covariant_override.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -enable-sil-ownership -enable-resilience %s | %FileCheck %s
 
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership %s
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership -enable-resilience %s
+// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir -enable-resilience %s
 
 public class C : Hashable {
   public static func ==(lhs: C, rhs: C) -> Bool { return lhs === rhs }

--- a/test/SILGen/keypath_witness_overrides.swift
+++ b/test/SILGen/keypath_witness_overrides.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name protocol_overrides -emit-module -enable-sil-ownership -enable-resilience -emit-module-path=%t/protocol_overrides.swiftmodule %S/Inputs/protocol_overrides.swift
+// RUN: %target-swift-frontend -module-name protocol_overrides -emit-module -enable-resilience -emit-module-path=%t/protocol_overrides.swiftmodule %S/Inputs/protocol_overrides.swift
 // RUN: %target-swift-emit-silgen %s -I %t | %FileCheck %s
 
 // Check that keypath formation properly records the point at which the witness

--- a/test/SILGen/keypaths_inlinable.swift
+++ b/test/SILGen/keypaths_inlinable.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=FRAGILE
 // RUN: %target-swift-emit-silgen -enable-resilience %s | %FileCheck %s --check-prefix=CHECK --check-prefix=RESILIENT
 
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership %s
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership -enable-resilience %s
+// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir -enable-resilience %s
 
 public struct KeypathStruct {
   public var stored: Int = 0

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -1,5 +1,4 @@
-
-// RUN: %target-swift-frontend -module-name mangling -Xllvm -sil-full-demangle -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-frontend -module-name mangling -Xllvm -sil-full-demangle -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/mangling_ext_structA.swift
+++ b/test/SILGen/mangling_ext_structA.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-sil-ownership -o %t %S/Inputs/def_structA.swift
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name ext_structA -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_structA.swift
+// RUN: %target-swift-emit-silgen -module-name ext_structA -I %t %s | %FileCheck %s
 
 // Ensure that members of extensions of types from another module are mangled
 // correctly.

--- a/test/SILGen/mangling_private.swift
+++ b/test/SILGen/mangling_private.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-sil-ownership -emit-module -o %t %S/Inputs/mangling_private_helper.swift
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %S/Inputs/mangling_private_helper.swift | %FileCheck %s -check-prefix=CHECK-BASE
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/mangling_private_helper.swift
+// RUN: %target-swift-emit-silgen %S/Inputs/mangling_private_helper.swift | %FileCheck %s -check-prefix=CHECK-BASE
 
-// RUN: %target-swift-emit-silgen %s -I %t -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %t | %FileCheck %s
 
 // RUN: cp %s %t
-// RUN: %target-swift-emit-silgen %t/mangling_private.swift -I %t -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen %t/mangling_private.swift -I %t | %FileCheck %s
 
 // RUN: cp %s %t/other_name.swift
-// RUN: %target-swift-emit-silgen %t/other_name.swift -I %t -enable-sil-ownership -module-name mangling_private | %FileCheck %s -check-prefix=OTHER-NAME
+// RUN: %target-swift-emit-silgen %t/other_name.swift -I %t -module-name mangling_private | %FileCheck %s -check-prefix=OTHER-NAME
 
 import mangling_private_helper
 

--- a/test/SILGen/mangling_retroactive.swift
+++ b/test/SILGen/mangling_retroactive.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-sil-ownership -o %t %S/Inputs/RetroactiveA.swift
-// RUN: %target-swift-frontend -emit-module -enable-sil-ownership -o %t %S/Inputs/RetroactiveB.swift
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/RetroactiveA.swift
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/RetroactiveB.swift
+// RUN: %target-swift-emit-silgen -I %t %s | %FileCheck %s
 
 
 import RetroactiveA

--- a/test/SILGen/nsmanaged-witness-multi.swift
+++ b/test/SILGen/nsmanaged-witness-multi.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -module-name main -emit-silgen -enable-sil-ownership -sdk %S/Inputs -primary-file %s %S/Inputs/nsmanaged-witness-multi-other.swift -I %S/Inputs -I %t -enable-source-import | %FileCheck %s
+// RUN: %target-swift-frontend -module-name main -emit-silgen -sdk %S/Inputs -primary-file %s %S/Inputs/nsmanaged-witness-multi-other.swift -I %S/Inputs -I %t -enable-source-import | %FileCheck %s
 
-// RUN: %target-swift-frontend -module-name main -emit-silgen -enable-sil-ownership -sdk %S/Inputs -primary-file %s -primary-file %S/Inputs/nsmanaged-witness-multi-other.swift -I %S/Inputs -I %t -enable-source-import | %FileCheck %s
+// RUN: %target-swift-frontend -module-name main -emit-silgen -sdk %S/Inputs -primary-file %s -primary-file %S/Inputs/nsmanaged-witness-multi-other.swift -I %S/Inputs -I %t -enable-source-import | %FileCheck %s
 
-// RUN: %target-swift-frontend -module-name main -emit-silgen -enable-sil-ownership -sdk %S/Inputs %s %S/Inputs/nsmanaged-witness-multi-other.swift -I %S/Inputs -I %t -enable-source-import | %FileCheck %s
+// RUN: %target-swift-frontend -module-name main -emit-silgen -sdk %S/Inputs %s %S/Inputs/nsmanaged-witness-multi-other.swift -I %S/Inputs -I %t -enable-source-import | %FileCheck %s
 
 // REQUIRES: objc_interop
 import Foundation

--- a/test/SILGen/objc_required_designated_init.swift
+++ b/test/SILGen/objc_required_designated_init.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-sil-ownership %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule -import-objc-header %S/Inputs/objc_required_designated_init.h
-// RUN: %target-swift-emit-silgen -I %t -enable-sil-ownership -verify %s -import-objc-header %S/Inputs/objc_required_designated_init.h | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule -import-objc-header %S/Inputs/objc_required_designated_init.h
+// RUN: %target-swift-emit-silgen -I %t -verify %s -import-objc-header %S/Inputs/objc_required_designated_init.h | %FileCheck %s
 // RUN: %target-swift-emit-ir -I %t %s -import-objc-header %S/Inputs/objc_required_designated_init.h
 
 // REQUIRES: objc_interop

--- a/test/SILGen/private_import.swift
+++ b/test/SILGen/private_import.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -module-name Mod -emit-module -enable-private-imports -enable-sil-ownership -swift-version 5 -o %t %S/Inputs/private_import_module.swift
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t -primary-file %s %S/private_import_other.swift -module-name main -swift-version 5 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %s %S/private_import_other.swift -module-name main -swift-version 5 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %S/private_import_other.swift %s -module-name main -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-frontend -module-name Mod -emit-module -enable-private-imports -swift-version 5 -o %t %S/Inputs/private_import_module.swift
+// RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/private_import_other.swift -module-name main -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %s %S/private_import_other.swift -module-name main -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %S/private_import_other.swift %s -module-name main -swift-version 5 | %FileCheck %s
 // RUN: %target-swift-emit-ir -enable-sil-ownership -I %t -primary-file %s %S/private_import_other.swift -module-name main -o /dev/null
 // RUN: %target-swift-emit-ir -enable-sil-ownership -I %t -O -primary-file %s %S/private_import_other.swift -module-name main -o /dev/null
 

--- a/test/SILGen/private_import_other.swift
+++ b/test/SILGen/private_import_other.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -module-name Mod -emit-module -enable-private-imports -enable-sil-ownership -swift-version 5 -o %t %S/Inputs/private_import_module.swift
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t -primary-file %s %S/private_import.swift -module-name main -swift-version 5 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %s %S/private_import.swift -module-name main -swift-version 5 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %S/private_import.swift %s -module-name main -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-frontend -module-name Mod -emit-module -enable-private-imports -swift-version 5 -o %t %S/Inputs/private_import_module.swift
+// RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/private_import.swift -module-name main -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %s %S/private_import.swift -module-name main -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %S/private_import.swift %s -module-name main -swift-version 5 | %FileCheck %s
 // RUN: %target-swift-emit-ir -enable-sil-ownership -I %t -primary-file %s %S/private_import.swift -module-name main -o /dev/null
 // RUN: %target-swift-emit-ir -enable-sil-ownership -I %t -O -primary-file %s %S/private_import.swift -module-name main -o /dev/null
 

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -1,6 +1,6 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name protocol_resilience -emit-module -enable-sil-ownership -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -module-name protocol_resilience -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
 // RUN: %target-swift-emit-silgen -module-name protocol_resilience -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
 
 import resilient_protocol

--- a/test/SILGen/protocol_with_superclass.swift
+++ b/test/SILGen/protocol_with_superclass.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s
 
 // Protocols with superclass-constrained Self.
 

--- a/test/SILGen/protocol_with_superclass_where_clause.swift
+++ b/test/SILGen/protocol_with_superclass_where_clause.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name protocol_with_superclass %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership %s
+// RUN: %target-swift-frontend -emit-ir %s
 
 // Protocols with superclass-constrained Self, written using a 'where' clause.
 

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -1,7 +1,6 @@
-
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -enable-sil-ownership %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-emit-silgen -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-emit-silgen -I %t -enable-resilience %s | %FileCheck %s
 
 import resilient_struct
 

--- a/test/SILGen/struct_resilience_testable.swift
+++ b/test/SILGen/struct_resilience_testable.swift
@@ -1,7 +1,6 @@
-
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-testing -emit-module-path=%t/resilient_struct.swiftmodule -enable-sil-ownership %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-emit-silgen -I %t -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-testing -emit-module-path=%t/resilient_struct.swiftmodule %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-emit-silgen -I %t %s | %FileCheck %s
 
 @testable import resilient_struct
 

--- a/test/SILGen/subscript_accessor.swift
+++ b/test/SILGen/subscript_accessor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -O -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden [transparent] @$s18subscript_accessor1XVxSgyciM
 // CHECK: [[SETTER:%.*]] = function_ref @$s18subscript_accessor1XVxSgycis

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -1,11 +1,11 @@
 // This test is paired with testable-multifile-other.swift.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -enable-sil-ownership -o %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -o %t
 
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
 
 // Just make sure we don't crash later on.
 // RUN: %target-swift-emit-ir -enable-sil-ownership -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null

--- a/test/SILGen/witness_tables_serialized_import.swift
+++ b/test/SILGen/witness_tables_serialized_import.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-sil-ownership -emit-module %S/witness_tables_serialized.swift -o %t -enable-resilience
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module %S/witness_tables_serialized.swift -o %t -enable-resilience
+// RUN: %target-swift-emit-silgen -I %t %s | %FileCheck %s
 
 import witness_tables_serialized
 

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enable-sil-ownership -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -parse-as-library %s | %FileCheck %s
 
 // This tests SILGen and AccessEnforcementSelection as a single set of tests.
 // (Some static/dynamic enforcement selection is done in SILGen, and some is

--- a/test/SILOptimizer/access_enforcement_noescape_error.swift
+++ b/test/SILOptimizer/access_enforcement_noescape_error.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enable-sil-ownership -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -verify -parse-as-library %s
+// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -verify -parse-as-library %s
 // REQUIRES: asserts
 
 // This is the subset of tests from access_enforcement_noescape.swift

--- a/test/SILOptimizer/access_enforcement_options.swift
+++ b/test/SILOptimizer/access_enforcement_options.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -Onone -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=NONE
-// RUN: %target-swift-frontend -enable-sil-ownership -Osize -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=OPT
-// RUN: %target-swift-frontend -enable-sil-ownership -O -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=OPT
-// RUN: %target-swift-frontend -enable-sil-ownership -Ounchecked -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=UNCHECKED
+// RUN: %target-swift-frontend -Onone -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=NONE
+// RUN: %target-swift-frontend -Osize -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=OPT
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=OPT
+// RUN: %target-swift-frontend -Ounchecked -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=UNCHECKED
 
 @inline(never)
 func takesInoutAndEscaping(_: inout Int, _ f: @escaping () -> ()) {

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -1,5 +1,4 @@
-
-// RUN: %target-swift-frontend -module-name access_marker_mandatory -enable-sil-ownership -parse-as-library -Xllvm -sil-full-demangle -emit-sil -Onone -enforce-exclusivity=checked %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name access_marker_mandatory -parse-as-library -Xllvm -sil-full-demangle -emit-sil -Onone -enforce-exclusivity=checked %s | %FileCheck %s
 
 public struct S {
   var i: Int

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -1,7 +1,6 @@
-
-// RUN: %target-swift-frontend -module-name access_marker_verify -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -emit-silgen -swift-version 4 -parse-as-library %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name access_marker_verify -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -Onone -emit-sil -swift-version 4 -parse-as-library %s -o /dev/null
-// RUN: %target-swift-frontend -module-name access_marker_verify -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -O -emit-sil -swift-version 4 -parse-as-library %s -o /dev/null
+// RUN: %target-swift-frontend -module-name access_marker_verify -enable-verify-exclusivity -enforce-exclusivity=checked -emit-silgen -swift-version 4 -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name access_marker_verify -enable-verify-exclusivity -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -parse-as-library %s -o /dev/null
+// RUN: %target-swift-frontend -module-name access_marker_verify -enable-verify-exclusivity -enforce-exclusivity=checked -O -emit-sil -swift-version 4 -parse-as-library %s -o /dev/null
 // REQUIRES: asserts
 
 // Test the combination of SILGen + DiagnoseStaticExclusivity with verification.

--- a/test/SILOptimizer/access_marker_verify_objc.swift
+++ b/test/SILOptimizer/access_marker_verify_objc.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -enforce-exclusivity=checked -enable-sil-ownership -import-objc-header %S/Inputs/access_marker_verify_objc.h -Onone -emit-silgen -swift-version 4 -parse-as-library %s | %FileCheck %s
-// RUN: %target-swift-frontend -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -import-objc-header %S/Inputs/access_marker_verify_objc.h -Onone -emit-sil -swift-version 4 -parse-as-library %s
+// RUN: %target-swift-frontend -enforce-exclusivity=checked -import-objc-header %S/Inputs/access_marker_verify_objc.h -Onone -emit-silgen -swift-version 4 -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-verify-exclusivity -enforce-exclusivity=checked -import-objc-header %S/Inputs/access_marker_verify_objc.h -Onone -emit-sil -swift-version 4 -parse-as-library %s
 // REQUIRES: asserts
 // REQUIRES: OS=macosx
 

--- a/test/SILOptimizer/allocbox_to_stack_not_crash_ownership.swift
+++ b/test/SILOptimizer/allocbox_to_stack_not_crash_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -verify -enable-sil-ownership
+// RUN: %target-swift-frontend %s -emit-ir -verify
 
 // Verify we don't crash on this.
 // rdar://15595118

--- a/test/SILOptimizer/bridged_casts_folding.sil
+++ b/test/SILOptimizer/bridged_casts_folding.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name bridged_casts_folding -O -enable-sil-ownership -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name bridged_casts_folding -O -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -1,5 +1,4 @@
-
-// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -O -Xllvm -sil-fso-enable-generics=false %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O -Xllvm -sil-fso-enable-generics=false %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/capture_promotion_ownership.swift
+++ b/test/SILOptimizer/capture_promotion_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -enable-sil-ownership -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-sil -o - | %FileCheck %s
 
 class Foo {
   func foo() -> Int {

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/../Inputs/resilient_struct.swift -enable-resilience -emit-module -emit-module-path %t/resilient_struct.swiftmodule
 // RUN: %target-swift-frontend %S/../Inputs/resilient_enum.swift -I %t -enable-resilience -emit-module -emit-module-path %t/resilient_enum.swiftmodule
-// RUN: %target-swift-frontend %s -sil-verify-all -enable-sil-ownership -emit-sil -I %t -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -I %t -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=%target-os
 
 import resilient_struct
 import resilient_enum

--- a/test/SILOptimizer/closure_lifetime_fixup_objc.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -enable-sil-ownership -sil-verify-all -emit-sil -o - -I %S/Inputs/usr/include | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -o - -I %S/Inputs/usr/include | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILOptimizer/definite-init-convert-to-escape.swift
+++ b/test/SILOptimizer/definite-init-convert-to-escape.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -disable-objc-attr-requires-foundation-module -enable-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -disable-objc-attr-requires-foundation-module -enable-sil-ownership -Xllvm -sil-disable-convert-escape-to-noescape-switch-peephole %s | %FileCheck %s --check-prefix=NOPEEPHOLE
+// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-convert-escape-to-noescape-switch-peephole %s | %FileCheck %s --check-prefix=NOPEEPHOLE
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/definite_init.swift
+++ b/test/SILOptimizer/definite_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null
 
 class SomeClass {}
 

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/definite_init_diagnostics_objc.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/SILOptimizer/definite_init_existential_let.swift
+++ b/test/SILOptimizer/definite_init_existential_let.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
 
 // rdar://problem/29716016 - Check that we properly enforce DI on `let`
 // variables and class properties.

--- a/test/SILOptimizer/definite_init_extension.swift
+++ b/test/SILOptimizer/definite_init_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null
 
 struct S<T> {
   let t: T // expected-note {{'self.t.1' not initialized}}

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 
 // High-level tests that DI handles early returns from failable and throwing
 // initializers properly. The main complication is conditional release of self

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -disable-objc-attr-requires-foundation-module -verify %s
+// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
 
 // High-level tests that DI rejects certain invalid idioms for early
 // return from initializers.

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/definite_init_hang.swift
+++ b/test/SILOptimizer/definite_init_hang.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -parse-as-library -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -parse-as-library -o /dev/null -verify
 
 var gg: Bool = false
 var rg: Int = 0

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -disable-objc-attr-requires-foundation-module -verify %s
+// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
 
 // High-level tests that DI rejects passing let constants to
 // mutating witness methods

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -swift-version 5 -verify | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s -swift-version 5 -verify | %FileCheck %s
 
 // Ensure that convenience initializers on concrete types can
 // delegate to factory initializers defined in protocol

--- a/test/SILOptimizer/definite_init_value_types.swift
+++ b/test/SILOptimizer/definite_init_value_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 
 enum ValueEnum {
   case a(String)

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 
 struct EmptyStruct {}
 

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -1,5 +1,4 @@
-
-// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -primary-file %s -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil -o - -verify | %FileCheck %s
 
 // These tests are deliberately shallow, because I do not want to depend on the
 // specifics of SIL generation, which might change for reasons unrelated to this

--- a/test/SILOptimizer/mandatory_inlining_circular.swift
+++ b/test/SILOptimizer/mandatory_inlining_circular.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify
 
 @_transparent func waldo(_ x: Double) -> Double {
   return fred(x); // expected-error {{inlining 'transparent' functions forms circular loop}} expected-note 1 {{while inlining here}}

--- a/test/SILOptimizer/mandatory_inlining_devirt.swift
+++ b/test/SILOptimizer/mandatory_inlining_devirt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all %s -module-name test -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all %s -module-name test -emit-sil -o - -verify | %FileCheck %s
 
 
 // Constructor calls are dispatched dynamically for open classes, even if

--- a/test/SILOptimizer/mandatory_inlining_devirt_multifile.swift
+++ b/test/SILOptimizer/mandatory_inlining_devirt_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -module-name test -primary-file %s %S/Inputs/mandatory_inlining_devirt_other.swift -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend -module-name test -primary-file %s %S/Inputs/mandatory_inlining_devirt_other.swift -emit-sil -o - | %FileCheck %s
 
 // rdar://45110471
 

--- a/test/SILOptimizer/mandatory_inlining_dynamic_method.swift
+++ b/test/SILOptimizer/mandatory_inlining_dynamic_method.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILOptimizer/mandatory_nil_comparison_inlining.swift
+++ b/test/SILOptimizer/mandatory_nil_comparison_inlining.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -primary-file %s -module-name=test -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all -primary-file %s -module-name=test -emit-sil -o - -verify | %FileCheck %s
 
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}generic_func

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -Onone -Xllvm \
+// RUN: %target-swift-frontend -emit-sil %s -Onone -Xllvm \
 // RUN:   -sil-print-after=allocbox-to-stack -Xllvm \
 // RUN:   -sil-print-only-functions=$s3red19ThrowAddrOnlyStructV016throwsOptionalToG0ACyxGSgSi_tcfC \
 // RUN:   -Xllvm -sil-print-debuginfo -o %t -module-name red 2>&1 | %FileCheck %s


### PR DESCRIPTION
…now just get it from their pattern.

This just eliminates -enable-sil-ownership from all target-swift-frontend and
target-swift-emit-silgen RUN lines. Both of those now include
enable-sil-ownership in their expansion.

----

NOTE: This needs #23260 before it lands.