### PR TITLE
[5.1] [ParseableInterfaces] Preserve -enforce-exclusivity in interface args

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -856,7 +856,8 @@ def index_ignore_system_modules : Flag<["-"], "index-ignore-system-modules">,
   HelpText<"Avoid indexing system modules">;
 
 def enforce_exclusivity_EQ : Joined<["-"], "enforce-exclusivity=">,
-  Flags<[FrontendOption]>, MetaVarName<"<enforcement>">,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  MetaVarName<"<enforcement>">,
   HelpText<"Enforce law of exclusivity">;
 
 def working_directory : Separate<["-"], "working-directory">,

--- a/test/ParseableInterface/option-preservation.swift
+++ b/test/ParseableInterface/option-preservation.swift
@@ -1,20 +1,22 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-resilience -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null -Onone
+// RUN: %target-swift-frontend -enable-resilience -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE: swift-module-flags:
 // CHECK-SWIFTINTERFACE-SAME: -enable-resilience
 // CHECK-SWIFTINTERFACE-SAME: -Onone
+// CHECK-SWIFTINTERFACE-SAME: -enforce-exclusivity=unchecked
 
 // Make sure flags show up when filelists are enabled
 
-// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation -Ounchecked 2>&1
+// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation -Ounchecked -enforce-exclusivity=unchecked 2>&1
 // RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
 
 // CHECK-FILELIST-INTERFACE: swift-module-flags:
 // CHECK-FILELIST-INTERFACE-SAME: -target
 // CHECK-FILELIST-INTERFACE-SAME: -module-link-name fooCore
+// CHECK-FILELIST-INTERFACE-SAME: -enforce-exclusivity=unchecked
 // CHECK-FILELIST-INTERFACE-SAME: -Ounchecked
 // CHECK-FILELIST-INTERFACE-SAME: -module-name foo
 


### PR DESCRIPTION
By default, we compile the standard library with
`-enforce-exclusivity=unchecked`. If we don't preserve this argument,
then the standard library compiled from an interface includes
exclusivity enforcement, which pessimizes inlining those functions,
which decreases performance for clients.

Part of rdar://46431767

(cherry-picked from #23281)