### PR TITLE
Update linux-fatal-backtrace.swift

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -4,7 +4,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
-// XFAIL: CPU=powerpc64le
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.


### PR DESCRIPTION
"swift/test/Runtime/linux-fatal-backtrace.swift" test case was earlier marked as XFAIL since it was failing when run as root users( #21541 ). However, this test case now passes successfully when run as non-root(normal) user. Submitting this changeset/pull request since the test suite proceeds ahead to other test suites like those for TestFoundation, etc as non-root(normal) user successfully.

Also this test case has some fixes done by users post PR#21541 which may be causing the test case to pass successfully.