### PR TITLE
Set CPU Device Count from environment variable in tests.

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -571,6 +571,14 @@ private func configureRuntimeFromEnvironment() {
     _RuntimeConfig.runMetadataOutputPath = path
     debugLog("Setting run metadata output path to \(path) from env.")
   }
+
+  if let value = getenv("SWIFT_TENSORFLOW_CPU_DEVICE_COUNT") {
+    guard let cpuDeviceCount = UInt32(String(cString: value)) else {
+      fatalError("SWIFT_TENSORFLOW_CPU_DEVICE_COUNT must take an int value.")
+    }
+    _RuntimeConfig.cpuDeviceCount = cpuDeviceCount
+    debugLog("Setting number of CPU devices to \(cpuDeviceCount) from env.")
+  }
 }
 
 /// Initialize the TPU system.

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -17,7 +17,7 @@ var CollectiveTests = TestSuite("Collective")
 
 CollectiveTests.testAllBackends("ConfigTest") {
   // Run some tensor code to trigger runtime configuration.
-  _hostOp(Tensor<Float>(0.0))
+  _hostOp(Tensor<Float>(0.0) + Tensor<Float>(1.0))
   expectEqual(3, _RuntimeConfig.cpuDeviceCount)
 }
 

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -15,6 +15,12 @@ import StdlibUnittest
 
 var CollectiveTests = TestSuite("Collective")
 
+CollectiveTests.testAllBackends("ConfigTest") {
+  // Run some tensor code to trigger runtime configuration.
+  _hostOp(Tensor<Float>(0.0))
+  expectEqual(3, _RuntimeConfig.cpuDeviceCount)
+}
+
 // TODO: Probably should be disabled for TPU execution.
 CollectiveTests.testAllBackends("SingletonGroup") {
   let x = Tensor<Float>(1.0)
@@ -78,5 +84,4 @@ CollectiveTests.testAllBackends("GroupWithSize2_threads") {
   }
 }
 
-_RuntimeConfig.cpuDeviceCount = 3
 runAllTests()

--- a/test/TensorFlowRuntime/lit.local.cfg
+++ b/test/TensorFlowRuntime/lit.local.cfg
@@ -1,0 +1,1 @@
+config.environment['SWIFT_TENSORFLOW_CPU_DEVICE_COUNT'] = '3'

--- a/test/TensorFlowRuntime/with_device_1.swift
+++ b/test/TensorFlowRuntime/with_device_1.swift
@@ -15,6 +15,12 @@ import StdlibUnittest
 
 var WithDeviceTests = TestSuite("WithDevice")
 
+WithDeviceTests.testAllBackends("ConfigTest") {
+  // Run some tensor code to trigger runtime configuration.
+  _hostOp(Tensor<Float>(0.0))
+  expectEqual(3, _RuntimeConfig.cpuDeviceCount)
+}
+
 WithDeviceTests.testAllBackends("Basic") {
   func foo() {
     let x = Tensor<Float>(1.0)
@@ -35,5 +41,4 @@ WithDeviceTests.testAllBackends("Basic") {
   #endif
 }
 
-_RuntimeConfig.cpuDeviceCount = 3
 runAllTests()

--- a/test/TensorFlowRuntime/with_device_1.swift
+++ b/test/TensorFlowRuntime/with_device_1.swift
@@ -17,7 +17,7 @@ var WithDeviceTests = TestSuite("WithDevice")
 
 WithDeviceTests.testAllBackends("ConfigTest") {
   // Run some tensor code to trigger runtime configuration.
-  _hostOp(Tensor<Float>(0.0))
+  _hostOp(Tensor<Float>(0.0) + Tensor<Float>(1.0))
   expectEqual(3, _RuntimeConfig.cpuDeviceCount)
 }
 


### PR DESCRIPTION
The cpuDeviceCount cannot be set in the test as the initialization order between _ExecutionContext and _RuntimeConfig is not guaranteed, which makes the tests flakey.
