### PR TITLE
[test] Mark string_switch.swift as executable test.

### DIFF
--- a/validation-test/SILOptimizer/string_switch.swift
+++ b/validation-test/SILOptimizer/string_switch.swift
@@ -3,6 +3,7 @@
 // RUN: %target-run %t.out
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: stress_test
+// REQUIRES: executable_test
 // UNSUPPORTED: nonatomic_rc
 
 import StdlibUnittest


### PR DESCRIPTION
The test might want to be split in two, because it does both checks for
the output of the compilation, and the run time itself, but for now mark
it as executable, so it doesn't break the Android test suite (which
cannot execute tests).

/cc @davezarzycki 