### PR TITLE
Rebase: [ConstraintSystem] Ability to treat key path literal syntax as function type (Root) -> Value.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4472,42 +4472,98 @@ namespace {
       if (!isFunctionType)
         return E;
 
-      // Construct an implicit closure which applies this KeyPath.
-      auto resultTy = cs.getType(E);
+      // If we've gotten here, the user has used key path literal syntax to form
+      // a closure. The type checker has given E a function type to indicate
+      // this; we're going to change E's type to KeyPath<baseTy, leafTy> and
+      // then wrap it in a larger closure expression with the appropriate type.
+
+      // baseTy has been overwritten by the loop above; restore it.
+      baseTy = exprType->getAs<FunctionType>()->getParams()[0].getPlainType();
+
+      // Compute KeyPath<baseTy, leafTy> and set E's type back to it.
+      auto kpDecl = cs.getASTContext().getKeyPathDecl();
+      auto keyPathTy =
+          BoundGenericType::get(kpDecl, nullptr, { baseTy, leafTy });
+      E->setType(keyPathTy);
+      cs.cacheType(E);
+
+      // To ensure side effects of the key path expression (mainly indices in
+      // subscripts) are only evaluated once, we construct an outer closure,
+      // which is immediately evaluated, and an inner closure, which it returns.
+      // The result looks like this:
+      //
+      //     return "{ $kp$ in { $0[keyPath: $kp$] } }( \(E) )"
+
       auto &ctx = cs.getASTContext();
-      auto toFunc = exprType->getAs<FunctionType>();
-      auto argTy = toFunc->getParams()[0].getPlainType();
       auto discriminator = AutoClosureExpr::InvalidDiscriminator;
+
+      // The inner closure.
+      //
+      //     let closure = "{ $0[keyPath: $kp$] }"
+      auto closureTy =
+          FunctionType::get({ FunctionType::Param(baseTy) }, leafTy);
       auto closure = new (ctx)
-          AutoClosureExpr(E, toFunc->getResult(), discriminator, cs.DC);
-      auto param = new (ctx) ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
-                                       SourceLoc(), Identifier(), SourceLoc(),
-                                       ctx.getIdentifier("$0"), closure);
-      param->setType(argTy);
-      param->setInterfaceType(argTy->mapTypeOutOfContext());
+          AutoClosureExpr(E, leafTy, discriminator, cs.DC);
+      auto param = new (ctx)
+          ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
+                    /*argument label*/ SourceLoc(), Identifier(),
+                    /*parameter name*/ SourceLoc(), ctx.getIdentifier("$0"),
+                    closure);
+      param->setType(baseTy);
+      param->setInterfaceType(baseTy->mapTypeOutOfContext());
+
+      // The outer closure.
+      //
+      //    let outerClosure = "{ $kp$ in \(closure) }"
+      auto outerClosureTy =
+          FunctionType::get({ FunctionType::Param(keyPathTy) }, closureTy);
+      auto outerClosure = new (ctx)
+          AutoClosureExpr(closure, closureTy, discriminator, cs.DC);
+      auto outerParam = new (ctx)
+          ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
+                    /*argument label*/ SourceLoc(), Identifier(),
+                    /*parameter name*/ SourceLoc(), ctx.getIdentifier("$kp$"),
+                    outerClosure);
+      outerParam->setType(keyPathTy);
+      outerParam->setInterfaceType(keyPathTy->mapTypeOutOfContext());
+
+      // let paramRef = "$0"
       auto *paramRef = new (ctx)
           DeclRefExpr(param, DeclNameLoc(E->getLoc()), /*Implicit=*/true);
-      paramRef->setType(argTy);
+      paramRef->setType(baseTy);
       cs.cacheType(paramRef);
 
