### PR TITLE
[NFC] Remove CompilerInstance::setVirtualFileSystem

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1017,9 +1017,8 @@ ClangImporter::create(ASTContext &ctx,
       if (!instance.getHeaderSearchOpts().VFSOverlayFiles.empty()) {
         ctx.Diags.diagnose(SourceLoc(), diag::clang_vfs_overlay_is_ignored);
       }
-      instance.setVirtualFileSystem(ctx.SourceMgr.getFileSystem());
     }
-    instance.createFileManager();
+    instance.createFileManager(ctx.SourceMgr.getFileSystem());
   }
 
   // Don't stop emitting messages if we ever can't load a module.


### PR DESCRIPTION
CompilerInstance::setVirtualFileSystem was removed in r357037.