### PR TITLE
[test] Transform you-should-be-using-LLVM_DEBUG to Python.

### DIFF
--- a/test/Misc/you-should-be-using-LLVM_DEBUG.test-sh
+++ b/test/Misc/you-should-be-using-LLVM_DEBUG.test-sh
@@ -1,4 +1,28 @@
-// RUN: not test -d '%swift_src_root'/.git || not git -C '%swift_src_root' grep '\bDEBUG[(]' || (printf '\n*** The DE'B'UG(...) macro is being renamed to LLVM_DEBUG(...);\n*** please use that instead.\n' && false)
+#! /usr/bin/env python
+# -*- python -*-
+# RUN: %{python} %s '%swift_src_root'
 
-If you see a failure in this test, that means you introduced a use of the DEBUG
-macro from LLVM, which is being renamed to LLVM_DEBUG.
+import os.path
+import subprocess
+import sys
+
+if len(sys.argv) < 2:
+    print('Invalid number of arguments.')
+    sys.exit(1)
+
+swift_src_root = sys.argv[1]
+if not os.path.exists(os.path.join(swift_src_root, '.git')):
+    # It is fine if the folder doesn't exist
+    sys.exit(0)
+
+returncode = subprocess.call(
+    ['git', '-C', swift_src_root, 'grep', r'\bDEBUG[(]'])
+if returncode == 0:  # We found some DEBUG in there.
+    print('\n'
+          '*** The DEBUG'
+          '(...) macro is being renamed to LLVM_DEBUG(...);\n'
+          '*** please use that instead.')
+    sys.exit(1)
+
+# If you see a failure in this test, that means you introduced a use of the
+# DEBUG macro from LLVM, which is being renamed to LLVM_DEBUG.


### PR DESCRIPTION
Avoids the usage of Bash `test` and it should be more portable to other
platforms.
