### PR TITLE
When emitting no-escape closures, make sure that we copy the closure …

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3327,8 +3327,11 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
 
   // Create it in our current function.
   auto thunkValue = B.createFunctionRefFor(loc, thunk);
+
+  // Create a copy for the noescape value, so we can mark_dependence upon the
+  // original value.
   SILValue noEscapeValue =
-      noEscapingFunctionValue.ensurePlusOne(*this, loc).forward(*this);
+      noEscapingFunctionValue.copy(*this, loc).forward(*this);
   SingleValueInstruction *thunkedFn = B.createPartialApply(
       loc, thunkValue,
       SILType::getPrimitiveObjectType(substFnTy),
@@ -3336,8 +3339,8 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
       noEscapeValue,
       SILType::getPrimitiveObjectType(escapingFnTy));
   // We need to ensure the 'lifetime' of the trivial values context captures. As
-  // long as we rerpresent these captures by the same value the following works.
-  thunkedFn = B.createMarkDependence(loc, thunkedFn, noEscapeValue);
+  // long as we represent these captures by the same value the following works.
+  thunkedFn = B.createMarkDependence(loc, thunkedFn, noEscapingFunctionValue.getValue());
 
   return emitManagedRValueWithCleanup(thunkedFn);
 }

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 4 %s -o %t/a.out -enforce-exclusivity=checked -Onone
+// RUN: %target-build-swift -Xfrontend -verify-sil-ownership -swift-version 4 %s -o %t/a.out -enforce-exclusivity=checked -Onone
 //
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out


### PR DESCRIPTION
…before we pass it into the partial apply to eliminate an ownership violation.

The problem here is that without this patch we emit code like this:

```
bb0(%0 : @owned $T):
  %1 = partial_apply %foo(%0)
  %2 = mark_dependence %1 on %0
```

Since a partial_apply consumes the object, the mark_dependence is a use after
free (especially if one has any further uses of %0 after the mark_dependence).
So what I did was I copied the value before creating the partial_apply. So
now we get this:

```
bb0(%0 : @owned $T):
  %1 = copy_value %0
  %2 = partial_apply %foo(%1)
  %3 = mark_dependence %2 on %0
  ...
  destroy_value %0
```

This ensures that one can actually have uses after the mark_dependence of both
operands.

This enables ownership verification to be enabled on
Interpreter/enforce_exclusive_access.

rdar://48521061
