### PR TITLE
[SR-10128] fix crash in metatype fulfillment search

### DIFF
--- a/test/IRGen/metatype_fulfillment_SR10128.swift
+++ b/test/IRGen/metatype_fulfillment_SR10128.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+protocol ProtoA { }
+
+protocol ProtoB {
+    associatedtype T: ProtoA
+    var stuff: Int { get }
+}
+
+extension ProtoB {
+    var stuff: Int {
+        return 0
+    }
+}
+
+class Foo<T: ProtoA>: ProtoB { }


### PR DESCRIPTION
This patch resolves https://bugs.swift.org/browse/SR-10128

In `requirements.enumerateFulfillments` in `FulfillmentMap::searchNominalTypeMetadata`,
sometimes archetype has requirement but has not conformance corresponding it.
It happens when conformance is erased by equivalence group 
in building minimized generic signature in sema stage.

For example:

```swift
protocol ProtoA {}
protocol ProtoB {
    associatedtype T: ProtoA
    var stuff: Int { get }
}
extension ProtoB {
    var stuff: Int { return 0 }
}
extension Int : ProtoA {}
class Foo<X: ProtoA>: ProtoB {
    typealias T = X
}
```

With this code,
`Foo.stuff` conformance for `ProtoB` has this signature.

```swift
sil private [transparent] [thunk] @$S2ng3FooCyqd__GAA6ProtoBA2aEP5stuffSivgTW :
 $@convention(witness_method: ProtoB) 
<τ_0_0><τ_1_0 where τ_0_0 : Foo<τ_1_0>> (@in_guaranteed τ_0_0) -> Int 
```

`τ_1_0` from `Foo.X` does not have requirement `: ProtoA`.
Because this is conformed already in conformance of `Self: Foo<τ_1_0>, Self: ProtoB` via `ProtoB.T`.

But this requirement checked in `enumerateFulfillments`.
Because `GenericTypeRequirements` is built from `NominalTypeDecl` of `Foo`.
In logic after here to search metatype fulfillments from witness table,
compiler will crash by null pointer access of `ProtocolConformanceRef`.

So I check this situation by `ProtocolConformanceRef.isInvalid` and simply skip it.

Sorry I did not add test case yet.
I don't know where is best location to add it.
If patch itself is reasonable, please tell me for test location.
