### PR TITLE
[SR-10150] Specify supported python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ several hours. Naturally, incremental builds are much faster.
 macOS, Ubuntu Linux LTS, and the latest Ubuntu Linux release are the current
 supported host development operating systems.
 
+Please make sure you use Python 2.x. Python 3.x is not supported currently.
+
 #### macOS
 
 To build for macOS, you need [Xcode 10.2 beta](https://developer.apple.com/xcode/downloads/).


### PR DESCRIPTION
<!-- What's in this pull request? -->
We cannot follow the instructions in README if we use python 3.x for now.

If we use python 3.x, some errors occur such as: https://bugs.swift.org/browse/SR-9941
The supported python version is unclear and this will block contributors to get started.

There are already some PRs for better python support but those are still WIPs.

- https://github.com/apple/swift/pull/23272
- https://github.com/apple/swift/pull/23038
- https://github.com/apple/swift/pull/23256

Those would take more time to be merged so that revising current README would be better.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10150](https://bugs.swift.org/browse/SR-10150).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
