### PR TITLE
test: improve ClangImporter.ctypes_parse on Windows

### DIFF
--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -31,7 +31,7 @@ func testTribool() {
 func testAnonEnum() {
   var a = AnonConst1
   a = AnonConst2
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || os(Windows)
   _ = a as CUnsignedLongLong
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   _ = a as CUnsignedLong

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -7,10 +7,18 @@ enum Tribool {
   True, False, Indeterminate
 };
 
-enum {
+// This is explicitly sized on Windows since we do not use the type to infer the
+// type that we are importing it as as this is known to be explicitly different
+// in that environment.
+enum
+#if defined(_WIN32)
+: unsigned long long
+#endif
+{
   AnonConst1 = 0x700000000,
   AnonConst2
 };
+_Static_assert(sizeof(AnonConst1) == 8);
 
 enum {
   AnonConstSmall1 = 16,


### PR DESCRIPTION
Windows uses signed enumeration types, which means that the value si
imported as `Int` rather than `CInt`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
