### PR TITLE
[AutoDiff] Fix `@differentiating` type-checking for differentials.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2745,15 +2745,19 @@ ERROR(differentiating_attr_expected_result_tuple,none,
       "'(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or "
       "'(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'", ())
 ERROR(differentiating_attr_invalid_result_tuple_value_label,none,
-      "'@differentiating' attribute requires function to return a two-element tuple (first element must have label 'value:')", ())
+      "'@differentiating' attribute requires function to return a two-element "
+      "tuple (first element must have label 'value:')", ())
 ERROR(differentiating_attr_invalid_result_tuple_func_label,none,
-      "'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')", ())
+      "'@differentiating' attribute requires function to return a two-element "
+      "tuple (second element must have label 'pullback:' or 'differential:')", ())
 ERROR(differentiating_attr_result_value_not_differentiable,none,
-      "'@differentiating' attribute requires function to return a two-element tuple (first element type %0 must conform to 'Differentiable')", (Type))
-ERROR(differentiating_attr_result_func_invalid_type,none,
-      "unexpected %0 type; got %1, but expected %2", (Identifier, Type, Type))
+      "'@differentiating' attribute requires function to return a two-element "
+      "tuple (first element type %0 must conform to 'Differentiable')", (Type))
+ERROR(differentiating_attr_result_func_unexpected_type,none,
+      "%0 does not have expected type %1", (Identifier, Type))
 ERROR(differentiating_attr_no_diff_parameters,none,
-      "'@differentiating' attribute requires function to have at least one differentiation parameter", ())
+      "'@differentiating' attribute requires function to have at least one "
+      "differentiation parameter", ())
 ERROR(differentiating_attr_overload_not_found,none,
       "%0 does not have expected type %1", (DeclName, Type))
 ERROR(differentiating_attr_not_in_same_file_as_original,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2739,23 +2739,21 @@ ERROR(differentiable_attr_class_unsupported,none,
 NOTE(protocol_witness_missing_specific_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 
-// @differentiang
+// @differentiating
 ERROR(differentiating_attr_expected_result_tuple,none,
       "'@differentiating' attribute requires function to return a two-element tuple of type "
       "'(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or "
       "'(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'", ())
-ERROR(differentiating_attr_expected_result_tuple_value_label,none,
+ERROR(differentiating_attr_invalid_result_tuple_value_label,none,
       "'@differentiating' attribute requires function to return a two-element tuple (first element must have label 'value:')", ())
-ERROR(differentiating_attr_expected_result_tuple_func_label,none,
+ERROR(differentiating_attr_invalid_result_tuple_func_label,none,
       "'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')", ())
 ERROR(differentiating_attr_result_value_not_differentiable,none,
       "'@differentiating' attribute requires function to return a two-element tuple (first element type %0 must conform to 'Differentiable')", (Type))
-ERROR(differentiating_attr_result_func_invalid_parameter,none,
-      "expected %0 to be a function with a single parameter of type %1", (Identifier, Type))
+ERROR(differentiating_attr_result_func_invalid_type,none,
+      "unexpected %0 type; got %1, but expected %2", (Identifier, Type, Type))
 ERROR(differentiating_attr_no_diff_parameters,none,
       "'@differentiating' attribute requires function to have at least one differentiation parameter", ())
-ERROR(differentiating_attr_unexpected_diff_params_type,none,
-      "unexpected differentiation parameters type; got %0, but expected %1", (Type, Type))
 ERROR(differentiating_attr_overload_not_found,none,
       "%0 does not have expected type %1", (DeclName, Type))
 ERROR(differentiating_attr_not_in_same_file_as_original,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2753,13 +2753,17 @@ ERROR(differentiating_attr_invalid_result_tuple_func_label,none,
 ERROR(differentiating_attr_result_value_not_differentiable,none,
       "'@differentiating' attribute requires function to return a two-element "
       "tuple (first element type %0 must conform to 'Differentiable')", (Type))
-ERROR(differentiating_attr_result_func_unexpected_type,none,
-      "%0 does not have expected type %1", (Identifier, Type))
+ERROR(differentiating_attr_result_func_type_mismatch,none,
+      "function result's %0 type does not match %1", (Identifier, DeclName))
+NOTE(differentiating_attr_result_func_type_mismatch_note,none,
+     "%0 does not have expected type %1", (Identifier, Type))
+NOTE(differentiating_attr_result_func_original_note,none,
+     "%0 defined here", (DeclName))
 ERROR(differentiating_attr_no_diff_parameters,none,
       "'@differentiating' attribute requires function to have at least one "
       "differentiation parameter", ())
 ERROR(differentiating_attr_overload_not_found,none,
-      "%0 does not have expected type %1", (DeclName, Type))
+      "could not find function %0 with expected type %1", (DeclName, Type))
 ERROR(differentiating_attr_not_in_same_file_as_original,none,
       "derivative not in the same file as the original function", ())
 ERROR(differentiating_attr_original_already_has_derivative,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3063,9 +3063,14 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
   expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
   // Check if differential/pullback type matches expected type.
   if (!funcEltType->isEqual(expectedFuncEltType)) {
-    TC.diagnose(attr->getLocation(),
-                diag::differentiating_attr_result_func_invalid_type,
-                funcResultElt.getName(), funcEltType, expectedFuncEltType);
+    // Emit an error highlighting the differential/pullback type.
+    auto *tupleReturnTypeRepr =
+        cast<TupleTypeRepr>(derivative->getReturnTypeLoc().getTypeRepr());
+    auto *funcEltTypeRepr = tupleReturnTypeRepr->getElementType(1);
+    TC.diagnose(funcEltTypeRepr->getStartLoc(),
+                diag::differentiating_attr_result_func_unexpected_type,
+                funcResultElt.getName(), expectedFuncEltType)
+        .highlight(funcEltTypeRepr->getSourceRange());
     attr->setInvalid();
     return;
   }

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -14,19 +14,23 @@ func vjpSin(x: Float) -> (value: Float, pullback: (Float) -> Float) {
 func jvpSin(x: @nondiff Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })
 }
-@differentiating(sin) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple of type '(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'}}
+// expected-error @+1 {{'@differentiating' attribute requires function to return a two-element tuple of type '(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'}}
+@differentiating(sin)
 func jvpSinResultInvalid(x: @nondiff Float) -> Float {
   return x
 }
-@differentiating(sin) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+// expected-error @+1 {{'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+@differentiating(sin)
 func vjpSinResultWrongLabel(x: Float) -> (value: Float, (Float) -> Float) {
   return (x, { $0 })
 }
-@differentiating(sin) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+// expected-error @+1 {{'@differentiating' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+@differentiating(sin)
 func vjpSinResultNotDifferentiable(x: Int) -> (value: Int, pullback: (Int) -> Int) {
   return (x, { $0 })
 }
-@differentiating(sin) // expected-error {{expected 'pullback' to be a function with a single parameter of type 'Float.CotangentVector' (aka 'Float')}}
+// expected-error @+1 {{unexpected 'pullback' type; got '(Double) -> Double', but expected '(Float.CotangentVector) -> (Float.CotangentVector)' (aka '(Float) -> Float')}}
+@differentiating(sin)
 func vjpSinResultInvalidSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
   return (x, { $0 })
 }
@@ -39,14 +43,16 @@ func vjpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, pullback: (T.Cotan
   return (x, { ($0, $0) })
 }
 @differentiating(generic)
-func jvpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, differential: (T.TangentVector) -> (T.TangentVector, T.TangentVector)) {
-  return (x, { ($0, $0) })
+func jvpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, differential: (T.TangentVector, T.TangentVector) -> T.TangentVector) {
+  return (x, { $0 + $1 })
 }
-@differentiating(generic) // expected-error {{'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+// expected-error @+1 {{'@differentiating' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+@differentiating(generic)
 func vjpGenericWrongLabel<T : Differentiable>(x: T, y: T) -> (value: T, (T) -> (T, T)) {
   return (x, { ($0, $0) })
 }
-@differentiating(generic) // expected-error {{unexpected differentiation parameters type; got '(T, T)', but expected 'T'}}
+// expected-error @+1 {{unexpected 'pullback' type; got '(T) -> (T, T)', but expected '(T) -> (T)'}}
+@differentiating(generic)
 func vjpGenericDiffParamMismatch<T : Differentiable>(x: T) -> (value: T, pullback: (T) -> (T, T)) where T == T.CotangentVector {
   return (x, { ($0, $0) })
 }
@@ -99,7 +105,7 @@ extension Differentiable where Self : AdditiveArithmetic {
 }
 
 extension AdditiveArithmetic where Self : Differentiable, Self == Self.CotangentVector {
-  // expected-error @+1 {{unexpected differentiation parameters type; got '(Self, Self)', but expected '(Self, Self, Self)'}}
+  // expected-error @+1 {{unexpected 'pullback' type; got '(Self) -> (Self, Self)', but expected '(Self) -> (Self, Self, Self)'}}
   @differentiating(+)
   func vjpPlusInstanceMethod(x: Self, y: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
     return (x + y, { v in (v, v) })
@@ -110,11 +116,12 @@ extension AdditiveArithmetic where Self : Differentiable, Self == Self.Cotangent
 
 protocol InstanceMethod : Differentiable {
   func foo(_ x: Self) -> Self
+  func bar<T : Differentiable>(_ x: T) -> Self
 }
 
 extension InstanceMethod {
   // If `Self` conforms to `Differentiable`, then `Self` is currently always inferred to be a differentiation parameter.
-  // expected-error @+1 {{unexpected differentiation parameters type; got 'Self.CotangentVector', but expected '(Self.CotangentVector, Self.CotangentVector)'}}
+  // expected-error @+1 {{unexpected 'pullback' type; got '(Self.CotangentVector) -> Self.CotangentVector', but expected '(Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)'}}
   @differentiating(foo)
   func vjpFoo(x: Self) -> (value: Self, pullback: (Self.CotangentVector) -> Self.CotangentVector) {
     return (x, { $0 })
@@ -126,10 +133,43 @@ extension InstanceMethod {
   }
 }
 
-extension InstanceMethod where Self == Self.CotangentVector {
+extension InstanceMethod {
+  // expected-error @+1 {{unexpected 'pullback' type; got '(Self.CotangentVector) -> T.CotangentVector', but expected '(Self.CotangentVector) -> (Self.CotangentVector, T.CotangentVector)'}}
+  @differentiating(bar)
+  func vjpBar<T : Differentiable>(_ x: T) -> (value: Self, pullback: (Self.CotangentVector) -> T.CotangentVector) {
+    return (self, { _ in .zero })
+  }
+
+  @differentiating(bar)
+  func vjpBar<T : Differentiable>(_ x: T) -> (value: Self, pullback: (Self.CotangentVector) -> (Self.CotangentVector, T.CotangentVector)) {
+    return (self, { ($0, .zero) })
+  }
+
+  @differentiating(bar)
+  func jvpBar<T : Differentiable>(_ x: T) -> (value: Self, differential: (Self.TangentVector, T.TangentVector) -> Self.TangentVector) {
+    return (self, { dself, dx in dself })
+  }
+}
+
+extension InstanceMethod where Self == Self.TangentVector, Self == Self.CotangentVector {
   @differentiating(foo)
   func vjpFooExtraRequirements(x: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
     return (x, { ($0, $0) })
+  }
+
+  @differentiating(foo)
+  func jvpFooExtraRequirements(x: Self) -> (value: Self, differential: (Self, Self) -> (Self)) {
+    return (x, { $0 + $1 })
+  }
+
+  @differentiating(bar)
+  func vjpBarExtraRequirements<T : Differentiable>(x: T) -> (value: Self, pullback: (Self) -> (Self, T.CotangentVector)) {
+    return (self, { ($0, .zero) })
+  }
+
+  @differentiating(bar)
+  func jvpBarExtraRequirements<T : Differentiable>(_ x: T) -> (value: Self, differential: (Self, T.TangentVector) -> Self) {
+    return (self, { dself, dx in dself })
   }
 }
 

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -29,7 +29,7 @@ func vjpSinResultWrongLabel(x: Float) -> (value: Float, (Float) -> Float) {
 func vjpSinResultNotDifferentiable(x: Int) -> (value: Int, pullback: (Int) -> Int) {
   return (x, { $0 })
 }
-// expected-error @+1 {{unexpected 'pullback' type; got '(Double) -> Double', but expected '(Float.CotangentVector) -> (Float.CotangentVector)' (aka '(Float) -> Float')}}
+// expected-error @+2 {{'pullback' does not have expected type '(Float.CotangentVector) -> (Float.CotangentVector)' (aka '(Float) -> Float')}}
 @differentiating(sin)
 func vjpSinResultInvalidSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
   return (x, { $0 })
@@ -51,7 +51,7 @@ func jvpGeneric<T : Differentiable>(x: T, y: T) -> (value: T, differential: (T.T
 func vjpGenericWrongLabel<T : Differentiable>(x: T, y: T) -> (value: T, (T) -> (T, T)) {
   return (x, { ($0, $0) })
 }
-// expected-error @+1 {{unexpected 'pullback' type; got '(T) -> (T, T)', but expected '(T) -> (T)'}}
+// expected-error @+2 {{'pullback' does not have expected type '(T) -> (T)'}}
 @differentiating(generic)
 func vjpGenericDiffParamMismatch<T : Differentiable>(x: T) -> (value: T, pullback: (T) -> (T, T)) where T == T.CotangentVector {
   return (x, { ($0, $0) })
@@ -105,7 +105,7 @@ extension Differentiable where Self : AdditiveArithmetic {
 }
 
 extension AdditiveArithmetic where Self : Differentiable, Self == Self.CotangentVector {
-  // expected-error @+1 {{unexpected 'pullback' type; got '(Self) -> (Self, Self)', but expected '(Self) -> (Self, Self, Self)'}}
+  // expected-error @+2 {{'pullback' does not have expected type '(Self) -> (Self, Self, Self)'}}
   @differentiating(+)
   func vjpPlusInstanceMethod(x: Self, y: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
     return (x + y, { v in (v, v) })
@@ -121,7 +121,7 @@ protocol InstanceMethod : Differentiable {
 
 extension InstanceMethod {
   // If `Self` conforms to `Differentiable`, then `Self` is currently always inferred to be a differentiation parameter.
-  // expected-error @+1 {{unexpected 'pullback' type; got '(Self.CotangentVector) -> Self.CotangentVector', but expected '(Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)'}}
+  // expected-error @+2 {{'pullback' does not have expected type '(Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)'}}
   @differentiating(foo)
   func vjpFoo(x: Self) -> (value: Self, pullback: (Self.CotangentVector) -> Self.CotangentVector) {
     return (x, { $0 })
@@ -134,7 +134,7 @@ extension InstanceMethod {
 }
 
 extension InstanceMethod {
-  // expected-error @+1 {{unexpected 'pullback' type; got '(Self.CotangentVector) -> T.CotangentVector', but expected '(Self.CotangentVector) -> (Self.CotangentVector, T.CotangentVector)'}}
+  // expected-error @+2 {{'pullback' does not have expected type '(Self.CotangentVector) -> (Self.CotangentVector, T.CotangentVector)'}}
   @differentiating(bar)
   func vjpBar<T : Differentiable>(_ x: T) -> (value: Self, pullback: (Self.CotangentVector) -> T.CotangentVector) {
     return (self, { _ in .zero })


### PR DESCRIPTION
Fix type-checking for differential functions.
Simplify pullback/differential type-checking diagnostics.

Resolves [TF-366](https://bugs.swift.org/browse/TF-366).