### PR TITLE
[SE-0252][TypeChecker] Keypath Dynamic Member Lookup

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1057,8 +1057,8 @@ ERROR(missing_dynamic_callable_kwargs_method,none,
 
 ERROR(invalid_dynamic_member_lookup_type,none,
       "@dynamicMemberLookup attribute requires %0 to have a "
-      "'subscript(dynamicMember:)' method with an "
-      "'ExpressibleByStringLiteral' parameter", (Type))
+      "'subscript(dynamicMember:)' method that accepts either "
+      "'ExpressibleByStringLiteral' or a keypath", (Type))
 
 ERROR(string_index_not_integer,none,
       "String must not be indexed with %0, it has variable size elements",

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1573,7 +1573,7 @@ namespace {
 
         Expr *trailingClosure = nullptr;
         if (SE->hasTrailingClosure())
-          trailingClosure = arguments.pop_back_val();
+          trailingClosure = arguments.back();
 
         componentExpr = SubscriptExpr::create(
             ctx, dotExpr, SE->getStartLoc(), arguments, SE->getArgumentLabels(),

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1257,7 +1257,9 @@ namespace {
       if (selected->choice.isDecl()) {
         auto locatorKind = ConstraintLocator::SubscriptMember;
         if (selected->choice.getKind() ==
-            OverloadChoiceKind::DynamicMemberLookup)
+                OverloadChoiceKind::DynamicMemberLookup ||
+            selected->choice.getKind() ==
+                OverloadChoiceKind::KeyPathDynamicMemberLookup)
           locatorKind = ConstraintLocator::Member;
 
         newSubscript =

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2695,6 +2695,10 @@ namespace {
                               /*isImplicit*/false,
                               AccessSemantics::Ordinary, selected);
       }
+
+      case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
+        break;
+      }
       }
 
       llvm_unreachable("Unhandled OverloadChoiceKind in switch.");
@@ -4194,8 +4198,10 @@ namespace {
           if (foundDecl) {
             // If this was a @dynamicMemberLookup property, then we actually
             // form a subscript reference, so switch the kind.
-            if (foundDecl->choice.getKind()
-                    == OverloadChoiceKind::DynamicMemberLookup) {
+            if (foundDecl->choice.getKind() ==
+                    OverloadChoiceKind::DynamicMemberLookup ||
+                foundDecl->choice.getKind() ==
+                    OverloadChoiceKind::KeyPathDynamicMemberLookup) {
               kind = KeyPathExpr::Component::Kind::UnresolvedSubscript;
             }
           }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -811,6 +811,7 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
   if (sameProblem) {
     switch (firstProblem) {
     case MemberLookupResult::UR_LabelMismatch:
+    case MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember:
       break;
     case MemberLookupResult::UR_UnavailableInExistential:
       diagnose(loc, diag::could_not_use_member_on_existential,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -812,6 +812,7 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
     switch (firstProblem) {
     case MemberLookupResult::UR_LabelMismatch:
     case MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember:
+    case MemberLookupResult::UR_ReferenceWritableKeyPathOnMutatingMember:
       break;
     case MemberLookupResult::UR_UnavailableInExistential:
       diagnose(loc, diag::could_not_use_member_on_existential,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -776,7 +776,7 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
 bool RValueTreatedAsLValueFailure::diagnoseAsError() {
   Diag<StringRef> subElementDiagID;
   Diag<Type> rvalueDiagID = diag::assignment_lhs_not_lvalue;
-  Expr *diagExpr = getLocator()->getAnchor();
+  Expr *diagExpr = getRawAnchor();
   SourceLoc loc = diagExpr->getLoc();
 
   if (auto assignExpr = dyn_cast<AssignExpr>(diagExpr)) {
@@ -854,12 +854,18 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
       }
     }
 
-    if (auto resolvedOverload = getResolvedOverload(getLocator()))
+    if (auto resolvedOverload = getResolvedOverload(getLocator())) {
       if (resolvedOverload->Choice.getKind() ==
-              OverloadChoiceKind::DynamicMemberLookup ||
-          resolvedOverload->Choice.getKind() ==
-              OverloadChoiceKind::KeyPathDynamicMemberLookup)
+          OverloadChoiceKind::DynamicMemberLookup)
         subElementDiagID = diag::assignment_dynamic_property_has_immutable_base;
+
+      if (resolvedOverload->Choice.getKind() ==
+          OverloadChoiceKind::KeyPathDynamicMemberLookup) {
+        if (!getType(member->getBase())->hasLValueType())
+          subElementDiagID =
+              diag::assignment_dynamic_property_has_immutable_base;
+      }
+    }
   } else if (auto sub = dyn_cast<SubscriptExpr>(diagExpr)) {
       subElementDiagID = diag::assignment_subscript_has_immutable_base;
   } else {
@@ -1204,7 +1210,7 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
     if (!member) {
       auto loc =
           cs.getConstraintLocator(SE, ConstraintLocator::SubscriptMember);
-      member = dyn_cast_or_null<SubscriptDecl>(cs.findResolvedMemberRef(loc));
+      member = dyn_cast_or_null<SubscriptDecl>(getMemberRef(loc));
     }
 
     // If it isn't settable, return it.
@@ -1233,9 +1239,10 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
     // If we found a decl for the UDE, check it.
     auto loc = cs.getConstraintLocator(UDE, ConstraintLocator::Member);
 
+    auto *member = getMemberRef(loc);
     // If we can resolve a member, we can determine whether it is settable in
     // this context.
-    if (auto *member = cs.findResolvedMemberRef(loc)) {
+    if (member) {
       auto *memberVD = dyn_cast<VarDecl>(member);
 
       // If the member isn't a vardecl (e.g. its a funcdecl), or it isn't
@@ -1281,6 +1288,43 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
     return resolveImmutableBase(SAE->getFn());
 
   return {expr, nullptr};
+}
+
+ValueDecl *AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
+  auto member = getOverloadChoiceIfAvailable(locator);
+  if (!member || !member->choice.isDecl())
+    return nullptr;
+
+  auto *DC = getDC();
+  auto &TC = getTypeChecker();
+
+  auto *decl = member->choice.getDecl();
+  if (isa<SubscriptDecl>(decl) &&
+      isValidDynamicMemberLookupSubscript(cast<SubscriptDecl>(decl), DC, TC)) {
+    auto *subscript = cast<SubscriptDecl>(decl);
+    // If this is a keypath dynamic member lookup, we have to
+    // adjust the locator to find member referred by it.
+    if (isValidKeyPathDynamicMemberLookup(subscript, TC)) {
+      auto &cs = getConstraintSystem();
+      // Type has a following format:
+      // `(Self) -> (dynamicMember: {Writable}KeyPath<T, U>) -> U`
+      auto *fullType = member->openedFullType->castTo<FunctionType>();
+      auto *fnType = fullType->getResult()->castTo<FunctionType>();
+
+      auto paramTy = fnType->getParams()[0].getPlainType();
+      auto keyPath = paramTy->getAnyNominal();
+      auto memberLoc = cs.getConstraintLocator(
+          locator, LocatorPathElt::getKeyPathDynamicMember(keyPath));
+
+      auto memberRef = getOverloadChoiceIfAvailable(memberLoc);
+      return memberRef ? memberRef->choice.getDecl() : nullptr;
+    }
+
+    // If this is a string based dynamic lookup, there is no member declaration.
+    return nullptr;
+  }
+
+  return decl;
 }
 
 Diag<StringRef> AssignmentFailure::findDeclDiagonstic(ASTContext &ctx,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -856,7 +856,9 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
 
     if (auto resolvedOverload = getResolvedOverload(getLocator()))
       if (resolvedOverload->Choice.getKind() ==
-          OverloadChoiceKind::DynamicMemberLookup)
+              OverloadChoiceKind::DynamicMemberLookup ||
+          resolvedOverload->Choice.getKind() ==
+              OverloadChoiceKind::KeyPathDynamicMemberLookup)
         subElementDiagID = diag::assignment_dynamic_property_has_immutable_base;
   } else if (auto sub = dyn_cast<SubscriptExpr>(diagExpr)) {
       subElementDiagID = diag::assignment_subscript_has_immutable_base;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -647,6 +647,10 @@ private:
              isLoadedLValue(ifExpr->getElseExpr());
     return false;
   }
+
+  /// Retrive an member reference associated with given member
+  /// looking through dynamic member lookup on the way.
+  ValueDecl *getMemberRef(ConstraintLocator *locator) const;
 };
 
 /// Intended to diagnose any possible contextual failure

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -151,6 +151,7 @@ static bool sameOverloadChoice(const OverloadChoice &x,
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
+  case OverloadChoiceKind::KeyPathDynamicMemberLookup:
     return sameDecl(x.getDecl(), y.getDecl());
 
   case OverloadChoiceKind::TupleIndex:
@@ -893,6 +894,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     case OverloadChoiceKind::DeclViaBridge:
     case OverloadChoiceKind::DeclViaUnwrappedOptional:
     case OverloadChoiceKind::DynamicMemberLookup:
+    case OverloadChoiceKind::KeyPathDynamicMemberLookup:
       break;
     }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -876,6 +876,20 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
         continue;
       }
 
+      // Dynamic member lookup through a keypath is better than one using string
+      // because it carries more type information.
+      if (choice1.getKind() == OverloadChoiceKind::KeyPathDynamicMemberLookup &&
+          choice2.getKind() == OverloadChoiceKind::DynamicMemberLookup) {
+        score1 += weight;
+        continue;
+      }
+
+      if (choice1.getKind() == OverloadChoiceKind::DynamicMemberLookup &&
+          choice2.getKind() == OverloadChoiceKind::KeyPathDynamicMemberLookup) {
+        score2 += weight;
+        continue;
+      }
+
       continue;
     }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -172,9 +172,6 @@ Solution ConstraintSystem::finalize() {
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
-  for (auto &arg : DynamicMemberArguments)
-    solution.DynamicMemberArguments.insert(arg);
-
   return solution;
 }
 
@@ -245,11 +242,6 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register any missing members encountered along this path.
   MissingMembers.insert(solution.MissingMembers.begin(),
                         solution.MissingMembers.end());
-
-  // Register any implicitly generated argument used by keypath
-  // based dynamic member lookup.
-  DynamicMemberArguments.append(solution.DynamicMemberArguments.begin(),
-                                solution.DynamicMemberArguments.end());
 }
 
 /// Restore the type variable bindings to what they were before
@@ -433,7 +425,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numMissingMembers = cs.MissingMembers.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
-  numDynamicMemberArguments = cs.DynamicMemberArguments.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -487,10 +478,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any missing members found along the current path.
   truncate(cs.MissingMembers, numMissingMembers);
-
-  // Remove any implicitly generated arguments used by keypath
-  // based dynamic lookup generated along the current path.
-  truncate(cs.DynamicMemberArguments, numDynamicMemberArguments);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1344,13 +1344,22 @@ ConstraintSystem::filterDisjunction(
   case 1: {
     // Only a single constraint remains. Retire the disjunction and make
     // the remaining constraint active.
+    auto choice = disjunction->getNestedConstraints()[choiceIdx];
+
+    // This can only happen when subscript syntax is used to lookup
+    // something which doesn't exist in type marked with
+    // `@dynamicMemberLookup`. Early simplification of the key path
+    // dynamic member lookup choice is impossible because it requires
+    // constraints associated with subscript index expression to be present.
+    if (!solverState && choice->getOverloadChoice().getKind() ==
+                            OverloadChoiceKind::KeyPathDynamicMemberLookup)
+      return SolutionKind::Unsolved;
 
     // Retire the disjunction. It's been solved.
     retireConstraint(disjunction);
 
     // Note the choice we made and simplify it. This introduces the
     // new constraint into the system.
-    auto choice = disjunction->getNestedConstraints()[choiceIdx];
     if (disjunction->shouldRememberChoice()) {
       recordDisjunctionChoice(disjunction->getLocator(), choiceIdx);
     }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -172,6 +172,9 @@ Solution ConstraintSystem::finalize() {
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
+  for (auto &arg : DynamicMemberArguments)
+    solution.DynamicMemberArguments.insert(arg);
+
   return solution;
 }
 
@@ -242,6 +245,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register any missing members encountered along this path.
   MissingMembers.insert(solution.MissingMembers.begin(),
                         solution.MissingMembers.end());
+
+  // Register any implicitly generated argument used by keypath
+  // based dynamic member lookup.
+  DynamicMemberArguments.append(solution.DynamicMemberArguments.begin(),
+                                solution.DynamicMemberArguments.end());
 }
 
 /// Restore the type variable bindings to what they were before
@@ -425,6 +433,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numMissingMembers = cs.MissingMembers.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
+  numDynamicMemberArguments = cs.DynamicMemberArguments.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -478,6 +487,10 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any missing members found along the current path.
   truncate(cs.MissingMembers, numMissingMembers);
+
+  // Remove any implicitly generated arguments used by keypath
+  // based dynamic lookup generated along the current path.
+  truncate(cs.DynamicMemberArguments, numDynamicMemberArguments);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -356,6 +356,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
       printDecl();
       break;
     case OverloadChoiceKind::DynamicMemberLookup:
+    case OverloadChoiceKind::KeyPathDynamicMemberLookup:
       Out << "dynamic member lookup '" << overload.getName() << "'";
       break;
     case OverloadChoiceKind::BaseType:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -45,6 +45,10 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
       id.AddPointer(elt.getWitness());
       break;
 
+    case KeyPathDynamicMember:
+      id.AddPointer(elt.getKeyPath());
+      break;
+
     case ApplyArgument:
     case ApplyFunction:
     case FunctionArgument:
@@ -265,6 +269,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case SynthesizedArgument:
       out << " synthesized argument #" << llvm::utostr(elt.getValue());
+      break;
+
+    case KeyPathDynamicMember:
+      out << " keypath dynamic member lookup";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -89,6 +89,18 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
   }
 }
 
+/// Determine whether given locator points to the subscript reference
+/// e.g. `foo[0]` or `\Foo.[0]`
+bool ConstraintLocator::isSubscriptMemberRef() const {
+  auto *anchor = getAnchor();
+  auto path = getPath();
+
+  if (!anchor || path.empty())
+    return false;
+
+  return path.back().getKind() == ConstraintLocator::SubscriptMember;
+}
+
 void ConstraintLocator::dump(SourceManager *sm) {
   dump(sm, llvm::errs());
   llvm::errs() << "\n";

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -514,6 +514,10 @@ public:
     return (getSummaryFlags() & IsFunctionConversion);
   }
 
+  /// Determine whether given locator points to the subscript reference
+  /// e.g. `foo[0]` or `\Foo.[0]`
+  bool isSubscriptMemberRef() const;
+
   /// Produce a profile of this locator, for use in a folding set.
   static void Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
                       ArrayRef<PathElement> path);

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -127,6 +127,8 @@ public:
     ContextualType,
     /// The missing argument synthesized by the solver.
     SynthesizedArgument,
