### PR TITLE
test: create a stub BlocksRuntime for the tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -195,6 +195,29 @@ foreach(SDK ${SWIFT_SDKS})
 
     set(test_dependencies)
     get_test_dependencies("${SDK}" test_dependencies)
+
+    # NOTE create a stub BlocksRuntime library that can be used for the
+    # reflection tests
+    file(WRITE ${test_bin_dir}/BlocksRuntime.c
+      "void
+#if defined(_WIN32)
+__declspec(dllexport)
+#endif
+_Block_release(void) { }\n")
+    add_library(BlocksRuntimeStub-${SDK}-${ARCH} SHARED
+      ${test_bin_dir}/BlocksRuntime.c)
+    if(CMAKE_C_COMPILER_ID STREQUAL Clang AND
+        NOT CMAKE_C_COMPILER_SIMULATE_ID STREQUAL MSVC)
+      target_compile_options(BlocksRuntimeStub-${SDK}-${ARCH} PRIVATE
+        -target;${SWIFT_SDK_${SDK}_ARCH_${ARCH}_TRIPLE})
+    endif()
+    set_target_properties(BlocksRuntimeStub-${SDK}-${ARCH} PROPERTIES
+      ARCHIVE_OUTPUT_DIRECTORY ${test_bin_dir}
+      LIBRARY_OUTPUT_DIRECTORY ${test_bin_dir}
+      RUNTIME_OUTPUT_DIRECTORY ${test_bin_dir}
+      OUTPUT_NAME BlocksRuntime)
+    list(APPEND test_dependencies BlocksRuntimeStub-${SDK}-${ARCH})
+
     list(APPEND test_dependencies
         "swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
 

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -1,7 +1,7 @@
 
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix}
+// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix} -L%t/../../.. -lBlocksRuntime
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
 sil_stage canonical


### PR DESCRIPTION
This is needed primarily for Windows which has the same semantics as
ELF's `-z defs`.  Provide a stub that will fulfill the dependency.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
