### PR TITLE
test: augment the SDK sysroot for Windows

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -170,6 +170,10 @@ typedef SInt32 OSStatus;
 
 // Types from stdint.h.
 #include <stdint.h>
+#if defined(_WIN32)
+typedef __INTPTR_TYPE__ intptr_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+#endif
 STDLIB_TEST(__UINT8_TYPE__, uint8_t);
 STDLIB_TEST(__UINT16_TYPE__, uint16_t);
 STDLIB_TEST(__UINT32_TYPE__, uint32_t);


### PR DESCRIPTION
Windows does not have `intptr_t` and `uintptr_t` defined properly.
Define the types using the clang builtin types in the SDK.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
