### PR TITLE
[const evaluator] Parameterize allocation of symbolic values in the constant interpreter.

### DIFF
--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -26,7 +26,6 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
-#include "llvm/Support/Allocator.h"
 
 namespace swift {
 class ApplyInst;
@@ -37,15 +36,13 @@ class SILModule;
 class SILNode;
 class SILValue;
 class SymbolicValue;
+class SymbolicValueAllocator;
 enum class UnknownReason;
 
 /// This class is the main entrypoint for evaluating constant expressions.  It
 /// also handles caching of previously computed constexpr results.
 class ConstExprEvaluator {
-  /// We store arguments and result values for the cached constexpr calls we
-  /// have already analyzed in this ASTContext so that they are available even
-  /// after this ConstExprEvaluator is gone.
-  ASTContext &astContext;
+  SymbolicValueAllocator &allocator;
 
   /// The current call stack, used for providing accurate diagnostics.
   llvm::SmallVector<SourceLoc, 4> callStack;
@@ -54,10 +51,10 @@ class ConstExprEvaluator {
   void operator=(const ConstExprEvaluator &) = delete;
 
 public:
-  explicit ConstExprEvaluator(SILModule &m);
+  explicit ConstExprEvaluator(SymbolicValueAllocator &alloc);
   ~ConstExprEvaluator();
 
-  ASTContext &getASTContext() { return astContext; }
+  SymbolicValueAllocator &getAllocator() { return allocator; }
 
   void pushCallStack(SourceLoc loc) { callStack.push_back(loc); }
 

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -175,7 +175,8 @@ class EmitDFDiagnostics : public SILFunctionTransform {
       }
 
     if (M.getASTContext().LangOpts.EnableExperimentalStaticAssert) {
-      ConstExprEvaluator constantEvaluator(M);
+      SymbolicValueBumpAllocator allocator;
+      ConstExprEvaluator constantEvaluator(allocator);
       for (auto &BB : *getFunction())
         for (auto &I : BB)
           diagnosePoundAssert(&I, M, constantEvaluator);


### PR DESCRIPTION
Based on this feature, change to a short-lived bump allocator for storing symbolic values in the pass that checks #assert.