### PR TITLE
[android][test] Disabling autolinking tests for Android AArch64

### DIFF
--- a/test/ClangImporter/MixedSource/autolinking.swift
+++ b/test/ClangImporter/MixedSource/autolinking.swift
@@ -2,10 +2,7 @@
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.
-// UNSUPPORTED: OS=linux-gnu
-// UNSUPPORTED: OS=linux-gnueabihf
-// UNSUPPORTED: OS=freebsd
-// UNSUPPORTED: OS=linux-androideabi
+// UNSUPPORTED: autolink-extract
 
 // Use a type declared in the Clang part of the module.
 public let y = Test()

--- a/test/ClangImporter/autolinking.swift
+++ b/test/ClangImporter/autolinking.swift
@@ -14,10 +14,7 @@
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.
-// UNSUPPORTED: OS=linux-gnu
-// UNSUPPORTED: OS=linux-gnueabihf
-// UNSUPPORTED: OS=freebsd
-// UNSUPPORTED: OS=linux-androideabi
+// UNSUPPORTED: autolink-extract
 
 import LinkMusket
 import LinkFramework

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -11,10 +11,7 @@
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.
-// UNSUPPORTED: OS=linux-gnu
-// UNSUPPORTED: OS=linux-gnueabihf
-// UNSUPPORTED: OS=freebsd
-// UNSUPPORTED: OS=linux-androideabi
+/// UNSUPPORTED: autolink-extract
 
 import autolinking_module_inferred
 

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -21,10 +21,7 @@
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.
-// UNSUPPORTED: OS=linux-gnu
-// UNSUPPORTED: OS=linux-gnueabihf
-// UNSUPPORTED: OS=freebsd
-// UNSUPPORTED: OS=linux-androideabi
+// UNSUPPORTED: autolink-extract
 
 import someModule
 


### PR DESCRIPTION
The OS sadly changes between Android ARMv7 and Android AArch64, to
avoid this and any future problems, mark the autolinking tests that
I can find with `UNSUPPORTED: autolink-extract`, which should apply
to all platforms that need autolink-extract.

This should remove these tests from failing in Android 64.
