### PR TITLE
test: improve test coverage rate for Windows

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -370,8 +370,12 @@ config.substitutions.append( ('%{python}', sys.executable) )
 config.substitutions.append( ('%mcp_opt', mcp_opt) )
 config.substitutions.append( ('%swift_driver_plain', "%r" % config.swift) )
 config.substitutions.append( ('%swiftc_driver_plain', "%r" % config.swiftc) )
-config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s %s" % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
-config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s %s" % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+if kIsWindows:
+    config.substitutions.append( ('%swift_driver', "%r %s %s %s" % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+    config.substitutions.append( ('%swiftc_driver', "%r %s %s %s" % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+else:
+    config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s %s" % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+    config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s %s" % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
 config.substitutions.append( ('%sil-opt', "%r %s %s" % (config.sil_opt, mcp_opt, config.sil_test_options)) )
 config.substitutions.append( ('%sil-func-extractor', "%r %s" % (config.sil_func_extractor, mcp_opt)) )
 config.substitutions.append( ('%sil-llvm-gen', "%r %s" % (config.sil_llvm_gen, mcp_opt)) )
@@ -1379,8 +1383,7 @@ config.substitutions.append(('%FileCheck',
                              '%r %r --sanitize BUILD_DIR=%r --sanitize SOURCE_DIR=%r --use-filecheck %r' % (
         sys.executable,
         config.PathSanitizingFileCheck,
-        # Match lit/python, which, on Windows, normalizes path case (lowercases)
-        swift_obj_root.lower() if kIsWindows else swift_obj_root,
+        swift_obj_root,
         config.swift_src_root,
         config.filecheck)))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))


### PR DESCRIPTION
Strip the use of `env` on Windows which will swallow the error code if
the GnuWin32 version (which is recommended/used by LLVM) is used.  Since
SDKROOT should not be set on Windows anyways, this should not matter
much in practice but will help improve the test coverage on Windows.

Additionally, remove the path lowercasing on Windows as the path is kept
in the proper case, even on the nightlies.  This should help improve the
number of Driver tests that pass.

With this change, I now can get all the Driver tests to pass locally.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
