### PR TITLE
test: make Frontend.dependencies pass on Windows

### DIFF
--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -10,7 +10,7 @@
 // CHECK-BASIC-LABEL: - :
 // CHECK-BASIC: Inputs/empty\ file.swift
 // CHECK-BASIC: Swift.swiftmodule
-// CHECK-BASIC-NOT: {{[^\\]}}:
+// CHECK-BASIC-NOT: {{ }}:{{ }}
 
 // CHECK-BASIC-YAML-LABEL: depends-external:
 // CHECK-BASIC-YAML-NOT: empty\ file.swift
@@ -37,7 +37,7 @@
 // CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.h :
 // CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
-// CHECK-MULTIPLE-OUTPUTS-NOT: {{[^\\]}}:
+// CHECK-MULTIPLE-OUTPUTS-NOT: {{ }}:{{ }}
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s


### PR DESCRIPTION
Windows absolute paths contain [A-Z]:.  Filter out the explicit ' : '
separator that we were trying to check for to allow the test to pass on
Windows as well.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
