### PR TITLE
[AutoDiff] Fix `wrt` differentiation parameter clause printing.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1506,6 +1506,10 @@ public:
     return ParameterIndices->parameters == other.ParameterIndices->parameters;
   }
 
+  // Print the attribute to the given stream.
+  void print(llvm::raw_ostream &OS, const Decl *D,
+             ModuleDecl *prettyPrintInModule) const;
+
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Differentiable;
   }

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -210,7 +210,12 @@ public:
   /// Sets the parameters at indices in the specified range.
   void setParameters(unsigned lowerBound, unsigned upperBound);
 
-  /// Returns the number of parameters.
+  /// Returns the number of set parameters.
+  unsigned count() { return parameters.count(); }
+
+  /// Returns the number of bits in the `parameters` bitvector.
+  // TODO: After `getNumAutoDiffParameterIndices` is fixed to compute exact
+  // parameter count, update doc comment to "Returns the number of parameters".
   unsigned size() { return parameters.size(); }
 };
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -280,6 +280,71 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
   Printer.printNewline();
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+// Returns the differentiation parameters clause string for the given function,
+// parameter indices, and parsed parameters.
+std::string getDifferentiationParametersClauseString(
+    const AbstractFunctionDecl *function, AutoDiffParameterIndices *indices,
+    ArrayRef<ParsedAutoDiffParameter> parsedParams) {
+  auto *functionType = function->getInterfaceType()->eraseDynamicSelfType()
+      ->castTo<AnyFunctionType>();
+  bool isInstanceMethod = function && function->isInstanceMember();
+
+  // If the number of specified parameters is equal to the number of inferred
+  // differentiation parameters, then return an empty string.
+  auto parameterCount =
+      indices ? indices->parameters.count() : parsedParams.size();
+  auto inferredParametersCount =
+      AutoDiffParameterIndicesBuilder::inferParameters(
+          functionType, function->getModuleContext()).count();
+  if (parameterCount == inferredParametersCount)
+    return "";
+
+  std::string result;
+  llvm::raw_string_ostream printer(result);
+
+  // Use parameters from `AutoDiffParameterIndices`, if specified.
+  if (indices) {
+    SmallBitVector parameters(indices->parameters);
+    auto parameterCount = parameters.count();
+    printer << "wrt: ";
+    if (parameterCount > 1)
+      printer << '(';
+    // Check if differentiating wrt `self`. If so, manually print it first.
+    if (isInstanceMethod && parameters.test(parameters.size() - 1)) {
+      parameters.reset(parameters.size() - 1);
+      printer << "self";
+      if (parameters.any())
+        printer << ", ";
+    }
+    // Print remaining differentiation parameters.
+    interleave(parameters.set_bits(), [&](unsigned index) {
+      printer << function->getParameters()->get(index)->getName().str();
+    }, [&] { printer << ", "; });
+    if (parameterCount > 1)
+      printer << ')';
+  }
+  // Otherwise, use the parsed parameters.
+  else if (!parsedParams.empty()) {
+    printer << "wrt: ";
+    if (parsedParams.size() > 1)
+      printer << '(';
+    interleave(parsedParams, [&](const ParsedAutoDiffParameter &param) {
+      switch (param.getKind()) {
+      case ParsedAutoDiffParameter::Kind::Named:
+        printer << param.getName();
+        break;
+      case ParsedAutoDiffParameter::Kind::Self:
+        printer << "self";
+        break;
+      }
+    }, [&] { printer << ", "; });
+    if (parsedParams.size() > 1)
+      printer << ')';
+  }
+  return printer.str();
+}
+
 void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
                            const Decl *D) const {
   if (!DeclAttrs)
@@ -558,16 +623,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_Differentiable: {
     Printer.printAttrName("@differentiable");
     auto *attr = cast<DifferentiableAttr>(this);
-    auto parsedParams = attr->getParsedParameters();
-    // If no attribute parameter is specified, do not print parentheses at all.
-    if (parsedParams.empty() && !attr->getJVP() && !attr->getVJP() &&
-        !attr->getWhereClause())
-      break;
-    Printer << '(';
+    // Create a temporary string for the attribute argument text.
+    std::string attrArgText;
+    llvm::raw_string_ostream stream(attrArgText);
+
     // Get original function.
     auto *original = dyn_cast_or_null<AbstractFunctionDecl>(D);
-    if (auto *varDecl = dyn_cast_or_null<VarDecl>(D))
-      original = varDecl->getGetter();
+    // Handle stored/computed properties and subscript methods.
+    if (auto *asd = dyn_cast_or_null<AbstractStorageDecl>(D))
+      original = asd->getGetter();
 
     // Print comma if not leading clause.
     bool isLeadingClause = true;
@@ -576,43 +640,29 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
         isLeadingClause = false;
         return;
       }
-      Printer << ", ";
+      stream << ", ";
     };
 
     // Print differentiation parameters, if any.
