### PR TITLE
[Python] Make `Optional` conditionally `PythonConvertible`.

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -979,6 +979,27 @@ extension Float : PythonConvertible {
 }
 
 //===----------------------------------------------------------------------===//
+// `PythonConvertible` conformance for `Optional`
+//===----------------------------------------------------------------------===//
+
+extension Optional : PythonConvertible where Wrapped : PythonConvertible {
+  public init?(_ object: PythonObject) {
+    if object == Python.None {
+      self = .none
+    } else {
+      guard let converted = Wrapped(object) else {
+        return nil
+      }
+      self = .some(converted)
+    }
+  }
+
+  public var pythonObject: PythonObject {
+    return self?.pythonObject ?? Python.None
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // `PythonConvertible` conformance for `Array` and `Dictionary`
 //===----------------------------------------------------------------------===//
 

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -298,6 +298,17 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonConvertible") {
   expectEqual(five, Double(5).pythonObject)
 }
 
+PythonRuntimeTestSuite.testWithLeakChecking("Optional") {
+  let five: PythonObject = 5
+  expectEqual(five, (5 as Int?).pythonObject)
+  expectEqual(Python.None, (nil as Int?).pythonObject)
+
+  let xx: [Int?] = [1, 2, nil, 3, nil, 4]
+  let pyxx: PythonObject = [1, 2, Python.None, 3, Python.None, 4]
+  expectEqual(pyxx, xx.pythonObject)
+  expectEqual(xx, [Int?](pyxx))
+}
+
 PythonRuntimeTestSuite.testWithLeakChecking("SR-9230") {
   expectEqual(2, Python.len(Python.dict(a: "a", b: "b")))
 }


### PR DESCRIPTION
Enables the conversion from optional value to a Python object. The most notable use case is calling a Python API on an array of optionals.

```swift
let xx: [Int?] = [1, 2, nil, 4, 5]
Python.print(xx) // [1, 2, None, 4, 5]
```

Similarly, a Python list with `None`s can also be converted back to a Swift array of optionals.

```swift
let xx: [PythonObject] = [1, 2, Python.None, 4, 5]
[Int](xx) // => nil, because conversion failed
[Int?](xx) // => [1, 2, nil, 4, 5]
```