### PR TITLE
[TF-86] using expectEqual to compare tensors and expected values.

### DIFF
--- a/test/TensorFlowRuntime/codable.swift
+++ b/test/TensorFlowRuntime/codable.swift
@@ -29,17 +29,7 @@ private func _testRoundTrip<T>(
   do {
     let decoder = JSONDecoder()
     let decoded = try decoder.decode(T.self, from: payload)
-
-    // NOTE: `expectEqual` cannot be called with `Tensor` arguments because it
-    // is not @inlinable and defined in another module. Calling it with
-    // `Tensor` arguments results in a crash:
-    // !!! Compiler bug -- Tensor op builtin __tfop_Equal,$in,$in,T cannot be lowered to LLVM IR !!!
-    // This bug is a challenge for graph program extraction and will surface
-    // in cross-module code (when an inlinable `Tensor` op is called from an
-    // opaque, non-inlinable context).
-    // expectEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
-
-    expectTrue(decoded == value, "\(T.self) did not round-trip to an equal value.")
+    expectEqual(value, decoded, "\(T.self) did not round-trip to an equal value.")
   } catch {
     expectUnreachable("Failed to decode \(T.self) from JSON: \(error)")
   }

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -20,13 +20,13 @@ RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
   // We must do a copy, i.e. a retain on the tensor handle, to make sure it won't
   // get double-free'd when both `zero` and `anyHandle` below go out of scope.
   cHandle = TFE_TensorHandleCopySharingTensor(cHandle, status)
-  expectEqual(TF_GetCode(status), TF_OK)
+  expectEqual(TF_OK, TF_GetCode(status))
   TF_DeleteStatus(status)
   let anyHandle = _TFCCreateTensorHandleFromC(cHandle)
   let tensor = Tensor(handle: anyHandle as! TensorHandle<Float>)
   print(tensor)
   // This line hangs in GPE
-  expectTrue(tensor == Tensor(0.0))
+  expectEqual(Tensor(0.0), tensor)
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -17,8 +17,8 @@ TensorADTests.testAllBackends("TestSimpleGrad") {
   func square(_ x: Tensor<Float>) -> Tensor<Float> {
     return x * x
   }
-  expectTrue(gradient(at: [0.1, 0.2, 0.3], in: square) == [0.2, 0.4, 0.6])
-  expectTrue(gradient(at: [[10], [20]], in: square) == [[20], [40]])
+  expectEqual([0.2, 0.4, 0.6], gradient(at: [0.1, 0.2, 0.3], in: square))
+  expectEqual([[20], [40]], gradient(at: [[10], [20]], in: square))
 }
 
 TensorADTests.testAllBackends("TestGenericGrad") {
@@ -45,45 +45,45 @@ TensorADTests.testAllBackends("TestScalarized") {
 
 TensorADTests.testAllBackends("+") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a + b }
-  expectTrue((Tensor(1), Tensor(1)) == gradient(at: Tensor(0), Tensor(0), in: f))
-  expectTrue(([1], [1]) == pullback(at: [1], [10], in: f)([1]))
+  expectEqual((Tensor(1), Tensor(1)), gradient(at: Tensor(0), Tensor(0), in: f))
+  expectEqual(([1], [1]), pullback(at: [1], [10], in: f)([1]))
 }
 
 TensorADTests.testAllBackends("-") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a - b }
-  expectTrue((Tensor(1), Tensor(-1)) == gradient(at: Tensor(0), Tensor(0), in: f))
-  expectTrue(([1], [-1]) == pullback(at: [1], [10], in: f)([1]))
+  expectEqual((Tensor(1), Tensor(-1)), gradient(at: Tensor(0), Tensor(0), in: f))
+  expectEqual(([1], [-1]), pullback(at: [1], [10], in: f)([1]))
 }
 
 TensorADTests.testAllBackends("*") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a * b }
-  expectTrue(([0], [0]) == gradient(at: [0], [0], in: f))
-  expectTrue(([10], [1]) == gradient(at: [1], [10], in: f))
+  expectEqual(([0], [0]), gradient(at: [0], [0], in: f))
+  expectEqual(([10], [1]), gradient(at: [1], [10], in: f))
 }
 
 TensorADTests.testAllBackends("/") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a / b }
-  expectTrue(([0.1], [-0.01]) == gradient(at: [1], [10], in: f))
+  expectEqual(([0.1], [-0.01]), gradient(at: [1], [10], in: f))
 }
 
 TensorADTests.testAllBackends("matmul") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in matmul(a, b) }
   let v = Tensor<Float>(ones: [1, 1])
