### PR TITLE
[stdlib] Fix availability of Dictionary’s bulk-loading initializer

### DIFF
--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -71,6 +71,7 @@ extension Dictionary {
   ///   - body: A closure that can initialize the dictionary's elements. This
   ///     closure must return the count of the initialized elements, starting at
   ///     the beginning of the buffer.
+  @_alwaysEmitIntoClient // Introduced in 5.1
   @inlinable
   public // SPI(Foundation)
   init(
@@ -90,6 +91,7 @@ extension Dictionary {
 }
 
 extension _NativeDictionary {
+  @_alwaysEmitIntoClient // Introduced in 5.1
   @inlinable
   internal init(
     _unsafeUninitializedCapacity capacity: Int,


### PR DESCRIPTION
These entry points were introduced in https://github.com/apple/swift/pull/21235. Adding `@_alwaysEmitIntoClient` makes them available in all OS versions.

rdar://problem/49404177