### PR TITLE
[AutoDiff] Fix `@differentiating` attribute.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -401,8 +401,8 @@ DECL_ATTR(differentiable, Differentiable,
   AllowMultipleAttributes,
   83)
 DECL_ATTR(differentiating, Differentiating,
-  OnFunc | LongAttribute | AllowMultipleAttributes,
-  84)
+  OnFunc | LongAttribute | AllowMultipleAttributes |
+  NotSerialized, 84)
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
                  OnAccessor | OnFunc | OnConstructor | OnSubscript,
                  /* Not serialized */ 85)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1497,9 +1497,9 @@ public:
   void setRequirements(ASTContext &context, ArrayRef<Requirement> requirements);
 
   FuncDecl *getJVPFunction() const { return JVPFunction; }
-  void setJVPFunction(FuncDecl *decl) { JVPFunction = decl; }
+  void setJVPFunction(FuncDecl *decl);
   FuncDecl *getVJPFunction() const { return VJPFunction; }
-  void setVJPFunction(FuncDecl *decl) { VJPFunction = decl; }
+  void setVJPFunction(FuncDecl *decl);
 
   bool parametersMatch(const DifferentiableAttr &other) const {
     assert(ParameterIndices && other.ParameterIndices);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1281,13 +1281,13 @@ void DifferentiableAttr::setRequirements(ASTContext &context,
 
 void DifferentiableAttr::setJVPFunction(FuncDecl *decl) {
   JVPFunction = decl;
-  if (decl)
+  if (decl && !JVP)
     JVP = {decl->getFullName(), DeclNameLoc(decl->getNameLoc())};
 }
 
 void DifferentiableAttr::setVJPFunction(FuncDecl *decl) {
   VJPFunction = decl;
-  if (decl)
+  if (decl && !VJP)
     VJP = {decl->getFullName(), DeclNameLoc(decl->getNameLoc())};
 }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1279,6 +1279,18 @@ void DifferentiableAttr::setRequirements(ASTContext &context,
   Requirements = context.AllocateCopy(requirements);
 }
 
+void DifferentiableAttr::setJVPFunction(FuncDecl *decl) {
+  JVPFunction = decl;
+  if (decl)
+    JVP = {decl->getFullName(), DeclNameLoc(decl->getNameLoc())};
+}
+
+void DifferentiableAttr::setVJPFunction(FuncDecl *decl) {
+  VJPFunction = decl;
+  if (decl)
+    VJP = {decl->getFullName(), DeclNameLoc(decl->getNameLoc())};
+}
+
 void DifferentiableAttr::print(llvm::raw_ostream &OS, const Decl *D,
                                ModuleDecl *prettyPrintInModule) const {
   StreamPrinter P(OS);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2590,31 +2590,6 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
         break;
       }
 
-      // SWIFT_ENABLE_TENSORFLOW
-      case decls_block::Differentiating_DECL_ATTR: {
-        bool isImplicit;
-        uint64_t origNameId;
-        DeclID origDeclId;
-        ArrayRef<uint64_t> parameters;
-
-        serialization::decls_block::DifferentiatingDeclAttrLayout::readRecord(
-            scratch, isImplicit, origNameId, origDeclId, parameters);
-
-        DeclNameWithLoc origName = {getIdentifier(origNameId), DeclNameLoc()};
-        FuncDecl *origDecl = cast<FuncDecl>(getDecl(origDeclId));
-
-        llvm::SmallBitVector parametersBitVector(parameters.size());
-        for (unsigned i : indices(parameters))
-          parametersBitVector[i] = parameters[i];
-        auto *indices = AutoDiffParameterIndices::get(parametersBitVector, ctx);
-
-        auto diffAttr = DifferentiatingAttr::create(
-            ctx, isImplicit, SourceLoc(), SourceRange(), origName, indices);
-        diffAttr->setOriginalFunction(origDecl);
-        Attr = diffAttr;
-        break;
-      }
-
       case decls_block::DynamicReplacement_DECL_ATTR: {
         bool isImplicit;
         uint64_t numArgs;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2193,6 +2193,8 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
   case DAK_RestatedObjCConformance:
   case DAK_ClangImporterSynthesizedType:
   case DAK_PrivateImport:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DAK_Differentiating:
     llvm_unreachable("cannot serialize attribute");
 
   case DAK_Count:
@@ -2395,26 +2397,6 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
         jvpName, jvpRef, vjpName, vjpRef, indices);
 
     writeGenericRequirements(attr->getRequirements(), DeclTypeAbbrCodes);
-    return;
-  }
-
-  // SWIFT_ENABLE_TENSORFLOW
-  case DAK_Differentiating: {
-    auto abbrCode = DeclTypeAbbrCodes[DifferentiatingDeclAttrLayout::Code];
-    auto attr = cast<DifferentiatingAttr>(DA);
-    IdentifierID origName =
-        addDeclBaseNameRef(attr->getOriginal().Name.getBaseName());
-    DeclID origRef = addDeclRef(attr->getOriginalFunction());
-
-    auto paramIndices = attr->getParameterIndices();
-    assert(paramIndices && "Checked parameter indices must be resolved");
-    SmallVector<bool, 4> indices;
-    for (unsigned i : swift::indices(paramIndices->parameters))
-      indices.push_back(paramIndices->parameters[i]);
-
-    DifferentiatingDeclAttrLayout::emitRecord(
-        Out, ScratchRecord, abbrCode, attr->isImplicit(), origName, origRef,
-        indices);
     return;
   }
   }


### PR DESCRIPTION
Update derivative name in `@differentiable` attribute when a derivative
function is set. This prevents linker errors.

Disable serialization for `@differentiable` attribute. It is unnecessary:
- Currently, type-checking sets the derivative in a `@differentiable` attribute
  on the original function, which is serialized.
  - If both `@differentiable` and `@differentiating` are serializable, using
    `@differentiating` attribute causes an infinite loop occurs during
    deserialization.
- In the future, `@differentiating` attribute will be lowered to SIL
  differentiability witness tables, which will be serialized.

Unblocks #23193: using `@differentiating` attribute in the stdlib.