### PR TITLE
[Driver] TSan runtime now has a link-time dependency on libdispatch

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -278,6 +278,12 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   if (job.getKind() == LinkKind::Executable && context.OI.SelectedSanitizers) {
     Arguments.push_back(context.Args.MakeArgString(
         "-fsanitize=" + getSanitizerList(context.OI.SelectedSanitizers)));
+
+    // The TSan runtime depends on the blocks runtime and libdispatch.
+    if (context.OI.SelectedSanitizers & SanitizerKind::Thread) {
+      Arguments.push_back("-lBlocksRuntime");
+      Arguments.push_back("-ldispatch");
+    }
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -86,7 +86,7 @@
 // TSAN_watchOS_SIM: unsupported option '-sanitize=thread' for target 'i386-apple-watchos2.0'
 // TSAN_watchOS: unsupported option '-sanitize=thread' for target 'armv7k-apple-watchos2.0'
 // FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
-// TSAN_LINUX: -fsanitize=thread
+// TSAN_LINUX: -fsanitize=thread -lBlocksRuntime -ldispatch
 // TSAN_WINDOWS: unsupported option '-sanitize=thread' for target 'x86_64-unknown-windows-msvc'
 
 // TSAN: -rpath @executable_path


### PR DESCRIPTION
Previously, the TSan runtime only required libdispatch on Darwin, which
required no explicit linker flags, because libdispatch is always
provided by the system (via libSystem).

Now, the TSan runtime also has a link-time dependency on libdispatch on
Linux, where libdispatch (and the blocks runtime) is just another
library. We therefore need to specify them as additional linker options.
