### PR TITLE
[5.1] SIMD Overlay: inline deprecated methods (#23250)

### DIFF
--- a/stdlib/public/Darwin/simd/simd.swift.gyb
+++ b/stdlib/public/Darwin/simd/simd.swift.gyb
@@ -18,6 +18,7 @@ import Darwin
 
 public extension SIMD {
   @available(swift, deprecated:5, renamed: "init(repeating:)")
+  @_transparent
   init(_ scalar: Scalar) { self.init(repeating: scalar) }
 }
 
@@ -35,6 +36,7 @@ internal extension SIMD4 {
 
 public extension SIMD where Scalar : FixedWidthInteger {
   @available(swift, deprecated:5, message: "use 0 &- rhs")
+  @_transparent
   static prefix func -(rhs: Self) -> Self { return 0 &- rhs }
 }
 


### PR DESCRIPTION
On Swift 5, using the deprecated `SIMD.init(_ scalar: Scalar)` initialiser rather than `SIMD.init(repeating scalar: Scalar)` will cause the type to fail to be specialised, resulting in performance degradation. Mark this method and `static prefix func -` as `@_transparent` to ensure they are correctly specialised.

Fixes rdar://problem/48755752