### PR TITLE
Implement rethrowing from variadic and array arguments.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -87,6 +87,7 @@ namespace swift {
   class InheritedProtocolConformance;
   class SelfProtocolConformance;
   class SpecializedProtocolConformance;
+  class SubscriptDecl;
   enum class ProtocolConformanceState;
   class Pattern;
   enum PointerTypeKind : unsigned;
@@ -522,6 +523,9 @@ public:
 
   /// Retrieve the declaration of Swift._hashValue<H>(for: H) -> Int.
   FuncDecl *getHashValueForDecl() const;
+
+  /// Retrieve the declaration for Array.subscript(index: Int) -> Element
+  SubscriptDecl *getArrayIntSubscriptDecl() const;
 
   /// Retrieve the declaration of Array.append(element:)
   FuncDecl *getArrayAppendElementDecl() const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -687,6 +687,9 @@ public:
     return getAnyPointerElementType(Ignore);
   }
   
+  /// Returns the `Element` type if this is a bound `Array`, otherwise null.
+  Type getArrayElementType();
+
   /// Determine whether the given type is "specialized", meaning that
   /// it involves generic types for which generic arguments have been provided.
   /// For example, the types Vector<Int> and Vector<Int>.Element are both

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -611,6 +611,13 @@ Type TypeBase::getAnyPointerElementType(PointerTypeKind &PTK) {
   return Type();
 }
 
+Type TypeBase::getArrayElementType() {
+  if (auto boundStruct = getAs<BoundGenericStructType>())
+    if (getASTContext().getArrayDecl() == boundStruct->getDecl())
+      return boundStruct->getGenericArgs().front();
+  return Type();
+}
+
 Type TypeBase::lookThroughAllOptionalTypes() {
   Type type(this);
   while (auto objType = type->getOptionalObjectType())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1567,6 +1567,16 @@ static bool hasThrowingFunctionParameter(CanType type) {
     return false;
   }
 
+  // Look into Array.Element.
+  if (auto boundStruct = dyn_cast<BoundGenericStructType>(type)) {
+    if (type->getASTContext().getArrayDecl() ==
+        boundStruct->getDecl()) {
+      return hasThrowingFunctionParameter(boundStruct
+                 ->getGenericArgs().front()
+                 ->getCanonicalType());
+    }
+  }
+
   // Suppress diagnostics in the presence of errors.
   if (type->hasError()) {
     return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1568,13 +1568,9 @@ static bool hasThrowingFunctionParameter(CanType type) {
   }
 
   // Look into Array.Element.
-  if (auto boundStruct = dyn_cast<BoundGenericStructType>(type)) {
-    if (type->getASTContext().getArrayDecl() ==
-        boundStruct->getDecl()) {
-      return hasThrowingFunctionParameter(boundStruct
-                 ->getGenericArgs().front()
-                 ->getCanonicalType());
-    }
+  if (auto elementTy = type->getArrayElementType()) {
+    return hasThrowingFunctionParameter(
+                elementTy->getCanonicalType());
   }
 
   // Suppress diagnostics in the presence of errors.

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -703,6 +703,9 @@ private:
       }
     }
 
+    if (auto inject = dyn_cast<InjectIntoOptionalExpr>(arg))
+      arg = inject->getSubExpr()->getValueProvidingExpr();
+
     // If the parameter was structurally a tuple, try to look through the
     // various tuple operations.
     if (auto paramTupleType = dyn_cast<TupleType>(paramType.getPointer())) {

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -691,6 +691,7 @@ private:
   /// Classify an argument being passed to a rethrows function.
   Classification classifyRethrowsArgument(Expr *arg, Type paramType) {
     arg = arg->getValueProvidingExpr();
+    paramType = paramType->lookThroughAllOptionalTypes();
 
     // If this argument is `nil` literal or `.none`,
     // it doesn't cause the call to throw.

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -10,6 +10,14 @@ let r3 : Optional<() rethrows -> ()> = nil // expected-error {{only function dec
 func f1(_ f: () throws -> ()) rethrows { try f() }
 func f2(_ f: () -> ()) rethrows { f() } // expected-error {{'rethrows' function must take a throwing function argument}}
 func f3(_ f: UndeclaredFunctionType) rethrows { f() } // expected-error {{use of undeclared type 'UndeclaredFunctionType'}}
+func f4(_ f: (() throws -> Void)?...) rethrows {} // expected-error {{'rethrows' function must take a throwing function argument}}
+func f5(_ f: ((() throws -> Void)?, Bool)) rethrows {} // expected-error {{'rethrows' function must take a throwing function argument}}
+
+typealias VoidToVoidThrows = () throws -> Void
+
+func f6(_ f: () throws -> Void...) rethrows {} // Ok
+func f7(_ f: [VoidToVoidThrows]) rethrows {} // Ok
+func f8(_ f: [() throws -> Void]?) rethrows {} // Ok
 
 /** Protocol conformance checking ********************************************/
 

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -49,6 +49,28 @@ func testArrayAndTupleRethrowing() {
   rethrowArray2(arg: throwsFunc, nothrowsFunc)
   // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error}}
   // expected-note@-2 {{call is to 'rethrows' function}}
+
+  let optArray: [() throws -> Void]? = nil
+
+  try! rethrowArray3(arg: [throwsFunc]) // OK
+  rethrowArray3(arg: nil) // OK
+  rethrowArray3(arg: [nothrowsFunc, throwsFunc])
+  // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  // expected-note@-2 {{call is to 'rethrows' function}}
+  rethrowArray3(arg: optArray) // Opaque
+  // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
+
+  let tuple: (() throws -> Void, Bool)? = nil
+
+  try! rethrowTuple1(arg: (throwsFunc, true)) // OK
+  rethrowTuple1(arg: nil) // OK
+  rethrowTuple1(arg: (throwsFunc, true)) // OK
+  // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
+  rethrowTuple1(arg: tuple) // Opaque
+  // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
 }
 
 /** Protocol conformance checking ********************************************/

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -54,6 +54,7 @@ func testArrayAndTupleRethrowing() {
 
   try! rethrowArray3(arg: [throwsFunc]) // OK
   rethrowArray3(arg: nil) // OK
+  rethrowArray3(arg: [nothrowsFunc]) // OK
   rethrowArray3(arg: [nothrowsFunc, throwsFunc])
   // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
   // expected-note@-2 {{call is to 'rethrows' function}}
@@ -65,6 +66,7 @@ func testArrayAndTupleRethrowing() {
 
   try! rethrowTuple1(arg: (throwsFunc, true)) // OK
   rethrowTuple1(arg: nil) // OK
+  rethrowTuple1(arg: (nothrowsFunc, true)) // OK
   rethrowTuple1(arg: (throwsFunc, true)) // OK
   // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
   // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}


### PR DESCRIPTION
For example, this allows `func foo(args: () throws -> Void...) rethrows`.

Previously, the compiler ignored `Array`s that are bound to throwing function types when verifying `rethrows`.

I'm not sure how reasonable it would be to expand this for dictionaries or arbitrary generic types, but an array of throwing predicates is quite a sensible use case.


