### PR TITLE
Add DebugPrefixMap remapping back to module creation

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -637,6 +637,8 @@ private:
     if (Val != DIModuleCache.end())
       return cast<llvm::DIModule>(Val->second);
 
+    std::string RemappedIncludePath = DebugPrefixMap.remapPath(IncludePath);
+
     // For Clang modules / PCH, create a Skeleton CU pointing to the PCM/PCH.
     bool CreateSkeletonCU = !ASTFile.empty();
     bool IsRootModule = !Parent;
@@ -644,7 +646,7 @@ private:
       llvm::DIBuilder DIB(M);
       DIB.createCompileUnit(IGM.ObjCInterop ? llvm::dwarf::DW_LANG_ObjC
                                             : llvm::dwarf::DW_LANG_C99,
-                            DIB.createFile(Name, IncludePath),
+                            DIB.createFile(Name, RemappedIncludePath),
                             TheCU->getProducer(), true, StringRef(), 0, ASTFile,
                             llvm::DICompileUnit::FullDebug, Signature);
       DIB.finalize();
@@ -652,7 +654,8 @@ private:
 
     StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
     llvm::DIModule *M =
-        DBuilder.createModule(Parent, Name, ConfigMacros, IncludePath, Sysroot);
+        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath,
+                              Sysroot);
     DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
     return M;
   }

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -1,7 +1,12 @@
-// RUN: %swiftc_driver -g -debug-prefix-map %/S=/var/empty %/s -emit-ir -o - | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
+// RUN: %swiftc_driver -g -debug-prefix-map %/S=/var/empty -debug-prefix-map %t=/var/empty %/s -I %t -emit-ir -o - | %FileCheck %s
+
+import Globals
 
 func square(_ n: Int) -> Int {
   return n * n
 }
 
 // CHECK: !DIFile(filename: "/var/empty/debug_prefix_map.swift"
+// CHECK: !DIModule(scope: null, name: "Globals", includePath: "/var/empty/Globals.swiftmodule"

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
-// RUN: %swiftc_driver -g -debug-prefix-map %/S=/var/empty -debug-prefix-map %t=/var/empty %/s -I %t -emit-ir -o - | %FileCheck %s
+// RUN: %target-swiftc_driver -g -debug-prefix-map %/S=/var/empty -debug-prefix-map %t=/var/empty %/s -I %t -emit-ir -o - | %FileCheck %s
 
 import Globals
 


### PR DESCRIPTION
@adrian-prantl This was accidentally removed in commit 10004edf49e39f98f2c7498f9c15a79d364eb05c.

EDIT: Also would be great to merge this into swift-5.0-branch (minor update) if possible. Thanks!