### PR TITLE
[test] Style fixes for "Modify test scripts for aarch64 and modern NDKs"

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -946,7 +946,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     def get_architecture_value(**kwargs):
         result = kwargs[run_cpu]
         if result is None:
-          if run_cpu == "armv7s" or run_cpu == "armv7k":
+          if run_cpu.startswith("armv7"):
             result = kwargs["armv7"]
           elif run_cpu == "arm64":
             result = kwards["aarch64"]
@@ -957,9 +957,22 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     ndk_platform_triple = get_architecture_value(armv7="arm-linux-androideabi",
                                                  aarch64="aarch64-linux-android")
     toolchain_directory_name = "{}-{}".format(ndk_platform_triple, config.android_ndk_gcc_version)
-    tools_directory = make_path(config.android_ndk_path, "toolchains",
-        toolchain_directory_name, "prebuilt", "linux-x86_64",
-        ndk_platform_triple, "bin")
+    if platform.system() == 'Linux':
+        prebuilt_directory = 'linux-x86_64'
+    elif platform.system() == 'Darwin':
+        prebuilt_directory = 'darwin-x86_64'
+    elif platform.system() == 'Windows':
+        # TODO: NDK distributes for Windows 32 and 64 bits. platform.machine()
+        # should allow us to find out the word size, but I don't have a
+        # machine to test right now. I think the values are AMD64 and x86, but
+        # I'm not sure. Everybody gets the 64 bits version for now.
+        prebuilt_directory = 'windows-x86_64'
+
+    toolchain_directory = make_path(
+        config.android_ndk_path, "toolchains", toolchain_directory_name,
+        "prebuilt", prebuilt_directory)
+    tools_directory = pipes.quote(make_path(
+        toolchain_directory, ndk_platform_triple, "bin"))
     lit_config.note("Testing Android " + config.variant_triple)
     config.target_object_format = "elf"
     config.target_shared_library_prefix = 'lib'
@@ -971,67 +984,82 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_sdk_name = "android"
-    android_link_paths_opt = "-L {libcxx} -L {libgcc}".format(
-        libcxx=make_path(config.android_ndk_path,
-                         "sources", "cxx-stl", "llvm-libc++", "libs", ndk_platform_tuple),
-        libgcc=make_path(config.android_ndk_path,
-                         "toolchains", toolchain_directory_name, "prebuilt",
-                         "linux-x86_64", "lib", "gcc", ndk_platform_triple,
-                         "{}.x".format(config.android_ndk_gcc_version)))
+    android_link_paths_opt = "-L {} -L {} -L {}".format(
+        pipes.quote(make_path(
+            config.android_ndk_path, "sources", "cxx-stl", "llvm-libc++",
+            "libs", ndk_platform_tuple)),
+        pipes.quote(make_path(
+            toolchain_directory, "lib", "gcc", ndk_platform_triple,
+            "{}.x".format(config.android_ndk_gcc_version))),
+        pipes.quote(make_path(
+            toolchain_directory, ndk_platform_triple, "lib")))
     # Since NDK r14 the headers are unified under $NDK_PATH/sysroot, so the -sdk
     # switch is not enough. Additionally we have to include both the unified
     # sysroot, and the architecture sysroot.
