### PR TITLE
multifile: make protocol-conformance-member pass on Windows

### DIFF
--- a/test/multifile/Inputs/protocol-conformance-member-helper.swift
+++ b/test/multifile/Inputs/protocol-conformance-member-helper.swift
@@ -1,3 +1,3 @@
-struct CoolStruct {
-  let coolFactor: Double
+public struct CoolStruct {
+  public let coolFactor: Double
 }

--- a/test/multifile/protocol-conformance-member.swift
+++ b/test/multifile/protocol-conformance-member.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library %s %S/Inputs/protocol-conformance-member-helper.swift -o %t/%target-library-name(Test) -module-name Test
-// RUN: llvm-nm %t/%target-library-name(Test) | %FileCheck %s
+// RUN: llvm-readobj -symbols -coff-exports %t/%target-library-name(Test) | %FileCheck %s
 
-// CHECK: $s4Test10CoolStructV10coolFactorSdvg
+// CHECK: Name: {{_?}}$s4Test10CoolStructV10coolFactorSdvg
 
 // SR-156: Make sure we synthesize getters for members used as protocol
 // witnesses. Check that we link correctly; we don't care which file


### PR DESCRIPTION
PE/COFF does not include a symbol table in the generated executable
binary.  Instead, use `public` to expose the getter, and then use
`-coff-exports` from `llvm-readobj` to get the symbols that are
exported.  Fortunately, the same tool can be used to list the symbol
table contents for ELF and MachO binary.  This allows us to share the
test across all the targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
