### PR TITLE
[AutoDiff] Improve nondifferentiability diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -364,11 +364,12 @@ ERROR(pound_assert_failure,none,
 // Automatic differentiation diagnostics
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
-// FIXME: Find a more informative workaround for this generic error.
-ERROR(autodiff_generic_nondifferentiable_error,none,
-      "value is not differentiable", ())
-ERROR(autodiff_function_not_differentiable,none,
+ERROR(autodiff_function_not_differentiable_error,none,
       "function is not differentiable", ())
+ERROR(autodiff_expression_not_differentiable_error,none,
+      "expression is not differentiable", ())
+NOTE(autodiff_expression_not_differentiable_note,none,
+     "expression is not differentiable", ())
 NOTE(autodiff_external_nondifferentiable_function,none,
      "cannot differentiate an external function that has not been marked "
      "'@differentiable'", ())
@@ -415,12 +416,10 @@ NOTE(autodiff_when_differentiating_function_call,none,
      "when differentiating this function call", ())
 NOTE(autodiff_when_differentiating_function_definition,none,
      "when differentiating this function definition", ())
-NOTE(autodiff_expression_is_not_differentiable,none,
-     "expression is not differentiable", ())
 NOTE(autodiff_cannot_differentiate_through_inout_arguments,none,
      "cannot differentiate through 'inout' arguments", ())
 NOTE(autodiff_control_flow_not_supported,none,
-     "differentiating control flow is not supported yet", ())
+     "differentiating control flow is not yet supported", ())
 NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not supported yet", ())
 NOTE(autodiff_missing_return,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -364,6 +364,9 @@ ERROR(pound_assert_failure,none,
 // Automatic differentiation diagnostics
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
+// FIXME: Find a more informative workaround for this generic error.
+ERROR(autodiff_generic_nondifferentiable_error,none,
+      "value is not differentiable", ())
 ERROR(autodiff_function_not_differentiable,none,
       "function is not differentiable", ())
 NOTE(autodiff_external_nondifferentiable_function,none,

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -4,7 +4,7 @@
 // Top-level (before primal/adjoint synthesis)
 //===----------------------------------------------------------------------===//
 
-// expected-error @+2 {{value is not differentiable}}
+// expected-error @+2 {{expression is not differentiable}}
 // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
 func foo(_ f: (Float) -> Float) -> Float {
   return gradient(at: 0, in: f)
@@ -67,42 +67,40 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
 // Function composition
 //===----------------------------------------------------------------------===//
 
-// FIXME: Figure out why diagnostics no longer accumulate after we removed
-// gradient synthesis. When it's fixed, replace "xpected" with "expected" below.
-#if false
-
 func uses_optionals(_ x: Float) -> Float {
   var maybe: Float? = 10
   maybe = x
-  // xpected-note @+1 {{differentiating control flow is not supported yet}}
+  // expected-note @+1 {{differentiating control flow is not yet supported}}
   return maybe!
 }
 
-_ = gradient(at: 0, in: uses_optionals) // xpected-error {{function is not differentiable}}
+_ = gradient(at: 0, in: uses_optionals) // expected-error {{function is not differentiable}}
 
 func f0(_ x: Float) -> Float {
   return x // okay!
 }
 
 func nested(_ x: Float) -> Float {
-  return gradient(at: x, in: f0) // xpected-note {{nested differentiation is not supported yet}}
+  // TODO(TF-375): Improve this nested differentiation diagnostic.
+  // Currently, `gradient` is diagnosed as a non-`@differentiable` external function.
+  return gradient(at: x, in: f0) // expected-note {{cannot differentiate an external function that has not been marked '@differentiable'}}
 }
 
 func middle(_ x: Float) -> Float {
   let y = uses_optionals(x)
-  return nested(y) // xpected-note {{when differentiating this function call}}
+  return nested(y) // expected-note {{when differentiating this function call}}
 }
 
 func middle2(_ x: Float) -> Float {
-  return middle(x) // xpected-note {{when differentiating this function call}}
+  return middle(x) // expected-note {{when differentiating this function call}}
 }
 
 func func_to_diff(_ x: Float) -> Float {
-  return middle2(x) // xpected-note {{expression is not differentiable}}
+  return middle2(x) // expected-note {{expression is not differentiable}}
 }
 
 func calls_grad_of_nested(_ x: Float) -> Float {
-  return gradient(at: x, in: func_to_diff) // xpected-error {{function is not differentiable}}
+  return gradient(at: x, in: func_to_diff) // expected-error {{function is not differentiable}}
 }
 
 //===----------------------------------------------------------------------===//
@@ -111,7 +109,7 @@ func calls_grad_of_nested(_ x: Float) -> Float {
 
 func if_else(_ x: Float, _ flag: Bool) -> Float {
   let y: Float
-  // xpected-note @+1 {{differentiating control flow is not supported yet}}
+  // expected-note @+1 {{differentiating control flow is not yet supported}}
   if flag {
     y = x + 1
   } else {
@@ -120,10 +118,12 @@ func if_else(_ x: Float, _ flag: Bool) -> Float {
   return y
 }
 
-// xpected-error @+1 {{function is not differentiable}}
-_ = gradient(at: 0) { x in if_else(0, true) }
+// expected-error @+2 {{function is not differentiable}}
+// expected-note @+1 {{expression is not differentiable}}
+_ = gradient(at: 0) { x in if_else(x, true) }
 
-#endif
+// expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{44-44=.withoutDerivative()}}
+_ = gradient(at: 0) { x in if_else(0, true) }
 
 //===----------------------------------------------------------------------===//
 // @differentiable attributes
@@ -194,7 +194,7 @@ func triesToDifferentiateClassMethod(x: Float) -> Float {
   return Foo().class_method(x)
 }
 
-// expected-error @+2 {{value is not differentiable}}
+// expected-error @+2 {{expression is not differentiable}}
 // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
 _ = gradient(at: .zero, in: Foo().class_method)
 

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -4,9 +4,9 @@
 // Top-level (before primal/adjoint synthesis)
 //===----------------------------------------------------------------------===//
 
+// expected-error @+2 {{value is not differentiable}}
 // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
 func foo(_ f: (Float) -> Float) -> Float {
-  // expected-error @+1 {{function is not differentiable}}
   return gradient(at: 0, in: f)
 }
 
@@ -187,15 +187,14 @@ class Foo {
 }
 
 // Nested call case.
-@differentiable // expected-error 2 {{function is not differentiable}}
-// expected-note @+1 2 {{when differentiating this function definition}}
+@differentiable // expected-error {{function is not differentiable}}
+// expected-note @+1 {{when differentiating this function definition}}
 func triesToDifferentiateClassMethod(x: Float) -> Float {
-  // expected-note @+2 {{expression is not differentiable}}
   // expected-note @+1 {{differentiating class members is not supported yet}}
   return Foo().class_method(x)
 }
 
-// expected-error @+2 {{function is not differentiable}}
+// expected-error @+2 {{value is not differentiable}}
 // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
 _ = gradient(at: .zero, in: Foo().class_method)
 
@@ -210,12 +209,11 @@ let no_return: @differentiable (Float) -> Float = { x in
 // expected-error @+1 {{missing return in a closure expected to return 'Float'}}
 }
 
-// expected-error @+1 2 {{function is not differentiable}}
+// expected-error @+1 {{function is not differentiable}}
 @differentiable
-// expected-note @+1 2 {{when differentiating this function definition}}
+// expected-note @+1 {{when differentiating this function definition}}
 func roundingGivesError(x: Float) -> Float {
-  // expected-note @+2 {{cannot differentiate through a non-differentiable result; do you want to add '.withoutDerivative()'?}}
-  // expected-note @+1 {{expression is not differentiable}}
+  // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to add '.withoutDerivative()'?}}
   return Float(Int(x))
 }
 

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -4,13 +4,11 @@
 // due to direct differentiation of reabstraction thunks, which emits errors
 // with unknown location.
 
-// expected-error @+1 2 {{function is not differentiable}}
+// expected-error @+1 {{function is not differentiable}}
 @differentiable()
-// expected-note @+2 {{when differentiating this function definition}}
 // expected-note @+1 {{when differentiating this function definition}}
 func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
-  // expected-note @+2 {{member is not differentiable because the corresponding protocol requirement is not '@differentiable'}}
-  // expected-note @+1 {{expression is not differentiable}}
+  // expected-note @+1 {{member is not differentiable because the corresponding protocol requirement is not '@differentiable'}}
   return x + 1
 }
 _ = gradient(at: 1.0, in: generic) // expected-error {{function is not differentiable}}


### PR DESCRIPTION
- Ensure that every call to `emitNondifferentiabilityError` produces an error.
  - This is done using a fallback generic nondifferentiability error.
    A more informative workaround would be ideal.
- Ensure diagnostics are not emitted twice.
  - `emitNondifferentiabilityError` emits diagnostics and callers should not.