### PR TITLE
[Stdlib] Remove a / from the comment describing the ObjC runtime name for AnyKeyPath.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -26,11 +26,11 @@ internal func _abstract(
 
 // MARK: Type-erased abstract base classes
 
-/// A type-erased key path, from any root type to any resulting value
-/// type. NOTE: older runtimes had Swift.AnyKeyPath as the ObjC name.
-/// The two must coexist, so it was renamed. The old name must not be
-/// used in the new runtime. _TtCs11_AnyKeyPath is the mangled name for
-/// Swift._AnyKeyPath.
+// A type-erased key path, from any root type to any resulting value
+// type. NOTE: older runtimes had Swift.AnyKeyPath as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtCs11_AnyKeyPath is the mangled name for
+// Swift._AnyKeyPath.
 @_objcRuntimeName(_TtCs11_AnyKeyPath)
 public class AnyKeyPath: Hashable, _AppendKeyPath {
   /// The root type for this key path.


### PR DESCRIPTION
With three /'s, it got interpreted as documentation, which it definitely is not meant to be.