-  expectTrue(([[0]], [[0]]) == pullback(at: [[0]], [[0]], in: f)(v))
-  expectTrue(([[10]], [[1]]) == pullback(at: [[1]], [[10]], in: f)(v))
+  expectEqual(([[0]], [[0]]), pullback(at: [[0]], [[0]], in: f)(v))
+  expectEqual(([[10]], [[1]]), pullback(at: [[1]], [[10]], in: f)(v))
 }
 
 TensorADTests.testAllBackends("•") {
   let f = { (a: Tensor<Float>, b: Tensor<Float>) in a • b }
   let v = Tensor<Float>(ones: [1, 1])
-  expectTrue(([[0]], [[0]]) == pullback(at: [[0]], [[0]], in: f)(v))
-  expectTrue(([[10]], [[1]]) == pullback(at: [[1]], [[10]], in: f)(v))
+  expectEqual(([[0]], [[0]]), pullback(at: [[0]], [[0]], in: f)(v))
+  expectEqual(([[10]], [[1]]), pullback(at: [[1]], [[10]], in: f)(v))
 }
 
 TensorADTests.testAllBackends("negate") {
   let f = { (a: Tensor<Float>) in -a }
-  expectTrue([-1] == gradient(at: [0], in: f))
-  expectTrue([-1] == gradient(at: [10], in: f))
+  expectEqual([-1], gradient(at: [0], in: f))
+  expectEqual([-1], gradient(at: [10], in: f))
 }
 
 TensorADTests.testAllBackends("sum") {
@@ -92,12 +92,12 @@ TensorADTests.testAllBackends("sum") {
   let sumPullbackAlongAxes = pullback(at: input) { (a: Tensor<Float>) in a.sum(alongAxes: 0, 1) }
 
   let expected = Tensor<Float>(ones: [2, 2])
-  expectTrue(sumPullbackScalar(Tensor(1)) == expected)
-  // expectTrue(sumPullbackSqueezingAxes(Tensor(1)) == expected)
-  expectTrue(sumPullbackAlongAxes(Tensor(1))  == expected)
-  expectTrue(sumPullbackScalar(Tensor(3)) == expected * 3)
-  // expectTrue(sumPullbackSqueezingAxes(Tensor(3)) == expected * 3)
-  expectTrue(sumPullbackAlongAxes(Tensor(3)) == expected * 3)
+  expectEqual(expected, sumPullbackScalar(Tensor(1)))
+  // expectEqual(expected, sumPullbackSqueezingAxes(Tensor(1)))
+  expectEqual(expected, sumPullbackAlongAxes(Tensor(1)))
+  expectEqual(expected * 3, sumPullbackScalar(Tensor(3)))
+  // expectEqual(expected * 3, sumPullbackSqueezingAxes(Tensor(3)))
+  expectEqual(expected * 3, sumPullbackAlongAxes(Tensor(3)))
 }
 
 TensorADTests.testAllBackends("mean") {
@@ -107,9 +107,9 @@ TensorADTests.testAllBackends("mean") {
 
   let input = Tensor<Float>(ones: [2, 2])
   let expected = Tensor<Float>(shape: [2, 2], repeating: 0.25)
-  expectTrue(meanGradScalar(input) == expected)
-  // expectTrue(meanGradSqueezingAxes(input) == expected)
-  expectTrue(meanGradAlongAxes(input) == expected)
+  expectEqual(expected, meanGradScalar(input))
+  // expectEqual(expected, meanGradSqueezingAxes(input))
+  expectEqual(expected, meanGradAlongAxes(input))
 }
 
 TensorADTests.testAllBackends("reshaped") {
@@ -117,7 +117,7 @@ TensorADTests.testAllBackends("reshaped") {
   let input = Tensor<Float>(ones: [2, 4])
   let reshapedPullback = pullback(at: input) { (a: Tensor<Float>) in a.reshaped(toShape: shapeTensor) }
   let reshaped = Tensor<Float>(ones: [2, 2, 2])
-  expectTrue(reshapedPullback(reshaped) == input)
+  expectEqual(input, reshapedPullback(reshaped))
 }
 
 TensorADTests.testAllBackends("transposed") {
@@ -127,25 +127,25 @@ TensorADTests.testAllBackends("transposed") {
   let transposedPermutationsPullback = pullback(at: input) { (a: Tensor<Float>) in a.transposed(withPermutations: [1, 0]) }
   let transposedVariadicsPullback = pullback(at: input) { (a: Tensor<Float>) in a.transposed(withPermutations: 1, 0) }
 
-  expectTrue(transposedPullback(transposed) == input)
-  expectTrue(transposedPermutationsPullback(transposed) == input)
-  expectTrue(transposedVariadicsPullback(transposed) == input)
+  expectEqual(input, transposedPullback(transposed))
+  expectEqual(input, transposedPermutationsPullback(transposed))
+  expectEqual(input, transposedVariadicsPullback(transposed))
 }
 
 TensorADTests.testAllBackends("relu") {
   let f = { (a: Tensor<Float>) in relu(a) }
-  expectTrue([1, 0, 0] == gradient(at: [5, -5, 0], in: f))
+  expectEqual([1, 0, 0], gradient(at: [5, -5, 0], in: f))
 }
 
 TensorADTests.testAllBackends("softmax") {
   let pb = pullback(at: Tensor(ones: [2, 2])) { (a: Tensor<Float>) in softmax(a) }
-  expectTrue([[0, 0], [0, 0]] == pb([[1, 1], [1, 1]]))
-  expectTrue([[-0.25, 0.25], [0.75, -0.75]] == pb([[1, 2], [4, 1]]))
+  expectEqual([[0, 0], [0, 0]], pb([[1, 1], [1, 1]]))
+  expectEqual([[-0.25, 0.25], [0.75, -0.75]], pb([[1, 2], [4, 1]]))
 }
 
 TensorADTests.testAllBackends("log_softmax") {
   let pb = pullback(at: Tensor(ones: [3, 3])) { (a: Tensor<Float>) in logSoftmax(a) }
-  expectTrue(Tensor(shape: [3, 3], repeating: 5.9604645e-08) == pb(Tensor(ones: [3, 3])))
+  expectEqual(Tensor(shape: [3, 3], repeating: 5.9604645e-08), pb(Tensor(ones: [3, 3])))
 }
 
 TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {


### PR DESCRIPTION
It's now possible to use expectEqual instead of expectTrue.
expectEqual would give better error messages in case the comparison
fails.

As well, expectEqual expects the first parameters to be the expected
value so I changed some of the statements to match this assumption.
When printing failure messages getting right expected and actual values
avoids confusions.

Resolves [TF-86](https://bugs.swift.org/browse/TF-86).