### PR TITLE
[NFC][test] Making placeholder.swift test more portable without use of not

### DIFF
--- a/test/PlaygroundTransform/Inputs/not.py
+++ b/test/PlaygroundTransform/Inputs/not.py
@@ -1,0 +1,13 @@
+import shlex
+import subprocess
+import sys
+
+if len(sys.argv) < 2:
+    print("Too few args to " + sys.argv[0])
+    sys.exit(0)
+
+try:
+    subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
+    sys.exit(1)
+except subprocess.CalledProcessError as e:
+    sys.exit(0)

--- a/test/PlaygroundTransform/placeholder.swift
+++ b/test/PlaygroundTransform/placeholder.swift
@@ -3,19 +3,19 @@
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -o %t/main %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: ! %target-run %t/main --crash 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
+// RUN: %{python} %S/Inputs/not.py "%target-run %t/main --crash" 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
 // REQUIRES: executable_test
 
-// NOTE: "!" is used above instead of "not --crash" because simctl's exit
+// NOTE: not.py is used above instead of "not --crash" because simctl's exit
 // status doesn't reflect whether its child process crashed or not. So "not
 // --crash %target-run ..." always fails when testing for the iOS Simulator.
-// The more precise solution would be to use a version of 'not' cross-compiled
-// for the simulator.
+// not.py also works on win32, where ! does not.
+// Checking for ".[Ff]atal" because of d03a575279c.
 
 func f(crash crash: Bool) -> Int {
   if crash {
     return <#T#>
-    // CRASH-CHECK: fatal error: attempt to evaluate editor placeholder: file {{.*}}/main.swift, line [[@LINE-1]]
+    // CRASH-CHECK: {{[fF]}}atal error: attempt to evaluate editor placeholder: file {{.*}}/main.swift, line [[@LINE-1]]
   } else {
     return 42
   }


### PR DESCRIPTION

Also, it appears this test was not really working before because I had
to change the case of the error output to match properly.

<!-- What's in this pull request? -->

This PR alters swift/test/PlaygroundTransform/placeholder.swift so that it passes across more platforms. I did this using a pretty beefy python one-liner. In fact, it kind of appears that the way that the test was using ! instead of not, that it was consuming the error print output and just passing regardless. 