### PR TITLE
ASTMangler: Fix mangling of type aliases in fully-constrained extensions

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -793,7 +793,7 @@ void ASTMangler::appendType(Type type) {
         return appendType(aliasTy->getSinglyDesugaredType());
       }
 
-      if (aliasTy->getSubstitutionMap().hasAnySubstitutableParams()) {
+      if (aliasTy->getSubstitutionMap()) {
         // Try to mangle the entire name as a substitution.
         if (tryMangleTypeSubstitution(tybase))
           return;

--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -101,3 +101,10 @@ public func usesGeneric(y: (GenericAlias<Int>, GenericClass<Int>, GenericAlias<I
   let x = y
   markUsed(x)
 }
+
+public struct Ox<T> {}
+extension Ox where T == Int {
+  public typealias Plow = Int
+}
+
+var v: Ox<Int>.Plow = 0


### PR DESCRIPTION
We should still mangle these as generic types.

Fixes <rdar://problem/47980487>.
