### PR TITLE
IRGen: Use maximal resilience expansion to lower SIL types

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1434,29 +1434,25 @@ const TypeInfo &IRGenFunction::getTypeInfo(SILType T) {
 
 /// Return the SIL-lowering of the given type.
 SILType IRGenModule::getLoweredType(AbstractionPattern orig, Type subst) const {
-  // FIXME: Expansion
   return getSILTypes().getLoweredType(orig, subst,
-                                      ResilienceExpansion::Minimal);
+                                      ResilienceExpansion::Maximal);
 }
 
 /// Return the SIL-lowering of the given type.
 SILType IRGenModule::getLoweredType(Type subst) const {
-  // FIXME: Expansion
   return getSILTypes().getLoweredType(subst,
-                                      ResilienceExpansion::Minimal);
+                                      ResilienceExpansion::Maximal);
 }
 
 /// Return the SIL-lowering of the given type.
 const Lowering::TypeLowering &IRGenModule::getTypeLowering(SILType type) const {
-  // FIXME: Expansion
   return getSILTypes().getTypeLowering(type,
-                                       ResilienceExpansion::Minimal);
+                                       ResilienceExpansion::Maximal);
 }
 
 bool IRGenModule::isTypeABIAccessible(SILType type) const {
-  // FIXME: Expansion
   return getSILModule().isTypeABIAccessible(type,
-                                            ResilienceExpansion::Minimal);
+                                            ResilienceExpansion::Maximal);
 }
 
 /// Get a pointer to the storage type for the given type.  Note that,


### PR DESCRIPTION
Follow-up to #23263.

Peeling patches from #23170 to identify the code size regression.

rdar://problem/24057844, https://bugs.swift.org/browse/SR-261.