### PR TITLE
Convert ArrayExpr to not use callWitness() or generate a SemanticExpr.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2207,6 +2207,7 @@ public:
 class CollectionExpr : public Expr {
   SourceLoc LBracketLoc;
   SourceLoc RBracketLoc;
+  ConcreteDeclRef Initializer;
 
   Expr *SemanticExpr = nullptr;
 
@@ -2283,6 +2284,14 @@ public:
            e->getKind() <= ExprKind::Last_CollectionExpr;
   }
 
+  /// Retrieve the initializer that will be used to construct the 'array'
+  /// literal from the result of the initializer.
+  ConcreteDeclRef getInitializer() const { return Initializer; }
+
+  /// Set the initializer that will be used to construct the 'array' literal.
+  void setInitializer(ConcreteDeclRef initializer) {
+    Initializer = initializer;
+  }
 };
  
 /// An array literal expression [a, b, c].
@@ -2313,6 +2322,8 @@ public:
   static bool classof(const Expr *e) {
     return e->getKind() == ExprKind::Array;
   }
+
+  Type getElementType();
 };
 
 /// A dictionary literal expression [a : x, b : y, c : z].

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2068,6 +2068,8 @@ public:
   }
   void visitArrayExpr(ArrayExpr *E) {
     printCommon(E, "array_expr");
+    PrintWithColorRAII(OS, LiteralValueColor) << " initializer=";
+    E->getInitializer().dump(PrintWithColorRAII(OS, LiteralValueColor).getOS());
     for (auto elt : E->getElements()) {
       OS << '\n';
       printRec(elt);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1488,6 +1488,19 @@ ArrayExpr *ArrayExpr::create(ASTContext &C, SourceLoc LBracketLoc,
   return new (Mem) ArrayExpr(LBracketLoc, Elements, CommaLocs, RBracketLoc, Ty);
 }
 
+Type ArrayExpr::getElementType() {
+  auto init = getInitializer();
+  if (!init)
+    return Type();
+
+  auto *decl = cast<ConstructorDecl>(init.getDecl());
+  return decl->getMethodInterfaceType()
+      ->getAs<AnyFunctionType>()
+      ->getParams()[0]
+      .getPlainType()
+      .subst(init.getSubstitutions());
+}
+
 DictionaryExpr *DictionaryExpr::create(ASTContext &C, SourceLoc LBracketLoc,
                              ArrayRef<Expr*> Elements,
                              ArrayRef<SourceLoc> CommaLocs,

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -588,6 +588,12 @@ class ExprContextAnalyzer {
       analyzeApplyExpr(Parent);
       break;
     }
+    case ExprKind::Array: {
+      if (auto type = ParsedExpr->getType()) {
+        recordPossibleType(type);
+      }
+      break;
+    }
     case ExprKind::Assign: {
       auto *AE = cast<AssignExpr>(Parent);
 
@@ -744,6 +750,7 @@ public:
         case ExprKind::PrefixUnary:
         case ExprKind::Assign:
         case ExprKind::Subscript:
+        case ExprKind::Array:
           return true;
         case ExprKind::Tuple: {
           auto ParentE = Parent.getAsExpr();

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -308,42 +308,6 @@ public:
   /// be returned. Otherwise, an object will be returned. So this is a
   /// convenient way to determine if an RValue needs an address.
   SILType getLoweredImplodedTupleType(SILGenFunction &SGF) const &;
-
-  /// Rewrite the type of this r-value.
-  void rewriteType(CanType newType) & {
-#ifndef NDEBUG
-    static const auto areSimilarTypes = [](CanType l, CanType r) {
-      if (l == r) return true;
-
-      // Allow function types to disagree about 'noescape'.
-      if (auto lf = dyn_cast<FunctionType>(l)) {
-        if (auto rf = dyn_cast<FunctionType>(r)) {
-          auto lParams = lf.getParams();
-          auto rParams = rf.getParams();
-          return AnyFunctionType::equalParams(lParams, rParams) &&
-                 lf.getResult() == rf.getResult() &&
-                 lf->getExtInfo().withNoEscape(false) ==
-                     rf->getExtInfo().withNoEscape(false);
-        }
-      }
-      return false;
-    };
-
-    static const auto isSingleElementTuple = [](CanType type, CanType eltType) {
-      if (auto tupleType = dyn_cast<TupleType>(type)) {
-        return tupleType->getNumElements() == 1 &&
-               areSimilarTypes(tupleType.getElementType(0), eltType);
-      }
-      return false;
-    };
-
-    // We only allow a very modest set of changes to a type.
-    assert(areSimilarTypes(newType, type) ||
-           isSingleElementTuple(newType, type) ||
-           isSingleElementTuple(type, newType));
-#endif
-    type = newType;
-  }
   
   /// Emit an equivalent value with independent ownership.
   RValue copy(SILGenFunction &SGF, SILLocation loc) const &;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3684,6 +3684,11 @@ RValue RValueEmitter::visitArrayExpr(ArrayExpr *E, SGFContext C) {
 
   arg = scope.popPreservingValue(std::move(arg));
 
+  // If we're building an array, we don't have to call the initializer;
+  // we've already built one.
+  if (arrayTy->isEqual(E->getType()))
+    return arg;
+
   // Call the builtin initializer.
   return SGF.emitApplyAllocatingInitializer(
       loc, E->getInitializer(), std::move(arg), E->getType(), C);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3684,6 +3684,8 @@ RValue RValueEmitter::visitArrayExpr(ArrayExpr *E, SGFContext C) {
   RValue arg(SGF, loc, arrayTy,
              emitEndVarargs(SGF, loc, std::move(varargsInfo)));
 
+  arg = scope.popPreservingValue(std::move(arg));
+
   // Add an argument label for init(arrayLiteral: T...) as the above tuple is of
   // the form (T...) with no label.
   assert(argLabels.size() == 1 && !argLabels[0].empty() &&
@@ -3693,8 +3695,8 @@ RValue RValueEmitter::visitArrayExpr(ArrayExpr *E, SGFContext C) {
   arg.rewriteType(newType->getCanonicalType());
 
   // Call the builtin initializer.
-  return scope.popPreservingValue(SGF.emitApplyAllocatingInitializer(
-      loc, init, std::move(arg), E->getType(), C));
+  return SGF.emitApplyAllocatingInitializer(
+      loc, init, std::move(arg), E->getType(), C);
 }
 
 RValue RValueEmitter::visitDictionaryExpr(DictionaryExpr *E, SGFContext C) {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -368,12 +368,12 @@ func f() -> SomeEnum1 {
   return .#^UNRESOLVED_27^#
 }
 
-let TopLevelVar1 = OptionSetTaker7([.#^UNRESOLVED_28^#], Op2: [.Option4])
+let TopLevelVar1 = OptionSetTaker7([.#^UNRESOLVED_28^#], [.Option4])
 
 let TopLevelVar2 = OptionSetTaker1([.#^UNRESOLVED_29^#])
 
-let TopLevelVar3 = OptionSetTaker7([.Option1], Op2: [.#^UNRESOLVED_30^#])
-let TopLevelVar4 = OptionSetTaker7([.Option1], Op2: [.Option4, .#^UNRESOLVED_31^#])
+let TopLevelVar3 = OptionSetTaker7([.Option1], [.#^UNRESOLVED_30^#])
+let TopLevelVar4 = OptionSetTaker7([.Option1], [.Option4, .#^UNRESOLVED_31^#])
 
 let _: [SomeEnum1] = [.#^UNRESOLVED_32^#]
 let _: [SomeEnum1] = [.South, .#^UNRESOLVED_33^#]

--- a/test/Interpreter/arrays.swift
+++ b/test/Interpreter/arrays.swift
@@ -161,3 +161,25 @@ test()
 let mdaPerf = [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12]]
 print(mdaPerf)
 // CHECK: {{\[}}[1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12]]
+
+class Deinitable {
+  deinit {
+    print("deinit called")
+  }
+}
+
+enum E : Error {
+  case error
+}
+
+func throwingFunc() throws -> Deinitable {
+  throw E.error
+}
+
+do {
+  let array = try [Deinitable(), throwingFunc()]
+} catch {
+  // CHECK: deinit called
+  // CHECK: error thrown
+  print("error thrown")
+}

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -245,10 +245,7 @@ func makeBasic<T : FooProtocol>() -> T { return T() }
 // CHECK: try_apply [[FN]]<T>([[POINTER1]]) : {{.*}} normal bb1, error bb2
 
 // CHECK: bb1([[TMP:%.*]] : $()):
-// CHECK: [[METATYPE:%.*]] = metatype $@thin Array<T>.Type
-// CHECK: [[CTOR:%.*]] = function_ref @$sSa12arrayLiteralSayxGxd_tcfC : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
-// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<T>([[ARR]], [[METATYPE]])
-// CHECK: return [[RESULT]]
+// CHECK: return [[ARR]]
 
 // CHECK: bb2([[ERR:%.*]] : @owned $Error):
 // CHECK: [[DEALLOC:%.*]] = function_ref @$ss29_deallocateUninitializedArrayyySayxGnlF

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -248,6 +248,7 @@ func makeBasic<T : FooProtocol>() -> T { return T() }
 // CHECK: return [[ARR]]
 
 // CHECK: bb2([[ERR:%.*]] : @owned $Error):
+// CHECK: destroy_addr [[POINTER]] : $*T
 // CHECK: [[DEALLOC:%.*]] = function_ref @$ss29_deallocateUninitializedArrayyySayxGnlF
 // CHECK: [[TMP:%.*]] = apply [[DEALLOC]]<T>([[ARR]])
 // CHECK: throw [[ERR]] : $Error

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -41,3 +41,219 @@ class CustomStringSubclass : CustomStringClass {}
 func returnsCustomStringSubclass() -> CustomStringSubclass {
   return "hello world"
 }
+
+class TakesArrayLiteral<Element> : ExpressibleByArrayLiteral {
+  required init(arrayLiteral elements: Element...) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals18returnsCustomArrayAA05TakesD7LiteralCySiGyF : $@convention(thin) () -> @owned TakesArrayLiteral<Int>
+// CHECK: [[TMP:%.*]] = apply %2(%0, %1) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Int>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: store [[TMP:%.*]] to [trivial] [[POINTER]]
+// CHECK: [[IDX1:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[POINTER1:%.*]] = index_addr [[POINTER]] : $*Int, [[IDX1]] : $Builtin.Word
+// CHECK: store [[TMP:%.*]] to [trivial] [[POINTER1]]
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Int>.Type
+// CHECK: [[CTOR:%.*]] = class_method %15 : $@thick TakesArrayLiteral<Int>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Int>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+func returnsCustomArray() -> TakesArrayLiteral<Int> {
+  // Use temporary to simplify generated_sil
+  let tmp = 77
+  return [tmp, tmp]
+}
+
+class Klass {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals24returnsClassElementArrayAA05TakesE7LiteralCyAA5KlassCGyF : $@convention(thin) () -> @owned TakesArrayLiteral<Klass>
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Klass>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: [[KLASS_METATYPE:%.*]] = metatype $@thick Klass.Type
+// CHECK: [[CTOR:%.*]] = function_ref @$s8literals5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[TMP:%.*]] = apply [[CTOR]]([[KLASS_METATYPE]]) : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: store [[TMP]] to [init] [[POINTER]]
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Klass>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<Klass>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Klass>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+func returnsClassElementArray() -> TakesArrayLiteral<Klass> {
+  return [Klass()]
+}
+
+struct Foo<T> {
+  var t: T
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals30returnsAddressOnlyElementArray1tAA05TakesF7LiteralCyAA3FooVyxGGAH_tlF : $@convention(thin) <T> (@in_guaranteed Foo<T>) -> @owned TakesArrayLiteral<Foo<T>>
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: copy_addr %0 to [initialization] [[POINTER]] : $*Foo<T>
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Foo<T>>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<Foo<T>>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Foo<T>>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+func returnsAddressOnlyElementArray<T>(t: Foo<T>) -> TakesArrayLiteral<Foo<T>> {
+  return [t]
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals3FooV20returnsArrayFromSelfAA05TakesD7LiteralCyACyxGGyF : $@convention(method) <T> (@in_guaranteed Foo<T>) -> @owned TakesArrayLiteral<Foo<T>>
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: copy_addr %0 to [initialization] [[POINTER]] : $*Foo<T>
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Foo<T>>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<Foo<T>>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Foo<T>>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+extension Foo {
+  func returnsArrayFromSelf() -> TakesArrayLiteral<Foo<T>> {
+    return [self]
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals3FooV28returnsArrayFromMutatingSelfAA05TakesD7LiteralCyACyxGGyF : $@convention(method) <T> (@inout Foo<T>) -> @owned TakesArrayLiteral<Foo<T>>
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*Foo<T>
+// CHECK: copy_addr [[ACCESS]] to [initialization] [[POINTER]] : $*Foo<T>
+// CHECK: end_access [[ACCESS]] : $*Foo<T>
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Foo<T>>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<Foo<T>>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Foo<T>>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+extension Foo {
+  mutating func returnsArrayFromMutatingSelf() -> TakesArrayLiteral<Foo<T>> {
+    return [self]
+  }
+}
+
+struct Foo2 {
+  var k: Klass
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals23returnsNonTrivialStructAA17TakesArrayLiteralCyAA4Foo2VGyF : $@convention(thin) () -> @owned TakesArrayLiteral<Foo2>
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo2>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: [[METATYPE_FOO2:%.*]] = metatype $@thin Foo2.Type
+// CHECK: [[METATYPE_KLASS:%.*]] = metatype $@thick Klass.Type
+// CHECK: [[CTOR:%.*]] = function_ref @$s8literals5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[K:%.*]] = apply [[CTOR]]([[METATYPE_KLASS]]) : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[CTOR:%.*]] = function_ref @$s8literals4Foo2V1kAcA5KlassC_tcfC : $@convention(method) (@owned Klass, @thin Foo2.Type) -> @owned Foo2
+// CHECK: [[TMP:%.*]] = apply [[CTOR]]([[K]], [[METATYPE_FOO2]]) : $@convention(method) (@owned Klass, @thin Foo2.Type) -> @owned Foo2
+// store [[TMP]] to [init] [[POINTER]] : $*Foo2
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Foo2>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<Foo2>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Foo2>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+func returnsNonTrivialStruct() -> TakesArrayLiteral<Foo2> {
+  return [Foo2(k: Klass())]
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals16NestedLValuePathV11wrapInArrayyyF : $@convention(method) (@inout NestedLValuePath) -> ()
+// CHECK: [[METATYPE_NESTED:%.*]] = metatype $@thin NestedLValuePath.Type
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<NestedLValuePath>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*NestedLValuePath
+// CHECK: [[OTHER_FN:%.*]] = function_ref @$s8literals16NestedLValuePathV21otherMutatingFunctionACyF : $@convention(method) (@inout NestedLValuePath) -> @owned NestedLValuePath
+// CHECK: [[TMP:%.*]] = apply [[OTHER_FN]]([[ACCESS]]) : $@convention(method) (@inout NestedLValuePath) -> @owned NestedLValuePath
+// CHECK: end_access [[ACCESS]] : $*NestedLValuePath
+// CHECK: store [[TMP]] to [init] [[POINTER]] : $*NestedLValuePath
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<NestedLValuePath>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<NestedLValuePath>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[ARR_RESULT:%.*]] = apply [[CTOR]]<NestedLValuePath>([[ARR]], [[METATYPE]])
+// CHECK: [[CTOR:%.*]] = function_ref @$s8literals16NestedLValuePathV3arrAcA17TakesArrayLiteralCyACG_tcfC : $@convention(method) (@owned TakesArrayLiteral<NestedLValuePath>, @thin NestedLValuePath.Type) -> @owned NestedLValuePath // user: %18
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]([[ARR_RESULT]], [[METATYPE_NESTED]]) : $@convention(method) (@owned TakesArrayLiteral<NestedLValuePath>, @thin NestedLValuePath.Type) -> @owned NestedLValuePath
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*NestedLValuePath
+// CHECK: assign [[RESULT]] to [[ACCESS]] : $*NestedLValuePath
+// CHECK: end_access [[ACCESS]] : $*NestedLValuePath
+// CHECK: [[VOID:%.*]] = tuple ()
+// CHECK: return [[VOID]] : $()
+struct NestedLValuePath {
+  var arr: TakesArrayLiteral<NestedLValuePath>
+
+  mutating func wrapInArray() {
+    self = NestedLValuePath(arr: [self.otherMutatingFunction()])
+  }
+
+  mutating func otherMutatingFunction() -> NestedLValuePath {
+    return self
+  }
+}
+
+protocol WrapsSelfInArray {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals16WrapsSelfInArrayPAAE04wrapdE0AA05TakesE7LiteralCyAaB_pGyF : $@convention(method) <Self where Self : WrapsSelfInArray> (@inout Self) -> @owned TakesArrayLiteral<WrapsSelfInArray>
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<WrapsSelfInArray>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*Self
+// CHECK: [[EXISTENTIAL:%.*]] = init_existential_addr [[POINTER]] : $*WrapsSelfInArray, $Self
+// CHECK: copy_addr [[ACCESS]] to [initialization] [[EXISTENTIAL]] : $*Self
+// CHECK: end_access [[ACCESS]] : $*Self
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<WrapsSelfInArray>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesArrayLiteral<WrapsSelfInArray>.Type, #TakesArrayLiteral.init!allocator.1 : <Element> (TakesArrayLiteral<Element>.Type) -> (Element...) -> TakesArrayLiteral<Element>, $@convention(method)
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<WrapsSelfInArray>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+extension WrapsSelfInArray {
+  mutating func wrapInArray() -> TakesArrayLiteral<WrapsSelfInArray> {
+    return [self]
+  }
+}
+
+protocol FooProtocol {
+  init()
+}
+
+func makeThrowing<T : FooProtocol>() throws -> T { return T() }
+func makeBasic<T : FooProtocol>() -> T { return T() }
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals15throwingElementSayxGyKAA11FooProtocolRzlF : $@convention(thin) <T where T : FooProtocol> () -> (@owned Array<T>, @error Error)
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<T>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
+// CHECK: [[FN:%.*]] = function_ref @$s8literals9makeBasicxyAA11FooProtocolRzlF : $@convention(thin)
+// CHECK: [[TMP:%.*]] = apply [[FN]]<T>([[POINTER]])
+// CHECK: [[IDX:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[POINTER1:%.*]] = index_addr [[POINTER]] : $*T, [[IDX]] : $Builtin.Word
+// CHECK: [[FN:%.*]] = function_ref @$s8literals12makeThrowingxyKAA11FooProtocolRzlF : $@convention(thin)
+// CHECK: try_apply [[FN]]<T>([[POINTER1]]) : {{.*}} normal bb1, error bb2
+
+// CHECK: bb1([[TMP:%.*]] : $()):
+// CHECK: [[METATYPE:%.*]] = metatype $@thin Array<T>.Type
+// CHECK: [[CTOR:%.*]] = function_ref @$sSa12arrayLiteralSayxGxd_tcfC : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<T>([[ARR]], [[METATYPE]])
+// CHECK: return [[RESULT]]
+
+// CHECK: bb2([[ERR:%.*]] : @owned $Error):
+// CHECK: [[DEALLOC:%.*]] = function_ref @$ss29_deallocateUninitializedArrayyySayxGnlF
+// CHECK: [[TMP:%.*]] = apply [[DEALLOC]]<T>([[ARR]])
+// CHECK: throw [[ERR]] : $Error
+func throwingElement<T : FooProtocol>() throws -> [T] {
+  return try [makeBasic(), makeThrowing()]
+}

--- a/test/SILGen/objc_bridging_array.swift
+++ b/test/SILGen/objc_bridging_array.swift
@@ -1,0 +1,41 @@
+
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+class Child : NSObject {}
+
+@objc protocol Parent {
+  var children: [Child] { get set }
+}
+
+func setChildren(p: Parent, c: Child) {
+  p.children = [c]
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s19objc_bridging_array11setChildren1p1cyAA6Parent_p_AA5ChildCtF : $@convention(thin) (@guaranteed Parent, @guaranteed Child) -> () {
+// CHECK: [[OPENED:%.*]] = open_existential_ref %0 : $Parent to $[[OPENED_TYPE:.* Parent]]
+// CHECK: [[COPIED:%.*]] = copy_value [[OPENED]] : $[[OPENED_TYPE]]
+// CHECK: [[LENGTH:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[FN:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [[ARRAY_AND_BUFFER:%.*]] = apply [[FN]]<Child>([[LENGTH]]) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: ([[ARRAY:%.*]], [[BUFFER_PTR:%.*]]) = destructure_tuple [[ARRAY_AND_BUFFER]] : $(Array<Child>, Builtin.RawPointer)
+// CHECK: [[BUFFER:%.*]] = pointer_to_address [[BUFFER_PTR]] : $Builtin.RawPointer to [strict] $*Child
+// CHECK: [[CHILD:%.*]] = copy_value %1 : $Child
+// CHECK: store [[CHILD]] to [init] [[BUFFER]] : $*Child
+// CHECK: [[METATYPE:%.*]] = metatype $@thin Array<Child>.Type
+// CHECK: [[FN:%.*]] = function_ref @$sSa12arrayLiteralSayxGxd_tcfC : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
+// CHECK: [[NEW_ARRAY:%.*]] = apply [[FN]]<Child>([[ARRAY]], [[METATYPE]]) : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
+// CHECK: [[FN:%.*]] = function_ref @$sSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @owned NSArray
+// CHECK: [[BORROW_ARRAY:%.*]] = begin_borrow [[NEW_ARRAY]] : $Array<Child>
+// CHECK: [[BRIDGED_ARRAY:%.*]] = apply [[FN]]<Child>([[BORROW_ARRAY]]) : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @owned NSArray
+// CHECK: end_borrow [[BORROW_ARRAY]] : $Array<Child>
+// CHECK: destroy_value [[NEW_ARRAY]] : $Array<Child>
+// CHECK: [[FN:%.*]] = objc_method [[COPIED]] : $[[OPENED_TYPE]], #Parent.children!setter.1.foreign : <Self where Self : Parent> (Self) -> ([Child]) -> (), $@convention(objc_method) <τ_0_0 where τ_0_0 : Parent> (NSArray, τ_0_0) -> ()
+// CHECK: apply [[FN]]<[[OPENED_TYPE]]>([[BRIDGED_ARRAY]], [[COPIED]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Parent> (NSArray, τ_0_0) -> ()
+// CHECK: destroy_value [[BRIDGED_ARRAY]] : $NSArray
+// CHECK: destroy_value [[COPIED]] : $[[OPENED_TYPE]]
+// CHECK: [[RESULT:%.*]] = tuple ()
+// CHECK: return [[RESULT]] : $()

--- a/test/SILGen/objc_bridging_array.swift
+++ b/test/SILGen/objc_bridging_array.swift
@@ -25,14 +25,11 @@ func setChildren(p: Parent, c: Child) {
 // CHECK: [[BUFFER:%.*]] = pointer_to_address [[BUFFER_PTR]] : $Builtin.RawPointer to [strict] $*Child
 // CHECK: [[CHILD:%.*]] = copy_value %1 : $Child
 // CHECK: store [[CHILD]] to [init] [[BUFFER]] : $*Child
-// CHECK: [[METATYPE:%.*]] = metatype $@thin Array<Child>.Type
-// CHECK: [[FN:%.*]] = function_ref @$sSa12arrayLiteralSayxGxd_tcfC : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
-// CHECK: [[NEW_ARRAY:%.*]] = apply [[FN]]<Child>([[ARRAY]], [[METATYPE]]) : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
 // CHECK: [[FN:%.*]] = function_ref @$sSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @owned NSArray
-// CHECK: [[BORROW_ARRAY:%.*]] = begin_borrow [[NEW_ARRAY]] : $Array<Child>
+// CHECK: [[BORROW_ARRAY:%.*]] = begin_borrow [[ARRAY]] : $Array<Child>
 // CHECK: [[BRIDGED_ARRAY:%.*]] = apply [[FN]]<Child>([[BORROW_ARRAY]]) : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @owned NSArray
 // CHECK: end_borrow [[BORROW_ARRAY]] : $Array<Child>
-// CHECK: destroy_value [[NEW_ARRAY]] : $Array<Child>
+// CHECK: destroy_value [[ARRAY]] : $Array<Child>
 // CHECK: [[FN:%.*]] = objc_method [[COPIED]] : $[[OPENED_TYPE]], #Parent.children!setter.1.foreign : <Self where Self : Parent> (Self) -> ([Child]) -> (), $@convention(objc_method) <τ_0_0 where τ_0_0 : Parent> (NSArray, τ_0_0) -> ()
 // CHECK: apply [[FN]]<[[OPENED_TYPE]]>([[BRIDGED_ARRAY]], [[COPIED]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Parent> (NSArray, τ_0_0) -> ()
 // CHECK: destroy_value [[BRIDGED_ARRAY]] : $NSArray

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -15,7 +15,6 @@ struct TakesArray<T> {
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
 // CHECK: array_expr type='[(X) -> Void]'
-// CHECK: semantic_expr
 // CHECK: function_conversion_expr implicit type='(X) -> Void'
 // CHECK-NEXT: {{declref_expr.*x1}}
 // CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'

--- a/test/refactoring/RefactoringKind/trailingclosure.swift
+++ b/test/refactoring/RefactoringKind/trailingclosure.swift
@@ -39,7 +39,7 @@ func testTrailingClosure() -> String {
 // RUN: %refactor -source-filename %s -pos=10:9 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
 // RUN: %refactor -source-filename %s -pos=10:17 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
 
-// RUN: %refactor -source-filename %s -pos=12:4 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=12:4 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
 // RUN: %refactor -source-filename %s -pos=13:5 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
 // RUN: %refactor -source-filename %s -pos=14:5 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
 


### PR DESCRIPTION
This PR builds on @pschuh's https://github.com/apple/swift/pull/23177. @pschuh did not have a Mac to test so I helped fix an issue specific to bridging conversions. See the original PR for motivation and review discussion.

- The first commit is from the original PR
- Second commit fixes the bridging issue
- Followed by two cleanups of some related code that was already in SILGen
- Followed by another fix to properly clean up uninitialized arrays when an array literal contains throwing expressions