### PR TITLE
[SE] Allow where clauses on non-generic declarations in generic contexts

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1218,7 +1218,9 @@ public:
   void print(raw_ostream &OS) const;
   void print(ASTPrinter &Printer) const;
 };
-  
+
+using GenericParamSource = PointerUnion<GenericContext *, GenericParamList *>;
+
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1650,10 +1650,9 @@ ERROR(redundant_class_requirement,none,
       "redundant 'class' requirement", ())
 ERROR(late_class_requirement,none,
       "'class' must come first in the requirement list", ())
-ERROR(where_without_generic_params,none,
-      "'where' clause cannot be attached to "
-      "%select{a non-generic|a protocol|an associated type}0 "
-      "declaration", (unsigned))
+ERROR(where_toplevel_nongeneric,none,
+      "'where' clause cannot be attached to non-generic "
+      "top-level declaration", ())
 ERROR(where_inside_brackets,none,
         "'where' clause next to generic parameters is obsolete, "
         "must be written following the declaration's type", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2751,6 +2751,10 @@ ERROR(dynamic_self_stored_property_init,none,
 ERROR(dynamic_self_default_arg,none,
       "covariant 'Self' type cannot be referenced from a default argument expression", ())
 
+ERROR(where_nongeneric_ctx,none,
+      "'where' clause on non-generic member declaration requires a "
+      "generic context", ())
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes
 //------------------------------------------------------------------------------

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1108,7 +1108,7 @@ class InferredGenericSignatureRequest :
     public SimpleRequest<InferredGenericSignatureRequest,
                          GenericSignature (ModuleDecl *,
                                             GenericSignatureImpl *,
-                                            GenericParamList *,
+                                            GenericParamSource,
                                             SmallVector<Requirement, 2>,
                                             SmallVector<TypeLoc, 2>,
                                             bool),
@@ -1124,7 +1124,7 @@ private:
   evaluate(Evaluator &evaluator,
            ModuleDecl *module,
            GenericSignatureImpl *baseSignature,
-           GenericParamList *gpl,
+           GenericParamSource paramSource,
            SmallVector<Requirement, 2> addedRequirements,
            SmallVector<TypeLoc, 2> inferenceSources,
            bool allowConcreteGenericParams) const;

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -83,7 +83,7 @@ SWIFT_REQUEST(TypeChecker, HasDynamicMemberLookupAttributeRequest,
               bool(CanType), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature (ModuleDecl *, GenericSignatureImpl *,
-                                 GenericParamList *,
+                                 GenericParamSource,
                                  SmallVector<Requirement, 2>,
                                  SmallVector<TypeLoc, 2>, bool),
               Cached, NoLocationInfo)

--- a/include/swift/Basic/SimpleDisplay.h
+++ b/include/swift/Basic/SimpleDisplay.h
@@ -135,6 +135,15 @@ namespace swift {
     }
     out << "}";
   }
+
+  template<typename T, typename U>
+  void simple_display(llvm::raw_ostream &out,
+                      const llvm::PointerUnion<T, U> &ptrUnion) {
+    if (const auto t = ptrUnion.template dyn_cast<T>())
+      simple_display(out, t);
+    else
+      simple_display(out, ptrUnion.template get<U>());
+  }
 }
 
 #endif // SWIFT_BASIC_SIMPLE_DISPLAY_H

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1066,7 +1066,7 @@ public:
                                 bool allowClassRequirement,
                                 bool allowAnyObject);
   ParserStatus parseDeclItem(bool &PreviousHadSemi,
-                             Parser::ParseDeclOptions Options,
+                             ParseDeclOptions Options,
                              llvm::function_ref<void(Decl*)> handler);
   std::pair<std::vector<Decl *>, Optional<std::string>>
   parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc, Diag<> ErrorDiag,
@@ -1634,14 +1634,10 @@ public:
   void
   diagnoseWhereClauseInGenericParamList(const GenericParamList *GenericParams);
 
-  enum class WhereClauseKind : unsigned {
-    Declaration,
-    Protocol,
-    AssociatedType
-  };
   ParserStatus
