### PR TITLE
test: split up ClangImporter.enum-anon

### DIFF
--- a/test/ClangImporter/enum-anon-sized.swift
+++ b/test/ClangImporter/enum-anon-sized.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-objc-interop -import-objc-header %S/Inputs/enum-anon.h | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-runtime %s
+
+func verifyIsInt(_: inout Int) { }
+func verifyIsInt32(_: inout Int32) { }
+func verifyIsUInt32(_: inout UInt32) { }
+
+var a = Constant2
+var b = VarConstant2
+var c = SR2511().y
+
+verifyIsInt(&a)
+#if !os(Windows)
+verifyIsUInt32(&b)
+verifyIsUInt32(&c)
+#else
+verifyIsInt32(&b)
+verifyIsInt32(&c)
+#endif
+
+// CHECK: %TSo6SR2511V = type <{ %Ts5Int32V, [[ENUM_TYPE:%Ts5Int32V|%Ts6UInt32V]], %Ts5Int32V }>
+// CHECK-LABEL: define{{.*}} i32 @"$s4main6testIR1xs5Int32VSPySo6SR2511VG_tF"(
+public func testIR(x: UnsafePointer<SR2511>) -> CInt {
+  // CHECK: store i32 1, i32* getelementptr inbounds ([[ENUM_TYPE]], [[ENUM_TYPE]]* bitcast (i32* @global to [[ENUM_TYPE]]*), i32 0, i32 0), align 4
+  global = VarConstant2
+
+#if _runtime(_ObjC)
+  // CHECK-objc: store i16 1, i16* getelementptr inbounds (%Ts6UInt16V, %Ts6UInt16V* bitcast (i16* @usGlobal to %Ts6UInt16V*), i32 0, i32 0), align 2
+  usGlobal = USVarConstant2
+#endif
+
+  // Force the definition of the type above.
+  // CHECK: ret
+  return x.pointee.z
+} // CHECK-NEXT: {{^}$}}
+

--- a/test/ClangImporter/enum-anon.swift
+++ b/test/ClangImporter/enum-anon.swift
@@ -1,11 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/enum-anon.h -DDIAGS -verify
-// RUN: %target-swift-frontend -emit-ir %s -enable-objc-interop -import-objc-header %S/Inputs/enum-anon.h | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-runtime %s
 
-#if DIAGS
 func testDiags() {
-  let _: String = Constant2 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
-  let _: String = VarConstant2 // expected-error {{cannot convert value of type 'UInt32' to specified type 'String'}}
-
 #if _runtime(_ObjC)
   let us2 = USConstant2
 #else
@@ -20,27 +15,8 @@ func testDiags() {
 #endif
   let _: String = usVar2 // expected-error {{cannot convert value of type 'UInt16' to specified type 'String'}}
 
-  let _: String = SR2511().y // expected-error {{cannot convert value of type 'UInt32' to specified type 'String'}}
-
   // The nested anonymous enum value should still have top-level scope, because
   // that's how C works. It should also have the same type as the field (above).
-  let _: String = SR2511B // expected-error {{cannot convert value of type 'UInt32' to specified type 'String'}}
   let _: String = SR2511.SR2511B // expected-error {{type 'SR2511' has no member 'SR2511B'}}
 }
-#endif
 
-// CHECK-LABEL: %TSo6SR2511V = type <{ %Ts5Int32V, %Ts6UInt32V, %Ts5Int32V }>
-// CHECK-LABEL: define{{.*}} i32 @"$s4main6testIR1xs5Int32VSPySo6SR2511VG_tF"(
-public func testIR(x: UnsafePointer<SR2511>) -> CInt {
-  // CHECK: store i32 1, i32* getelementptr inbounds (%Ts6UInt32V, %Ts6UInt32V* bitcast (i32* @global to %Ts6UInt32V*), i32 0, i32 0), align 4
-  global = VarConstant2
-
-#if _runtime(_ObjC)
-  // CHECK-objc: store i16 1, i16* getelementptr inbounds (%Ts6UInt16V, %Ts6UInt16V* bitcast (i16* @usGlobal to %Ts6UInt16V*), i32 0, i32 0), align 2
-  usGlobal = USVarConstant2
-#endif
-
-  // Force the definition of the type above.
-  // CHECK: ret
-  return x.pointee.z
-} // CHECK-NEXT: {{^}$}}


### PR DESCRIPTION
This splits up the test into two halves in order to allow the test to
pass on Windows.  Loosen the test to allow the enumeration to be
imported with signed and unsigned types as Windows uses signed
enumerations by default.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
