### PR TITLE
[AutoDiff] Fix `@differentiable` attribute where clause printing.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -393,7 +393,9 @@ static void printDifferentiableAttrArguments(
   }
   // Print 'where' clause, if any.
   if (!attr->getRequirements().empty()) {
-    stream << " where ";
+    if (!isLeadingClause)
+      stream << ' ';
+    stream << "where ";
     std::function<Type(Type)> getInterfaceType;
     if (!original || !original->getGenericEnvironment()) {
       getInterfaceType = [](Type Ty) -> Type { return Ty; };

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -586,6 +586,10 @@ protocol DiffReq : Differentiable {
   // expected-note @+2 {{protocol requires function 'f2'}}
   @differentiable(wrt: (self, x, y))
   func f2(_ x: Float, _ y: Float) -> Float
+
+  // expected-note @+2 {{protocol requires function 'generic'}}
+  @differentiable(where T : Differentiable)
+  func generic<T>(_ x: T) -> T
 }
 
 // expected-error @+1 {{does not conform to protocol 'DiffReq'}}
@@ -599,6 +603,13 @@ struct ConformingWithErrors : DiffReq {
   @differentiable(wrt: (self, x))
   func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
+  }
+
+  // FIXME(TF-371): Fix misleading `@differentiable` attribute shown in diagnostic.
+  // The `Self : DiffRep` requirement should not be shown.
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(where Self : DiffReq, T : Differentiable)'}}
+  func generic<T>(_ x: T) -> T {
+    return x
   }
 }
 

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -45,6 +45,13 @@ struct InstanceMethod : Differentiable {
   }
 }
 
+// CHECK-DAG: @differentiable(where T : Differentiable, T : Numeric)
+// CHECK-DAG: func testOnlyWhereClause<T>(x: T) -> T where T : Numeric
+@differentiable(where T : Differentiable)
+func testOnlyWhereClause<T : Numeric>(x: T) -> T {
+  return x
+}
+
 // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)


### PR DESCRIPTION
Do not print space in front of where clause if it is the leading clause.
Add tests.

Exposes [TF-371](https://bugs.swift.org/browse/TF-371).