### PR TITLE
SwiftOnoneSupport: create the import library always

### DIFF
--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -9,7 +9,7 @@ add_swift_target_library(swiftSwiftOnoneSupport ${SWIFT_STDLIB_LIBRARY_BUILD_TYP
   SWIFT_COMPILE_FLAGS "-parse-stdlib" "-Xllvm" "-sil-inline-generics=false" "-Xfrontend" "-validate-tbd-against-ir=none" "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)
-if(CMAKE_BUILD_TYPE STREQUAL Debug AND WINDOWS IN_LIST SWIFT_SDKS)
+if(WINDOWS IN_LIST SWIFT_SDKS)
   # When building in Debug mode, the standard library provides the symbols that
   # we need and as such SwiftOnoneSupport does not need to provide any exported
   # interfaces.  This results in the import library beinging elided.  However,


### PR DESCRIPTION
This needs to be added to the release mode builds as well which stopped
generating exported interfaces.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
