### PR TITLE
[AutoDiff] Support `@differentiating` with extra generic constraints.

### DIFF
--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -260,3 +260,34 @@ extension GenericInstanceMethod {
     return (x, { v in (self, v) })
   }
 }
+
+// Test extra generic constraints.
+
+func bar<T>(_ x: T) -> T {
+  return x
+}
+@differentiating(bar)
+func vjpBar<T : Differentiable & VectorNumeric>(_ x: T) -> (value: T, pullback: (T.CotangentVector) -> T.CotangentVector) {
+  return (x, { $0 })
+}
+
+func baz<T, U>(_ x: T, _ y: U) -> T {
+  return x
+}
+@differentiating(baz)
+func vjpBaz<T : Differentiable & VectorNumeric, U : Differentiable>(_ x: T, _ y: U)
+    -> (value: T, pullback: (T) -> (T, U))
+  where T == T.CotangentVector, U == U.CotangentVector
+{
+  return (x, { ($0, .zero) })
+}
+
+protocol InstanceMethodProto {
+  func bar() -> Float
+}
+extension InstanceMethodProto where Self : Differentiable {
+  @differentiating(bar)
+  func vjpBar() -> (value: Float, pullback: (Float) -> CotangentVector) {
+    return (bar(), { _ in .zero })
+  }
+}


### PR DESCRIPTION
Support `@differentiating` attribute on derivative functions with more generic
requirements than the original function. This functionality is the counterpart
to trailing where clauses for `@differentiable` attributes.

Currently, the extra requirements are used when constructing a
`@differentiable` attribute on the original function. Eventually, these
requirements may be stored in a SIL differentiability witness.

Resolves [TF-358](https://bugs.swift.org/projects/TF/issues/TF-358).