### PR TITLE
[semantic-arc-opts] Teach the guaranteed copy_value peephole how to h…

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -586,6 +586,11 @@ public:
   SILInstruction *getUser() { return Owner; }
   const SILInstruction *getUser() const { return Owner; }
 
+  /// Return true if this operand is a type dependent operand.
+  ///
+  /// Implemented in SILInstruction.h
+  bool isTypeDependent() const;
+
   /// Return which operand this is in the operand list of the using instruction.
   unsigned getOperandNumber() const;
 

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -719,6 +719,10 @@ OperandOwnershipKindClassifier::visitFullApply(FullApplySite apply) {
     return Map::allLive();
   }
 
+  // If we have a type dependent operand, return an empty map.
+  if (apply.getInstruction()->isTypeDependentOperand(op))
+    return Map();
+
   unsigned argIndex = apply.getCalleeArgIndex(op);
   auto conv = apply.getSubstCalleeConv();
   SILParameterInfo paramInfo = conv.getParamInfoForSILArg(argIndex);

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -40,36 +40,73 @@ STATISTIC(NumLoadCopyConvertedToLoadBorrow,
 ///
 /// Semantically this implies that a value is never passed off as +1 to memory
 /// or another function implying it can be used everywhere at +0.
-static bool isConsumed(SILValue v,
-                       SmallVectorImpl<DestroyValueInst *> &destroys) {
+static bool isConsumed(
+    SILValue v, SmallVectorImpl<DestroyValueInst *> &destroys,
+    NullablePtr<SmallVectorImpl<SILInstruction *>> forwardingInsts = nullptr) {
   assert(v.getOwnershipKind() == ValueOwnershipKind::Owned);
-  return !all_of(v->getUses(), [&destroys](Operand *op) {
-    // We know that a copy_value produces an @owned value. Look
-    // through all of our uses and classify them as either
-    // invalidating or not invalidating. Make sure that all of the
-    // invalidating ones are destroy_value since otherwise the
-    // live_range is not complete.
+  SmallVector<Operand *, 32> worklist(v->use_begin(), v->use_end());
+  while (!worklist.empty()) {
+    auto *op = worklist.pop_back_val();
+
+    // Skip type dependent operands.
+    if (op->isTypeDependent())
+      continue;
+
+    auto *user = op->getUser();
+
+    // We know that a copy_value produces an @owned value. Look through all of
+    // our uses and classify them as either invalidating or not
+    // invalidating. Make sure that all of the invalidating ones are
+    // destroy_value since otherwise the live_range is not complete.
     auto map = op->getOwnershipKindMap();
     auto constraint = map.getLifetimeConstraint(ValueOwnershipKind::Owned);
     switch (constraint) {
     case UseLifetimeConstraint::MustBeInvalidated: {
       // See if we have a destroy value. If we don't we have an
       // unknown consumer. Return false, we need this live range.
-      auto *dvi = dyn_cast<DestroyValueInst>(op->getUser());
-      if (!dvi)
-        return false;
+      if (auto *dvi = dyn_cast<DestroyValueInst>(user)) {
+        destroys.push_back(dvi);
+        continue;
+      }
 
-      // Otherwise, return true and stash this destroy value.
-      destroys.push_back(dvi);
+      // Otherwise, see if we have a forwarding value that has a single
+      // non-trivial operand that can accept a guaranteed value. If so, at its
+      // users to the worklist and continue.
+      //
+      // DISCUSSION: For now we do not support forwarding instructions with
+      // multiple non-trivial arguments since we would need to optimize all of
+      // the non-trivial arguments at the same time.
+      //
+      // NOTE: Today we do not support TermInsts for simplicity... we /could/
+      // support it though if we need to.
+      if (forwardingInsts.isNonNull() && !isa<TermInst>(user) &&
+          isGuaranteedForwardingInst(user) &&
+          1 == count_if(user->getOperandValues(
+                            true /*ignore type dependent operands*/),
+                        [&](SILValue v) {
+                          return v.getOwnershipKind() ==
+                                 ValueOwnershipKind::Owned;
+                        })) {
+        forwardingInsts.get()->push_back(user);
+        for (SILValue v : user->getResults()) {
+          copy(v->getUses(), std::back_inserter(worklist));
+        }
+        continue;
+      }
+
+      // Otherwise be conservative and assume that we /may consume/ the value.
       return true;
     }
     case UseLifetimeConstraint::MustBeLive:
       // Ok, this constraint can take something owned as live. Lets
       // see if it can also take something that is guaranteed. If it
       // can not, then we bail.
-      return map.canAcceptKind(ValueOwnershipKind::Guaranteed);
+      map.canAcceptKind(ValueOwnershipKind::Guaranteed);
+      continue;
     }
-  });
+  }
+
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -168,13 +205,14 @@ static bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi) {
   if (!canHandleOperand(cvi->getOperand(), borrowIntroducers))
     return false;
 
-  // Then go over all of our uses. Find our destroying instructions
-  // and make sure all of them are destroy_value. For our
-  // non-destroying instructions, make sure that they accept a
-  // guaranteed value. After that, make sure that our destroys are
-  // within the lifetime of our borrowed values.
+  // Then go over all of our uses. Find our destroying instructions (ignoring
+  // forwarding instructions that can forward both owned and guaranteed) and
+  // make sure all of them are destroy_value. For our non-destroying
+  // instructions, make sure that they accept a guaranteed value. After that,
+  // make sure that our destroys are within the lifetime of our borrowed values.
   SmallVector<DestroyValueInst *, 16> destroys;
-  if (isConsumed(cvi, destroys))
+  SmallVector<SILInstruction *, 16> guaranteedForwardingInsts;
+  if (isConsumed(cvi, destroys, &guaranteedForwardingInsts))
     return false;
 
   // If we reached this point, then we know that all of our users can
@@ -189,8 +227,8 @@ static bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi) {
   assert(all_of(borrowIntroducers,
                 [](SILValue v) { return isa<SILFunctionArgument>(v); }));
 
-  // Otherwise, we know that our copy_value/destroy_values are all
-  // completely within the guaranteed value scope.
+  // Otherwise, we know that our copy_value/destroy_values are all completely
+  // within the guaranteed value scope. First delete the destroys/copies.
   while (!destroys.empty()) {
     auto *dvi = destroys.pop_back_val();
     dvi->eraseFromParent();
@@ -198,6 +236,47 @@ static bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi) {
   }
   cvi->replaceAllUsesWith(cvi->getOperand());
   cvi->eraseFromParent();
+
+  // Then change all of our guaranteed forwarding insts to have guaranteed
+  // ownership kind instead of what ever they previously had (ignoring trivial
+  // results);
+  while (!guaranteedForwardingInsts.empty()) {
+    auto *i = guaranteedForwardingInsts.pop_back_val();
+
+    assert(i->hasResults());
+
+    for (SILValue result : i->getResults()) {
+      if (auto *svi = dyn_cast<OwnershipForwardingSingleValueInst>(result)) {
+        if (svi->getOwnershipKind() == ValueOwnershipKind::Owned) {
+          svi->setOwnershipKind(ValueOwnershipKind::Guaranteed);
+        }
+        continue;
+      }
+
+      if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(result)) {
+        if (ofci->getOwnershipKind() == ValueOwnershipKind::Owned) {
+          ofci->setOwnershipKind(ValueOwnershipKind::Guaranteed);
+        }
+        continue;
+      }
+
+      if (auto *sei = dyn_cast<OwnershipForwardingSelectEnumInstBase>(result)) {
+        if (sei->getOwnershipKind() == ValueOwnershipKind::Owned) {
+          sei->setOwnershipKind(ValueOwnershipKind::Guaranteed);
+        }
+        continue;
+      }
+
+      if (auto *mvir = dyn_cast<MultipleValueInstructionResult>(result)) {
+        if (mvir->getOwnershipKind() == ValueOwnershipKind::Owned) {
+          mvir->setOwnershipKind(ValueOwnershipKind::Guaranteed);
+        }
+        continue;
+      }
+
+      llvm_unreachable("unhandled forwarding instruction?!");
+    }
+  }
   ++NumEliminatedInsts;
   return true;
 }
@@ -350,6 +429,11 @@ bool SemanticARCOptVisitor::visitLoadInst(LoadInst *li) {
   // load_borrow.
   auto *lbi =
       SILBuilderWithScope(li).createLoadBorrow(li->getLoc(), li->getOperand());
+
+  // Since we are looking through forwarding uses that can accept guaranteed
+  // parameters, we can have multiple destroy_value along the same path. We need
+  // to find the post-dominating block set of these destroy value to ensure that
+  // we do not insert multiple end_borrow.
   while (!destroyValues.empty()) {
     auto *dvi = destroyValues.pop_back_val();
     SILBuilderWithScope(dvi).createEndBorrow(dvi->getLoc(), lbi);

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -16,6 +16,24 @@ struct NativeObjectPair {
   var obj2 : Builtin.NativeObject
 }
 
+class Klass {}
+
+struct AnotherStruct {
+  var i : Builtin.Int32
+  var c : Klass
+}
+
+struct StructMemberTest {
+  var c : Klass
+  var s : AnotherStruct
+  var t : (Builtin.Int32, AnotherStruct)
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
 ///////////
 // Tests //
 ///////////
@@ -142,12 +160,10 @@ bb0(%0 : @guaranteed $NativeObjectPair):
   return %9999 : $()
 }
 
-// For now we do not support recreating forwarding instructions since we do not
-// dynamically recompute ownership.
-// CHECK-LABEL: sil [ossa] @do_not_process_forwarding_uses : $@convention(thin) (@guaranteed NativeObjectPair) -> () {
-// CHECK: copy_value
-// CHECK: } // end sil function 'do_not_process_forwarding_uses'
-sil [ossa] @do_not_process_forwarding_uses : $@convention(thin) (@guaranteed NativeObjectPair) -> () {
+// CHECK-LABEL: sil [ossa] @process_forwarding_uses : $@convention(thin) (@guaranteed NativeObjectPair) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'process_forwarding_uses'
+sil [ossa] @process_forwarding_uses : $@convention(thin) (@guaranteed NativeObjectPair) -> () {
 bb0(%0 : @guaranteed $NativeObjectPair):
   %1 = copy_value %0 : $NativeObjectPair
   (%2, %3) = destructure_struct %1 : $NativeObjectPair
@@ -160,10 +176,10 @@ bb0(%0 : @guaranteed $NativeObjectPair):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @do_not_process_forwarding_uses_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-// CHECK: copy_value
-// CHECK: } // end sil function 'do_not_process_forwarding_uses_2'
-sil [ossa] @do_not_process_forwarding_uses_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [ossa] @process_forwarding_uses_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'process_forwarding_uses_2'
+sil [ossa] @process_forwarding_uses_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
   %2 = unchecked_ref_cast %1 : $Builtin.NativeObject to $Builtin.NativeObject
@@ -273,6 +289,92 @@ bb3:
   %3 = load [copy] %0 : $*Builtin.NativeObject
   %4 = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
   apply %4(%3) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @destructure_test : $@convention(thin) (@guaranteed StructMemberTest) -> Builtin.Int32 {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $StructMemberTest):
+// CHECK:   [[EXT:%.*]] = struct_extract [[ARG]]
+// CHECK:   ([[DEST_1:%.*]], [[DEST_2:%.*]]) = destructure_tuple [[EXT]]
+// CHECK:   [[RESULT:%.*]] = struct_extract [[DEST_2]]
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function 'destructure_test'
+sil [ossa] @destructure_test : $@convention(thin) (@guaranteed StructMemberTest) -> Builtin.Int32 {
+bb0(%0 : @guaranteed $StructMemberTest):
+  %2 = struct_extract %0 : $StructMemberTest, #StructMemberTest.t
+  %3 = copy_value %2 : $(Builtin.Int32, AnotherStruct)
+  (%4, %5) = destructure_tuple %3 : $(Builtin.Int32, AnotherStruct)
+  %6 = begin_borrow %5 : $AnotherStruct
+  %7 = struct_extract %6 : $AnotherStruct, #AnotherStruct.i
+  end_borrow %6 : $AnotherStruct
+  destroy_value %5 : $AnotherStruct
+  return %7 : $Builtin.Int32
+}
+
+// Make sure that in a case where we have multiple non-trivial values passed to
+// a forwarding instruction we do not optimize... but if we only have one (and
+// multiple trivial arguments), we can.
+//
+// CHECK-LABEL: sil [ossa] @multiple_arg_forwarding_inst_test : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
+// CHECK: copy_value
+// CHECK: copy_value
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'multiple_arg_forwarding_inst_test'
+sil [ossa] @multiple_arg_forwarding_inst_test : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject, %1a : $Builtin.Int32):
+  %2 = copy_value %0 : $Builtin.NativeObject
+  %3 = copy_value %1 : $Builtin.NativeObject
+  %4 = tuple(%2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+  destroy_value %4 : $(Builtin.NativeObject, Builtin.NativeObject)
+
+  %5 = copy_value %0 : $Builtin.NativeObject
+  %6 = tuple(%5 : $Builtin.NativeObject, %1a : $Builtin.Int32)
+  destroy_value %6 : $(Builtin.NativeObject, Builtin.Int32)
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// TODO: We should be able to optimize these switch_enum. Make sure that today
+// we do not do so though.
+// CHECK-LABEL: sil [ossa] @switch_enum_test_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'switch_enum_test_no_default'
+sil [ossa] @switch_enum_test_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
+  %1 = copy_value %0 : $FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'switch_enum_test_with_default'
+sil [ossa] @switch_enum_test_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
+  %1 = copy_value %0 : $FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, default bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2(%3 : @owned $FakeOptional<Builtin.NativeObject>):
+  destroy_value %3 : $FakeOptional<Builtin.NativeObject>
+  br bb3
+
+bb3:
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
…andle instructions that can forward either owned or guaranteed ownership.

This fixes issues exposed by my turning off the Nominal Type RValue peephole. It
should give us some nice ARC wins as well potentially.
