### PR TITLE
[Reflection] Fix several issues for COFF and ELF

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -322,14 +322,21 @@ public:
                 : llvm::StringRef(COFFSec->Name, llvm::COFF::NameSize);
         if (SectionName != Name)
           continue;
-        auto Addr = ImageStart.getAddressData() + COFFSec->PointerToRawData;
+        auto Addr = ImageStart.getAddressData() + COFFSec->VirtualAddress;
         auto Buf = this->getReader().readBytes(RemoteAddress(Addr),
                                                COFFSec->VirtualSize);
         const char *Begin = reinterpret_cast<const char *>(Buf.get());
         const char *End = Begin + COFFSec->VirtualSize;
         savedBuffers.push_back(std::move(Buf));
-        return {{Begin, End},
-                COFFSec->VirtualAddress - COFFSec->PointerToRawData};
+
+        // FIXME: This code needs to be cleaned up and updated
+        // to make it work for 32 bit platforms.
+        if (SectionName != ".sw5cptr") {
+          Begin += 8;
+          End -= 8;
+        }
+
+        return {{Begin, End}, 0};
       }
       return {{nullptr, nullptr}, 0};
     };
@@ -338,20 +345,15 @@ public:
         findCOFFSectionByName(".sw5cptr");
     std::pair<std::pair<const char *, const char *>, uint32_t> TypeRefMdSec =
         findCOFFSectionByName(".sw5tyrf");
-
-    // FIXME: Make use of .sw5flmd section (the section content appears to be
-    // incorrect on Windows at the moment).
-    std::pair<std::pair<const char *, const char *>, uint32_t> FieldMdSec = {
-        {nullptr, nullptr}, 0};
-    // FIXME: Make use of .sw5asty.
-    std::pair<std::pair<const char *, const char *>, uint32_t> AssocTySec = {
-        {nullptr, nullptr}, 0};
-    // FIXME: Make use of .sw5bltn.
-    std::pair<std::pair<const char *, const char *>, uint32_t> BuiltinTySec = {
-        {nullptr, nullptr}, 0};
-    // FIXME: Make use of .sw5repl.
-    std::pair<std::pair<const char *, const char *>, uint32_t> ReflStrMdSec = {
-        {nullptr, nullptr}, 0};
+    std::pair<std::pair<const char *, const char *>, uint32_t> FieldMdSec =
+        findCOFFSectionByName(".sw5flmd");
+    std::pair<std::pair<const char *, const char *>, uint32_t> AssocTySec =
+        findCOFFSectionByName(".sw5asty");
+    // FIXME: Use the section .sw5bltn instead.
+    std::pair<std::pair<const char *, const char *>, uint32_t> BuiltinTySec =
+        {{nullptr, nullptr}, 0};
+    std::pair<std::pair<const char *, const char *>, uint32_t> ReflStrMdSec =
+        findCOFFSectionByName(".sw5rfst");
 
     if (FieldMdSec.first.first == nullptr &&
         AssocTySec.first.first == nullptr &&
@@ -457,12 +459,11 @@ public:
         if (SecName != Name)
           continue;
         auto SecStart =
-            RemoteAddress(ImageStart.getAddressData() + Hdr->sh_offset);
+            RemoteAddress(ImageStart.getAddressData() + Hdr->sh_addr);
         auto SecSize = Hdr->sh_size;
         auto SecBuf = this->getReader().readBytes(SecStart, SecSize);
         auto SecContents = reinterpret_cast<const char *>(SecBuf.get());
-        return {{SecContents, SecContents + SecSize},
-                Hdr->sh_addr - Hdr->sh_offset};
+        return {{SecContents, SecContents + SecSize}, 0};
       }
       return {{nullptr, nullptr}, 0};
     };

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -14,15 +14,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/ABI/MetadataValues.h"
-#include "swift/Demangling/Demangle.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Demangling/Demangle.h"
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Object/Archive.h"
-#include "llvm/Object/MachOUniversal.h"
+#include "llvm/Object/COFF.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/MachOUniversal.h"
 #include "llvm/Support/CommandLine.h"
 
 #if defined(_WIN32)