-      if (resultTy->is<FunctionType>()) {
-        auto kpDecl = cs.getASTContext().getKeyPathDecl();
-        E->setType(BoundGenericType::get(kpDecl, nullptr,
-                                         {argTy, toFunc->getResult()}));
-        cs.cacheType(E);
-      }
+      // let outerParamRef = "$kp$"
+      auto outerParamRef = new (ctx)
+          DeclRefExpr(outerParam, DeclNameLoc(E->getLoc()), /*Implicit=*/true);
+      outerParamRef->setType(keyPathTy);
+      cs.cacheType(outerParamRef);
+
+      // let application = "\(paramRef)[keyPath: \(outerParamRef)]"
       auto *application = new (ctx)
-          KeyPathApplicationExpr(paramRef, E->getStartLoc(), E, E->getEndLoc(),
-                                 toFunc->getResult(), /*implicit=*/true);
+          KeyPathApplicationExpr(paramRef,
+                                 E->getStartLoc(), outerParamRef, E->getEndLoc(),
+                                 leafTy, /*implicit=*/true);
       cs.cacheType(application);
+
+      // Finish up the inner closure.
       closure->setParameterList(ParameterList::create(ctx, {param}));
       closure->setBody(application);
-
-      if (!resultTy->is<FunctionType>())
-        resultTy = toFunc->withExtInfo(toFunc->getExtInfo().withThrows(false));
-      closure->setType(resultTy);
+      closure->setType(closureTy);
       cs.cacheType(closure);