-    if (auto indices = attr->getParameterIndices()) {
-      if (!parsedParams.empty()) {
-        printCommaIfNecessary();
-        Printer << "wrt: ";
-        if (parsedParams.size() > 1)
-          Printer << '(';
-        interleave(parsedParams, [&](const ParsedAutoDiffParameter &param) {
-          switch (param.getKind()) {
-          case ParsedAutoDiffParameter::Kind::Named:
-            Printer << param.getName();
-            break;
-          case ParsedAutoDiffParameter::Kind::Self:
-            Printer << "self";
-            break;
-          }
-        }, [&]{ Printer << ", "; });
-        if (parsedParams.size() > 1)
-          Printer << ')';
-      }
+    auto diffParamsString = getDifferentiationParametersClauseString(
+        original, attr->getParameterIndices(), attr->getParsedParameters());
+    if (!diffParamsString.empty()) {
+      isLeadingClause = false;
+      stream << diffParamsString;
     }
     // Print jvp function name.
     if (auto jvp = attr->getJVP()) {
       printCommaIfNecessary();
-      Printer << "jvp: " << jvp->Name;
+      stream << "jvp: " << jvp->Name;
     }
     // Print vjp function name.
     if (auto vjp = attr->getVJP()) {
       printCommaIfNecessary();
-      Printer << "vjp: " << vjp->Name;
+      stream << "vjp: " << vjp->Name;
     }
     // Print 'where' clause, if any.
     if (!attr->getRequirements().empty()) {
-      Printer << " where ";
+      stream << " where ";
       std::function<Type(Type)> getInterfaceType;
       if (!original || !original->getGenericEnvironment()) {
         getInterfaceType = [](Type Ty) -> Type { return Ty; };
@@ -630,16 +680,23 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
         if (req.getKind() != RequirementKind::Layout) {
           auto SecondTy = getInterfaceType(req.getSecondType());
           Requirement ReqWithDecls(req.getKind(), FirstTy, SecondTy);
-          ReqWithDecls.print(Printer, Options);
+          ReqWithDecls.print(stream, Options);
         } else {
           Requirement ReqWithDecls(req.getKind(), FirstTy,
           req.getLayoutConstraint());
-          ReqWithDecls.print(Printer, Options);
+          ReqWithDecls.print(stream, Options);
         }
       }, [&] {
-        Printer << ", ";
+        stream << ", ";
       });
     }
