### PR TITLE
[Typechecker] Support Self inside class bodies

### DIFF
--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -24,9 +24,9 @@ enum E0 {
 class C0 {
   func f() -> Self { } // okay
 
-  func g(_ ds: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{16-20=C0}}
+  func g(_ ds: Self) { } // okay
 
-  func h(_ ds: Self) -> Self { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{16-20=C0}}
+  func h(_ ds: Self) -> Self { } // okay
 }
 
 protocol P0 {
@@ -73,7 +73,7 @@ class C1 {
     if !b { return type(of: self).init(int: 5) }
 
     // Can't utter Self within the body of a method.
-    var _: Self = self // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C1'?}} {{12-16=C1}}
+    var _: Self = self
 
     // Okay to return 'self', because it has the appropriate type.
     return self // okay

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -5,7 +5,7 @@ struct S0<T> {
 }
 
 class C0<T> {
-  func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{21-25=C0}}
+  func foo(_ other: Self) { }
 }
 
 enum E0<T> {
@@ -53,7 +53,6 @@ class A<T> {
     b = a
   }
   static func z(n: Self? = nil) {
-    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
     print("\(Self.self).\(#function)")
   }
   class func y() {
@@ -65,7 +64,6 @@ class A<T> {
     Self.y()
     Self.z()
     let _: Self = Self.init(a: 66)
-    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
     return Self.init(a: 77) as? Self as? A
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
     // expected-warning@-2 {{conditional downcast from 'Self?' to 'A<T>' is equivalent to an implicit conversion to an optional 'A<T>'}}


### PR DESCRIPTION
This PR adds support for `Self` inside classes. This is a follow up to SE-0068, which was recently implemented.

According to the core team:

>  use of “Self” as shorthand for referring to the containing type (in the case of structs, enums, and final class) or the dynamic type (in the case of non-final classes).

Resolves [SR-10121](https://bugs.swift.org/browse/SR-10121).
