### PR TITLE
[TF] Bug fix in the 'Tensor.concatenated' VJP

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -692,7 +692,7 @@ internal extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable @inline(__always)
   func _vjpConcatenated(with other: Tensor, alongAxis axis: Int32)
     -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-    let idx = axis >= 0 ? axis : rank - axis
+   let idx = axis < 0 ? axis + rank : axis
     let splits = Tensor<Int32>([shapeTensor[idx], other.shapeTensor[idx]])
     return (Raw.concatV2([self, other], axis: Tensor<Int32>(axis)), { result in
       let ret: (TensorHandle<Scalar>, TensorHandle<Scalar>) = #tfop("SplitV",

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -692,7 +692,7 @@ internal extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable @inline(__always)
   func _vjpConcatenated(with other: Tensor, alongAxis axis: Int32)
     -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-   let idx = axis < 0 ? axis + rank : axis
+    let idx = axis < 0 ? axis + rank : axis
     let splits = Tensor<Int32>([shapeTensor[idx], other.shapeTensor[idx]])
     return (Raw.concatV2([self, other], axis: Tensor<Int32>(axis)), { result in
       let ret: (TensorHandle<Scalar>, TensorHandle<Scalar>) = #tfop("SplitV",

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -221,6 +221,21 @@ TensorTests.testAllBackends("VJPConcatenation") {
   expectEqual(b1, grads.1)
 }
 
+TensorTests.testAllBackends("VJPConcatenationNegativeAxis") {
+  let a1 = Tensor<Float>([1,2,3,4])
+  let b1 = Tensor<Float>([5,6,7,8,9,10])
+
+  let a2 = Tensor<Float>([1,1,1,1])
+  let b2 = Tensor<Float>([1,1,1,1,1,1])
+
+  let grads = gradient(at: a2, b2) { a, b in
+    return (a1 * a).concatenated(with: b1 * b, alongAxis: -1).sum()
+  }
+
+  expectEqual(a1, grads.0)
+  expectEqual(b1, grads.1)
+}
+
 TensorTests.test("EwiseComparison") {
   let x = Tensor<Float>([0, 1, 2])
   let y = Tensor<Float>([2, 1, 3])


### PR DESCRIPTION
There was a bug in the handling of negative axis arguments. This PR fixes it and also adds a simple test for this case.