### PR TITLE
test: make Parse.objc_enum pass on Windows

### DIFF
--- a/test/Parse/objc_enum.swift
+++ b/test/Parse/objc_enum.swift
@@ -8,7 +8,7 @@
   case Zim, Zang, Zung
 }
 
-@objc(EnumRuntimeName) enum RuntimeNamed: Int {
+@objc(EnumRuntimeName) enum RuntimeNamed: Int32 {
   case Zim, Zang, Zung
 }
 


### PR DESCRIPTION
Int is not always Int32.  Explicitly use Int32 to ensure that the type
is handled properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
