### PR TITLE
Fix a PerformanceInliner crash caused by a null callee signature.

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -363,7 +363,7 @@ bool SILPerformanceInliner::isProfitableToInline(
         auto Subs = FAI.getSubstitutionMap();
 
         // Bail if it is not a generic call or inlining of generics is forbidden.
-        if (!EnableSILInliningOfGenerics || Subs.empty())
+        if (!EnableSILInliningOfGenerics || !Subs.hasAnySubstitutableParams())
           continue;
 
         if (!isa<FunctionRefInst>(def) && !isa<ClassMethodInst>(def) &&

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -390,6 +390,8 @@ static bool shouldNotSpecialize(SILFunction *Callee, SILFunction *Caller,
 bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
                                         SubstitutionMap ParamSubs,
                                         OptRemark::Emitter *ORE) {
+  assert(ParamSubs.hasAnySubstitutableParams());
+
   if (shouldNotSpecialize(Callee, Apply ? Apply.getFunction() : nullptr))
     return false;
 


### PR DESCRIPTION
This is an obvious drive-by fix. It will crash when building
Foundation after I commit changes to the pipeline. My attempts at
creating a unit test were unsuccessful because it depends on some
interaction between inlining and specialization heuristics.
