### PR TITLE
[ast] Add some special dump methods to SwitchStmt, CaseStmt for dumpi…

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1088,6 +1088,10 @@ public:
   size_t numTrailingObjects(OverloadToken<FallthroughStmt *>) const {
     return hasFallthroughDest() ? 1 : 0;
   }
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dumpVarDeclState(const char *prefix = "")
+                                const LLVM_ATTRIBUTE_USED,
+                            "Only for use in the debugger");
 };
 
 /// Switch statement.
@@ -1159,6 +1163,9 @@ public:
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::Switch;
   }
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dumpVarDeclState() const LLVM_ATTRIBUTE_USED,
+                            "Only for use in the debugger");
 };
 
 /// BreakStmt - The "break" and "break label" statement.

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -456,6 +456,46 @@ SwitchStmt *SwitchStmt::create(LabeledStmtInfo LabelInfo, SourceLoc SwitchLoc,
   return theSwitch;
 }
 
+void CaseStmt::dumpVarDeclState(const char *prefix) const {
+#ifndef NDEBUG
+  printf("%sCaseStmt: %p\n", prefix, this);
+  printf("%s  HasFallthroughDest: %s\n", prefix,
+         hasFallthroughDest() ? "true" : "false");
+  for (const auto &caseLabelItem : getCaseLabelItems()) {
+    printf("%s  CaseLabel: %p\n", prefix, &caseLabelItem);
+    caseLabelItem.getPattern()->forEachVariable([&](VarDecl *vd) {
+      printf("%s    VarDecl: %p\n", prefix, vd);
+      printf("%s      Corresponding Canonical Var Decl: %p\n", prefix,
+             vd->getCanonicalVarDecl());
+      printf("%s      Corresponding First Case Label Item Var Decl: %p\n",
+             prefix,
+             vd->getCorrespondingFirstCaseLabelItemVarDecl().getPtrOrNull());
+      printf("%s      Corresponding Case Body Var: %p\n", prefix,
+             vd->getCorrespondingCaseBodyVariable().getPtrOrNull());
+    });
+  }
+  printf("%s  CaseBodyVariables\n", prefix);
+  for (auto *vd : getCaseBodyVariablesOrEmptyArray()) {
+    printf("%s    VarDecl: %p\n", prefix, vd);
+    printf("%s      Corresponding Canonical Var Decl: %p\n", prefix,
+           vd->getCanonicalVarDecl());
+    printf("%s      Corresponding First Case Label Item Var Decl: %p\n", prefix,
+           vd->getCorrespondingFirstCaseLabelItemVarDecl().getPtrOrNull());
+    printf("%s      Corresponding Case Body Var: %p\n", prefix,
+           vd->getCorrespondingCaseBodyVariable().getPtrOrNull());
+  }
+#endif
+}
+
+void SwitchStmt::dumpVarDeclState() const {
+#ifndef NDEBUG
+  printf("VarDeclState Of SwitchStmt: %p\n", this);
+  for (auto *caseStmt : getCases()) {
+    caseStmt->dumpVarDeclState("  ");
+  }
+#endif
+}
+
 // See swift/Basic/Statistic.h for declaration: this enables tracing Stmts, is
 // defined here to avoid too much layering violation / circular linkage
 // dependency.


### PR DESCRIPTION
…ng their var decl state.

This is useful when one is trying to debug how the var decls are wired up. It is disabled without asserts and emits a warning if not used in the debugger.