### PR TITLE
[ownership] Fix up some parse/serialization tests for ownership.

### DIFF
--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -3,12 +3,12 @@
 import Builtin
 
 // CHECK-LABEL: sil [ossa] @test_copy_release_value
-// CHECK: bb0([[T0:%[0-9]+]] : @unowned $Builtin.NativeObject):
+// CHECK: bb0([[T0:%[0-9]+]] : @owned $Builtin.NativeObject):
 // CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_value [[T0]] : $Builtin.NativeObject
 // CHECK-NEXT: destroy_value [[T0]] : $Builtin.NativeObject
 // CHECK-NEXT: return [[COPY_RESULT]]
-sil [ossa] @test_copy_release_value : $@convention(thin) (Builtin.NativeObject) -> Builtin.NativeObject {
-bb0(%0 : @unowned $Builtin.NativeObject):
+sil [ossa] @test_copy_release_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   return %1 : $Builtin.NativeObject

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -5,17 +5,16 @@ sil_stage canonical
 import Builtin
 
 // We do not verify here, but just make sure that all of the combinations parse and print correctly.
-// CHECK-LABEL: sil [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
-// CHECK: begin_borrow [[ARG2]]
+// CHECK-LABEL: sil [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @guaranteed $Builtin.NativeObject):
+// CHECK: [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
+// CHECK: end_borrow [[BORROWED_ARG2]]
 // CHECK: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK: store_borrow [[ARG2]] to [[MEM]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
-sil [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
+// CHECK: end_borrow [[MEM]] : $*Builtin.NativeObject
+// CHECK: } // end sil function 'borrow_test'
+sil [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
   end_borrow %2 : $Builtin.NativeObject
 
@@ -24,10 +23,6 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   end_borrow %3 : $*Builtin.NativeObject
   dealloc_stack %3 : $*Builtin.NativeObject
 
-  end_borrow %0 : $*Builtin.NativeObject
-  end_borrow %1 : $Builtin.NativeObject
-  end_borrow %0 : $*Builtin.NativeObject
-  end_borrow %1 : $Builtin.NativeObject
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -50,8 +50,8 @@ struct T {
   let w: (Int, C)
 }
 
-// CHECK-LABEL: sil shared [ossa] @stored_properties
-sil shared [ossa] @stored_properties : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared @stored_properties
+sil shared @stored_properties : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
   %a = keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
@@ -65,8 +65,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [ossa] @stored_properties_generic
-sil shared [ossa] @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared @stored_properties_generic
+sil shared @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where {{.*}}> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; stored_property #Gen.x : $τ_0_0) <D, E, F>
   %a = keypath $WritableKeyPath<Gen<D,E,F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; stored_property #Gen.x : $G) <D, E, F>
@@ -76,8 +76,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [ossa] @tuple_elements
-sil shared [ossa] @tuple_elements : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared @tuple_elements
+sil shared @tuple_elements : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<T, Int>, (root $T; stored_property #T.x : $(Int, Int); tuple_element #0 : $Int)
   %a = keypath $WritableKeyPath<T, Int>, (root $T; stored_property #T.x : $(Int, Int); tuple_element #0 : $Int)
@@ -108,8 +108,8 @@ sil @gen_subs_eq : $@convention(thin) <A: Hashable, B: Hashable, C: Hashable> (U
 sil @gen_subs_hash : $@convention(thin) <A: Hashable, B: Hashable, C: Hashable> (UnsafeRawPointer) -> Int
 
 
-// CHECK-LABEL: sil shared [ossa] @computed_properties
-sil shared [ossa] @computed_properties : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared @computed_properties
+sil shared @computed_properties : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in_guaranteed S) -> @out Int)
   %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in_guaranteed S) -> @out Int)
@@ -157,10 +157,10 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil [ossa] @indexes
-sil [ossa] @indexes : $@convention(thin) (S, C) -> () {
-// CHECK: bb0([[S:%.*]] : @unowned $S, [[C:%.*]] : @unowned $C):
-entry(%s : @unowned $S, %c : @unowned $C):
+// CHECK-LABEL: sil @indexes
+sil @indexes : $@convention(thin) (S, C) -> () {
+// CHECK: bb0([[S:%.*]] : $S, [[C:%.*]] : $C):
+entry(%s : $S, %c : $C):
   // CHECK: keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) ([[S]], [[C]])
   %a = keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) (%s, %c)
   // CHECK: [[T:%.*]] = alloc_stack

--- a/test/SIL/Parser/ownership_qualified_memopts.sil
+++ b/test/SIL/Parser/ownership_qualified_memopts.sil
@@ -3,20 +3,24 @@
 
 import Builtin
 
-// CHECK-LABEL: sil [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
+// CHECK-LABEL: sil [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
 // CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
-// CHECK: store [[ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: [[COPY_ARG2:%.*]] = copy_value [[ARG2]]
+// CHECK: store [[COPY_ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
-sil [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
-  load [take] %0 : $*Builtin.NativeObject
-  load [copy] %0 : $*Builtin.NativeObject
-  store %1 to [init] %0 : $*Builtin.NativeObject
+sil [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = load [take] %0 : $*Builtin.NativeObject
+  %3 = load [copy] %0 : $*Builtin.NativeObject
+  %4 = copy_value %1 : $Builtin.NativeObject
+  store %4 to [init] %0 : $*Builtin.NativeObject
   store %1 to [assign] %0 : $*Builtin.NativeObject
-  %2 = tuple()
-  return %2 : $()
+  destroy_value %2 : $Builtin.NativeObject
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
 }
 
 // CHECK-LABEL: sil [ossa] @trivial_args : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {

--- a/test/SIL/Parser/without_actually_escaping.sil
+++ b/test/SIL/Parser/without_actually_escaping.sil
@@ -10,10 +10,10 @@ bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
 }
 
 // Check that the convert_function [without_actually_escaping] attribute is parsed and printed.
-// CHECK-LABEL: sil hidden [ossa] @testWithoutActuallyEscapingBlock : $@convention(thin) (@guaranteed @convention(block) @noescape () -> ()) -> () {
+// CHECK-LABEL: sil hidden [ossa] @testWithoutActuallyEscapingBlock : $@convention(thin) (@owned @convention(block) @noescape () -> ()) -> () {
 // CHECK: convert_function %0 : $@convention(block) @noescape () -> () to [without_actually_escaping] $@convention(block) () -> ()
-sil hidden [ossa] @testWithoutActuallyEscapingBlock : $@convention(thin) (@guaranteed @convention(block) @noescape () -> ()) -> () {
-bb0(%0 : @guaranteed $@convention(block) @noescape () -> ()):
+sil hidden [ossa] @testWithoutActuallyEscapingBlock : $@convention(thin) (@owned @convention(block) @noescape () -> ()) -> () {
+bb0(%0 : @owned $@convention(block) @noescape () -> ()):
   %cvt = convert_function %0 : $@convention(block) @noescape () -> () to [without_actually_escaping] $@convention(block) () -> ()
   %f = function_ref @closure1 : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> ()
   %call = apply %f(%cvt) : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> ()

--- a/test/SIL/Serialization/assignattr.sil
+++ b/test/SIL/Serialization/assignattr.sil
@@ -18,14 +18,16 @@ bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
   return %2 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [ossa] @non_trivial_assign : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
-// CHECK: assign [[ARG2]] to [reassign] [[ARG1]] : $*Builtin.NativeObject
+// CHECK-LABEL: sil [serialized] [ossa] @non_trivial_assign : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
+// CHECK: [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
+// CHECK: assign [[ARG2_COPY]] to [reassign] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: assign [[ARG2]] to [reinit] [[ARG1]] : $*Builtin.NativeObject
-sil [serialized] [ossa] @non_trivial_assign : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
-  assign %1 to [reassign] %0 : $*Builtin.NativeObject
+sil [serialized] [ossa] @non_trivial_assign : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = copy_value %1 : $Builtin.NativeObject
+  assign %2 to [reassign] %0 : $*Builtin.NativeObject
   assign %1 to [reinit] %0 : $*Builtin.NativeObject
-  %2 = tuple()
-  return %2 : $()
+  %9999 = tuple()
+  return %9999 : $()
 }

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -10,7 +10,8 @@ import Builtin
 // CHECK: unchecked_ownership_conversion {{%.*}} : $Builtin.NativeObject, @guaranteed to @owned
 sil [serialized] [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
-  unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+  %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+  destroy_value %1 : $Builtin.NativeObject
   return undef : $()
 }
 

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -9,17 +9,15 @@ sil_stage canonical
 import Builtin
 
 // We do not verify here, but just make sure that all of the combinations parse and print correctly.
-// CHECK-LABEL: sil [serialized] [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
-// CHECK: begin_borrow [[ARG2]]
+// CHECK-LABEL: sil [serialized] [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @guaranteed $Builtin.NativeObject):
+// CHECK: [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
+// CHECK: end_borrow [[BORROWED_ARG2]]
 // CHECK: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK: store_borrow [[ARG2]] to [[MEM]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
-sil [serialized] [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
+// CHECK: } // end sil function 'borrow_test'
+sil [serialized] [ossa] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
   end_borrow %2 : $Builtin.NativeObject
 
@@ -27,11 +25,6 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   store_borrow %1 to %3 : $*Builtin.NativeObject
   end_borrow %3 : $*Builtin.NativeObject
   dealloc_stack %3 : $*Builtin.NativeObject
-
-  end_borrow %0 : $*Builtin.NativeObject
-  end_borrow %1 : $Builtin.NativeObject
-  end_borrow %0 : $*Builtin.NativeObject
-  end_borrow %1 : $Builtin.NativeObject
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -62,8 +62,8 @@ public struct GenT<A, B> {
   public let z: (e0: External<A>, e1: External<B>)
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @stored_properties
-sil shared [serialized] [ossa] @stored_properties : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @stored_properties
+sil shared [serialized] @stored_properties : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
   %a = keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
@@ -77,8 +77,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @stored_properties_generic
-sil shared [serialized] [ossa] @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared [serialized] @stored_properties_generic
+sil shared [serialized] @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where {{.*}}> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; stored_property #Gen.x : $τ_0_0) <D, E, F>
   %a = keypath $WritableKeyPath<Gen<D,E,F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; stored_property #Gen.x : $G) <D, E, F>
@@ -88,8 +88,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @tuple_elements
-sil shared [serialized] [ossa] @tuple_elements : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @tuple_elements
+sil shared [serialized] @tuple_elements : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<T, Int>, (root $T; stored_property #T.x : $(Int, Int); tuple_element #0 : $Int)
   %a = keypath $WritableKeyPath<T, Int>, (root $T; stored_property #T.x : $(Int, Int); tuple_element #0 : $Int)
@@ -103,8 +103,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @tuple_generic
-sil shared [serialized] [ossa] @tuple_generic : $@convention(thin) <T, U> () -> () {
+// CHECK-LABEL: sil shared [serialized] @tuple_generic
+sil shared [serialized] @tuple_generic : $@convention(thin) <T, U> () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<(T, U), T>, <τ_0_0, τ_0_1> (root $(τ_0_0, τ_0_1); tuple_element #0 : $τ_0_0) <T, U>
   %a = keypath $WritableKeyPath<(T, U), T>, <τ_0_0, τ_0_1> (root $(τ_0_0, τ_0_1); tuple_element #0 : $τ_0_0) <T, U>
@@ -145,8 +145,8 @@ sil @set_gen_int_subs : $@convention(thin) <A: Hashable, B: Hashable, C: Hashabl
 sil @gen_subs_eq : $@convention(thin) <A: Hashable, B: Hashable, C: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool
 sil @gen_subs_hash : $@convention(thin) <A: Hashable, B: Hashable, C: Hashable> (UnsafeRawPointer) -> Int
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @computed_properties
-sil shared [serialized] [ossa] @computed_properties : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @computed_properties
+sil shared [serialized] @computed_properties : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in_guaranteed S) -> @out Int)
   %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in_guaranteed S) -> @out Int)
@@ -163,8 +163,8 @@ entry:
 sil @get_gen_a : $@convention(thin) <X1: P, Y1: Q, Z1: R> (@in_guaranteed Gen<X1, Y1, Z1>) -> @out X1
 sil @set_gen_a : $@convention(thin) <X2: P, Y2: Q, Z2: R> (@in_guaranteed X2, @in_guaranteed Gen<X2, Y2, Z2>) -> ()
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @computed_properties_generic
-sil shared [serialized] [ossa] @computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared [serialized] @computed_properties_generic
+sil shared [serialized] @computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $KeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; settable_property $τ_0_0, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> @out τ_0_0, setter @set_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed τ_0_0, @in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> ()) <D, E, F>
   %a = keypath $KeyPath<Gen<D, E, F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; settable_property $G, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <X3: P, Y3: Q, Z3: R> (@in_guaranteed Gen<X3, Y3, Z3>) -> @out X3, setter @set_gen_a : $@convention(thin) <X4: P, Y4: Q, Z4: R> (@in_guaranteed X4, @in_guaranteed Gen<X4, Y4, Z4>) -> ()) <D, E, F>
@@ -172,8 +172,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @optional
-sil shared [serialized] [ossa] @optional : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @optional
+sil shared [serialized] @optional : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
   %a = keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
@@ -183,10 +183,10 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @indexes
-sil shared [serialized] [ossa] @indexes : $@convention(thin) (S, C) -> () {
-// CHECK: bb0([[S:%.*]] : @unowned $S, [[C:%.*]] : @unowned $C):
-entry(%s : @unowned $S, %c : @unowned $C):
+// CHECK-LABEL: sil shared [serialized] @indexes
+sil shared [serialized] @indexes : $@convention(thin) (S, C) -> () {
+// CHECK: bb0([[S:%.*]] : $S, [[C:%.*]] : $C):
+entry(%s : $S, %c : $C):
   // CHECK: keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) ([[S]], [[C]])
   %a = keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) (%s, %c)
   // CHECK: [[T:%.*]] = alloc_stack
@@ -202,8 +202,8 @@ entry(%s : @unowned $S, %c : @unowned $C):
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] [ossa] @external
-sil shared [serialized] [ossa] @external : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared [serialized] @external
+sil shared [serialized] @external : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $KeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; settable_property $τ_0_0, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> @out τ_0_0, setter @set_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed τ_0_0, @in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> (), external #Gen.x<τ_0_0, τ_0_1, τ_0_2>) <D, E, F>
   %a = keypath $KeyPath<Gen<D, E, F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; settable_property $G, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <X3: P, Y3: Q, Z3: R> (@in_guaranteed Gen<X3, Y3, Z3>) -> @out X3, setter @set_gen_a : $@convention(thin) <X4: P, Y4: Q, Z4: R> (@in_guaranteed X4, @in_guaranteed Gen<X4, Y4, Z4>) -> (), external #Gen.x<G, H, I>) <D, E, F>
@@ -211,7 +211,7 @@ entry:
   return undef : $()
 }
 
-sil [serialized] [ossa] @serialize_all : $@convention(thin) () -> () {
+sil [serialized] @serialize_all : $@convention(thin) () -> () {
 entry:
   %0 = function_ref @stored_properties : $@convention(thin) () -> ()
   %1 = function_ref @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()

--- a/test/SIL/Serialization/ownership_qualified_memopts.sil
+++ b/test/SIL/Serialization/ownership_qualified_memopts.sil
@@ -21,18 +21,21 @@ bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
   return %2 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
-// CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
-// CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
-// CHECK: store [[ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
+// CHECK-LABEL: sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
+// CHECK: [[ARG1_VAL:%.*]] = load [take] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: [[ARG1_VAL_2:%.*]] = load [copy] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG1_VAL]] to [init] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
-sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
-  load [take] %0 : $*Builtin.NativeObject
-  load [copy] %0 : $*Builtin.NativeObject
-  store %1 to [init] %0 : $*Builtin.NativeObject
+// CHECK: destroy_value [[ARG1_VAL_2]]
+// CHECK: } // end sil function 'non_trivial'
+sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = load [take] %0 : $*Builtin.NativeObject
+  %3 = load [copy] %0 : $*Builtin.NativeObject
+  store %2 to [init] %0 : $*Builtin.NativeObject
   store %1 to [assign] %0 : $*Builtin.NativeObject
-  %2 = tuple()
-  return %2 : $()
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
 }

--- a/test/SIL/Serialization/without_actually_escaping.sil
+++ b/test/SIL/Serialization/without_actually_escaping.sil
@@ -14,10 +14,10 @@ bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
 }
 
 // Check that the convert_function [without_actually_escaping] attribute is parsed and printed.
-// CHECK-LABEL: sil hidden [ossa] @f2_testWithoutActuallyEscapingBlock : $@convention(thin) (@guaranteed @convention(block) @noescape () -> ()) -> () {
+// CHECK-LABEL: sil hidden [ossa] @f2_testWithoutActuallyEscapingBlock : $@convention(thin) (@owned @convention(block) @noescape () -> ()) -> () {
 // CHECK: convert_function %0 : $@convention(block) @noescape () -> () to [without_actually_escaping] $@convention(block) () -> ()
-sil hidden [ossa] @f2_testWithoutActuallyEscapingBlock : $@convention(thin) (@guaranteed @convention(block) @noescape () -> ()) -> () {
-bb0(%0 : @guaranteed $@convention(block) @noescape () -> ()):
+sil hidden [ossa] @f2_testWithoutActuallyEscapingBlock : $@convention(thin) (@owned @convention(block) @noescape () -> ()) -> () {
+bb0(%0 : @owned $@convention(block) @noescape () -> ()):
   %cvt = convert_function %0 : $@convention(block) @noescape () -> () to [without_actually_escaping] $@convention(block) () -> ()
   %f = function_ref @closure1 : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> ()
   %call = apply %f(%cvt) : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> ()


### PR DESCRIPTION
Since I am enabling ownership verification by default, rather than disabling it
on these tests I just fixed them to follow ownership invariants.
