### PR TITLE
[Sema] Fix a crash when attempting to synthesise raw representable conformance

### DIFF
--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -501,6 +501,11 @@ static bool canSynthesizeRawRepresentable(DerivedConformance &derived) {
   // - the enum elements all have the same type
   // - they all match the enum type
   for (auto elt : enumDecl->getAllElements()) {
+    // We cannot synthesize raw representable conformance for an enum with
+    // cases that have a payload.
+    if (elt->hasAssociatedValues())
+      return false;
+
     tc.validateDecl(elt);
     if (elt->isInvalid()) {
       return false;

--- a/validation-test/compiler_crashers_2_fixed/sr10108.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10108.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 
 // Just make sure we don't crash.
 

--- a/validation-test/compiler_crashers_2_fixed/sr10108.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10108.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+// Just make sure we don't crash.
+
+enum Crash: String {
+  case foo
+  case bar(String)
+    
+  static let shared = Crash()
+}
+
+extension Crash {
+  init() { self = .foo }
+}


### PR DESCRIPTION
This PR fixes a crash when attempting to derive raw representable conformance for an enum which has cases with payloads.

```swift
enum Crash: String {
  case foo
  case bar(String)
    
  static let shared = Crash()
}

extension Crash {
  init() { self = .foo }
}
```

Resolves [SR-10108](https://bugs.swift.org/browse/SR-10108).