### PR TITLE
test: make IDE.complete_with_multiple_imports work on Windows

### DIFF
--- a/test/IDE/Inputs/mock-sdk/FooHelper.framework/Frameworks/FooHelperSub.framework/Headers/FooHelperSub.h
+++ b/test/IDE/Inputs/mock-sdk/FooHelper.framework/Frameworks/FooHelperSub.framework/Headers/FooHelperSub.h
@@ -1,3 +1,7 @@
+
+#ifndef FooHelperSub_FooHelperSub_h
+#define FooHelperSub_FooHelperSub_h
+
 int fooHelperSubFunc1(int a);
 
 enum FooHelperSubEnum1 {
@@ -8,4 +12,6 @@ enum FooHelperSubEnum1 {
 enum {
   FooHelperSubUnnamedEnumeratorA1
 };
+
+#endif
 

--- a/test/IDE/Inputs/mock-sdk/FooHelper.framework/Headers/FooHelper.h
+++ b/test/IDE/Inputs/mock-sdk/FooHelper.framework/Headers/FooHelper.h
@@ -1,4 +1,8 @@
-#import <FooHelperSub/FooHelperSub.h>
+
+#ifndef FooHelper_FooHelper_h
+#define FooHelper_FooHelper_h
+
+#include <FooHelperSub/FooHelperSub.h>
 
 int fooHelperFunc1(int a);
 
@@ -6,4 +10,6 @@ enum {
   FooHelperUnnamedEnumeratorA1,
   FooHelperUnnamedEnumeratorA2,
 };
+
+#endif
 


### PR DESCRIPTION
`#import` has target dependent behaviour.  Rather than enabling ObjC
interop, switch to `#include` with include guards.  This permits the IDE
tests to fully pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
