### PR TITLE
Update operator to be borrowing to reflect the ref-counting semantics.

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -1122,7 +1122,7 @@ private typealias PythonBinaryOp =
 private func performBinaryOp(
   _ op: PythonBinaryOp, lhs: PythonObject, rhs: PythonObject
 ) -> PythonObject {
-  let result = op(lhs.ownedPyObject, rhs.ownedPyObject)
+  let result = op(lhs.borrowedPyObject, rhs.borrowedPyObject)
   // If binary operation fails (e.g. due to `TypeError`), throw an exception.
   try! throwPythonErrorIfPresent()
   return PythonObject(consuming: result!)

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -326,6 +326,11 @@ PythonRuntimeTestSuite.testWithLeakChecking("SR-9230") {
   expectEqual(2, Python.len(Python.dict(a: "a", b: "b")))
 }
 
+PythonRuntimeTestSuite.testWithLeakChecking("ArrayOpsForLeakChecking") {
+  expectEqual([1, 2], PythonObject([1]) + PythonObject([2]))
+  expectTrue(PythonObject([1]) != PythonObject([2]))
+}
+
 // TF-78: isType() consumed refcount for type objects like `PyBool_Type`.
 PythonRuntimeTestSuite.testWithLeakChecking("PythonRefCount") {
   let b: PythonObject = true


### PR DESCRIPTION
Thanks to Stephen Johnson for finding this issue.