### PR TITLE
[WIP] Import C structs with non-trivially copyable fields

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1414,17 +1414,6 @@ static ImportedType adjustTypeForConcreteImport(
   if (!importedType)
     return {importedType, false};
 
-  if (importKind == ImportTypeKind::RecordField &&
-      importedType->isAnyClassReferenceType()) {
-    // Wrap retainable struct fields in Unmanaged.
-    // FIXME: Eventually we might get C++-like support for strong pointers in
-    // structs, at which point we should really be checking the lifetime
-    // qualifiers.
-    // FIXME: This should apply to blocks as well, but Unmanaged is constrained
-    // to AnyObject.
-    importedType = getUnmanagedType(impl, importedType);
-  }
-
   // Treat va_list specially: null-unspecified va_list parameters should be
   // assumed to be non-optional. (Most people don't even think of va_list as a
   // pointer, and it's not a portable assumption anyway.)

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -669,8 +669,8 @@ func testBridgeFunctionPointerTypedefs(fptrTypedef: FPTypedef) {
 }
 
 func testNonTrivialStructs() {
-  _ = NonTrivialToCopy() // expected-error {{use of unresolved identifier 'NonTrivialToCopy'}}
-  _ = NonTrivialToCopyWrapper() // expected-error {{use of unresolved identifier 'NonTrivialToCopyWrapper'}}
+  _ = NonTrivialToCopy() // okay
+  _ = NonTrivialToCopyWrapper() // okay
   _ = TrivialToCopy() // okay
 }
 


### PR DESCRIPTION
_Still very much a work in progress._ Drafting it while I seek out feedback on the forums.

So far, this just makes the `struct` able to be imported by ClangImporter and applies the appropriate storage types based on the Objective-C lifetime. The SIL/IR-side work still needs to be finished.
