### PR TITLE
[CodeCompletion] Fix an assertion failure

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1948,6 +1948,10 @@ public:
         if (!MaybeNominalType->mayHaveMembers())
           return T;
 
+        // We can't do anything if the base type has unbound generic parameters.
+        if (MaybeNominalType->hasUnboundGenericType())
+          return T;
+
         // For everything else, substitute in the base type.
         auto Subs = MaybeNominalType->getMemberSubstitutionMap(M, VD);
 

--- a/validation-test/IDE/crashers_2_fixed/rdar48896424.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar48896424.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+class Foo<T> {
+}
+
+extension Foo where T: Comparable {
+  func foo() {}
+}
+
+protocol P {
+  typealias alias = Foo
+}
+protocol P {}
+
+func Test() {
+  P.alias.#^COMPLETE^#
+}


### PR DESCRIPTION
If the type has unbound generic parameter, we cannot substitute types for member decls.

rdar://problem/48896424
