### PR TITLE
[AutoDiff] Unify code for differentiation parameter inference.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -187,9 +187,13 @@ class AutoDiffParameterIndicesBuilder {
   llvm::SmallBitVector parameters;
 
 public:
-  /// Start building an `AutoDiffParameterIndices` for the given function type.
-  AutoDiffParameterIndicesBuilder(AnyFunctionType *functionType,
-                                  bool setAllParams = false);
+  /// Creates a `AutoDiffParameterIndicesBuilder` for the given function type.
+  AutoDiffParameterIndicesBuilder(AnyFunctionType *functionType);
+
+  /// Creates a `AutoDiffParameterIndicesBuilder` for the given function type,
+  /// inferring all differentiation parameters.
+  static AutoDiffParameterIndicesBuilder inferParameters(
+      AnyFunctionType *functionType, ModuleDecl *module);
 
   /// Builds the `AutoDiffParameterIndices`, returning a pointer to an existing
   /// one if it has already been allocated in the `ASTContext`.
@@ -201,9 +205,6 @@ public:
 
   /// Sets the parameters at indices in the specified range.
   void setParameters(unsigned lowerBound, unsigned upperBound);
-
-  /// Sets all parameters.
-  void setAllParameters();
 
   /// Returns the number of parameters.
   unsigned size() { return parameters.size(); }

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -192,6 +192,10 @@ public:
 
   /// Creates a `AutoDiffParameterIndicesBuilder` for the given function type,
   /// inferring all differentiation parameters.
+  /// The differentiation parameters are inferred to be:
+  /// - All parameters of the function type that conform to `Differentiable`.
+  /// - If the function type's result is a function type, then also all
+  ///   parameters of the function result type that conform to `Dfiferentiable`.
   static AutoDiffParameterIndicesBuilder inferParameters(
       AnyFunctionType *functionType, ModuleDecl *module);
 

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Range.h"
@@ -261,9 +262,60 @@ static unsigned getNumAutoDiffParameterIndices(AnyFunctionType *fnTy) {
   return numAutoDiffParameterIndices;
 }
 
+/// Returns true if the given type conforms to `Differentiable` in the given
+/// module.
+static bool conformsToDifferentiableInModule(Type type, ModuleDecl *module) {
+  auto &ctx = module->getASTContext();
+  auto *differentiableProto =
+      ctx.getProtocol(KnownProtocolKind::Differentiable);
+  return LookUpConformanceInModule(module)(
+      differentiableProto->getDeclaredInterfaceType()->getCanonicalType(),
+      type, differentiableProto).hasValue();
+};
+
 AutoDiffParameterIndicesBuilder::AutoDiffParameterIndicesBuilder(
-    AnyFunctionType *functionType, bool setAllParams)
-    : parameters(getNumAutoDiffParameterIndices(functionType), setAllParams) {
+    AnyFunctionType *functionType)
+    : parameters(getNumAutoDiffParameterIndices(functionType)) {}
+
+AutoDiffParameterIndicesBuilder
+AutoDiffParameterIndicesBuilder::inferParameters(AnyFunctionType *functionType,
+                                                 ModuleDecl *module) {
+  AutoDiffParameterIndicesBuilder builder(functionType);
+  SmallVector<Type, 4> allParamTypes;
+
+  // Returns true if the i-th parameter type is differentiable.
+  auto isDifferentiableParam = [&](unsigned i) -> bool {
+    if (i >= allParamTypes.size())
+      return false;
+    auto paramType = allParamTypes[i];
+    // Return false for class/existential types.
+    if ((!paramType->hasTypeParameter() &&
+         paramType->isAnyClassReferenceType()) ||
+        paramType->isExistentialType())
+      return false;
+    // Return false for function types.
+    if (paramType->is<AnyFunctionType>())
+      return false;
+    // Return true if the type conforms to `Differentiable`.
+    return conformsToDifferentiableInModule(paramType, module);
+  };
+
+  // Get all parameter types.
+  // NOTE: To be robust, result function type parameters should be added only if
+  // `functionType` comes from a static/instance method, and not a free function
+  // returning a function type.
+  if (auto resultFnType = functionType->getResult()->getAs<AnyFunctionType>())
+    for (auto &param : resultFnType->getParams())
+      allParamTypes.push_back(param.getPlainType());
+  for (auto &param : functionType->getParams())
+    allParamTypes.push_back(param.getPlainType());
+
+  // Set differentiation parameters.
+  for (unsigned i : range(builder.parameters.size()))
+    if (isDifferentiableParam(i))
+      builder.setParameter(i);
+
+  return builder;
 }
 
 AutoDiffParameterIndices *
@@ -279,10 +331,6 @@ void AutoDiffParameterIndicesBuilder::setParameter(unsigned paramIndex) {
 void AutoDiffParameterIndicesBuilder::setParameters(unsigned lowerBound,
                                                     unsigned upperBound) {
   parameters.set(lowerBound, upperBound);
-}
-
-void AutoDiffParameterIndicesBuilder::setAllParameters() {
-  parameters.set();
 }
 
 Type VectorSpace::getType() const {

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -303,7 +303,8 @@ AutoDiffParameterIndicesBuilder::inferParameters(AnyFunctionType *functionType,
   // Get all parameter types.
   // NOTE: To be robust, result function type parameters should be added only if
   // `functionType` comes from a static/instance method, and not a free function
-  // returning a function type.
+  // returning a function type. In practice, this code path should not be
+  // reachable for free functions returning a function type.
   if (auto resultFnType = functionType->getResult()->getAs<AnyFunctionType>())
     for (auto &param : resultFnType->getParams())
       allParamTypes.push_back(param.getPlainType());

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1077,8 +1077,9 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
       firstArgGen.build(builder)->castTo<AnyFunctionType>();
   origFnTy = origFnTy->withExtInfo(
       origFnTy->getExtInfo().withDifferentiable(false).withNoEscape(false));
-  auto *paramIndices = AutoDiffParameterIndicesBuilder(
-      origFnTy, /*setAllParams*/ true).build(Context);
+  auto autodiffBuilder = AutoDiffParameterIndicesBuilder::inferParameters(
+      origFnTy, Context.getStdlibModule());
+  auto *paramIndices = autodiffBuilder.build(Context);
   // Generator for the resultant function type, i.e. the AD associated function.
   BuiltinGenericSignatureBuilder::LambdaGenerator resultGen{
       [=, &Context](BuiltinGenericSignatureBuilder &builder) -> Type {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3247,10 +3247,10 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
       outputOrigTypeNotDiff, outputSubstTypeNotDiff, expectedTLNotDiff);
 
   // TODO: Use parameter indices specified in the function type.
-  AutoDiffParameterIndicesBuilder parameterIndicesBuilder(
-      inputSubstType, /*setAllParams*/ true);
+  auto autodiffBuilder = AutoDiffParameterIndicesBuilder::inferParameters(
+      inputSubstType, SGF.getModule().getSwiftModule());
   auto *parameterIndices =
-      parameterIndicesBuilder.build(inputSubstType->getASTContext());
+      autodiffBuilder.build(inputSubstType->getASTContext());
 
   auto getAssocFnTy =
       [&](CanAnyFunctionType fnTy, AutoDiffAssociatedFunctionKind kind)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2524,10 +2524,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  auto originalParamTypes = map<SmallVector<TupleTypeElt, 8>>(
-      originalParams.getArray(),
-      [&](ParamDecl *decl) { return decl->getInterfaceType(); });
-
   // Start type-checking the arguments of the @differentiable attribute. This
   // covers 'wrt:', 'jvp:', and 'vjp:', all of which are optional.
 
@@ -2621,76 +2617,19 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // If checked wrt param indices are not specified, compute them using parsed
   // wrt param indices.
   if (!checkedWrtParamIndices) {
-    AutoDiffParameterIndicesBuilder autoDiffParameterIndicesBuilder(
-        originalFnTy);
+    // If parsed wrt param indices are not specified, infer differentiation
+    // parameters.
     if (parsedWrtParams.empty()) {
-      SmallVector<Type, 4> allWrtParamTypes;
-
-      // Returns true if the i-th parameter type is differentiable.
-      auto isDifferentiableParam = [&](unsigned i) {
-        if (i >= allWrtParamTypes.size())
-          return false;
-        auto wrtParamType = original->mapTypeIntoContext(allWrtParamTypes[i]);
-        // Return false for class/existential types.
-        if (wrtParamType->isAnyClassReferenceType() ||
-            wrtParamType->isExistentialType())
-          return false;
-        // Return false for function types.
-        if (wrtParamType->is<AnyFunctionType>())
-          return false;
-        if (whereClauseGenEnv) {
-          auto wrtParamInterfaceType = !wrtParamType->hasTypeParameter()
-                                           ? wrtParamType->mapTypeOutOfContext()
-                                           : wrtParamType;
-          wrtParamType =
-              whereClauseGenEnv->mapTypeIntoContext(wrtParamInterfaceType);
-        }
-        // Return true if the type conforms to `Differentiable`.
-        return conformsToDifferentiable(wrtParamType);
-      };
-
-      // The wrt types listed when verifying are in (T1) -> (T2, T3) -> R order,
-      // but the bits are in T2, T3, T1 order.
-      //
-      // That works out to three cases:
-      // Static function on a type:
-      // Check: (T2, T3).
-      //
-      // Method function:
-      // Check: (T2, T3, T1).
-      //
-      // Free standing function: (This will be: (T1, T2, T3) -> R)
-      // Check (T1, T2, T3).
-      // TODO: Clean all this up.
-      bool isStaticSelf =
-          original->isStatic() || isa<ConstructorDecl>(original);
-      if (auto *fnTy = originalResultTy->getAs<AnyFunctionType>()) {
-        if ((!isInstanceMethod && !isStaticSelf) ||
-            fnTy->getResult()->is<AnyFunctionType>()) {
-          TC.diagnose(attr->getLocation(),
-                      diag::differentiable_attr_no_currying);
-          return;
-        }
-        for (auto &param : fnTy->getParams())
-          allWrtParamTypes.push_back(param.getPlainType());
-        assert(originalFnTy->getNumParams() == 1 &&
-               "This must be in the form (Self) -> (Args...) -> R");
-      }
-
-      if (isStaticSelf) {
-        auto *methodTy = originalResultTy->castTo<AnyFunctionType>();
-        for (unsigned i : range(methodTy->getNumParams()))
-          if (isDifferentiableParam(i))
-            autoDiffParameterIndicesBuilder.setParameter(i);
-      } else {
-        for (auto &param : originalFnTy->getParams())
-          allWrtParamTypes.push_back(param.getPlainType());
-
-        for (unsigned i : range(autoDiffParameterIndicesBuilder.size()))
-          if (isDifferentiableParam(i))
-            autoDiffParameterIndicesBuilder.setParameter(i);
-      }
+      auto derivativeFnTy = originalFnTy;
+      if (whereClauseGenEnv)
+        derivativeFnTy = whereClauseGenEnv->mapTypeIntoContext(derivativeFnTy)
+            ->castTo<AnyFunctionType>();
+      checkedWrtParamIndices = AutoDiffParameterIndicesBuilder::inferParameters(
+          derivativeFnTy, original->getModuleContext())
+          .build(ctx);
     } else {
+      AutoDiffParameterIndicesBuilder autoDiffParameterIndicesBuilder(
+          originalFnTy);
       // 'wrt:' is specified. Validate and collect the selected parameters.
       int lastIndex = -1;
       for (unsigned i : indices(parsedWrtParams)) {
@@ -2738,8 +2677,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         }
         }
       }
+      checkedWrtParamIndices = autoDiffParameterIndicesBuilder.build(ctx);
     }
-    checkedWrtParamIndices = autoDiffParameterIndicesBuilder.build(ctx);
   }
 
   auto insertion =
@@ -3060,8 +2999,9 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     attr->setInvalid();
     return;
   }
-  // Function tuple result must take one parameter with type either
-  // `R.TangentVector` or `R.CotangentVector`.
+  // Pullback must take one parameter with type `R.CotangentVector`.
+  // FIXME(TF-363): Fix type-checking for differentials. The current logic is
+  // completely wrong.
   auto seedTy = ProtocolConformanceRef::getTypeWitnessByName(
       valueResultType, *valueResultConf, autoDiffAssocTyId,
       ctx.getLazyResolver());
@@ -3229,9 +3169,9 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
   // TODO: When `wrt:` is supported in the `@differentiating` attribute, replace
   // this with the parameter indices resolved by the earlier checking logic in
   // this function.
-  auto allParameterIndices =
-      AutoDiffParameterIndicesBuilder(originalFnType, /*setAllParams*/ true)
-          .build(ctx);
+  auto allParameterIndices = AutoDiffParameterIndicesBuilder::inferParameters(
+      originalFnType, originalFn->getModuleContext())
+      .build(ctx);
 
   // Add the derivative function to the original function's `@differentiable`
   // attribute with the same parameters. If this attribute does not exist,

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -70,19 +70,6 @@ CustomDerivativesTests.test("Checkpointing") {
   expectEqual(2, count)
 }
 
-@_semantics("autodiff.opaque")
-func functionWithRetroDeriv(x: Float) -> Float {
-  return x
-}
-@differentiating(functionWithRetroDeriv)
-func retroDeriv(x: Float) -> (value: Float, pullback: (Float) -> Float) {
-  return (value: x, pullback: { _ in 100 })
-}
-
-CustomDerivativesTests.test("Retroactive") {
-  expectEqual(100, gradient(at: 3, in: functionWithRetroDeriv))
-}
-
 CustomDerivativesTests.test("SumOfGradPieces") {
   var grad: Float = 0
   let addToGrad = { grad += $0 }

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -70,7 +70,6 @@ CustomDerivativesTests.test("Checkpointing") {
   expectEqual(2, count)
 }
 
-
 @_semantics("autodiff.opaque")
 func functionWithRetroDeriv(x: Float) -> Float {
   return x

--- a/test/AutoDiff/derivative_registration.swift
+++ b/test/AutoDiff/derivative_registration.swift
@@ -3,7 +3,19 @@
 
 import StdlibUnittest
 
-var RetroactiveDerivativeTests = TestSuite("RetroactiveDerivative")
+var DerivativeRegistrationTests = TestSuite("DerivativeRegistration")
+
+@_semantics("autodiff.opaque")
+func unary(x: Float) -> Float {
+  return x
+}
+@differentiating(unary)
+func _vjpUnary(x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (value: x, pullback: { v in v })
+}
+DerivativeRegistrationTests.test("UnaryFreeFunction") {
+  expectEqual(1, gradient(at: 3.0, in: unary))
+}
 
 @_semantics("autodiff.opaque")
 func multiply(_ x: Float, _ y: Float) -> Float {
@@ -14,7 +26,7 @@ func _vjpMultiply(_ x: Float, _ y: Float)
   -> (value: Float, pullback: (Float) -> (Float, Float)) {
   return (x * y, { v in (v * y, v * x) })
 }
-RetroactiveDerivativeTests.test("TestFreeFunction") {
+DerivativeRegistrationTests.test("BinaryFreeFunction") {
   expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, in: { x, y in multiply(x, y) }))
 }
 
@@ -34,7 +46,7 @@ extension Wrapper {
     return (x * y, { v in (v * y, v * x) })
   }
 }
-RetroactiveDerivativeTests.test("TestStaticMethod") {
+DerivativeRegistrationTests.test("StaticMethod") {
   expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, in: { x, y in Wrapper.multiply(x, y) }))
 }
 
@@ -52,7 +64,7 @@ extension Wrapper {
     })
   }
 }
