### PR TITLE
[parser] Fix infinite loop with erroneously placed attribute at statement level

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -601,6 +601,11 @@ ParserResult<Stmt> Parser::parseStmt() {
     LLVM_FALLTHROUGH;
   default:
     diagnose(Tok, tryLoc.isValid() ? diag::expected_expr : diag::expected_stmt);
+    if (Tok.is(tok::at_sign)) {
+      // Recover from erroneously placed attribute.
+      consumeToken(tok::at_sign);
+      consumeIf(tok::identifier);
+    }
     return nullptr;
   case tok::kw_return:
     if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);

--- a/test/Parse/fixed_infinite_loops.swift
+++ b/test/Parse/fixed_infinite_loops.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -parse -verify %s
+
+func test1() {
+  @s // expected-error {{expected statement}}
+  return
+}
+func test2() {
+  @unknown // expected-error {{expected statement}}
+  return
+}


### PR DESCRIPTION
This infinite loop case was introduced after changes of https://github.com/apple/swift/pull/22974
It was found by the stress tester.