-    android_include_paths_opt = "-I {sysroot} -I {sysroot_arch}".format(
-        sysroot=make_path(config.android_ndk_path, "sysroot", "usr", "include"),
-        sysroot_arch=make_path(config.android_ndk_path, "sysroot", "usr",
-                              "include", ndk_platform_triple))
-    config.target_build_swift = (
-        '%s -target %s -sdk %r -tools-directory %r %s %s '
-        '-use-ld=%s %s %s %s %s %s'
-        % (config.swiftc,
-           config.variant_triple, config.variant_sdk,
-           tools_directory, android_include_paths_opt, android_link_paths_opt,
-           config.android_linker_name,
-           resource_dir_opt, mcp_opt, config.swift_test_options,
-           config.swift_driver_test_options, swift_execution_tests_extra_flags))
+    unified_android_include_path = pipes.quote(make_path(
+        config.android_ndk_path, "sysroot", "usr", "include"))
+    architecture_android_include_path = pipes.quote(make_path(
+        config.android_ndk_path, "sysroot", "usr", "include",
+        ndk_platform_triple))
+    android_include_paths_opt = "-I {} -I {}".format(
+        unified_android_include_path, architecture_android_include_path)
+    # clang can use -isystem, but Swift cannot.
+    android_include_system_paths_opt = "-isystem {} -isystem {}".format(
+        unified_android_include_path, architecture_android_include_path)
+    config.target_build_swift = ' '.join([
+        config.swiftc,
+        '-target', config.variant_triple,
+        '-sdk', config.variant_sdk,
+        '-tools-directory', tools_directory,
+        android_include_paths_opt, android_link_paths_opt,
+        '-use-ld=%s' % config.android_linker_name,
+        resource_dir_opt, mcp_opt, config.swift_test_options,
+        config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
-    config.target_build_swift_dylib = (
-        "%s -parse-as-library -emit-library -o '\\1'"
-        % (config.target_build_swift))
+    config.target_build_swift_dylib = ' '.join([
+        config.target_build_swift,
+        '-parse-as-library', '-emit-library',
+        '-o', "'\\1'"])
     config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
-    config.target_swift_frontend = (
-        '%s -frontend -target %s -sdk %r %s %s %s %s %s %s'
-        % (config.swift, config.variant_triple, config.variant_sdk,
-           android_include_paths_opt, android_link_paths_opt, resource_dir_opt,
-           mcp_opt, config.swift_test_options,
-           config.swift_frontend_test_options))
+    config.target_swift_frontend = ' '.join([
+        config.swift,
+        '-frontend',
+        '-target', config.variant_triple,
+        '-sdk', config.variant_sdk,
+        android_include_paths_opt, android_link_paths_opt,
+        resource_dir_opt, mcp_opt, config.swift_test_options,
+        config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = make_path(config.swift_src_root, 'utils', 'android', 'adb_test_runner.py')
     # FIXME: Include -sdk in this invocation.
-    config.target_sil_opt = (
-        '%s -target %s %s %s %s' %
-        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
-    config.target_swift_ide_test = (
-        '%s -target %s %s %s %s' %
-        (config.swift_ide_test, config.variant_triple, resource_dir_opt,
-         mcp_opt, ccp_opt))
+    config.target_sil_opt = ' '.join([
+        config.sil_opt,
+        '-target', config.variant_triple,
+        resource_dir_opt, mcp_opt, config.sil_test_options])
+    config.target_swift_ide_test = ' '.join([
+        config.swift_ide_test,
+        '-target', config.variant_triple,
+        resource_dir_opt, mcp_opt, ccp_opt])
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
-    config.target_swiftc_driver = (
-        "%s -target %s -sdk %r -tools-directory %s %s %s %s -use-ld=%s" %
-        (config.swiftc, config.variant_triple, config.variant_sdk,
-         tools_directory, android_link_paths_opt, resource_dir_opt, mcp_opt,
-         config.android_linker_name))
-    config.target_swift_modulewrap = (
-        '%s -modulewrap -target %s' %
-        (config.swiftc, config.variant_triple))
-    config.target_clang = (
-        "clang++ -target %s %s %s" %
-        (config.variant_triple, clang_mcp_opt, android_include_paths_opt))
-    config.target_ld = "{} -L{}".format(
+    config.target_swiftc_driver = ' '.join([
+        config.swiftc,
+        '-target', config.variant_triple,
+        '-sdk', config.variant_sdk,
+        '-tools-directory', tools_directory,
+        android_link_paths_opt, resource_dir_opt, mcp_opt,
+        '-use-ld=%s' % config.android_linker_name])
+    config.target_swift_modulewrap = ' '.join([
+        config.swiftc, '-modulewrap',
+        '-target', config.variant_triple])
+    config.target_clang = ' '.join([
+        'clang++',
+        '-target', config.variant_triple,
+        clang_mcp_opt, android_include_system_paths_opt])
+    config.target_ld = ' '.join([
         tools_directory,
-        make_path(test_resource_dir, config.target_sdk_name))
+        '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])
     # The Swift interpreter is not available when targeting Android.
     config.available_features.remove('swift_interpreter')
 


### PR DESCRIPTION
Some style fixes that @compnerd proposed in PR #19503.

- Instead of checking for the two known ARMv7 subarchitectures, check for everything that starts with armv7 and consider it armv7.
- Try finding the current platform to select the right prebuilt directory for the NDK tools.
- Use -isystem for the system header includes when passing them to
  clang.
- Modify the format strings which started to be very wild into simpler `' '.join([...])` which, IMO, read better.
- Hoist some common path parts to not repeat the same long paths in a
  couple of places.
- Add more library search paths (missing for atomic)
