### PR TITLE
LLVMPasses: addjust for SVN r356783

### DIFF
--- a/lib/LLVMPasses/LLVMSwiftAA.cpp
+++ b/lib/LLVMPasses/LLVMSwiftAA.cpp
@@ -41,7 +41,8 @@ ModRefInfo SwiftAAResult::getModRefInfo(const llvm::CallBase *Call,
     return ModRefInfo::NoModRef;
 
   // Otherwise, delegate to the rest of the AA ModRefInfo machinery.
-  return AAResultBase::getModRefInfo(Call, Loc);
+  AAQueryInfo AAQI;
+  return AAResultBase::getModRefInfo(Call, Loc, AAQI);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
SVN r356783 added a new parameter to `modRefInfo` for caching the results.
Update the API usage.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
