### PR TITLE
[ParseableInterface] Make the module caches relocatable and respect -track-system-dependencies

### DIFF
--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -156,7 +156,7 @@ public:
   static bool buildSwiftModuleFromSwiftInterface(
     ASTContext &Ctx, StringRef CacheDir, StringRef PrebuiltCacheDir,
     StringRef ModuleName, StringRef InPath, StringRef OutPath,
-    bool SerializeDependencyHashes);
+    bool SerializeDependencyHashes, bool TrackSystemDependencies);
 };
 
 /// Extract the specified-or-defaulted -module-cache-path that winds up in

--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -139,6 +139,8 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) override;
 
+  bool isCached(StringRef DepPath) override;
+
 public:
   static std::unique_ptr<ParseableInterfaceModuleLoader>
   create(ASTContext &ctx, StringRef cacheDir, StringRef prebuiltCacheDir,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 483; // Remove default arg expansion
+const uint16_t SWIFTMODULE_VERSION_MINOR = 484; // SDK-relative dependencies flag
 
 using DeclIDField = BCFixed<31>;
 
@@ -687,6 +687,7 @@ namespace input_block {
     FileSizeField,                 // file size (for validation)
     FileModTimeOrContentHashField, // mtime or content hash (for validation)
     BCFixed<1>,                    // are we reading mtime (0) or hash (1)?
+    BCFixed<1>,                    // SDK-relative?
     BCBlob                         // path
   >;
 }

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -39,10 +39,13 @@ namespace swift {
     /// appropriate strategy for how to verify if it's up-to-date.
     class FileDependency {
       /// The size of the file on disk, in bytes.
-      uint64_t Size : 63;
+      uint64_t Size : 62;
 
       /// A dependency can be either hash-based or modification-time-based.
       bool IsHashBased : 1;
+
+      /// The dependency path can be absolute or relative to the SDK
+      bool IsSDKRelative : 1;
 
       union {
         /// The last modification time of the file.
@@ -56,22 +59,22 @@ namespace swift {
       std::string Path;
 
       FileDependency(uint64_t size, bool isHash, uint64_t hashOrModTime,
-                     StringRef path):
-        Size(size), IsHashBased(isHash), ModificationTime(hashOrModTime),
-        Path(path) {}
+                     StringRef path, bool isSDKRelative):
+        Size(size), IsHashBased(isHash), IsSDKRelative(isSDKRelative),
+        ModificationTime(hashOrModTime), Path(path) {}
     public:
       FileDependency() = delete;
 
       /// Creates a new hash-based file dependency.
       static FileDependency
-      hashBased(StringRef path, uint64_t size, uint64_t hash) {
-        return FileDependency(size, /*isHash*/true, hash, path);
+      hashBased(StringRef path, bool isSDKRelative, uint64_t size, uint64_t hash) {
+        return FileDependency(size, /*isHash*/true, hash, path, isSDKRelative);
       }
 
       /// Creates a new modification time-based file dependency.
       static FileDependency
-      modTimeBased(StringRef path, uint64_t size, uint64_t mtime) {
-        return FileDependency(size, /*isHash*/false, mtime, path);
+      modTimeBased(StringRef path, bool isSDKRelative, uint64_t size, uint64_t mtime) {
+        return FileDependency(size, /*isHash*/false, mtime, path, isSDKRelative);
       }
 
       /// Updates the last-modified time of this dependency.
@@ -93,6 +96,9 @@ namespace swift {
       /// Determines if this dependency is hash-based and should be validated
       /// based on content hash.
       bool isHashBased() const { return IsHashBased; }
+
+      /// Determines if this dependency is absolute or relative to the SDK.
+      bool isSDKRelative() const { return IsSDKRelative; }
 
       /// Determines if this dependency is hash-based and should be validated
       /// based on modification time.

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -80,6 +80,12 @@ protected:
     return false;
   }
 
+  /// Determines if the provided path is a cached artifact for dependency
+  /// tracking purposes.
+  virtual bool isCached(StringRef DepPath) {
+    return false;
+  }
+
 public:
   virtual ~SerializedModuleLoaderBase();
   SerializedModuleLoaderBase(const SerializedModuleLoaderBase &) = delete;

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -34,9 +34,8 @@ void
 DependencyTracker::addDependency(StringRef File, bool IsSystem) {
   // DependencyTracker exposes an interface that (intentionally) does not talk
   // about clang at all, nor about missing deps. It does expose an IsSystem
-  // dimension, though it is presently always false, we accept it and pass it
-  // along to the clang DependencyCollector in case Swift callers start setting
-  // it to true someday.
+  // dimension, which we accept and pass along to the clang DependencyCollector.
+  // along to the clang DependencyCollector.
   clangCollector->maybeAddDependency(File, /*FromModule=*/false,
                                      IsSystem, /*IsModuleFile=*/false,
                                      /*IsMissing=*/false);

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -359,9 +359,6 @@ class swift::ParseableInterfaceBuilder {
   /// Determines if the dependency with the provided path is a swiftmodule in
   /// either the module cache or prebuilt module cache
   bool isCachedModule(StringRef DepName) const {
-    if (moduleCachePath.empty() && prebuiltCachePath.empty())
-      return false;
-
     auto Ext = llvm::sys::path::extension(DepName);
     auto Ty = file_types::lookupTypeForExtension(Ext);
 

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -356,19 +356,6 @@ class swift::ParseableInterfaceBuilder {
     return false;
   }
 
-  /// Determines if the dependency with the provided path is a swiftmodule in
-  /// either the module cache or prebuilt module cache
-  bool isCachedModule(StringRef DepName) const {
-    auto Ext = llvm::sys::path::extension(DepName);
-    auto Ty = file_types::lookupTypeForExtension(Ext);
-
-    if (Ty != file_types::TY_SwiftModuleFile)
-      return false;
-    if (!moduleCachePath.empty() && DepName.startswith(moduleCachePath))
-      return true;
-    return !prebuiltCachePath.empty() && DepName.startswith(prebuiltCachePath);
-  }
-
   /// Populate the provided \p Deps with \c FileDependency entries for all
   /// dependencies \p SubInstance's DependencyTracker recorded while compiling
   /// the module, excepting .swiftmodules in \p moduleCachePath or
@@ -379,12 +366,31 @@ class swift::ParseableInterfaceBuilder {
                                    SmallVectorImpl<FileDependency> &Deps,
                                    bool IsHashBased) {
     StringRef SDKPath = SubInstance.getASTContext().SearchPathOpts.SDKPath;
+    StringRef ResourcePath =
+        SubInstance.getASTContext().SearchPathOpts.RuntimeResourcePath;
     auto DTDeps = SubInstance.getDependencyTracker()->getDependencies();
     SmallVector<StringRef, 16> InitialDepNames(DTDeps.begin(), DTDeps.end());
     InitialDepNames.push_back(interfacePath);
     llvm::StringSet<> AllDepNames;
 
     for (auto const &DepName : InitialDepNames) {
+      assert(moduleCachePath.empty() || !DepName.startswith(moduleCachePath));
+      assert(prebuiltCachePath.empty() || !DepName.startswith(prebuiltCachePath));
+
+      /// Lazily load the dependency buffer if we need it. If we're not
+      /// dealing with a hash-based dependencies, and if the dependency is
+      /// not a .swiftmodule, we can avoid opening the buffer.
+      std::unique_ptr<llvm::MemoryBuffer> DepBuf = nullptr;
+      auto getDepBuf = [&]() -> llvm::MemoryBuffer * {
+        if (DepBuf) return DepBuf.get();
+        if (auto Buf = getBufferOfDependency(fs, DepName, interfacePath,
+                                             diags, diagnosticLoc)) {
+          DepBuf = std::move(Buf);
+          return DepBuf.get();
+        }
+        return nullptr;
+      };
+
       // Adjust the paths of dependences in the SDK to be relative to it
       bool IsSDKRelative = false;
       StringRef DepNameToStore = DepName;
@@ -410,48 +416,10 @@ class swift::ParseableInterfaceBuilder {
         dependencyTracker->addDependency(DepName, /*isSystem*/IsSDKRelative);
       }
 
-      /// Lazily load the dependency buffer if we need it. If we're not
-      /// dealing with a hash-based dependencies, and if the dependency is
-      /// not a .swiftmodule, we can avoid opening the buffer.
-      std::unique_ptr<llvm::MemoryBuffer> DepBuf = nullptr;
-      auto getDepBuf = [&]() -> llvm::MemoryBuffer * {
-        if (DepBuf) return DepBuf.get();
-        if (auto Buf = getBufferOfDependency(fs, DepName, interfacePath,
-                                             diags, diagnosticLoc)) {
-          DepBuf = std::move(Buf);
-          return DepBuf.get();
-        }
-        return nullptr;
-      };
-
-      // If Dep is itself a cached .swiftmodule, pull out its deps and include
-      // them in our own, so we have a single-file view of transitive deps:
-      // removes redundancies, makes the cache more relocatable, and avoids
-      // opening and reading multiple swiftmodules during future loads.
-      if (isCachedModule(DepName)) {
-        auto buf = getDepBuf();
-        if (!buf) return true;
-        SmallVector<FileDependency, 16> SubDeps;
-        auto VI = serialization::validateSerializedAST(buf->getBuffer(),
-          /*ExtendedValidationInfo=*/nullptr, &SubDeps);
-        if (VI.status != serialization::Status::Valid) {
-          diags.diagnose(diagnosticLoc,
-                         diag::error_extracting_dependencies_from_cached_module,
-                         DepName);
-          return true;
-        }
-        for (auto const &SubDep : SubDeps) {
-          if (AllDepNames.insert(SubDep.getPath()).second) {
-            Deps.push_back(SubDep);
-            if (dependencyTracker)
-              dependencyTracker->addDependency(
-                  SubDep.getPath(), /*IsSystem=*/SubDep.isSDKRelative());
-          }
-        }
+      // Don't serialize compiler-relative deps so the cache is relocatable.
+      if (DepName.startswith(ResourcePath))
         continue;
-      }
 
-      // Otherwise, include this dependency directly
       auto Status = getStatusOfDependency(fs, DepName, interfacePath,
                                           diags, diagnosticLoc);
       if (!Status)
@@ -761,11 +729,11 @@ class ParseableInterfaceModuleLoaderImpl {
       if (dependencyTracker)
         dependencyTracker->addDependency(fullPath, /*isSystem*/in.isSDKRelative());
       if (!dependencyIsUpToDate(in, fullPath)) {
-        LLVM_DEBUG(llvm::dbgs() << "Dep " << in.getPath()
+        LLVM_DEBUG(llvm::dbgs() << "Dep " << fullPath
                    << " is directly out of date\n");
         return false;
       }
-      LLVM_DEBUG(llvm::dbgs() << "Dep " << in.getPath() << " is up to date\n");
+      LLVM_DEBUG(llvm::dbgs() << "Dep " << fullPath << " is up to date\n");
     }
     return true;
   }
@@ -1046,6 +1014,12 @@ class ParseableInterfaceModuleLoaderImpl {
 };
 
 } // end anonymous namespace
+
+bool ParseableInterfaceModuleLoader::isCached(StringRef DepPath) {
+  if (!CacheDir.empty() && DepPath.startswith(CacheDir))
+    return true;
+  return !PrebuiltCacheDir.empty() && DepPath.startswith(PrebuiltCacheDir);
+}
 
 /// Load a .swiftmodule associated with a .swiftinterface either from a
 /// cache or by converting it in a subordinate \c CompilerInstance, caching

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -587,7 +587,8 @@ static bool buildModuleFromParseableInterface(CompilerInvocation &Invocation,
       Instance.getASTContext(), Invocation.getClangModuleCachePath(),
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
-      FEOpts.SerializeParseableModuleInterfaceDependencyHashes);
+      FEOpts.SerializeParseableModuleInterfaceDependencyHashes,
+      FEOpts.TrackSystemDeps);
 }
 
 static bool compileLLVMIR(CompilerInvocation &Invocation,

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -253,14 +253,16 @@ static bool validateInputBlock(
     switch (kind) {
     case input_block::FILE_DEPENDENCY: {
       bool isHashBased = scratch[2] != 0;
+      bool isSDKRelative = scratch[3] != 0;
+
       if (isHashBased) {
         dependencies.push_back(
           SerializationOptions::FileDependency::hashBased(
-            blobData, scratch[0], scratch[1]));
+            blobData, isSDKRelative, scratch[0], scratch[1]));
       } else {
         dependencies.push_back(
           SerializationOptions::FileDependency::modTimeBased(
-            blobData, scratch[0], scratch[1]));
+            blobData, isSDKRelative, scratch[0], scratch[1]));
       }
       break;
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1076,6 +1076,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
                         dep.getSize(),
                         getRawModTimeOrHash(dep),
                         dep.isHashBased(),
+                        dep.isSDKRelative(),
                         dep.getPath());
   }
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -645,9 +645,13 @@ ModuleDecl *SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
                     isFramework)) {
       return nullptr;
     }
-    if (dependencyTracker)
-      dependencyTracker->addDependency(moduleInputBuffer->getBufferIdentifier(),
-                                       /*isSystem=*/false);
+    if (dependencyTracker) {
+      // Don't record cached artifacts as dependencies.
+      StringRef DepPath = moduleInputBuffer->getBufferIdentifier();
+      if (!isCached(DepPath)) {
+        dependencyTracker->addDependency(DepPath, /*isSystem=*/false);
+      }
+    }
   }
 
   assert(moduleInputBuffer);

--- a/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/ExportedLib.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/ExportedLib.swiftinterface
@@ -1,0 +1,11 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name ExportedLib
+
+@_exported import SomeCModule
+
+public struct ExportedInterface {
+  @inlinable public init() {}
+}
+public var testValue: ExportedInterface {
+  @inlinable get { return ExportedInterface() }
+}

--- a/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/SdkLib.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/SdkLib.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name SdkLib
+
+@_exported import ExportedLib
+
+public var testValue2: ExportedInterface {
+  @inlinable get { return ExportedInterface() }
+}

--- a/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/SomeCModule.h
+++ b/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/SomeCModule.h
@@ -1,0 +1,1 @@
+extern int x;

--- a/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/module.modulemap
+++ b/test/ParseableInterface/ModuleCache/Inputs/mock-sdk/usr/include/module.modulemap
@@ -1,0 +1,3 @@
+module SomeCModule {
+  header "SomeCModule.h"
+}

--- a/test/ParseableInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies.swift
@@ -1,6 +1,3 @@
-// swift-interface-format-version: 1.0
-// swift-module-flags: -module-name SDKDependencies
-
 // RUN: %empty-directory(%t)
 
 // 1) Build a prebuilt cache for our SDK
@@ -46,11 +43,10 @@
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=EXLIB
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=EXLIB,SDKLIB
 //
-// EXLIB-DAG: /prebuilt-cache/ExportedLib.swiftmodule
+// EXLIB: dependencies:
 // EXLIB-DAG: /my-sdk/usr/include/module.modulemap
 // EXLIB-DAG: /my-sdk/usr/include/SomeCModule.h
 // EXLIB-DAG: /my-sdk/ExportedLib.swiftinterface
-// SDKLIB-DAG: /prebuilt-cache/SdkLib.swiftmodule
 // SDKLIB-DAG: /my-sdk/SdkLib.swiftinterface
 //
 // RUN: %empty-directory(%t/MCP)
@@ -60,7 +56,8 @@
 // 4) Move the SDK without changing its contents
 //
 // RUN: mv %t/my-sdk %t/my-new-sdk
-// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+// RUN: mv %t/prebuilt-cache %t/new-prebuilt-cache
+// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/new-prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
 //
 // Check SdkLib and ExportedLib are in the module cache
 // RUN: test -f %t/MCP/SdkLib-*.swiftmodule
@@ -74,11 +71,9 @@
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NEW-EXLIB
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=NEW-EXLIB,NEW-SDKLIB
 //
-// NEW-EXLIB-DAG: /prebuilt-cache/ExportedLib.swiftmodule
 // NEW-EXLIB-DAG: /my-new-sdk/usr/include/module.modulemap
 // NEW-EXLIB-DAG: /my-new-sdk/usr/include/SomeCModule.h
 // NEW-EXLIB-DAG: /my-new-sdk/ExportedLib.swiftinterface
-// NEW-SDKLIB-DAG: /prebuilt-cache/SdkLib.swiftmodule
 // NEW-SDKLIB-DAG: /my-new-sdk/SdkLib.swiftinterface
 //
 // RUN: %empty-directory(%t/MCP)
@@ -88,7 +83,7 @@
 // 5) Now change the SDK's content and check it no longer uses the prebuilt modules
 //
 // RUN: echo "// size change" >> %t/my-new-sdk/SdkLib.swiftinterface
-// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/new-prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
 //
 // Check SDKLib and ExportedLib are in the module cache
 // RUN: test -f %t/MCP/SdkLib-*.swiftmodule
@@ -104,7 +99,7 @@
 // RUN: %empty-directory(%t/MCP)
 //
 // RUN: echo "// size change" >> %t/my-new-sdk/usr/include/SomeCModule.h
-// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/new-prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
 //
 // Check SDKLib and ExportLib are in the module cache
 // RUN: test -f %t/MCP/SdkLib-*.swiftmodule

--- a/test/ParseableInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies.swift
@@ -7,13 +7,14 @@
 // RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/ExportedLib.swiftmodule -track-system-dependencies -module-name ExportedLib %t/my-sdk/ExportedLib.swiftinterface
 // RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/SdkLib.swiftmodule -track-system-dependencies -module-name SdkLib %t/my-sdk/SdkLib.swiftinterface
 //
-// Check the prebuilt modules don't contain dependencies in the module cache or prebuilt cache
+// Check the prebuilt modules don't contain dependencies in the module cache, prebuilt cache, or resource dir
 // RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/ExportedLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
 // RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/SdkLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
 //
 // PREBUILT: MODULE_BLOCK
 // PREBUILT-NOT: FILE_DEPENDENCY {{.*}}/MCP/{{.*}}
 // PREBUILT-NOT: FILE_DEPENDENCY {{.*}}/prebuilt-cache/{{.*}}
+// PREBUILD-NOT: FILE_DEPENDENCY {{.*}}/lib/swift/{{.*}}
 //
 // Re-build them in the opposite order
 // RUN: %empty-directory(%t/prebuilt-cache)
@@ -44,6 +45,12 @@
 // Check they don't contain dependencies in the module cache (..or prebuilt cache)
 // RUN: llvm-bcanalyzer -dump %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
 // RUN: llvm-bcanalyzer -dump %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+//
+// Check we didn't emit anything from the cache in the .d file either
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
+//
+// DEPFILE-NOT: /MCP/
+// DEPFILE-NOT: /prebuilt-cache/
 //
 // RUN: %empty-directory(%t/MCP)
 // RUN: echo '2: PASSED'
@@ -82,6 +89,9 @@
 // NOCACHE-NOT: /prebuilt-cache/
 // NOCACHE-NOT: /MCP/
 //
+// Check we didn't emit anything from the cache in the .d file either
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
+//
 // RUN: %empty-directory(%t/MCP)
 // RUN: echo '3: PASSED'
 
@@ -114,6 +124,9 @@
 // cache, or new prebuilt cache
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=ExportedLib
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=SdkLib
+//
+// Check we didn't emit anything from the cache in the .d file either
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
 //
 // RUN: %empty-directory(%t/MCP)
 // RUN: echo '4: PASSED'
@@ -155,6 +168,9 @@
 // Check neither contains dependencies in the module cache or prebuilt cache
 // RUN: llvm-bcanalyzer -dump %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
 // RUN: llvm-bcanalyzer -dump %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+//
+// Check we didn't emit anything from the cache in the .d file either
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
 //
 // RUN: echo '5: PASSED'
 

--- a/test/ParseableInterface/ModuleCache/SDKDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies.swiftinterface
@@ -1,0 +1,123 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name SDKDependencies
+
+// RUN: %empty-directory(%t)
+
+// 1) Build a prebuilt cache for our SDK
+//
+// RUN: mkdir %t/MCP %t/prebuilt-cache %t/my-sdk
+// RUN: cp -r %S/Inputs/mock-sdk/. %t/my-sdk
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/ExportedLib.swiftmodule -track-system-dependencies -module-name ExportedLib %t/my-sdk/ExportedLib.swiftinterface
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/SdkLib.swiftmodule -track-system-dependencies -module-name SdkLib %t/my-sdk/SdkLib.swiftinterface
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: echo '1: PASSED'
+
+
+// 2) Baseline check: Make sure we use the interface when not passing the prebuilt module cache path
+//
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+//
+// Check SdkLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+//
+// Check they are *not* forwarding modules
+// RUN: head -n 1 %t/MCP/SdkLib-*.swiftmodule | not grep -e '---'
+// RUN: head -n 1 %t/MCP/ExportedLib-*.swiftmodule | not grep -e '---'
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: echo '2: PASSED'
+
+
+// 3) Baseline check: Make sure we use the the prebuilt module cache when using the SDK it was built with
+//
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+//
+// Check SdkLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check they *are* forwarding modules
+// RUN: head -n 1 %t/MCP/SdkLib-*.swiftmodule | grep -e '---'
+// RUN: head -n 1 %t/MCP/ExportedLib-*.swiftmodule | grep -e '---'
+//
+// Check they contain the expected dependencies
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=EXLIB
+// RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=EXLIB,SDKLIB
+//
+// EXLIB-DAG: /prebuilt-cache/ExportedLib.swiftmodule
+// EXLIB-DAG: /my-sdk/usr/include/module.modulemap
+// EXLIB-DAG: /my-sdk/usr/include/SomeCModule.h
+// EXLIB-DAG: /my-sdk/ExportedLib.swiftinterface
+// SDKLIB-DAG: /prebuilt-cache/SdkLib.swiftmodule
+// SDKLIB-DAG: /my-sdk/SdkLib.swiftinterface
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: echo '3: PASSED'
+
+
+// 4) Move the SDK without changing its contents
+//
+// RUN: mv %t/my-sdk %t/my-new-sdk
+// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+//
+// Check SdkLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check they are still both forwarding modules
+// RUN: head -n 1 %t/MCP/SdkLib-*.swiftmodule | grep -e '---'
+// RUN: head -n 1 %t/MCP/ExportedLib-*.swiftmodule | grep -e '---'
+//
+// Check they contain the expected dependencies
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NEW-EXLIB
+// RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=NEW-EXLIB,NEW-SDKLIB
+//
+// NEW-EXLIB-DAG: /prebuilt-cache/ExportedLib.swiftmodule
+// NEW-EXLIB-DAG: /my-new-sdk/usr/include/module.modulemap
+// NEW-EXLIB-DAG: /my-new-sdk/usr/include/SomeCModule.h
+// NEW-EXLIB-DAG: /my-new-sdk/ExportedLib.swiftinterface
+// NEW-SDKLIB-DAG: /prebuilt-cache/SdkLib.swiftmodule
+// NEW-SDKLIB-DAG: /my-new-sdk/SdkLib.swiftinterface
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: echo '4: PASSED'
+
+
+// 5) Now change the SDK's content and check it no longer uses the prebuilt modules
+//
+// RUN: echo "// size change" >> %t/my-new-sdk/SdkLib.swiftinterface
+// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+//
+// Check SDKLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check ExportedLib is still a forwarding module and SdkLib is not
+// RUN: head -n 1 %t/MCP/ExportedLib-*.swiftmodule | grep -e '---'
+// RUN: head -n 1 %t/MCP/SdkLib-*.swiftmodule | not grep -e '---'
+//
+// Check ExportedLib still contains the same dependencies
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NEW-EXLIB
+//
+// RUN: %empty-directory(%t/MCP)
+//
+// RUN: echo "// size change" >> %t/my-new-sdk/usr/include/SomeCModule.h
+// RUN: %target-swift-frontend -typecheck -I %t/my-new-sdk -sdk %t/my-new-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+//
+// Check SDKLib and ExportLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check neither are forwarding modules
+// RUN: head -n 1 %t/MCP/SdkLib-*.swiftmodule | not grep -e '---'
+// RUN: head -n 1 %t/MCP/ExportedLib-*.swiftmodule | not grep -e '---'
+//
+// RUN: echo '5: PASSED'
+
+import SdkLib
+
+func foo() -> ExportedInterface {
+	return x > 3 ? testValue : testValue2
+}

--- a/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -1,0 +1,44 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name SystemDependencies
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mock-sdk %t/mock-sdk
+
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d
+// RUN: test -f %t/MCP/SystemDependencies*.swiftmodule
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t/dummy.d
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP/SystemDependencies*.swiftmodule
+
+// Baseline: running the same command again doesn't rebuild the cached module.
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SystemDependencies*.swiftmodule
+
+// Now try changing the contents.
+// RUN: echo "// size change" >> %t/mock-sdk/usr/include/SomeCModule.h
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SystemDependencies*.swiftmodule
+
+// Okay, now let's try again with system dependency tracking on.
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: test -f %t/MCP-system/SystemDependencies*.swiftmodule
+// RUN: %FileCheck -check-prefix CHECK %s < %t/dummy.d
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP-system/SystemDependencies*.swiftmodule
+
+// Baseline: running the same command again doesn't rebuild the cached module.
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP-system/SystemDependencies*.swiftmodule
+
+// Now try changing the contents.
+// RUN: echo "// size change" >> %t/mock-sdk/usr/include/SomeCModule.h
+// RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
+// RUN: %{python} %S/Inputs/check-is-new.py %t/MCP-system/SystemDependencies*.swiftmodule
+
+// Check that it picked a different cache key.
+// RUN: %empty-directory(%t/MCP-combined)
+// RUN: cp -n %t/MCP/SystemDependencies*.swiftmodule %t/MCP-combined
+// RUN: cp -n %t/MCP-system/SystemDependencies*.swiftmodule %t/MCP-combined
+
+// NEGATIVE-NOT: SomeCModule.h
+// CHECK: SomeCModule.h
+
+import SomeCModule

--- a/test/ParseableInterface/ModuleCache/module-cache-init.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-init.swift
@@ -39,7 +39,6 @@
 // CHECK-OTHERMODULE: {{MODULE_NAME.*blob data = 'OtherModule'}}
 // CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*Swift.swiftmodule([/\\].+[.]swiftmodule)?'}}
 // CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*LeafModule.swiftinterface'}}
-// CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*LeafModule-.*.swiftmodule'}}
 // CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*OtherModule.swiftinterface'}}
 // CHECK-OTHERMODULE: FUNC_DECL
 //

--- a/test/ParseableInterface/ModuleCache/module-cache-init.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-init.swift
@@ -24,9 +24,10 @@
 // RUN: test -f %t/modulecache/LeafModule-*.swiftmodule
 // RUN: llvm-bcanalyzer -dump %t/modulecache/LeafModule-*.swiftmodule | %FileCheck %s -check-prefix=CHECK-LEAFMODULE
 // CHECK-LEAFMODULE: {{MODULE_NAME.*blob data = 'LeafModule'}}
-// CHECK-LEAFMODULE: {{FILE_DEPENDENCY.*Swift.swiftmodule([/\\].+[.]swiftmodule)?'}}
 // CHECK-LEAFMODULE: {{FILE_DEPENDENCY.*LeafModule.swiftinterface'}}
 // CHECK-LEAFMODULE: FUNC_DECL
+// RUN: llvm-bcanalyzer -dump %t/modulecache/LeafModule-*.swiftmodule | %FileCheck %s -check-prefix=CHECK-LEAFMODULE-NEGATIVE
+// CHECK-LEAFMODULE-NEGATIVE-NOT: {{FILE_DEPENDENCY.*Swift.swiftmodule([/\\].+[.]swiftmodule)?'}}
 //
 //
 // Phase 3: build TestModule into a .swiftmodule explicitly us OtherModule via OtherModule.swiftinterface, creating OtherModule-*.swiftmodule along the way.
@@ -37,7 +38,7 @@
 // RUN: test -f %t/TestModule.d
 // RUN: llvm-bcanalyzer -dump %t/modulecache/OtherModule-*.swiftmodule | %FileCheck %s -check-prefix=CHECK-OTHERMODULE
 // CHECK-OTHERMODULE: {{MODULE_NAME.*blob data = 'OtherModule'}}
-// CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*Swift.swiftmodule([/\\].+[.]swiftmodule)?'}}
+// CHECK-OTHERMODULE-NOT: {{FILE_DEPENDENCY.*Swift.swiftmodule([/\\].+[.]swiftmodule)?'}}
 // CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*LeafModule.swiftinterface'}}
 // CHECK-OTHERMODULE: {{FILE_DEPENDENCY.*OtherModule.swiftinterface'}}
 // CHECK-OTHERMODULE: FUNC_DECL
@@ -56,10 +57,13 @@
 // CHECK-DEPENDS: TestModule.swiftmodule :
 // CHECK-DEPENDS-DAG: LeafModule.swiftinterface
 // CHECK-DEPENDS-DAG: OtherModule.swiftinterface
-// CHECK-DEPENDS-DAG: {{OtherModule-[^ ]+.swiftmodule}}
 // CHECK-DEPENDS-DAG: Swift.swiftmodule
 // CHECK-DEPENDS-DAG: SwiftOnoneSupport.swiftmodule
-// CHECK-DEPENDS-DAG: {{LeafModule-[^ ]+.swiftmodule}}
+//
+// RUN: %FileCheck %s -check-prefix=CHECK-DEPENDS-NEGATIVE <%t/TestModule.d
+//
+// CHECK-DEPENDS-NEGATIVE-NOT: {{LeafModule-[^ ]+.swiftmodule}}
+// CHECK-DEPENDS-NEGATIVE-NOT: {{OtherModule-[^ ]+.swiftmodule}}
 
 import OtherModule
 


### PR DESCRIPTION
1. Honor `-track-system-dependencies` when building parseable interfaces on demand
    - FIXME: won't be tracked when the top-level invocation isn't tracking dependencies at all
2. Honor `-track-system-dependencies` with `-build-module-from-parseable-interface`
3. Serialize dependencies in the SDK as SDK-relative paths
    - These are expanded to full paths by appending the SDK path when writing out forwarding modules and when checking dependencies are up-to-date.
4. Stop serializing `.swiftmodule` dependencies that are from the regular and prebuilt module caches
    - Note: `.swiftmodule`s in the regular module cache still get reported to the dependency tracker. Is this what we want?

Resolves rdar://problem/49292914