### PR TITLE
Shrink AST DenseMaps

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2332,7 +2332,9 @@ enum class MetatypeRepresentation : char {
   /// which permit dynamic behavior.
   Thick,
   /// An Objective-C metatype refers to an Objective-C class object.
-  ObjC
+  ObjC,
+
+  Last_MetatypeRepresentation = ObjC
 };
 
 /// AnyMetatypeType - A common parent class of MetatypeType and


### PR DESCRIPTION
Memory saves are generally good. Also, searching a DenseMap for a `llvm::PointerIntPair` is slightly faster than a `std:pair`.