### PR TITLE
SILGen: Kill "scalar" PreparedArguments

### DIFF
--- a/lib/SILGen/ASTVisitor.h
+++ b/lib/SILGen/ASTVisitor.h
@@ -57,7 +57,8 @@ public:
   }
 
   ExprRetTy visitVarargExpansionExpr(VarargExpansionExpr *E, Args... AA) {
-    llvm_unreachable("vararg expansion should not appear in this position");
+    return static_cast<ImplClass*>(this)->visit(E->getSubExpr(),
+                                                std::forward<Args>(AA)...);
   }
 
   ExprRetTy visitIdentityExpr(IdentityExpr *E, Args...AA) {

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -240,9 +240,6 @@ public:
                            AbstractionPattern origFormalType,
                            SILType expectedType = SILType()) &&;
 
-  /// Whether this argument source is an ArgumentShuffleExpr.
-  bool isShuffle() const;
-
   bool isObviouslyEqual(const ArgumentSource &other) const;
 
   ArgumentSource copyForDiagnostics() const;
@@ -268,9 +265,9 @@ class PreparedArguments {
   unsigned IsNull : 1;
 public:
   PreparedArguments() : IsScalar(false), IsNull(true) {}
-  PreparedArguments(ArrayRef<AnyFunctionType::Param> params, bool isScalar)
-      : IsNull(true) {
-    emplace(params, isScalar);
+  explicit PreparedArguments(ArrayRef<AnyFunctionType::Param> params)
+      : IsScalar(false), IsNull(true) {
+    emplace(params);
   }
 
   // Decompse an argument list expression.
@@ -323,15 +320,12 @@ public:
   }
 
   /// Emplace a (probably incomplete) argument list.
-  void emplace(ArrayRef<AnyFunctionType::Param> params, bool isScalar) {
+  void emplace(ArrayRef<AnyFunctionType::Param> params) {
     assert(isNull());
     Params.append(params.begin(), params.end());
-    IsScalar = isScalar;
+    IsScalar = false;
     IsNull = false;
   }
-
-  /// Emplace an empty argument list.
-  void emplaceEmptyArgumentList(SILGenFunction &SGF);
 
   /// Add an emitted r-value argument to this argument list.
   void add(SILLocation loc, RValue &&arg) {

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -273,6 +273,9 @@ public:
     emplace(params, isScalar);
   }
 
+  // Decompse an argument list expression.
+  PreparedArguments(ArrayRef<AnyFunctionType::Param> params, Expr *arg);
+
   // Move-only.
   PreparedArguments(const PreparedArguments &) = delete;
   PreparedArguments &operator=(const PreparedArguments &) = delete;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2599,27 +2599,25 @@ namespace {
 /// arguments are going into a varargs array.
 struct ArgSpecialDest {
   VarargsInfo *SharedInfo;
-  unsigned Index : 31;
-  unsigned IsExpansion : 1;
+  unsigned Index : 32;
   CleanupHandle Cleanup;
 
   ArgSpecialDest() : SharedInfo(nullptr) {}
-  explicit ArgSpecialDest(VarargsInfo &info, unsigned index, bool isExpansion)
-    : SharedInfo(&info), Index(index), IsExpansion(isExpansion) {}
+  explicit ArgSpecialDest(VarargsInfo &info, unsigned index)
+    : SharedInfo(&info), Index(index) {}
 
   // Reference semantics: need to preserve the cleanup handle.
   ArgSpecialDest(const ArgSpecialDest &) = delete;
   ArgSpecialDest &operator=(const ArgSpecialDest &) = delete;
   ArgSpecialDest(ArgSpecialDest &&other)
     : SharedInfo(other.SharedInfo), Index(other.Index),
-      IsExpansion(other.IsExpansion), Cleanup(other.Cleanup) {
+      Cleanup(other.Cleanup) {
     other.SharedInfo = nullptr;
   }
   ArgSpecialDest &operator=(ArgSpecialDest &&other) {
     assert(!isValid() && "overwriting valid special destination!");
     SharedInfo = other.SharedInfo;
     Index = other.Index;
-    IsExpansion = other.IsExpansion;
     Cleanup = other.Cleanup;
     other.SharedInfo = nullptr;
     return *this;
@@ -2637,14 +2635,6 @@ struct ArgSpecialDest {
             AbstractionPattern _unused_origType,
             SILType loweredSubstParamType) {
     assert(isValid() && "filling an invalid destination");
-
-    if (IsExpansion) {
-      auto expr = std::move(arg).asKnownExpr()->getSemanticsProvidingExpr();
-      auto array = cast<VarargExpansionExpr>(expr)->getSubExpr();
-      SharedInfo->setExpansion(Index, SGF.emitRValueAsSingleValue(array));
-      Cleanup = CleanupHandle::invalid();
-      return;
-    }
 
     SILLocation loc = arg.getLocation();
     auto destAddr = SharedInfo->getBaseAddress();
@@ -3473,9 +3463,8 @@ struct ElementExtent {
   ClaimedParamsRef Params;
   /// The destination index, if any.
   /// This is set in the first pass.
-  unsigned DestIndex : 29;
+  unsigned DestIndex : 30;
   unsigned HasDestIndex : 1;
-  unsigned IsVarargExpansion : 1;
 #ifndef NDEBUG
   unsigned Used : 1;
 #endif
@@ -3520,7 +3509,6 @@ class ArgumentShuffleEmitter {
   /// Extents of the inner elements.
   SmallVector<ElementExtent, 8> innerExtents;
   Optional<VarargsInfo> varargsInfo;
-  SmallVector<unsigned, 4> varargExpansions;
   SILParameterInfo variadicParamInfo; // innerExtents will point at this
   Optional<SmallVector<ArgSpecialDest, 8>> innerSpecialDests;
 
@@ -3575,18 +3563,6 @@ private:
     assert(!isResultScalar || index == 0);
     return origParamType.getTupleElementType(index);
   }
-
-  VarargExpansionExpr *getVarargExpansion(unsigned innerIndex) {
-    Expr *expr = inner->getSemanticsProvidingExpr();
-    if (cast<ArgumentShuffleExpr>(outer)->isSourceScalar()) {
-      assert(innerIndex == 0);
-    } else {
-      auto tuple = dyn_cast<TupleExpr>(expr);
-      if (!tuple) return nullptr;
-      expr = tuple->getElement(innerIndex)->getSemanticsProvidingExpr();
-    }
-    return dyn_cast<VarargExpansionExpr>(expr);
-  }
 };
 
 } // end anonymous namespace
@@ -3635,22 +3611,10 @@ void ArgumentShuffleEmitter::constructInnerTupleTypeInfo(ArgEmitter &parent) {
       unsigned numVarargs = variadicArgs.size();
       assert(canVarargsArrayType == substEltType);
 
-      // Check for vararg expansions, since their presence changes our
-      // emission strategy.
-      {
-        for (auto i : indices(variadicArgs)) {
-          unsigned innerIndex = variadicArgs[i];
-          if (getVarargExpansion(innerIndex)) {
-            varargExpansions.push_back(i);
-          }
-        }
-      }
-
       // If we don't have any vararg expansions, eagerly emit into
       // the array value.
       varargsInfo.emplace(emitBeginVarargs(parent.SGF, outer, varargsEltType,
-                                           canVarargsArrayType, numVarargs,
-                                           varargExpansions));
+                                           canVarargsArrayType, numVarargs));
 
       // If we have any varargs, we'll need to actually initialize
       // the array buffer.
@@ -3679,12 +3643,9 @@ void ArgumentShuffleEmitter::constructInnerTupleTypeInfo(ArgEmitter &parent) {
           innerExtents[innerIndex].Used = true;
 #endif
 
-          auto expansion = getVarargExpansion(innerIndex);
-
           // Set the destination index.
           innerExtents[innerIndex].HasDestIndex = true;
           innerExtents[innerIndex].DestIndex = i++;
-          innerExtents[innerIndex].IsVarargExpansion = (expansion != nullptr);
 
           // Use the singleton param info we prepared before.
           innerExtents[innerIndex].Params =
@@ -3714,8 +3675,7 @@ void ArgumentShuffleEmitter::flattenPatternFromInnerExtendIntoInnerParams(
       if (extent.HasDestIndex) {
         assert(extent.Params.size() == 1);
         innerSpecialDests->push_back(
-            ArgSpecialDest(*varargsInfo, extent.DestIndex,
-                           extent.IsVarargExpansion));
+            ArgSpecialDest(*varargsInfo, extent.DestIndex));
 
         // Otherwise, fill in with the appropriate number of invalid
         // special dests.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2415,7 +2415,7 @@ loadIndexValuesForKeyPathComponent(SILGenFunction &SGF, SILLocation loc,
     indexParams.emplace_back(SGF.F.mapTypeIntoContext(elt.first));
   }
   
-  PreparedArguments indexValues(indexParams, /*scalar*/ indexes.size() == 1);
+  PreparedArguments indexValues(indexParams, /*scalar*/ false);
   if (indexes.empty()) {
     assert(indexValues.isValid());
     return indexValues;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1868,8 +1868,7 @@ static RValue emitBoolLiteral(SILGenFunction &SGF, SILLocation loc,
   RValue builtinArg(SGF, ManagedValue::forUnmanaged(builtinBool),
                     builtinArgType);
 
-  PreparedArguments builtinArgs(AnyFunctionType::Param(builtinArgType),
-                                /*scalar*/ false);
+  PreparedArguments builtinArgs((AnyFunctionType::Param(builtinArgType)));
   builtinArgs.add(loc, std::move(builtinArg));
 
   auto result =
@@ -2415,7 +2414,7 @@ loadIndexValuesForKeyPathComponent(SILGenFunction &SGF, SILLocation loc,
     indexParams.emplace_back(SGF.F.mapTypeIntoContext(elt.first));
   }
   
-  PreparedArguments indexValues(indexParams, /*scalar*/ false);
+  PreparedArguments indexValues(indexParams);
   if (indexes.empty()) {
     assert(indexValues.isValid());
     return indexValues;
@@ -3649,8 +3648,7 @@ RValue RValueEmitter::visitArrayExpr(ArrayExpr *E, SGFContext C) {
     return array;
 
   // Call the builtin initializer.
-  PreparedArguments args(AnyFunctionType::Param(E->getType()),
-                         /*scalar*/ false);
+  PreparedArguments args(AnyFunctionType::Param(E->getType()));
   args.add(E, std::move(array));
 
   return SGF.emitApplyAllocatingInitializer(

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1413,7 +1413,7 @@ public:
   // Helpers for emitting ApplyExpr chains.
   //
 
-  RValue emitApplyExpr(Expr *e, SGFContext c);
+  RValue emitApplyExpr(ApplyExpr *e, SGFContext c);
 
   /// Emit a function application, assuming that the arguments have been
   /// lowered appropriately for the abstraction level but that the

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1210,10 +1210,6 @@ public:
                                             AccessStrategy strategy,
                                             Expr *indices);
 
-  RValue prepareEnumPayload(EnumElementDecl *element,
-                            CanFunctionType substFnType,
-                            ArgumentSource &&indexExpr);
-
   ArgumentSource prepareAccessorBaseArg(SILLocation loc, ManagedValue base,
                                         CanType baseFormalType,
                                         SILDeclRef accessor);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1459,7 +1459,7 @@ public:
                                      SGFContext ctx);
 
   RValue emitApplyAllocatingInitializer(SILLocation loc, ConcreteDeclRef init,
-                                        RValue &&args, Type overriddenSelfType,
+                                        PreparedArguments &&args, Type overriddenSelfType,
                                         SGFContext ctx);
 
   CleanupHandle emitBeginApply(SILLocation loc, ManagedValue fn,

--- a/lib/SILGen/SpecializedEmitter.h
+++ b/lib/SILGen/SpecializedEmitter.h
@@ -32,6 +32,7 @@ class ManagedValue;
 class SGFContext;
 class SILGenFunction;
 class SILGenModule;
+class PreparedArguments;
 
 /// Some kind of specialized emitter for a builtin function.
 class SpecializedEmitter {
@@ -41,7 +42,7 @@ public:
   using EarlyEmitter = ManagedValue (SILGenFunction &,
                                      SILLocation,
                                      SubstitutionMap,
-                                     Expr *argument,
+                                     PreparedArguments &&args,
                                      SGFContext);
 
   /// A special function for emitting a call after the arguments

--- a/lib/SILGen/Varargs.h
+++ b/lib/SILGen/Varargs.h
@@ -35,23 +35,12 @@ class VarargsInfo {
   SILValue BaseAddress;
   AbstractionPattern BasePattern;
   const TypeLowering &BaseTL;
-  bool IsExpansionPeephole = false;
 public:
   VarargsInfo(ManagedValue array, CleanupHandle abortCleanup,
               SILValue baseAddress, const TypeLowering &baseTL,
-              AbstractionPattern basePattern, bool isExpansionPeephole)
+              AbstractionPattern basePattern)
     : Array(array), AbortCleanup(abortCleanup),
-      BaseAddress(baseAddress), BasePattern(basePattern), BaseTL(baseTL),
-      IsExpansionPeephole(isExpansionPeephole) {}
-
-  void setExpansion(unsigned index, ManagedValue expansion) {
-    assert(IsExpansionPeephole);
-    assert(index == 0 && "non-initial index for peephole?");
-    assert(!Array && "array already filled");
-    Array = expansion;
-  }
-
-  bool isExpansionPeephole() const { return IsExpansionPeephole; }
+      BaseAddress(baseAddress), BasePattern(basePattern), BaseTL(baseTL) {}
 
   /// Return the array value.  emitEndVarargs() is really the only
   /// function that should be accessing this directly.
@@ -75,8 +64,7 @@ public:
 /// Begin a varargs emission sequence.
 VarargsInfo emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
                              CanType baseTy, CanType arrayTy,
-                             unsigned numElements,
-                             ArrayRef<unsigned> expansions);
+                             unsigned numElements);
 
 /// Successfully end a varargs emission sequence.
 ManagedValue emitEndVarargs(SILGenFunction &SGF, SILLocation loc,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2945,11 +2945,7 @@ namespace {
     Expr *visitVarargExpansionExpr(VarargExpansionExpr *expr) {
       simplifyExprType(expr);
 
-      auto elementTy = cs.getType(expr);
-      auto arrayTy =
-        cs.getTypeChecker().getArraySliceType(expr->getLoc(), elementTy);
-      if (!arrayTy) return expr;
-
+      auto arrayTy = cs.getType(expr);
       expr->setSubExpr(coerceToType(expr->getSubExpr(), arrayTy,
                                     cs.getConstraintLocator(expr)));
       return expr;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1718,7 +1718,9 @@ namespace {
       for (unsigned i = 0, n = expr->getNumElements(); i != n; ++i) {
         auto *elt = expr->getElement(i);
         auto ty = CS.getType(elt);
-        auto flags = ParameterTypeFlags().withInOut(elt->isSemanticallyInOutExpr());
+        auto flags = ParameterTypeFlags()
+            .withInOut(elt->isSemanticallyInOutExpr())
+            .withVariadic(isa<VarargExpansionExpr>(elt));
         elements.push_back(TupleTypeElt(ty->getInOutObjectType(),
                                         expr->getElementName(i), flags));
       }
@@ -2438,12 +2440,7 @@ namespace {
       CS.addConstraint(ConstraintKind::Conversion,
                        CS.getType(expr->getSubExpr()), array,
                        CS.getConstraintLocator(expr));
-
-      // The apparent type of the expression is the element type, as far as
-      // the type-checker is concerned.  When this becomes a real feature,
-      // we should syntactically restrict these expressions to only appear
-      // in specific positions.
-      return element;
+      return array;
     }
 
     Type visitDynamicTypeExpr(DynamicTypeExpr *expr) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -390,6 +390,13 @@ matchCallArguments(ArrayRef<AnyFunctionType::Param> args,
       // Record the first argument for the variadic.
       parameterBindings[paramIdx].push_back(*claimed);
 
+      // If the argument is itself variadic, we're forwarding varargs
+      // with a VarargExpansionExpr; don't collect any more arguments.
+      if (args[*claimed].isVariadic()) {
+        skipClaimedArgs();
+        return;
+      }
+
       auto currentNextArgIdx = nextArgIdx;
       {
         nextArgIdx = *claimed;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -457,7 +457,8 @@ static Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
   }
   
   // A single unlabeled value is not a tuple.
-  if (args.size() == 1 && labels[0].empty()) {
+  if (args.size() == 1 && labels[0].empty() &&
+      !isa<VarargExpansionExpr>(args[0])) {
     return new (ctx) ParenExpr(SourceLoc(), args[0], SourceLoc(),
                                /*hasTrailingClosure=*/false);
   }


### PR DESCRIPTION
The PreparedArguments abstraction could be used in two ways: you could either build it from a decomposed argument list with one expression per argument, or build a "scalar" one with a single expression for all the arguments.

This PR removes the "scalar" case, _except_ when the expression is an ArgumentShuffleExpr. That's not a problem because my next PR will completely remove ArgumentShuffleExpr.