### PR TITLE
test: disable Index.Store.output-failure on Windows

### DIFF
--- a/test/Index/Store/output-failure.swift
+++ b/test/Index/Store/output-failure.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/idx
+// UNSUPPORTED: OS=windows-msvc
 
 // Before indexing, do a dry-run to ensure any clang modules are cached. We
 // want to isolate the error that comes from swift's indexing support, not


### PR DESCRIPTION
`chmod -w` really doesn't make sense on Windows.  Although NTFS allows
for readonly directories, it is something done through file system level
ACLs.  This test doesn't really apply to Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
