### PR TITLE
Exclude properties of class with type Self

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1065,7 +1065,8 @@ static Type diagnoseUnknownType(TypeResolution resolution,
           methodDecl->getDeclContext() == dc->getParentForLookup();
 
         if (((!insideClass || !declaringMethod) &&
-             !options.is(TypeResolverContext::GenericRequirement)) ||
+             !options.is(TypeResolverContext::GenericRequirement) &&
+             !options.is(TypeResolverContext::PatternBindingDecl)) ||
             options.is(TypeResolverContext::ExplicitCastExpr)) {
           Type SelfType = nominal->getSelfInterfaceType();
           if (insideClass)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1063,9 +1063,10 @@ static Type diagnoseUnknownType(TypeResolution resolution,
         AbstractFunctionDecl *methodDecl = dc->getInnermostMethodContext();
         bool declaringMethod = methodDecl &&
           methodDecl->getDeclContext() == dc->getParentForLookup();
+        bool isPropertyOfClass = insideClass &&
+          options.is(TypeResolverContext::PatternBindingDecl);
 
-        if (((!insideClass || !declaringMethod) && !(insideClass &&
-               options.is(TypeResolverContext::PatternBindingDecl)) &&
+        if (((!insideClass || !declaringMethod) && !isPropertyOfClass &&
              !options.is(TypeResolverContext::GenericRequirement)) ||
             options.is(TypeResolverContext::ExplicitCastExpr)) {
           Type SelfType = nominal->getSelfInterfaceType();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1064,9 +1064,9 @@ static Type diagnoseUnknownType(TypeResolution resolution,
         bool declaringMethod = methodDecl &&
           methodDecl->getDeclContext() == dc->getParentForLookup();
 
-        if (((!insideClass || !declaringMethod) &&
-             !options.is(TypeResolverContext::GenericRequirement) &&
-             !options.is(TypeResolverContext::PatternBindingDecl)) ||
+        if (((!insideClass || !declaringMethod) && !(insideClass &&
+               options.is(TypeResolverContext::PatternBindingDecl)) &&
+             !options.is(TypeResolverContext::GenericRequirement)) ||
             options.is(TypeResolverContext::ExplicitCastExpr)) {
           Type SelfType = nominal->getSelfInterfaceType();
           if (insideClass)

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -70,6 +70,15 @@ class A<T> {
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
     // expected-warning@-2 {{conditional downcast from 'Self?' to 'A<T>' is equivalent to an implicit conversion to an optional 'A<T>'}}
   }
+  func copy() -> Self {
+    let copy = Self.init(a: 11)
+    return copy
+  }
+
+  var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+    let copy = Self.init(a: 11)
+    return copy
+  }
 }
 
 class B: A<Int> {
@@ -87,6 +96,14 @@ class B: A<Int> {
   }
   override class func y() {
     print("override \(Self.self).\(#function)")
+  }
+  override func copy() -> Self {
+    let copy = super.copy() as! Self // supported
+    return copy
+  }
+  override var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'B'?}}
+    let copy = super.copied as! Self // unsupported
+    return copy
   }
 }
 
@@ -121,6 +138,15 @@ struct S2 {
       // expected-warning@-1 {{conditional cast from 'S2.S3<T>' to 'S2.S3<T>' always succeeds}}
     }
   }
+  func copy() -> Self {
+    let copy = Self.init()
+    return copy
+  }
+
+  var copied: Self {
+    let copy = Self.init()
+    return copy
+  }
 }
 
 extension S2 {
@@ -149,29 +175,5 @@ enum E {
   func h(h: Self) -> Self {
     Self.f()
     return .e
-  }
-}
-
-class A1 {
-  required init() {}
-  func copy() -> Self {
-    let copy = Self.init()
-    return copy
-  }
-
-  var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A1'?}}
-    let copy = Self.init()
-    return copy
-  }
-}
-
-class B1: A1 {
-  override func copy() -> Self {
-    let copy = super.copy() as! Self // supported
-    return copy
-  }
-  override var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'B1'?}}
-    let copy = super.copied as! Self // unsupported
-    return copy
   }
 }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -151,3 +151,27 @@ enum E {
     return .e
   }
 }
+
+class A1 {
+  required init() {}
+  func copy() -> Self {
+    let copy = Self.init()
+    return copy
+  }
+
+  var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A1'?}}
+    let copy = Self.init()
+    return copy
+  }
+}
+
+class B1: A1 {
+  override func copy() -> Self {
+    let copy = super.copy() as! Self // supported
+    return copy
+  }
+  override var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'B1'?}}
+    let copy = super.copied as! Self // unsupported
+    return copy
+  }
+}


### PR DESCRIPTION
Hi Apple,

as a followup to https://github.com/apple/swift/pull/22863, prevent people from declaring properties of type `Self` which seems to not work particularly well as mentioned in the Jira below and the [previous PR](https://github.com/apple/swift/pull/22863#issuecomment-475434671). This isn't really a solution but prevents compiler crashes and erratic diagnostics. cc @slavapestov. It now gives the error below when a user tries to declare a property with type `Self` in a class:
```
h.swift:155:15: error: 'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A1'?
  var copied: Self {
              ^~~~
              A1
```
Resolves #52537.