### PR TITLE
[ParseableInterface] Honor "exported module names"

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -810,6 +810,14 @@ public:
     return nullptr;
   }
 
+  /// Returns the name to use when referencing entities in this file.
+  ///
+  /// Usually this is the module name itself, but certain Clang features allow
+  /// substituting another name instead.
+  virtual StringRef getExportedModuleName() const {
+    return getParentModule()->getName().str();
+  }
+
   /// Traverse the decls within this file.
   ///
   /// \returns true if traversal was aborted, false if it completed

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -185,6 +185,12 @@ struct PrintOptions {
   /// type might be ambiguous.
   bool FullyQualifiedTypesIfAmbiguous = false;
 
+  /// If true, printed module names will use the "exported" name, which may be
+  /// different from the regular name.
+  ///
+  /// \see FileUnit::getExportedModuleName
+  bool UseExportedModuleNames = false;
+
   /// Print Swift.Array and Swift.Optional with sugared syntax
   /// ([] and ?), even if there are no sugar type nodes.
   bool SynthesizeSugarOnTypes = false;

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -62,7 +62,7 @@ public:
   /// Retrieve the "exported" name of the module, which is usually the module
   /// name, but might be the name of the public module through which this
   /// (private) module is re-exported.
-  StringRef getExportedModuleName() const;
+  StringRef getExportedModuleName() const override;
 
   virtual bool isSystemModule() const override;
 

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -62,7 +62,7 @@ public:
   /// Retrieve the "exported" name of the module, which is usually the module
   /// name, but might be the name of the public module through which this
   /// (private) module is re-exported.
-  std::string getExportedModuleName() const;
+  StringRef getExportedModuleName() const;
 
   virtual bool isSystemModule() const override;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -99,6 +99,7 @@ PrintOptions PrintOptions::printParseableInterfaceFile() {
   result.TypeDefinitions = true;
   result.PrintIfConfig = false;
   result.FullyQualifiedTypes = true;
+  result.UseExportedModuleNames = true;
   result.AllowNullTypes = false;
   result.SkipImports = true;
   result.OmitNameOfInaccessibleProperties = true;
@@ -3342,8 +3343,14 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
 
   template <typename T>
   void printModuleContext(T *Ty) {
-    ModuleDecl *Mod = Ty->getDecl()->getModuleContext();
-    Printer.printModuleRef(Mod, Mod->getName());
+    FileUnit *File = cast<FileUnit>(Ty->getDecl()->getModuleScopeContext());
+    ModuleDecl *Mod = File->getParentModule();
+
+    Identifier Name = Mod->getName();
+    if (Options.UseExportedModuleNames)
+      Name = Mod->getASTContext().getIdentifier(File->getExportedModuleName());
+
+    Printer.printModuleRef(Mod, Name);
     Printer << ".";
   }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3146,7 +3146,7 @@ clang::ASTContext &ClangModuleUnit::getClangASTContext() const {
   return owner.getClangASTContext();
 }
 
-std::string ClangModuleUnit::getExportedModuleName() const {
+StringRef ClangModuleUnit::getExportedModuleName() const {
   if (clangModule && !clangModule->ExportAsModule.empty())
     return clangModule->ExportAsModule;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1149,7 +1149,7 @@ static bool isReExportedToModule(const ValueDecl *value,
       = dyn_cast<ClangModuleUnit>(valueDC->getModuleScopeContext());
   if (!fromClangModule)
     return false;
-  std::string exportedName = fromClangModule->getExportedModuleName();
+  StringRef exportedName = fromClangModule->getExportedModuleName();
 
   auto toClangModule
       = dyn_cast<ClangModuleUnit>(expectedModule->getFiles().front());

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -25,7 +25,6 @@
 #include "swift/AST/USRGeneration.h"
 #include "swift/Basic/Range.h"
 #include "swift/ClangImporter/ClangImporter.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Serialization/BCReadingExtras.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "llvm/ADT/StringExtras.h"
@@ -1842,15 +1841,8 @@ void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
   }
 
   if (nominal->getParent()->isModuleScopeContext()) {
-    auto parentModule = nominal->getParentModule();
-    StringRef moduleName = parentModule->getName().str();
-
-    // If the originating module is a private module whose interface is
-    // re-exported via public module, check the name of the public module.
-    if (auto clangModuleUnit =
-            dyn_cast<ClangModuleUnit>(parentModule->getFiles().front())) {
-      moduleName = clangModuleUnit->getExportedModuleName();
-    }
+    auto parentFile = cast<FileUnit>(nominal->getParent());
+    StringRef moduleName = parentFile->getExportedModuleName();
 
     for (auto item : *iter) {
       if (item.first != moduleName)

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1847,11 +1847,9 @@ void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
 
     // If the originating module is a private module whose interface is
     // re-exported via public module, check the name of the public module.
-    std::string exportedModuleName;
     if (auto clangModuleUnit =
             dyn_cast<ClangModuleUnit>(parentModule->getFiles().front())) {
-      exportedModuleName = clangModuleUnit->getExportedModuleName();
-      moduleName = exportedModuleName;
+      moduleName = clangModuleUnit->getExportedModuleName();
     }
 
     for (auto item : *iter) {

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -540,13 +540,16 @@ public:
   /// Records the use of the given SILLayout.
   SILLayoutID addSILLayoutRef(SILLayout *layout);
 
-  /// Records the use of the given module.
+  /// Records the module containing \p DC.
   ///
-  /// The module's name will be scheduled for serialization if necessary.
+  /// The module's name will be scheduled for serialization if necessary. This
+  /// may not be exactly the same as the name of the module containing DC;
+  /// instead, it will match the containing file's "exported module name".
   ///
   /// \returns The ID for the identifier for the module's name, or one of the
   /// special module codes defined above.
-  IdentifierID addModuleRef(const ModuleDecl *M);
+  /// \see FileUnit::getExportedModuleName
+  IdentifierID addContainingModuleRef(const DeclContext *DC);
 
   /// Write a normal protocol conformance.
   void writeNormalConformance(const NormalProtocolConformance *conformance);

--- a/test/ParseableInterface/Inputs/exported-module-name-after/CoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-after/CoreKit.h
@@ -1,0 +1,1 @@
+#import <ExportAsCoreKit.h>

--- a/test/ParseableInterface/Inputs/exported-module-name-after/ExportAsCoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-after/ExportAsCoreKit.h
@@ -1,0 +1,3 @@
+struct CKThing {
+  long value;
+};

--- a/test/ParseableInterface/Inputs/exported-module-name-after/module.modulemap
+++ b/test/ParseableInterface/Inputs/exported-module-name-after/module.modulemap
@@ -1,0 +1,5 @@
+module CoreKit {
+  header "CoreKit.h"
+  header "ExportAsCoreKit.h"
+  export *
+}

--- a/test/ParseableInterface/Inputs/exported-module-name-before/CoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-before/CoreKit.h
@@ -1,0 +1,1 @@
+#import <ExportAsCoreKit.h>

--- a/test/ParseableInterface/Inputs/exported-module-name-before/ExportAsCoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-before/ExportAsCoreKit.h
@@ -1,0 +1,3 @@
+struct CKThing {
+  long value;
+};

--- a/test/ParseableInterface/Inputs/exported-module-name-before/module.modulemap
+++ b/test/ParseableInterface/Inputs/exported-module-name-before/module.modulemap
@@ -1,0 +1,10 @@
+module CoreKit {
+  header "CoreKit.h"
+  export *
+}
+
+module ExportAsCoreKit_BAD {
+  header "ExportAsCoreKit.h"
+  export_as CoreKit
+  export *
+}

--- a/test/ParseableInterface/exported-module-name.swift
+++ b/test/ParseableInterface/exported-module-name.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/CoreKitClient.swiftinterface -module-name CoreKitClient -I %S/Inputs/exported-module-name-before %s
+// RUN: %FileCheck -implicit-check-not BAD %s < %t/CoreKitClient.swiftinterface
+
+// Test that we can rebuild it even when the "export as" module goes away.
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -o %t/CoreKitClient.swiftmodule -I %S/Inputs/exported-module-name-after %t/CoreKitClient.swiftinterface
+
+// CHECK: import CoreKit
+import CoreKit
+
+// CHECK-LABEL: public struct CKThingWrapper : RawRepresentable {
+public struct CKThingWrapper: RawRepresentable {
+  public var rawValue: CKThing
+  public init(rawValue: CKThing) {
+    self.rawValue = rawValue
+  }
+  // Note that this is CoreKit.CKThing, not ExportAsCoreKit.CKThing
+  // CHECK: public typealias RawValue = CoreKit.CKThing
+} // CHECK: {{^}$}}


### PR DESCRIPTION
Clang's "exported module name" is a pretty obscure feature (and one we wish we didn't need), but sometimes API is initially exposed through one module in order to build another one, and we want the canonical presented name to be something else. Push this concept into Swift's AST properly, then use that name when printing a parseable interface, just like we do with serialization.

rdar://problem/49114811