### PR TITLE
[ConstraintSystem] Delay adding contextual requirements until parent …

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0189-rdar49371608.swift
+++ b/validation-test/compiler_crashers_2_fixed/0189-rdar49371608.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+struct A<T> {
+  let foo: [T]
+}
+
+extension A : Codable where T: Codable {
+  enum CodingKeys: String, CodingKey {
+    case foo = "foo"
+  }
+}


### PR DESCRIPTION
…type is opened

`openUnboundGenericType` eagerly tries to add conditional requirements
associated with chain of parents of the given type if type has been
declared inside of constrained extension. But one of the parent types
might be unbound e.g. `A.B` which means it has to be opened, which
by itself, would add such requirements.

Resolves: rdar://problem/49371608

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
