### PR TITLE
Remove redundant space in first(where:) of Sequence

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -734,7 +734,7 @@ extension Sequence {
   public func first(
     where predicate: (Element) throws -> Bool
   ) rethrows -> Element? {
-    for element in self  {
+    for element in self {
       if try predicate(element) {
         return element
       }


### PR DESCRIPTION
Removed the redundant space which is not consistent with others.