### PR TITLE
[CodeCompletion] Provide empty call pattern after paren

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1190,8 +1190,6 @@ void CodeCompletionString::getName(raw_ostream &OS) const {
       }
     }
   }
-  assert((TextSize > 0) &&
-         "code completion string should have non-empty name!");
 }
 
 void CodeCompletionContext::sortCompletionResults(
@@ -2255,14 +2253,8 @@ public:
       else
         Builder.addAnnotatedLeftParen();
 
-      bool anyParam = addCallArgumentPatterns(Builder, AFT->getParams(),
-                                              declParams, includeDefaultArgs);
-
-      if (HaveLParen && !anyParam) {
-        // Empty result, don't add it.
-        Builder.cancel();
-        return;
-      }
+      addCallArgumentPatterns(Builder, AFT->getParams(), declParams,
+                              includeDefaultArgs);
 
       // The rparen matches the lparen here so that we insert both or neither.
       if (!HaveLParen)
@@ -2508,14 +2500,8 @@ public:
       else
         Builder.addAnnotatedLeftParen();
 
-      bool anyParam = addCallArgumentPatterns(
-          Builder, ConstructorType, CD->getParameters(), includeDefaultArgs);
-
-      if (HaveLParen && !anyParam) {
-        // Empty result, don't add it.
-        Builder.cancel();
-        return;
-      }
+      addCallArgumentPatterns(Builder, ConstructorType, CD->getParameters(),
+                              includeDefaultArgs);
 
       // The rparen matches the lparen here so that we insert both or neither.
       if (!HaveLParen)

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -262,7 +262,9 @@ class SuperDerivedA : SuperBaseA {
   }
   init (b: Float) {
     super.init(#^CONSTRUCTOR_SUPER_INIT_PAREN_1^#
-// CONSTRUCTOR_SUPER_INIT_PAREN_1-NOT: Pattern/
+// CONSTRUCTOR_SUPER_INIT_PAREN_1: Begin completions, 1 items
+// CONSTRUCTOR_SUPER_INIT_PAREN_1: Pattern/CurrModule: ['('][')'][#SuperBaseA#]; name=
+// CONSTRUCTOR_SUPER_INIT_PAREN_1: End completions
   }
 
   deinit {

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -483,8 +483,9 @@ _ = EmptyOverload(foo: #^EMPTY_OVERLOAD_2^#)
 public func fopen() -> TestBoundGeneric1! { fatalError() }
 func other() {
   _ = fopen(#^CALLARG_IUO^#)
-// CALLARG_IUO-NOT: Begin completions
-// CALLARG_IUO-NOT: End completions
+// CALLARG_IUO: Begin completions, 1 items
+// CALLARG_IUO: Pattern/CurrModule: ['('][')'][#TestBoundGeneric1!#]; name=
+// CALLARG_IUO: End completions
 }
 
 class Foo { let x: Int }

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -69,7 +69,9 @@ func testImplicitConstructors1() {
 }
 func testImplicitConstructors1P() {
   ImplicitConstructors1(#^IMPLICIT_CONSTRUCTORS_1P^#
-// IMPLICIT_CONSTRUCTORS_1P-NOT: Begin completions
+// IMPLICIT_CONSTRUCTORS_1P: Begin completions, 1 items
+// IMPLICIT_CONSTRUCTORS_1P: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors1#]; name=
+// IMPLICIT_CONSTRUCTORS_1P: End completions
 }
 
 struct ImplicitConstructors2 {
@@ -89,6 +91,7 @@ func testImplicitConstructors2P() {
   ImplicitConstructors2(#^IMPLICIT_CONSTRUCTORS_2P^#
 // IMPLICIT_CONSTRUCTORS_2P: Begin completions
 // IMPLICIT_CONSTRUCTORS_2P-NEXT: Decl[Constructor]/CurrNominal: ['(']{#instanceVar: Int#}[')'][#ImplicitConstructors2#]{{; name=.+$}}
+// IMPLICIT_CONSTRUCTORS_2P-NEXT: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors2#]; name=
 // IMPLICIT_CONSTRUCTORS_2P-NEXT: End completions
 }
 
@@ -111,6 +114,7 @@ func testExplicitConstructors1() {
 func testExplicitConstructors1P() {
   ExplicitConstructors1(#^EXPLICIT_CONSTRUCTORS_1P^#
 // EXPLICIT_CONSTRUCTORS_1P: Begin completions
+// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal: ['('][')'][#ExplicitConstructors1#]; name=
 // EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}[')'][#ExplicitConstructors1#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors1#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_1P-NEXT: End completions
@@ -276,13 +280,16 @@ struct ExplicitConstructorsDerived3 {
 
 func testHaveRParen1() {
   ImplicitConstructors1(#^HAVE_RPAREN_1^#)
-// HAVE_RPAREN_1-NOT: Decl[Constructor]
+// HAVE_RPAREN_1: Begin completions, 1 items
+// HAVE_RPAREN_1: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors1#]; name=
+// HAVE_RPAREN_1: End completions
 }
 
 func testHaveRParen2() {
   ImplicitConstructors2(#^HAVE_RPAREN_2^#)
 // HAVE_RPAREN_2-NOT: Decl[Constructor]
 // HAVE_RPAREN_2:     Decl[Constructor]/CurrNominal: ['(']{#instanceVar: Int#}[')'][#ImplicitConstructors2#]{{; name=.+$}}
+// HAVE_RPAREN_2:     Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors2#]; name=
 // HAVE_RPAREN_2-NOT: Decl[Constructor]
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -729,9 +729,9 @@ func testInsideFunctionCall0() {
 func testInsideFunctionCall1() {
   var a = FooStruct()
   a.instanceFunc0(#^INSIDE_FUNCTION_CALL_1^#
-// There should be no results here because the function call
-// unambiguously resolves to overload that takes 0 arguments.
-// INSIDE_FUNCTION_CALL_1-NOT: Begin completions
+// INSIDE_FUNCTION_CALL_1: Begin completions, 1 items
+// INSIDE_FUNCTION_CALL_1: Pattern/CurrModule: ['('][')'][#Void#]; name=
+// INSIDE_FUNCTION_CALL_1: End completions
 }
 
 func testInsideFunctionCall2() {
@@ -782,8 +782,9 @@ func testInsideFunctionCall7() {
 
 func testInsideFunctionCall8(_ x: inout FooStruct) {
   x.instanceFunc0(#^INSIDE_FUNCTION_CALL_8^#)
-// Since we already have '()', there is no pattern to complete.
-// INSIDE_FUNCTION_CALL_8-NOT: Pattern/{{.*}}:
+// INSIDE_FUNCTION_CALL_8: Begin completions
+// INSIDE_FUNCTION_CALL_8: Pattern/CurrModule: ['('][')'][#Void#]; name=
+// INSIDE_FUNCTION_CALL_8: End completions
 }
 func testInsideFunctionCall9(_ x: inout FooStruct) {
   x.instanceFunc1(#^INSIDE_FUNCTION_CALL_9^#)


### PR DESCRIPTION
This improves discoverability of no-parameter initializers.

rdar://problem/46215262
