### PR TITLE
[5.1] Search for SwiftShims in SDK (#23287)

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -424,6 +424,17 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     });
   }
 
+  // If there are no shims in the resource dir, add a search path in the SDK.
+  SmallString<128> shimsPath(searchPathOpts.RuntimeResourcePath);
+  llvm::sys::path::append(shimsPath, "shims");
+  if (!llvm::sys::fs::exists(shimsPath)) {
+    shimsPath = searchPathOpts.SDKPath;
+    llvm::sys::path::append(shimsPath, "usr", "lib", "swift", "shims");
+    invocationArgStrs.insert(invocationArgStrs.end(), {
+      "-isystem", shimsPath.str()
+    });
+  }
+
   // Construct the invocation arguments for the current target.
   // Add target-independent options first.
   invocationArgStrs.insert(invocationArgStrs.end(), {

--- a/test/Serialization/runtime-import-from-sdk.swift
+++ b/test/Serialization/runtime-import-from-sdk.swift
@@ -5,18 +5,25 @@
 // resource directory will contain a swiftmodule for the standard library.
 
 // %t/good-sdk contains a loadable standard library.
+// RUN: %empty-directory(%t/good-sdk)
 // RUN: %empty-directory(%t/good-sdk/usr/lib/swift)
 // RUN: cp -r %platform-module-dir/Swift.swiftmodule %t/good-sdk/usr/lib/swift/Swift.swiftmodule
 
 // %t/bad-sdk contains an invalid standard library that cannot be loaded.
+// RUN: %empty-directory(%t/bad-sdk)
 // RUN: %empty-directory(%t/bad-sdk/usr/lib/swift/Swift.swiftmodule)
 // RUN: touch %t/bad-sdk/usr/lib/swift/Swift.swiftmodule/garbage-garbage-garbage.swiftmodule
 
 // %t/empty-toolchain does not contain a standard library.
+// RUN: %empty-directory(%t/empty-toolchain)
 // RUN: %empty-directory(%t/empty-toolchain/usr/lib/swift)
 
 // FIXME: Until we have private imports, we need SwiftShims in the toolchain.
 // RUN: cp -r %test-resource-dir/shims %t/empty-toolchain/usr/lib/swift/shims
+
+// %t/really-empty-toolchain does not contain a standard library or SwiftShims.
+// RUN: %empty-directory(%t/really-empty-toolchain)
+// RUN: %empty-directory(%t/really-empty-toolchain/usr/lib/swift)
 
 // If the compiler's resource directory does not contain a runtime swiftmodule,
 // we should fall back to the SDK.
@@ -34,6 +41,9 @@
 // If neither the resource directory nor the SDK contains a runtime swiftmodule,
 // loading should fail. This just proves that we aren't getting runtime imports
 // some other way.
+//
+// We also check that ClangImporter noticed SwiftShims in the toolchain and
+// didn't add a -isystem flag to look in the SDK.
 
 // FIXME: We can't properly test this on a non-Darwin platform because we'll get
 // the same error message for "unloadable standard library" and "no standard
@@ -41,7 +51,16 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t/mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-sdk) -resource-dir %t/empty-toolchain/usr/lib/swift -module-cache-path %t/mcp -typecheck %s 2>&1 | %FileCheck %s
-// CHECK: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-sdk) -resource-dir %t/empty-toolchain/usr/lib/swift -module-cache-path %t/mcp -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck --check-prefix CHECK-EMPTY %s
+// CHECK-EMPTY-NOT: '-isystem' '{{.*}}/bad-sdk/usr/lib/swift/shims'
+// CHECK-EMPTY: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage
+
+// Check that, when the toolchain *doesn't* have SwiftShims in it, ClagImporter
+// *does* add a -I flag to look in the SDK.
+
+// RUN: %empty-directory(%t/mcp)
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-sdk) -resource-dir %t/really-empty-toolchain/usr/lib/swift -module-cache-path %t/mcp -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck --check-prefix CHECK-REALLY-EMPTY %s
+// CHECK-REALLY-EMPTY: '-isystem' '{{.*}}/bad-sdk/usr/lib/swift/shims'
+// CHECK-REALLY-EMPTY: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage
 
 let x: Int = 1


### PR DESCRIPTION
…but only if the compiler resource directory doesn’t have them. These will move to the SDK soon.

Resolves rdar://problem/48865477.