### PR TITLE
Driver: perform the ModuleWrap job for COFF

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1946,7 +1946,8 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
 
     if (MergeModuleAction) {
       if (OI.DebugInfoLevel == IRGenDebugInfoLevel::Normal) {
-        if (TC.getTriple().getObjectFormat() == llvm::Triple::ELF) {
+        if (TC.getTriple().getObjectFormat() == llvm::Triple::ELF ||
+            TC.getTriple().getObjectFormat() == llvm::Triple::COFF) {
           auto *ModuleWrapAction =
               C.createAction<ModuleWrapJobAction>(MergeModuleAction);
           LinkAction->addInput(ModuleWrapAction);


### PR DESCRIPTION
The ModuleWrap job is responsible for wrapping the AST into the swift
module.  It was only enabled for ELF objects, but COFF needs this
operation to be performed as well.  Enable this for the COFF targets as
well.  This is needed to fix the DebugInfo AST Section verification.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
