### PR TITLE
[stdlib] Reintroduce _getBool for ABI

### DIFF
--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -13,6 +13,14 @@
 // This file contains non-API (or underscored) declarations that are needed to
 // be kept around for ABI compatibility
 
+// This is an old intrinsic known by the compiler, but exists solely for ABI
+// compatibility at this point.
+@available(swift, obsoleted: 5.0)
+@usableFromInline
+internal func _getBool(_ v: Builtin.Int1) -> Bool {
+  return Bool(v)
+}
+
 extension Unicode.UTF16 {
   @available(*, unavailable, renamed: "Unicode.UTF16.isASCII")
   @inlinable


### PR DESCRIPTION
https://github.com/apple/swift/pull/20948 didn't make the 5.0 branch. Reintroduce the API function as internal so that older binaries can still call it. As requested from Ben: https://github.com/apple/swift/pull/21872#issuecomment-464581970

cc: @airspeedswift 