### PR TITLE
[android][tests] Pass Android include paths to sil-opt for testing.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1036,6 +1036,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_sil_opt = ' '.join([
         config.sil_opt,
         '-target', config.variant_triple,
+        android_include_paths_opt,
         resource_dir_opt, mcp_opt, config.sil_test_options])
     config.target_swift_ide_test = ' '.join([
         config.swift_ide_test,


### PR DESCRIPTION
The Android NDK has the SDK for each architecture in one place, while
the headers are in an unified sysroot. This makes the --sdk option
insufficient for compiling GlibC. This commits adds the include paths so
the test can succeed.

Fixes `SIL/verify_all_overlays.py` in Android.