+    /// The member looked up via keypath based dynamic lookup.
+    KeyPathDynamicMember,
   };
 
   /// Determine the number of numeric values used for the given path
@@ -165,6 +167,7 @@ public:
     case TupleElement:
     case KeyPathComponent:
     case SynthesizedArgument:
+    case KeyPathDynamicMember:
       return 1;
 
     case TypeParameterRequirement:
@@ -221,6 +224,7 @@ public:
     case DynamicLookupResult:
     case ContextualType:
     case SynthesizedArgument:
+    case KeyPathDynamicMember:
       return 0;
 
     case FunctionArgument:
@@ -241,6 +245,7 @@ public:
       StoredRequirement,
       StoredWitness,
       StoredGenericSignature,
+      StoredKeyPathDynamicMemberBase,
       StoredKindAndValue
     };
 
@@ -289,6 +294,10 @@ public:
     PathElement(GenericSignature *sig)
         : storage((reinterpret_cast<uintptr_t>(sig) >> 3)),
           storedKind(StoredGenericSignature) {}
+
+    PathElement(const NominalTypeDecl *keyPath)
+        : storage((reinterpret_cast<uintptr_t>(keyPath) >> 3)),
+          storedKind(StoredKeyPathDynamicMemberBase) {}
 
     friend class ConstraintLocator;
 
