### PR TITLE
test: use the clang definition for UNIT{32,64}_MAX

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -12,7 +12,13 @@
 #define EOF (-1)
 #define UINT32_MAX 0xFFFFFFFFU
 #define INT64_MAX 0x7FFFFFFFFFFFFFFFLL
+#if defined(_WIN32)
+// MSVC compatibility will always return a signed value when the suffix is `LL`
+// or `i64` and other targets will promote it to an unsigned type.
+#define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL
+#else
 #define UINT64_MAX 0xFFFFFFFFFFFFFFFFLL
+#endif
 #define MINUS_THREE -3
 #define true 1
 #define false 0


### PR DESCRIPTION
Rather than defining our own type, use the clang definition which is
what Swift actually uses.  This repairs the ClangImporter.macros and
ClangImporter.macro_literals tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
