### PR TITLE
[ast]/[silgen] If a case stmt is a fallthrough source, tail allocate a pointer in the case stmt to the fallthrough case.

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -26,16 +26,18 @@
 #include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
-  class AnyPattern;
-  class ASTContext;
-  class ASTWalker;
-  class Decl;
-  class Expr;
-  class FuncDecl;
-  class Pattern;
-  class PatternBindingDecl;
-  class VarDecl;
-  
+
+class AnyPattern;
+class ASTContext;
+class ASTWalker;
+class Decl;
+class Expr;
+class FuncDecl;
+class Pattern;
+class PatternBindingDecl;
+class VarDecl;
+class CaseStmt;
+
 enum class StmtKind {
 #define STMT(ID, PARENT) ID,
 #define LAST_STMT(ID) Last_Stmt = ID,
@@ -920,6 +922,45 @@ public:
   }
 };
 
+/// FallthroughStmt - The keyword "fallthrough".
+class FallthroughStmt : public Stmt {
+  SourceLoc Loc;
+  CaseStmt *FallthroughSource;
+  CaseStmt *FallthroughDest;
+
+public:
+  FallthroughStmt(SourceLoc Loc, Optional<bool> implicit = None)
+      : Stmt(StmtKind::Fallthrough, getDefaultImplicitFlag(implicit, Loc)),
+        Loc(Loc), FallthroughSource(nullptr), FallthroughDest(nullptr) {}
+
+  SourceLoc getLoc() const { return Loc; }
+
+  SourceRange getSourceRange() const { return Loc; }
+
+  /// Get the CaseStmt block from which the fallthrough transfers control.
+  /// Set during Sema. (May stay null if fallthrough is invalid.)
+  CaseStmt *getFallthroughSource() const { return FallthroughSource; }
+  void setFallthroughSource(CaseStmt *C) {
+    assert(!FallthroughSource && "fallthrough source already set?!");
+    FallthroughSource = C;
+  }
+
+  /// Get the CaseStmt block to which the fallthrough transfers control.
+  /// Set during Sema.
+  CaseStmt *getFallthroughDest() const {
+    assert(FallthroughDest && "fallthrough dest is not set until Sema");
+    return FallthroughDest;
+  }
+  void setFallthroughDest(CaseStmt *C) {
+    assert(!FallthroughDest && "fallthrough dest already set?!");
+    FallthroughDest = C;
+  }
+
+  static bool classof(const Stmt *S) {
+    return S->getKind() == StmtKind::Fallthrough;
+  }
+};
+
 /// A 'case' or 'default' block of a switch statement.  Only valid as the
 /// substatement of a SwitchStmt.  A case block begins either with one or more
 /// CaseLabelItems or a single 'default' label.
@@ -933,8 +974,10 @@ public:
 ///   default:
 /// \endcode
 ///
