### PR TITLE
Windows: Close Handle after Resolving Symlinks

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -859,6 +859,7 @@ std::string SwiftLangSupport::resolvePathSymlinks(StringRef FilePath) {
 
   DWORD success = GetFinalPathNameByHandleA(
       fileHandle, full_path, sizeof(full_path), FILE_NAME_NORMALIZED);
+  CloseHandle(fileHandle);
   return (success ? full_path : InputPath);
 #endif
 }


### PR DESCRIPTION
Calling resolvePathSymlinks twice on the same path failed with a sharing
exception due to the old handle still being help.