-      return coerceToType(closure, exprType, cs.getConstraintLocator(E));
+
+      // Finish up the outer closure.
+      outerClosure->setParameterList(ParameterList::create(ctx, {outerParam}));
+      outerClosure->setBody(closure);
+      outerClosure->setType(outerClosureTy);
+      cs.cacheType(outerClosure);
+
+      // let outerApply = "\( outerClosure )( \(E) )"
+      auto outerApply = CallExpr::createImplicit(ctx, outerClosure, {E}, {});
+      outerApply->setType(closureTy);
+      cs.cacheExprTypes(outerApply);
+
+      return coerceToType(outerApply, exprType, cs.getConstraintLocator(E));
     }
 
     KeyPathExpr::Component

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3075,18 +3075,12 @@ namespace {
       CS.addConstraint(ConstraintKind::Equal, base, rvalueBase, locator);
 
       // The result is a KeyPath from the root to the end component.
-      Type kpTy;
-      if (didOptionalChain) {
-        // Optional-chaining key paths are always read-only.
-        kpTy = BoundGenericType::get(kpDecl, Type(), {root, rvalueBase});
-      } else {
-        // The type of key path depends on the overloads chosen for the key
-        // path components.
-        auto typeLoc =
-            CS.getConstraintLocator(locator, ConstraintLocator::KeyPathType);
-        kpTy = CS.createTypeVariable(typeLoc, TVO_CanBindToNoEscape);
-        CS.addKeyPathConstraint(kpTy, root, rvalueBase, locator);
-      }
+      // The type of key path depends on the overloads chosen for the key
+      // path components.
+      auto typeLoc =
+          CS.getConstraintLocator(locator, ConstraintLocator::KeyPathType);
+      Type kpTy = CS.createTypeVariable(typeLoc, TVO_CanBindToNoEscape);
+      CS.addKeyPathConstraint(kpTy, root, rvalueBase, locator);
       return kpTy;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3073,7 +3073,7 @@ namespace {
       auto rvalueBase = CS.createTypeVariable(baseLocator,
                                               TVO_CanBindToNoEscape);
       CS.addConstraint(ConstraintKind::Equal, base, rvalueBase, locator);
-      
+
       // The result is a KeyPath from the root to the end component.
       Type kpTy;
       if (didOptionalChain) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1080,7 +1080,7 @@ namespace {
 
       // Add the member constraint for a subscript declaration.
       // FIXME: weak name!
-      auto memberTy = CS.createTypeVariable(resultLocator, TVO_CanBindToNoEscape);
+      auto memberTy = CS.createTypeVariable(memberLocator, TVO_CanBindToNoEscape);
 
       // FIXME: synthesizeMaterializeForSet() wants to statically dispatch to
       // a known subscript here. This might be cleaner if we split off a new

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1138,6 +1138,17 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
         ++score1;
       continue;
     }
+
+    // If one is a function type and the other is a key path, prefer the other.
+    if (type1->is<FunctionType>() != type2->is<FunctionType>()) {
+      auto anyKeyPathTy =
+          cs.DC->getASTContext().getAnyKeyPathDecl()->getDeclaredType();
+
+      if (tc.isSubtypeOf(type1, anyKeyPathTy, cs.DC))
+        ++score1;
+      else if (tc.isSubtypeOf(type2, anyKeyPathTy, cs.DC))
+        ++score2;
+    }
     
     // FIXME:
     // This terrible hack is in place to support equality comparisons of non-

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -201,7 +201,8 @@ enum class ConversionRestrictionKind {
   MetatypeToExistentialMetatype,
   /// Existential metatype to metatype conversion.
   ExistentialMetatypeToMetatype,
-  /// T -> U? value to optional conversion (or to implicitly unwrapped optional).
+  /// T -> U? value to optional conversion (or to implicitly unwrapped
+  /// optional).
   ValueToOptional,
   /// T? -> U? optional to optional conversion (or unchecked to unchecked).
   OptionalToOptional,
@@ -219,7 +220,7 @@ enum class ConversionRestrictionKind {
   CFTollFreeBridgeToObjC,
   /// Implicit conversion from an Objective-C class type to its
   /// toll-free-bridged CF type.
-  ObjCTollFreeBridgeToCF
+  ObjCTollFreeBridgeToCF,
 };
 
 /// Return a string representation of a conversion restriction.

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -34,3 +34,10 @@ class Demo {
 let some = Some(keyPath: \Demo.here)
 // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<_, ((_) -> Void)?>'}}
 
+// SE-0249
+func testFunc() {
+  let _: (S) -> Int = \.i
+  _ = ([S]()).map(\.i)
+  _ = ([S]()).map(\.init)
+  // expected-error@-1 {{static member 'init' cannot be used on instance of type 'S'}}
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -122,12 +122,14 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   // expected-error@+1{{}}
   _ = \(() -> ()).noMember
 
+  let _: (A) -> Prop = \.property
   let _: PartialKeyPath<A> = \.property
   let _: KeyPath<A, Prop> = \.property
   let _: WritableKeyPath<A, Prop> = \.property
   let _: ReferenceWritableKeyPath<A, Prop> = \.property
   //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, Prop>' to specified type 'ReferenceWritableKeyPath<A, Prop>'}}
 
+  let _: (A) -> A = \.[sub]
   // FIXME: shouldn't be ambiguous
   // expected-error@+1{{ambiguous}}
   let _: PartialKeyPath<A> = \.[sub]
@@ -136,6 +138,7 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>}}
 
+  let _: (A) -> Prop? = \.optProperty?
   let _: PartialKeyPath<A> = \.optProperty?
   let _: KeyPath<A, Prop?> = \.optProperty?
   // expected-error@+1{{cannot convert}}
@@ -143,6 +146,7 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   // expected-error@+1{{cannot convert}}
   let _: ReferenceWritableKeyPath<A, Prop?> = \.optProperty?
 
+  let _: (A) -> A? = \.optProperty?[sub]
   let _: PartialKeyPath<A> = \.optProperty?[sub]
   let _: KeyPath<A, A?> = \.optProperty?[sub]
   // expected-error@+1{{cannot convert}}
@@ -155,18 +159,21 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty!
   let _: KeyPath<A, A?> = \.property[optSub]?.optProperty![sub]
 
+  let _: (C<A>) -> A = \.value
   let _: PartialKeyPath<C<A>> = \.value
   let _: KeyPath<C<A>, A> = \.value
   let _: WritableKeyPath<C<A>, A> = \.value
   let _: ReferenceWritableKeyPath<C<A>, A> = \.value
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<C<A>, A>' to specified type 'ReferenceWritableKeyPath<C<A>, A>'}}
 
+  let _: (C<A>) -> A = \C.value
   let _: PartialKeyPath<C<A>> = \C.value
   let _: KeyPath<C<A>, A> = \C.value
   let _: WritableKeyPath<C<A>, A> = \C.value
   // expected-error@+1{{cannot convert}}
   let _: ReferenceWritableKeyPath<C<A>, A> = \C.value
 
+  let _: (Prop) -> B = \.nonMutatingProperty
   let _: PartialKeyPath<Prop> = \.nonMutatingProperty
   let _: KeyPath<Prop, B> = \.nonMutatingProperty
   let _: WritableKeyPath<Prop, B> = \.nonMutatingProperty
@@ -705,6 +712,8 @@ var identity8: PartialKeyPath = \Container.self
 var identity9: PartialKeyPath<Container> = \Container.self
 var identity10: PartialKeyPath<Container> = \.self
 var identity11: AnyKeyPath = \Container.self
+var identity12: (Container) -> Container = \Container.self
+var identity13: (Container) -> Container = \.self
 
 var interleavedIdentityComponents = \Container.self.base.self?.self.i.self
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -926,6 +926,52 @@ keyPath.test("let-ness") {
   expectNotNil(\Point.secretlyMutableHypotenuse as? WritableKeyPath)
 }
 
+keyPath.test("key path literal closures") {
+  // Property access
+  let fnX: (C<String>) -> Int = \C<String>.x
+  let fnY: (C<String>) -> LifetimeTracked? = \C<String>.y
+  let fnZ: (C<String>) -> String = \C<String>.z
+  let fnImmutable: (C<String>) -> String = \C<String>.immutable
+  let fnSecretlyMutable: (C<String>) -> String = \C<String>.secretlyMutable
+  let fnComputed: (C<String>) -> String = \C<String>.computed
+  
+  let lifetime = LifetimeTracked(249)
+  let base = C(x: 1, y: lifetime, z: "SE-0249")
+
+  expectEqual(1, fnX(base))
+  expectEqual(lifetime, fnY(base))
+  expectEqual("SE-0249", fnZ(base))
+  expectEqual("1 Optional(249) SE-0249", fnImmutable(base))
+  expectEqual("1 Optional(249) SE-0249", fnSecretlyMutable(base))
+  expectEqual("SE-0249", fnComputed(base))
+  
+  // Subscripts
+  var callsToComputeIndex = 0
+  func computeIndexWithSideEffect(_ i: Int) -> Int {
+    callsToComputeIndex += 1
+    return -i
+  }
+  
+  let fnSubscriptResultA: (Subscripts<String>) -> SubscriptResult<String, Int>
+    = \Subscripts<String>.["A", computeIndexWithSideEffect(13)]
+  let fnSubscriptResultB: (Subscripts<String>) -> SubscriptResult<String, Int>
+    = \Subscripts<String>.["B", computeIndexWithSideEffect(42)]
+  
+  let subscripts = Subscripts<String>()
+  
+  expectEqual("A", fnSubscriptResultA(subscripts).left)
+  expectEqual(-13, fnSubscriptResultA(subscripts).right)
+  
+  expectEqual("B", fnSubscriptResultB(subscripts).left)
+  expectEqual(-42, fnSubscriptResultB(subscripts).right)
+  
+  // Did we compute the indices once per closure construction, or once per
+  // closure application?
+  // FIXME: Currently fails.
+  // expectEqual(2, callsToComputeIndex)
+  expectEqual(4, callsToComputeIndex)
+}
+
 // SR-6096
 
 protocol Protocol6096 {}

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -967,9 +967,7 @@ keyPath.test("key path literal closures") {
   
   // Did we compute the indices once per closure construction, or once per
   // closure application?
-  // FIXME: Currently fails.
-  // expectEqual(2, callsToComputeIndex)
-  expectEqual(4, callsToComputeIndex)
+  expectEqual(2, callsToComputeIndex)
 }
 
 // SR-6096


### PR DESCRIPTION
Rebase of #19448 with an important bug fix. The original PR did not have a rule that would cause the solver to prefer `KeyPath` solutions to function solutions, making them ambiguous.