-class CaseStmt final : public Stmt,
-    private llvm::TrailingObjects<CaseStmt, CaseLabelItem> {
+class CaseStmt final
+    : public Stmt,
+      private llvm::TrailingObjects<CaseStmt, FallthroughStmt *,
+                                    CaseLabelItem> {
   friend TrailingObjects;
 
   SourceLoc UnknownAttrLoc;
@@ -943,23 +986,46 @@ class CaseStmt final : public Stmt,
 
   llvm::PointerIntPair<Stmt *, 1, bool> BodyAndHasBoundDecls;
 
+  /// Set to true if we have a fallthrough.
+  ///
+  /// TODO: Once we have CaseBodyVarDecls, use the bit in BodyAndHasBoundDecls
+  /// for this instead. This is separate now for staging reasons.
+  bool hasFallthrough;
+
   CaseStmt(SourceLoc CaseLoc, ArrayRef<CaseLabelItem> CaseLabelItems,
            bool HasBoundDecls, SourceLoc UnknownAttrLoc, SourceLoc ColonLoc,
-           Stmt *Body, Optional<bool> Implicit);
+           Stmt *Body, Optional<bool> Implicit,
+           NullablePtr<FallthroughStmt> fallthroughStmt);
 
 public:
-  static CaseStmt *create(ASTContext &C, SourceLoc CaseLoc,
-                          ArrayRef<CaseLabelItem> CaseLabelItems,
-                          bool HasBoundDecls, SourceLoc UnknownAttrLoc,
-                          SourceLoc ColonLoc, Stmt *Body,
-                          Optional<bool> Implicit = None);
+  static CaseStmt *
+  create(ASTContext &C, SourceLoc CaseLoc,
+         ArrayRef<CaseLabelItem> CaseLabelItems, bool HasBoundDecls,
+         SourceLoc UnknownAttrLoc, SourceLoc ColonLoc, Stmt *Body,
+         Optional<bool> Implicit = None,
+         NullablePtr<FallthroughStmt> fallthroughStmt = nullptr);
 
   ArrayRef<CaseLabelItem> getCaseLabelItems() const {
     return {getTrailingObjects<CaseLabelItem>(), Bits.CaseStmt.NumPatterns};
   }
+
   MutableArrayRef<CaseLabelItem> getMutableCaseLabelItems() {
     return {getTrailingObjects<CaseLabelItem>(), Bits.CaseStmt.NumPatterns};
   }
+
+  unsigned getNumCaseLabelItems() const { return Bits.CaseStmt.NumPatterns; }
+
+  NullablePtr<CaseStmt> getFallthroughDest() const {
+    return const_cast<CaseStmt &>(*this).getFallthroughDest();
+  }
+
+  NullablePtr<CaseStmt> getFallthroughDest() {
+    if (!hasFallthrough)
+      return nullptr;
+    return (*getTrailingObjects<FallthroughStmt *>())->getFallthroughDest();
+  }
+
+  bool hasFallthroughDest() const { return hasFallthrough; }
 
   Stmt *getBody() const { return BodyAndHasBoundDecls.getPointer(); }
   void setBody(Stmt *body) { BodyAndHasBoundDecls.setPointer(body); }
@@ -991,6 +1057,14 @@ public:
   }
 
   static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Case; }
+
+  size_t numTrailingObjects(OverloadToken<CaseLabelItem>) const {
+    return getNumCaseLabelItems();
+  }
+
+  size_t numTrailingObjects(OverloadToken<FallthroughStmt *>) const {
+    return size_t(hasFallthrough);
+  }
 };
 
 /// Switch statement.
@@ -1132,48 +1206,6 @@ public:
 
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::Continue;
-  }
-};
-
-/// FallthroughStmt - The keyword "fallthrough".
-class FallthroughStmt : public Stmt {
-  SourceLoc Loc;
-  CaseStmt *FallthroughSource;
-  CaseStmt *FallthroughDest;
-  
-public:
-  FallthroughStmt(SourceLoc Loc, Optional<bool> implicit = None)
-    : Stmt(StmtKind::Fallthrough, getDefaultImplicitFlag(implicit, Loc)),
-      Loc(Loc), FallthroughSource(nullptr), FallthroughDest(nullptr)
-  {}
-  
-  SourceLoc getLoc() const { return Loc; }
-  
-  SourceRange getSourceRange() const { return Loc; }
-
-  /// Get the CaseStmt block from which the fallthrough transfers control.
-  /// Set during Sema. (May stay null if fallthrough is invalid.)
-  CaseStmt *getFallthroughSource() const {
-    return FallthroughSource;
-  }
-  void setFallthroughSource(CaseStmt *C) {
-    assert(!FallthroughSource && "fallthrough source already set?!");
-    FallthroughSource = C;
-  }
-
-  /// Get the CaseStmt block to which the fallthrough transfers control.
-  /// Set during Sema.
-  CaseStmt *getFallthroughDest() const {
-    assert(FallthroughDest && "fallthrough dest is not set until Sema");
-    return FallthroughDest;
-  }
-  void setFallthroughDest(CaseStmt *C) {
-    assert(!FallthroughDest && "fallthrough dest already set?!");
-    FallthroughDest = C;
-  }
-  
-  static bool classof(const Stmt *S) {
-    return S->getKind() == StmtKind::Fallthrough;
   }
 };
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1063,7 +1063,7 @@ public:
   }
 
   size_t numTrailingObjects(OverloadToken<FallthroughStmt *>) const {
-    return size_t(hasFallthrough);
+    return hasFallthrough ? 1 : 0;
   }
 };
 

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -385,33 +385,44 @@ SourceLoc CaseLabelItem::getEndLoc() const {
   return CasePattern->getEndLoc();
 }
 
