### PR TITLE
SILGen: Fix emission of keypath getter/setter when generic signature has only concrete parameters

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2672,6 +2672,10 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
   auto genericSig = genericEnv
     ? genericEnv->getGenericSignature()->getCanonicalSignature()
     : nullptr;
+  if (genericSig && genericSig->areAllParamsConcrete()) {
+    genericSig = nullptr;
+    genericEnv = nullptr;
+  }
 
   // Build the signature of the thunk as expected by the keypath runtime.
   CanType loweredBaseTy, loweredPropTy;
@@ -2800,6 +2804,11 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   auto genericSig = genericEnv
     ? genericEnv->getGenericSignature()->getCanonicalSignature()
     : nullptr;
+
+  if (genericSig && genericSig->areAllParamsConcrete()) {
+    genericSig = nullptr;
+    genericEnv = nullptr;
+  }
 
   // Build the signature of the thunk as expected by the keypath runtime.
   CanType loweredBaseTy, loweredPropTy;
@@ -2956,6 +2965,11 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
   auto genericSig = genericEnv
     ? genericEnv->getGenericSignature()->getCanonicalSignature()
     : nullptr;
+
+  if (genericSig && genericSig->areAllParamsConcrete()) {
+    genericSig = nullptr;
+    genericEnv = nullptr;
+  }
 
   auto &C = SGM.getASTContext();
   auto unsafeRawPointerTy = C.getUnsafeRawPointerDecl()->getDeclaredType()

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -154,3 +154,17 @@ public struct FixedLayout {
   // RESILIENT-LABEL: sil_property #FixedLayout.c (stored_property
   public var c: Int
 }
+
+public class Foo {}
+extension Array where Element == Foo {
+  public class Bar {
+    // NONRESILIENT-LABEL: sil_property #Array.Bar.dontCrash<τ_0_0 where τ_0_0 == Foo> (settable_property $Int
+    public private(set) var dontCrash : Int {
+      get {
+        return 10
+      }
+      set {
+      }
+    }
+  }
+}


### PR DESCRIPTION

We used to crash when creating a function type with a generic signature
that has only concrete parameters.
