### PR TITLE
test: make Misc.dump_api pass on Windows

### DIFF
--- a/test/Misc/dump_api.swift
+++ b/test/Misc/dump_api.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -dump-api-path %t.dump
-// RUN: diff -du %S/Inputs/dumped_api.swift %t.dump/dump_api.swift
+// RUN: diff -u %S/Inputs/dumped_api.swift %t.dump/dump_api.swift
 
 public class _AnyIteratorBase {}
 


### PR DESCRIPTION
`diff` may be intercepted by lit which does not support the `-d` option.
This doesn't really help much for the line differences, so, remove the
`-d` option.  This allows the test to pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
