### PR TITLE
Create mandatory and opt versions of TFDeabstraction and TFPartition passes.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -283,9 +283,13 @@ PASS(SwiftArrayOpts, "array-specialize",
 // SWIFT_ENABLE_TENSORFLOW
 PASS(Differentiation, "differentiation",
      "Automatic Differentiation")
-PASS(TFDeabstraction, "tf-deabstraction",
+PASS(TFDeabstractionMandatory, "tf-deabstraction-mandatory",
      "Deabstract tensor operations")
-PASS(TFPartition, "tf-partition-impl",
+PASS(TFDeabstractionOpt, "tf-deabstraction-opt",
+     "Deabstract tensor operations")
+PASS(TFPartitionMandatory, "tf-partition-mandatory",
+     "Partition accelerator operations out of mainline control flow")
+PASS(TFPartitionOpt, "tf-partition-opt",
      "Partition accelerator operations out of mainline control flow")
 PASS(TFPartitionTest, "tf-partition",
      "Partition accelerator operations out of mainline control flow")

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_SILOPTIMIZER_TENSORFLOW_H
 #define SWIFT_SILOPTIMIZER_TENSORFLOW_H
 
+#include "TFConstExpr.h"
 #include "TFDeviceSupport.h"
 #include "swift/AST/TensorFlow.h"
 #include "swift/SIL/GraphOperationInfo.h"
@@ -272,6 +273,12 @@ private:
                               const std::string &graphFnNameForCaller,
                               bool isAcceleratorOnly,
                               const GraphFunctionDeviceInfo &deviceInfo);
+};
+
+enum class TFPassKind {
+  Test,         // Use for testing
+  Mandatory,    // process tensorflow conventio functions.
+  Opt,          // process non-tensorflow convention functions.
 };
 
 } // end namespace tf

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -118,7 +118,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addSplitNonCondBrCriticalEdges();
 
   // SWIFT_ENABLE_TENSORFLOW
-  P.addTFDeabstraction();
+  P.addTFDeabstractionMandatory();
 }
 
 SILPassPipelinePlan
