### PR TITLE
[5.1][sourcekitd] Improve CursorInfo, RelatedIdents, and local rename to better handle VarDecls involved in case fallthroughs

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -167,6 +167,9 @@ static bool shouldUseObjCUSR(const Decl *D) {
 llvm::Expected<std::string>
 swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
                                       const ValueDecl *D) const {
+  if (auto *VD = dyn_cast<VarDecl>(D))
+    D = VD->getCanonicalVarDecl();
+
   if (!D->hasName() && !isa<ParamDecl>(D) && !isa<AccessorDecl>(D))
     return std::string(); // Ignore.
   if (D->getModuleContext()->isBuiltinModule())

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -79,11 +79,19 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
   if (!D->hasName())
     return false;
 
-  if (Loc == LocToResolve) {
-    CursorInfo.setValueRef(D, CtorTyRef, ExtTyRef, IsRef, Ty, ContainerType);
-    return true;
+  if (Loc != LocToResolve)
+    return false;
+
+  if (auto *VD = dyn_cast<VarDecl>(D)) {
+    // Handle references to the implicitly generated vars in case statements
+    // matching multiple patterns
+    if (VD->isImplicit()) {
+      if (auto * Parent = VD->getParentVarDecl())
+        D = Parent;
+    }
   }
-  return false;
+  CursorInfo.setValueRef(D, CtorTyRef, ExtTyRef, IsRef, Ty, ContainerType);
+  return true;
 }
 
 bool CursorInfoResolver::tryResolve(ModuleEntity Mod, SourceLoc Loc) {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1204,7 +1204,6 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
     
     for (auto VD : repeatedDecls) {
       VD->setHasNonPatternBindingInit();
-      VD->setImplicit();
     }
 
     // Parse the optional 'where' guard, with this particular pattern's bound

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -35,9 +35,47 @@ func foo(a: Int, b: Int, c: Int) {
     let _ = LocalEnum.foo(x: LocalStruct())
     // LOCAL: [[@LINE-1]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-2]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
-  // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
+    // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-4]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
     // LOCAL: [[@LINE-5]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-6]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
 
+}
+
+func bar(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    // LOCAL: [[@LINE-1]]:18 | variable(local)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
+    // LOCAL: [[@LINE-2]]:27 | variable(local)/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-3]]:18 | variable(local)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
+    // CHECK-NOT: [[@LINE-4]]:27 | variable(local)/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    print(x)
+    // LOCAL: [[@LINE-1]]:11 | variable(local)/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-2]]:11 | variable(local)/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+
+  case let .some(x) where x == 1,
+    // LOCAL: [[@LINE-1]]:18 | variable(local)/Swift | x | [[x2_USR:.*]] | Def,RelChild | rel: 1
+    // LOCAL: [[@LINE-2]]:27 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-3]]:18 | variable(local)/Swift | x | [[x2_USR:.*]] | Def,RelChild | rel: 1
+    // CHECK-NOT: [[@LINE-4]]:27 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+       let .some(x) where x == 2:
+    // LOCAL: [[@LINE-1]]:18 | variable(local)/Swift | x | [[x2_USR]] | Def,RelChild | rel: 1
+    // LOCAL: [[@LINE-2]]:27 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-3]]:18 | variable(local)/Swift | x | [[x2_USR]] | Def,RelChild | rel: 1
+    // CHECK-NOT: [[@LINE-4]]:27 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    print(x)
+    // LOCAL: [[@LINE-1]]:11 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-2]]:11 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    fallthrough
+  case let .some(x) where x == 3:
+    // LOCAL: [[@LINE-1]]:18 | variable(local)/Swift | x | [[x2_USR]] | Def,RelChild | rel: 1
+    // LOCAL: [[@LINE-2]]:27 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-1]]:18 | variable(local)/Swift | x | [[x2_USR]] | Def,RelChild | rel: 1
+    // CHECK-NOT: [[@LINE-2]]:27 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    print(x)
+    // LOCAL: [[@LINE-1]]:11 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-1]]:11 | variable(local)/Swift | x | [[x2_USR]] | Ref,Read,RelCont | rel: 1
+  default:
+    break
+  }
 }

--- a/test/SourceKit/CursorInfo/cursor_vardecl_across_fallthrough.swift
+++ b/test/SourceKit/CursorInfo/cursor_vardecl_across_fallthrough.swift
@@ -1,0 +1,57 @@
+
+enum X {
+  case first(Int, String)
+  case second(Int, String)
+  case third(Int, String)
+  case fourth(Int, String)
+  case fifth(Int, String)
+}
+
+let p = X.first(3, "hello")
+
+switch p {
+  case .first(let x, let y)
+    print("foo \(x) \(y)")
+    fallthrough
+  case .second(let x, let y), .third(let x, let y):
+    print("bar \(x) \(y)")
+  default:
+    print("other")
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=13:19 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKX,CHECK1DECL %s
+// RUN: %sourcekitd-test -req=cursor -pos=14:18 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKX,CHECK1REF %s
+
+// CHECK1DECL: source.lang.swift.decl.var.local (13:19-13:20)
+// CHECK1REF: source.lang.swift.ref.var.local (13:19-13:20)
+
+// RUN: %sourcekitd-test -req=cursor -pos=16:20 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKX,CHECK2DECL %s
+// RUN: %sourcekitd-test -req=cursor -pos=16:42 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKX,CHECK2DECL2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=17:18 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKX,CHECK2REF %s
+
+// CHECK2DECL: source.lang.swift.decl.var.local (16:20-16:21)
+// CHECK2DECL2: source.lang.swift.decl.var.local (16:42-16:43)
+// CHECK2REF: source.lang.swift.ref.var.local (16:20-16:21)
+
+// CHECKX: x
+// CHECKX: s:33cursor_vardecl_across_fallthrough1xL_Sivp
+// CHECKX: Int
+
+
+// RUN: %sourcekitd-test -req=cursor -pos=13:26 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKY,CHECK3DECL %s
+// RUN: %sourcekitd-test -req=cursor -pos=14:23 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKY,CHECK3REF %s
+
+// CHECK3DECL: source.lang.swift.decl.var.local (13:26-13:27)
+// CHECK3REF: source.lang.swift.ref.var.local (13:26-13:27)
+
+// RUN: %sourcekitd-test -req=cursor -pos=16:27 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKY,CHECK4DECL %s
+// RUN: %sourcekitd-test -req=cursor -pos=16:49 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKY,CHECK4DECL2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=17:23 %s -- %mcp_opt %s | %FileCheck -check-prefixes=CHECKY,CHECK4REF %s
+
+// CHECK4DECL: source.lang.swift.decl.var.local (16:27-16:28)
+// CHECK4DECL2: source.lang.swift.decl.var.local (16:49-16:50)
+// CHECK4REF: source.lang.swift.ref.var.local (16:27-16:28)
+
+// CHECKY: y
+// CHECKY: s:33cursor_vardecl_across_fallthrough1yL_SSvp
+// CHECKY: String

--- a/test/SourceKit/RelatedIdents/related_idents.swift
+++ b/test/SourceKit/RelatedIdents/related_idents.swift
@@ -23,6 +23,27 @@ class C2<Param> {
 	func f(t : Param) -> Param {return t}
 }
 
+enum X {
+  case first(Int, String)
+  case second(Int, String)
+  case third(Int, String)
+  case fourth(Int, String)
+}
+
+switch X.first(2, "") {
+  case .first(let x, let y):
+    print(y)
+    fallthrough
+  case .second(let x, _):
+    print(x)
+  case .third(let x, let y):
+    fallthrough
+  case .fourth(let x, let y):
+    print(y)
+    print(x)
+    break
+}
+
 // RUN: %sourcekitd-test -req=related-idents -pos=6:17 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: START RANGES
 // CHECK1-NEXT: 1:7 - 2
@@ -53,3 +74,37 @@ class C2<Param> {
 // CHECK5-NEXT: 23:13 - 5
 // CHECK5-NEXT: 23:23 - 5
 // CHECK5-NEXT: END RANGES
+
+// RUN: %sourcekitd-test -req=related-idents -pos=34:19 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK6 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=37:20 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK6 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=38:11 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK6 %s
+// CHECK6:      START RANGES
+// CHECK6-NEXT: 34:19 - 1
+// CHECK6-NEXT: 37:20 - 1
+// CHECK6-NEXT: 38:11 - 1
+// CHECK6-NEXT: END RANGES
+
+// RUN: %sourcekitd-test -req=related-idents -pos=34:26 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK7 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=35:11 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK7 %s
+// CHECK7:      START RANGES
+// CHECK7-NEXT: 34:26 - 1
+// CHECK7-NEXT: 35:11 - 1
+// CHECK7-NEXT: END RANGES
+
+// RUN: %sourcekitd-test -req=related-idents -pos=39:26 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK8 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=41:27 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK8 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=42:11 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK8 %s
+// CHECK8:      START RANGES
+// CHECK8-NEXT: 39:26 - 1
+// CHECK8-NEXT: 41:27 - 1
+// CHECK8-NEXT: 42:11 - 1
+// CHECK8-NEXT: END RANGES
+
+// RUN: %sourcekitd-test -req=related-idents -pos=39:19 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK9 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=41:20 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK9 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=43:11 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK9 %s
+// CHECK9:      START RANGES
+// CHECK9-NEXT: 39:19 - 1
+// CHECK9-NEXT: 41:20 - 1
+// CHECK9-NEXT: 43:11 - 1
+// CHECK9-NEXT: END RANGES

--- a/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(xRenamed) where xRenamed == 0:
     print(xRenamed)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(xRenamed) where xRenamed == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(xRenamed) where xRenamed == 2:
+    print(xRenamed)
+    fallthrough
+  case let .some(xRenamed) where xRenamed == 3:
     print(xRenamed)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/catch_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_1.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/catch_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_2.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/ifbind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_1.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/param_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/param_1.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/Outputs/local/param_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/param_2.swift.expected
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break

--- a/test/refactoring/rename/local.swift
+++ b/test/refactoring/rename/local.swift
@@ -21,7 +21,10 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(x) where x == 1,
-       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2:
+    print(x)
+    fallthrough
+  case let .some(x) where x == 3:
     print(x)
   default:
     break
@@ -57,11 +60,11 @@ func test5(_ x: Int) {
 // RUN: %refactor -rename -source-filename %s -pos=25:11 -new-name="xRenamed" >> %t.result/casebind_2.swift
 // RUN: diff -u %S/Outputs/local/casebind_1.swift.expected %t.result/casebind_1.swift
 // RUN: diff -u %S/Outputs/local/casebind_2.swift.expected %t.result/casebind_2.swift
-// RUN: %refactor -rename -source-filename %s -pos=35:15 -new-name="xRenamed" >> %t.result/catch_1.swift
-// RUN: %refactor -rename -source-filename %s -pos=38:11 -new-name="xRenamed" >> %t.result/catch_2.swift
+// RUN: %refactor -rename -source-filename %s -pos=38:15 -new-name="xRenamed" >> %t.result/catch_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=41:11 -new-name="xRenamed" >> %t.result/catch_2.swift
 // RUN: diff -u %S/Outputs/local/catch_1.swift.expected %t.result/catch_1.swift
 // RUN: diff -u %S/Outputs/local/catch_2.swift.expected %t.result/catch_2.swift
-// RUN: %refactor -rename -source-filename %s -pos=42:14 -new-name="xRenamed" >> %t.result/param_1.swift
-// RUN: %refactor -rename -source-filename %s -pos=44:9 -new-name="xRenamed" >> %t.result/param_2.swift
+// RUN: %refactor -rename -source-filename %s -pos=45:14 -new-name="xRenamed" >> %t.result/param_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=47:9 -new-name="xRenamed" >> %t.result/param_2.swift
 // RUN: diff -u %S/Outputs/local/param_1.swift.expected %t.result/param_1.swift
 // RUN: diff -u %S/Outputs/local/param_2.swift.expected %t.result/param_2.swift


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/23448 for 5.1 branch