### PR TITLE
make TensorHandle Scalar @usableFromInline

### DIFF
--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -241,7 +241,7 @@ extension ResourceHandle : TensorSendableReceivable {
 
   // TODO: Remove this dummy `Scalar` typealias, currently required in order to
   // conform to `TensorSendableReceivable`.
-  typealias Scalar = Float
+  @usableFromInline typealias Scalar = Float
   @inlinable
   static func scalar(_ scalar: Scalar) -> ResourceHandle {
     fatalError("Unsupported")
@@ -294,7 +294,7 @@ extension VariantHandle : TensorSendableReceivable {
 
   // TODO: Remove this dummy `Scalar` typealias, currently required in order to
   // conform to `TensorSendableReceivable`.
-  typealias Scalar = Float
+  @usableFromInline typealias Scalar = Float
   @inlinable
   static func scalar(_ scalar: Scalar) -> VariantHandle {
     fatalError("Unsupported")


### PR DESCRIPTION
This is causing an error in Piper:
```
error: type alias 'Scalar' is internal and cannot be referenced from an '@inlinable' function
```
