### PR TITLE
IRGen: use APInt to represent spare bit masks for pointers

### DIFF
--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -29,9 +29,7 @@ static unsigned getNumLowObjCReservedBits(const IRGenModule &IGM) {
     return 0;
 
   // Get the index of the first non-reserved bit.
-  SpareBitVector ObjCMask = IGM.TargetInfo.ObjCPointerReservedBits;
-  ObjCMask.flipAll();
-  return ObjCMask.enumerateSetBits().findNext().getValue();
+  return IGM.TargetInfo.ObjCPointerReservedBits.countTrailingOnes();
 }
 
 /*****************************************************************************/

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -676,10 +676,9 @@ public:
   
   /// Return the spare bit mask to use for types that comprise heap object
   /// pointers.
-  const SpareBitVector &getHeapObjectSpareBits() const;
-
-  const SpareBitVector &getFunctionPointerSpareBits() const;
-  const SpareBitVector &getWitnessTablePtrSpareBits() const;
+  SpareBitVector getHeapObjectSpareBits() const;
+  SpareBitVector getFunctionPointerSpareBits() const;
+  SpareBitVector getWitnessTablePtrSpareBits() const;
 
   /// Return runtime specific extra inhabitant and spare bits policies.
   unsigned getReferenceStorageExtraInhabitantCount(ReferenceOwnership ownership,

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -27,20 +27,14 @@
 using namespace swift;
 using namespace irgen;
 
-/// Initialize a bit vector to be equal to the given bit-mask.
-static void setToMask(SpareBitVector &bits, unsigned size, uint64_t mask) {
-  bits.clear();
-  bits.add(size, mask);
-}
-
 /// Configures target-specific information for arm64 platforms.
 static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
                            SwiftTargetInfo &target) {
-  setToMask(target.PointerSpareBits, 64,
+  target.PointerSpareBits = llvm::APInt(64,
             SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK);
-  setToMask(target.ObjCPointerReservedBits, 64,
+  target.ObjCPointerReservedBits = llvm::APInt(64,
             SWIFT_ABI_ARM64_OBJC_RESERVED_BITS_MASK);
-  setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_ARM64_IS_OBJC_BIT);
+  target.IsObjCPointerBit = llvm::APInt(64, SWIFT_ABI_ARM64_IS_OBJC_BIT);
 
   if (triple.isOSDarwin()) {
     target.LeastValidPointerValue =
@@ -65,15 +59,16 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
 /// Configures target-specific information for x86-64 platforms.
 static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
                             SwiftTargetInfo &target) {
-  setToMask(target.PointerSpareBits, 64,
-            SWIFT_ABI_X86_64_SWIFT_SPARE_BITS_MASK);
-  setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_X86_64_IS_OBJC_BIT);
+  target.PointerSpareBits = llvm::APInt(64,
+              SWIFT_ABI_X86_64_SWIFT_SPARE_BITS_MASK);
+  target.IsObjCPointerBit = llvm::APInt(64,
+              SWIFT_ABI_X86_64_IS_OBJC_BIT);
 
   if (tripleIsAnySimulator(triple)) {
-    setToMask(target.ObjCPointerReservedBits, 64,
+    target.ObjCPointerReservedBits = llvm::APInt(64,
               SWIFT_ABI_X86_64_SIMULATOR_OBJC_RESERVED_BITS_MASK);
   } else {
-    setToMask(target.ObjCPointerReservedBits, 64,
+    target.ObjCPointerReservedBits = llvm::APInt(64,
               SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK);
   }
 
@@ -97,18 +92,18 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
 /// Configures target-specific information for 32-bit x86 platforms.
 static void configureX86(IRGenModule &IGM, const llvm::Triple &triple,
                          SwiftTargetInfo &target) {
-  setToMask(target.PointerSpareBits, 32,
+  target.PointerSpareBits = llvm::APInt(32,
             SWIFT_ABI_I386_SWIFT_SPARE_BITS_MASK);
 
   // x86 uses objc_msgSend_fpret but not objc_msgSend_fp2ret.
   target.ObjCUseFPRet = true;
-  setToMask(target.IsObjCPointerBit, 32, SWIFT_ABI_I386_IS_OBJC_BIT);
+  target.IsObjCPointerBit = llvm::APInt(32, SWIFT_ABI_I386_IS_OBJC_BIT);
 }
 
 /// Configures target-specific information for 32-bit arm platforms.
 static void configureARM(IRGenModule &IGM, const llvm::Triple &triple,
                          SwiftTargetInfo &target) {
-  setToMask(target.PointerSpareBits, 32,
+  target.PointerSpareBits = llvm::APInt(32,
             SWIFT_ABI_ARM_SWIFT_SPARE_BITS_MASK);
 
   // ARM requires marker assembly for objc_retainAutoreleasedReturnValue.
@@ -119,20 +114,20 @@ static void configureARM(IRGenModule &IGM, const llvm::Triple &triple,
   if (triple.getSubArch() == llvm::Triple::SubArchType::ARMSubArch_v7k)
     target.ObjCHasOpaqueISAs = true;
 
-  setToMask(target.IsObjCPointerBit, 32, SWIFT_ABI_ARM_IS_OBJC_BIT);
+  target.IsObjCPointerBit = llvm::APInt(32, SWIFT_ABI_ARM_IS_OBJC_BIT);
 }
 
 /// Configures target-specific information for powerpc64 platforms.
 static void configurePowerPC64(IRGenModule &IGM, const llvm::Triple &triple,
                                SwiftTargetInfo &target) {
-  setToMask(target.PointerSpareBits, 64,
+  target.PointerSpareBits = llvm::APInt(64,
             SWIFT_ABI_POWERPC64_SWIFT_SPARE_BITS_MASK);
 }
 
 /// Configures target-specific information for SystemZ platforms.
 static void configureSystemZ(IRGenModule &IGM, const llvm::Triple &triple,
                              SwiftTargetInfo &target) {
-  setToMask(target.PointerSpareBits, 64,
+  target.PointerSpareBits = llvm::APInt(64,
             SWIFT_ABI_S390X_SWIFT_SPARE_BITS_MASK);
 }
 
@@ -144,11 +139,11 @@ SwiftTargetInfo::SwiftTargetInfo(
     HeapObjectAlignment(numPointerBits / 8),
     LeastValidPointerValue(SWIFT_ABI_DEFAULT_LEAST_VALID_POINTER)
 {
-  setToMask(PointerSpareBits, numPointerBits,
+  PointerSpareBits = llvm::APInt(numPointerBits,
             SWIFT_ABI_DEFAULT_SWIFT_SPARE_BITS_MASK);
-  setToMask(ObjCPointerReservedBits, numPointerBits,
+  ObjCPointerReservedBits = llvm::APInt(numPointerBits,
             SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK);
-  setToMask(FunctionPointerSpareBits, numPointerBits,
+  FunctionPointerSpareBits = llvm::APInt(numPointerBits,
             SWIFT_ABI_DEFAULT_FUNCTION_SPARE_BITS_MASK);
 }
 
@@ -202,5 +197,5 @@ SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {
 }
 
 bool SwiftTargetInfo::hasObjCTaggedPointers() const {
-  return ObjCPointerReservedBits.any();
+  return ObjCPointerReservedBits != 0;
 }

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -19,7 +19,7 @@
 #define SWIFT_IRGEN_SWIFTTARGETINFO_H
 
 #include "swift/Basic/LLVM.h"
-#include "swift/Basic/ClusteredBitVector.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Triple.h"
 #include "IRGen.h"
 
@@ -53,24 +53,26 @@ public:
 
   /// The target's object format type.
   llvm::Triple::ObjectFormatType OutputObjectFormat;
-  
-  /// The spare bit mask for pointers. Bits set in this mask are unused by
-  /// pointers of any alignment.
-  SpareBitVector PointerSpareBits;
 
-  /// The spare bit mask for (ordinary C) thin function pointers.
-  SpareBitVector FunctionPointerSpareBits;
-  
+  /// Bits set in this mask are unused by pointers of any alignment. This
+  /// integer is in target byte order and should be converted to little-
+  /// endian byte order before being added to a spare bit mask.
+  llvm::APInt PointerSpareBits;
+
+  /// Bits set in this mask are unused by (ordinary C) thin function pointers.
+  /// This integer is in target byte order and should be converted to little-
+  /// endian byte order before being added to a spare bit mask.
+  llvm::APInt FunctionPointerSpareBits;
+
   /// The reserved bit mask for Objective-C pointers. Pointer values with
   /// bits from this mask set are reserved by the ObjC runtime and cannot be
   /// used for Swift value layout when a reference type may reference ObjC
   /// objects.
-  SpareBitVector ObjCPointerReservedBits;
+  llvm::APInt ObjCPointerReservedBits;
 
   /// These bits, if set, indicate that a Builtin.BridgeObject value is holding
   /// an Objective-C object.
-  SpareBitVector IsObjCPointerBit;
-
+  llvm::APInt IsObjCPointerBit;
 
   /// The alignment of heap objects.  By default, assume pointer alignment.
   Alignment HeapObjectAlignment;


### PR DESCRIPTION
This allows us to define these masks in platform byte order so we
can modify these masks without worrying about endianness.

When these marks are converted into spare bit vectors we will need
to explicitly put them in little-endian byte order when targeting
big-endian platforms. That will be done in a future change.
