### PR TITLE
build: correct the variable name for cross-compiling

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -63,8 +63,8 @@ macro(swift_common_standalone_build_config_llvm product)
   endif()
 
   if(CMAKE_CROSSCOMPILING)
-    set(LLVM_NATIVE_BUILD "${LLVM_BINARY_DIR}/NATIVE")
-    if(NOT EXISTS "${LLVM_NATIVE_BUILD}")
+    set(LLVM_NATIVE_BUILD_DIR "${LLVM_BINARY_DIR}/NATIVE")
+    if(NOT EXISTS "${LLVM_NATIVE_BUILD_DIR}")
       message(FATAL_ERROR
         "Attempting to cross-compile swift standalone but no native LLVM build
         found.  Please cross-compile LLVM as well.")


### PR DESCRIPTION
A typo snuck into the cross-compiling path and due to the machine that it was
tested on hvaing `/bin/llvm-tblgen`, the build succeeded.  Correct the typo to
ensure that we use the correct tblgen.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