@@ -369,6 +378,10 @@ public:
       return PathElement(SynthesizedArgument, position);
     }
 
+    static PathElement getKeyPathDynamicMember(const NominalTypeDecl *base) {
+      return PathElement(base);
+    }
+
     /// Retrieve the kind of path element.
     PathElementKind getKind() const {
       switch (static_cast<StoredKind>(storedKind)) {
@@ -383,6 +396,9 @@ public:
 
       case StoredGenericSignature:
         return OpenedGeneric;
+
+      case StoredKeyPathDynamicMemberBase:
+        return KeyPathDynamicMember;
 
       case StoredKindAndValue:
         return decodeStorage(storage).first;
@@ -443,6 +459,13 @@ public:
       return reinterpret_cast<GenericSignature *>(storage << 3);
     }
 
+    NominalTypeDecl *getKeyPath() const {
+      assert((static_cast<StoredKind>(storedKind) ==
+              StoredKeyPathDynamicMemberBase) &&
+             "Is not a keypath dynamic member");
+      return reinterpret_cast<NominalTypeDecl *>(storage << 3);
+    }
+
     /// Return the summary flags for this particular element.
     unsigned getNewSummaryFlags() const {
       return getSummaryFlagsForPathElement(getKind());
@@ -458,6 +481,10 @@ public:
 
     bool isSynthesizedArgument() const {
       return getKind() == PathElementKind::SynthesizedArgument;
+    }
+
+    bool isKeyPathDynamicMember() const {
+      return getKind() == PathElementKind::KeyPathDynamicMember;
     }
   };
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1988,29 +1988,6 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       }
     }
 
-    // Check whether this is overload choice found via keypath
-    // based dynamic member lookup. Since it's unknown upfront
-    // what kind of declaration lookup is going to find, let's
-    // double check here that given keypath is appropriate for it.
-    auto path = locator->getPath();
-    if (!path.empty() && path.back().isKeyPathDynamicMember()) {
-      auto *keyPath = path.back().getKeyPath();
-      if (auto *storage = dyn_cast<AbstractStorageDecl>(decl)) {
-        // If this is an attempt to access read-only member via
-        // writable key path, let's fail this choice early.
-        //
-        // TODO(diagnostics): Add a new fix that is suggests to
-        // add `subscript(dynamicMember: WritableKeyPath<T, U>)`
-        // overload here, instead of failing.
-        if (isReadOnlyKeyPathComponent(storage) &&
-            keyPath == getASTContext().getWritableKeyPathDecl()) {
-          failedConstraint = Constraint::create(*this, ConstraintKind::Bind,
-                                                boundType, refType, locator);
-          return;
-        }
-      }
-    }
-
     // Check whether applying this overload would result in invalid
     // partial function application e.g. partial application of
     // mutating method or initializer.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1912,7 +1912,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       auto memberTy = createTypeVariable(keyPathLoc, TVO_CanBindToLValue);
       // Attempt to lookup a member with a give name in the root type and
       // assign result to the leaf type of the keypath.
-      bool isSubscriptRef = isa<SubscriptExpr>(locator->getAnchor());
+      bool isSubscriptRef = locator->isSubscriptMemberRef();
       DeclName memberName =
           isSubscriptRef ? DeclBaseName::createSubscript() : choice.getName();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1894,10 +1894,12 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       refType = fnType->getResult();
 
       auto *keyPathDecl = keyPathTy->getAnyNominal();