+
+    // If the attribute argument text is empty, break. Do not print parentheses.
+    if (stream.str().empty())
+      break;
+    // Otherwise, print the attribute argument text enclosed in parentheses.
+    Printer << '(';
+    Printer << stream.str();
     Printer << ')';
     break;
   }

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -255,6 +255,9 @@ AutoDiffParameterIndices::getLowered(AnyFunctionType *functionType) const {
 
 static unsigned getNumAutoDiffParameterIndices(AnyFunctionType *fnTy) {
   unsigned numAutoDiffParameterIndices = 0;
+  // FIXME: Compute the exact parameter count.
+  // Do not loop ad-infinitum; loop either 1 or 2 iterations, depending on
+  // whether the function is a free function/static method/instance method.
   while (fnTy != nullptr) {
     numAutoDiffParameterIndices += fnTy->getNumParams();
     fnTy = fnTy->getResult()->getAs<AnyFunctionType>();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2797,6 +2797,9 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
+  // Set the checked differentiation parameter indices in the attribute.
+  attr->setParameterIndices(checkedWrtParamIndices);
+
   auto insertion =
       ctx.DifferentiableAttrs.try_emplace({D, checkedWrtParamIndices}, attr);
   // Differentiable attributes are uniqued by their parameter indices.
@@ -2806,7 +2809,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  // Check that result type conforms to `Differentiable`.
+  // Check that original function's result type conforms to `Differentiable`.
   if (whereClauseGenEnv) {
     auto originalResultInterfaceType = !originalResultTy->hasTypeParameter()
         ? originalResultTy->mapTypeOutOfContext()
@@ -2821,9 +2824,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     attr->setInvalid();
     return;
   }
-
-  // Memorize the checked parameter indices in the attribute.
-  attr->setParameterIndices(checkedWrtParamIndices);
 
   // Checks that the `candidate` function type equals the `required` function
   // type, disregarding parameter labels.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2248,7 +2248,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
       assert(da);
       std::string diffAttrReq;
       llvm::raw_string_ostream stream(diffAttrReq);
-      da->print(stream, req);
+      da->print(stream, req,
+                /*prettyPrintInModule*/ match.Witness->getModuleContext());
       diags.diagnose(match.Witness,
           diag::protocol_witness_missing_specific_differentiable_attr,
           StringRef(stream.str()).trim());

--- a/test/AutoDiff/Inputs/differentiable_requirement_other_module.swift
+++ b/test/AutoDiff/Inputs/differentiable_requirement_other_module.swift
@@ -1,0 +1,8 @@
+public struct Empty {
+  public init() {}
+}
+
+public protocol DifferentiableRequirement {
+  @differentiable
+  func foo(float: Float, empty: Empty) -> Float
+}

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -590,12 +590,12 @@ protocol DiffReq : Differentiable {
 
 // expected-error @+1 {{does not conform to protocol 'DiffReq'}}
 struct ConformingWithErrors : DiffReq {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (self, x))'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
   func f1(_ x: Float) -> Float {
     return x
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: (self, x, y))'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
   @differentiable(wrt: (self, x))
   func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
@@ -618,14 +618,14 @@ struct DifferentiableInitStruct : DifferentiableInit {
 
   // FIXME(TF-284): Fix unexpected diagnostic.
   // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: x)'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
   init(x: Float, y: Float) {
     self.x = x
     self.y = y
   }
 
   // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
   // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
   init(x: Float, y: Int) {
     self.x = x

--- a/test/AutoDiff/differentiable_requirement_cross_module.swift
+++ b/test/AutoDiff/differentiable_requirement_cross_module.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -primary-file %S/Inputs/differentiable_requirement_other_module.swift -emit-module-path %t/differentiable_requirement_other_module.swiftmodule
+// RUN: %target-swift-frontend -typecheck -I %t -primary-file %s -verify
+
+import differentiable_requirement_other_module
+
+// Conform `Empty` to `Differentiable`.
+// The `foo` protocol requirement is `@differentiable` and has an `Empty` parameter.
+extension Empty : Differentiable {}
+
+// expected-error @+1 {{type 'Conforming' does not conform to protocol 'DifferentiableRequirement'}}
+struct Conforming : DifferentiableRequirement {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (self, float))'}}
+  func foo(float: Float, empty: Empty) -> Float {
+    return float
+  }
+}

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -29,6 +29,22 @@ func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
 }
 
+// CHECK-DAG: @differentiable(wrt: x)
+// CHECK-DAG: func testWrtClause(x: Float, y: Float) -> Float
+@differentiable(wrt: x)
+func testWrtClause(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+struct InstanceMethod : Differentiable {
+  // CHECK-DAG: @differentiable(wrt: (self, y))
+  // CHECK-DAG: func testWrtClause(x: Float, y: Float) -> Float
+  @differentiable(wrt: (self, y))
+  func testWrtClause(x: Float, y: Float) -> Float {
+    return x + y
+  }
+}
+
 // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
@@ -55,9 +71,6 @@ extension P where Self : Differentiable {
     return (self, { v in v })
   }
 }
-
-// NOTE: The failing tests involve where clauses with member type constraints.
-// They pass type-checking but crash during serialization.
 
 // CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T : Numeric, T == T.CotangentVector)
 // CHECK-DAG: func testWhereClauseMemberTypeConstraint<T>(x: T) -> T where T : Numeric


### PR DESCRIPTION
Fix `wrt` parameter clause printing for `@differentiable` attribute.
- Previously, only parsed parameters (`ArrayRef<ParsedAutoDiffParameter>`) were used.
- Now, `AutoDiffParameterIndices` are used and preferred, while maintaining the same
  printing behavior.
  - Always print `@differentiable`; never `@differentiable()`.
  - Always print `@differentiable(wrt: x)`; never `@differentiable(wrt: (x))`.

Add tests, update affected existing tests.

Up next: fix `wrt` printing/serialization for `@differentiating` attribute.