### PR TITLE
DebugInfo: deal with absolute path on Windows

### DIFF
--- a/test/DebugInfo/line-directive.swift
+++ b/test/DebugInfo/line-directive.swift
@@ -8,7 +8,10 @@ func f() {
   markUsed("Test")
 #sourceLocation(file: "abc.swift", line: 142)
   markUsed("abc again")
-#sourceLocation(file: "/absolute/path/def.swift", line:  142)
+  // NOTE: we use `//absolute/path` here as this is an absolute path on the
+  // alternate root.  However, it is also a path which is a UNC path on Windows.
+  // This allows the path to be absolute across both environments.
+#sourceLocation(file: "//absolute/path/def.swift", line:  142)
   markUsed("jump directly to def")
 }
 
@@ -19,7 +22,7 @@ func f() {
 // CHECK: .loc	[[ABC]] 42
 // CHECK: .loc	[[MAIN]] 8
 // CHECK: .loc	[[ABC]] 142
-// CHECK: .file	[[DEF:.*]] "/absolute/path/def.swift"
+// CHECK: .file	[[DEF:.*]] "//absolute/path{{/|\\\\}}def.swift"
 // CHECK: .loc	[[DEF]] 142
 // CHECK: .asciz "{{.*}}test/DebugInfo"
 
@@ -32,6 +35,6 @@ func f() {
 // VFS: .loc  [[ABC]] 42
 // VFS: .loc  [[MAIN]] 8
 // VFS: .loc  [[ABC]] 142
-// VFS: .file  [[DEF:.*]] "/absolute/path/def.swift"
+// VFS: .file  [[DEF:.*]] "//absolute/path{{/|\\\\}}def.swift"
 // VFS: .loc  [[DEF]] 142
 // VFS: .asciz "{{.*}}test/DebugInfo"


### PR DESCRIPTION
Windows absolute paths are either UNC paths (begin with \\) or are
rooted with a drive letter.  Unfortunately, we cannot conditionalise the
path itself on the OS type.  On Unices // indicates the alternate root
path as per POSIX.  However, Linux does not implement this and // is
treated as /.  Use this to create a path that appears to be absolute on
all the targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
