### PR TITLE
Set up testing with the standard libraries coming from the OS

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -113,6 +113,8 @@ out with ``lit.py -h``. We document some of the more useful ones below:
 * ``--param swift_test_mode=<MODE>`` drives the various suffix variations
   mentioned above. Again, it's best to get the invocation from the existing
   build system targets and modify it rather than constructing it yourself.
+* ``--param use_os_stdlib`` will run all tests with the standard libraries
+  coming from the OS.
 
 ##### Remote testing options
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -12,9 +12,9 @@
 #
 # This is a configuration file for the 'lit' test runner.
 #
-# Refer to docs/Testing.rst for documentation.
+# Refer to docs/Testing.md for documentation.
 #
-# Update docs/Testing.rst when changing this file.
+# Update docs/Testing.md when changing this file.
 #
 # -----------------------------------------------------------------------------
 
@@ -1032,6 +1032,15 @@ if (not getattr(config, 'target_run', None) and
     remote_run_host = lit_config.params['remote_run_host']
     remote_tmp_dir = lit_config.params['remote_run_tmpdir']
     remote_lib_dir = os.path.join(remote_tmp_dir, 'stdlib')
+    remote_run_lib_path = ''
+    if 'use_os_stdlib' not in lit_config.params:
+        remote_run_lib_path = remote_lib_dir
+    else:
+        os_stdlib_path = ''
+        if run_vendor == 'apple':
+            #If we get swift-in-the-OS for non-Apple platforms, add a condition here
+            os_stdlib_path = "/usr/lib/swift"
+        remote_run_lib_path = os.path.pathsep.join((os_stdlib_path, remote_lib_dir))
 
     remote_run_extra_args_param = lit_config.params.get('remote_run_extra_args')
     remote_run_extra_args = shlex.split(remote_run_extra_args_param or '')
@@ -1080,7 +1089,7 @@ if (not getattr(config, 'target_run', None) and
         "REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='{0}' " # Apple option
         "REMOTE_RUN_CHILD_LD_LIBRARY_PATH='{0}' " # Linux option
         "'{1}'/remote-run --input-prefix '{2}' --output-prefix %t "
-        "--remote-dir '{3}'%t {4} {5}".format(remote_lib_dir,
+        "--remote-dir '{3}'%t {4} {5}".format(remote_run_lib_path,
                                               config.swift_utils,
                                               config.swift_src_root,
                                               remote_tmp_dir,
@@ -1400,6 +1409,29 @@ if os.path.exists(libswiftCore_path):
     config.available_features.add("static_stdlib")
     config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
     lit_config.note('using static stdlib path: %s' % static_stdlib_path)
+
+# Set up testing with the standard libraries coming from the OS / just-built libraries
+# default Swift tests to use the just-built libraries
+target_stdlib_path = platform_module_dir
+if 'use_os_stdlib' not in lit_config.params:
+	lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
+	config.target_run = (
+        "/usr/bin/env "
+        "DYLD_LIBRARY_PATH='{0}' " # Apple option
+        "LD_LIBRARY_PATH='{0}' " # Linux option
+        .format(target_stdlib_path))
+else:
+	os_stdlib_path = ''
+	if run_vendor == 'apple':
+		#If we get swift-in-the-OS for non-Apple platforms, add a condition here
+		os_stdlib_path = "/usr/lib/swift"
+	all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
+	lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
+	config.target_run = (
+        "/usr/bin/env "
+        "DYLD_LIBRARY_PATH='{0}' " # Apple option
+        "LD_LIBRARY_PATH='{0}' " # Linux option
+        .format(all_stdlib_path))
 
 if config.lldb_build_root != "":
     config.available_features.add('lldb')


### PR DESCRIPTION
We  default Swift tests to use the just-built libraries
See radars rdar://problem/35163663 and rdar://problem/42176864

cherry-pick of https://github.com/apple/swift/pull/23583 to 5.1 branch