### PR TITLE
test: mark IDE test as needing XML support

### DIFF
--- a/test/IDE/comment_extensions.swift
+++ b/test/IDE/comment_extensions.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-comments -source-filename %S/Inputs/comment_extensions.swift -comments-xml-schema %S/../../bindings/xml/comment-xml-schema.rng | %FileCheck %s
+// REQUIRES: libxml2
 
 // Content is in separate file in ./Inputs due to the "requires" keyword getting
 // recognized by lit.


### PR DESCRIPTION
The `comment_extensions` tests use XML.  Mark the test accordingly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
