### PR TITLE
test: make DebugInfo.macro pass on Windows

### DIFF
--- a/test/DebugInfo/macro.swift
+++ b/test/DebugInfo/macro.swift
@@ -6,7 +6,7 @@
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "macro_enum",
 // CHECK-SAME:             file: ![[MACRO_H:[0-9]+]]
-// CHECK: ![[MACRO_H]] = !DIFile(filename: "{{.*}}/Inputs/Macro.h",
+// CHECK: ![[MACRO_H]] = !DIFile(filename: "{{.*}}{{(/|\\5C)}}Inputs{{(/|\\5C)}}Macro.h",
 
 import Macro
 


### PR DESCRIPTION
The path separator on Windows is \ which is encoded as \5C.  Account for
this in the test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
