### PR TITLE
DebugInfo: account for quoting on Windows

### DIFF
--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -18,5 +18,5 @@
 // Check that we don't write temporary file names in the debug info
 // RUN: env TMP=abc/def TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -debug-info-store-invocation -o - | %FileCheck --check-prefix CHECK-TEMP %s
 // RUN: env TMP=%t TMPDIR=%t %target-swift-frontend %s -I %t/xyz -g -emit-ir -debug-info-store-invocation -o - | %FileCheck --check-prefix CHECK-TEMP %s
-// CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>
+// CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I {{(\\22)?}}<temporary-file>
 


### PR DESCRIPTION
Windows will quote the temporary path.  Account for it in the test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
