### PR TITLE
test: make ClangImporter.cfuncs_parse pass on LLP64

### DIFF
--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -9,7 +9,12 @@ func test_cfunc1(_ i: Int) {
 }
 
 func test_cfunc2(_ i: Int) {
+#if os(Windows) && (arch(arm64) || arch(x86_64))
+  // LLP64 targets will import `long` as `Int32`
+  let f = cfunc2(Int32(i), 17)
+#else
   let f = cfunc2(i, 17)
+#endif
   _ = f as Float
   cfunc2(b:17, a:i) // expected-error{{extraneous argument labels 'b:a:' in call}}
   cfunc2(17, i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'Int32'}}


### PR DESCRIPTION
`long` is treated as `Int32` on LLP64 targets and `Int` on LP64 targets.
Add a `numericCast` for that particular case.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
