### PR TITLE
[AutoDiff] Improve `AnyDerivative` fatal error message.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -539,7 +539,7 @@ extension _AnyDerivativeBox {
 internal func _derivativeTypeMismatch(
   _ x: Any.Type, _ y: Any.Type, file: StaticString = #file, line: UInt = #line
 ) -> Never {
-  fatalError("""
+  preconditionFailure("""
     Derivative type mismatch: \
     \(String(reflecting: x)) and \(String(reflecting: y))
     """, file: file, line: line)

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -539,7 +539,10 @@ extension _AnyDerivativeBox {
 internal func _derivativeTypeMismatch(
   _ x: Any.Type, _ y: Any.Type, file: StaticString = #file, line: UInt = #line
 ) -> Never {
-  fatalError("Derivative type mismatch: \(x) and \(y)", file: file, line: line)
+  fatalError("""
+    Derivative type mismatch: \
+    \(String(reflecting: x)) and \(String(reflecting: y))
+    """, file: file, line: line)
 }
 
 internal struct _ConcreteDerivativeBox<T> : _AnyDerivativeBox


### PR DESCRIPTION
Show fully qualified type names in derivative type mismatch message.

---
Example:
```swift
struct Generic<T: Differentiable> : Differentiable {
  let x: T
}
var tan = AnyDerivative(Generic<Float>.TangentVector(x: 1))
let cotan = AnyDerivative(Generic<Float>.CotangentVector(x: 3))
print(tan + cotan)
```

Previously:
`Fatal error: Derivative type mismatch: TangentVector and CotangentVector`

Now:
`Fatal error: Derivative type mismatch: main.Generic<Swift.Float>.TangentVector and main.Generic<Swift.Float>.CotangentVector`