### PR TITLE
[Typechecker] Dont infer @objc for typealiases inside @objc protocol

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1131,8 +1131,11 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
   if (VD->getAttrs().hasAttribute<NSManagedAttr>())
     return ObjCReason(ObjCReason::ExplicitlyNSManaged);
   // A member of an @objc protocol is implicitly @objc.
-  if (isMemberOfObjCProtocol)
+  if (isMemberOfObjCProtocol) {
+    if (!VD->isProtocolRequirement())
+      return None;
     return ObjCReason(ObjCReason::MemberOfObjCProtocol);
+  }
 
   // A @nonobjc is not @objc, even if it is an override of an @objc, so check
   // for @nonobjc first.

--- a/test/attr/attr_objc_typealias_inside_protocol.swift
+++ b/test/attr/attr_objc_typealias_inside_protocol.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -enable-objc-interop -parse-as-library %s -o /dev/null -disable-objc-attr-requires-foundation-module -module-name typealias_objc -emit-module -emit-module-path %t/typealias_objc.swiftmodule
-// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module | %FileCheck %s
 @objc public protocol P {
   typealias T = () -> Bool
   // CHECK: typealias T = () -> Bool

--- a/test/attr/attr_objc_typealias_inside_protocol.swift
+++ b/test/attr/attr_objc_typealias_inside_protocol.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -c -enable-objc-interop -parse-as-library %s -o /dev/null -disable-objc-attr-requires-foundation-module -module-name typealias_objc -emit-module -emit-module-path %t/typealias_objc.swiftmodule
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
+@objc public protocol P {
+  typealias T = () -> Bool
+  // CHECK: typealias T = () -> Bool
+}


### PR DESCRIPTION
Dont infer @objc for typealiases inside @objc protocol. This stops the assertion from being hit inside Serialization.cpp.

Resolves [SR-10115](https://bugs.swift.org/browse/SR-10115).