### PR TITLE
[python interop][TF-361] improve error message in dynamicallyCall

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -289,12 +289,7 @@ public struct ThrowingPythonObject {
   public func dynamicallyCall(
     withArguments args: [PythonConvertible] = []
   ) throws -> PythonObject {
-    // Make sure there are no state errors.
-    if PyErr_Occurred() != nil {
-      // FIXME: This should be an assert, but the failure mode in Playgrounds
-      // is just awful.
-      fatalError("Python error state must be clear")
-    }
+    try throwPythonErrorIfPresent()
 
     // Positional arguments are passed as a tuple of objects.
     let argTuple = pyTuple(args.map { $0.pythonObject })
@@ -324,12 +319,7 @@ public struct ThrowingPythonObject {
     withKeywordArguments args:
       KeyValuePairs<String, PythonConvertible> = [:]
   ) throws -> PythonObject {
-    // Make sure there are no state errors.
-    if PyErr_Occurred() != nil {
-      // FIXME: This should be an assert, but the failure mode in Playgrounds
-      // is just awful.
-      fatalError("Python error state must be clear")
-    }
+    try throwPythonErrorIfPresent()
 
     // An array containing positional arguments.
     var positionalArgs: [PythonObject] = []

--- a/stdlib/public/Python/PythonLibrary+Symbols.swift
+++ b/stdlib/public/Python/PythonLibrary+Symbols.swift
@@ -98,7 +98,7 @@ let PyObject_GetAttrString: @convention(c) (
   PythonLibrary.loadSymbol(name: "PyObject_GetAttrString")
 
 let PyObject_SetAttrString: @convention(c) (
-  PyObjectPointer, PyCCharPointer, PyObjectPointer) -> Int =
+  PyObjectPointer, PyCCharPointer, PyObjectPointer) -> Int32 =
   PythonLibrary.loadSymbol(name: "PyObject_SetAttrString")
 
 let PySlice_New: @convention(c) (

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -199,6 +199,11 @@ PythonRuntimeTestSuite.testWithLeakChecking("Errors") {
     // `expectThrows` does not fail if no error is thrown.
     fatalError("No error was thrown.")
   })
+
+  expectCrash(executing: {
+    let a = Python.object()
+    a.foo = "bar"
+  })
 }
 
 PythonRuntimeTestSuite.testWithLeakChecking("Tuple") {


### PR DESCRIPTION
This small change resolves [TF-361](https://bugs.swift.org/projects/TF/issues/TF-361) by improving the error output produced from a Python exception.  My first contribution to swift4tf.

Please see my comment [here](https://bugs.swift.org/browse/TF-361?focusedCommentId=44878&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-44878) on the issue.  My understanding of the bug is that it requires "option A" -- just relating to the error message and not to changing the failure mode altogether.  And I think this change is a small incremental improvement that is worth making in anyway.