### PR TITLE
[CSApply] Fix a KeyPath crash in SIL when base type is AnyObject

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4184,7 +4184,16 @@ namespace {
       auto keyPathTy = cs.getType(E)->castTo<BoundGenericType>();
       Type baseTy = keyPathTy->getGenericArgs()[0];
       Type leafTy = keyPathTy->getGenericArgs()[1];
-      
+
+      // We do not allow keypaths to go through AnyObject
+      if (baseTy->isAnyObject()) {
+        auto rootTyRepr = E->getRootType();
+        cs.TC.diagnose(rootTyRepr->getLoc(),
+                       diag::expr_swift_keypath_invalid_component)
+             .highlight(rootTyRepr->getSourceRange());
+        return nullptr;
+      }
+
       for (unsigned i : indices(E->getComponents())) {
         auto &origComponent = E->getMutableComponents()[i];
         

--- a/validation-test/compiler_crashers_2_fixed/sr10146.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10146.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend -emit-sil %s
+// REQUIRES: OS=ios
+
+import UIKit
+
+// Just make sure we don't crash.
+
+class Foo: NSObject {
+  func crash() {
+    let kp = \AnyObject.accessibilityFrame
+  }
+}


### PR DESCRIPTION
This PR fixes a SIL crash when the base type of a Swift KeyPath is AnyObject. For example:

```swift
import UIKit

class Foo: NSObject {
  func crash() {
    let kp = \AnyObject.accessibilityFrame
  }
}
```

Resolves [SR-10146](https://bugs.swift.org/browse/SR-10146).