### PR TITLE
[Serialization] Fix bad tagging of deserialized decls that can result in failed member lookups

### DIFF
--- a/validation-test/Serialization/xref-badtag-49336277/Inputs/basemod.swift
+++ b/validation-test/Serialization/xref-badtag-49336277/Inputs/basemod.swift
@@ -1,0 +1,13 @@
+import itermod
+
+public protocol MySequence {
+  associatedtype Element
+  associatedtype Iterator: MyIter where Iterator.Element == Element
+}
+
+public struct MyBar: MySequence, MyIter {
+  public func callme() {}
+
+  public typealias Element = UInt8
+  public typealias Iterator = MyBar
+}

--- a/validation-test/Serialization/xref-badtag-49336277/Inputs/dependmod.swift
+++ b/validation-test/Serialization/xref-badtag-49336277/Inputs/dependmod.swift
@@ -1,0 +1,4 @@
+import itermod
+import basemod
+
+extension MyIter where Element == MyBar {}

--- a/validation-test/Serialization/xref-badtag-49336277/Inputs/itermod.swift
+++ b/validation-test/Serialization/xref-badtag-49336277/Inputs/itermod.swift
@@ -1,0 +1,3 @@
+public protocol MyIter {
+  associatedtype Element
+}

--- a/validation-test/Serialization/xref-badtag-49336277/main.swift
+++ b/validation-test/Serialization/xref-badtag-49336277/main.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/itermod.swift -module-name itermod -emit-module -o %t/itermod.swiftmodule
+// RUN: %target-swift-frontend %S/Inputs/basemod.swift -module-name basemod -emit-module -o %t/basemod.swiftmodule -I %t
+// RUN: %target-swift-frontend %S/Inputs/dependmod.swift -module-name dependmod -emit-module -o %t/dependmod.swiftmodule -I %t
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify
+
+import basemod
+import dependmod
+
+func test(b: MyBar) {
+  b.callme()
+  // Check that there was typechecking.
+  b.non_existent() // expected-error {{no member 'non_existent'}}
+}


### PR DESCRIPTION
The issue was introduced in https://github.com/apple/swift/pull/22610/commits/ec95e68ab91dd57dae9c7d2729484501bfc37d98 which changed the behavior of `ModuleFile::getDeclChecked()` slightly.

rdar://49336277