### PR TITLE
Use mapSignatureFunctionType on SubscriptDecls

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2226,6 +2226,15 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
                                      bool isMethod,
                                      bool isInitializer,
                                      unsigned curryLevels) {
+  if (auto errorType = type->getAs<ErrorType>()) {
+    if (auto originalType = errorType->getOriginalType()) {
+      return ErrorType::get(mapSignatureFunctionType(
+        ctx, originalType, topLevelFunction, isMethod, isInitializer,
+        curryLevels));
+    }
+    return type;
+  }
+
   if (curryLevels == 0) {
     // In an initializer, ignore optionality.
     if (isInitializer) {
@@ -2316,7 +2325,12 @@ CanType ValueDecl::getOverloadSignatureType() const {
     if (isa<VarDecl>(this)) {
       defaultSignatureType = TupleType::getEmpty(getASTContext());
     } else {
-      defaultSignatureType = getInterfaceType()->getCanonicalType();
+      defaultSignatureType = mapSignatureFunctionType(
+          getASTContext(), getInterfaceType(),
+          /*topLevelFunction=*/true,
+          /*isMethod=*/true,
+          /*isInitializer=*/false,
+          1)->getCanonicalType();
     }
 
     // We want to curry the default signature type with the 'self' type of the

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2328,7 +2328,7 @@ CanType ValueDecl::getOverloadSignatureType() const {
       defaultSignatureType = mapSignatureFunctionType(
           getASTContext(), getInterfaceType(),
           /*topLevelFunction=*/true,
-          /*isMethod=*/true,
+          /*isMethod=*/false,
           /*isInitializer=*/false,
           1)->getCanonicalType();
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2226,12 +2226,7 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
                                      bool isMethod,
                                      bool isInitializer,
                                      unsigned curryLevels) {
-  if (auto errorType = type->getAs<ErrorType>()) {
-    if (auto originalType = errorType->getOriginalType()) {
-      return ErrorType::get(mapSignatureFunctionType(
-        ctx, originalType, topLevelFunction, isMethod, isInitializer,
-        curryLevels));
-    }
+  if (type->hasError()) {
     return type;
   }
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -258,6 +258,16 @@ struct Subscript3 {
   subscript(x x: Int) -> String { return "" }
 }
 
+struct Subscript4 {
+    subscript(f: @escaping (Int) -> Int) -> Int { // expected-note{{previously declared here}}
+        get { return f(0) }
+    }
+
+    subscript(f: (Int) -> Int) -> Int { // expected-error{{invalid redeclaration of 'subscript(_:)'}}
+        get { return f(0) }
+    }
+}
+
 struct GenericSubscripts {
   subscript<T>(x: T) -> Int { return 0 } // expected-note{{previously declared here}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
When we call `getOverloadSignatureType()` on a `SubscriptDecl`, use `mapSignatureFunctionType` to perform the same transform that we use for other function types. This makes the allowed overloading behavior consistent between `AbstractFunctionDecl` and `SubscriptDecl`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10088](https://bugs.swift.org/browse/SR-10088).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->