### PR TITLE
Fix FixedArray.swift.gyb typo

### DIFF
--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -22,7 +22,7 @@
 % for N in sizes:
 
 internal struct _FixedArray${N}<T> {
-  // ABI TODO: The has assumptions about tuple layout in the ABI, namely that
+  // ABI TODO: This makes assumptions about tuple layout in the ABI, namely that
   // they are laid out contiguously and individually addressable (i.e. strided).
   //
   internal var storage: (


### PR DESCRIPTION
This contains a typo fix in a code comment.