### PR TITLE
 [Demangle] Check for old-style mangling in getObjCClassByMangledName

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -839,7 +839,7 @@ func _childProcess() {
     var stderr = _Stderr()
     print("\(_stdlibUnittestStreamPrefix);end", to: &stderr)
 
-    if !testSuite._testByName(testName).canReuseChildProcessAfterTest {
+    if testSuite._shouldShutDownChildProcess(forTestNamed: testName) {
       return
     }
   }
@@ -1107,7 +1107,7 @@ class _ParentProcess {
     // Check if the child has sent us "end" markers for the current test.
     if stdoutEnd && stderrEnd {
       var status: ProcessTerminationStatus?
-      if !testSuite._testByName(testName).canReuseChildProcessAfterTest {
+      if testSuite._shouldShutDownChildProcess(forTestNamed: testName) {
         status = _waitForChild()
         switch status! {
         case .exit(0):
@@ -1147,7 +1147,11 @@ class _ParentProcess {
       return (failed: false, ())
     }
 #endif
-    print("\(_stdlibUnittestStreamPrefix);shutdown", to: &_childStdin)
+    // If the child process expects an EOF, its stdin fd has already been closed and
+    // it will shut itself down automatically.
+    if !_childStdin.isClosed {
+      print("\(_stdlibUnittestStreamPrefix);shutdown", to: &_childStdin)
+    }
 
     var childCrashed = false
 
@@ -1208,6 +1212,9 @@ class _ParentProcess {
     if _runTestsInProcess {
       if t.stdinText != nil {
         print("The test \(fullTestName) requires stdin input and can't be run in-process, marking as failed")
+        _anyExpectFailed = true
+      } else if t.requiresOwnProcess {
+        print("The test \(fullTestName) requires running in a child process and can't be run in-process, marking as failed.")
         _anyExpectFailed = true
       } else {
         _anyExpectFailed = false
@@ -1550,6 +1557,17 @@ public final class TestSuite {
     return _tests[_testNameToIndex[testName]!]
   }
 
+  /// Determines if we should shut down the current test process, i.e. if this
+  /// test or the next test requires executing in its own process.
+  func _shouldShutDownChildProcess(forTestNamed testName: String) -> Bool {
+    let index = _testNameToIndex[testName]!
+    if index == _tests.count - 1 { return false }
+    let currentTest = _tests[index]
+    let nextTest = _tests[index + 1]
+    if !currentTest.canReuseChildProcessAfterTest { return true }
+    return currentTest.requiresOwnProcess || nextTest.requiresOwnProcess
+  }
+
   internal enum _TestCode {
     case single(code: () -> Void)
     case parameterized(code: (Int) -> Void, count: Int)
@@ -1564,6 +1582,7 @@ public final class TestSuite {
     let stdinEndsWithEOF: Bool
     let crashOutputMatches: [String]
     let code: _TestCode
+    let requiresOwnProcess: Bool
 
     /// Whether the test harness should stop reusing the child process after
     /// running this test.
@@ -1601,6 +1620,7 @@ public final class TestSuite {
       var _stdinEndsWithEOF: Bool = false
       var _crashOutputMatches: [String] = []
       var _testLoc: SourceLoc?
+      var _requiresOwnProcess: Bool = false
     }
 
     init(testSuite: TestSuite, name: String, loc: SourceLoc) {
@@ -1630,6 +1650,11 @@ public final class TestSuite {
       return self
     }
 
+    public func requireOwnProcess() -> _TestBuilder {
+      _data._requiresOwnProcess = true
+      return self
+    }
+
     internal func _build(_ testCode: _TestCode) {
       _testSuite._tests.append(
         _Test(
@@ -1638,7 +1663,8 @@ public final class TestSuite {
           stdinText: _data._stdinText,
           stdinEndsWithEOF: _data._stdinEndsWithEOF,
           crashOutputMatches: _data._crashOutputMatches,
-          code: testCode))
+          code: testCode,
+          requiresOwnProcess: _data._requiresOwnProcess))
       _testSuite._testNameToIndex[_name] = _testSuite._tests.count - 1
     }
 

--- a/test/Inputs/resilient_objc_class.swift
+++ b/test/Inputs/resilient_objc_class.swift
@@ -1,0 +1,68 @@
+
+import resilient_struct
+import Foundation
+
+
+// Resilient base class
+
+open class ResilientNSObjectOutsideParent: NSObject {
+  open var property: String = "ResilientNSObjectOutsideParent.property"
+  public final var finalProperty: String = "ResilientNSObjectOutsideParent.finalProperty"
+
+  open class var classProperty: String {
+    return "ResilientNSObjectOutsideParent.classProperty"
+  }
+
+  override public init() {
+    print("ResilientNSObjectOutsideParent.init()")
+  }
+
+  open func method() {
+    print("ResilientNSObjectOutsideParent.method()")
+  }
+
+  open class func classMethod() {
+    print("ResilientNSObjectOutsideParent.classMethod()")
+  }
+
+  open func getValue() -> Int {
+    return 0
+  }
+}
+
+// Resilient generic base class
+
+open class ResilientGenericNSObjectOutsideParent<A>: NSObject {
+  open var property: A
+  public init(property: A) {
+    self.property = property
+    print("ResilientGenericNSObjectOutsideParent.init()")
+  }
+
+  open func method() {
+    print("ResilientGenericNSObjectOutsideParent.method()")
+  }
+
+  open class func classMethod() {
+    print("ResilientGenericNSObjectOutsideParent.classMethod()")
+  }
+}
+
+// Resilient subclass of generic class
+
+open class ResilientConcreteNSObjectOutsideChild : ResilientGenericNSObjectOutsideParent<String> {
+  public override init(property: String) {
+    print("ResilientConcreteNSObjectOutsideChild.init(property: String)")
+    super.init(property: property)
+  }
+
+  open override func method() {
+    print("ResilientConcreteNSObjectOutsideChild.method()")
+    super.method()
+  }
+
+  open override class func classMethod() {
+    print("ResilientConcreteNSObjectOutsideChild.classMethod()")
+    super.classMethod()
+  }
+}

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -6,10 +6,13 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_class)) -Xfrontend -enable-resilience %S/../../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_class)
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_objc_class)) -Xfrontend -enable-resilience %S/../../Inputs/resilient_objc_class.swift -emit-module -emit-module-path %t/resilient_objc_class.swiftmodule -module-name resilient_objc_class -I%t -L%t -lresilient_struct
+// RUN: %target-codesign %t/%target-library-name(resilient_objc_class)
+
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -lresilient_objc_class -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/libresilient_class%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/libresilient_class%{target-shared-library-suffix} %t/libresilient_objc_class%{target-shared-library-suffix}
 
 
 // REQUIRES: executable_test
@@ -22,6 +25,7 @@ import ObjectiveC
 import Foundation
 import resilient_struct
 import resilient_class
+import resilient_objc_class
 
 // Old OS versions do not have this hook.
 let getClassHookMissing = {
@@ -110,6 +114,19 @@ class ResilientFieldSubclassObjC : ResilientFieldSuperclassObjC {
   var subvalue = ResilientInt(i: 4)
 }
 
+class ResilientSubclassOfNSObject :  ResilientNSObjectOutsideParent {
+  var subvalue = ResilientInt(i: 5)
+}
+
+class ResilientSubclassOfGenericNSObject :  ResilientGenericNSObjectOutsideParent<Int> {
+  var subvalue = ResilientInt(i: 6)
+  init() { super.init(property: 0) }
+}
+
+class ResilientSubclassOfConcreteNSObject :  ResilientConcreteNSObjectOutsideChild {
+  var subvalue = ResilientInt(i: 7)
+  init() { super.init(property: "") }
+}
 
 func requireClass(named name: String, demangledName: String) {
   for _ in 1...2 {
@@ -124,14 +141,18 @@ func requireClass(named name: String) {
   return requireClass(named: name, demangledName: name)
 }
 
-testSuite.test("Basic") {
+testSuite.test("Basic")
+  .requireOwnProcess()
+  .code {
   requireClass(named: "main.SwiftSubclass")
   requireClass(named: "main.SwiftSuperclass")
   requireClass(named: "main.ObjCSubclass")
   requireClass(named: "main.ObjCSuperclass")
 }
 
-testSuite.test("BasicMangled") {
+testSuite.test("BasicMangled")
+  .requireOwnProcess()
+  .code {
   requireClass(named:   "_TtC4main20MangledSwiftSubclass",
                demangledName: "main.MangledSwiftSubclass")
   requireClass(named:   "_TtC4main22MangledSwiftSuperclass",
@@ -145,6 +166,7 @@ testSuite.test("BasicMangled") {
 testSuite.test("Generic")
   .skip(.custom({ getClassHookMissing },
                 reason: "objc_getClass hook not present"))
+  .requireOwnProcess()
   .code {
   requireClass(named: "main.ConstrainedSwiftSubclass")
   requireClass(named: "main.ConstrainedSwiftSuperclass")
@@ -155,6 +177,7 @@ testSuite.test("Generic")
 testSuite.test("GenericMangled")
   .skip(.custom({ getClassHookMissing },
                 reason: "objc_getClass hook not present"))
+  .requireOwnProcess()
   .code {
   requireClass(named:   "_TtC4main24ConstrainedSwiftSubclass",
                demangledName: "main.ConstrainedSwiftSubclass")
@@ -169,6 +192,7 @@ testSuite.test("GenericMangled")
 testSuite.test("ResilientSubclass")
   .skip(.custom({ getClassHookMissing },
                 reason: "objc_getClass hook not present"))
+  .requireOwnProcess()
   .code {
   requireClass(named: "main.ResilientSubclass")
   requireClass(named: "main.ResilientSuperclass")
@@ -181,6 +205,7 @@ testSuite.test("ResilientSubclass")
 testSuite.test("ResilientField")
   .skip(.custom({ getClassHookMissing },
                 reason: "objc_getClass hook not present"))
+  .requireOwnProcess()
   .code {
   requireClass(named: "main.ResilientFieldSubclassSwift")
   requireClass(named: "main.ResilientFieldSuperclassSwift")
@@ -195,6 +220,23 @@ testSuite.test("ResilientField")
   expectEqual(ResilientFieldSubclassObjC().subvalue.i, 4)
 }
 
+testSuite.test("ResilientNSObject")
+  .skip(.custom({ getClassHookMissing },
+                reason: "objc_getClass hook not present"))
+  .requireOwnProcess()
+  .code {
+  requireClass(named: "_TtC4main27ResilientSubclassOfNSObject",
+               demangledName: "main.ResilientSubclassOfNSObject")
+  requireClass(named: "_TtC4main34ResilientSubclassOfGenericNSObject",
+               demangledName: "main.ResilientSubclassOfGenericNSObject")
+  requireClass(named: "_TtC4main35ResilientSubclassOfConcreteNSObject",
+               demangledName: "main.ResilientSubclassOfConcreteNSObject")
+
+  expectEqual(ResilientSubclassOfNSObject().subvalue.i, 5)
+  expectEqual(ResilientSubclassOfGenericNSObject().subvalue.i, 6)
+  expectEqual(ResilientSubclassOfConcreteNSObject().subvalue.i, 7)
+}
+
 testSuite.test("NotPresent") {
   // This class does not exist.
   expectNil(NSClassFromString("main.ThisClassDoesNotExist"));
@@ -207,4 +249,3 @@ testSuite.test("NotPresent") {
 }
 
 runAllTests()
-

--- a/validation-test/StdlibUnittest/ChildProcessShutdown/RequireOwnProcess.swift
+++ b/validation-test/StdlibUnittest/ChildProcessShutdown/RequireOwnProcess.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+#else
+#error("Unsupported platform")
+#endif
+
+//
+// Test that a test runs in its own child process if asked.
+//
+
+enum Globals {
+  static var modifiedByChildProcess = false
+}
+
+var TestSuiteRequireNewProcess = TestSuite("TestSuiteRequireNewProcess")
+
+TestSuiteRequireNewProcess.test("RequireOwnProcessBefore")
+  .code {
+  Globals.modifiedByChildProcess = true
+}
+
+TestSuiteRequireNewProcess.test("RequireOwnProcess")
+  .requireOwnProcess()
+  .code {
+  expectEqual(false, Globals.modifiedByChildProcess)
+  Globals.modifiedByChildProcess = true
+}
+
+TestSuiteRequireNewProcess.test("ShouldNotReusePreviousProcess") {
+  expectEqual(false, Globals.modifiedByChildProcess)
+}
+
+runAllTests()


### PR DESCRIPTION
This caused an issue where the runtime was unable to find subclasses of resilient subclasses of NSObject until they were first registered by their sugared name with NSClassFromString or were instantiated directly.

rdar://48892003