### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ First, create a directory for all of the Swift sources:
 **Note:** This is important since update-checkout (see below) checks out
 repositories next to the Swift source directory. This means that if one clones
 Swift and has other unrelated repositories, update-checkout may not clone those
-repositories and will update them instead.
+repositories and will update them instead. Additionally, ensure Python 2.7 is being 
+used for this step, whether via conda environment or other means.
 
 **TensorFlow Support:** To build with TensorFlow support, the `tensorflow`
 scheme must be specified when cloning sources. The `tensorflow` scheme pins


### PR DESCRIPTION
`./swift/utils/update-checkout` will fail if Python 3 is used (in [Getting Sources for Swift and Related Projects](https://github.com/apple/swift/tree/tensorflow#getting-sources-for-swift-and-related-projects)).

Added note to specify usage of Python 2.7 environment for the failing step. 

See: https://forums.swift.org/t/problem-in-building-swift-for-tensorflow/21416/4
