### PR TITLE
[AutoDiff][TF] Add derivative for `abs`.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -361,6 +361,14 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
 }
 
 @inlinable
+func _vjpAbs<T : TensorFlowFloatingPoint>(
+  _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+  let sign = Raw.sign(x)
+  return (abs(x), { v in v * sign })
+}
+
+@inlinable
 func _vjpLog<T : TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -781,6 +781,7 @@ public extension Tensor where Scalar : SignedNumeric {
 
 /// Computes the absolute value of the specified tensor element-wise.
 @inlinable @inline(__always)
+@differentiable(vjp: _vjpAbs(_:) where T : TensorFlowFloatingPoint)
 public func abs<T : SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.abs(x)
 }

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -86,6 +86,11 @@ TensorADTests.testAllBackends("negate") {
   expectEqual([-1], gradient(at: [10], in: f))
 }
 
+TensorADTests.testAllBackends("Abs") {
+  let f = { (a: Tensor<Float>) in abs(a) }
+  expectEqual([1, -1, 0], gradient(at: [3.0, -3.0, 0], in: f))
+}
+
 TensorADTests.testAllBackends("sum") {
   let input = Tensor<Float>(shape: [2, 2], repeating: 42)
   let sumPullbackScalar = pullback(at: input) { (a: Tensor<Float>) in a.sum() }


### PR DESCRIPTION
Resolves [TF-349](https://bugs.swift.org/browse/TF-349).