### PR TITLE
[android] Fix IRGen/condfail.sil test for Android ARMv7/AArch64.

### DIFF
--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -11,6 +11,7 @@ import Swift
 // CHECK-x86_64:      {{.cfi_startproc|Lfunc_begin}}
 // CHECK-i386:        .cfi_startproc
 // CHECK-arm64:       .cfi_startproc
+// CHECK-aarch64:     .cfi_startproc
 // CHECK-armv7:       Lfunc_begin
 // CHECK-armv7s:      Lfunc_begin
 // CHECK-powerpc64:   .cfi_startproc
@@ -22,23 +23,33 @@ import Swift
 // CHECK-OPT-linux:   ##NO_APP
 // CHECK-OPT-windows:   ##APP
 // CHECK-OPT-windows:   ##NO_APP
+// CHECK-OPT-linux-androideabi:   @APP
+// CHECK-OPT-linux-androideabi:   @NO_APP
+// CHECK-OPT-linux-android:       //APP
+// CHECK-OPT-linux-android:       //NO_APP
 // CHECK-NOOPT-macosx-NOT: ## InlineAsm Start
 // CHECK-NOOPT-macosx-NOT: ## InlineAsm End
 // CHECK-NOOPT-linux-NOT:  ##APP
 // CHECK-NOOPT-linux-NOT:  ##NO_APP
 // CHECK-NOOPT-windows-NOT:  ##APP
 // CHECK-NOOPT-windows-NOT:  ##NO_APP
+// CHECK-OPT-linux-androideabi-NOT:   @APP
+// CHECK-OPT-linux-androideabi-NOT:   @NO_APP
+// CHECK-OPT-linux-android-NOT:       //APP
+// CHECK-OPT-linux-android-NOT:       //NO_APP
 // CHECK-x86_64:      ud2
 // CHECK-i386:        ud2
 // CHECK-arm64:       brk
-// CHECK-armv7:       trap
-// CHECK-armv7s:      trap
+// CHECK-aarch64:     brk
+// CHECK-armv7:       {{trap|.inst 0xe7ffdefe}}
+// CHECK-armv7s:      {{trap|.inst 0xe7ffdefe}}
 // CHECK-powerpc64:   trap
 // CHECK-powerpc64le: trap
 // CHECK-s390x:       j       .Ltmp{{[0-9]+}}+2
 // CHECK-NOT-x86_64:      {{.cfi_endproc|Lfunc_end}}
 // CHECK-NOT-i386:        .cfi_endproc
 // CHECK-NOT-arm64:       .cfi_endproc
+// CHECK-NOT-aarch64:     .cfi_endproc
 // CHECK-NOT-armv7:       Lfunc_end
 // CHECK-NOT-armv7s:      Lfunc_end
 // CHECK-NOT-powerpc64:   .cfi_endproc
@@ -59,14 +70,16 @@ import Swift
 // CHECK-x86_64:      ud2
 // CHECK-i386:        ud2
 // CHECK-arm64:       brk
-// CHECK-armv7:       trap
-// CHECK-armv7s:      trap
+// CHECK-aarch64:     brk
+// CHECK-armv7:       {{trap|.inst 0xe7ffdefe}}
+// CHECK-armv7s:      {{trap|.inst 0xe7ffdefe}}
 // CHECK-powerpc64:   trap
 // CHECK-powerpc64le: trap
 // CHECK-s390x:       j       .Ltmp{{[0-9]+}}+2
 // CHECK-x86_64:      {{.cfi_endproc|Lfunc_end}}
 // CHECK-i386:        .cfi_endproc
 // CHECK-arm64:       .cfi_endproc
+// CHECK-aarch64:     .cfi_endproc
 // CHECK-armv7:       Lfunc_end
 // CHECK-armv7s:      Lfunc_end
 // CHECK-powerpc64:   .cfi_endproc


### PR DESCRIPTION
For AArch64, the fix is duplicating the arm64 lines, since those are not
taken when testing Android/Linux which use AArch64 as the architecture.

For ARMv7, the change is supporting both trap and .inst 0xe7ffdefe.
According to llvm/lib/Target/ARM/ARMAsmPrinter.cpp, non-Darwin binutils
do not support the mnemonic trap, so an .inst is emitted instead. The
same instruction has to be used in both places, though.

For both architectures add the Android version of APP/NO_APP, which uses
@-symbols instead of ##.
