### PR TITLE
[TSan] TSan runtime now requires libdispatch at link time

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -299,8 +299,10 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
       if (context.OI.SelectedSanitizers & SanitizerKind::Address)
         addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "asan", *this);
 
-      if (context.OI.SelectedSanitizers & SanitizerKind::Thread)
+      if (context.OI.SelectedSanitizers & SanitizerKind::Thread) {
         addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "tsan", *this);
+        Arguments.push_back("-ldispatch");
+      }
 
       if (context.OI.SelectedSanitizers & SanitizerKind::Undefined)
         addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "ubsan", *this);


### PR DESCRIPTION
This change should have been part of the following PR:
https://github.com/apple/swift/pull/23455
