### PR TITLE
[silgenlvalue] NFC refactorings.

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -69,6 +69,13 @@ struct LValueTypeData {
   }
 
   SGFAccessKind getAccessKind() const { return AccessKind; }
+
+  LValueTypeData getTupleElementTypeData(SGFAccessKind accessKind,
+                                         unsigned index) const {
+    return {accessKind, OrigFormalType.getTupleElementType(index),
+            cast<TupleType>(SubstFormalType).getElementType(index),
+            cast<TupleType>(TypeOfRValue).getElementType(index)};
+  }
 };
 
 /// An l-value path component represents a chunk of the access path to

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3188,16 +3188,8 @@ LValue SILGenLValue::visitTupleElementExpr(TupleElementExpr *e,
   LValue lv = visitRec(e->getBase(),
                        getBaseAccessKindForStorage(accessKind),
                        options.forProjectedBaseLValue());
-
-  auto baseTypeData = lv.getTypeData();
-  LValueTypeData typeData = {
-    accessKind,
-    baseTypeData.OrigFormalType.getTupleElementType(index),
-    cast<TupleType>(baseTypeData.SubstFormalType).getElementType(index),
-    cast<TupleType>(baseTypeData.TypeOfRValue).getElementType(index)
-  };
-
-  lv.add<TupleElementComponent>(index, typeData);
+  lv.add<TupleElementComponent>(
+      index, lv.getTypeData().getTupleElementTypeData(accessKind, index));
   return lv;
 }
 


### PR DESCRIPTION
I am preparing this code for eliminating the NominalType peephole in RValue emission for member_ref_expr. The key way I am planning on doing this is by teaching LValue emission to use LValue components for project operations instead of evaluating each of the member_ref_expr as individual RValues.

These two commits take us on the way to that world by:

1. Adding a small helper for generating a tuple child LValueData.
2. Moving the creation of the creation of the ValueComponent into visitRecInOutBase instead of doing it upon returning to visitRec from said function. This will enable me to add additional components to whatever LValue is returned from visitRec from within visitRecInOutBase. For instance, I could add a StructElementComponent.