### PR TITLE
[test] Tweak check-is-forwarding-module.py to handle multiple inputs

### DIFF
--- a/test/ParseableInterface/ModuleCache/Inputs/check-is-forwarding-module.py
+++ b/test/ParseableInterface/ModuleCache/Inputs/check-is-forwarding-module.py
@@ -1,7 +1,8 @@
 import sys
 
-with open(sys.argv[1], 'r') as yaml_file:
-    # Forwarding files are YAML files that start with '---'
-    if yaml_file.read(3) != '---':
-        print("swiftmodule '%s' is not a forwarding module!")
-        sys.exit(1)
+for input_path in sys.argv[1:]:
+    with open(input_path, 'r') as yaml_file:
+        # Forwarding files are YAML files that start with '---'
+        if yaml_file.read(3) != '---':
+            print("swiftmodule '%s' is not a forwarding module!" % input_path)
+            sys.exit(1)


### PR DESCRIPTION
And fix the error message printing while I'm at it.

I don't have a public test for this at the moment, but a test for an Apple-internal tool will use it. I hope to upstream that tool in the future.