### PR TITLE
[CodeCompletion] Look through implicit exprs to find the parsed expr

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -176,8 +176,8 @@ public:
   Expr *get() const { return FoundExpr; }
 
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-    if (TargetRange == E->getSourceRange() && !isa<ImplicitConversionExpr>(E) &&
-        !isa<AutoClosureExpr>(E) && !isa<ConstructorRefCallExpr>(E)) {
+    if (TargetRange == E->getSourceRange() && !E->isImplicit() &&
+        !isa<ConstructorRefCallExpr>(E)) {
       assert(!FoundExpr && "non-nullptr for found expr");
       FoundExpr = E;
       return {false, nullptr};

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -195,6 +195,11 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLOSURE_IN_MEMBERDECLINIT_2 | %FileCheck %s -check-prefix=FOO_OBJECT_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLOSURE_IN_MEMBERDECLINIT_3 | %FileCheck %s -check-prefix=FOO_OBJECT_DOT
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_ARRAY_LITERAL_1 | %FileCheck %s -check-prefix=SIMPLE_OBJECT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_ARRAY_LITERAL_2 | %FileCheck %s -check-prefix=SIMPLE_OBJECT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_DICTIONARY_LITERAL_1 | %FileCheck %s -check-prefix=SIMPLE_OBJECT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_DICTIONARY_LITERAL_2 | %FileCheck %s -check-prefix=SIMPLE_OBJECT_DOT
+
 // Test code completion of expressions that produce a value.
 
 struct FooStruct {
@@ -2142,4 +2147,26 @@ extension String {
   static let v = { (obj: FooStruct) in
     obj.#^CLOSURE_IN_MEMBERDECLINIT_3^#
   }
+}
+
+struct SimpleStruct {
+  func foo() -> SimpleStruct {}
+}
+// SIMPLE_OBJECT_DOT: Begin completions
+// SIMPLE_OBJECT_DOT-DAG: Keyword[self]/CurrNominal:          self[#SimpleStruct#]; name=self
+// SIMPLE_OBJECT_DOT-DAG: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: foo()[#SimpleStruct#]; name=foo()
+// SIMPLE_OBJECT_DOT: End completions
+func testInCollectionLiteral(value: SimpleStruct) {
+  let _ = [
+    value.#^IN_ARRAY_LITERAL_1^#
+  ]
+  let _ = [
+    value.#^IN_ARRAY_LITERAL_2^#,
+  ]
+  let _: [String: String] = [
+    value.#^IN_DICTIONARY_LITERAL_1^#
+  ]
+  let _: [String: String] = [
+    value.#^IN_DICTIONARY_LITERAL_2^# : "test"
+  ]
 }


### PR DESCRIPTION
The parsed expression may be wrapped with various implicit expressions.
For example, if the expression is only element in array literal, it's wrapped with `(arrayLiteral: <expr>)`.
