### PR TITLE
[SR-7467] Skip inference from no potential member interface

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -773,6 +773,11 @@ private:
                    const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                    AssociatedTypeDecl *assocType);
 
+  bool shouldInferViaWitness(
+    const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+    ValueDecl *req,
+    ValueDecl *witness);
+
   /// Infer associated type witnesses for all relevant value requirements.
   ///
   /// \param assocTypes The set of associated types we're interested in.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/Basic/Defer.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "llvm/ADT/Statistic.h"
@@ -246,6 +247,9 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
       if (!isExtensionUsableForInference(extension))
         continue;
 
+    if (!shouldInferViaWitness(allUnresolved, req, witness)) {
+      continue;
+    }
     // Try to resolve the type witness via this value witness.
     auto witnessResult = inferTypeWitnessesViaValueWitness(req, witness);
 
@@ -406,6 +410,79 @@ next_witness:;
 }
 
   return result;
+}
+
+bool AssociatedTypeInference::shouldInferViaWitness(
+  const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+  ValueDecl *req,
+  ValueDecl *witness)
+{
+  if (witness->getKind() != req->getKind()) return true;
+
+  switch (witness->getKind()) {
+  case DeclKind::Func: {
+
+    auto isSameName = [](TypeRepr *lhs, TypeRepr *rhs) -> bool {
+
+      if (lhs->getKind() != rhs->getKind()) return false;
+
+      switch (lhs->getKind()) {
+      case TypeReprKind::SimpleIdent: {
+
+        auto LIdentRepr = dyn_cast<ComponentIdentTypeRepr>(lhs);
+        auto RIdentRepr = dyn_cast<ComponentIdentTypeRepr>(rhs);
+
+        if (!LIdentRepr->getBoundDecl() || !RIdentRepr->getBoundDecl()) {
+            return RIdentRepr->getIdentifier() == LIdentRepr->getIdentifier();
+        }
+
+        return RIdentRepr->getIdentifier() == LIdentRepr->getIdentifier() &&
+               LIdentRepr->getBoundDecl() == RIdentRepr->getBoundDecl();
+      }
+      default:
+        return false;
+      }
+    };
+
+    auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness);
+    auto reqFunc = dyn_cast<AbstractFunctionDecl>(req);
+    auto witnessParams = witnessFunc->getParameters();
+    auto reqParams = reqFunc->getParameters();
+
+    assert(witnessParams->size() == reqParams->size());
+
+    if (witnessParams->size() == 0) return true;
+
+
+    // If all parameter type use unresolved assoctype name,
+    // we can't infer the assoctypes from the func interface.
+    for (unsigned i = 0; i < witnessParams->size(); i++) {
+
+      auto reqParam = reqParams->get(i);
+      auto witnessParam = witnessParams->get(i);
+
+      if (!reqParam->hasInterfaceType()) return true;
+
+      auto dmt = reqParam->getInterfaceType()->getAs<DependentMemberType>();
+
+      if (!dmt || !allUnresolved.count(dmt->getAssocType())) return true;
+
+      auto witnessParamTypeRepr = witnessParam->getTypeLoc().getTypeRepr();
+      auto reqParamTypeRepr = reqParam->getTypeLoc().getTypeRepr();
+
+      if (!witnessParamTypeRepr || !reqParamTypeRepr) return true;
+
+      if (isSameName(witnessParamTypeRepr, reqParamTypeRepr)) {
+        continue;
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
+  default:
+    return true;
+  }
 }
 
 InferredAssociatedTypes

--- a/test/Sema/recursive_conformance_check.swift
+++ b/test/Sema/recursive_conformance_check.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+protocol P {
+    associatedtype X = Int
+
+    func f1(_ x: X)
+    func f2(_ x: X)
+}
+
+struct S: P {
+    func f1(_ x: X) {}
+    func f2(_ x: X) {}
+}
+ 


### PR DESCRIPTION
<!-- What's in this pull request? -->

While TypeChecker checking protocol conformance of `S: P`,  it also checks `func f1(_ x: X)` and failed because `X` is unresolved assoctype and TypeCheker doesn't support recursive inference of assoctype.

### Failure Steps
1. Validate protocol conformance of `S: P`
2. Validate `S` members to infer `X`
3. Infer from `func f1(_ x: X)` and validate it
4. Validate parameter type `X` and infer it while validating it.
5. Validate protocol conformance `S: P` to infer `X`
6. Validate `S` members to infer `X`
7. Infer from `func f1(_ x: X)` and validate it but skipped because of its checking flag
8. Infer from `func f2(_ x: X)` and validate it
9. Validate parameter type `X` and infer it while validating it.
10. Validate protocol conformance `S: P` to infer `X` but failed because typechecker doesn't support recursive inference of assoctype

### Change

I changed to skip inferring from conformance member which doesn't have any potential for inference like `func f1(_ x: X)`. 

```swift
protocol P {
    associatedtype X = Int

    func f1(_ x: X)
    func f2(_ x: X)
}

struct S: P {
    func f1(_ x: X) {}
    func f2(_ x: X) {}
}
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7467](https://bugs.swift.org/browse/SR-7467).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
