### PR TITLE
[CSSimplify] Teach disjunction filtering that some enum cases have curried self

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -132,8 +132,11 @@ bool constraints::areConservativelyCompatibleArgumentLabels(
     hasCurriedSelf = false;
   } else if (baseType->is<AnyMetatypeType>() && decl->isInstanceMember()) {
     hasCurriedSelf = false;
-  } else if (isa<EnumElementDecl>(decl)) {
-    hasCurriedSelf = false;
+  } else if (auto *EED = dyn_cast<EnumElementDecl>(decl)) {
+    // enum elements have either `(Self.Type) -> (Arg...) -> Self`, or
+    // `(Self.Type) -> Self`, in the former case self type has to be
+    // stripped off.
+    hasCurriedSelf = bool(EED->getParameterList());
   } else {
     hasCurriedSelf = true;
   }

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -124,3 +124,34 @@ func rdar34583132() {
     }
   }
 }
+
+func rdar_49159472() {
+  struct A {}
+  struct B {}
+  struct C {}
+
+  enum E {
+  case foo(a: A, b: B?)
+
+    var foo: C? {
+      return nil
+    }
+  }
+
+  class Test {
+    var e: E
+
+    init(_ e: E) {
+      self.e = e
+    }
+
+    func bar() {
+      e = .foo(a: A(), b: nil)   // Ok
+      e = E.foo(a: A(), b: nil)  // Ok
+      baz(e: .foo(a: A(), b: nil))  // Ok
+      baz(e: E.foo(a: A(), b: nil)) // Ok
+    }
+
+    func baz(e: E) {}
+  }
+}


### PR DESCRIPTION
Cases with arguments form `(Self.Type) -> (Arg...) -> Self`
function types, so `areConservativelyCompatibleArgumentLabels`
should remove curried self before trying to match argument/parameter
labels.

Resolves: rdar://problem/49159472

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
