### PR TITLE
[5.1] test: temporarily disable test_runtime_function_counters.swift for CI failure

### DIFF
--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/test_runtime_function_counters 2>&1 | %FileCheck %s
 // REQUIRES: runtime_function_counters
 // REQUIRES: executable_test
+// REQUIRES: rdar48995133
 
 /// Test functionality related to the runtime function counters.
 


### PR DESCRIPTION
rdar://48995133