### PR TITLE
SourceKit: fallback to just built clang-cl

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -4,6 +4,31 @@ include(CheckSymbolExists)
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(SEND_ERROR "SourceKit cannot be built standalone")
+endif()
+
+if(NOT CMAKE_C_COMPILER_ID MATCHES Clang)
+  if(CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)
+    get_target_property(CLANG_LOCATION clang LOCATION)
+    get_filename_component(CLANG_LOCATION ${CLANG_LOCATION} DIRECTORY)
+
+    if(CMAKE_C_COMPILER_ID STREQUAL MSVC OR CMAKE_C_SIMULATE_ID STREQUAL MSVC)
+      set(CMAKE_C_COMPILER_ID
+        ${CLANG_LOCATION}/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
+      set(CMAKE_CXX_COMPILER_ID
+        ${CLANG_LOCATION}/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
+    else()
+      set(CMAKE_C_COMPILER_ID
+        ${CLANG_LOCATION}/clang${CMAKE_EXECUTABLE_SUFFIX})
+      set(CMAKE_CXX_COMPILER_ID
+        ${CLANG_LOCATION}/clang++${CMAKE_EXECUTABLE_SUFFIX})
+    endif()
+  else()
+    message(SEND_ERROR "SourceKit requires a clang based compiler")
+  endif()
+endif()
+
 if (DARWIN_TOOLCHAIN_VERSION)
   set(SOURCEKIT_VERSION_STRING "${DARWIN_TOOLCHAIN_VERSION}")
 else()


### PR DESCRIPTION
SourceKit uses libdispatch for concurrency.  Unfortunately, libdispatch
requires clang due to extensions.  Switch to `clang-cl` or `clang` as
appropriate when building with a non-clang based host compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