-      assert(keyPathDecl &&
-             (keyPathDecl == getASTContext().getKeyPathDecl() ||
-              keyPathDecl == getASTContext().getWritableKeyPathDecl()) &&
-             "parameter is supposed to be a keypath");
+      assert(
+          keyPathDecl &&
+          (keyPathDecl == getASTContext().getKeyPathDecl() ||
+           keyPathDecl == getASTContext().getWritableKeyPathDecl() ||
+           keyPathDecl == getASTContext().getReferenceWritableKeyPathDecl()) &&
+          "parameter is supposed to be a keypath");
 
       auto *keyPathLoc = getConstraintLocator(
           locator, LocatorPathElt::getKeyPathDynamicMember(keyPathDecl));
@@ -1965,7 +1967,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
         // form additional `applicable fn` constraint here and bind it to a
         // function type, but it would create inconsistency with how properties
         // are handled, which means more special handling in CSApply.
-        if (keyPathDecl == getASTContext().getWritableKeyPathDecl())
+        if (keyPathDecl == getASTContext().getWritableKeyPathDecl() ||
+            keyPathDecl == getASTContext().getReferenceWritableKeyPathDecl())
           dynamicResultTy->getImpl().setCanBindToLValue(getSavedBindings(),
                                                         /*enabled=*/true);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -381,14 +381,18 @@ public:
     rep->getImpl().ParentOrFixed = type.getPointer();
   }
 
-  void setCannotBindToLValue(constraints::SavedTypeVariableBindings *record) {
-    auto rep = getRepresentative(record);
-    if (rep->getImpl().canBindToLValue()) {
-      if (record)
-        rep->getImpl().recordBinding(*record);
-      rep->getImpl().getTypeVariable()->Bits.TypeVariableType.Options
-        &= ~TVO_CanBindToLValue;
-    }
+  void setCanBindToLValue(constraints::SavedTypeVariableBindings *record,
+                          bool enabled) {
+    auto &impl = getRepresentative(record)->getImpl();
+    if (record)
+      impl.recordBinding(*record);
+
+    if (enabled)
+      impl.getTypeVariable()->Bits.TypeVariableType.Options |=
+          TVO_CanBindToLValue;
+    else
+      impl.getTypeVariable()->Bits.TypeVariableType.Options &=
+          ~TVO_CanBindToLValue;
   }
 
   /// Print the type variable to the given output stream.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -882,6 +882,11 @@ struct MemberLookupResult {
     /// because it's not known upfront what access capability would the
     /// member have.
     UR_WritableKeyPathOnReadOnlyMember,
+    /// This is a `ReferenceWritableKeyPath` being used to look up mutating
+    /// member, used in situations involving dynamic member lookup via keypath,
+    /// because it's not known upfront what access capability would the
+    /// member have.
+    UR_ReferenceWritableKeyPathOnMutatingMember,
   };
 
   /// This is a list of considered (but rejected) candidates, along with a

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -613,11 +613,6 @@ public:
   llvm::SmallVector<std::pair<ConstraintLocator *, ProtocolConformanceRef>, 8>
       Conformances;
 
-  /// The set of implicitly generated arguments used by keypath based
-  /// dynamic lookup.
-  llvm::SmallDenseMap<ConstraintLocator *, KeyPathExpr *>
-      DynamicMemberArguments;
-
   /// Simplify the given type by substituting all occurrences of
   /// type variables for their fixed types.
   Type simplifyType(Type type) const;
@@ -1080,11 +1075,6 @@ private:
 
   SmallVector<std::pair<ConstraintLocator *, ProtocolConformanceRef>, 8>
       CheckedConformances;
-
-  /// A cache that stores implicitly generated arguments for keypath based
-  /// dynamic lookup.
-  SmallVector<std::pair<ConstraintLocator *, KeyPathExpr *>, 4>
-      DynamicMemberArguments;
 
 public:
   /// The locators of \c Defaultable constraints whose defaults were used.
@@ -1552,8 +1542,6 @@ public:
     unsigned numDisabledConstraints;
 
     unsigned numFavoredConstraints;
-
-    unsigned numDynamicMemberArguments;
 
     /// The previous score.
     Score PreviousScore;
@@ -2761,16 +2749,6 @@ public:
                                          bool includeInaccessibleMembers);
 
 private:
-  /// Build an implicit argument for keypath based dynamic lookup,
-  /// which consists of KeyPath expression and a single component.
-  ///
-  /// \param member The member being dynamically lookuped up.
-  /// \param keyPathTy The type of the keypath argument.
-  /// \param locator The locator to be associated with new argument.
-  KeyPathExpr *buildImplicitDynamicKeyPathArgument(Expr *member,
-                                                   BoundGenericType *keyPathTy,
-                                                   ConstraintLocator *locator);
-
   /// Attempt to simplify the given construction constraint.
   ///
   /// \param valueType The type being constructed.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -872,6 +872,12 @@ struct MemberLookupResult {
     
     /// The member is inaccessible (e.g. a private member in another file).
     UR_Inaccessible,
