### PR TITLE
SwiftPrivate: add `isClosed` property

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -161,6 +161,9 @@ public struct _Stderr : TextOutputStream {
 #if os(Windows)
 public struct _FDOutputStream : TextOutputStream {
   public var handle: HANDLE
+  public var isClosed: Bool {
+    return handle == INVALID_HANDLE_VALUE
+  }
 
   public init(handle: HANDLE) {
     self.handle = handle


### PR DESCRIPTION
Since the `_FDOutputStream` type does not conform to a protocol, the
required interface was missed.  The changes in
fbce6e7873590f497b3bb0d91c701483b62c2bd6 introduced a use of the
`isClosed` property which broke the Windows build.  This should fix the
windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
