### PR TITLE
[android] Fix c_layout test for platforms which default to unsigned chars

### DIFF
--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-cpu -check-prefix CHECK-%target-abi-%target-cpu
+// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-cpu -check-prefix CHECK-%target-abi-%target-cpu -check-prefix CHECK-%target-sdk-name-%target-cpu
 
 sil_stage canonical
 import c_layout
@@ -173,21 +173,33 @@ bb0:
 // CHECK-i386-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
 // CHECK-i386-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
-// CHECK-armv7:         call signext i8 @chareth(i8 signext
-// CHECK-armv7:         call signext i8 @signedChareth(i8 signext
-// CHECK-armv7:         call zeroext i8 @unsignedChareth(i8 zeroext
-// CHECK-armv7:         call signext i16 @eatMyShorts(i16 signext
-// CHECK-armv7:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
-// CHECK-armv7:         call i32 @ints(i32 %5)
-// CHECK-armv7:         call i32 @unsigneds(i32 %6)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
-// CHECK-armv7-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
+// CHECK-armv7-LABEL:         define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-ios-armv7:             call signext i8 @chareth(i8 signext
+// CHECK-ios-armv7:             call signext i8 @signedChareth(i8 signext
+// CHECK-android-armv7:         call zeroext i8 @chareth(i8 zeroext
+// CHECK-android-armv7:         call zeroext i8 @signedChareth(i8 zeroext
+// CHECK-linux-armv7:           call zeroext i8 @chareth(i8 zeroext
+// CHECK-linux-armv7:           call zeroext i8 @signedChareth(i8 zeroext
+// CHECK-windows-armv7:         call zeroext i8 @chareth(i8 zeroext
+// CHECK-windows-armv7:         call zeroext i8 @signedChareth(i8 zeroext
+// CHECK-armv7:                 call zeroext i8 @unsignedChareth(i8 zeroext
+// CHECK-armv7:                 call signext i16 @eatMyShorts(i16 signext
+// CHECK-armv7:                 call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
+// CHECK-armv7:                 call i32 @ints(i32 %5)
+// CHECK-armv7:                 call i32 @unsigneds(i32 %6)
+// CHECK-ios-armv7-LABEL:     declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-ios-armv7-LABEL:     declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-android-armv7-LABEL: declare{{( dllimport)?}} zeroext i8 @chareth(i8 zeroext)
+// CHECK-android-armv7-LABEL: declare{{( dllimport)?}} zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-linux-armv7-LABEL:   declare{{( dllimport)?}} zeroext i8 @chareth(i8 zeroext)
+// CHECK-linux-armv7-LABEL:   declare{{( dllimport)?}} zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-windows-armv7-LABEL: declare{{( dllimport)?}} zeroext i8 @chareth(i8 zeroext)
+// CHECK-windows-armv7-LABEL: declare{{( dllimport)?}} zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-armv7-LABEL:         declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-armv7-LABEL:         declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-armv7-LABEL:         declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-armv7-LABEL:         declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-armv7-LABEL:         declare{{( dllimport)?}} i32 @unsigneds(i32)
 
 // CHECK-armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-armv7s:         call signext i8 @chareth(i8 signext


### PR DESCRIPTION
ARMv7 seems to default to unsigned chars, so the checks should look more
like other platforms that prefer unsigned chars (like PowerPC64). Seems
that iOS prefers to have a common signedness with other Darwin platforms
and have signed chars.

Introduce a new check prefix which include the SDK name (the OS is quite
wildly in the case of Linux and Android), and differentiate the ARMv7
using the SDK. I'm confident about the Android tests. I only find two
other ARMv7 platfoms: iOS, which keeps the previous tests; and Linux and Windows,
which should also follow the unsigned char version.

I tried setting `CChar` to `UInt8`, but sadly many parts of the API (the `String` API to be exact) rely on `CChar` and `UInt8` being different, so making that change would be a bigger change. It makes sense that PowerPC64 didn’t had that either.
