### PR TITLE
[AutoDiff] Fix `@differentiable` attribute where clause printing.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -393,7 +393,9 @@ static void printDifferentiableAttrArguments(
   }
   // Print 'where' clause, if any.
   if (!attr->getRequirements().empty()) {
-    stream << " where ";
+    if (!isLeadingClause)
+      stream << ' ';
+    stream << "where ";
     std::function<Type(Type)> getInterfaceType;
     if (!original || !original->getGenericEnvironment()) {
       getInterfaceType = [](Type Ty) -> Type { return Ty; };

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -586,6 +586,10 @@ protocol DiffReq : Differentiable {
   // expected-note @+2 {{protocol requires function 'f2'}}
   @differentiable(wrt: (self, x, y))
   func f2(_ x: Float, _ y: Float) -> Float
+
+  // expected-note @+2 {{protocol requires function 'generic'}}
+  @differentiable(where T : Differentiable)
+  func generic<T>(_ x: T) -> T
 }
 
 // expected-error @+1 {{does not conform to protocol 'DiffReq'}}
@@ -599,6 +603,13 @@ struct ConformingWithErrors : DiffReq {
   @differentiable(wrt: (self, x))
   func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
+  }
+
+  // FIXME(TF-371): Fix misleading `@differentiable` attribute shown in diagnostic.
+  // The `Self : DiffRep` requirement should not be shown.
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(where Self : DiffReq, T : Differentiable)'}}
+  func generic<T>(_ x: T) -> T {
+    return x
   }
 }
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -605,9 +605,7 @@ struct ConformingWithErrors : DiffReq {
     return x + y
   }
 
-  // FIXME(TF-371): Fix misleading `@differentiable` attribute shown in diagnostic.
-  // The `Self : DiffRep` requirement should not be shown.
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(where Self : DiffReq, T : Differentiable)'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(where T : Differentiable)'}}
   func generic<T>(_ x: T) -> T {
     return x
   }

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -45,14 +45,14 @@ struct InstanceMethod : Differentiable {
   }
 }
 
-// CHECK-DAG: @differentiable(where T : Differentiable, T : Numeric)
+// CHECK-DAG: @differentiable(where T : Differentiable)
 // CHECK-DAG: func testOnlyWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(where T : Differentiable)
 func testOnlyWhereClause<T : Numeric>(x: T) -> T {
   return x
 }
 
-// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
 func testWhereClause<T : Numeric>(x: T) -> T {
@@ -66,7 +66,7 @@ func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector
 
 protocol P {}
 extension P {
-  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where Self : Differentiable, Self : P)
+  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where Self : Differentiable)
   // CHECK-DAG: func testWhereClause() -> Self
   @differentiable(wrt: self, vjp: vjpTestWhereClause where Self : Differentiable)
   func testWhereClause() -> Self {
@@ -79,7 +79,7 @@ extension P where Self : Differentiable {
   }
 }
 
-// CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T : Numeric, T == T.CotangentVector)
+// CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
 // CHECK-DAG: func testWhereClauseMemberTypeConstraint<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
 func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
@@ -92,7 +92,7 @@ func vjpTestWhereClauseMemberTypeConstraint<T>(x: T) -> (T, (T) -> T)
 }
 
 extension P {
-  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self : P, Self == Self.CotangentVector)
+  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self == Self.CotangentVector)
   // CHECK-DAG: func testWhereClauseMemberTypeConstraint() -> Self
   @differentiable(wrt: self, vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
   func testWhereClauseMemberTypeConstraint() -> Self {

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -45,6 +45,13 @@ struct InstanceMethod : Differentiable {
   }
 }
 
+// CHECK-DAG: @differentiable(where T : Differentiable, T : Numeric)
+// CHECK-DAG: func testOnlyWhereClause<T>(x: T) -> T where T : Numeric
+@differentiable(where T : Differentiable)
+func testOnlyWhereClause<T : Numeric>(x: T) -> T {
+  return x
+}
+
 // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable, T : Numeric)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)


### PR DESCRIPTION
Only print where clause requirements that are not satisfied by the original
function's generic signature. This improves diagnostics and reduces noise.

Resolves [TF-371](https://bugs.swift.org/browse/TF-371).