### PR TITLE
Fix a comment typo in AccessEnforcementOpts.

### DIFF
--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -327,10 +327,10 @@ private:
 void AccessConflictAndMergeAnalysis::recordInScopeConflicts(
     RegionState &state, const AccessedStorage &currStorage,
     SILAccessKind currKind) {
-  // It is tempting to combine loop with the loop in removeConflicts, which also
-  // checks isDistinctFrom for each element. However, since SetVector does not
-  // support 'llvm::erase_if', it is actually more efficient to do the removal
-  // in a separate 'remove_if' loop.
+  // It is tempting to combine this loop with the loop in removeConflicts, which
+  // also checks isDistinctFrom for each element. However, since SetVector does
+  // not support 'llvm::erase_if', it is actually more efficient to do the
+  // removal in a separate 'remove_if' loop.
   llvm::for_each(state.inScopeConflictFreeAccesses, [&](BeginAccessInst *bai) {
     auto &accessInfo = result.getAccessInfo(bai);
     if (accessKindMayConflict(currKind, bai->getAccessKind())

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1681,7 +1681,7 @@ bb0:
 
 // public func testNestedWriteBailout() {
 // Same as testNestedReadBailout but with modify
-// We will create two scopes - nested conflict
+// We will create two scopes - the nested conflict must be preserved.
 //
 // CHECK-LABEL: sil @testNestedWriteBailout : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X


### PR DESCRIPTION
This was supposed to land in the previous commit but was dropped.
