### PR TITLE
Revert "For checking deterministic compilation, do an initial "warm-u…

### DIFF
--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -74,11 +74,6 @@ def main():
     if VERBOSE:
         print("Reference compilation of " + output_file + ":")
 
-    # As a workaround for rdar://problem/43442957 and rdar://problem/43439465
-    # we have to "warm-up" the clang module cache. Without that in some cases
-    # we end up with small differences in the debug info.
-    compile_and_stat(new_args, output_file)
-
     reference_md5, reference_time = compile_and_stat(new_args, output_file)
 
     subprocess.check_call(["cp", output_file, output_file + ".ref.o"])


### PR DESCRIPTION
…p" compilation for the clang module cache."

This reverts commit 6ee1a77fa2c6caf392a8cd48dd619161be0eb0b0.

The bugs are fixed, so the workaround is no longer needed.