-RetroactiveDerivativeTests.test("TestInstanceMethod") {
+DerivativeRegistrationTests.test("InstanceMethod") {
   let x: Float = 2
   let wrapper = Wrapper(float: 3)
   let (𝛁wrapper, 𝛁x) = wrapper.gradient(at: x) { wrapper, x in wrapper.multiply(x) }

--- a/test/AutoDiff/retroactive_derivatives.swift
+++ b/test/AutoDiff/retroactive_derivatives.swift
@@ -1,0 +1,63 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var RetroactiveDerivativeTests = TestSuite("RetroactiveDerivative")
+
+@_semantics("autodiff.opaque")
+func multiply(_ x: Float, _ y: Float) -> Float {
+  return x * y
+}
+@differentiating(multiply)
+func _vjpMultiply(_ x: Float, _ y: Float)
+  -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x * y, { v in (v * y, v * x) })
+}
+RetroactiveDerivativeTests.test("TestFreeFunction") {
+  expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, in: { x, y in multiply(x, y) }))
+}
+
+struct Wrapper : Differentiable {
+  var float: Float
+}
+
+extension Wrapper {
+  @_semantics("autodiff.opaque")
+  static func multiply(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+
+  @differentiating(multiply)
+  static func _vjpMultiply(_ x: Float, _ y: Float)
+    -> (value: Float, pullback: (Float) -> (Float, Float)) {
+    return (x * y, { v in (v * y, v * x) })
+  }
+}
+RetroactiveDerivativeTests.test("TestStaticMethod") {
+  expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, in: { x, y in Wrapper.multiply(x, y) }))
+}
+
+extension Wrapper {
+  @_semantics("autodiff.opaque")
+  func multiply(_ x: Float) -> Float {
+    return float * x
+  }
+
+  @differentiating(multiply)
+  func _vjpMultiply(_ x: Float)
+    -> (value: Float, pullback: (Float) -> (Wrapper.CotangentVector, Float)) {
+    return (float * x, { v in
+      (Wrapper.CotangentVector(float: v * x), v * self.float)
+    })
+  }
+}
+RetroactiveDerivativeTests.test("TestInstanceMethod") {
+  let x: Float = 2
+  let wrapper = Wrapper(float: 3)
+  let (𝛁wrapper, 𝛁x) = wrapper.gradient(at: x) { wrapper, x in wrapper.multiply(x) }
+  expectEqual(Wrapper.CotangentVector(float: 2), 𝛁wrapper)
+  expectEqual(3, 𝛁x)
+}
+
+runAllTests()

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -293,8 +293,7 @@ ATTRIBUTE_NODES = [
     # SWIFT_ENABLE_TENSORFLOW
     # The argument of '@differentiating(...)'.
     # differentiating-attr-arguments ->
-    #     differentiable-attr-func-specifier # original
-    #     ','? differentiable-attr-parameters?
+    #     func-decl-name ','? differentiable-attr-parameters?
     Node('DifferentiatingAttributeArguments', kind='Syntax',
          description='''
          The arguments for the `@differentiating` attribute: the original


### PR DESCRIPTION
Previously, `@differentiable` attribute type-checking used ad-hoc
differentiation parameter inference logic.

Now, that differentiation parameter inference logic has been moved to
`AutoDiffParameterIndicesBuilder::inferParameters` so that it can be shared
with `@differentiable` attribute type-checking.

Add retroactive derivative tests.

Resolves [TF-363](https://bugs.swift.org/browse/TF-363).