### PR TITLE
build-script fix for --extra-swift-args.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -763,8 +763,8 @@ class BuildScriptInvocation(object):
         # add them as one command.
         if args.extra_swift_args:
             impl_args += [
-                "--extra-swift-args",
-                ";".join(args.extra_swift_args)]
+                "--extra-swift-args=%s" % ';'.join(args.extra_swift_args)
+            ]
 
         # If we have extra_cmake_options, combine all of them together and then
         # add them as one command.


### PR DESCRIPTION
Passing an empty string to this option either as
"--extra-swift-args=''" or "--extra-swift-args ''" would cause
build-script-impl to fail to parse some arbitrary number of other
options.

This is impossible to debug from the build log because all of the
build-script-impl options still show up in the log. So, cutting and
pasting the build-script-impl command actually works.

Turns out this is why build-script build and install stages never
worked for me, beyond running cmake.