@@ -32,12 +34,12 @@
 #endif
 
 #include <algorithm>
-#include <iostream>
 #include <csignal>
+#include <iostream>
 
+using llvm::ArrayRef;
 using llvm::dyn_cast;
 using llvm::StringRef;
-using llvm::ArrayRef;
 using namespace llvm::object;
 
 using namespace swift;
@@ -45,187 +47,238 @@ using namespace swift::reflection;
 using namespace swift::remote;
 using namespace Demangle;
 
-enum class ActionType {
-  DumpReflectionSections,
-  DumpTypeLowering
-};
+enum class ActionType { DumpReflectionSections, DumpTypeLowering };
 
 namespace options {
-static llvm::cl::opt<ActionType>
-Action(llvm::cl::desc("Mode:"),
-       llvm::cl::values(
-         clEnumValN(ActionType::DumpReflectionSections,
-                    "dump-reflection-sections",
-                    "Dump the field reflection section"),
-         clEnumValN(ActionType::DumpTypeLowering,
-                    "dump-type-lowering",
-                    "Dump the field layout for typeref strings read from stdin")),
-       llvm::cl::init(ActionType::DumpReflectionSections));
+static llvm::cl::opt<ActionType> Action(
+    llvm::cl::desc("Mode:"),
+    llvm::cl::values(
+        clEnumValN(ActionType::DumpReflectionSections,
+                   "dump-reflection-sections",
+                   "Dump the field reflection section"),
+        clEnumValN(
+            ActionType::DumpTypeLowering, "dump-type-lowering",
+            "Dump the field layout for typeref strings read from stdin")),
+    llvm::cl::init(ActionType::DumpReflectionSections));
 
 static llvm::cl::list<std::string>
-BinaryFilename("binary-filename", llvm::cl::desc("Filenames of the binary files"),
-               llvm::cl::OneOrMore);
+    BinaryFilename("binary-filename",
+                   llvm::cl::desc("Filenames of the binary files"),
+                   llvm::cl::OneOrMore);
 
 static llvm::cl::opt<std::string>
-Architecture("arch", llvm::cl::desc("Architecture to inspect in the binary"),
-             llvm::cl::Required);
+    Architecture("arch",
+                 llvm::cl::desc("Architecture to inspect in the binary"),
+                 llvm::cl::Required);
 } // end namespace options
 