-CaseStmt::CaseStmt(SourceLoc CaseLoc, ArrayRef<CaseLabelItem> CaseLabelItems,
-                   bool HasBoundDecls, SourceLoc UnknownAttrLoc,
-                   SourceLoc ColonLoc, Stmt *Body, Optional<bool> Implicit)
-    : Stmt(StmtKind::Case, getDefaultImplicitFlag(Implicit, CaseLoc)),
-      UnknownAttrLoc(UnknownAttrLoc), CaseLoc(CaseLoc), ColonLoc(ColonLoc),
-      BodyAndHasBoundDecls(Body, HasBoundDecls) {
-  Bits.CaseStmt.NumPatterns = CaseLabelItems.size();
+CaseStmt::CaseStmt(SourceLoc caseLoc, ArrayRef<CaseLabelItem> caseLabelItems,
+                   bool hasBoundDecls, SourceLoc unknownAttrLoc,
+                   SourceLoc colonLoc, Stmt *body, Optional<bool> implicit,
+                   NullablePtr<FallthroughStmt> fallthroughStmt)
+    : Stmt(StmtKind::Case, getDefaultImplicitFlag(implicit, caseLoc)),
+      UnknownAttrLoc(unknownAttrLoc), CaseLoc(caseLoc), ColonLoc(colonLoc),
+      BodyAndHasBoundDecls(body, hasBoundDecls),
+      hasFallthrough(fallthroughStmt.isNonNull()) {
+  Bits.CaseStmt.NumPatterns = caseLabelItems.size();
   assert(Bits.CaseStmt.NumPatterns > 0 &&
          "case block must have at least one pattern");
-  MutableArrayRef<CaseLabelItem> Items{ getTrailingObjects<CaseLabelItem>(),
-                                        Bits.CaseStmt.NumPatterns };
 
-  for (unsigned i = 0; i < Bits.CaseStmt.NumPatterns; ++i) {
-    new (&Items[i]) CaseLabelItem(CaseLabelItems[i]);
-    Items[i].getPattern()->markOwnedByStatement(this);
+  if (hasFallthrough) {
+    *getTrailingObjects<FallthroughStmt *>() = fallthroughStmt.get();
+  }
+
+  MutableArrayRef<CaseLabelItem> items{getTrailingObjects<CaseLabelItem>(),
+                                       Bits.CaseStmt.NumPatterns};
+
+  for (unsigned i : range(Bits.CaseStmt.NumPatterns)) {
+    new (&items[i]) CaseLabelItem(caseLabelItems[i]);
+    items[i].getPattern()->markOwnedByStatement(this);
   }
 }
 
-CaseStmt *CaseStmt::create(ASTContext &C, SourceLoc CaseLoc,
-                           ArrayRef<CaseLabelItem> CaseLabelItems,
-                           bool HasBoundDecls, SourceLoc UnknownAttrLoc,
-                           SourceLoc ColonLoc, Stmt *Body,
-                           Optional<bool> Implicit) {
-  void *Mem = C.Allocate(totalSizeToAlloc<CaseLabelItem>(CaseLabelItems.size()),
-                         alignof(CaseStmt));
-  return ::new (Mem) CaseStmt(CaseLoc, CaseLabelItems, HasBoundDecls,
-                              UnknownAttrLoc, ColonLoc, Body, Implicit);
+CaseStmt *CaseStmt::create(ASTContext &ctx, SourceLoc caseLoc,
+                           ArrayRef<CaseLabelItem> caseLabelItems,
+                           bool hasBoundDecls, SourceLoc unknownAttrLoc,
+                           SourceLoc colonLoc, Stmt *body,
+                           Optional<bool> implicit,
+                           NullablePtr<FallthroughStmt> fallthroughStmt) {
+  void *mem =
+      ctx.Allocate(totalSizeToAlloc<FallthroughStmt *, CaseLabelItem>(
+                       fallthroughStmt.isNonNull(), caseLabelItems.size()),
+                   alignof(CaseStmt));
+  return ::new (mem)
+      CaseStmt(caseLoc, caseLabelItems, hasBoundDecls, unknownAttrLoc, colonLoc,
+               body, implicit, fallthroughStmt);
 }
 
 SwitchStmt *SwitchStmt::create(LabeledStmtInfo LabelInfo, SourceLoc SwitchLoc,


### PR DESCRIPTION
The second commit uses this in SILGenPattern in a trivial way to show that everything works.