### PR TITLE
[ownership] Enable ownership verification by default.

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -314,7 +314,6 @@ function (swift_benchmark_compile_archopts)
 
   set(common_options
       "-c"
-      "-Xfrontend" "-verify-sil-ownership"
       "-target" "${target}"
       "-${BENCH_COMPILE_ARCHOPTS_OPT}" ${PAGE_ALIGNMENT_OPTION})
 
@@ -344,7 +343,6 @@ function (swift_benchmark_compile_archopts)
 
   set(common_options_driver
       "-c"
-      "-Xfrontend" "-verify-sil-ownership"
       "-target" "${target}"
       "-${driver_opt}")
 

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -236,7 +236,6 @@ function(_compile_swift_files
   endif()
 
   if(SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-Xfrontend" "-verify-sil-ownership")
     list(APPEND swift_flags "-Xfrontend" "-enable-mandatory-semantic-arc-opts")
   endif()
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -112,7 +112,7 @@ public:
   std::string SILOutputFileNameForDebugging;
 
   /// If set to true, compile with the SIL Ownership Model enabled.
-  bool VerifySILOwnership = false;
+  bool VerifySILOwnership = true;
 
   /// Assume that code will be executed in a single-threaded environment.
   bool AssumeSingleThreaded = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -299,8 +299,8 @@ def emit_pch : Flag<["-"], "emit-pch">,
 def pch_disable_validation : Flag<["-"], "pch-disable-validation">,
   HelpText<"Disable validating the persistent PCH">;
 
-def verify_sil_ownership : Flag<["-"], "verify-sil-ownership">,
-  HelpText<"Verify ownership invariants during SIL Verification ">;
+def disable_sil_ownership_verifier : Flag<["-"], "disable-sil-ownership-verifier">,
+  HelpText<"Do not verify ownership invariants during SIL Verification ">;
 
 def enable_mandatory_semantic_arc_opts : Flag<["-"], "enable-mandatory-semantic-arc-opts">,
   HelpText<"Enable the mandatory semantic arc optimizer">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -767,7 +767,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.EmitProfileCoverageMapping |= Args.hasArg(OPT_profile_coverage_mapping);
   Opts.DisableSILPartialApply |=
     Args.hasArg(OPT_disable_sil_partial_apply);
-  Opts.VerifySILOwnership |= Args.hasArg(OPT_verify_sil_ownership);
+  Opts.VerifySILOwnership &= !Args.hasArg(OPT_disable_sil_ownership_verifier);
   Opts.EnableMandatorySemanticARCOpts |=
       Args.hasArg(OPT_enable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);

--- a/test/ClangImporter/optional.swift
+++ b/test/ClangImporter/optional.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name optional -I %S/Inputs/custom-modules -verify-sil-ownership -emit-silgen -o - %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name optional -I %S/Inputs/custom-modules -emit-silgen -o - %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_dealloc.sil
+++ b/test/IRGen/objc_dealloc.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -verify-sil-ownership -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -verify-sil-ownership -swift-version 4 %s -o %t/a.out -enforce-exclusivity=checked -Onone
+// RUN: %target-build-swift  -swift-version 4 %s -o %t/a.out -enforce-exclusivity=checked -Onone
 //
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Misc/tbi.sil
+++ b/test/Misc/tbi.sil
@@ -4,12 +4,12 @@
 
 // RUN: %swiftc_driver -parse-sil -Xfrontend -disable-legacy-type-info -target arm64-apple-ios8.0 -target-cpu cyclone \
 // RUN:   -O -S %s -parse-as-library -parse-stdlib -module-name Swift \
-// RUN:   -Xfrontend -verify-sil-ownership | \
+// RUN:    | \
 // RUN:   %FileCheck --check-prefix=TBI %s
 
 // RUN: %swiftc_driver -parse-sil -Xfrontend -disable-legacy-type-info -target arm64-apple-ios7.0 -target-cpu cyclone \
 // RUN:     -O -S %s -parse-as-library -parse-stdlib -module-name Swift \
-// RUN:     -Xfrontend -verify-sil-ownership | \
+// RUN:      | \
 // RUN:   %FileCheck --check-prefix=NO_TBI %s
 
 // REQUIRES: CODEGENERATOR=AArch64

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -1,8 +1,8 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -verify-sil-ownership -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -verify-sil-ownership -parse-as-library %t/blocks.swiftmodule -typecheck -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/blocks.swiftmodule -typecheck -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/blocks.h
 // RUN: %check-in-clang %t/blocks.h
 

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -1,8 +1,8 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/extensions.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/extensions.h
 // RUN: %check-in-clang %t/extensions.h

--- a/test/Profiler/pgo_switchenum.swift
+++ b/test/Profiler/pgo_switchenum.swift
@@ -1,6 +1,6 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -Xfrontend -verify-sil-ownership -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_switchenum -o %t/main
+// RUN: %target-build-swift %s  -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_switchenum -o %t/main
 
 // This unusual use of 'sh' allows the path of the profraw file to be
 // substituted by %target-run.

--- a/test/SIL/Parser/borrow_argument.sil
+++ b/test/SIL/Parser/borrow_argument.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership %s | %target-sil-opt -verify-sil-ownership | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Parser/ownership_arguments.sil
+++ b/test/SIL/Parser/ownership_arguments.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership %s | %target-sil-opt -verify-sil-ownership | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/borrow_argument.sil
+++ b/test/SIL/Serialization/borrow_argument.sil
@@ -1,8 +1,8 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -verify-sil-ownership %s -emit-sib -o %t/tmp.sib -module-name borrow
-// RUN: %target-sil-opt -verify-sil-ownership %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
-// RUN: %target-sil-opt -verify-sil-ownership %t/tmp.2.sib -module-name borrow | %FileCheck %s
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/literals.sil
+++ b/test/SIL/Serialization/literals.sil
@@ -1,8 +1,8 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -verify-sil-ownership %s -emit-sib -o %t/tmp.sib -module-name literals
-// RUN: %target-sil-opt -verify-sil-ownership %t/tmp.sib -o %t/tmp.2.sib -module-name literals
-// RUN: %target-sil-opt -verify-sil-ownership %t/tmp.2.sib -module-name literals | %FileCheck %s
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name literals
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name literals
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name literals | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -verify-sil-ownership -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
 // This is a test that verifies ownership behavior around arguments that should

--- a/test/SIL/ownership-verifier/cond_br_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -sil-ownership-verifier-enable-testing  -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing  -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SIL/ownership-verifier/cond_br_no_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_no_crash.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all=0 %s -o /dev/null
+// RUN: %target-sil-opt -enable-sil-verify-all=0 %s -o /dev/null
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SIL/ownership-verifier/definite_init.sil
+++ b/test/SIL/ownership-verifier/definite_init.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -verify-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1 %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all=0 -o /dev/null 2>&1 %s
 // REQUIRES: asserts
 
 sil_stage raw

--- a/test/SIL/ownership-verifier/disable_verifier_using_semantic_tag.sil
+++ b/test/SIL/ownership-verifier/disable_verifier_using_semantic_tag.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
 // This test makes sure that the ownership verifier can be disabled on specific

--- a/test/SIL/ownership-verifier/false_positive_leaks.sil
+++ b/test/SIL/ownership-verifier/false_positive_leaks.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -verify-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 
 // This file is meant to contain dataflow tests that if they fail are false

--- a/test/SIL/ownership-verifier/leaks.sil
+++ b/test/SIL/ownership-verifier/leaks.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -verify-sil-ownership -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
 // This file is meant to contain dataflow tests that are true leaks. It is

--- a/test/SIL/ownership-verifier/objc_use_verifier.sil
+++ b/test/SIL/ownership-verifier/objc_use_verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all=0 -module-name ObjectiveC -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name ObjectiveC -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 // REQUIRES: objc_interop
 

--- a/test/SIL/ownership-verifier/opaque_use_verifier.sil
+++ b/test/SIL/ownership-verifier/opaque_use_verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -verify-sil-ownership -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 
 // This file is meant to contain tests that previously the verifier treated

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SIL/ownership-verifier/over_consume_positive.sil
+++ b/test/SIL/ownership-verifier/over_consume_positive.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 
 // This file is meant to contain tests that previously the verifier treated

--- a/test/SIL/ownership-verifier/subobject_borrowing.sil
+++ b/test/SIL/ownership-verifier/subobject_borrowing.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -verify-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
-// RUN: %target-sil-opt -verify-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck -check-prefix=NEGATIVE-TEST %s
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck -check-prefix=NEGATIVE-TEST %s
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SIL/ownership-verifier/unreachable_code.sil
+++ b/test/SIL/ownership-verifier/unreachable_code.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all=0 -module-name Swift -o /dev/null %s 2>&1
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name Swift -o /dev/null %s 2>&1
 // REQUIRES: asserts
 
 // Make sure that we properly handle unreachable code the likes of which come

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -verify-sil-ownership -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 
 // This file is meant to contain tests that previously the verifier treated

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -1,7 +1,7 @@
 
-// RUN: %target-swift-emit-sil -verify-sil-ownership -parse-stdlib %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -parse-stdlib %s | %FileCheck %s -check-prefix=SILGEN
-// RUN: %target-swift-emit-ir -verify-sil-ownership -parse-stdlib %s
+// RUN: %target-swift-emit-sil -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s -check-prefix=SILGEN
+// RUN: %target-swift-emit-ir -parse-stdlib %s
 
 // This test includes some calls to transparent stdlib functions.
 // We pattern match for the absence of access markers in the inlined code.

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -parse-stdlib %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
-// RUN: %target-swift-emit-sil -verify-sil-ownership -Onone -parse-stdlib %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck -check-prefix=CANONICAL %s
+// RUN: %target-swift-emit-silgen -parse-stdlib %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil -Onone -parse-stdlib %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck -check-prefix=CANONICAL %s
 
 import Swift
 

--- a/test/SILGen/closure_script_global_escape.swift
+++ b/test/SILGen/closure_script_global_escape.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name foo -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name foo -verify-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen -module-name foo %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name foo -verify %s
 
 // CHECK-LABEL: sil [ossa] @main
 

--- a/test/SILGen/closure_self_recursion.swift
+++ b/test/SILGen/closure_self_recursion.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name foo -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name foo -verify-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen -module-name foo %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name foo -verify %s
 
 // CHECK-LABEL: sil [ossa] @main
 

--- a/test/SILGen/conditionally_unreachable.swift
+++ b/test/SILGen/conditionally_unreachable.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -parse-stdlib -primary-file %s | %FileCheck %s -check-prefix=RAW
-// RUN: %target-swift-emit-sil -verify-sil-ownership -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
-// RUN: %target-swift-emit-sil -verify-sil-ownership -O -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
-// RUN: %target-swift-emit-sil -verify-sil-ownership -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
-// RUN: %target-swift-emit-sil -verify-sil-ownership -O -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
+// RUN: %target-swift-emit-silgen -parse-stdlib -primary-file %s | %FileCheck %s -check-prefix=RAW
+// RUN: %target-swift-emit-sil -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
+// RUN: %target-swift-emit-sil -O -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
+// RUN: %target-swift-emit-sil -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
+// RUN: %target-swift-emit-sil -O -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
 
 import Swift
 

--- a/test/SILGen/default_arguments_serialized.swift
+++ b/test/SILGen/default_arguments_serialized.swift
@@ -2,9 +2,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/default_arguments_other.swiftmodule -emit-module -swift-version 4 -primary-file %S/Inputs/default_arguments_other.swift
 
-// RUN: %target-swift-emit-silgen -module-name default_arguments_serialized -Xllvm -sil-full-demangle -verify-sil-ownership -swift-version 4 -I %t %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name default_arguments_serialized -Xllvm -sil-full-demangle -swift-version 4 -I %t %s | %FileCheck %s
 
-// RUN: %target-swift-emit-sil -module-name default_arguments_serialized -Xllvm -sil-full-demangle -verify-sil-ownership -O -swift-version 4 -I %t %s | %FileCheck %s --check-prefix=OPT
+// RUN: %target-swift-emit-sil -module-name default_arguments_serialized -Xllvm -sil-full-demangle -O -swift-version 4 -I %t %s | %FileCheck %s --check-prefix=OPT
 
 // Check that default arguments are serialized in Swift 4 mode.
 

--- a/test/SILGen/enum_default_arguments.swift
+++ b/test/SILGen/enum_default_arguments.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name default_arguments -Xllvm -sil-full-demangle -verify-sil-ownership -swift-version 4 %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name default_arguments -Xllvm -sil-full-demangle -swift-version 4 %s | %FileCheck %s
 
 protocol DefaultInitializable {
   init()

--- a/test/SILGen/existential_erasure_mutating_covariant_self.swift
+++ b/test/SILGen/existential_erasure_mutating_covariant_self.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -verify %s
-// RUN: %target-swift-emit-sil -verify-sil-ownership %s | %FileCheck --check-prefix=AFTER-MANDATORY-PASSES %s
+// RUN: %target-swift-emit-silgen -verify %s
+// RUN: %target-swift-emit-sil %s | %FileCheck --check-prefix=AFTER-MANDATORY-PASSES %s
 
 // ensure escape analysis killed the box allocations used for delayed Self
 // return buffers

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name function_conversion -verify-sil-ownership -primary-file %s | %FileCheck %s
-// RUN: %target-swift-emit-ir -module-name function_conversion -verify-sil-ownership -primary-file %s
+// RUN: %target-swift-emit-silgen -module-name function_conversion -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -module-name function_conversion -primary-file %s
 
 // Check SILGen against various FunctionConversionExprs emitted by Sema.
 

--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify-sil-ownership %s -o /dev/null -verify
+// RUN: %target-swift-emit-sil %s -o /dev/null -verify
 
 //===--- Function declaration with uninhabited parameter type
                                    

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name generic_witness -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-ir -module-name generic_witness -verify-sil-ownership %s
+// RUN: %target-swift-emit-silgen -module-name generic_witness %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -module-name generic_witness %s
 
 protocol Runcible {
   func runce<A>(_ x: A)

--- a/test/SILGen/ivar_destroyer_resilience.swift
+++ b/test/SILGen/ivar_destroyer_resilience.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -verify-sil-ownership %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-emit-silgen -I %t -verify-sil-ownership -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-emit-silgen -I %t -enable-library-evolution %s | %FileCheck %s
 
 import resilient_struct
 

--- a/test/SILGen/keypath_covariant_override.swift
+++ b/test/SILGen/keypath_covariant_override.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-library-evolution %s | %FileCheck %s
 
 // RUN: %target-swift-frontend -emit-ir %s
 // RUN: %target-swift-frontend -emit-ir -enable-library-evolution %s

--- a/test/SILGen/local_types.swift
+++ b/test/SILGen/local_types.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen  -parse-as-library -verify-sil-ownership %s -verify | %FileCheck %s
-// RUN: %target-swift-emit-ir  -parse-as-library -verify-sil-ownership %s
+// RUN: %target-swift-emit-silgen  -parse-as-library %s -verify | %FileCheck %s
+// RUN: %target-swift-emit-ir  -parse-as-library %s
 
 func function1() {
   return

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -1,8 +1,8 @@
 
-// RUN: %target-swift-emit-silgen -module-name nested_generics -verify-sil-ownership -Xllvm -sil-full-demangle  -parse-as-library %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name nested_generics -verify-sil-ownership -Xllvm -sil-full-demangle -parse-as-library %s > /dev/null
-// RUN: %target-swift-emit-sil -module-name nested_generics -verify-sil-ownership -Xllvm -sil-full-demangle -O -parse-as-library %s > /dev/null
-// RUN: %target-swift-emit-ir -module-name nested_generics -verify-sil-ownership -Xllvm -sil-full-demangle -parse-as-library %s > /dev/null
+// RUN: %target-swift-emit-silgen -module-name nested_generics -Xllvm -sil-full-demangle  -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name nested_generics -Xllvm -sil-full-demangle -parse-as-library %s > /dev/null
+// RUN: %target-swift-emit-sil -module-name nested_generics -Xllvm -sil-full-demangle -O -parse-as-library %s > /dev/null
+// RUN: %target-swift-emit-ir -module-name nested_generics -Xllvm -sil-full-demangle -parse-as-library %s > /dev/null
 
 // TODO:
 // - test generated SIL -- mostly we're just testing mangling here

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -verify-sil-ownership -enable-objc-interop -enable-source-import %s | %FileCheck %s -check-prefix=CHECK-RAW
-// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -verify-sil-ownership -enable-objc-interop -enable-source-import %s | %FileCheck %s -check-prefix=CHECK-CANONICAL
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -enable-objc-interop -enable-source-import %s | %FileCheck %s -check-prefix=CHECK-RAW
+// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -enable-objc-interop -enable-source-import %s | %FileCheck %s -check-prefix=CHECK-CANONICAL
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_block_to_func_to_block.swift
+++ b/test/SILGen/objc_block_to_func_to_block.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -verify-sil-ownership -import-objc-header %S/Inputs/objc_block_to_func_to_block.h -emit-silgen -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_block_to_func_to_block.h -emit-silgen -verify %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_bridged_generic_conformance.swift
+++ b/test/SILGen/objc_bridged_generic_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s -enable-objc-interop -import-objc-header %S/Inputs/objc_bridged_generic_conformance.h -verify -verify-sil-ownership
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s -enable-objc-interop -import-objc-header %S/Inputs/objc_bridged_generic_conformance.h -verify
 
 protocol P { func test() }
 

--- a/test/SILGen/objc_bridging_nsstring.swift
+++ b/test/SILGen/objc_bridging_nsstring.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -sil-full-demangle %s -verify-sil-ownership
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -sil-full-demangle %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_disable_brigding.swift
+++ b/test/SILGen/objc_disable_brigding.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify-sil-ownership -emit-module -o %t -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift -I %t
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -I %S/../Inputs/ObjCBridging -disable-swift-bridge-attr -Xllvm -sil-full-demangle %s -verify-sil-ownership | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift -I %t
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -I %S/../Inputs/ObjCBridging -disable-swift-bridge-attr -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_dynamic_replacement.swift
+++ b/test/SILGen/objc_dynamic_replacement.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -I %t -module-name SomeModule -emit-module -emit-module-path=%t/SomeModule.swiftmodule %S/Inputs/objc_dynamic_replacement.swift -enable-private-imports -swift-version 5 -enable-implicit-dynamic
-// RUN: %target-swift-emit-silgen -I %t -verify-sil-ownership %s -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %s -swift-version 5 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_keypath.swift
+++ b/test/SILGen/objc_keypath.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify-sil-ownership -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_selector.swift
+++ b/test/SILGen/objc_selector.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify-sil-ownership -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-objc-interop | %FileCheck %s
 
 import ObjectiveC
 import Foundation

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name partial_apply_protocol -verify-sil-ownership -primary-file %s | %FileCheck %s
-// RUN: %target-swift-emit-ir -module-name partial_apply_protocol -verify-sil-ownership -primary-file %s
+// RUN: %target-swift-emit-silgen -module-name partial_apply_protocol -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -module-name partial_apply_protocol -primary-file %s
 
 protocol Clonable {
   func clone() -> Self

--- a/test/SILGen/private_import.swift
+++ b/test/SILGen/private_import.swift
@@ -4,8 +4,8 @@
 // RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/private_import_other.swift -module-name main -swift-version 5 | %FileCheck %s
 // RUN: %target-swift-emit-silgen -I %t %s %S/private_import_other.swift -module-name main -swift-version 5 | %FileCheck %s
 // RUN: %target-swift-emit-silgen -I %t %S/private_import_other.swift %s -module-name main -swift-version 5 | %FileCheck %s
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -primary-file %s %S/private_import_other.swift -module-name main -o /dev/null
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -O -primary-file %s %S/private_import_other.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -primary-file %s %S/private_import_other.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -O -primary-file %s %S/private_import_other.swift -module-name main -o /dev/null
 
 
 @_private(sourceFile: "private_import_module.swift") import Mod

--- a/test/SILGen/private_import_other.swift
+++ b/test/SILGen/private_import_other.swift
@@ -4,8 +4,8 @@
 // RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/private_import.swift -module-name main -swift-version 5 | %FileCheck %s
 // RUN: %target-swift-emit-silgen -I %t %s %S/private_import.swift -module-name main -swift-version 5 | %FileCheck %s
 // RUN: %target-swift-emit-silgen -I %t %S/private_import.swift %s -module-name main -swift-version 5 | %FileCheck %s
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -primary-file %s %S/private_import.swift -module-name main -o /dev/null
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -O -primary-file %s %S/private_import.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -primary-file %s %S/private_import.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -O -primary-file %s %S/private_import.swift -module-name main -o /dev/null
 
 @_private(sourceFile: "private_import_module.swift") import Mod
 

--- a/test/SILGen/protocol_cast_toplevel.swift
+++ b/test/SILGen/protocol_cast_toplevel.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -enable-objc-interop -disable-objc-attr-requires-foundation-module -verify-sil-ownership
+// RUN: %target-swift-emit-silgen %s -enable-objc-interop -disable-objc-attr-requires-foundation-module
 
 @objc protocol Unrelated {}
 

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name protocol_resilience -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
-// RUN: %target-swift-emit-silgen -module-name protocol_resilience -I %t -verify-sil-ownership -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name protocol_resilience -I %t -enable-library-evolution %s | %FileCheck %s
 
 import resilient_protocol
 

--- a/test/SILGen/protocol_with_superclass_where_clause.swift
+++ b/test/SILGen/protocol_with_superclass_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -module-name protocol_with_superclass %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name protocol_with_superclass %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
 // Protocols with superclass-constrained Self, written using a 'where' clause.

--- a/test/SILGen/reabstract.swift
+++ b/test/SILGen/reabstract.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name reabstract -Xllvm -sil-full-demangle -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name reabstract -Xllvm -sil-full-demangle -verify-sil-ownership %s | %FileCheck %s --check-prefix=MANDATORY
+// RUN: %target-swift-emit-silgen -module-name reabstract -Xllvm -sil-full-demangle %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name reabstract -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=MANDATORY
 
 func takeFn<T>(_ f : (T) -> T?) {}
 func liftOptional(_ x : Int) -> Int? { return x }

--- a/test/SILGen/rethrows.swift
+++ b/test/SILGen/rethrows.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-sil -module-name rethrows -verify-sil-ownership -verify %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name rethrows -verify %s | %FileCheck %s
 
 @discardableResult
 func rethrower(_ fn: () throws -> Int) rethrows -> Int {

--- a/test/SILGen/testable-multifile-other.swift
+++ b/test/SILGen/testable-multifile-other.swift
@@ -4,13 +4,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -o %t
 
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -I %t %s %S/testable-multifile.swift -module-name main | %FileCheck %s
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -I %t %S/testable-multifile.swift %s -module-name main | %FileCheck %s
-// RUN: %target-swift-emit-silgen -verify-sil-ownership -I %t -primary-file %s %S/testable-multifile.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %s %S/testable-multifile.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t %S/testable-multifile.swift %s -module-name main | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/testable-multifile.swift -module-name main | %FileCheck %s
 
 // Just make sure we don't crash later on.
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -O -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -O -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
 
 @testable import TestableMultifileHelper
 

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -8,8 +8,8 @@
 // RUN: %target-swift-emit-silgen -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
 
 // Just make sure we don't crash later on.
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
-// RUN: %target-swift-emit-ir -verify-sil-ownership -I %t -O -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
+// RUN: %target-swift-emit-ir -I %t -O -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
 
 @testable import TestableMultifileHelper
 

--- a/test/SILGen/unmanaged.swift
+++ b/test/SILGen/unmanaged.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-sil -module-name unmanaged -verify-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name unmanaged %s | %FileCheck %s
 
 class C {}
 

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify-sil-ownership %s -o /dev/null -verify
+// RUN: %target-swift-emit-sil %s -o /dev/null -verify
 
 func testUnreachableAfterReturn() -> Int {
   var x: Int = 3

--- a/test/SILGen/witness-init-requirement-with-base-class-init.swift
+++ b/test/SILGen/witness-init-requirement-with-base-class-init.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -verify-sil-ownership  %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -verify-sil-ownership -verify %s
+// RUN: %target-swift-emit-silgen  %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -verify %s
 
 protocol BestFriend: class {
   init()

--- a/test/SILGen/witness_accessibility_multi.swift
+++ b/test/SILGen/witness_accessibility_multi.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/witness_accessibility_other.swiftmodule %S/Inputs/witness_accessibility_other.swift
-// RUN: %target-swift-emit-silgen -I %t  -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -I %t -verify-sil-ownership %s
+// RUN: %target-swift-emit-silgen -I %t  %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %t %s
 
 import witness_accessibility_other
 

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-emit-silgen -module-name witness_same_type -verify-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-emit-ir -module-name witness_same_type -verify-sil-ownership %s
+// RUN: %target-swift-emit-silgen -module-name witness_same_type %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -module-name witness_same_type %s
 
 protocol Fooable {
   associatedtype Bar

--- a/test/SILOptimizer/access_enforcement_selection.sil
+++ b/test/SILOptimizer/access_enforcement_selection.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -access-enforcement-selection -enforce-exclusivity=checked %s | %FileCheck %s
+// RUN: %target-sil-opt -access-enforcement-selection -enforce-exclusivity=checked %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt  %s -verify-sil-ownership -access-summary-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt  %s -access-summary-dump -o /dev/null | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -allocbox-to-stack | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -capture-promotion -verify-sil-ownership | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -capture-promotion | %FileCheck %s
 
 // Check to make sure that the process of promoting closure captures results in
 // a correctly cloned and modified closure function body. This test

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
 
 import Swift
 import Builtin

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -copy-propagation -verify-sil-ownership -enable-sil-opaque-values -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -copy-propagation -enable-sil-opaque-values -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/definite_init_crashes.sil
+++ b/test/SILOptimizer/definite_init_crashes.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering | %FileCheck %s
 
 // These are all regression tests to ensure that the memory promotion pass
 // doesn't crash.

--- a/test/SILOptimizer/definite_init_inout_super_init.swift
+++ b/test/SILOptimizer/definite_init_inout_super_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -Xfrontend -disable-sil-ownership-verifier -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // TODO: Change this back to using target-swift-frontend once we move errors to
 // type checker and SILGen.

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
 
 // This test only tests mark_uninitialized [delegatingself]
 

--- a/test/SILOptimizer/definite_init_markuninitialized_derivedself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_derivedself.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
 
 // This test only tests mark_uninitialized [derivedself]
 

--- a/test/SILOptimizer/definite_init_markuninitialized_rootself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_rootself.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
 
 // This file tests mark_uninitialized [rootself]
 

--- a/test/SILOptimizer/definite_init_markuninitialized_var.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_var.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -definite-init -verify | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -verify | %FileCheck %s
 
 // This file contains tests that test diagnostics emitted for var initialization
 // by DI.

--- a/test/SILOptimizer/definite_init_nsmanagedvalue.swift
+++ b/test/SILOptimizer/definite_init_nsmanagedvalue.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../ClangImporter/Inputs/custom-modules %s -emit-sil -verify-sil-ownership
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../ClangImporter/Inputs/custom-modules %s -emit-sil
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/definite_init_objc_factory_init.swift
+++ b/test/SILOptimizer/definite_init_objc_factory_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../IDE/Inputs/custom-modules %s -emit-sil -verify-sil-ownership | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../IDE/Inputs/custom-modules %s -emit-sil | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/definite_init_scalarization_test.sil
+++ b/test/SILOptimizer/definite_init_scalarization_test.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering | %FileCheck %s
 //
 // Make sure that we properly scalarize tuples.
 //

--- a/test/SILOptimizer/devirt_access_ownership.sil
+++ b/test/SILOptimizer/devirt_access_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_access_serialized_ownership.sil
+++ b/test/SILOptimizer/devirt_access_serialized_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_alloc_ref_dynamic_ownership.sil
+++ b/test/SILOptimizer/devirt_alloc_ref_dynamic_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -sil-combine -devirtualizer -dce | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -devirtualizer -dce | %FileCheck %s
 
 // REQUIRES: SR9831
 

--- a/test/SILOptimizer/devirt_ctors_ownership.sil
+++ b/test/SILOptimizer/devirt_ctors_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_default_witness_method_ownership.sil
+++ b/test/SILOptimizer/devirt_default_witness_method_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -devirtualizer -enable-library-evolution | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -enable-library-evolution | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/devirt_generic_witness_method_ownership.sil
+++ b/test/SILOptimizer/devirt_generic_witness_method_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_override_ownership.sil
+++ b/test/SILOptimizer/devirt_override_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirt_try_apply_ownership.sil
+++ b/test/SILOptimizer/devirt_try_apply_ownership.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -devirtualizer -inline  | %FileCheck %s --check-prefix=CHECK-DEVIRT
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -mandatory-inlining  | %FileCheck %s --check-prefix=CHECK-MANDATORY-INLINING
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -inline  | %FileCheck %s --check-prefix=CHECK-DEVIRT
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining  | %FileCheck %s --check-prefix=CHECK-MANDATORY-INLINING
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirtualize2_ownership.sil
+++ b/test/SILOptimizer/devirtualize2_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -devirtualizer -dce | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -dce | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/devirtualize_ownership.sil
+++ b/test/SILOptimizer/devirtualize_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %/s -devirtualizer -dce -save-optimization-record-path=%t.yaml | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %/s -devirtualizer -dce -save-optimization-record-path=%t.yaml | %FileCheck %s
 // RUN: %FileCheck -check-prefix=YAML -input-file=%t.yaml %s
 
 sil_stage canonical

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -234,26 +234,28 @@ class ClassWithStoredProperty {
   init()
 }
 // CHECK-LABEL: sil hidden [ossa] @classStoredProperty
-sil hidden [ossa] @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -> () {
-bb0(%0 : @unowned $ClassWithStoredProperty):
-  %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
+sil hidden [ossa] @classStoredProperty : $@convention(thin) (@owned ClassWithStoredProperty) -> () {
+bb0(%0 : @owned $ClassWithStoredProperty):
+  %0a = begin_borrow %0 : $ClassWithStoredProperty
+  %1 = ref_element_addr %0a : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
   // expected-error@+1{{overlapping accesses to 'f', but modification requires exclusive access; consider copying to a local variable}}
   %2 = begin_access [modify] [dynamic] %1 : $*Int
-  %3 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
+  %3 = ref_element_addr %0a : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
   // expected-note@+1{{conflicting access is here}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   end_access %4 : $*Int
   end_access %2 : $*Int
+  end_borrow %0a : $ClassWithStoredProperty
   destroy_value %0 : $ClassWithStoredProperty
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil hidden [ossa] @lookThroughBeginBorrow
-sil hidden [ossa] @lookThroughBeginBorrow : $@convention(thin) (ClassWithStoredProperty) -> () {
-bb0(%0 : @unowned $ClassWithStoredProperty):
+sil hidden [ossa] @lookThroughBeginBorrow : $@convention(thin) (@owned ClassWithStoredProperty) -> () {
+bb0(%0 : @owned $ClassWithStoredProperty):
   %1 = begin_borrow %0 : $ClassWithStoredProperty
   %2 = begin_borrow %0 : $ClassWithStoredProperty
   %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
@@ -605,6 +607,7 @@ bb0(%0 : $Int):
   %7 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %8 = apply %4(%7, %conv) : $@convention(thin) (@inout Int, @noescape @owned @callee_owned (Int) -> ()) -> ()
   end_access %7: $*Int
+  destroy_value %6 : $@callee_owned (Int) -> ()
   destroy_value %2 : ${ var Int }
   %9 = tuple ()
   return %9 : $()
@@ -625,6 +628,7 @@ bb0(%0 : $Int):
   %8 = apply %4(%7, %bconv) : $@convention(thin) (@inout Int, @noescape @guaranteed @callee_guaranteed (Int) -> ()) -> ()
   end_access %7: $*Int
   end_borrow %bconv : $@callee_guaranteed @noescape (Int) -> ()
+  destroy_value %6 : $@callee_guaranteed (Int) -> ()
   destroy_value %2 : ${ var Int }
   %9 = tuple ()
   return %9 : $()
@@ -651,6 +655,7 @@ bb0(%0 : $Int):
   %7 = begin_access [read] [unknown] %3 : $*Int // expected-note {{conflicting access is here}}
   %8 = apply %4(%3, %conv) : $@convention(thin) (@inout Int, @noescape @owned @callee_owned () -> ()) -> ()
   end_access %7: $*Int
+  destroy_value %6 : $@callee_owned () -> ()
   destroy_value %2 : ${ var Int }
   %9 = tuple ()
   return %9 : $()
@@ -681,6 +686,8 @@ bb0(%0 : $Int):
   %11 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %12 = apply %4<Int>(%11, %10) : $@convention(thin) <T_0> (@inout Int, @noescape @callee_owned (Int) -> @out T_0) -> ()
   end_access %11: $*Int
+  destroy_value %9 : $@callee_owned (Int) -> @out Int
+  destroy_value %6 : $@callee_owned (Int) -> Int
   destroy_value %2 : ${ var Int }
   %13 = tuple ()
   return %13 : $()
@@ -722,6 +729,8 @@ bb0(%0 : $Int):
   end_access %13 : $*Int
   destroy_addr %8 : $*@callee_guaranteed() -> ()
   dealloc_stack %7 : $*@block_storage @callee_guaranteed () -> ()
+  destroy_value %sentinel2 : $@callee_guaranteed () -> ()
+  destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_value %2 : ${ var Int }
   %ret = tuple ()
   return %ret : $()
@@ -753,6 +762,8 @@ bb0(%0 : $Int):
   end_access %14 : $*Int
   destroy_addr %8 : $*@callee_guaranteed () -> ()
   dealloc_stack %7 : $*@block_storage @callee_guaranteed () -> ()
+  destroy_value %sentinel2 : $@callee_guaranteed () -> ()
+  destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_value %2 : ${ var Int }
   %ret = tuple ()
   return %ret : $()
@@ -909,6 +920,7 @@ bb0(%0 : $Int):
   %4 = enum $Optional<@convention(block) @noescape () -> ()>, #Optional.none!enumelt
   %5 = function_ref @takesInoutAndNoEscapeOptionalBlockClosure : $@convention(thin) (@inout Int, @owned Optional<@convention(block) @noescape () -> ()>) -> ()
   %6 = apply %5(%3, %4) : $@convention(thin) (@inout Int, @owned Optional<@convention(block) @noescape () -> ()>) -> ()
+  destroy_value %2 : ${ var Int }
   %7 = tuple ()
   return %7 : $()
 }
@@ -933,6 +945,7 @@ bb0(%0 : $Int):
   %access = begin_access [modify] [unknown] %boxadr : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %call = apply %nepa(%access) : $@noescape @callee_guaranteed (@inout Int) -> ()
   end_access %access : $*Int
+  destroy_value %pa : $@callee_guaranteed (@inout Int) -> ()
   destroy_value %box : ${ var Int }
   %v = tuple ()
   return %v : $()
@@ -959,6 +972,7 @@ bb0(%0 : $Int):
   %access = begin_access [modify] [unknown] %boxadr : $*Int   // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %call = apply %nepa(%access) : $@noescape @callee_guaranteed (@inout Int) -> ()
   end_access %access : $*Int
+  destroy_value %pa2 : $@callee_guaranteed (@inout Int) -> ()
   destroy_value %box : ${ var Int }
   %v = tuple ()
   return %v : $()
@@ -986,6 +1000,7 @@ bb0(%0 : $Int):
   %8 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %9 = apply %4(%8, %conv) : $@convention(thin) (@inout Int, @noescape @owned @callee_owned () -> ()) -> ()
   end_access %8: $*Int
+  destroy_value %7 : $@callee_owned () -> ()
   destroy_value %2 : ${ var Int }
   %v = tuple ()
   return %v : $()
@@ -1086,6 +1101,7 @@ bb0(%0 : $UnsafePointer<Int32>, %1 : $*Int32):
   %closure = convert_escape_to_noescape [not_guaranteed] %pa2 : $@callee_guaranteed (UnsafePointer<Int32>) -> () to $@noescape @callee_guaranteed (UnsafePointer<Int32>) -> ()
   %f2 = function_ref @takeMutatingNoescapeClosure : $@convention(thin) <τ_0_0> (UnsafePointer<τ_0_0>, @noescape @callee_guaranteed (UnsafePointer<Int32>) -> ()) -> ()
   %call = apply %f2<Int32>(%0, %closure) : $@convention(thin) <τ_0_0> (UnsafePointer<τ_0_0>, @noescape @callee_guaranteed (UnsafePointer<Int32>) -> ()) -> ()
+  destroy_value %pa2 : $@callee_guaranteed (UnsafePointer<Int32>) -> ()
   %v = tuple ()
   return %v : $()
 }
@@ -1102,6 +1118,7 @@ bb0(%0 : $UnsafePointer<Int32>, %1 : $*Int32):
   %f2 = function_ref @takeInoutAndMutatingNoescapeClosure : $@convention(thin) <τ_0_0> (@inout Int32, UnsafePointer<τ_0_0>, @noescape @callee_guaranteed (UnsafePointer<Int32>) -> ()) -> ()
   %access = begin_access [modify] [unknown] %1 : $*Int32  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %call = apply %f2<Int32>(%access, %0, %closure) : $@convention(thin) <τ_0_0> (@inout Int32, UnsafePointer<τ_0_0>, @noescape @callee_guaranteed (UnsafePointer<Int32>) -> ()) -> ()
+  destroy_value %pa2 : $@callee_guaranteed (UnsafePointer<Int32>) -> ()
   end_access %access : $*Int32
   %v = tuple ()
   return %v : $()
@@ -1159,6 +1176,7 @@ bb1:
   %copyblock1 = copy_block %initblock1 : $@convention(block) @noescape () -> ()
   destroy_addr %pbs1 : $*@callee_guaranteed() -> ()
   dealloc_stack %bs1 : $*@block_storage @callee_guaranteed () -> ()
+  destroy_value %sentinel2 : $@callee_guaranteed () -> ()
   br bb3(%copyblock1 : $@convention(block) @noescape () -> ())
 
 bb2:
@@ -1169,6 +1187,7 @@ bb2:
   %copyblock2 = copy_block %initblock2 : $@convention(block) @noescape () -> ()
   destroy_addr %pbs2 : $*@callee_guaranteed() -> ()
   dealloc_stack %bs2 : $*@block_storage @callee_guaranteed () -> ()
+  destroy_value %sentinel2 : $@callee_guaranteed () -> ()
   br bb3(%copyblock2 : $@convention(block) @noescape () -> ())
 
 bb3(%block : @owned $@convention(block) @noescape () -> ()):
@@ -1176,6 +1195,7 @@ bb3(%block : @owned $@convention(block) @noescape () -> ()):
   %f = function_ref @takesInoutAndNoEscapeBlockClosure : $@convention(thin) (@inout Int, @owned @convention(block) @noescape () -> ()) -> ()
   %call = apply %f(%access, %block) : $@convention(thin) (@inout Int, @owned @convention(block) @noescape () -> ()) -> ()
   end_access %access : $*Int
+  destroy_value %pa : $@callee_guaranteed () -> ()
   destroy_value %box : ${ var Int }
   %ret = tuple ()
   return %ret : $()
@@ -1308,13 +1328,15 @@ bb0(%0 : $*Int):
   %3 = partial_apply [callee_guaranteed] %2(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
 
   %4 = function_ref @thunkForWithoutActuallyEscapingVerify : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
-  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
+  %3a = copy_value %3 : $@callee_guaranteed () -> ()
+  %5 = partial_apply [callee_guaranteed] %4(%3a) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
   %6 = mark_dependence %5 : $@callee_guaranteed () -> () on %3 : $@callee_guaranteed () -> ()
 
   %8 = function_ref @closureForWithoutActuallyEscapingVerify : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
   %9 = apply %8(%6) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
   %10 = is_escaping_closure %6 : $@callee_guaranteed () -> ()
   cond_fail %10 : $Builtin.Int1
+  destroy_value %3 : $@callee_guaranteed () -> ()
   destroy_value %6 : $@callee_guaranteed () -> ()
   %14 = tuple ()
   return %14 : $()
@@ -1354,7 +1376,8 @@ bb0(%0 : $Int):
   store %closure to [init] %blockproj : $*@callee_guaranteed () -> ()
   // function_ref thunk for @escaping @callee_guaranteed () -> ()
   %thunkF = function_ref @$sIeg_IeyB_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> ()) -> ()
-  %initblock = init_block_storage_header %block : $*@block_storage @callee_guaranteed () -> (), invoke %thunkF : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> ()) -> (), type $@convention(block) () -> ()
+  %initblock_unowned = init_block_storage_header %block : $*@block_storage @callee_guaranteed () -> (), invoke %thunkF : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> ()) -> (), type $@convention(block) () -> ()
+  %initblock = copy_block %initblock_unowned : $@convention(block) () -> ()
   destroy_addr %blockproj : $*@callee_guaranteed () -> ()
   dealloc_stack %block : $*@block_storage @callee_guaranteed () -> ()
   %borrow = begin_borrow %initblock : $@convention(block) () -> ()

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -verify-sil-ownership -inline -verify %s | %FileCheck %s
-// RUN: %target-sil-opt -verify-sil-ownership -mandatory-inlining -verify %s | %FileCheck %s
+// RUN: %target-sil-opt -inline -verify %s | %FileCheck %s
+// RUN: %target-sil-opt -mandatory-inlining -verify %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa.sil
+++ b/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining -verify-sil-ownership | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa_objc.sil
+++ b/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining -verify-sil-ownership | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining -verify-sil-ownership | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/mandatory_inlining_ownership2.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership2.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-objc-interop -module-name mandatory_inlining -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -module-name mandatory_inlining -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mandatory_inlining_resilience.sil
+++ b/test/SILOptimizer/mandatory_inlining_resilience.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/mark_uninitialized_fixup.sil
+++ b/test/SILOptimizer/mark_uninitialized_fixup.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -mark-uninitialized-fixup %s | %FileCheck %s
+// RUN: %target-sil-opt -mark-uninitialized-fixup %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/noreturn_folding_ownership.sil
+++ b/test/SILOptimizer/noreturn_folding_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -verify-sil-ownership -enable-sil-verify-all -noreturn-folding < %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -noreturn-folding < %s | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/ome_non_transparent.sil
+++ b/test/SILOptimizer/ome_non_transparent.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -non-transparent-func-ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -non-transparent-func-ownership-model-eliminator %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/ome_strip_deserialize.sil
+++ b/test/SILOptimizer/ome_strip_deserialize.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -module-name OMEStripDeserializationInput %S/Inputs/ome_strip_deserialize_input.sil -emit-module -o %t/OMEStripDeserializationInput.swiftmodule
-// RUN: %target-sil-opt -verify-sil-ownership -non-transparent-func-ownership-model-eliminator -performance-linker -I %t %s | %FileCheck %s
-// RUN: %target-sil-opt -verify-sil-ownership -ownership-model-eliminator -performance-linker -I %t %s | %FileCheck --check-prefix=CHECK-STRIP-ALL %s
+// RUN: %target-sil-opt -non-transparent-func-ownership-model-eliminator -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -ownership-model-eliminator -performance-linker -I %t %s | %FileCheck --check-prefix=CHECK-STRIP-ALL %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -ownership-model-eliminator %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/pound_assert_ossa.sil
+++ b/test/SILOptimizer/pound_assert_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-experimental-static-assert %s -dataflow-diagnostics -verify
+// RUN: %target-sil-opt -enable-experimental-static-assert %s -dataflow-diagnostics -verify
 
 sil_stage canonical
 

--- a/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
+++ b/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -verify-sil-ownership %s -predictable-deadalloc-elim | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -predictable-deadalloc-elim | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/predictable_memaccess_opts.sil
+++ b/test/SILOptimizer/predictable_memaccess_opts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -verify-sil-ownership -predictable-memaccess-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -predictable-memaccess-opts %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -predictable-memaccess-opts -predictable-deadalloc-elim  | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -predictable-memaccess-opts -predictable-deadalloc-elim  | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/raw_sil_inst_lowering.sil
+++ b/test/SILOptimizer/raw_sil_inst_lowering.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -verify-sil-ownership -enable-sil-verify-all %s -raw-sil-inst-lowering | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -raw-sil-inst-lowering | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -verify-sil-ownership -semantic-arc-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -semantic-arc-opts %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/verify_noescape_closure.sil
+++ b/test/SILOptimizer/verify_noescape_closure.sil
@@ -31,6 +31,7 @@ bb0(%0 : $Int):
   %5 = function_ref @closureWithArgument : $@convention(thin) (@inout_aliasable Int) -> ()
   %6 = partial_apply %5(%3) : $@convention(thin) (@inout_aliasable Int) -> ()
   %8 = apply %4(%6) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  destroy_value %2 : ${ var Int }
   %9 = tuple ()
   return %9 : $()
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -784,7 +784,7 @@ if run_vendor == 'apple':
     config.target_sdk_name = xcrun_sdk_name
     config.target_ld = "%s ld -L%r" % (xcrun_prefix, make_path(test_resource_dir, config.target_sdk_name))
     config.target_swift_frontend = (
-        "%s -frontend %s -sdk %r %s %s -verify-sil-ownership " %
+        "%s -frontend %s -sdk %r %s %s " %
         (config.swiftc, target_options, config.variant_sdk,
          config.swift_test_options, config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = (
@@ -915,7 +915,7 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         % (config.target_build_swift))
     config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
     config.target_swift_frontend = (
-        '%s -frontend -target %s %s %s %s %s -verify-sil-ownership '
+        '%s -frontend -target %s %s %s %s %s '
         % (config.swift, config.variant_triple, resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
@@ -1207,21 +1207,21 @@ config.substitutions.append(('%sftp-server',
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized =                               \
         (SubstituteCaptures('%%empty-directory(%%t) && '
-                            '%s %s %%s \\1 -o %%t/a.out -module-name main -Xfrontend -verify-sil-ownership && '
+                            '%s %s %%s \\1 -o %%t/a.out -module-name main  && '
                             '%s %%t/a.out &&'
                             '%s %%t/a.out' % (config.target_build_swift,
                                               mcp_opt, config.target_codesign,
                                               config.target_run)))
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main -Xfrontend -verify-sil-ownership && '
+        '%s %s %%s -o %%t/a.out -module-name main  && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control -Xfrontend -verify-sil-ownership && '
+        '-Xfrontend -disable-access-control  && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
@@ -1229,7 +1229,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
-        '%s %s %%t/main.swift -o %%t/a.out -module-name main -Xfrontend -verify-sil-ownership && '
+        '%s %s %%t/main.swift -o %%t/a.out -module-name main  && '
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
@@ -1239,7 +1239,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
         '%s %s %%t/main.swift -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control -Xfrontend -verify-sil-ownership && '
+        '-Xfrontend -disable-access-control  && '
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
@@ -1301,8 +1301,8 @@ config.substitutions.append(('%target-runtime', config.target_runtime))
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
 
 config.substitutions.append(('%target-swift-emit-silgen\(mock-sdk:([^)]+)\)',
-                             SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-silgen -verify-syntax-tree -verify-sil-ownership')))
-config.substitutions.append(('%target-swift-emit-silgen', '%target-swift-frontend -emit-silgen -verify-syntax-tree -verify-sil-ownership'))
+                             SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-silgen -verify-syntax-tree')))
+config.substitutions.append(('%target-swift-emit-silgen', '%target-swift-frontend -emit-silgen -verify-syntax-tree'))
 config.substitutions.append(('%target-swift-emit-sil\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-sil -verify-syntax-tree')))
 config.substitutions.append(('%target-swift-emit-sil', '%target-swift-frontend -emit-sil -verify-syntax-tree'))

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -76,10 +76,10 @@ EnableLibraryEvolution("enable-library-evolution",
                                       "interfaces for all public declarations by "
                                       "default"));
 
-static llvm::cl::opt<bool> VerifySILOwnershipOpt(
-    "verify-sil-ownership",
+static llvm::cl::opt<bool> DisableSILOwnershipVerifier(
+    "disable-sil-ownership-verifier",
     llvm::cl::desc(
-        "Compile the module with sil ownership verification enabled"));
+        "Do not verify SIL ownership invariants during SIL verification"));
 
 static llvm::cl::opt<bool>
 EnableSILOpaqueValues("enable-sil-opaque-values",
@@ -338,7 +338,7 @@ int main(int argc, char **argv) {
   SILOpts.AssertConfig = AssertConfId;
   if (OptimizationGroup != OptGroup::Diagnostics)
     SILOpts.OptMode = OptimizationMode::ForSpeed;
-  SILOpts.VerifySILOwnership = VerifySILOwnershipOpt;
+  SILOpts.VerifySILOwnership = !DisableSILOwnershipVerifier;
 
   SILOpts.VerifyExclusivity = VerifyExclusivity;
   if (EnforceExclusivity.getNumOccurrences() != 0) {


### PR DESCRIPTION
[ownership] Enable ownership verification by default.

I also removed the -verify-sil-ownership flag in favor of a disable flag
-disable-sil-ownership-verifier. I used this on only two tests that still need
work to get them to pass with ownership, but whose problems are well understood,
small corner cases. I am going to fix them in follow on commits. I detail them
below:

1. SILOptimizer/definite_init_inout_super_init.swift. This is a test case where
DI is supposed to error. The only problem is that we crash before we error since
the code emitting by SILGen to trigger this error does not pass ownership
invariants. I have spoken with JoeG about this and he suggested that I fix this
earlier in the compiler. Since we do not run the ownership verifier without
asserts enabled, this should not affect compiler users. Given that it has
triggered DI errors previously I think it is safe to disable ownership here.

2. PrintAsObjC/extensions.swift. In this case, the signature generated by type
lowering for one of the thunks here uses an unsafe +0 return value instead of
doing an autorelease return. The ownership checker rightly flags this leak. This
is going to require either an AST level change or a change to TypeLowering. I
think it is safe to turn this off since it is such a corner case that it was
found by a test that has nothing to do with it.

rdar://43398898

----

NOTE: This is mostly updating tests. Also I left in part of #23529 b/c I want to start the testing here. 