-  parseFreestandingGenericWhereClause(GenericParamList *GPList,
-                             WhereClauseKind kind=WhereClauseKind::Declaration);
+  parseFreestandingGenericWhereClause(GenericContext *genCtx,
+                                      GenericParamList *&GPList,
+                                      ParseDeclOptions flags);
 
   ParserStatus parseGenericWhereClause(
       SourceLoc &WhereLoc, SmallVectorImpl<RequirementRepr> &Requirements,

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -194,8 +194,8 @@ bool ASTScopeImpl::doesContextMatchStartingContext(
 // For a SubscriptDecl with generic parameters, the call tries to do lookups
 // with startingContext equal to either the get or set subscript
 // AbstractFunctionDecls. Since the generic parameters are in the
-// SubScriptDeclScope, and not the AbstractFunctionDecl scopes (after all how
-// could one parameter be in two scopes?), GenericParamScoped intercepts the
+// SubscriptDeclScope, and not the AbstractFunctionDecl scopes (after all how
+// could one parameter be in two scopes?), GenericParamScope intercepts the
 // match query here and tests against the accessor DeclContexts.
 bool GenericParamScope::doesContextMatchStartingContext(
     const DeclContext *context) const {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -126,6 +126,31 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   //                                 Decls
   //===--------------------------------------------------------------------===//
 
+  bool visitGenericParamListIfNeeded(GenericContext *GC) {
+    // Must check this first in case extensions have not been bound yet
+    if (Walker.shouldWalkIntoGenericParams()) {
+      if (auto *params = GC->getGenericParams()) {
+        visitGenericParamList(params);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  bool visitTrailingRequirements(GenericContext *GC) {
+    if (const auto Where = GC->getTrailingWhereClause()) {
+      for (auto &Req: Where->getRequirements())
+        if (doIt(Req))
+          return true;
+    } else if (!isa<ExtensionDecl>(GC)) {
+      if (const auto GP = GC->getGenericParams())
+        for (auto Req: GP->getTrailingRequirements())
+          if (doIt(Req))
+            return true;
+    }
+    return false;
+  }
+
   bool visitImportDecl(ImportDecl *ID) {
     return false;
   }
@@ -138,12 +163,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       if (doIt(Inherit))
         return true;
     }
-    if (auto *Where = ED->getTrailingWhereClause()) {
-      for(auto &Req: Where->getRequirements()) {
-        if (doIt(Req))
-          return true;
-      }
-    }
+    if (visitTrailingRequirements(ED))
+      return true;
+
     for (Decl *M : ED->getMembers()) {
       if (doIt(M))
         return true;
@@ -223,15 +245,13 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitTypeAliasDecl(TypeAliasDecl *TAD) {
-    if (Walker.shouldWalkIntoGenericParams() && TAD->getGenericParams()) {
-      if (visitGenericParamList(TAD->getGenericParams()))
-        return true;
-    }
+    bool WalkGenerics = visitGenericParamListIfNeeded(TAD);
 
     if (auto typerepr = TAD->getUnderlyingTypeRepr())
       if (doIt(typerepr))
         return true;
-    return false;
+
+    return WalkGenerics && visitTrailingRequirements(TAD);
   }
   
   bool visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
@@ -269,20 +289,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }
 
     // Visit requirements
-    if (WalkGenerics) {
-      ArrayRef<swift::RequirementRepr> Reqs = None;
-      if (auto *Protocol = dyn_cast<ProtocolDecl>(NTD)) {
-        if (auto *WhereClause = Protocol->getTrailingWhereClause())
-          Reqs = WhereClause->getRequirements();
-      } else {
-        Reqs = NTD->getGenericParams()->getTrailingRequirements();
-      }
-      for (auto Req: Reqs) {
-        if (doIt(Req))
-          return true;
-      }
-    }
-    
+    if (WalkGenerics && visitTrailingRequirements(NTD))
+      return true;
+
     for (Decl *Member : NTD->getMembers()) {
       if (doIt(Member))
         return true;
@@ -325,13 +334,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (doIt(SD->getElementTypeLoc()))
       return true;
 
-    if (WalkGenerics) {
-      // Visit generic requirements
-      for (auto Req : SD->getGenericParams()->getTrailingRequirements()) {
-        if (doIt(Req))
-          return true;
-      }
-    }
+   // Visit trailing requirements
+    if (WalkGenerics && visitTrailingRequirements(SD))
+      return true;
 
     if (!Walker.shouldWalkAccessorsTheOldWay()) {
       for (auto *AD : SD->getAllAccessors())
@@ -364,13 +369,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         if (doIt(FD->getBodyResultTypeLoc()))
           return true;
 
-    if (WalkGenerics) {
-      // Visit trailing requirments
-      for (auto Req : AFD->getGenericParams()->getTrailingRequirements()) {
-        if (doIt(Req))
-          return true;
-      }
-    }
+    // Visit trailing requirements
+    if (WalkGenerics && visitTrailingRequirements(AFD))
+      return true;
 
     if (AFD->getBody(/*canSynthesize=*/false)) {
       AbstractFunctionDecl::BodyKind PreservedKind = AFD->getBodyKind();
@@ -1320,17 +1321,6 @@ public:
       if (doIt(Req.getFirstTypeLoc()))
         return true;
       break;
-    }
-    return false;
-  }
-
-private:
-  bool visitGenericParamListIfNeeded(GenericContext *gc) {
-    if (Walker.shouldWalkIntoGenericParams()) {
-      if (auto *params = gc->getGenericParams()) {
-        visitGenericParamList(params);
-        return true;
-      }
     }
     return false;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1077,9 +1077,12 @@ void GenericContext::setGenericSignature(GenericSignature genericSig) {
 }
 
 SourceRange GenericContext::getGenericTrailingWhereClauseSourceRange() const {
-  if (!isGeneric())
-    return SourceRange();
-  return getGenericParams()->getTrailingWhereClauseSourceRange();
+  if (isGeneric())
+    return getGenericParams()->getTrailingWhereClauseSourceRange();
+  else if (const auto *where = getTrailingWhereClause())
+    return where->getSourceRange();
+
+  return SourceRange();
 }
 
 ImportDecl *ImportDecl::create(ASTContext &Ctx, DeclContext *DC,

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -392,8 +392,9 @@ ParserStatus Parser::parseGenericWhereClause(
 }
 
 
-/// Parse a free-standing where clause attached to a declaration, adding it to
-/// a generic parameter list that may (or may not) already exist.
+/// Parse a free-standing where clause attached to a declaration,
+/// adding it to a generic parameter list, if any, or to the given
+/// generic context representing the declaration.
 ParserStatus Parser::
 parseFreestandingGenericWhereClause(GenericContext *genCtx,
                                     GenericParamList *&genericParams,

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -395,18 +395,11 @@ ParserStatus Parser::parseGenericWhereClause(
 /// Parse a free-standing where clause attached to a declaration, adding it to
 /// a generic parameter list that may (or may not) already exist.
 ParserStatus Parser::
-parseFreestandingGenericWhereClause(GenericParamList *genericParams,
-                                    WhereClauseKind kind) {
+parseFreestandingGenericWhereClause(GenericContext *genCtx,
+                                    GenericParamList *&genericParams,
+                                    ParseDeclOptions flags) {
   assert(Tok.is(tok::kw_where) && "Shouldn't call this without a where");
-  
-  // Push the generic arguments back into a local scope so that references will
-  // find them.
-  Scope S(this, ScopeKind::Generics);
-  
-  if (genericParams)
-    for (auto pd : genericParams->getParams())
-      addToScope(pd);
-  
+
   SmallVector<RequirementRepr, 4> Requirements;
   SourceLoc WhereLoc;
   bool FirstTypeInComplete;
@@ -415,10 +408,23 @@ parseFreestandingGenericWhereClause(GenericParamList *genericParams,
   if (result.shouldStopParsing() || Requirements.empty())
     return result;
 
-  if (!genericParams)
-    diagnose(WhereLoc, diag::where_without_generic_params, unsigned(kind));
-  else
+  if (genericParams) {
+    // Push the generic arguments back into a local scope so that references will
+    // find them.
+    Scope S(this, ScopeKind::Generics);
+    for (auto pd : genericParams->getParams())
+      addToScope(pd);
+
     genericParams->addTrailingWhereClause(Context, WhereLoc, Requirements);
+
+  // A where clause that references only outer generic parameters?
+  } else if (flags.contains(PD_HasContainerType)) {
+    genCtx->setTrailingWhereClause(
+        TrailingWhereClause::create(Context, WhereLoc, Requirements));
+  } else {
+    diagnose(WhereLoc, diag::where_toplevel_nongeneric);
+  }
+
   return ParserStatus();
 }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -450,16 +450,17 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
 ///
 
 GenericSignature TypeChecker::checkGenericSignature(
-                      GenericParamList *genericParamList,
+                      GenericParamSource paramSource,
                       DeclContext *dc,
                       GenericSignature parentSig,
                       bool allowConcreteGenericParams,
                       SmallVector<Requirement, 2> additionalRequirements,
                       SmallVector<TypeLoc, 2> inferenceSources) {
-  assert(genericParamList && "Missing generic parameters?");
+  if (auto genericParamList = paramSource.dyn_cast<GenericParamList *>())
+    assert(genericParamList && "Missing generic parameters?");
 
   auto request = InferredGenericSignatureRequest{
-    dc->getParentModule(), parentSig.getPointer(), genericParamList,
+    dc->getParentModule(), parentSig.getPointer(), paramSource,
     additionalRequirements, inferenceSources,
     allowConcreteGenericParams};
   auto sig = evaluateOrDefault(dc->getASTContext().evaluator,
@@ -489,7 +490,7 @@ GenericSignature TypeChecker::checkGenericSignature(
 /// extension's list of generic parameters.
 static Type formExtensionInterfaceType(
                          ExtensionDecl *ext, Type type,
-                         GenericParamList *genericParams,
+                         const GenericParamList *genericParams,
                          SmallVectorImpl<Requirement> &sameTypeReqs,
                          bool &mustInferRequirements) {
   if (type->is<ErrorType>())
@@ -602,28 +603,45 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     return sig;
   }
 
-  // We can fast-path computing the generic signature of non-generic
-  // declarations by re-using the parent context's signature.
-  auto *gp = GC->getGenericParams();
-  if (!gp) {
+  bool allowConcreteGenericParams = false;
+  const auto *genericParams = GC->getGenericParams();
+  if (genericParams) {
+    // Setup the depth of the generic parameters.
+    const_cast<GenericParamList *>(genericParams)
+        ->setDepth(GC->getGenericContextDepth());
+
+    // Accessors can always use the generic context of their storage
+    // declarations. This is a compile-time optimization since it lets us
+    // avoid the requirements-gathering phase, but it also simplifies that
+    // work for accessors which don't mention the value type in their formal
+    // signatures (like the read and modify coroutines, since yield types
+    // aren't tracked in the AST type yet).
+    if (auto accessor = dyn_cast<AccessorDecl>(GC->getAsDecl())) {
+      return cast<SubscriptDecl>(accessor->getStorage())->getGenericSignature();
+    }
+
+  // ...or we may have a where clause dependent on outer generic parameters.
+  } else if (const auto *where = GC->getTrailingWhereClause()) {
+    // If there is no generic context for the where clause to
+    // rely on, diagnose that now and bail out.
+    if (!GC->isGenericContext()) {
+      GC->getASTContext().Diags.diagnose(where->getWhereLoc(),
+                                         diag::where_nongeneric_ctx);
+      return nullptr;
+    }
+
+    allowConcreteGenericParams = true;
+  } else {
+    // We can fast-path computing the generic signature of non-generic
+    // declarations by re-using the parent context's signature.
+    if (auto accessor = dyn_cast<AccessorDecl>(GC->getAsDecl()))
+      if (auto subscript = dyn_cast<SubscriptDecl>(accessor->getStorage()))
+         return subscript->getGenericSignature();
+
     return GC->getParent()->getGenericSignatureOfContext();
   }
 
-  // Setup the depth of the generic parameters.
-  gp->setDepth(GC->getGenericContextDepth());
-
-  // Accessors can always use the generic context of their storage
-  // declarations. This is a compile-time optimization since it lets us
-  // avoid the requirements-gathering phase, but it also simplifies that
-  // work for accessors which don't mention the value type in their formal
-  // signatures (like the read and modify coroutines, since yield types
-  // aren't tracked in the AST type yet).
-  if (auto accessor = dyn_cast<AccessorDecl>(GC->getAsDecl())) {
-    return cast<SubscriptDecl>(accessor->getStorage())->getGenericSignature();
-  }
-
   auto parentSig = GC->getParent()->getGenericSignatureOfContext();
-  bool allowConcreteGenericParams = false;
   SmallVector<TypeLoc, 2> inferenceSources;
   SmallVector<Requirement, 2> sameTypeReqs;
   if (auto VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl())) {
@@ -685,11 +703,11 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     bool mustInferRequirements = false;
     Type extInterfaceType =
       formExtensionInterfaceType(ext, ext->getExtendedType(),
-                                 gp, sameTypeReqs,
+                                 genericParams, sameTypeReqs,
                                  mustInferRequirements);
     
     auto cannotReuseNominalSignature = [&]() -> bool {
-      const auto finalDepth = gp->getParams().back()->getDepth();
+      const auto finalDepth = genericParams->getParams().back()->getDepth();
       return mustInferRequirements
           || !sameTypeReqs.empty()
           || ext->getTrailingWhereClause()
@@ -717,7 +735,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
   }
   
   return TypeChecker::checkGenericSignature(
-      gp, GC, parentSig,
+      GC, GC, parentSig,
       allowConcreteGenericParams,
       sameTypeReqs, inferenceSources);
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -696,7 +696,9 @@ public:
 
   /// Construct a new generic environment for the given declaration context.
   ///
-  /// \param genericParams The generic parameters to validate.
+  /// \param paramSource The source of generic info: either a generic parameter
+  /// list or a generic context with a \c where clause dependent on outer
+  /// generic parameters.
   ///
   /// \param dc The declaration context in which to perform the validation.
   ///
@@ -714,7 +716,7 @@ public:
   ///
   /// \returns the resulting generic signature.
   static GenericSignature checkGenericSignature(
-                        GenericParamList *genericParams,
+                        GenericParamSource paramSource,
                         DeclContext *dc,
                         GenericSignature outerSignature,
                         bool allowConcreteGenericParams,

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -1,11 +1,16 @@
 // RUN: %target-typecheck-verify-swift
 
-func bet() where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
+func bet() where A : B {} // expected-error {{'where' clause cannot be attached to non-generic top-level declaration}}
 
-typealias gimel where A : B // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
-// expected-error@-1 {{expected '=' in type alias declaration}}
+typealias gimel = Int where A : B // expected-error {{'where' clause cannot be attached to non-generic top-level declaration}}
 
-class dalet where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
+class dalet where A : B {} // expected-error {{'where' clause cannot be attached to non-generic top-level declaration}}
+
+struct Where {
+  func bet() where A == B {}  // expected-error {{'where' clause on non-generic member declaration requires a generic context}}
+  typealias gimel = Int where A : B  // expected-error {{'where' clause on non-generic member declaration requires a generic context}}
+  class dalet where A : B {}  // expected-error {{'where' clause on non-generic member declaration requires a generic context}}
+}
 
 protocol he where A : B { // expected-error {{use of undeclared type 'A'}}
   // expected-error@-1 {{use of undeclared type 'B'}}

--- a/test/Generics/where_clause_contextually_generic_decls.swift
+++ b/test/Generics/where_clause_contextually_generic_decls.swift
@@ -1,0 +1,98 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 4
+
+protocol Whereable {
+  associatedtype Assoc
+  associatedtype Bssoc
+
+  // expected-error@+1 {{instance method requirement 'requirement1()' cannot add constraint 'Self.Assoc: Sequence' on 'Self'}}
+  func requirement1() where Assoc: Sequence
+  // expected-error@+1 {{instance method requirement 'requirement2()' cannot add constraint 'Self.Bssoc == Never' on 'Self'}}
+  func requirement2() where Bssoc == Never
+}
+
+extension Whereable {
+  // expected-note@+1 {{where 'Self' = 'T1'}}
+  static func staticExtensionFunc(arg: Self.Element) -> Self.Element
+    where Self: Sequence {
+      return arg
+  }
+
+  // expected-note@+1 {{where 'Self.Assoc' = 'T1.Assoc', 'Self.Bssoc' = 'T1.Bssoc'}}
+  func extensionFunc() where Assoc == Bssoc { }
+
+
+  // expected-note@+1 {{where 'Self.Assoc' = 'T1.Assoc'}}
+  subscript() -> Assoc where Assoc: Whereable {
+    fatalError()
+  }
+}
+
+func testProtocolExtensions<T1, T2, T3, T4>(t1: T1, t2: T2, t3: T3, t4: T4)
+  where T1: Whereable,
+        T2: Whereable & Sequence,
+        T3: Whereable, T3.Assoc == T3.Bssoc,
+        T4: Whereable, T4.Assoc: Whereable {
+  _ = T1.staticExtensionFunc // expected-error {{static method 'staticExtensionFunc(arg:)' requires that 'T1' conform to 'Sequence'}}
+  _ = T2.staticExtensionFunc
+
+  t1.extensionFunc() // expected-error {{instance method 'extensionFunc()' requires the types 'T1.Assoc' and 'T1.Bssoc' be equivalent}}
+  t3.extensionFunc()
+
+  _ = t1[] // expected-error {{subscript 'subscript()' requires that 'T1.Assoc' conform to 'Whereable'}}
+  _ = t4[]
+}
+
+class Class<T> {
+  // expected-note@+1 {{where 'T' = 'T}} // expected-note@+1 {{where 'T.Assoc' = 'T.Assoc'}}
+  static func staticFunc() where T: Whereable, T.Assoc == Int { }
+
+  // expected-note@+1 {{candidate requires that the types 'T' and 'Bool' be equivalent}}
+  func func1() where T == Bool { }
+  // FIXME: The rhs type at the end of the error message is not persistent across compilations.
+  // expected-note@+1 {{candidate requires that the types 'T' and 'Int' be equivalent (requirement specified as 'T' == }}
+  func func1() where T == Int { }
+
+  func func2() where T == Int { } // expected-note {{where 'T' = 'T'}}
+
+  subscript() -> T.Element where T: Sequence { // expected-note {{where 'T' = 'T'}}
+    fatalError()
+  }
+}
+
+extension Class {
+  static func staticExtensionFunc() where T: Class<Int> { } // expected-note {{where 'T' = 'T'}}
+
+  subscript(arg: T.Element) -> T.Element where T == Array<Int> {
+    fatalError()
+  }
+}
+
+extension Class where T: Equatable {
+  func extensionFunc() where T: Comparable { } // expected-note {{where 'T' = 'T'}}
+
+  // expected-error@+1 {{same-type constraint type 'Class<Int>' does not conform to required protocol 'Equatable'}}
+  func badRequirement1() where T == Class<Int> { }
+}
+
+extension Class where T == Bool {
+  // expected-error@+1 {{generic parameter 'T' cannot be equal to both 'Int' and 'Bool'}}
+  func badRequirement2() where T == Int { }
+}
+
+func testMemberDeclarations<T, U: Comparable>(arg1: Class<T>, arg2: Class<U>) {
+  // expected-error@+2 {{static method 'staticFunc()' requires the types 'T.Assoc' and 'Int' be equivalent}}
+  // expected-error@+1 {{static method 'staticFunc()' requires that 'T' conform to 'Whereable'}}
+  Class<T>.staticFunc()
+  Class<T>.staticExtensionFunc() // expected-error {{static method 'staticExtensionFunc()' requires that 'T' inherit from 'Class<Int>'}}
+  Class<Class<Int>>.staticExtensionFunc()
+
+  arg1.func1() // expected-error {{no exact matches in call to instance method 'func1'}}
+  arg1.func2() // expected-error {{instance method 'func2()' requires the types 'T' and 'Int' be equivalent}}
+  arg1.extensionFunc() // expected-error {{instance method 'extensionFunc()' requires that 'T' conform to 'Comparable'}}
+  arg2.extensionFunc()
+  Class<Int>().func1()
+  Class<Int>().func2()
+
+  arg1[] // expected-error {{subscript 'subscript()' requires that 'T' conform to 'Sequence'}}
+  _ = Class<Array<Int>>()[Int.zero]
+}

--- a/test/Generics/where_clause_contextually_generic_decls.swift
+++ b/test/Generics/where_clause_contextually_generic_decls.swift
@@ -1,5 +1,14 @@
 // RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 4
 
+// Make sure Self: ... is correctly diagnosed in classes
+
+class SelfInGenericClass<T> {
+  // expected-error@+1 {{type 'Self' in conformance requirement does not refer to a generic parameter or associated type}}
+  func foo() where Self: Equatable { }
+  // expected-error@+1 {{generic signature requires types 'Self' and 'Bool' to be the same}}
+  func bar() where Self == Bool { }
+}
+
 protocol Whereable {
   associatedtype Assoc
   associatedtype Bssoc

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -522,3 +522,22 @@ enum E {
 // CHECK: <kw>var</kw> <kw>_</kw> = <int>10</int>
 @available(iOS 99, *)
 var _ = 10
+
+// CHECK: <type>Array</type><<type>T</type>> <kw>where</kw> <type>T</type>: <type>Equatable</type>
+typealias GenericAlias<T> = Array<T> where T: Equatable
+
+// Where clauses on contextually generic declarations
+//
+struct FreeWhere<T> {
+  // CHECK: <kw>func</kw> foo() <kw>where</kw> <type>T</type> == <type>Int</type>
+  func foo() where T == Int {}
+
+  // CHECK: <kw>subscript</kw>() -> <type>Int</type> <kw>where</kw> <type>T</type>: <type>Sequence</type>
+  subscript() -> Int where T: Sequence {}
+
+  // CHECK: <kw>enum</kw> Enum <kw>where</kw> <type>T</type> == <type>Int</type>
+  enum Enum where T == Int {}
+
+  // CHECK: <kw>typealias</kw> Alias = <type>Int</type> <kw>where</kw> <type>T</type> == <type>Int</type>
+  typealias Alias = Int where T == Int
+}

--- a/test/Interpreter/where_clause_contextually_generic_decl.swift
+++ b/test/Interpreter/where_clause_contextually_generic_decl.swift
@@ -1,0 +1,101 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+protocol Protocol {}
+extension Protocol {
+  func foo() {
+    print("I survived in \(Self.self).\(#function)")
+  }
+}
+
+struct Foo<T: Equatable> {
+  struct Inner1 where T: Protocol {
+    let bar: T
+  }
+
+  struct Inner2 where T == String {
+    func getString() -> T {
+      return "I survived in \(#function), T := \(T.self)"
+    }
+  }
+
+  struct Inner3<U: Hashable> {
+    func isLessThan(lhs: T, rhs: T) -> U where T: Comparable, U == Bool {
+      return lhs < rhs
+    }
+
+    init() {
+      print("This is the unconstrained \(#function)")
+    }
+    init() where U == T {
+      print("I survived in \(#function), T := \(T.self), U := \(U.self)")
+    }
+  }
+}
+
+struct ProtocolAdopter: Protocol, Equatable {}
+
+// CHECK: I survived in ProtocolAdopter.foo()
+Foo<ProtocolAdopter>.Inner1(bar: ProtocolAdopter()).bar.foo()
+
+// CHECK: I survived in getString(), T := String
+print(Foo<String>.Inner2().getString())
+
+// CHECK: This is the unconstrained init()
+// CHECK: false
+print(Foo<Int>.Inner3<Bool>().isLessThan(lhs: .zero, rhs: .zero))
+
+// CHECK: I survived in init(), T := Bool, U := Bool
+_ = Foo<Bool>.Inner3<Bool>()
+
+protocol RefinedProtocol: Protocol {
+  associatedtype Assoc = Self
+  associatedtype Bssoc: RefinedProtocol
+
+  func overload()
+}
+
+extension RefinedProtocol {
+  func callOverload() {
+    overload()
+    print("Assoc := \(Assoc.self), Bssoc := \(Bssoc.self)")
+  }
+
+  func overload() where Assoc == Bssoc {
+    print("I survived in \(Self.self).\(#function) (1)")
+  }
+  func overload() where Assoc == Self {
+    print("I survived in \(Self.self).\(#function) (2)")
+  }
+  func overload() where Assoc: Sequence, Bssoc == Assoc.Element {
+    print("I survived in \(Self.self).\(#function) (3)")
+  }
+}
+
+struct RefinedProtocolAdopter1: RefinedProtocol {
+  typealias Assoc = RefinedProtocolAdopter2
+  typealias Bssoc = RefinedProtocolAdopter2
+}
+struct RefinedProtocolAdopter2: RefinedProtocol {
+  typealias Bssoc = RefinedProtocolAdopter1
+}
+struct RefinedProtocolAdopter3: RefinedProtocol {
+  typealias Assoc = Array<Bssoc>
+  typealias Bssoc = RefinedProtocolAdopter3
+}
+
+@inline(never)
+func callThroughToOverload<T: RefinedProtocol>(arg: T) {
+  arg.callOverload()
+}
+
+// CHECK: I survived in RefinedProtocolAdopter1.overload() (1)
+// CHECK: Assoc := RefinedProtocolAdopter2, Bssoc := RefinedProtocolAdopter2
+callThroughToOverload(arg: RefinedProtocolAdopter1())
+// CHECK: I survived in RefinedProtocolAdopter2.overload() (2)
+// CHECK: Assoc := RefinedProtocolAdopter2, Bssoc := RefinedProtocolAdopter1
+callThroughToOverload(arg: RefinedProtocolAdopter2())
+// CHECK: I survived in RefinedProtocolAdopter3.overload() (3)
+// CHECK: Assoc := Array<RefinedProtocolAdopter3>, Bssoc := RefinedProtocolAdopter3
+callThroughToOverload(arg: RefinedProtocolAdopter3())
+

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -245,11 +245,18 @@ struct ConformsToP1: P1 { }
 struct ConformsToP2: P2 { }
 struct ConformsToP3: P3 { }
 
+struct ContextualWhere1<T> {
+  class Nested1 where T: P1 { }
+  struct Nested2 where T == Int { }
+}
+
 DemangleToMetadataTests.test("protocol conformance requirements") {
   expectEqual(CG4<ConformsToP1, ConformsToP2>.self,
     _typeByName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP2VG")!)
   expectEqual(CG4<ConformsToP1, ConformsToP2>.InnerGeneric<ConformsToP3>.self,
     _typeByName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP3VG")!)
+  expectEqual(ContextualWhere1<ConformsToP1>.Nested1.self,
+    _typeByName("4main16ContextualWhere1V7Nested1CyAA12ConformsToP1V_G")!)
 
   // Failure cases: failed conformance requirements.
   expectNil(_typeByName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP1VG"))
@@ -274,9 +281,16 @@ struct ConformsToP4c : P4 {
   typealias Assoc2 = ConformsToP2
 }
 
+struct ContextualWhere2<U: P4> {
+  struct Nested1 where U.Assoc1: P1, U.Assoc2: P2 { }
+  enum Nested2 where U.Assoc1 == U.Assoc2 { }
+}
+
 DemangleToMetadataTests.test("associated type conformance requirements") {
   expectEqual(SG5<ConformsToP4a>.self,
     _typeByName("4main3SG5VyAA13ConformsToP4aVG")!)
+  expectEqual(ContextualWhere2<ConformsToP4a>.Nested1.self,
+    _typeByName("4main16ContextualWhere2V7Nested1VyAA13ConformsToP4aV_G")!)
 
   // Failure cases: failed conformance requirements.
   expectNil(_typeByName("4main3SG5VyAA13ConformsToP4bVG"))
@@ -297,12 +311,16 @@ DemangleToMetadataTests.test("same-type requirements") {
   // Concrete type.
   expectEqual(SG7<S>.self,
     _typeByName("4main3SG7VyAA1SVG")!)
+  expectEqual(ContextualWhere1<Int>.Nested2.self,
+    _typeByName("4main16ContextualWhere1V7Nested2VySi_G")!)
 
   // Other associated type.
   expectEqual(SG6<ConformsToP4b>.self,
     _typeByName("4main3SG6VyAA13ConformsToP4bVG")!)
   expectEqual(SG6<ConformsToP4c>.self,
     _typeByName("4main3SG6VyAA13ConformsToP4cVG")!)
+  expectEqual(ContextualWhere2<ConformsToP4b>.Nested2.self,
+    _typeByName("4main16ContextualWhere2V7Nested2OyAA13ConformsToP4bV_G")!)
 
   // Structural type.
   expectEqual(SG8<ConformsToP4d>.self,

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -579,6 +579,60 @@ class SR_4206_DerivedGeneric_6<T>: SR_4206_BaseConcrete_6 {
   override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{overridden method 'foo' has generic signature <T, T where T : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_2>; expected generic signature to be <T, T where T : SR_4206_Protocol_2>}}
 }
 
+// Where clauses on contextually generic declarations
+
+class SR_4206_Base_7<T> {
+  func foo1() where T: SR_4206_Protocol_1 {} // expected-note {{overridden declaration is here}}
+  func foo2() where T: SR_4206_Protocol_1 {}
+}
+
+class SR_4206_Derived_7<T>: SR_4206_Base_7<T> {
+  override func foo1() where T: SR_4206_Protocol_2 {} // expected-error {{overridden method 'foo1' has generic signature <T where T : SR_4206_Protocol_2> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T where τ_0_0 : SR_4206_Protocol_1>}}
+
+  override func foo2() {} // OK
+}
+
+// Subclass with new constraint on inherited generic param
+
+class SR_4206_Base_8<T> {
+  func foo() where T: SR_4206_Protocol_1 {}
+}
+class SR_4206_Derived_8<T: SR_4206_Protocol_2, U>: SR_4206_Base_8<T> {
+  override func foo() where T: SR_4206_Protocol_1 {} // OK
+}
+
+// Same-type to conformance visibility reabstraction
+
+class SR_4206_Base_9<T> {
+  func foo() where T == Int {}
+}
+class SR_4206_Derived_9<T>: SR_4206_Base_9<T> {
+  override func foo() where T: FixedWidthInteger {} // OK
+}
+
+// Override with constraint on a non-inherited generic param
+
+class SR_4206_Base_10<T> {
+  func foo() where T: SR_4206_Protocol_1 {} // expected-note {{overridden declaration is here}}
+}
+class SR_4206_Derived_10<T, U>: SR_4206_Base_10<T> {
+  override func foo() where U: SR_4206_Protocol_1 {} // expected-error {{overridden method 'foo' has generic signature <T, U where U : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T, U where τ_0_0 : SR_4206_Protocol_1>}}
+}
+
+// Override with return type specialization
+
+class SR_4206_Base_11<T> {
+  // The fact that the return type matches the substitution
+  // for T must hold across overrides.
+  func foo() -> T where T: FixedWidthInteger { fatalError() } // expected-note {{potential overridden instance method 'foo()' here}}
+}
+class SR_4206_Derived_11: SR_4206_Base_11<Int> {
+  override func foo() -> Int { return .zero } // OK
+}
+class SR_4206_Derived2_11: SR_4206_Base_11<Bool> {
+  override func foo() -> Int { return .zero } // expected-error {{method does not override any method from its superclass}}
+}
+
 // Misc //
 
 protocol SR_4206_Key {}


### PR DESCRIPTION
[SE-0267](https://github.com/apple/swift-evolution/blob/master/proposals/0267-where-on-contextually-generic.md)

```swift
struct Foo<T> {
  func foo() where T: Equatable {}
}
```
I'm not happy with using pointer unions, but couldn't come up with a better idea that wouldn't require further unrelated changes of uncertain scale; there will be a lot of opportunities to get rid of this later through making where clauses less dependent on parameter lists.
___

- [x] Diagnose `where` on non-generic top-level declarations in Parse 
- [x] Provide syntax highlighting for contextual `where` clauses
- [x] Lift the restriction on contextual `where` clauses
- [x] Make sure subscript accessors pick this up as well
- [x] SILGen: Test that declarations with contextual `where` clauses are mangled correctly
- [x] Test that we can demangle nested type declarations with contextual `where` clauses
- [x] Add execution tests
- [x] Test overrides involving contextual `where` clauses
- [x] Tweak `checkConstrainedExtensionRequirements` to look out for contextual `where` clauses as well