### PR TITLE
[Testing] Mark FixedPointConversion tests as "long_test"

### DIFF
--- a/validation-test/stdlib/FixedPointConversion_Debug.test-sh
+++ b/validation-test/stdlib/FixedPointConversion_Debug.test-sh
@@ -5,3 +5,4 @@
 //
 // RUN: %line-directive %t/FixedPointConversion.swift -- %target-run %t/a.out_Debug
 // REQUIRES: executable_test
+// REQUIRES: long_test

--- a/validation-test/stdlib/FixedPointConversion_Release.test-sh
+++ b/validation-test/stdlib/FixedPointConversion_Release.test-sh
@@ -5,3 +5,4 @@
 //
 // RUN: %line-directive %t/FixedPointConversion.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// REQUIRES: long_test


### PR DESCRIPTION
As of 14d89ec1c112e196feaaedc26d22d351ec802eb8 (GitHub #23220), these tests now take 2.25x longer than the *entire* validation test suite on fast machines. Mark them as "long_test" for now until they can be broken into smaller concurrent tests.