### PR TITLE
test: loosen restrictions on DebugInfo test

### DIFF
--- a/test/DebugInfo/macro.swift
+++ b/test/DebugInfo/macro.swift
@@ -1,4 +1,3 @@
-// REQUIRES: objc-interop
 // RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs -o - \
 // RUN:    -parse-as-library | %FileCheck %s
 


### PR DESCRIPTION
This test does not require ObjectiveC interop.  Enable the test
globally.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
