### PR TITLE
Fix bug where inlined scopes where being inlined twice for codeview

### DIFF
--- a/test/DebugInfo/doubleinlines.swift
+++ b/test/DebugInfo/doubleinlines.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -parse-stdlib \
+// RUN: -debug-info-format=codeview -O -parse-as-library \
+// RUN: -module-name DoubleInlines -o - | %FileCheck %s
+
+func condFail(arg: Builtin.Int1 ) {
+    Builtin.condfail(arg)
+}
+
+func callCondFail(arg: Builtin.Int1) {
+    condFail(arg: arg)
+}
+
+// CHECK: define hidden swiftcc void @"$s13DoubleInlines12callCondFail3argyBi1__tF"{{.*}} !dbg ![[FUNCSCOPE:.*]] {
+// CHECK: tail call void asm sideeffect "", "n"(i32 0) #3, !dbg ![[SCOPEONE:.*]]
+// CHECK: ![[FUNCSCOPEOTHER:.*]] = distinct !DISubprogram(name: "condFail",{{.*}}
+// CHECK: ![[SCOPEFIVE:.*]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPE]], file: ![[FILE:.*]], line: 9)
+// CHECK: ![[SCOPESIX:.*]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPEOTHER]], file: ![[FILE]], line: 5)
+// CHECK: ![[SCOPEONE]] = !DILocation(line: 0, scope: ![[SCOPETWO:.*]], inlinedAt: ![[SCOPETHREE:.*]])
+// CHECK: ![[SCOPETHREE]] = !DILocation(line: 6, scope: ![[SCOPEFOUR:.*]])
+// CHECK: ![[SCOPEFOUR]] = distinct !DILexicalBlock(scope: ![[SCOPEFIVE]], file: ![[FILE]], line: 10)


### PR DESCRIPTION
    A workaround in codeview debuginfo generation was to declare a condfail
    instruction as inlined to avoid using 0 as an artificial line location.

    However, this was done without accounting for scopes that were already
    legitimately inlined. So we'd end up with a condfail inlined from
    function B into function A and then the IRGen for the condfail was
    being given a debugloc claiming to have been inlined again. This was
    causing a sitaution where we'd have debug info forfunctionA owning an
    instruction which claimed it was owned by a different function.

    Fix this by first checking if the `LastScope` was already inlined and,
    if so, just used that scope instead.