### PR TITLE
build: attempt to dynamically detect libdispatch

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -178,6 +178,12 @@ foreach(SDK ${SWIFT_SDKS})
       set(SWIFT_HAVE_LIBXML2 FALSE)
     endif()
 
+    if(${SDK} IN_LIST SWIFT_APPLE_PLATFORMS OR SWIFT_NEED_EXPLICIT_LIBDISPATCH)
+      set(SWIFT_HAVE_LIBDISPATCH TRUE)
+    else()
+      set(SWIFT_HAVE_LIBDISPATCH FALSE)
+    endif()
+
     swift_configure_lit_site_cfg(
         "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
         "${test_bin_dir}/lit.site.cfg"

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1516,7 +1516,6 @@ if platform.system() == 'Linux':
         lit_config.note('Running tests on %s-%s' % (distributor, release))
 
 if run_vendor == 'apple':
-    config.available_features.add('libdispatch')
     config.available_features.add('foundation')
     config.available_features.add('objc_interop')
 else:
@@ -1527,10 +1526,8 @@ else:
     def has_lib(name):
         return False
 
-    if has_lib('dispatch'):
-        config.available_features.add('libdispatch')
-    else:
-        # TSan runtime requires libdispatch on non-Apple platforms
+    # TSan runtime requires libdispatch on non-Apple platforms
+    if 'libdispatch' not in config.available_features:
         config.available_features.discard('tsan_runtime')
 
     if has_lib('Foundation'):

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -100,6 +100,9 @@ else:
     # even if SWIFT_ENABLE_GOLD_LINKER isn't set, we cannot use BFD for Android
     config.android_linker_name = "gold"
 
+if "@SWIFT_HAVE_LIBDISPATCH@" == "TRUE":
+    config.available_features.add('libdispatch')
+
 # Let the main config do the real work.
 if config.test_exec_root is None:
     config.test_exec_root = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
We know during the build whether we are building libdispatch for the
toolchain or not.  This wires that into the test suite.  From a quick
inspection, it seems that the tests currently do not depend on the Swift
SDK overlay for libdispatch.  We can easily wire the library path for
libdispatch to the tests through the substitutions that we perform
through lit.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
