### PR TITLE
[TF] Rename `ShapedArray` initializers to `init(repeating:shape:)`.

### DIFF
--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -406,11 +406,22 @@ public extension ShapedArray {
   }
 
   /// Creates a `ShapedArray` with the specified shape and a single, repeated
-  /// value.
+  /// scalar value.
   /// - Parameters:
   ///   - shape: The shape of the `ShapedArray`.
   ///   - repeatedValue: The scalar value to repeat.
+  @inlinable @inline(__always)
+  @available(*, deprecated, renamed: "init(repeating:shape:)")
   init(shape: __owned [Int], repeating repeatedValue: __owned Scalar) {
+    self.init(repeating: repeatedValue, shape: shape)
+  }
+
+  /// Creates a `ShapedArray` with the specified shape and a single, repeated
+  /// scalar value.
+  /// - Parameters:
+  ///   - repeatedValue: The scalar value to repeat.
+  ///   - shape: The shape of the `ShapedArray`.
+  init(repeating repeatedValue: __owned Scalar, shape: __owned [Int]) {
     let scalarCount = shape.reduce(1, *)
     let buffer = TensorBuffer<Scalar>(
       allocation: .native(.init(Array(repeating: repeatedValue,
@@ -676,7 +687,7 @@ extension ShapedArray : Codable where Scalar : Codable {
 ///
 /// For example:
 ///
-///     let zeros = ShapedArray(shape: [3, 2], repeating: 0)
+///     let zeros = ShapedArray(repeating: 0, shape: [3, 2])
 ///     var matrix = ShapedArray(shape: [3, 2], scalars: Array(0..<6))
 ///     // `zeros` represents [[0, 0], [0, 0], [0, 0]].
 ///     // `matrix` represents [[0, 1], [2, 3], [4, 5]].
@@ -766,12 +777,23 @@ public extension ShapedArraySlice {
   }
 
   /// Creates a `ShapedArraySlice` with the specified shape and a single,
-  /// repeated value.
+  /// repeated scalar value.
   /// - Parameters:
-  ///   - shape: The shape of the `ShapedArraySlice`.
   ///   - repeatedValue: The scalar value to repeat.
+  ///   - shape: The shape of the `ShapedArraySlice`.
+  @inlinable @inline(__always)
+  @available(*, deprecated, renamed: "init(repeating:shape:)")
   init(shape: __owned [Int], repeating repeatedValue: __owned Scalar) {
-    self.init(base: ShapedArray(shape: shape, repeating: repeatedValue))
+    self.init(repeating: repeatedValue, shape: shape)
+  }
+
+  /// Creates a `ShapedArraySlice` with the specified shape and a single,
+  /// repeated scalar value.
+  /// - Parameters:
+  ///   - repeatedValue: The scalar value to repeat.
+  ///   - shape: The shape of the `ShapedArraySlice`.
+  init(repeating repeatedValue: __owned Scalar, shape: __owned [Int]) {
+    self.init(base: ShapedArray(repeating: repeatedValue, shape: shape))
   }
 }
 

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -337,24 +337,22 @@ public extension Tensor {
 }
 
 public extension Tensor {
-  /// Creates a tensor with the specified shape and a single, repeated value.
+  /// Creates a tensor with the specified shape and a single, repeated scalar value.
   ///
   /// - Parameters:
   ///   - shape: The dimensions of the tensor.
   ///   - repeatedValue: The scalar value to repeat.
-  ///
   @inlinable @inline(__always)
   @available(*, deprecated, renamed: "init(repeating:shape:)")
   init(shape: TensorShape, repeating repeatedValue: Scalar) {
     self.init(repeating: repeatedValue, shape: shape)
   }
 
-  /// Creates a tensor with the specified shape and a single, repeated value.
+  /// Creates a tensor with the specified shape and a single, repeated scalar value.
   ///
   /// - Parameters:
-  ///   - shape: The dimensions of the tensor.
   ///   - repeatedValue: The scalar value to repeat.
-  ///
+  ///   - shape: The dimensions of the tensor.
   @inlinable @inline(__always)
   @differentiable(vjp: _vjpInit(repeating:shape:)
                   where Scalar : TensorFlowFloatingPoint)

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -41,7 +41,7 @@ NumpyConversionTests.test("shaped-array-conversion") {
   expectNil(ShapedArray<Double>(numpy: numpyArrayFloat))
   expectNil(ShapedArray<Int32>(numpy: numpyArrayFloat))
   if let array = expectNotNil(ShapedArray<Float>(numpy: numpyArrayFloat)) {
-    expectEqual(ShapedArray(shape: [2, 3], repeating: 1), array)
+    expectEqual(ShapedArray(repeating: 1, shape: [2, 3]), array)
   }
 
   let numpyArrayInt32 = np.array([[[1, 2, 3], [4, 5, 6]]], dtype: np.int32)
@@ -84,7 +84,7 @@ NumpyConversionTests.test("tensor-conversion") {
   expectNil(Tensor<Double>(numpy: numpyArrayFloat))
   expectNil(Tensor<Int32>(numpy: numpyArrayFloat))
   if let tensor = expectNotNil(Tensor<Float>(numpy: numpyArrayFloat)) {
-    expectEqual(ShapedArray(shape: [2, 3], repeating: 1), tensor.array)
+    expectEqual(ShapedArray(repeating: 1, shape: [2, 3]), tensor.array)
   }
 
   let numpyArrayInt32 = np.array([[[1, 2, 3], [4, 5, 6]]], dtype: np.int32)
@@ -109,13 +109,13 @@ NumpyConversionTests.test("tensor-round-trip") {
   guard numpyModule != nil else { return }
   guard ctypesModule != nil else { return }
 
-  let t1 = Tensor<Float>(shape: [1,2,3,4], repeating: 3.0)
+  let t1 = Tensor<Float>(repeating: 3.0, shape: [1,2,3,4])
   expectEqual(t1, Tensor<Float>(numpy: t1.makeNumpyArray())!)
 
   let t2 = Tensor<UInt8>(shape: [2,3], scalars: [1, 2, 3, 4, 5, 6])
   expectEqual(t2, Tensor<UInt8>(numpy: t2.makeNumpyArray())!)
 
-  let t3 = Tensor<Int32>(shape: [8,5,4], repeating: 30)
+  let t3 = Tensor<Int32>(repeating: 30, shape: [8,5,4])
   expectEqual(t3, Tensor<Int32>(numpy: t3.makeNumpyArray())!)
 }
 #endif

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -67,7 +67,7 @@ ShapedArrayTests.test("Indexing") {
 
 ShapedArrayTests.test("ElementMutation") {
   var tensor = ShapedArray(shape: [3, 4, 5], scalars: Array(0..<60))
-  tensor[0] = ShapedArraySlice<Int>(shape: [4, 5], repeating: 1)
+  tensor[0] = ShapedArraySlice<Int>(repeating: 1, shape: [4, 5])
   expectEqual(Array(repeating: 1, count: 20) + Array(20..<60), tensor.scalars)
 
   tensor[0..<2] = ShapedArraySlice<Int>(shape: [2, 4, 5], scalars: Array(0..<40))
@@ -106,25 +106,25 @@ struct Foo : Equatable, Hashable {
 
 ShapedArrayTests.test("Equatable") {
   checkEquatable([ShapedArray(shape: [], scalars: [1.0])], oracle: { $0 == $1 })
-  checkEquatable([ShapedArray(shape: [3, 4, 5], repeating: true)], oracle: { $0 == $1 })
-  checkEquatable([ShapedArray(shape: [3, 4, 5], repeating: Foo())], oracle: { $0 == $1 })
+  checkEquatable([ShapedArray(repeating: true, shape: [3, 4, 5])], oracle: { $0 == $1 })
+  checkEquatable([ShapedArray(repeating: Foo(), shape: [3, 4, 5])], oracle: { $0 == $1 })
   checkEquatable([ShapedArray(shape: [2, 3], scalars: Array(0..<6))], oracle: { $0 == $1 })
 
   checkEquatable([ShapedArraySlice(shape: [], scalars: [1.0])], oracle: { $0 == $1 })
-  checkEquatable([ShapedArraySlice(shape: [3, 4, 5], repeating: true)], oracle: { $0 == $1 })
-  checkEquatable([ShapedArraySlice(shape: [3, 4, 5], repeating: Foo())], oracle: { $0 == $1 })
+  checkEquatable([ShapedArraySlice(repeating: true, shape: [3, 4, 5])], oracle: { $0 == $1 })
+  checkEquatable([ShapedArraySlice(repeating: Foo(), shape: [3, 4, 5])], oracle: { $0 == $1 })
   checkEquatable([ShapedArraySlice(shape: [2, 3], scalars: Array(0..<6))], oracle: { $0 == $1 })
 }
 
 ShapedArrayTests.test("Hashable") {
   checkHashable([ShapedArray(shape: [], scalars: [1.0])], equalityOracle: { $0 == $1 })
-  checkHashable([ShapedArray(shape: [3, 4, 5], repeating: true)], equalityOracle: { $0 == $1 })
-  checkHashable([ShapedArray(shape: [3, 4, 5], repeating: Foo())], equalityOracle: { $0 == $1 })
+  checkHashable([ShapedArray(repeating: true, shape: [3, 4, 5])], equalityOracle: { $0 == $1 })
+  checkHashable([ShapedArray(repeating: Foo(), shape: [3, 4, 5])], equalityOracle: { $0 == $1 })
   checkHashable([ShapedArray(shape: [2, 3], scalars: Array(0..<6))], equalityOracle: { $0 == $1 })
 
   checkHashable([ShapedArraySlice(shape: [], scalars: [1.0])], equalityOracle: { $0 == $1 })
-  checkHashable([ShapedArraySlice(shape: [3, 4, 5], repeating: true)], equalityOracle: { $0 == $1 })
-  checkHashable([ShapedArraySlice(shape: [3, 4, 5], repeating: Foo())], equalityOracle: { $0 == $1 })
+  checkHashable([ShapedArraySlice(repeating: true, shape: [3, 4, 5])], equalityOracle: { $0 == $1 })
+  checkHashable([ShapedArraySlice(repeating: Foo(), shape: [3, 4, 5])], equalityOracle: { $0 == $1 })
   checkHashable([ShapedArraySlice(shape: [2, 3], scalars: Array(0..<6))], equalityOracle: { $0 == $1 })
 }
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -38,7 +38,7 @@ TensorTests.testAllBackends("Initializers") {
 
 TensorTests.testAllBackends("FactoryInitializers") {
   let x = Tensor<Float>(ones: [1, 10])
-  expectEqual(ShapedArray(shape: [1, 10], repeating: 1), x.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [1, 10]), x.array)
 }
 
 TensorTests.testAllBackends("NumericInitializers") {
@@ -57,7 +57,7 @@ TensorTests.testAllBackends("ScalarToTensorConversion") {
 }
 
 TensorTests.testAllBackends("ArrayConversion") {
-  let array3D = ShapedArray(shape: [2, 3, 4], repeating: 1.0)
+  let array3D = ShapedArray(repeating: 1.0, shape: [2, 3, 4])
   let tensor3D = Tensor(array3D)
   expectEqual(array3D, tensor3D.array)
 }
@@ -70,9 +70,9 @@ TensorTests.testAllBackends("DataTypeCast_NonTPU") {
   let ints = Tensor<Int64>(x)
   let floats = Tensor<Float>(x)
   let i8s = Tensor<Int8>(floats)
-  expectEqual(ShapedArray(shape: [5, 5], repeating: 1), ints.array)
-  expectEqual(ShapedArray(shape: [5, 5], repeating: 1), floats.array)
-  expectEqual(ShapedArray(shape: [5, 5], repeating: 1), i8s.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [5, 5]), ints.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [5, 5]), floats.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [5, 5]), i8s.array)
 }
 
 TensorTests.testAllBackends("DataTypeCast_TPU") {
@@ -83,9 +83,9 @@ TensorTests.testAllBackends("DataTypeCast_TPU") {
   let ints = Tensor<Int64>(x)
   let floats = Tensor<Float>(x)
   let u32s = Tensor<UInt32>(floats)
-  expectEqual(ShapedArray(shape: [5, 5], repeating: 1), ints.array)
-  expectEqual(ShapedArray(shape: [5, 5], repeating: 1), floats.array)
-  expectEqual(ShapedArray(shape: [5, 5], repeating: 1), u32s.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [5, 5]), ints.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [5, 5]), floats.array)
+  expectEqual(ShapedArray(repeating: 1, shape: [5, 5]), u32s.array)
 }
 
 TensorTests.testAllBackends("BoolToNumericCast_NonTPU") {
@@ -285,7 +285,7 @@ TensorTests.testAllBackends("BatchNormalization") {
 }
 
 TensorTests.testAllBackends("Convolution") {
-  let x = Tensor<Float>(shape: [1, 1, 3, 3], repeating: 0.5)
+  let x = Tensor<Float>(repeating: 0.5, shape: [1, 1, 3, 3])
   let filter = Tensor<Float>(shape: [1, 1, 3, 3],
                              scalars: [0, 1, 0, 1, 1, 1, 0, 1, 0])
   let y = x.convolved2D(withFilter: filter, strides: (1, 1, 1, 1),
@@ -443,27 +443,25 @@ TensorTests.testAllBackends("ReshapeToScalar") {
 
 TensorTests.testAllBackends("ReshapeTensor") {
   // 2 x 3 -> 1 x 3 x 1 x 2 x 1
-  let x = Tensor<Float>(shape: [2, 3], repeating: 0.0)
-  let y = Tensor<Float>(shape: [1, 3, 1, 2, 1], repeating: 0.0)
+  let x = Tensor<Float>(repeating: 0.0, shape: [2, 3])
+  let y = Tensor<Float>(repeating: 0.0, shape: [1, 3, 1, 2, 1])
   let result = x.reshaped(like: y)
   expectEqual([1, 3, 1, 2, 1], result.shape)
 }
 
 TensorTests.testAllBackends("Unbroadcast1") {
-  let x = Tensor<Float>(shape: [2, 3, 4, 5], repeating: 1)
-  let y = Tensor<Float>(shape: [4, 5], repeating: 1)
+  let x = Tensor<Float>(repeating: 1, shape: [2, 3, 4, 5])
+  let y = Tensor<Float>(repeating: 1, shape: [4, 5])
   let z = x.unbroadcast(like: y)
-  expectEqual(ShapedArray<Float>(shape: [4, 5],
-                                 repeating: 6),
+  expectEqual(ShapedArray<Float>(repeating: 6, shape: [4, 5]),
               z.array)
 }
 
 TensorTests.testAllBackends("Unbroadcast2") {
-  let x = Tensor<Float>(shape: [2, 3, 4, 5], repeating: 1)
-  let y = Tensor<Float>(shape: [3, 1, 5], repeating: 1)
+  let x = Tensor<Float>(repeating: 1, shape: [2, 3, 4, 5])
+  let y = Tensor<Float>(repeating: 1, shape: [3, 1, 5])
   let z = x.unbroadcast(like: y)
-  expectEqual(ShapedArray<Float>(shape: [3, 1, 5],
-                                 repeating: 8),
+  expectEqual(ShapedArray<Float>(repeating: 8, shape: [3, 1, 5]),
               z.array)
 }
 

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -29,18 +29,18 @@ TensorNonTPUTests.testAllBackends("SliceUpdate") {
                           scalars: [true, false, true, false, false, false]),
               t3.array)
   var t4 = Tensor<Bool>([[true, true, true], [false, false, false]])
-  t4[0] = Tensor(shape: [3], repeating: false)
-  expectEqual(ShapedArray(shape:[2, 3], repeating: false), t4.array)
+  t4[0] = Tensor(repeating: false, shape: [3])
+  expectEqual(ShapedArray(repeating: false, shape: [2, 3]), t4.array)
 }
 
 TensorNonTPUTests.testAllBackends("BroadcastTensor") {
   // 1 -> 2 x 3 x 4
   let one = Tensor<Float>(1)
-  var target = Tensor<Float>(shape: [2, 3, 4], repeating: 0.0)
+  var target = Tensor<Float>(repeating: 0.0, shape: [2, 3, 4])
   let broadcasted = one.broadcast(like: target)
-  expectEqual(Tensor(shape: [2, 3, 4], repeating: 1), broadcasted)
-  target .= Tensor(shape: [1, 3, 1], repeating: 1)
-  expectEqual(Tensor(shape: [2, 3, 4], repeating: 1), target)
+  expectEqual(Tensor(repeating: 1, shape: [2, 3, 4]), broadcasted)
+  target .= Tensor(repeating: 1, shape: [1, 3, 1])
+  expectEqual(Tensor(repeating: 1, shape: [2, 3, 4]), target)
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -92,7 +92,7 @@ TensorADTests.testAllBackends("Abs") {
 }
 
 TensorADTests.testAllBackends("sum") {
-  let input = Tensor<Float>(shape: [2, 2], repeating: 42)
+  let input = Tensor<Float>(repeating: 42, shape: [2, 2])
   let sumPullbackScalar = pullback(at: input) { (a: Tensor<Float>) in a.sum() }
   let sumPullbackAlongAxes = pullback(at: input) { (a: Tensor<Float>) in a.sum(alongAxes: 0, 1) }
 
@@ -111,7 +111,7 @@ TensorADTests.testAllBackends("mean") {
   let meanGradAlongAxes = gradient { (a: Tensor<Float>) in a.mean(alongAxes: 0, 1) }
 
   let input = Tensor<Float>(ones: [2, 2])
-  let expected = Tensor<Float>(shape: [2, 2], repeating: 0.25)
+  let expected = Tensor<Float>(repeating: 0.25, shape: [2, 2])
   expectEqual(expected, meanGradScalar(input))
   // expectEqual(expected, meanGradSqueezingAxes(input))
   expectEqual(expected, meanGradAlongAxes(input))
@@ -150,7 +150,7 @@ TensorADTests.testAllBackends("softmax") {
 
 TensorADTests.testAllBackends("log_softmax") {
   let pb = pullback(at: Tensor(ones: [3, 3])) { (a: Tensor<Float>) in logSoftmax(a) }
-  expectEqual(Tensor(shape: [3, 3], repeating: 5.9604645e-08), pb(Tensor(ones: [3, 3])))
+  expectEqual(Tensor(repeating: 5.9604645e-08, shape: [3, 3]), pb(Tensor(ones: [3, 3])))
 }
 
 TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {


### PR DESCRIPTION
Deprecate `init(shape:repeating:)` for `ShapedArray` and `ShapedArraySlice` in favor of `init(repeating:shape:)`.

This is a follow-up to https://github.com/apple/swift/pull/22979, in which `Tensor.init(shape:repeating:)` was similarly renamed/deprecated. The new initializer is consistent with `tf.constant`.

Update tests to use new initializers.