### PR TITLE
[Serialization] Drop inherited conformances on classes

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -149,6 +149,8 @@ enum class ConformanceLookupKind : unsigned {
   All,
   /// Only the explicit conformance.
   OnlyExplicit,
+  /// All conformances except for inherited ones.
+  NonInherited,
 };
 
 /// Describes a diagnostic for a conflict between two protocol

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -989,10 +989,30 @@ void ConformanceLookupTable::lookupConformances(
                        return true;
 
                      // If we are to filter out this result, do so now.
-                     if (lookupKind == ConformanceLookupKind::OnlyExplicit &&
-                         entry->getKind() != ConformanceEntryKind::Explicit &&
-                         entry->getKind() != ConformanceEntryKind::Synthesized)
-                       return false;
+                     switch (lookupKind) {
+                     case ConformanceLookupKind::OnlyExplicit:
+                       switch (entry->getKind()) {
+                       case ConformanceEntryKind::Explicit:
+                       case ConformanceEntryKind::Synthesized:
+                         break;
+                       case ConformanceEntryKind::Implied:
+                       case ConformanceEntryKind::Inherited:
+                         return false;
+                       }
+                       break;
+                     case ConformanceLookupKind::NonInherited:
+                       switch (entry->getKind()) {
+                       case ConformanceEntryKind::Explicit:
+                       case ConformanceEntryKind::Synthesized:
+                       case ConformanceEntryKind::Implied:
+                         break;
+                       case ConformanceEntryKind::Inherited:
+                         return false;
+                       }
+                       break;
+                     case ConformanceLookupKind::All:
+                       break;
+                     }
 
                      // Record the protocol.
                      if (protocols)

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1436,7 +1436,7 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
   case DeclKind::Class: {
     // Emit witness tables.
     auto nom = cast<NominalTypeDecl>(d);
-    for (auto c : nom->getLocalConformances(ConformanceLookupKind::All,
+    for (auto c : nom->getLocalConformances(ConformanceLookupKind::NonInherited,
                                             nullptr)) {
       auto *proto = c->getProtocol();
       if (Lowering::TypeConverter::protocolRequiresWitnessTable(proto) &&

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -976,7 +976,7 @@ public:
     // Emit witness tables for conformances of concrete types. Protocol types
     // are existential and do not have witness tables.
     for (auto *conformance : theType->getLocalConformances(
-                               ConformanceLookupKind::All, nullptr)) {
+                               ConformanceLookupKind::NonInherited, nullptr)) {
       if (conformance->isComplete()) {
         if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
           SGM.getWitnessTable(normal);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3217,7 +3217,7 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(theClass->getDeclContext());
 
     auto conformances = theClass->getLocalConformances(
-                          ConformanceLookupKind::All, nullptr);
+                          ConformanceLookupKind::NonInherited, nullptr);
 
     SmallVector<TypeID, 4> inheritedTypes;
     for (auto inherited : theClass->getInherited()) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -114,7 +114,8 @@ void TBDGenVisitor::addBaseConformanceDescriptor(
 }
 
 void TBDGenVisitor::addConformances(DeclContext *DC) {
-  for (auto conformance : DC->getLocalConformances()) {
+  for (auto conformance : DC->getLocalConformances(
+                            ConformanceLookupKind::NonInherited)) {
     auto protocol = conformance->getProtocol();
     auto needsWTable =
         Lowering::TypeConverter::protocolRequiresWitnessTable(protocol);

--- a/validation-test/Serialization/conformance-removed.swift
+++ b/validation-test/Serialization/conformance-removed.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-sil -emit-module-path %t/SwiftLib.swiftmodule -I %S/Inputs/conformance-removed/ %S/Inputs/conformance-removed/SwiftLib.swift -Xcc -DUSE_PROTO
-// RUN: not --crash %target-build-swift -typecheck -I %t -I %S/Inputs/custom-modules/ %s 2>&1 | %FileCheck %s
+// RUN: %target-build-swift -emit-module -emit-module-path %t/SwiftLib.swiftmodule -I %S/Inputs/conformance-removed/ %S/Inputs/conformance-removed/SwiftLib.swift -Xcc -DUSE_PROTO
+// RUN: not grep SomeProto %t/SwiftLib.swiftmodule
+// RUN: %target-build-swift -typecheck -I %t -I %S/Inputs/custom-modules/ %s
 
 // REQUIRES: objc_interop
 
 import SwiftLib
 class Rdar28282310: Sub {}
-// CHECK: If you're seeing a crash here, check that your SDK and dependencies are at least as new as the versions used to build 'SwiftLib'


### PR DESCRIPTION
These can be recreated if needed in a client library.

Note that this doesn't drop inherited conformances from the entire serialized interface, just from the list that a class explicitly declares.

rdar://problem/50541451