### PR TITLE
WinSDK: add convenience conversions for FILETIME/time_t

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -71,3 +71,17 @@ public let TOOLBARW_CLASSW: [WCHAR] = Array<WCHAR>("ToolbarWindow32".utf16)
 public let TRACKBAR_CLASSW: [WCHAR] = Array<WCHAR>("msctls_trackbar32".utf16)
 public let UPDOWN_CLASSW: [WCHAR] = Array<WCHAR>("msctls_updown32".utf16)
 
+// Swift Convenience
+public extension FILETIME {
+  var time_t: time_t {
+    let NTTime: Int64 = Int64(self.dwLowDateTime) | (Int64(self.dwHighDateTime) << 32)
+    return (NTTime - 116444736000000000) / 10000000
+  }
+
+  init(from time: time_t) {
+    let UNIXTime: Int64 = ((time * 10000000) + 116444736000000000)
+    self = FILETIME(dwLowDateTime: DWORD(UNIXTime & 0xffffffff),
+                    dwHighDateTime: DWORD((UNIXTime >> 32) & 0xffffffff))
+  }
+}
+


### PR DESCRIPTION
This conversion is error prone and pretty common.  Provide a helper
initializer and conversion through a getter.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
