### PR TITLE
test: use `#include` rather than `#import`

### DIFF
--- a/test/ParseableInterface/Inputs/exported-module-name-after/CoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-after/CoreKit.h
@@ -1,1 +1,1 @@
-#import <ExportAsCoreKit.h>
+#include <ExportAsCoreKit.h>

--- a/test/ParseableInterface/Inputs/exported-module-name-after/ExportAsCoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-after/ExportAsCoreKit.h
@@ -1,3 +1,9 @@
+#ifndef EXPORT_AS_COREKIT_H
+#define EXPORT_AS_COREKIT_H
+
 struct CKThing {
   long value;
 };
+
+#endif
+

--- a/test/ParseableInterface/Inputs/exported-module-name-before/CoreKit.h
+++ b/test/ParseableInterface/Inputs/exported-module-name-before/CoreKit.h
@@ -1,1 +1,1 @@
-#import <ExportAsCoreKit.h>
+#include <ExportAsCoreKit.h>


### PR DESCRIPTION
`#import` is an extension which behaves differently in different target.  On
Windows, it is used to import type libraries (for COM).  The options are to
either use `#include` or enable Objective-C interop.  Use the former since there
is no Objective-C specific behaviour needed here.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
