### PR TITLE
Fix test/decl/import/import.swift on Windows

### DIFF
--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: echo "public struct X {}; public var x = X()" | %target-swift-frontend -module-name import_builtin -parse-stdlib -emit-module -o %t -
 // RUN: echo "public func foo() -> Int { return false }" > %t/import_text.swift
-// RUN: echo "public func pho$(printf '\xC3\xBB')x() -> Int { return false }" > %t/fran$(printf '\xC3\xA7')ais.swift
+// RUN: echo "public func phoûx() -> Int { return false }" > %t/français.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal -verify-ignore-unknown
 
 // -verify-ignore-unknown is for:


### PR DESCRIPTION
Lit supports inline utf8 so do that instead of a subshell. This fixes
the test on Windows.