### PR TITLE
[NFC] Remove unnecessary REQUIRES from test

### DIFF
--- a/test/SILGen/tsan_instrumentation.swift
+++ b/test/SILGen/tsan_instrumentation.swift
@@ -1,9 +1,5 @@
 // RUN: %target-swift-emit-silgen -sanitize=thread %s | %FileCheck %s
-// REQUIRES: tsan_runtime
-
-// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
-// don't support TSan.
-// UNSUPPORTED: remote_run
+// REQUIRES: PTRSIZE=64
 
 func takesInout(_ p: inout Int) { }
 func takesInout(_ p: inout MyStruct) { }

--- a/test/Sanitizers/tsan-static-exclusivity.swift
+++ b/test/Sanitizers/tsan-static-exclusivity.swift
@@ -1,10 +1,4 @@
 // RUN: %target-swift-frontend -enforce-exclusivity=checked -sanitize=thread -emit-sil -primary-file %s -o /dev/null -verify
-// REQUIRES: tsan_runtime
-
-// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
-// don't support TSan.
-// UNSUPPORTED: remote_run
-
 
 struct OtherStruct {
   mutating


### PR DESCRIPTION
This test targets the swift frontend and never runs, so we don't require
the TSan runtime.
