### PR TITLE
[SR-10155] Support string interpolations with binary value

### DIFF
--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -25,6 +25,7 @@ public enum IntFormat {
   case decimal
   case hex
   case octal
+  case binary
 }
 
 /// Privacy qualifiers for indicating the privacy level of the logged data
@@ -232,6 +233,8 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
       formatSpecifier += "x"
     case .octal:
       formatSpecifier += "o"
+    case .binary:
+      formatSpecifier += "b"
     default:
       formatSpecifier += isSigned ? "d" : "u"
     }

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -37,6 +37,9 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
       level: .fault,
       "Invalid address: 0x\(addr, format: .hex, privacy: .public)")
 
+    let flag = 0b1011
+    h.log(level: .debug, "Flag: \(flag, format: .binary)")
+
     // Test logging with multiple arguments.
     let filePermissions = 0o777
     let pid = 122225


### PR DESCRIPTION
I made OSLog support String interpolations with binary value, not only hex, octal and decimal.

See:
https://github.com/apple/swift/pull/22914/files#diff-67e352846aa55b916212d76f5f4afda1R229
https://bugs.swift.org/browse/SR-10155