@@ -394,6 +394,7 @@ static void addMidModulePassesStackPromotePassPipeline(SILPassPipelinePlan &P) {
 
 static void addMidLevelPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("MidLevel");
+  P.addTFDeabstractionOpt();
   addSSAPasses(P, OptimizationLevelKind::MidLevel);
 
   // Specialize partially applied functions with dead arguments as a preparation
@@ -620,6 +621,8 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
 
   P.startPipeline("Rest of Onone");
 
+  P.addTFPartitionMandatory();
+
   // Has only an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();
 
@@ -637,7 +640,7 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
 SILPassPipelinePlan SILPassPipelinePlan::getTFPartitionPassPipeline() {
   SILPassPipelinePlan P;
   P.startPipeline("TensorFlow Partitioning");
-  P.addTFPartition();
+  P.addTFPartitionOpt();
   return P;
 }
 /// SWIFT_ENABLE_TENSORFLOW End

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -621,13 +621,14 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
 
   P.startPipeline("Rest of Onone");
 
-  P.addTFPartitionMandatory();
-
   // Has only an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();
 
   // Has only an effect if the -gsil option is specified.
   P.addSILDebugInfoGenerator();
+
+  // SWIFT_ENABLE_TENSORFLOW
+  P.addTFPartitionMandatory();
 
   return P;
 }

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -78,7 +78,7 @@ public func weighPetOnlyDefault(pet: Pet) {
 
 // CHECK-LABEL: ---- ANALYSIS STATE FOR FUNCTION {{.*}}testCondBranch
 // CHECK:       bb0:
-// CHECK:       [Copy]    cond_br {{.*}}, bb1, bb2
+// CHECK:       [Copy]    cond_br {{.*}}, bb2, bb1
 // CHECK:       bb1:
 // CHECK:       [Copy]    br bb3
 // CHECK:       bb2:

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -4,10 +4,10 @@ import TensorFlow
 // FIXME: This should not build with -O.
 
 // CHECK-LABEL: --- TFDeabstraction Result: {{.*}}reproduceSR9365{{.*}}
-// CHECK: graph_op "Reproduce SR-9365"() {test: [$String: ], 
+// CHECK: graph_op "TensorSummary"({{.*}}) {labels: [$String: ], 
 @TensorFlowGraph
 func reproduceSR9365() {
-   let _: () = #tfop("Reproduce SR-9365", test: Array<String>())
+  let _: () = #tfop("TensorSummary", Tensor<Float>(0.0), labels: Array<String>())
 }
 
 public func trivialAdd(a: Tensor<Float>) -> Tensor<Float> {
@@ -90,12 +90,13 @@ CHECK-LABEL: ----
 
 public func stringAttributes() {
   let str = "abc"
-  // expected-error @+1 {{op named 'foo' is not registered in TensorFlow}}
-  let _ : TensorHandle<Float> = #tfop("foo", attr1: String(), attr2: str)
+  let _ : ResourceHandle =
+    #tfop(
+      "TensorSummary", Tensor<Float>(0.0), description: "", display_name: str)
 }
 /*
 CHECK-LABEL: --- INPUT FUNCTION {{.*}}stringAttributes
- CHECK: graph_op "foo"() {attr1: "", attr2: "abc", __device: "/job:localhost/replica:0/task:0/device:CPU:0"}
+ CHECK: graph_op "TensorSummary"({{.*}}) {description: "", display_name: "abc", __device: "/job:localhost/replica:0/task:0/device:CPU:0"}
 */
 
 public func tensorShape() -> Tensor<Float> {

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -1,13 +1,15 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil -O %s | %FileCheck %s
 
 import TensorFlow
 
+@_optimize(none)
 public func basicDebugValues(_ x: Tensor<Float>) {
   let y = x + 1
   let z = y.squared()
 }
 
 // FIXME: `debug_value_addr` for `z` is not currently preserved due to SSA promotion in deabstraction.
+@_optimize(none)
 public func debugValuesInLoop(_ x: Tensor<Float>, _ n: Int) {
   var z = x.squared()
   for i in 0..<n {
@@ -17,37 +19,13 @@ public func debugValuesInLoop(_ x: Tensor<Float>, _ n: Int) {
 
 // Opaque handles should not trigger send/receive even at -Onone, so we won't
 // expect their `debug_value` to work.
+@_optimize(none)
 public func noCopyForOpaqueHandles() {
   let values = Tensor<Float>([1.0])
   let dataset: VariantHandle =
     #tfop("TensorSliceDataset", [values],
           Toutput_types$dtype: [Float.tensorFlowDataType], output_shapes: [TensorShape()])
 }
-
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}basicDebugValues
-// CHECK: @{{.*}}basicDebugValues{{.*}}.tf
-// CHECK: [[ONE:%.*]] = graph_op "Const"
-// CHECK: [[ADD_RESULT:%.*]] = graph_op "Add"
-// CHECK: graph_op "Square"([[ADD_RESULT]] : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
-
-
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}debugValuesInLoop
-// CHECK: bb0
-// CHECK:   [[SQUARED:%.*]] = graph_op "Square"
-// CHECK-NEXT:   br bb1([[SQUARED]] : $TensorHandle<Float>)
-// CHECK: bb1
-// CHECK:   graph_op "tfc.RecvFromHost"()
-// CHECK:   [[COND:%.*]] = graph_op "tf_tensor_to_i1"
-// CHECK:   cond_br [[COND]], bb2, bb3
-// CHECK: bb2:
-// CHECK:   [[ADD_RESULT:%.*]] = graph_op "Add"
-// CHECK-NEXT:   br bb1([[ADD_RESULT]]
-
-
-// CHECK-LABEL: ---- PARTITION STATE FOR FUNCTION ${{.*}}noCopyForOpaqueHandle
-// CHECK: result values:
-// CHECK-NOT: graph_op "TensorSliceDataset"([%4 : $TensorHandle<Float>])
-
 
 // CHECK-LABEL: --- TFPartition Host Result: {{.*}}basicDebugValues
 // CHECK: debug_value %{{.*}} : $Tensor<Float>, let, name "x", argno 1

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -57,7 +57,7 @@ public func f() {
 // should be a single copy-to-host compiler warning.
 public func SR8412_CopyToHost() {
   for _ in 0...10 {
-    let x = Tensor(1)  // expected-warning {{value implicitly copied to the host}}
+    let x = Tensor(1)
     _hostOp(x)
   }
 }

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -13,7 +13,6 @@ func testInferredElementResult() -> TensorHandle<Int32> {
   _ = #tfop("bar") as TensorHandle<Int32>
 }
 
-// expected-note @+1 2 {{value used here}}
 class ClassTest {
   // expected-warning @+2 {{value implicitly copied to the host}}
   // expected-warning @+1 {{'Tensor<Float>' implicitly copied to the accelerator}}

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -11,8 +11,8 @@ import TensorFlow
 
 // Verify we reject multiple attempts to configure hardware.
 public func testDeviceInvalid() {
-  TensorFlow.enableTPU() // expected-note {{previous configuration is specified here}}
-  TensorFlow.enableTPU() // expected-error {{device configuration specified multiple times}}
+  TensorFlow.enableTPU() // expected-note 2 {{previous configuration is specified here}}
+  TensorFlow.enableTPU() // expected-error 2 {{device configuration specified multiple times}}
 }
 
 public func shapeError() {

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -159,7 +159,7 @@ public func test_bool_param(cond: Bool, x: Tensor<Float>, y: Tensor<Float>) {
 // CHECK: sil private @{{.*}}test_bool_param{{.*}} : $@callee_owned (TensorHandle<Builtin.Int1>, TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float>
 // CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.Int1>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Float>):
 // CHECK: %3 = graph_op "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>) {{.*}} : $Builtin.Int1
-// CHECK: cond_br %3, bb1, bb2
+// CHECK: cond_br %3, bb2, bb1
 
 
 // CHECK-LABEL: --- TFPartition Host Result: {{.*}}test_bool_param{{.*}}
@@ -226,11 +226,11 @@ public func test_multiple_ifs(status: Bool) {
 // CHECK-LABEL: --- XLA CFG Canonicalize: {{.*}}test_multiple_ifs{{.*}}
 // CHECK-NEXT: [sequence
 // CHECK-NEXT:   {condition Header: bb0
-// CHECK-NEXT:     block bb1
-// CHECK-NEXT:     block bb2}
+// CHECK-NEXT:     block bb2
+// CHECK-NEXT:     block bb1}
 // CHECK-NEXT:   {condition Header: bb3
-// CHECK-NEXT:     block bb4
-// CHECK-NEXT:     block bb5}
+// CHECK-NEXT:     block bb5
+// CHECK-NEXT:     block bb4}
 // CHECK-NEXT:   block bb6]
 
 public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>) {
@@ -256,7 +256,7 @@ public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>)
 // CHECK-NEXT: graph_op "tf_tensor_to_i1"(
 // CHECK-NEXT: cond_br {{.*}}, bb2, bb1
 
-// CHECK: bb3([[A:%.*]] : @trivial $TensorHandle<Float>, [[COUNT:%.*]] : @trivial $TensorHandle<Builtin.Int64>):
+// CHECK: bb3([[COUNT:%.*]] : @trivial $TensorHandle<Builtin.Int64>, [[A:%.*]] : @trivial $TensorHandle<Float>):
 // CHECK:       [[NEXTA:%.*]] = graph_op "Sub"([[A]] : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:       [[NEXTCOUNT:%.*]] = graph_op "Add"([[COUNT]] : $TensorHandle<Builtin.Int64>
 // CHECK:       [[CONDT:%.*]] = graph_op "Less"([[NEXTCOUNT]] : $TensorHandle<Builtin.Int64>
@@ -264,7 +264,7 @@ public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>)
 // CHECK-NEXT:   cond_br [[COND]], bb5, bb4
 
 // CHECK: bb5:
-// CHECK-NEXT: br bb3([[NEXTA]] : $TensorHandle<Float>, [[NEXTCOUNT]] : $TensorHandle<Builtin.Int64>)
+// CHECK-NEXT: br bb3([[NEXTCOUNT]] : $TensorHandle<Builtin.Int64>, [[NEXTA]] : $TensorHandle<Float>)
 
 
 // CHECK-LABEL: --- XLA CFG Canonicalize: {{.*}}test_while1{{.*}}

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -8,8 +8,8 @@ public func testArrayValues() -> Tensor<Float> {
 
 /*
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testArrayValues
-CHECK: %0 = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
-CHECK: %1 = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x40000000 /* 2 */
+CHECK: {{.*}} = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+CHECK: {{.*}} = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x40000000 /* 2 */
 CHECK-LABEL: ----
 */
 

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -43,9 +43,8 @@ public func testSendsInALoopGPU() {
 // CHECK:   bb3:
 // CHECK-NOT:  graph_op "tfc.RecvFromHost
 // CHECK:      graph_op "tfc.TensorTransfer
+// CHECK:      graph_op "tfc.TensorTransfer
 // CHECK:      graph_op "tfc.SendToHost
 // Send/Receives/Transfers correspond to warnings after the loop.
-// CHECK:  bb6:
 // CHECK-NOT:  graph_op "tfc.RecvFromHost
-// CHECK:  graph_op "tfc.TensorTransfer
 // CHECK:      } // end sil function

--- a/test/TensorFlow/playground_1.swift
+++ b/test/TensorFlow/playground_1.swift
@@ -17,11 +17,8 @@ let x = 12345678  // a distinctive number to filecheck for.
 // CHECK: [[INT:%.*]] = integer_literal $Builtin.Int64, 12345678
 // CHECK: [[INT2:%.*]] = struct $Int ([[INT]] : $Builtin.Int64)
 // CHECK: store [[INT2]] to [[INTP:%.*]] : $*Int
-// CHECK: [[INT:%.*]] = load [[INTP]] : $*Int
-// CHECK: [[INTP:%.*]] = alloc_stack $Int
-// CHECK: store [[INT]] to [[INTP]] : $*Int
 // CHECK: [[LOGFN:%.*]] = function_ref @{{.*}}__builtin_log_with_id{{.*}}
-// CHECK: apply [[LOGFN]]<Int>([[INTP]],
+// CHECK: apply [[LOGFN]]([[INT2]],
 
 
 let a = Tensor<Float>([1,2,3])

--- a/test/TensorFlow/sese_loop_canonicalization.swift
+++ b/test/TensorFlow/sese_loop_canonicalization.swift
@@ -1,10 +1,11 @@
 // This test file has various test cases to check that unrollng the loop body
-// preserves the loop nesting.  Note that we use -Onone to preserve the
+// preserves the loop nesting.  Note that we use `@_optimize(none)` to preserve the
 // structure of control flow for tests.
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Onone -emit-sil %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
 
 import TensorFlow
 
+@_optimize(none)
 public func testLoopMovementFromOutside(_ breakIndex: Int32) -> Tensor<Int32> {
   var i: Int32 = 1
   var sum = Tensor<Int32>(0)
@@ -57,6 +58,7 @@ public func testLoopMovementFromOutside(_ breakIndex: Int32) -> Tensor<Int32> {
 
 // This example checks that the loop structure is preserved when we unroll
 // the body of a loop during canonicalization.
+@_optimize(none)
 public func testLoopWithNestedLoopsRequiringUnrolling(
   _ breakIndex:Int32, _ repetitions: Int32) -> Tensor<Int32> {
 	var result = Tensor<Int32>(0)
@@ -145,6 +147,7 @@ public func testLoopWithNestedLoopsRequiringUnrolling(
 
 // This example checks that the loop structure is preserved when we unroll
 // the body of a loop during canonicalization.
+@_optimize(none)
 public func testLoopWithDoublyNestedLoopsRequiringUnrolling(
 	_ breakIndex:Int32, _ repetitions: Int32) -> Tensor<Int32> {
 	var result = Tensor<Int32>(0)

--- a/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
+++ b/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shape_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shape_rank0.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // FIXME: Our graph lowering doesn't handle ops with explicit shape attrs.
 // XFAIL: *

--- a/test/TensorFlow/shape_lowering/shape_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shape_unknownrank.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // FIXME: Our graph lowering doesn't handle ops with explicit shape attrs.
 // XFAIL: *

--- a/test/TensorFlow/shape_lowering/shapelist_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank0.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank3.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/with_device.swift
+++ b/test/TensorFlow/with_device.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-use-device-stack -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-use-device-stack -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -emit-sil -O -verify %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -30,6 +30,10 @@ ControlFlowTests.testAllBackends("powerOfTwo") {
   expectNearlyEqualWithScalarTensor(1024.0, powerOfTwo(10))
 }
 
+// Disable this test in macos for now
+// https://bugs.swift.org/browse/SR-8986
+#if !os(macOS)
+
 func natSumWithBreak(_ breakIndex: Int32) -> Tensor<Int32> {
   var i: Int32 = 1
   var sum = Tensor<Int32>(0)
@@ -51,6 +55,8 @@ ControlFlowTests.testAllBackends("natSumWithBreak") {
   expectEqualWithScalarTensor(5050, natSumWithBreak(100))
   expectEqualWithScalarTensor(5050, natSumWithBreak(200))
 }
+
+#endif // !os(macOS)
 
 func sumOfProducts(_ M : Int32, _ N : Int32) -> Tensor<Float> {
   // Effectively computes natSum(M)*natSum(N)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1147,7 +1147,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_swift_gpe = (
         '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -tf-dynamic-compilation=false -DTF_NODYNAMIC_COMPILATION -o %%t/a.out -module-name main %s && '
+        '%s %s %%s -Xllvm -tf-dynamic-compilation=false -DTF_NODYNAMIC_COMPILATION -O -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))


### PR DESCRIPTION
The changes to the deabstraction and partition passes are as follows:
  - We have two versions of  `TFDeabstraction` and `TFPartition` now:  `...Mandatory` and `..Opt`.
 -  `Mandatory` versions of the passes _only_ process tensorflow convention functions. 
 - The `Opt` versions process non-tensorflow convention functions. This allows us to be less aggressive about the transformations we do. e.g., we can turn off inlining in the`TFDeabstractionOpt` pass. (This PR retains the current behavior to reduce the number of changes in the tests.) 
 - `TFDeabstractionOpt` is triggered in the opt pipeline after `EarlyInliner` but before `PerfInliner` to be able to see functions with `@_semantics` attributes (e.g., `String.init(...)`). If needed, it would be OK to invoke `TFDeabstractionOpt`multiple times.

In addition, this PR also adds interpretation of  `Array._adoptStorage` and `Array.init` to ConstExprEvaluator. This is needed as TFDeabstraction sees the SIL after the `EarlyInliner`, which inlines the compiler intrinsic `_allocateUninitializedArray`.

**Changes in tests**: These are mostly configuration changes (e.g., turn on -O) and changes in expectations due to a slightly changed control flow structure (e.g., reordered arguments of a basic block).