+
+    /// This is a `WritableKeyPath` being used to look up read-only member,
+    /// used in situations involving dynamic member lookup via keypath,
+    /// because it's not known upfront what access capability would the
+    /// member have.
+    UR_WritableKeyPathOnReadOnlyMember,
   };
 
   /// This is a list of considered (but rejected) candidates, along with a

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -977,7 +977,11 @@ visitDynamicCallableAttr(DynamicCallableAttr *attr) {
 
 static bool hasSingleNonVariadicParam(SubscriptDecl *decl) {
   auto *indices = decl->getIndices();
-  return indices->size() == 1 && !indices->get(0)->isVariadic();
+  if (decl->isInvalid() || indices->size() != 1)
+    return false;
+
+  auto *index = indices->get(0);
+  return !index->isVariadic() && index->hasValidSignature();
 }
 
 /// Returns true if the given subscript method is an valid implementation of
@@ -1020,9 +1024,6 @@ bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
     return false;
 
   const auto *param = decl->getIndices()->get(0);
-  if (param->isVariadic())
-    return false;
-
   if (auto NTD = param->getType()->getAnyNominal()) {
     return NTD == TC.Context.getKeyPathDecl() ||
            NTD == TC.Context.getWritableKeyPathDecl();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1026,7 +1026,8 @@ bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
   const auto *param = decl->getIndices()->get(0);
   if (auto NTD = param->getType()->getAnyNominal()) {
     return NTD == TC.Context.getKeyPathDecl() ||
-           NTD == TC.Context.getWritableKeyPathDecl();
+           NTD == TC.Context.getWritableKeyPathDecl() ||
+           NTD == TC.Context.getReferenceWritableKeyPathDecl();
   }
   return false;
 }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3311,6 +3311,7 @@ void Solution::dump(raw_ostream &out) const {
       break;
 
     case OverloadChoiceKind::DynamicMemberLookup:
+    case OverloadChoiceKind::KeyPathDynamicMemberLookup:
       out << "dynamic member lookup root "
           << choice.getBaseType()->getString()
           << " name='" << choice.getName() << "'\n";
@@ -3504,6 +3505,7 @@ void ConstraintSystem::print(raw_ostream &out) {
         break;
 
       case OverloadChoiceKind::DynamicMemberLookup:
+      case OverloadChoiceKind::KeyPathDynamicMemberLookup:
         out << "dynamic member lookup:"
             << choice.getBaseType()->getString() << "  name="
             << choice.getName() << "\n";

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2164,6 +2164,21 @@ bool isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
 bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, DeclContext *DC,
                                          TypeChecker &TC);
 
+/// Returns true if the given subscript method is an valid implementation of
+/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
+/// The method is given to be defined as `subscript(dynamicMember:)` which
+/// takes a single non-variadic parameter that conforms to
+/// `ExpressibleByStringLiteral` protocol.
+bool isValidStringDynamicMemberLookup(SubscriptDecl *decl, DeclContext *DC,
+                                      TypeChecker &TC);
+
+/// Returns true if the given subscript method is an valid implementation of
+/// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
+/// @dynamicMemberLookup.
+/// The method is given to be defined as `subscript(dynamicMember:)` which
+/// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
+bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl, TypeChecker &TC);
+
 /// Whether an overriding declaration requires the 'override' keyword.
 enum class OverrideRequiresKeyword {
   /// The keyword is never required.

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+struct Point {
+  let x: Int
+  var y: Int
+}
+
+struct Rectangle {
+  var topLeft, bottomRight: Point
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+  var obj: T
+
+  init(_ obj: T) {
+    self.obj = obj
+  }
+
+  subscript<U>(dynamicMember member: KeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+
+  // Used to make sure that keypath and string based lookup are
+  // property disambiguated.
+  subscript(dynamicMember member: String) -> Lens<Int> {
+    return Lens<Int>(42)
+  }
+}
+
+var topLeft = Point(x: 0, y: 0)
+var bottomRight = Point(x: 10, y: 10)
+
+var lens = Lens(Rectangle(topLeft: topLeft,
+                          bottomRight: bottomRight))
+
+// CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
+// CHECK-NEXT: apply %45<Rectangle, Point>({{.*}})
+// CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig
+// CHECK-NEXT: apply %54<Point, Int>({{.*}})
+_ = lens.topLeft.x
+
+// CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
+// CHECK-NEXT: apply %69<Rectangle, Point>({{.*}})
+// CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
+// CHECK-NEXT: apply %76<Point, Int>({{.*}})
+_ = lens.topLeft.y
+
+lens.topLeft = Lens(Point(x: 1, y: 2)) // Ok
+lens.bottomRight.y = Lens(12)          // Ok

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -206,3 +206,23 @@ func test_direct_subscript_ref(_ lens: OverloadedLens<Point>) {
   // CHECK: function_ref @$s29keypath_dynamic_member_lookup14OverloadedLensV0B6Memberqd__s7KeyPathCyxqd__G_tcluig
   _ = lens.y
 }
+
+func test_keypath_dynamic_lookup_inside_keypath() {
+  // CHECK: keypath $KeyPath<Point, Int>, (root $Point; stored_property #Point.x : $Int)
+  // CHECK-NEXT: keypath $KeyPath<Lens<Point>, Lens<Int>>, (root $Lens<Point>; gettable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<Point>.x
+  // CHECK: keypath $WritableKeyPath<Rectangle, Point>, (root $Rectangle; stored_property #Rectangle.topLeft : $Point)
+  // CHECK-NEXT: keypath $WritableKeyPath<Point, Int>, (root $Point; stored_property #Point.y : $Int)
+  // CHECK-NEXT: keypath $WritableKeyPath<Lens<Rectangle>, Lens<Int>>, (root $Lens<Rectangle>; settable_property $Lens<Point>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<Rectangle>.topLeft.y
+  // CHECK: keypath $KeyPath<Array<Int>, Int>, (root $Array<Int>; gettable_property $Int,  id @$sSa5countSivg : {{.*}})
+  // CHECK-NEXT: keypath $KeyPath<Lens<Array<Int>>, Lens<Int>>, (root $Lens<Array<Int>>; gettable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<[Int]>.count
+  // CHECK: keypath $WritableKeyPath<Array<Int>, Int>, (root $Array<Int>; settable_property $Int,  id @$sSayxSicig : {{.*}})
+  // CHECK-NEXT: keypath $WritableKeyPath<Lens<Array<Int>>, Lens<Int>>, (root $Lens<Array<Int>>; settable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<[Int]>.[0]
+  // CHECK: keypath $WritableKeyPath<Array<Array<Int>>, Array<Int>>, (root $Array<Array<Int>>; settable_property $Array<Int>,  id @$sSayxSicig : {{.*}})
+  // CHECK-NEXT: keypath $KeyPath<Array<Int>, Int>, (root $Array<Int>; gettable_property $Int,  id @$sSa5countSivg : {{.*}})
+  // CHECK-NEXT: keypath $KeyPath<Lens<Array<Array<Int>>>, Lens<Int>>, (root $Lens<Array<Array<Int>>>; settable_property $Lens<Array<Int>>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<[[Int]]>.[0].count
+}

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -226,3 +226,27 @@ func test_keypath_dynamic_lookup_inside_keypath() {
   // CHECK-NEXT: keypath $KeyPath<Lens<Array<Array<Int>>>, Lens<Int>>, (root $Lens<Array<Array<Int>>>; settable_property $Lens<Array<Int>>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig : {{.*}})
   _ = \Lens<[[Int]]>.[0].count
 }
+
+func test_recursive_dynamic_lookup(_ lens: Lens<Lens<Point>>) {
+  // CHECK: keypath $KeyPath<Point, Int>, (root $Point; stored_property #Point.x : $Int)
+  // CHECK-NEXT: keypath $KeyPath<Lens<Point>, Lens<Int>>, (root $Lens<Point>; gettable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
+  // CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig
+  _ = lens.x
+  // CHECK: keypath $KeyPath<Point, Int>, (root $Point; stored_property #Point.x : $Int)
+  // CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig
+  _ = lens.obj.x
+  // CHECK: [[FIRST_OBJ:%.*]] = struct_extract {{.*}} : $Lens<Lens<Point>>, #Lens.obj
+  // CHECK-NEXT: [[SECOND_OBJ:%.*]] = struct_extract [[FIRST_OBJ]] : $Lens<Point>, #Lens.obj
+  // CHECK-NEXT: struct_extract [[SECOND_OBJ]] : $Point, #Point.y
+  _ = lens.obj.obj.y
+  // CHECK: keypath $KeyPath<Point, Int>, (root $Point; stored_property #Point.x : $Int)
+  // CHECK-NEXT: keypath $KeyPath<Lens<Point>, Lens<Int>>, (root $Lens<Point>; gettable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
+  // CHECK-NEXT: keypath $KeyPath<Lens<Lens<Point>>, Lens<Lens<Int>>>, (root $Lens<Lens<Point>>; gettable_property $Lens<Lens<Int>>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<Lens<Point>>.x
+  // CHECK: keypath $WritableKeyPath<Rectangle, Point>, (root $Rectangle; stored_property #Rectangle.topLeft : $Point)
+  // CHECK-NEXT: keypath $WritableKeyPath<Lens<Rectangle>, Lens<Point>>, (root $Lens<Rectangle>; settable_property $Lens<Point>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig : {{.*}})
+  // CHECK-NEXT: keypath $KeyPath<Point, Int>, (root $Point; stored_property #Point.x : $Int)
+  // CHECK-NEXT: keypath $KeyPath<Lens<Point>, Lens<Int>>, (root $Lens<Point>; gettable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
+  // CHECK-NEXT: keypath $KeyPath<Lens<Lens<Rectangle>>, Lens<Lens<Int>>>, (root $Lens<Lens<Rectangle>>; settable_property $Lens<Lens<Point>>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig : {{.*}})
+  _ = \Lens<Lens<Rectangle>>.topLeft.x
+}

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -179,3 +179,30 @@ func dot_class_test(_ lens: inout DotLens<DotClass>) {
   // CHECK: keypath $ReferenceWritableKeyPath<DotClass, Int>, (root $DotClass; settable_property $Int,  id #DotClass.y!getter.1 : (DotClass) -> () -> Int, getter @$s29keypath_dynamic_member_lookup8DotClassC1ySivpACTK : {{.*}})
   let _ = lens.y
 }
+
+@dynamicMemberLookup
+struct OverloadedLens<T> {
+  var value: T
+
+  subscript<U>(keyPath: KeyPath<T, U>) -> U {
+    get { return value[keyPath: keyPath] }
+  }
+
+  subscript<U>(dynamicMember keyPath: KeyPath<T, U>) -> U {
+    get { return value[keyPath: keyPath] }
+  }
+}
+
+// Make sure if there is a subscript which accepts key path,
+// existing dynamic member overloads wouldn't interfere.
+func test_direct_subscript_ref(_ lens: OverloadedLens<Point>) {
+  // CHECK: function_ref @$s29keypath_dynamic_member_lookup14OverloadedLensVyqd__s7KeyPathCyxqd__Gcluig
+  _ = lens[\.x]
+  // CHECK: function_ref @$s29keypath_dynamic_member_lookup14OverloadedLensVyqd__s7KeyPathCyxqd__Gcluig
+  _ = lens[\.y]
+
+  // CHECK: function_ref @$s29keypath_dynamic_member_lookup14OverloadedLensV0B6Memberqd__s7KeyPathCyxqd__G_tcluig
+  _ = lens.x
+  // CHECK: function_ref @$s29keypath_dynamic_member_lookup14OverloadedLensV0B6Memberqd__s7KeyPathCyxqd__G_tcluig
+  _ = lens.y
+}

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -137,3 +137,45 @@ func keypath_with_subscripts(_ arr: SubscriptLens<[Int]>,
   // CHECK: keypath $WritableKeyPath<Dictionary<String, Int>, Optional<Int>>, (root $Dictionary<String, Int>; settable_property $Optional<Int>,  id @$sSDyq_Sgxcig : {{.*}})
   dict["ultimate question"] = 42
 }
+
+struct DotStruct {
+  var x, y: Int
+}
+
+class DotClass {
+  var x, y: Int
+
+  init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}
+
+@dynamicMemberLookup
+struct DotLens<T> {
+  var value: T
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> U {
+    get { return value[keyPath: member] }
+    set { value[keyPath: member] = newValue }
+  }
+
+  subscript<U>(dynamicMember member: ReferenceWritableKeyPath<T, U>) -> U {
+    get { return value[keyPath: member] }
+    set { value[keyPath: member] = newValue }
+  }
+}
+
+func dot_struct_test(_ lens: inout DotLens<DotStruct>) {
+  // CHECK: keypath $WritableKeyPath<DotStruct, Int>, (root $DotStruct; stored_property #DotStruct.x : $Int)
+  lens.x = 1
+  // CHECK: keypath $WritableKeyPath<DotStruct, Int>, (root $DotStruct; stored_property #DotStruct.y : $Int)
+  let _ = lens.y
+}
+
+func dot_class_test(_ lens: inout DotLens<DotClass>) {
+  // CHECK: keypath $ReferenceWritableKeyPath<DotClass, Int>, (root $DotClass; settable_property $Int,  id #DotClass.x!getter.1 : (DotClass) -> () -> Int, getter @$s29keypath_dynamic_member_lookup8DotClassC1xSivpACTK : {{.*}})
+  lens.x = 1
+  // CHECK: keypath $ReferenceWritableKeyPath<DotClass, Int>, (root $DotClass; settable_property $Int,  id #DotClass.y!getter.1 : (DotClass) -> () -> Int, getter @$s29keypath_dynamic_member_lookup8DotClassC1ySivpACTK : {{.*}})
+  let _ = lens.y
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -456,6 +456,14 @@ acceptKeyPathDynamicLookup(lens.topLeft.x)
 acceptKeyPathDynamicLookup(lens.topLeft.y)
 acceptKeyPathDynamicLookup(lens.topLeft.z) // expected-error {{'z' is inaccessible due to 'private' protection level}}
 
+var tupleLens = Lens<(String, Int)>(("ultimate question", 42))
+_ = tupleLens.0.count
+_ = tupleLens.1
+
+var namedTupleLens = Lens<(question: String, answer: Int)>((question: "ultimate question", answer: 42))
+_ = namedTupleLens.question.count
+_ = namedTupleLens.answer
+
 @dynamicMemberLookup
 class A<T> {
   var value: T
@@ -606,4 +614,12 @@ func keypath_with_trailing_closure_subscript(_ ty: inout SubscriptLens<WithTrail
   // expected-error@-2 {{type of expression is ambiguous without more context}}
   _ = ty[] { 42 }  // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
   _ = ty[] { 42 } = 0 // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
+}
+
+func keypath_to_subscript_to_property(_ lens: inout Lens<Array<Rectangle>>) {
+  _ = lens[0].topLeft.x
+  _ = lens[0].topLeft.y
+  _ = lens[0].topLeft.x = Lens(0)
+  _ = lens[0].topLeft.y = Lens(1) // FIXME(diagnostics): Diagnostic should point to 'y' instead of 'lens'
+  // expected-error@-1 {{cannot assign through dynamic lookup property: 'lens' is immutable}}
 }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -601,6 +601,9 @@ struct WithTrailingClosure {
 
 func keypath_with_trailing_closure_subscript(_ ty: inout SubscriptLens<WithTrailingClosure>) {
   _ = ty[0] { 42 } // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
+  _ = ty[0] { 42 } = 0 // FIXME(diagnostics): Once keypath related diagnostics are using fixes, "ambiguous" error would disappear
+  // expected-error@-1 {{subscript index of type '() -> Int' in a key path must be Hashable}}
+  // expected-error@-2 {{type of expression is ambiguous without more context}}
   _ = ty[] { 42 }  // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
   _ = ty[] { 42 } = 0 // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
 }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -140,7 +140,7 @@ func testIUOResult(x: IUOResult) {
 // Subscript index must be ExpressibleByStringLiteral.
 @dynamicMemberLookup
 struct Invalid1 {
-  // expected-error @+1 {{@dynamicMemberLookup attribute requires 'Invalid1' to have a 'subscript(dynamicMember:)' method with an 'ExpressibleByStringLiteral' parameter}}
+  // expected-error @+1 {{@dynamicMemberLookup attribute requires 'Invalid1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a keypath}}
   subscript(dynamicMember member: Int) -> Int {
     return 42
   }
@@ -149,7 +149,7 @@ struct Invalid1 {
 // Subscript may not be variadic.
 @dynamicMemberLookup
 struct Invalid2 {
-  // expected-error @+1 {{@dynamicMemberLookup attribute requires 'Invalid2' to have a 'subscript(dynamicMember:)' method with an 'ExpressibleByStringLiteral' parameter}}
+  // expected-error @+1 {{@dynamicMemberLookup attribute requires 'Invalid2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a keypath}}
   subscript(dynamicMember member: String...) -> Int {
     return 42
   }
@@ -188,7 +188,7 @@ func NotAllowedOnFunc() {}
 // @dynamicMemberLookup cannot be declared on a base class and fulfilled with a
 // derived class.
 
-// expected-error @+1 {{@dynamicMemberLookup attribute requires 'InvalidBase' to have a 'subscript(dynamicMember:)' method with an 'ExpressibleByStringLiteral' parameter}}
+// expected-error @+1 {{@dynamicMemberLookup attribute requires 'InvalidBase' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a keypath}}
 @dynamicMemberLookup
 class InvalidBase {}
 

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -402,7 +402,7 @@ _ = \KP.testLookup
 
 struct Point {
   var x: Int
-  let y: Int
+  let y: Int // expected-note 2 {{change 'let' to 'var' to make it mutable}}
 
   private let z: Int = 0 // expected-note 7 {{declared here}}
 }
@@ -447,7 +447,7 @@ _ = lens.bottomRight.z // expected-error {{'z' is inaccessible due to 'private' 
 
 lens.topLeft = Lens(Point(x: 1, y: 2)) // Ok
 lens.bottomRight.x = Lens(11)          // Ok
-lens.bottomRight.y = Lens(12)          // expected-error {{cannot assign through dynamic lookup property: 'lens' is immutable}}
+lens.bottomRight.y = Lens(12)          // expected-error {{cannot assign to property: 'y' is a 'let' constant}}
 lens.bottomRight.z = Lens(13)          // expected-error {{'z' is inaccessible due to 'private' protection level}}
 
 func acceptKeyPathDynamicLookup(_: Lens<Int>) {}
@@ -576,7 +576,7 @@ func keypath_with_subscripts(_ arr: SubscriptLens<[Int]>,
   _ = arr["hello"]  // Ok
   _ = dict["hello"] // Ok
 
-  _ = arr["hello"] = 42 // expected-error {{cannot assign through subscript: subscript is get-only}}
+  _ = arr["hello"] = 42 // expected-error {{cannot assign through subscript: 'arr' is a 'let' constant}}
   _ = dict["hello"] = 0 // Ok
 
   _ = arr[0] = 42 // expected-error {{cannot assign through subscript: 'arr' is a 'let' constant}}
@@ -620,6 +620,6 @@ func keypath_to_subscript_to_property(_ lens: inout Lens<Array<Rectangle>>) {
   _ = lens[0].topLeft.x
   _ = lens[0].topLeft.y
   _ = lens[0].topLeft.x = Lens(0)
-  _ = lens[0].topLeft.y = Lens(1) // FIXME(diagnostics): Diagnostic should point to 'y' instead of 'lens'
-  // expected-error@-1 {{cannot assign through dynamic lookup property: 'lens' is immutable}}
+  _ = lens[0].topLeft.y = Lens(1)
+  // expected-error@-1 {{cannot assign to property: 'y' is a 'let' constant}}
 }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -576,7 +576,7 @@ func keypath_with_subscripts(_ arr: SubscriptLens<[Int]>,
   _ = arr["hello"]  // Ok
   _ = dict["hello"] // Ok
 
-  _ = arr["hello"] = 42 // expected-error {{cannot assign through subscript: 'arr' is a 'let' constant}}
+  _ = arr["hello"] = 42 // expected-error {{cannot assign through subscript: subscript is get-only}}
   _ = dict["hello"] = 0 // Ok
 
   _ = arr[0] = 42 // expected-error {{cannot assign through subscript: 'arr' is a 'let' constant}}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -404,7 +404,7 @@ struct Point {
   var x: Int
   let y: Int // expected-note 2 {{change 'let' to 'var' to make it mutable}}
 
-  private let z: Int = 0 // expected-note 9 {{declared here}}
+  private let z: Int = 0 // expected-note 10 {{declared here}}
 }
 
 struct Rectangle {
@@ -653,4 +653,18 @@ struct SingleChoiceLens<T> {
 // simplify disjunctions with a single viable choice.
 func test_lens_with_a_single_choice(a: inout SingleChoiceLens<[Int]>) {
   a[0] = 1 // Ok
+}
+
+func test_chain_of_recursive_lookups(_ lens: Lens<Lens<Lens<Point>>>) {
+  _ = lens.x
+  _ = lens.y
+  _ = lens.z // expected-error {{'z' is inaccessible due to 'private' protection level}}
+  // Make sure that 'obj' field could be retrieved at any level
+  _ = lens.obj
+  _ = lens.obj.obj
+  _ = lens.obj.x
+  _ = lens.obj.obj.x
+
+  _ = \Lens<Lens<Point>>.x
+  _ = \Lens<Lens<Point>>.obj.x
 }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -579,3 +579,11 @@ func keypath_with_subscripts(_ arr: SubscriptLens<[Int]>,
   }
   dict["ultimate question"] = 42
 }
+
+func keypath_with_incorrect_return_type(_ arr: Lens<Array<Int>>) {
+  for idx in 0..<arr.count {
+    // expected-error@-1 {{binary operator '..<' cannot be applied to operands of type 'Int' and 'Lens<Int>'}}
+    // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
+    let _ = arr[idx]
+  }
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -587,3 +587,20 @@ func keypath_with_incorrect_return_type(_ arr: Lens<Array<Int>>) {
     let _ = arr[idx]
   }
 }
+
+struct WithTrailingClosure {
+  subscript(fn: () -> Int) -> Int {
+    get { return fn() }
+    nonmutating set { _ = fn() + newValue }
+  }
+
+  subscript(offset: Int, _ fn: () -> Int) -> Int {
+    get { return offset + fn() }
+  }
+}
+
+func keypath_with_trailing_closure_subscript(_ ty: inout SubscriptLens<WithTrailingClosure>) {
+  _ = ty[0] { 42 } // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
+  _ = ty[] { 42 }  // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
+  _ = ty[] { 42 } = 0 // expected-error {{subscript index of type '() -> Int' in a key path must be Hashable}}
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -404,7 +404,7 @@ struct Point {
   var x: Int
   let y: Int // expected-note 2 {{change 'let' to 'var' to make it mutable}}
 
-  private let z: Int = 0 // expected-note 7 {{declared here}}
+  private let z: Int = 0 // expected-note 9 {{declared here}}
 }
 
 struct Rectangle {
@@ -444,6 +444,16 @@ _ = lens.bottomRight
 _ = lens.bottomRight.x
 _ = lens.bottomRight.y
 _ = lens.bottomRight.z // expected-error {{'z' is inaccessible due to 'private' protection level}}
+
+_ = \Lens<Point>.x
+_ = \Lens<Point>.y
+_ = \Lens<Point>.z // expected-error {{'z' is inaccessible due to 'private' protection level}}
+_ = \Lens<Rectangle>.topLeft.x
+_ = \Lens<Rectangle>.topLeft.y
+_ = \Lens<Rectangle>.topLeft.z // expected-error {{'z' is inaccessible due to 'private' protection level}}
+_ = \Lens<[Int]>.count
+_ = \Lens<[Int]>.[0]
+_ = \Lens<[[Int]]>.[0].count
 
 lens.topLeft = Lens(Point(x: 1, y: 2)) // Ok
 lens.bottomRight.x = Lens(11)          // Ok

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -633,3 +633,24 @@ func keypath_to_subscript_to_property(_ lens: inout Lens<Array<Rectangle>>) {
   _ = lens[0].topLeft.y = Lens(1)
   // expected-error@-1 {{cannot assign to property: 'y' is a 'let' constant}}
 }
+
+@dynamicMemberLookup
+struct SingleChoiceLens<T> {
+  var obj: T
+
+  init(_ obj: T) {
+    self.obj = obj
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> U {
+    get { return obj[keyPath: member] }
+    set { obj[keyPath: member] = newValue }
+  }
+}
+
+// Make sure that disjunction filtering optimization doesn't
+// impede keypath dynamic member lookup by eagerly trying to
+// simplify disjunctions with a single viable choice.
+func test_lens_with_a_single_choice(a: inout SingleChoiceLens<[Int]>) {
+  a[0] = 1 // Ok
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -350,9 +350,9 @@ func testKeyPathSubscript(readonly: ZwithSubscript, writable: inout ZwithSubscri
   sink = writable[keyPath: wkp]
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
-  readonly[keyPath: kp] = sink  // expected-error {{cannot assign through subscript: 'kp' is a read-only key path}}
-  writable[keyPath: kp] = sink  // expected-error {{cannot assign through subscript: 'kp' is a read-only key path}}
-  readonly[keyPath: wkp] = sink // expected-error {{cannot assign through subscript: 'readonly' is a 'let' constant}}
+  readonly[keyPath: kp] = sink  // expected-error {{cannot assign through subscript: subscript is get-only}}
+  writable[keyPath: kp] = sink  // expected-error {{cannot assign through subscript: subscript is get-only}}
+  readonly[keyPath: wkp] = sink // expected-error {{cannot assign through subscript: subscript is get-only}}
   // FIXME: silently falls back to keypath application, which seems inconsistent
   writable[keyPath: wkp] = sink
   // FIXME: silently falls back to keypath application, which seems inconsistent

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -350,9 +350,9 @@ func testKeyPathSubscript(readonly: ZwithSubscript, writable: inout ZwithSubscri
   sink = writable[keyPath: wkp]
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: subscript is get-only}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: subscript is get-only}}
-  readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: subscript is get-only}}
+  readonly[keyPath: kp] = sink  // expected-error {{cannot assign through subscript: 'kp' is a read-only key path}}
+  writable[keyPath: kp] = sink  // expected-error {{cannot assign through subscript: 'kp' is a read-only key path}}
+  readonly[keyPath: wkp] = sink // expected-error {{cannot assign through subscript: 'readonly' is a 'let' constant}}
   // FIXME: silently falls back to keypath application, which seems inconsistent
   writable[keyPath: wkp] = sink
   // FIXME: silently falls back to keypath application, which seems inconsistent


### PR DESCRIPTION
Implement keypath based dynamic member lookup which augments
functionality of existing @dynamicMemberLookup attribute.

Three new subscript overloads are accepted:

```swift
subscript(dynamicMember member: KeyPath<T, ...>) -> ...
subscript(dynamicmember member: WritableKeyPath<T, ...>) -> ...
subscript(dynamicMember member: ReferenceWritableKeyPath<T, ...>) -> ...
```

**Example**:

```swift
struct Point {
  let x: Int
  var y: Int
}

@dynamicMemberLookup 
struct Lens<T> {
  var obj: T

  init(_ obj: T) {
    self.obj = obj
  }

  subscript<U>(dynamicMember member: KeyPath<T, U>) -> Lens<U> {
    get { return Lens<U>(obj[keyPath: member]) }
  }

  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
    get { return Lens<U>(obj[keyPath: member]) }
    set { obj[keyPath: member] = newValue.obj }
  }
}

var lens = Lens(Point(x: 0, y: 0))

_ = lens.x // converted into `lens[dynamicMember: KeyPath<Point, Int>`
_ = lens.y = Lens(10) // converted into `lens[dynamicMember: WritableKeyPath<Point, Int>]`
```

Resolves: rdar://problem/49069813
Resolves: rdar://problem/49533404

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
