### PR TITLE
[5.1] [Serialization] Recover when a typealias can't be deserialized

### DIFF
--- a/test/Serialization/Recovery/Inputs/custom-modules/TypeRemovalObjC.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/TypeRemovalObjC.h
@@ -12,6 +12,8 @@ __attribute__((objc_root_class))
 
 @protocol SomeProto
 @end
+
+typedef long long SomeTypedef;
 #endif
 
 @protocol ZProto

--- a/test/Serialization/Recovery/type-removal-objc.swift
+++ b/test/Serialization/Recovery/type-removal-objc.swift
@@ -34,6 +34,13 @@ public let someProtoCompositionValue: (AProto & SomeProto)? = nil
 // CHECK-RECOVERY-NEGATIVE-NOT: let someProtoCompositionValue2:
 public let someProtoCompositionValue2: (SomeProto & ZProto)? = nil
 
+// CHECK-DAG: let someTypedefValue: SomeTypedef
+// CHECK-RECOVERY-DAG: let someTypedefValue: Int64
+public let someTypedefValue: SomeTypedef = 0
+// CHECK-DAG: let someTypedefOptValue: SomeTypedef?
+// CHECK-RECOVERY-DAG: let someTypedefOptValue: Int64?
+public let someTypedefOptValue: SomeTypedef? = nil
+
 // CHECK-DAG: unowned var someUnownedObject: @sil_unowned Base
 // CHECK-RECOVERY-NEGATIVE-NOT: var someUnownedObject:
 public unowned var someUnownedObject: Base = Base()


### PR DESCRIPTION
Cherry-pick of #23419 to the 5.1 branch. Reviewed by @harlanhaskins and @slavapestov.

[SR-9811](https://bugs.swift.org/browse/SR-9811)