### PR TITLE
test: be more flexible about anonymous enumeration imports

### DIFF
--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -28,15 +28,19 @@ func testTribool() {
   _ = b.rawValue
 }
 
+func verifyIsInt(_: inout Int) { }
+func verifyIsUInt(_: inout UInt) { }
+func verifyIsUInt64(_: inout UInt64) { }
+
 func testAnonEnum() {
   var a = AnonConst1
   a = AnonConst2
-#if arch(i386) || arch(arm) || os(Windows)
-  _ = a as CUnsignedLongLong
+#if os(Windows)
+  verifyIsInt(&a)
+#elseif arch(i386) || arch(arm)
+  verifyIsUInt64(&a)
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  _ = a as CUnsignedLong
-#else
-  __portMe()
+  verifyIsUInt(&a)
 #endif
 }
 

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -7,18 +7,10 @@ enum Tribool {
   True, False, Indeterminate
 };
 
-// This is explicitly sized on Windows since we do not use the type to infer the
-// type that we are importing it as as this is known to be explicitly different
-// in that environment.
-enum
-#if defined(_WIN32)
-: unsigned long long
-#endif
-{
+enum {
   AnonConst1 = 0x700000000,
   AnonConst2
 };
-_Static_assert(sizeof(AnonConst1) == 8);
 
 enum {
   AnonConstSmall1 = 16,


### PR DESCRIPTION
This test ensures that we correctly translate the anonymous enumeration
value. However, this is an odd case within the specification.

C11 6.7.2.2p2:
"The expression that defines the value of an enumeration constant shall
be an integer constant expression that has a value representable as an
`int`."

C11 6.7.2.2p4:
"Each enumerated type shall be compatible with `char`, a signed integer
type, or an unsigned integer type.  The choice of type is
implementation-defined, but shall be capable of representing the values
of all the members of the enumeration."

C11 6.7.2.2p3:
"The identifiers in an enumerator list are declared as constants that
have type `int` and may appear wherever such are permitted."

Because the enumeration is anonymous, the value could never be written
as spelled.  This type is imported as an `int` on Windows as per the ABI
and as an `unsigned long` on LP64 targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
