### PR TITLE
[lit] Stub out lit feature detection on non-Apple platforms

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -633,10 +633,6 @@ if run_vendor == 'apple':
         { 'macosx': 'macos', 'darwin': 'macos' }.get(run_os, run_os)
     )
 
-    config.available_features.add('libdispatch')
-    config.available_features.add('foundation')
-    config.available_features.add('objc_interop')
-
     config.target_object_format = "macho"
     config.target_shared_library_prefix = 'lib'
     config.target_shared_library_suffix = ".dylib"
@@ -1419,5 +1415,26 @@ if platform.system() == 'Linux':
     if distributor != '' and release != '':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))
+
+if run_vendor == 'apple':
+    config.available_features.add('libdispatch')
+    config.available_features.add('foundation')
+    config.available_features.add('objc_interop')
+else:
+    # TODO(yln): Works with the packaged swift distribution, but not during build.
+    #            We need to make libdispatch/foundation available in the test resource directory
+    #            or pass along the proper library include paths in the compiler invocations that are used
+    #            to build the tests.
+    def has_lib(name):
+        return False
+
+    if has_lib('dispatch'):
+        config.available_features.add('libdispatch')
+    else:
+        # TSan runtime requires libdispatch on non-Apple platforms
+        config.available_features.remove('tsan_runtime')
+
+    if has_lib('Foundation'):
+        config.available_features.add('foundation')
 
 lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))


### PR DESCRIPTION
Quick fix for an oversight on my part that slipped through CI in my previous PR (https://github.com/apple/swift/pull/23455): the TSan runtime now has a link-time dependency on libdispatch (unfortunately).
This temporarily disables the following two tests on Linux to unbreak CI build.

Swift(linux-x86_64) :: Sanitizers/witness_table_lookup.swift
Swift(linux-x86_64) :: Sanitizers/tsan.swift

The above two tests are also the only 2 TSan (executable) tests that are run on Linux. Once I fix the TODO mentioned in this PR, I will go through all `REQUIRES: tsan_runtime` occurences and try to enable them by using libdispatch/foundation instead of objc_interop.
