### PR TITLE
Start using best resilience expansion in SIL

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -956,9 +956,8 @@ bool SILGenModule::hasNonTrivialIVars(ClassDecl *cd) {
     auto *vd = dyn_cast<VarDecl>(member);
     if (!vd || !vd->hasStorage()) continue;
 
-    // FIXME: Expansion
     auto &ti = Types.getTypeLowering(vd->getType(),
-                                     ResilienceExpansion::Minimal);
+                                     ResilienceExpansion::Maximal);
     if (!ti.isTrivial())
       return true;
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3313,6 +3313,7 @@ lowerKeyPathSubscriptIndexTypes(
                  SmallVectorImpl<IndexTypePair> &indexPatterns,
                  SubscriptDecl *subscript,
                  SubstitutionMap subscriptSubs,
+                 ResilienceExpansion expansion,
                  bool &needsGenericContext) {
   // Capturing an index value dependent on the generic context means we
   // need the generic context captured in the key path.
@@ -3330,11 +3331,9 @@ lowerKeyPathSubscriptIndexTypes(
       indexTy = indexTy.subst(subscriptSubs);
     }
 
-    // FIXME: Expansion
     auto indexLoweredTy = SGM.Types.getLoweredType(
                                                 AbstractionPattern::getOpaque(),
-                                                indexTy,
-                                                ResilienceExpansion::Minimal);
+                                                indexTy, expansion);
     indexLoweredTy = indexLoweredTy.mapTypeOutOfContext();
     indexPatterns.push_back({indexTy->mapTypeOutOfContext()
                                     ->getCanonicalType(),
@@ -3531,6 +3530,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     SmallVector<IndexTypePair, 4> indexTypes;
     lowerKeyPathSubscriptIndexTypes(*this, indexTypes,
                                     decl, subs,
+                                    expansion,
                                     needsGenericContext);
     
     SmallVector<KeyPathPatternComponent::Index, 4> indexPatterns;

--- a/test/SILGen/ivar_destroyer_resilience.swift
+++ b/test/SILGen/ivar_destroyer_resilience.swift
@@ -1,0 +1,39 @@
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -enable-sil-ownership %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-emit-silgen -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
+
+import resilient_struct
+
+public class Base {}
+
+public struct MyResilientInt {
+  var i: Int
+
+  public init(i: Int) { self.i = i }
+}
+
+public class NeedsIVarDetroyer : Base {
+  var x = ResilientInt(i: 0)
+}
+
+public class DoesNotNeedIVarDestroyer : Base {
+  var x = MyResilientInt(i: 0)
+}
+
+// CHECK-LABEL: sil_vtable NeedsIVarDetroyer {
+// CHECK-NEXT: #Base.init!allocator.1: (Base.Type) -> () -> Base
+// CHECK-NEXT: #NeedsIVarDetroyer.x!getter.1: (NeedsIVarDetroyer) -> () -> resilient_struct.ResilientInt
+// CHECK-NEXT: #NeedsIVarDetroyer.x!setter.1: (NeedsIVarDetroyer) -> (resilient_struct.ResilientInt) -> ()
+// CHECK-NEXT: #NeedsIVarDetroyer.x!modify.1: (NeedsIVarDetroyer) -> () -> ()
+// CHECK-NEXT: #NeedsIVarDetroyer.deinit!deallocator.1
+// CHECK-NEXT: #NeedsIVarDetroyer!ivardestroyer.1
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable DoesNotNeedIVarDestroyer {
+// CHECK-NEXT: #Base.init!allocator.1: (Base.Type) -> () -> Base
+// CHECK-NEXT: #DoesNotNeedIVarDestroyer.x!getter.1: (DoesNotNeedIVarDestroyer) -> () -> MyResilientInt
+// CHECK-NEXT: #DoesNotNeedIVarDestroyer.x!setter.1: (DoesNotNeedIVarDestroyer) -> (MyResilientInt) -> ()
+// CHECK-NEXT: #DoesNotNeedIVarDestroyer.x!modify.1: (DoesNotNeedIVarDestroyer) -> () -> ()
+// CHECK-NEXT: #DoesNotNeedIVarDestroyer.deinit!deallocator.1
+// CHECK-NEXT: }


### PR DESCRIPTION
Follow-up to #23263.

Peeling patches from https://github.com/apple/swift/pull/23170 to identify the code size regression. These are the first two patches in the series that actually change behavior; they should have minimal impact either way though.

rdar://problem/24057844, https://bugs.swift.org/browse/SR-261.