### PR TITLE
[iterator] Use iter and next to loop through Python Object (TF-337)

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -1266,7 +1266,6 @@ extension PythonObject : Sequence {
         try! throwPythonErrorIfPresent()
         return nil
       }
-
       return PythonObject(consuming: result)
     }
   }

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -1257,6 +1257,30 @@ extension PythonObject : MutableCollection {
   }
 }
 
+extension PythonObject : Sequence {
+  public struct Iterator : IteratorProtocol {
+    fileprivate let pythonIterator: PythonObject
+
+    public func next() -> PythonObject? {
+      guard let result = PyIter_Next(self.pythonIterator.borrowedPyObject) else {
+        try! throwPythonErrorIfPresent()
+        return nil
+      }
+
+      return PythonObject(consuming: result)
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    guard let result = PyObject_GetIter(borrowedPyObject) else {
+      try! throwPythonErrorIfPresent()
+      // Unreachable. A Python `TypeError` must have been thrown.
+      preconditionFailure()
+    }
+    return Iterator(pythonIterator: PythonObject(consuming: result))
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // `ExpressibleByLiteral` conformances
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/Python/PythonLibrary+Symbols.swift
+++ b/stdlib/public/Python/PythonLibrary+Symbols.swift
@@ -123,6 +123,14 @@ let PyDict_Next: @convention(c) (
   UnsafeMutablePointer<PyObjectPointer?>) -> Int32 =
   PythonLibrary.loadSymbol(name: "PyDict_Next")
 
+let PyIter_Next: @convention(c) (
+  PyObjectPointer) -> PyObjectPointer? =
+  PythonLibrary.loadSymbol(name: "PyIter_Next")
+
+let PyObject_GetIter: @convention(c) (
+  PyObjectPointer) -> PyObjectPointer? =
+  PythonLibrary.loadSymbol(name: "PyObject_GetIter")
+
 let PyList_New: @convention(c) (Int) -> PyObjectPointer? =
   PythonLibrary.loadSymbol(name: "PyList_New")
 

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -77,6 +77,14 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonDict") {
   expectEqual("d", dict["b"])
 }
 
+PythonRuntimeTestSuite.testWithLeakChecking("Iterator") {
+  var sum = PythonObject(0)
+  for v in Python.iter([1, 2, 3]) {
+    sum += v
+  }
+  expectEqual(6, sum)
+}
+
 PythonRuntimeTestSuite.testWithLeakChecking("Range") {
   let slice = PythonObject(5..<10)
   expectEqual(Python.slice(5, 10), slice)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds iterator support for iterating through the Python Object.

This replaces Mutable collection with the IteratorProtocol and Sequence. 


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [TF-337](https://bugs.swift.org/browse/TF-337).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
P.S. This is my first PR. 