### PR TITLE
[Driver][NFC] Define sanitizer mapping <kind, name, file> in one place

### DIFF
--- a/include/swift/Basic/Sanitizers.def
+++ b/include/swift/Basic/Sanitizers.def
@@ -1,0 +1,28 @@
+//===--- Sanitizers.def - Swift Sanitizers ß----------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the sanitizers supported by Swift.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SANITIZER
+#error "Define SANITIZER prior to including this file!"
+#endif
+
+// SANITIZER(enum_bit, kind, name, file)
+
+SANITIZER(0, Address,   address,    asan)
+SANITIZER(1, Thread,    thread,     tsan)
+SANITIZER(2, Undefined, undefined,  ubsan)
+SANITIZER(3, Fuzzer,    fuzzer,     fuzzer)
+
+#undef SANITIZER

--- a/include/swift/Basic/Sanitizers.h
+++ b/include/swift/Basic/Sanitizers.h
@@ -17,10 +17,8 @@ namespace swift {
 
 // Enabling bitwise masking.
 enum class SanitizerKind : unsigned {
-  Address = 1 << 1,
-  Thread = 1 << 2,
-  Fuzzer = 1 << 3,
-  Undefined = 1 << 4
+  #define SANITIZER(enum_bit, kind, name, file) kind = (1 << enum_bit),
+  #include "Sanitizers.def"
 };
 
 } // end namespace swift

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -31,30 +31,27 @@ using namespace swift;
 
 static StringRef toStringRef(const SanitizerKind kind) {
   switch (kind) {
-  case SanitizerKind::Address:
-    return "address";
-  case SanitizerKind::Thread:
-    return "thread";
-  case SanitizerKind::Fuzzer:
-    return "fuzzer";
-  case SanitizerKind::Undefined:
-    return "undefined";
+    #define SANITIZER(_, kind, name, file) \
+        case SanitizerKind::kind: return #name;
+    #include "swift/Basic/Sanitizers.def"
   }
-  llvm_unreachable("Unsupported sanitizer");
+  llvm_unreachable("Unknown sanitizer");
 }
 
-static const char* toFileName(const SanitizerKind kind) {
+static StringRef toFileName(const SanitizerKind kind) {
   switch (kind) {
-  case SanitizerKind::Address:
-    return "asan";
-  case SanitizerKind::Thread:
-    return "tsan";
-  case SanitizerKind::Fuzzer:
-    return "fuzzer";
-  case SanitizerKind::Undefined:
-    return "ubsan";
+    #define SANITIZER(_, kind, name, file) \
+        case SanitizerKind::kind: return #file;
+    #include "swift/Basic/Sanitizers.def"
   }
-  llvm_unreachable("Unsupported sanitizer");
+  llvm_unreachable("Unknown sanitizer");
+}
+
+static Optional<SanitizerKind> parse(const char* arg) {
+  return llvm::StringSwitch<Optional<SanitizerKind>>(arg)
+      #define SANITIZER(_, kind, name, file) .Case(#name, SanitizerKind::kind)
+      #include "swift/Basic/Sanitizers.def"
+      .Default(None);
 }
 
 llvm::SanitizerCoverageOptions swift::parseSanitizerCoverageArgValue(
@@ -133,35 +130,34 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
   OptionSet<SanitizerKind> sanitizerSet;
 
   // Find the sanitizer kind.
-  for (int i = 0, n = A->getNumValues(); i != n; ++i) {
-    auto kind = llvm::StringSwitch<Optional<SanitizerKind>>(A->getValue(i))
-        .Case("address", SanitizerKind::Address)
-        .Case("thread", SanitizerKind::Thread)
-        .Case("fuzzer", SanitizerKind::Fuzzer)
-        .Case("undefined", SanitizerKind::Undefined)
-        .Default(None);
-    bool isShared = kind && *kind != SanitizerKind::Fuzzer;
-    if (!kind) {
+  for (const char *arg : A->getValues()) {
+    Optional<SanitizerKind> optKind = parse(arg);
+
+    // Unrecognized sanitizer option
+    if (!optKind.hasValue()) {
       Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
-          A->getOption().getPrefixedName(), A->getValue(i));
+          A->getOption().getPrefixedName(), arg);
+      continue;
+    }
+    SanitizerKind kind = optKind.getValue();
+
+    // Support is determined by existance of the sanitizer library.
+    auto fileName = toFileName(kind);
+    bool isShared = (kind != SanitizerKind::Fuzzer);
+    bool sanitizerSupported = sanitizerRuntimeLibExists(fileName, isShared);
+
+    // TSan is explicitly not supported for 32 bits.
+    if (kind == SanitizerKind::Thread && !Triple.isArch64Bit())
+      sanitizerSupported = false;
+
+    if (!sanitizerSupported) {
+      SmallString<128> b;
+      Diags.diagnose(SourceLoc(), diag::error_unsupported_opt_for_target,
+                      (A->getOption().getPrefixedName() + toStringRef(kind))
+                          .toStringRef(b),
+                      Triple.getTriple());
     } else {
-      // Support is determined by existance of the sanitizer library.
-      bool sanitizerSupported =
-          sanitizerRuntimeLibExists(toFileName(*kind), isShared);
-
-      // TSan is explicitly not supported for 32 bits.
-      if (*kind == SanitizerKind::Thread && !Triple.isArch64Bit())
-        sanitizerSupported = false;
-
-      if (!sanitizerSupported) {
-        SmallString<128> b;
-        Diags.diagnose(SourceLoc(), diag::error_unsupported_opt_for_target,
-                       (A->getOption().getPrefixedName() + toStringRef(*kind))
-                           .toStringRef(b),
-                       Triple.getTriple());
-      } else {
-        sanitizerSet |= *kind;
-      }
+      sanitizerSet |= kind;
     }
   }
 
@@ -191,10 +187,12 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
 
 std::string swift::getSanitizerList(const OptionSet<SanitizerKind> &Set) {
   std::string list;
-  if (Set & SanitizerKind::Address) list += "address,";
-  if (Set & SanitizerKind::Thread) list += "thread,";
-  if (Set & SanitizerKind::Fuzzer) list += "fuzzer,";
-  if (Set & SanitizerKind::Undefined) list += "undefined,";
-  if (!list.empty()) list.pop_back(); // Remove last comma
+  #define SANITIZER(_, kind, name, file) \
+      if (Set & SanitizerKind::kind) list += #name ",";
+  #include "swift/Basic/Sanitizers.def"
+
+  if (!list.empty())
+    list.pop_back(); // Remove last comma
+
   return list;
 }

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -106,7 +106,7 @@
 
 // UBSAN: -rpath @executable_path
 
-// MULTIPLE_SAN_LINUX: -fsanitize=address,fuzzer,undefined
+// MULTIPLE_SAN_LINUX: -fsanitize=address,undefined,fuzzer
 
 // BADARG: unsupported argument 'unknown' to option '-sanitize='
 // INCOMPATIBLESANITIZERS: argument '-sanitize=address' is not allowed with '-sanitize=thread'


### PR DESCRIPTION
Lower maintenance cost for explicit mapping between sanitizer enum and string values.
