### PR TITLE
[SR-10149] Specify sphinx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ To read the compiler documentation, start by installing the
 [Sphinx](http://sphinx-doc.org) documentation generator tool by running the
 command:
 
-    easy_install -U Sphinx
+    easy_install -U "Sphinx < 2.0"
 
 Once complete, you can build the Swift documentation by changing directory into
 [docs](https://github.com/apple/swift/tree/master/docs) and typing `make`. This


### PR DESCRIPTION
<!-- What's in this pull request? -->
We will get `ERROR: Sphinx requires at least Python 3.5 to run.` after running the command in README:

```
easy_install -U Sphinx
```

This is because the latest sphinx version does not support python < 3.5 anymore.
https://github.com/sphinx-doc/sphinx/commit/9412bd76b7f5fdf0adc231ef8130e45bda130164#diff-2eeaed663bd0d25b7e608891384b7298

Currently, apple/swift supports python 2 so that it would be better to clarify to use like this:

```
easy_install -U "Sphinx < 2.0"
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10149](https://bugs.swift.org/browse/SR-10149).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
