### PR TITLE
ClangImporter: use `intptr_t` instead of `long`

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/UnimportableMembers.h
+++ b/test/ClangImporter/Inputs/custom-modules/UnimportableMembers.h
@@ -1,54 +1,57 @@
+
+typedef __INTPTR_TYPE__ intptr_t;
+
 __attribute__((objc_root_class))
 @interface Base
 - (instancetype)init;
 @end
 
 @interface IncompleteDesignatedInitializers : Base
-- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initMissing:(long)x, ... __attribute__((objc_designated_initializer));
-- (instancetype)initConveniently:(long)x;
+- (instancetype)initFirst:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initSecond:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(intptr_t)x, ... __attribute__((objc_designated_initializer));
+- (instancetype)initConveniently:(intptr_t)x;
 @end
 @interface IncompleteDesignatedInitializers (CategoryConvenience)
-- (instancetype)initCategory:(long)x;
+- (instancetype)initCategory:(intptr_t)x;
 @end
 
 @interface IncompleteConvenienceInitializers : Base
-- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initMissing:(long)x, ...;
-- (instancetype)initConveniently:(long)x;
+- (instancetype)initFirst:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initSecond:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(intptr_t)x, ...;
+- (instancetype)initConveniently:(intptr_t)x;
 @end
 @interface IncompleteConvenienceInitializers (CategoryConvenience)
-- (instancetype)initCategory:(long)x;
+- (instancetype)initCategory:(intptr_t)x;
 @end
 
 @interface IncompleteUnknownInitializers : Base
-- (instancetype)initFirst:(long)x;
-- (instancetype)initSecond:(long)x;
-- (instancetype)initMissing:(long)x, ...;
-- (instancetype)initConveniently:(long)x;
+- (instancetype)initFirst:(intptr_t)x;
+- (instancetype)initSecond:(intptr_t)x;
+- (instancetype)initMissing:(intptr_t)x, ...;
+- (instancetype)initConveniently:(intptr_t)x;
 @end
 @interface IncompleteUnknownInitializers (CategoryConvenience)
-- (instancetype)initCategory:(long)x;
+- (instancetype)initCategory:(intptr_t)x;
 @end
 
 @interface IncompleteDesignatedInitializersWithCategory : Base
-- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initMissing:(long)x, ... __attribute__((objc_designated_initializer));
-- (instancetype)initConveniently:(long)x;
+- (instancetype)initFirst:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(intptr_t)x, ... __attribute__((objc_designated_initializer));
+- (instancetype)initConveniently:(intptr_t)x;
 @end
 @interface IncompleteDesignatedInitializersWithCategory (/*class extension*/)
-- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initCategory:(long)x;
+- (instancetype)initSecond:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initCategory:(intptr_t)x;
 @end
 
 @interface DesignatedInitializerInAnotherModule : Base
-- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
-- (instancetype)initMissing:(long)x, ... __attribute__((objc_designated_initializer));
-- (instancetype)initConveniently:(long)x;
+- (instancetype)initFirst:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initSecond:(intptr_t)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(intptr_t)x, ... __attribute__((objc_designated_initializer));
+- (instancetype)initConveniently:(intptr_t)x;
 @end
 @interface DesignatedInitializerInAnotherModule (CategoryConvenience)
-- (instancetype)initCategory:(long)x;
+- (instancetype)initCategory:(intptr_t)x;
 @end


### PR DESCRIPTION
`long` is imported as `Int32` on LLP64, and `Int` on LP64.  Use
`intptr_t` instead which is always imported as `Int`.  This fixes the
clang-importer.objc_missing_designated_init test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