-template<typename T>
-static T unwrap(llvm::Expected<T> value) {
+template <typename T> static T unwrap(llvm::Expected<T> value) {
   if (value)
     return std::move(value.get());
-  std::cerr << "swift-reflection-test error: " << toString(value.takeError()) << "\n";
+  llvm::errs() << "swift-reflection-test error: " << toString(value.takeError())
+               << "\n";
   exit(EXIT_FAILURE);
 }
 
-using NativeReflectionContext
-    = swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
+static void reportError(std::error_code EC) {
+  assert(EC);
+  llvm::errs() << "swift-reflection-test error: " << EC.message() << ".\n";
+  exit(EXIT_FAILURE);
+}
+
+using NativeReflectionContext =
+    swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
+
+using ReadBytesResult = swift::remote::MemoryReader::ReadBytesResult;
+
+static uint64_t getSectionAddress(SectionRef S) {
+  // See COFFObjectFile.cpp for the implementation of 
+  // COFFObjectFile::getSectionAddress. The image base address is added
+  // to all the addresses of the sections, thus the behavior is slightly different from
+  // the other platforms.
+  if (auto C = dyn_cast<COFFObjectFile>(S.getObject()))
+    return S.getAddress() - C->getImageBase();
+  return S.getAddress();
+}
+
+static bool needToRelocate(SectionRef S) {
+  if (!getSectionAddress(S))
+    return false;
+
+  if (auto EO = dyn_cast<ELFObjectFileBase>(S.getObject())) {
+    static const llvm::StringSet<> ELFSectionsList = {
+      ".data", ".rodata", "swift5_protocols", "swift5_protocol_conformances",
+      "swift5_typeref", "swift5_reflstr", "swift5_assocty", "swift5_replace",
+      "swift5_type_metadata", "swift5_fieldmd", "swift5_capture", "swift5_builtin"
+    };
+    StringRef Name;
+    if (auto EC = S.getName(Name))
+      reportError(EC);
+    return ELFSectionsList.count(Name);
+  }
+
+  return true;
+}
+
+
+class Image {
+  std::vector<char> Memory;
+
+public:
+  explicit Image(const ObjectFile *O) {
+    uint64_t VASize = O->getData().size();
+    for (SectionRef S : O->sections()) {
+      if (auto SectionAddr = getSectionAddress(S))
+        VASize = std::max(VASize, SectionAddr + S.getSize());
+    }
+    Memory.resize(VASize);
+    std::memcpy(&Memory[0], O->getData().data(), O->getData().size());
+
+    for (SectionRef S : O->sections()) {
+      if (!needToRelocate(S))
+        continue;
+      StringRef Content;
+      if (auto EC = S.getContents(Content))
+        reportError(EC);
+      std::memcpy(&Memory[getSectionAddress(S)], Content.data(),
+                  Content.size());
+    }
+  }
+
+  RemoteAddress getStartAddress() const {
+    return RemoteAddress((uintptr_t)Memory.data());
+  }
+
+  bool isAddressValid(RemoteAddress Addr, uint64_t Size) const {
+    return (uintptr_t)Memory.data() <= Addr.getAddressData() &&
+           Addr.getAddressData() + Size <=
+               (uintptr_t)Memory.data() + Memory.size();
+  }
+
+  ReadBytesResult readBytes(RemoteAddress Addr, uint64_t Size) {
+    if (!isAddressValid(Addr, Size))
+      return ReadBytesResult(nullptr, [](const void *) {});
+    return ReadBytesResult((const void *)(Addr.getAddressData()),
+                           [](const void *) {});
+  }
+};
 
 class ObjectMemoryReader : public MemoryReader {
-  const std::vector<const ObjectFile *> &ObjectFiles;
+  std::vector<Image> Images;
+
 public:
-  ObjectMemoryReader(const std::vector<const ObjectFile *> &ObjectFiles)
-    : ObjectFiles(ObjectFiles)
-  {
+  explicit ObjectMemoryReader(
+      const std::vector<const ObjectFile *> &ObjectFiles) {
+    for (const ObjectFile *O : ObjectFiles)
+      Images.emplace_back(O);
   }
+
+  const std::vector<Image> &getImages() const { return Images; }
 
   bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
                        void *outBuffer) override {
     switch (type) {
-      case DLQ_GetPointerSize: {
-        auto result = static_cast<uint8_t *>(outBuffer);
-        *result = sizeof(void *);
-        return true;
-      }
-      case DLQ_GetSizeSize: {
-        auto result = static_cast<uint8_t *>(outBuffer);
-        *result = sizeof(size_t);
-        return true;
-      }
+    case DLQ_GetPointerSize: {
+      auto result = static_cast<uint8_t *>(outBuffer);
+      *result = sizeof(void *);
+      return true;
+    }
+    case DLQ_GetSizeSize: {
+      auto result = static_cast<uint8_t *>(outBuffer);
+      *result = sizeof(size_t);
+      return true;
+    }
     }
 
     return false;
   }
 
   RemoteAddress getSymbolAddress(const std::string &name) override {
-    for (auto &object : ObjectFiles) {
-      for (auto &symbol : object->symbols()) {
-        if (unwrap(symbol.getName()).equals(name)) {
-          // TODO: Account for offset in ELF binaries
-          return RemoteAddress(unwrap(symbol.getAddress()));
-        }
-      }
-    }
     return RemoteAddress(nullptr);
   }
-  
-  bool isAddressValid(RemoteAddress addr, uint64_t size) const {
-    // TODO: Account for offset in ELF binaries
 
-    auto src = addr.getAddressData();
-    
-    // Check that the source is in bounds of one of the object files.
-    for (auto &object : ObjectFiles) {
-      if ((uint64_t)object->getData().bytes_begin() <= src
-          && src + size <= (uint64_t)object->getData().bytes_end()) {
-        return true;
-      }
-    }
-    return false;
+  ReadBytesResult readBytes(RemoteAddress Addr, uint64_t Size) override {
+    auto I = std::find_if(Images.begin(), Images.end(), [=](const Image &I) {
+      return I.isAddressValid(Addr, Size);
+    });
+    return I == Images.end() ? ReadBytesResult(nullptr, [](const void *) {})
+                             : I->readBytes(Addr, Size);
   }
-  
-  ReadBytesResult readBytes(RemoteAddress address, uint64_t size) override {
-    if (!isAddressValid(address, size))
-      return ReadBytesResult(nullptr, [](const void *){});
 
-    // TODO: Account for offset in ELF binaries
-    return ReadBytesResult((const void *)address.getAddressData(), [](const void *) {});
-  }
-  
-  bool readString(RemoteAddress address, std::string &dest) override {
-    if (!isAddressValid(address, 1))
+  bool readString(RemoteAddress Addr, std::string &Dest) override {
+    ReadBytesResult R = readBytes(Addr, 1);
+    if (!R)
       return false;
-    // TODO: Account for running off the edge of an object, offset in ELF
-    // binaries
-    auto cString = StringRef((const char*)address.getAddressData());
-    dest.append(cString.begin(), cString.end());
+    StringRef Str((const char *)R.get());
+    Dest.append(Str.begin(), Str.end());
     return true;
   }
 };
 
-static int doDumpReflectionSections(ArrayRef<std::string> binaryFilenames,
-                                    StringRef arch,
-                                    ActionType action,
+static int doDumpReflectionSections(ArrayRef<std::string> BinaryFilenames,
+                                    StringRef Arch, ActionType Action,
                                     std::ostream &OS) {
   // Note: binaryOrError and objectOrError own the memory for our ObjectFile;
   // once they go out of scope, we can no longer do anything.
-  std::vector<OwningBinary<Binary>> binaryOwners;
-  std::vector<std::unique_ptr<ObjectFile>> objectOwners;
-  std::vector<const ObjectFile *> objectFiles;
+  std::vector<OwningBinary<Binary>> BinaryOwners;
+  std::vector<std::unique_ptr<ObjectFile>> ObjectOwners;
+  std::vector<const ObjectFile *> ObjectFiles;
 
-  // Construct the ReflectionContext.
-  // FIXME: Should pick a Runtime template based on the bitwidth of the target
-  // architecture.
-  auto reader = std::make_shared<ObjectMemoryReader>(objectFiles);
-  NativeReflectionContext context(std::move(reader));
-
-  for (auto binaryFilename : binaryFilenames) {
-    auto binaryOwner = unwrap(createBinary(binaryFilename));
-    Binary *binaryFile = binaryOwner.getBinary();
+  for (const std::string &BinaryFilename : BinaryFilenames) {
+    auto BinaryOwner = unwrap(createBinary(BinaryFilename));
+    Binary *BinaryFile = BinaryOwner.getBinary();
 
     // The object file we are doing lookups in -- either the binary itself, or
     // a particular slice of a universal binary.
-    std::unique_ptr<ObjectFile> objectOwner;
-    const ObjectFile *objectFile;
-
-    if (auto o = dyn_cast<ObjectFile>(binaryFile)) {
-      objectFile = o;
-    } else {
-      auto universal = cast<MachOUniversalBinary>(binaryFile);
-      objectOwner = unwrap(universal->getObjectForArch(arch));
-      objectFile = objectOwner.get();
+    std::unique_ptr<ObjectFile> ObjectOwner;
+    const ObjectFile *O = dyn_cast<ObjectFile>(BinaryFile);
+    if (!O) {
+      auto Universal = cast<MachOUniversalBinary>(BinaryFile);
+      ObjectOwner = unwrap(Universal->getObjectForArch(Arch));
+      O = ObjectOwner.get();
     }
 
     // Retain the objects that own section memory
-    binaryOwners.push_back(std::move(binaryOwner));
-    objectOwners.push_back(std::move(objectOwner));
-    objectFiles.push_back(objectFile);
-
-    auto startAddress = (uintptr_t)objectFile->getData().begin();
-    context.addImage(RemoteAddress(startAddress));
+    BinaryOwners.push_back(std::move(BinaryOwner));
+    ObjectOwners.push_back(std::move(ObjectOwner));
+    ObjectFiles.push_back(O);
   }
 
-  switch (action) {
+  auto Reader = std::make_shared<ObjectMemoryReader>(ObjectFiles);
+  NativeReflectionContext Context(Reader);
+  for (const Image &I : Reader->getImages())
+    Context.addImage(I.getStartAddress());
+
+  switch (Action) {
   case ActionType::DumpReflectionSections:
     // Dump everything
-    context.getBuilder().dumpAllSections(OS);
+    Context.getBuilder().dumpAllSections(OS);
     break;
   case ActionType::DumpTypeLowering: {
-    for (std::string line; std::getline(std::cin, line); ) {
-      if (line.empty())
+    for (std::string Line; std::getline(std::cin, Line);) {
+      if (Line.empty())
         continue;
 
-      if (StringRef(line).startswith("//"))
+      if (StringRef(Line).startswith("//"))
         continue;
 
       Demangle::Demangler Dem;
-      auto demangled = Dem.demangleType(line);
-      auto *typeRef = swift::Demangle::decodeMangledType(context.getBuilder(),
-                                                         demangled);
-      if (typeRef == nullptr) {
-        OS << "Invalid typeref: " << line << "\n";
+      auto Demangled = Dem.demangleType(Line);
+      auto *TypeRef =
+          swift::Demangle::decodeMangledType(Context.getBuilder(), Demangled);
+      if (TypeRef == nullptr) {
+        OS << "Invalid typeref: " << Line << "\n";
         continue;
       }
 
-      typeRef->dump(OS);
-      auto *typeInfo =
-        context.getBuilder().getTypeConverter().getTypeInfo(typeRef);
-      if (typeInfo == nullptr) {
+      TypeRef->dump(OS);
+      auto *TypeInfo =
+          Context.getBuilder().getTypeConverter().getTypeInfo(TypeRef);
+      if (TypeInfo == nullptr) {
         OS << "Invalid lowering\n";
         continue;
       }
-      typeInfo->dump(OS);
+      TypeInfo->dump(OS);
     }
     break;
   }
@@ -238,8 +291,6 @@ int main(int argc, char *argv[]) {
   PROGRAM_START(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift Reflection Dump\n");
   return doDumpReflectionSections(options::BinaryFilename,
-                                  options::Architecture,
-                                  options::Action,
+                                  options::Architecture, options::Action,
                                   std::cout);
 }
-


### PR DESCRIPTION
Previously when ReflectionContext was parsing the image of a binary
(for ELF or COFF) it was making some incorrect assumptions about the location
of sections in the memory of a remote process. In particular, it was using the offsets
rather than the virtual addresses and it was incorrectly calculating the references (relative pointers)
inside the metadata. In this diff we address these issues and adjust swift-reflection-dump
(used in tests) to emulate the runtime behavior more closely.
This diff has been extensively tested, the reflection tests are green on OSX and Linux,
on Windows it fixes 2 new tests:
    Reflection/typeref_decoding.swift
    stdlib/ReflectionHashing.swift
So now (with some minor fixes to the lit testsing infrastructure) the following reflection
tests pass:
    Reflection/box_descriptors.sil
    Reflection/capture_descriptors.sil
    Reflection/typeref_decoding.swift
    stdlib/ReflectionHashing.swift
