### PR TITLE
[NFC][not.py] Making escaping of argv more consistent. Addressing PR #23578.

### DIFF
--- a/test/PlaygroundTransform/Inputs/not.py
+++ b/test/PlaygroundTransform/Inputs/not.py
@@ -7,7 +7,7 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 try:
-    subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
+    subprocess.check_call(shlex.split(sys.argv[1]))
     sys.exit(1)
 except subprocess.CalledProcessError as e:
     sys.exit(0)


### PR DESCRIPTION

In https://github.com/apple/swift/pull/23578, @jrose-apple gave some
comments on correctness of argument concatenation in regards to not.py.
The PR merged before I was able to address those changes.
