### PR TITLE
fix autocomplete crasher related to autodiff

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -665,9 +665,11 @@ swift::matchWitness(
   for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
     auto witnessDiffAttrs =
         witnessAttrs.getAttributes<DifferentiableAttr, /*AllowInvalid*/ true>();
-    bool reqDiffAttrMatch = llvm::any_of(witnessDiffAttrs,
-        [&](const DifferentiableAttr *witnessDiffAttr) {
-          return witnessDiffAttr->parametersMatch(*reqDiffAttr);
+    bool reqDiffAttrMatch = llvm::any_of(
+        witnessDiffAttrs, [&](const DifferentiableAttr *witnessDiffAttr) {
+          return witnessDiffAttr->getParameterIndices() &&
+                 reqDiffAttr->getParameterIndices() &&
+                 witnessDiffAttr->parametersMatch(*reqDiffAttr);
         });
     if (!reqDiffAttrMatch) {
       if (auto *vdWitness = dyn_cast<VarDecl>(witness))

--- a/test/IDE/complete_autodiff.swift
+++ b/test/IDE/complete_autodiff.swift
@@ -1,16 +1,25 @@
 // SWIFT_ENABLE_TENSORFLOW
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE | %FileCheck %s
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE1 | %FileCheck --check-prefix=COMPLETE1 %s
 
 protocol DifferentiableRequirements {
   @differentiable
   func f(_ x: Float) -> Float
 }
 
-struct Foo : DifferentiableRequirements {
+struct Complete1 : DifferentiableRequirements {
   @differentiable
-  func f#^COMPLETE^#
+  func f#^COMPLETE1^#
 }
 
-// CHECK-LABEL: Begin completions
-// CHECK: func f(_ x: Float) -> Float
-// CHECK: End completions
+// COMPLETE1-LABEL: Begin completions
+// COMPLETE1: func f(_ x: Float) -> Float
+// COMPLETE1: End completions
+
+struct Complete2 : DifferentiableRequirements {
+  @differentiable
+  func f(_ x: Float)#^COMPLETE2^#
+}
+
+// COMPLETE2-LABEL: Begin completions
+// COMPLETE2: func f(_ x: Float) -> Float
+// COMPLETE2: End completions


### PR DESCRIPTION
The jupyter tests caught a new autocomplete crasher related to autodiff (http://sponge.corp.google.com/d427b231-fcfd-44b6-8943-0312c3bf41b1). Autocomplete calls `witnessDiffAttr->parametersMatch(*reqDiffAttr)` with `witnessDiffAttr->ParameterIndices == nullptr`, which causes an assertion failure in `parametersMatch`.

It happened on some commit in this range: https://github.com/apple/swift/compare/6850a0ef1de6ce6c08377008285b5febdb61fff2...d4e951ef11797eb9b25be9be8c12f50604387fb5

This PR fixes it and adds a compiler test that catches it.