### PR TITLE
Some cleanup of SIMDVector and SIMDVectorTypes source files [NFC]

### DIFF
--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -1,3 +1,15 @@
+//===--- SIMDVectorTypes.swift.gyb ----------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 %{
 from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
@@ -101,13 +113,13 @@ public struct SIMD${n}<Scalar> : SIMD where Scalar: SIMDScalar {
 % end
 }
 
-public extension SIMD${n} where Scalar : FixedWidthInteger {
+extension SIMD${n} where Scalar : FixedWidthInteger {
   /// Creates a new vector from the given vector, truncating the bit patterns
   /// of the given vector's elements if necessary.
   ///
   /// - Parameter other: The vector to convert.
   @inlinable
-  init<Other>(truncatingIfNeeded other: SIMD${n}<Other>)
+  public init<Other>(truncatingIfNeeded other: SIMD${n}<Other>)
   where Other : FixedWidthInteger {
     self.init()
     for i in indices { self[i] = Scalar(truncatingIfNeeded: other[i]) }
@@ -118,7 +130,7 @@ public extension SIMD${n} where Scalar : FixedWidthInteger {
   ///
   /// - Parameter other: The vector to convert.
   @inlinable
-  init<Other>(clamping other: SIMD${n}<Other>)
+  public init<Other>(clamping other: SIMD${n}<Other>)
   where Other : FixedWidthInteger {
     self.init()
     for i in indices { self[i] = Scalar(clamping: other[i]) }
@@ -132,7 +144,7 @@ public extension SIMD${n} where Scalar : FixedWidthInteger {
   ///   - rule: The round rule to use when converting elements of `other.` The
   ///     default is `.towardZero`.
   @inlinable
-  init<Other>(
+  public init<Other>(
     _ other: SIMD${n}<Other>,
     rounding rule: FloatingPointRoundingRule = .towardZero
   )
@@ -151,12 +163,12 @@ extension SIMD${n} : CustomDebugStringConvertible {
   }
 }
 
-public extension SIMD${n} where Scalar : BinaryFloatingPoint {
+extension SIMD${n} where Scalar : BinaryFloatingPoint {
   /// Creates a new vector from the given vector of integers.
   ///
   /// - Parameter other: The vector to convert.
   @inlinable
-  init<Other>(_ other: SIMD${n}<Other>)
+  public init<Other>(_ other: SIMD${n}<Other>)
   where Other : FixedWidthInteger {
     self.init()
     for i in indices { self[i] = Scalar(other[i]) }
@@ -166,7 +178,7 @@ public extension SIMD${n} where Scalar : BinaryFloatingPoint {
   ///
   /// - Parameter other: The vector to convert.
   @inlinable
-  init<Other>(_ other: SIMD${n}<Other>)
+  public init<Other>(_ other: SIMD${n}<Other>)
   where Other : BinaryFloatingPoint {
     self.init()
     for i in indices { self[i] = Scalar(other[i]) }


### PR DESCRIPTION
Bring formatting closer in line with the rest of the standard lib, remove "public" from extensions (moving it onto the contents defined therein). Restore Swift project headers that were apparently lost at some point.

"NFC," he said ...