### PR TITLE
Resolves [SR-9941] [SR-1805] remove python implicit import as it is deprecated

### DIFF
--- a/utils/update_checkout/__init__.py
+++ b/utils/update_checkout/__init__.py
@@ -1,4 +1,4 @@
 
-from update_checkout import main
+from .update_checkout import main
 
 __all__ = ["main"]

--- a/utils/update_checkout/update_checkout/__init__.py
+++ b/utils/update_checkout/update_checkout/__init__.py
@@ -1,4 +1,4 @@
 
-from update_checkout import main
+from .update_checkout import main
 
 __all__ = ["main"]


### PR DESCRIPTION
Removes usage of deprecated python sytax in update-checkout

<!-- What's in this pull request? -->
I ran into [this](https://bugs.swift.org/browse/SR-9941?) issue when building.  Looks like if you update the implicit relative imports to explicit, it will run fine on python2 & 3.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9941](https://bugs.swift.org/browse/SR-9941) and [SR-1805](https://bugs.swift.org/browse/SR-1805) which appears to be a duplicate.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
