### PR TITLE
Print `negative` on float literals in the ASTDumper

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1829,6 +1829,8 @@ public:
   }
   void visitFloatLiteralExpr(FloatLiteralExpr *E) {
     printCommon(E, "float_literal_expr");
+    if (E->isNegative())
+      PrintWithColorRAII(OS, LiteralValueColor) << " negative";
     PrintWithColorRAII(OS, LiteralValueColor)
       << " value=" << E->getDigitsText();
     PrintWithColorRAII(OS, LiteralValueColor) << " builtin_initializer=";


### PR DESCRIPTION
Negative float literals didn't dump any information on the fact that they were negative. For contrast, int literals dump `negative` on their AST when appropriate. This pull request adds the same logic from int literals to float literals.

Resolves [SR-10131](https://bugs.swift.org/browse/SR-10131).