### PR TITLE
[5.1] Property descriptor and symbolic type references need to ignore enable-private-import

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -103,7 +103,8 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       // when the referent may be in another file, once the on-disk
       // ObjectMemoryReader can handle them.
       // Private entities are known to be accessible.
-      if (type->getEffectiveAccess() >= AccessLevel::Internal &&
+      auto formalAccessScope = type->getFormalAccessScope(nullptr, true);
+      if ((formalAccessScope.isPublic() || formalAccessScope.isInternal()) &&
           (!IGM.CurSourceFile ||
            IGM.CurSourceFile != type->getParentSourceFile()))
         return false;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1380,14 +1380,10 @@ static bool canStorageUseTrivialDescriptor(SILGenModule &SGM,
     auto setter = decl->getSetter();
     if (setter == nullptr)
       return true;
-    
-    auto setterLinkage = SILDeclRef(setter, SILDeclRef::Kind::Func)
-      .getLinkage(NotForDefinition);
-    
-    if (setterLinkage == SILLinkage::PublicExternal
-        || setterLinkage == SILLinkage::Public)
+
+    if (setter->getFormalAccessScope(nullptr, true).isPublic())
       return true;
-    
+
     return false;
   }
   case ResilienceStrategy::Resilient: {

--- a/test/IRGen/symbolic_references.swift
+++ b/test/IRGen/symbolic_references.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-private-imports %s | %FileCheck %s --check-prefix=PRIVATE
+
+protocol P {
+  associatedtype A
+}
+// CHECK: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV9InnermostV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1,
+// CHECK: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+// CHECK: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+
+// PRIVATE: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV9InnermostV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 2
+// PRIVATE: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+// PRIVATE: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+fileprivate struct Foo {
+  fileprivate struct Inner: P {
+    fileprivate struct Innermost { }
+    typealias A = Innermost
+  }
+}

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck --check-prefix=CHECK --check-prefix=NONRESILIENT %s
 // RUN: %target-swift-emit-silgen -enable-library-evolution %s | %FileCheck --check-prefix=CHECK --check-prefix=RESILIENT %s
+// RUN: %target-swift-emit-silgen -enable-private-imports %s | %FileCheck --check-prefix=PRIVATEIMPORTS %s
 
 // TODO: globals should get descriptors
 public var a: Int = 0
@@ -12,30 +13,38 @@ internal var c: Int = 0
 
 // no descriptor
 // CHECK-NOT: sil_property #d
+// PRIVATEIMPORTS-NOT: sil_property #d
 internal var d: Int = 0
 // CHECK-NOT: sil_property #e
+// PRIVATEIMPORTS-NOT: sil_property #e
 private var e: Int = 0
 
 public struct A {
   // NONRESILIENT-LABEL: sil_property #A.a ()
   // RESILIENT-LABEL: sil_property #A.a (stored_property
+	// PRIVATEIMPORTS-LABEL: sil_property #A.a ()
   public var a: Int = 0
 
   // CHECK-LABEL: sil_property #A.b ()
+	// PRIVATEIMPORTS-LABEL: sil_property #A.b ()
   @inlinable
   public var b: Int { return 0 }
 
   // NONRESILIENT-LABEL: sil_property #A.c ()
   // RESILIENT-LABEL: sil_property #A.c (stored_property
+  // PRIVATEIMPORTS-LABEL: sil_property #A.c ()
   @usableFromInline
   internal var c: Int = 0
 
   // no descriptor
   // CHECK-NOT: sil_property #A.d
+  // PRIVATEIMPORTS-LABEL: sil_property #A.d ()
   internal var d: Int = 0
   // CHECK-NOT: sil_property #A.e
+  // PRIVATEIMPORTS-LABEL: sil_property #A.e ()
   fileprivate var e: Int = 0
   // CHECK-NOT: sil_property #A.f
+  // PRIVATEIMPORTS-LABEL: sil_property #A.f ()
   private var f: Int = 0
 
   // TODO: static vars should get descriptors
@@ -99,6 +108,7 @@ public struct A {
   private var _count: Int = 0
 
   // NONRESILIENT-LABEL: sil_property #A.getSet ()
+  // PRIVATEIMPORTS-LABEL: sil_property #A.getSet ()
   // RESILIENT-LABEL: sil_property #A.getSet (settable_property
   public var getSet: Int {
     get { return 0 }
@@ -106,12 +116,25 @@ public struct A {
   }
 
   // CHECK-LABEL: sil_property #A.hiddenSetter (settable_property
+  // PRIVATEIMPORTS-LABEL: sil_property #A.hiddenSetter (settable_property
   public internal(set) var hiddenSetter: Int {
     get { return 0 }
     set { }
   }
 
+  // PRIVATEIMPORTS-LABEL: sil_property #A.privateSetter (settable_property
+  public private(set) var privateSetter: Int {
+    get { return 0 }
+    set { }
+  }
+  // PRIVATEIMPORTS-LABEL: sil_property #A.fileprivateSetter (settable_property
+  public fileprivate(set) var fileprivateSetter: Int {
+    get { return 0 }
+    set { }
+  }
+
   // NONRESILIENT-LABEL: sil_property #A.usableFromInlineSetter ()
+  // PRIVATEIMPORTS-LABEL: sil_property #A.usableFromInlineSetter ()
   // RESILIENT-LABEL: sil_property #A.usableFromInlineSetter (settable_property
   public internal(set) var usableFromInlineSetter: Int {
     get { return 0 }

--- a/test/stdlib/Inputs/KeyPathMultiModule_b.swift
+++ b/test/stdlib/Inputs/KeyPathMultiModule_b.swift
@@ -36,6 +36,16 @@ public struct A {
     set { }
   }
 
+  public internal(set) var w: Int {
+    get { return 0 }
+    set { }
+  }
+  public fileprivate(set) var v: Int {
+    get { return 0 }
+    set { }
+  }
+
+
   public let immutable: Int = 1738
 }
 
@@ -88,6 +98,14 @@ public func A_y_keypath() -> KeyPath<A, Int> {
 
 public func A_z_keypath() -> KeyPath<A, Int> {
   return \A.z
+}
+
+public func A_w_keypath() -> KeyPath<A, Int> {
+  return \A.w
+}
+
+public func A_v_keypath() -> KeyPath<A, Int> {
+  return \A.v
 }
 
 public func A_immutable_keypath() -> KeyPath<A, Int> {

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -54,6 +54,8 @@ keyPathMultiModule.test("identity across multiple modules") {
     expectEqualWithHashes(A_x_keypath(), \A.x)
     expectEqualWithHashes(A_y_keypath(), \A.y)
     expectEqualWithHashes(A_z_keypath(), \A.z)
+    expectEqualWithHashes(A_w_keypath(), \A.w)
+    expectEqualWithHashes(A_v_keypath(), \A.v)
     expectEqualWithHashes(A_immutable_keypath(), \A.immutable)
     expectEqualWithHashes(A_subscript_withGeneric_keypath(index: 0), \A.[withGeneric: 0])
     expectEqualWithHashes(A_subscript_withGeneric_keypath(index: "butt"),


### PR DESCRIPTION
* SILGen: Fix property descriptor emission when enable-private-imports is enabled
* IRGen: Mangle symbolic type references as private types even with enable-private-imports