### PR TITLE
[5.1] [index] Fix infinite loop while looking at superclasses

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3626,6 +3626,19 @@ public:
     Bits.ClassDecl.Circularity = static_cast<unsigned>(circularity);
   }
 
+  /// Walk this class and all of the superclasses of this class, transitively,
+  /// invoking the callback function for each class.
+  ///
+  /// \param fn The callback function that will be invoked for each superclass.
+  /// It can return \c Continue to continue the traversal. Returning
+  /// \c SkipChildren halts the search and returns \c false, while returning
+  /// \c Stop halts the search and returns \c true.
+  ///
+  /// \returns \c true if \c fn returned \c Stop for any class, \c false
+  /// otherwise.
+  bool walkSuperclasses(
+      llvm::function_ref<TypeWalker::Action(ClassDecl *)> fn) const;
+
   //// Whether this class requires all of its stored properties to
   //// have initializers in the class definition.
   bool requiresStoredPropertyInits() const { 
@@ -3959,8 +3972,8 @@ public:
   /// a protocol having nested types (ObjC protocols).
   llvm::TinyPtrVector<AssociatedTypeDecl *> getAssociatedTypeMembers() const;
 
-  /// Walk all of the protocols inherited by this protocol, transitively,
-  /// invoking the callback function for each protocol.
+  /// Walk this protocol and all of the protocols inherited by this protocol,
+  /// transitively, invoking the callback function for each protocol.
   ///
   /// \param fn The callback function that will be invoked for each inherited
   /// protocol. It can return \c Continue to continue the traversal,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3768,6 +3768,27 @@ ClassDecl::findImplementingMethod(const AbstractFunctionDecl *Method) const {
   return nullptr;
 }
 
+bool ClassDecl::walkSuperclasses(
+    llvm::function_ref<TypeWalker::Action(ClassDecl *)> fn) const {
+
+  SmallPtrSet<ClassDecl *, 8> seen;
+  auto *cls = const_cast<ClassDecl *>(this);
+
+  while (cls && seen.insert(cls).second) {
+    switch (fn(cls)) {
+    case TypeWalker::Action::Stop:
+      return true;
+    case TypeWalker::Action::SkipChildren:
+      return false;
+    case TypeWalker::Action::Continue:
+      cls = cls->getSuperclassDecl();
+      continue;
+    }
+  }
+
+  return false;
+}
+
 EnumCaseDecl *EnumCaseDecl::create(SourceLoc CaseLoc,
                                    ArrayRef<EnumElementDecl *> Elements,
                                    DeclContext *DC) {

--- a/test/Index/circular.swift
+++ b/test/Index/circular.swift
@@ -1,0 +1,66 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+class SelfCycle : SelfCycle {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | SelfCycle | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:19 | class/Swift | SelfCycle | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | SelfCycle | {{\W*}}
+
+class Cycle1_A: Cycle1_B {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle1_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:17 | class/Swift | Cycle1_B | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | Cycle1_A | {{[^ ]*}}
+class Cycle1_B: Cycle1_A {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle1_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:17 | class/Swift | Cycle1_A | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | Cycle1_B | {{[^ ]*}}
+
+class Cycle2_A: Cycle2_C {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle2_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:17 | class/Swift | Cycle2_C | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | Cycle2_A | {{[^ ]*}}
+class Cycle2_B: Cycle2_A {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle2_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:17 | class/Swift | Cycle2_A | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | Cycle2_B | {{[^ ]*}}
+class Cycle2_C: Cycle2_B {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle2_C | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:17 | class/Swift | Cycle2_B | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | Cycle2_C | {{[^ ]*}}
+
+class TestCase1: XCTestCase {}
+// CHECK: [[@LINE-1]]:7 | class(test)/Swift | TestCase1 | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:18 | class/Swift | XCTestCase | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class(test)/Swift | TestCase1 | {{[^ ]*}}
+class XCTestCase: TestCase1 {}
+// CHECK: [[@LINE-1]]:7 | class/Swift | XCTestCase | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:19 | class(test)/Swift | TestCase1 | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class/Swift | XCTestCase | {{[^ ]*}}
+class TestCase2: TestCase1 {}
+// CHECK: [[@LINE-1]]:7 | class(test)/Swift | TestCase2 | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:18 | class(test)/Swift | TestCase1 | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | class(test)/Swift | TestCase2 | {{[^ ]*}}
+
+protocol SelfCycleP: SelfCycleP {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | SelfCycleP | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:22 | protocol/Swift | SelfCycleP | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | protocol/Swift | SelfCycleP | {{[^ ]*}}
+protocol Cycle1P_A: Cycle1P_B {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle1P_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle1P_B | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | protocol/Swift | Cycle1P_A | {{[^ ]*}}
+protocol Cycle1P_B: Cycle1P_A {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle1P_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle1P_A | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | protocol/Swift | Cycle1P_B | {{[^ ]*}}
+protocol Cycle2P_A: Cycle2P_C {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle2P_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle2P_C | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | protocol/Swift | Cycle2P_A | {{[^ ]*}}
+protocol Cycle2P_B: Cycle2P_A {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle2P_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle2P_A | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | protocol/Swift | Cycle2P_B | {{[^ ]*}}
+protocol Cycle2P_C: Cycle2P_B {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle2P_C | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle2P_B | {{[^ ]*}} | Ref,RelBase | rel: 1
+// CHECK:   RelBase | protocol/Swift | Cycle2P_C | {{[^ ]*}}


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/23674 to 5.1

---

* **Explanation**: Fixes an infinite loop when indexing an invalid class with circular inheritance.
* **Scope**: Affects indexing (including indexing while building) of classes.
* **SR Issue**: [SR-10236](https://bugs.swift.org/browse/SR-10236)
* **Radar**: rdar://49434989
* **Risk**: Low; avoids infinite loop by keeping track of already seen classes.
* **Testing**: Regression test cases added.
* **Reviewer**: @akyrtzi 

---

While checking for superclasses in isUnitTest, we need to handle
circular inheritance. For good measure, add tests for protocols as well.

The new API is designed to behave the same as walkInheritedProtocols
except that is walks over superclasses.

https://bugs.swift.org/browse/SR-10236
rdar://49434989