### PR TITLE
[Basic] Desensitize OutputFileMap to DenseMap implementation changes

### DIFF
--- a/lib/Basic/OutputFileMap.cpp
+++ b/lib/Basic/OutputFileMap.cpp
@@ -123,6 +123,7 @@ void OutputFileMap::write(llvm::raw_ostream &os,
     }
 
     os << "\n";
+    // DenseMap is unordered. If you write a test, please sort the output.
     for (auto &typeAndOutputPath : *outputMap) {
       file_types::ID type = typeAndOutputPath.getFirst();
       StringRef output = typeAndOutputPath.getSecond();

--- a/test/Driver/Inputs/filelists/check-filelist-abc.py
+++ b/test/Driver/Inputs/filelists/check-filelist-abc.py
@@ -56,7 +56,8 @@ if '-supplementary-output-file-map' in sys.argv:
     supplementaryOutputMapFile = \
         sys.argv[sys.argv.index('-supplementary-output-file-map') + 1]
     with open(supplementaryOutputMapFile, 'r') as f:
-        lines = f.readlines()
+        # The output is in DenseMap order, which is unstable, therefore sort.
+        lines = sorted(f.readlines())
         for line in lines:
             print("Supplementary", line.rstrip())
 

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -6,17 +6,17 @@
 
 // CHECK-NOT: Handled
 // CHECK: Handled a.swift
-// CHECK-NEXT: Supplementary "./a.swift":
-// CHECK-NEXT: Supplementary swiftmodule: "./a.swiftmodule"
 // CHECK-NEXT: Supplementary swiftdoc: "./a.swiftdoc"
+// CHECK-NEXT: Supplementary swiftmodule: "./a.swiftmodule"
+// CHECK-NEXT: Supplementary "./a.swift":
 // CHECK-NEXT: Handled b.swift
-// CHECK-NEXT: Supplementary "./b.swift":
-// CHECK-NEXT: Supplementary swiftmodule: "./b.swiftmodule"
 // CHECK-NEXT: Supplementary swiftdoc: "./b.swiftdoc"
+// CHECK-NEXT: Supplementary swiftmodule: "./b.swiftmodule"
+// CHECK-NEXT: Supplementary "./b.swift":
 // CHECK-NEXT: Handled c.swift
-// CHECK-NEXT: Supplementary "./c.swift":
-// CHECK-NEXT: Supplementary swiftmodule: "./c.swiftmodule"
 // CHECK-NEXT: Supplementary swiftdoc: "./c.swiftdoc"
+// CHECK-NEXT: Supplementary swiftmodule: "./c.swiftmodule"
+// CHECK-NEXT: Supplementary "./c.swift":
 // CHECK-NEXT: Handled modules
 // CHECK-NOT: Handled
 
@@ -26,8 +26,8 @@
 
 // CHECK-WMO-NOT: Handled
 // CHECK-WMO: Handled all
-// CHECK-WMO: Supplementary "{{.*}}/a.swift":
 // CHECK-WMO: Supplementary object: "main.o"
+// CHECK-WMO: Supplementary "{{.*}}/a.swift":
 // CHECK-WMO-NOT: output
 // CHECK-WMO-NOT: Handled
 
@@ -43,12 +43,12 @@
 
 // CHECK-WMO-THREADED-NOT: Handled
 // CHECK-WMO-THREADED: Handled all
-// CHECK-WMO-THREADED-NEXT: Supplementary "{{.*}}/a.swift":
 // CHECK-WMO-THREADED-NEXT: Supplementary {{object|llvm-bc}}: "{{.*}}/a.{{o|bc}}"
-// CHECK-WMO-THREADED-NEXT: Supplementary "{{.*}}/b.swift":
 // CHECK-WMO-THREADED-NEXT: Supplementary {{object|llvm-bc}}: "{{.*}}/b.{{o|bc}}"
-// CHECK-WMO-THREADED-NEXT: Supplementary "{{.*}}/c.swift":
 // CHECK-WMO-THREADED-NEXT: Supplementary {{object|llvm-bc}}: "{{.*}}/c.{{o|bc}}"
+// CHECK-WMO-THREADED-NEXT: Supplementary "{{.*}}/a.swift":
+// CHECK-WMO-THREADED-NEXT: Supplementary "{{.*}}/b.swift":
+// CHECK-WMO-THREADED-NEXT: Supplementary "{{.*}}/c.swift":
 // CHECK-WMO-THREADED-NEXT: ...with output!
 // CHECK-WMO-THREADED-NOT: Handled
 


### PR DESCRIPTION
(I'm surprised there isn't a DenseMap method that returns a sorted array of key-value pairs.)