### PR TITLE
[5.1] Sema: Don't implicitly mark functions with a cdecl as dynamic

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2570,6 +2570,9 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
     // Don't add dynamic to defer bodies.
     if (FD->isDeferBody())
       return;
+    // Don't add dynamic to functions with a cdecl.
+    if (FD->getAttrs().hasAttribute<CDeclAttr>())
+      return;
   }
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {

--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -357,6 +357,11 @@ dynamic func funcWithDefaultArg(_ arg : String = String("hello")) {
   print("hello")
 }
 
+// IMPLICIT-LABEL: sil hidden [thunk] [ossa] @barfoo
+@_cdecl("barfoo")
+func foobar() {
+}
+
 // IMPLICIT-LABEL: sil private [ossa] @$s23dynamically_replaceable6$deferL_yyF
 var x = 10
 defer {


### PR DESCRIPTION
This does not work without more work.