### PR TITLE
 Debug Info: Fix a bug when decoding the source file for a Clang Decl

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -241,11 +241,15 @@ private:
       return L;
 
     if (auto *ClangDecl = D->getClangDecl()) {
-      auto ClangSrcLoc = ClangDecl->getBeginLoc();
+      clang::SourceLocation ClangSrcLoc = ClangDecl->getBeginLoc();
       clang::SourceManager &ClangSM =
           CI.getClangASTContext().getSourceManager();
-      L.Line = ClangSM.getPresumedLineNumber(ClangSrcLoc);
-      L.Filename = ClangSM.getBufferName(ClangSrcLoc);
+      clang::PresumedLoc PresumedLoc = ClangSM.getPresumedLoc(ClangSrcLoc);
+      if (!PresumedLoc.isValid())
+        return L;
+      L.Line = PresumedLoc.getLine();
+      L.Column = PresumedLoc.getColumn();
+      L.Filename = PresumedLoc.getFilename();
       return L;
     }
     return getSwiftDebugLoc(DI, D, End);

--- a/test/DebugInfo/Inputs/Macro.h
+++ b/test/DebugInfo/Inputs/Macro.h
@@ -1,0 +1,7 @@
+#define MY_ENUM(NAME) \
+  enum NAME : int NAME; \
+  enum NAME : int
+
+MY_ENUM(macro_enum) {
+  zero = 0
+};

--- a/test/DebugInfo/Inputs/module.modulemap
+++ b/test/DebugInfo/Inputs/module.modulemap
@@ -15,3 +15,8 @@ module OtherClangModule {
     export *
   }
 }
+
+module Macro {
+  header "Macro.h"
+}
+

--- a/test/DebugInfo/macro.swift
+++ b/test/DebugInfo/macro.swift
@@ -1,0 +1,21 @@
+// REQUIRES: objc-interop
+// RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs -o - \
+// RUN:    -parse-as-library | %FileCheck %s
+
+// The source file for "macro_enum", which is defined using a macro, should be
+// correctly identified.
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "macro_enum",
+// CHECK-SAME:             file: ![[MACRO_H:[0-9]+]]
+// CHECK: ![[MACRO_H]] = !DIFile(filename: "{{.*}}/Inputs/Macro.h",
+
+import Macro
+
+public func f(_ e : macro_enum) -> Int32 {
+  switch (e) {
+  case zero:
+    return 0
+  default:
+    return e.rawValue
+  }
+}


### PR DESCRIPTION
that was defined using a Macro: Use the file of the presumed location,
not of the SourceBuffer.

rdar://problem/49181568
