### PR TITLE
[AutoDiff][TF] Derivatives for reshaping methods

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -547,7 +547,9 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   func _vjpSqueezingShape(at axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
     let value = squeezingShape(at: axes)
-    return (value, { $0.broadcast(toShape: self.shapeTensor) })
+    return (value, { v in
+      return v.reshaped(toShape: self.shapeTensor)
+    })
   }
 
   @inlinable

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -540,16 +540,13 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   ) -> (Tensor, (Tensor) -> Tensor) {
     let value = reshaped(toShape: newShape)
     return (value, { v in
-      return v.scalarCount == 1 ?
-        v.broadcast(toShape: self.shapeTensor) :
-        v.reshaped(toShape: self.shapeTensor)
+      return v.reshaped(toShape: self.shapeTensor)
     })
   }
 
   @inlinable
-  func _vjpSqueezingShape(at axes: Int32...) -> (Tensor, (Tensor) -> Tensor) {
-    // Cannot call squeezingShape(at:) since it has variadic arguments
-    let value = Raw.squeeze(self, squeezeDims: axes)
+  func _vjpSqueezingShape(at axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
+    let value = squeezingShape(at: axes)
     return (value, { $0.broadcast(toShape: self.shapeTensor) })
   }
 
@@ -559,9 +556,7 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   ) -> (Tensor, (Tensor) -> Tensor) {
     let value = expandingShape(at: shapeIndex)
     return (value, { v in
-      return v.scalarCount == 1 ?
-        v.broadcast(toShape: self.shapeTensor) :
-        v.reshaped(toShape: self.shapeTensor)
+      return v.squeezingShape(at: shapeIndex)
     })
   }
 }

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -539,16 +539,16 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
     toShape newShape: Tensor<Int32>
   ) -> (Tensor, (Tensor) -> Tensor) {
     let value = reshaped(toShape: newShape)
-    return (value, { v in
-      return v.reshaped(toShape: self.shapeTensor)
+    return (value, { [shape = shapeTensor] v in
+      v.reshaped(toShape: shape)
     })
   }
 
   @inlinable
   func _vjpSqueezingShape(at axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
     let value = squeezingShape(at: axes)
-    return (value, { v in
-      return v.reshaped(toShape: self.shapeTensor)
+    return (value, { [shape = shapeTensor] v in
+      v.reshaped(toShape: shape)
     })
   }
 
@@ -558,7 +558,7 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   ) -> (Tensor, (Tensor) -> Tensor) {
     let value = expandingShape(at: shapeIndex)
     return (value, { v in
-      return v.squeezingShape(at: shapeIndex)
+      v.squeezingShape(at: shapeIndex)
     })
   }
 }

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -683,12 +683,14 @@ public extension Tensor {
   /// Return a copy of the tensor collapsed into a 1-D `Tensor`, in row-major
   /// order.
   @inlinable @inline(__always)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func flattened() -> Tensor {
     return reshaped(to: [-1])
   }
 
   /// Returns a rank-lifted `Tensor` with a leading dimension of 1.
   @inlinable @inline(__always)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func rankLifted() -> Tensor {
     return expandingShape(at: 0)
   }
@@ -710,6 +712,10 @@ public extension Tensor {
   // FIXME: The gradient for variadic `squeezed` is difficult to express because
   // ExpandDims only expands one axis at a time.
   @inlinable @inline(__always)
+  @differentiable(
+    wrt: self, vjp: _vjpSqueezingShape(at:)
+    where Scalar : TensorFlowFloatingPoint
+  )
   func squeezingShape(at axes: Int32...) -> Tensor {
     return Raw.squeeze(self, squeezeDims: axes)
   }

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -709,14 +709,21 @@ public extension Tensor {
   /// Remove the specified dimensions of size 1 from the shape of a tensor. If
   /// no dimensions are specified, then all dimensions of size 1 will be
   /// removed.
-  // FIXME: The gradient for variadic `squeezed` is difficult to express because
-  // ExpandDims only expands one axis at a time.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  func squeezingShape(at axes: Int32...) -> Tensor {
+    return squeezingShape(at: axes)
+  }
+
+  /// Remove the specified dimensions of size 1 from the shape of a tensor. If
+  /// no dimensions are specified, then all dimensions of size 1 will be
+  /// removed.
   @inlinable @inline(__always)
   @differentiable(
     wrt: self, vjp: _vjpSqueezingShape(at:)
     where Scalar : TensorFlowFloatingPoint
   )
-  func squeezingShape(at axes: Int32...) -> Tensor {
+  func squeezingShape(at axes: [Int32]) -> Tensor {
     return Raw.squeeze(self, squeezeDims: axes)
   }
 

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -120,22 +120,22 @@ TensorADTests.testAllBackends("mean") {
 TensorADTests.testAllBackends("expandingShape") {
   let f1 = { (a: Tensor<Float>) in a.expandingShape(at: 0).squared() }
   let f2 = { (a: Tensor<Float>) in a.squared().expandingShape(at: 0) }
-  expectEqual([6, 10], gradient(at: [3, 5], in: f1))
-  expectEqual([6, 10], gradient(at: [3, 5], in: f2))
+  expectEqual([6, 10], pullback(at: [3, 5], in: f1)([[1, 1]]))
+  expectEqual([6, 10], pullback(at: [3, 5], in: f2)([[1, 1]]))
 }
 
 TensorADTests.testAllBackends("squeezingShape") {
   let f1 = { (a: Tensor<Float>) in a.squeezingShape(at: 0).squared() }
   let f2 = { (a: Tensor<Float>) in a.squared().squeezingShape(at: 0) }
-  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f1))
-  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f2))
+  expectEqual([[6, 10]], pullback(at: [[3, 5]], in: f1)([1, 1]))
+  expectEqual([[6, 10]], pullback(at: [[3, 5]], in: f2)([1, 1]))
 }
 
-TensorADTests.testAllBackends("reshapedGradient") {
+TensorADTests.testAllBackends("reshapedBackprop") {
   let f1 = { (a: Tensor<Float>) in a.reshaped(toShape: Tensor<Int32>([2, 1])).squared() }
   let f2 = { (a: Tensor<Float>) in a.squared().reshaped(toShape: Tensor<Int32>([2, 1])) }
-  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f1))
-  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f2))
+  expectEqual([[6, 10]], pullback(at: [[3, 5]], in: f1)([[1], [1]]))
+  expectEqual([[6, 10]], pullback(at: [[3, 5]], in: f2)([[1], [1]]))
 }
 
 TensorADTests.testAllBackends("reshaped") {

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -117,6 +117,27 @@ TensorADTests.testAllBackends("mean") {
   expectEqual(expected, meanGradAlongAxes(input))
 }
 
+TensorADTests.testAllBackends("expandingShape") {
+  let f1 = { (a: Tensor<Float>) in a.expandingShape(at: 0).squared() }
+  let f2 = { (a: Tensor<Float>) in a.squared().expandingShape(at: 0) }
+  expectEqual([6, 10], gradient(at: [3, 5], in: f1))
+  expectEqual([6, 10], gradient(at: [3, 5], in: f2))
+}
+
+TensorADTests.testAllBackends("squeezingShape") {
+  let f1 = { (a: Tensor<Float>) in a.squeezingShape(at: 0).squared() }
+  let f2 = { (a: Tensor<Float>) in a.squared().squeezingShape(at: 0) }
+  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f1))
+  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f2))
+}
+
+TensorADTests.testAllBackends("reshapedGradient") {
+  let f1 = { (a: Tensor<Float>) in a.reshaped(toShape: Tensor<Int32>([2, 1])).squared() }
+  let f2 = { (a: Tensor<Float>) in a.squared().reshaped(toShape: Tensor<Int32>([2, 1])) }
+  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f1))
+  expectEqual([[6, 10]], gradient(at: [[3, 5]], in: f2))
+}
+
 TensorADTests.testAllBackends("reshaped") {
   let shapeTensor = Tensor<Int32>([2, 2, 2])
   let input = Tensor<Float>(ones: [2, 4])


### PR DESCRIPTION
Add derivative for `squeezingShape`. Fix derivative chaining for `reshaped` and `expandingShape`. Make convenience methods `flattened` and `rankLifted` differentiable. Fixes TF-367.