### PR TITLE
[AutoDiff] Fix `.withoutDerivative()` fixit location.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3868,7 +3868,7 @@ public:
     // have a zero derivative.
     if (!activityInfo.isVaried(origResult, task->getIndices().parameters)) {
       // Emit fixit if original result has a valid source location.
-      auto sourceLoc = origResult.getLoc().getSourceLoc();
+      auto sourceLoc = origResult.getLoc().getEndSourceLoc();
       if (sourceLoc.isValid()) {
         getContext()
             .diagnose(sourceLoc, diag::autodiff_nonvaried_result_fixit)

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -176,7 +176,7 @@ struct TF_305 : Differentiable {
 }
 
 //===----------------------------------------------------------------------===//
-// Classes and existentials (unsupported yet)
+// Classes and existentials (not yet supported)
 //===----------------------------------------------------------------------===//
 
 class Foo {
@@ -241,3 +241,16 @@ func activeInoutArgTuple(_ x: Float) -> Float {
 }
 // expected-error @+1 {{function is not differentiable}}
 _ = pullback(at: .zero, in: activeInoutArgTuple(_:))
+
+//===----------------------------------------------------------------------===//
+// Non-varied results
+//===----------------------------------------------------------------------===//
+
+func one() -> Float {
+  return 1
+}
+@differentiable
+func nonVariedResult(_ x: Float) -> Float {
+  // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{15-15=.withoutDerivative()}}
+  return one()
+}

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -49,7 +49,7 @@ struct SupervisedTrainer<Model : Layer> {
   var model: Model
   var lossFunction: @differentiable (Model.Output, Model.Output) -> Float
   func fit(y: Model.Output) {
-    // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{58-58=.withoutDerivative()}}
+    // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{64-64=.withoutDerivative()}}
     _ = gradient(at: Float(1)) { _ in return lossFunction(y, y) }
   }
 }


### PR DESCRIPTION
The `.withoutDerivative()` fixit is now correctly inserted at the original
result's end source location.

Resolves [TF-351](https://bugs.swift.org/browse/TF-351).

---

Example:
```swift
func one() -> Float {
  return 1
}
@differentiable
func nonVariedResult(_ x: Float) -> Float {
  return one()
}
```

* Before:
  ```
  tf-351.swift:6:10: warning: result does not depend on differentiation arguments and will always have a  
  zero derivative; do you want to add '.withoutDerivative()'?
    return one()
           ^
              .withoutDerivative()
  ```

* After:
  ```
  tf-351.swift:6:14: warning: result does not depend on differentiation arguments and will always have a 
  zero derivative; do you want to add '.withoutDerivative()'?
    return one()
               ^
                .withoutDerivative()
  ```