### PR TITLE
Build compiler-rt with TSan interception for libdispatch on non-Apple platforms

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2169,6 +2169,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
+                    -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
                     "${llvm_cmake_options[@]}"
                 )
 


### PR DESCRIPTION
I recently enabled TSan interceptors for libdispatch on non-Apple
platforms in upstream. This is on by default on Apple platforms. Let's
try to switch it on for other platforms too.
