### PR TITLE
test: emergency patch to repair the Windows CI

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1057,8 +1057,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         tools_directory,
         '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])
     # The Swift interpreter is not available when targeting Android.
-    if 'swift_interpreter' in config.available_features:
-        config.available_features.remove('swift_interpreter')
+    config.available_features.discard('swift_interpreter')
 
 else:
     lit_config.fatal("Don't know how to define target_run and "
@@ -1500,8 +1499,7 @@ else:
         config.available_features.add('libdispatch')
     else:
         # TSan runtime requires libdispatch on non-Apple platforms
-        if 'tsan_runtime' in config.available_features:
-            config.available_features.remove('tsan_runtime')
+        config.available_features.discard('tsan_runtime')
 
     if has_lib('Foundation'):
         config.available_features.add('foundation')

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1500,7 +1500,8 @@ else:
         config.available_features.add('libdispatch')
     else:
         # TSan runtime requires libdispatch on non-Apple platforms
-        config.available_features.remove('tsan_runtime')
+        if 'tsan_runtime' in config.available_features:
+            config.available_features.remove('tsan_runtime')
 
     if has_lib('Foundation'):
         config.available_features.add('foundation')


### PR DESCRIPTION
The removal of a key not in the set is an error.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
