### PR TITLE
SILGen: explicitly state the constructor in use (NFC)

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1668,7 +1668,7 @@ static PreparedArguments emitStringLiteral(SILGenFunction &SGF, Expr *E,
                                    unicode::extractFirstUnicodeScalar(Str));
 
     AnyFunctionType::Param param(Int32Ty.getASTType());
-    PreparedArguments args({param});
+    PreparedArguments args(llvm::ArrayRef<AnyFunctionType::Param>{param});
     args.add(E, RValue(SGF, E, Int32Ty.getASTType(),
                        ManagedValue::forUnmanaged(UnicodeScalarValue)));
     return args;
@@ -4104,7 +4104,7 @@ public:
                     ArgumentSource &&selfArg,
                     AnyFunctionType::Param selfParam,
                     CanType methodType) {
-    PreparedArguments preparedSelf({selfParam});
+    PreparedArguments preparedSelf(llvm::ArrayRef<AnyFunctionType::Param>{selfParam});
     preparedSelf.addArbitrary(std::move(selfArg));
 
     addCallSite(loc, std::move(preparedSelf), methodType,


### PR DESCRIPTION
MSVC found the constructor to be ambiguous here:

	error C2668: 'swift::Lowering::PreparedArguments::PreparedArguments': ambiguous call to overloaded function
	note: could be 'swift::Lowering::PreparedArguments::PreparedArguments(swift::Lowering::PreparedArguments &&)'
	note: or       'swift::Lowering::PreparedArguments::PreparedArguments(llvm::ArrayRef<swift::AnyFunctionType::Param>)'
	note: while trying to match the argument list '(initializer list)'

Explicitly state the constructor in use.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
