### PR TITLE
master-next: adjust test output for change in LLVM block syntax

### DIFF
--- a/test/DebugInfo/dbgvalue-insertpt.swift
+++ b/test/DebugInfo/dbgvalue-insertpt.swift
@@ -9,10 +9,10 @@ for i in 0 ..< 3 {
   // CHECK: %[[LD:[0-9]+]] = load i{{32|64}}, i{{32|64}}*
   // CHECK: br i1 {{%.*}}, label %[[FAIL:.*]], label %[[SUCCESS:.*]],
   //
-  // CHECK: ; <label>:[[SUCCESS]]:
+  // CHECK: [[SUCCESS]]:
   // CHECK: br label %[[NEXT_BB:.*]],
   //
-  // CHECK: ; <label>:[[NEXT_BB]]:
+  // CHECK: [[NEXT_BB]]:
   // CHECK: %[[PHI_VAL:.*]] = phi i{{32|64}} [ %[[LD]], %[[SUCCESS]] ]
   // CHECK: store i{{32|64}} %[[PHI_VAL]], i{{32|64}}* %i.debug
   // CHECK: ![[I]] = !DILocalVariable(name: "i",

--- a/test/DebugInfo/linetable-cleanups.swift
+++ b/test/DebugInfo/linetable-cleanups.swift
@@ -19,7 +19,7 @@ func main() {
     markUsed("Done with the for loop")
 // CHECK: call {{.*}}void @"$s4main8markUsedyyxlF"
 // CHECK: br label
-// CHECK: <label>:
+// CHECK: {{[0-9]+}}:
 // CHECK: call %Ts16IndexingIteratorVySaySiGG* @"$ss16IndexingIteratorVySaySiGGWOh"(%Ts16IndexingIteratorVySaySiGG* %{{.*}}), !dbg ![[LOOPHEADER_LOC:.*]]
 // CHECK: call {{.*}}void @"$s4main8markUsedyyxlF"
 // The cleanups should share the line number with the ret stmt.

--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -62,7 +62,7 @@ func foo() {
   // CHECK: br label %[[RETLABEL:[0-9]+]], !dbg ![[CASE:[0-9]+]]
   // CHECK: call { i64, i1 } @llvm.sadd.with.overflow.i64{{.*}}
   // CHECK: br label %[[RETLABEL]], !dbg ![[DEFAULTCLEANUP:[0-9]+]]
-  // CHECK: ; <label>:[[RETLABEL]]:
+  // CHECK: [[RETLABEL]]:
   // CHECK-NEXT: ret void
 
 // func foo()

--- a/test/DebugInfo/patternvars.swift
+++ b/test/DebugInfo/patternvars.swift
@@ -36,22 +36,22 @@ public func mangle(s: [UnicodeScalar]) -> [UnicodeScalar] {
 // CHECK: define {{.*}}@"$s11patternvars6mangle1sSayAA13UnicodeScalarVGAF_tFA2EXEfU_"
 // CHECK: %[[VAL:[0-9]+]] = call swiftcc i32 @"$s11patternvars13UnicodeScalarV5values6UInt32Vvg"(i32 %0)
 // CHECK-NEXT:  call void @llvm.dbg.value(metadata i32 %[[VAL]]
-// CHECK:       ; <label>
+// CHECK:       {{[0-9]+}}:
 // CHECK:       call void @llvm.dbg.value(metadata i32 %[[VAL]]
 // CHECK-NOT:   call void @llvm.dbg.value
 // CHECK-NOT:   call void asm sideeffect "", "r"
 
-// CHECK:       ; <label>
+// CHECK:       {{[0-9]+}}:
 // CHECK:       call void @llvm.dbg.value(metadata i32 %[[VAL]]
 // CHECK-NOT:   call void @llvm.dbg.value
 // CHECK-NOT:   call void asm sideeffect "", "r"
 
-// CHECK:       ; <label>
+// CHECK:       {{[0-9]+}}:
 // CHECK:       call void @llvm.dbg.value(metadata i32 %[[VAL]]
 // CHECK-NOT:   call void @llvm.dbg.value
 // CHECK-NOT:   call void asm sideeffect "", "r"
 
-// CHECK:       ; <label>
+// CHECK:       {{[0-9]+}}:
 // CHECK:       call void @llvm.dbg.value(metadata i32 %[[VAL]]
 // CHECK-NOT:   call void @llvm.dbg.value
 // CHECK-NOT:   call void asm sideeffect "", "r"

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -201,7 +201,7 @@ func testMultiP(x: MultiPayload) -> Double {
 // CHECK: entry:
 // CHECK: [[TR:%.*]] = trunc i8 %1
 // CHECK: br i1 [[TR]], {{.*}}, label %[[PAYLOADLABEL:.*]]
-// CHECK: <label>:[[PAYLOADLABEL]]
+// CHECK: [[PAYLOADLABEL]]:
 // CHECK: [[ID:%[0-9]+]] = bitcast i32 %0 to float
 // CHECK: ret float
 // V7K-LABEL: _$s8test_v7k0A3Opt

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -316,17 +316,17 @@ func testStaticReport(_ b: Bool, ptr: Builtin.RawPointer) -> () {
 func testCondFail(_ b: Bool, c: Bool) {
   // CHECK: br i1 %0, label %[[FAIL:.*]], label %[[CONT:.*]]
   Builtin.condfail(b)
-  // CHECK: <label>:[[CONT]]
+  // CHECK: [[CONT]]:
   // CHECK: br i1 %1, label %[[FAIL2:.*]], label %[[CONT:.*]]
   Builtin.condfail(c)
-  // CHECK: <label>:[[CONT]]
+  // CHECK: [[CONT]]:
   // CHECK: ret void
 
-  // CHECK: <label>:[[FAIL]]
+  // CHECK: [[FAIL]]:
   // CHECK: call void @llvm.trap()
   // CHECK: unreachable
 
-  // CHECK: <label>:[[FAIL2]]
+  // CHECK: [[FAIL2]]:
   // CHECK: call void @llvm.trap()
   // CHECK: unreachable
 }

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -211,8 +211,8 @@ entry(%u : $Singleton):
 // CHECK-32:   br label %[[DEST:[0-9]+]]
   switch_enum %u : $Singleton, case #Singleton.value!enumelt.1: dest
 
-// CHECK-64: ; <label>:[[DEST]]
-// CHECK-32: ; <label>:[[DEST]]
+// CHECK-64: [[DEST]]:
+// CHECK-32: [[DEST]]:
 dest:
 // CHECK-64:   ret void
 // CHECK-32:   ret void
@@ -231,9 +231,9 @@ entry(%u : $Singleton):
 // CHECK-32:   br label %[[PREDEST:[0-9]+]]
   switch_enum %u : $Singleton, case #Singleton.value!enumelt.1: dest
 
-// CHECK-64: ; <label>:[[PREDEST]]
+// CHECK-64: [[PREDEST]]:
 // CHECK-64:   br label %[[DEST:[0-9]+]]
-// CHECK-64: ; <label>:[[DEST]]
+// CHECK-64: [[DEST]]:
 dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
 // CHECK-64:   {{%.*}} = phi i64 [ %0, %[[PREDEST]] ]
 // CHECK-64:   {{%.*}} = phi i64 [ %1, %[[PREDEST]] ]
@@ -245,7 +245,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(%T4enum9SingletonO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
-// CHECK: ; <label>:[[DEST]]
+// CHECK: [[DEST]]:
 // CHECK:   [[ADDR:%.*]] = bitcast %T4enum9SingletonO* %0 to <{ i64, i64 }>*
 // CHECK:   ret void
 // CHECK: }
@@ -323,25 +323,25 @@ entry(%u : $NoPayloads):
 // CHECK:     i8 1, label %[[Y_DEST:[0-9]+]]
 // CHECK:     i8 2, label %[[Z_DEST:[0-9]+]]
 // CHECK:   ]
-// CHECK: ; <label>:[[DFLT]]
+// CHECK: [[DFLT]]:
 // CHECK:   unreachable
   switch_enum %u : $NoPayloads, case #NoPayloads.x!enumelt: x_dest, case #NoPayloads.y!enumelt: y_dest, case #NoPayloads.z!enumelt: z_dest
 
-// CHECK: ; <label>:[[X_DEST]]
+// CHECK: [[X_DEST]]:
 // CHECK:   call swiftcc void @a()
 // CHECK:   br label %[[END:[0-9]+]]
 x_dest:
   %a = function_ref @a : $@convention(thin) () -> ()
   apply %a() : $@convention(thin) () -> ()
   br end
-// CHECK: ; <label>:[[Y_DEST]]
+// CHECK: [[Y_DEST]]:
 // CHECK:   call swiftcc void @b()
 // CHECK:   br label %[[END]]
 y_dest:
   %b = function_ref @b : $@convention(thin) () -> ()
   apply %b() : $@convention(thin) () -> ()
   br end
-// CHECK: ; <label>:[[Z_DEST]]
+// CHECK: [[Z_DEST]]:
 // CHECK:   call swiftcc void @c()
 // CHECK:   br label %[[END]]
 z_dest:
@@ -349,7 +349,7 @@ z_dest:
   apply %c() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[END]]
+// CHECK: [[END]]:
 // CHECK:   ret void
 end:
   %x = tuple ()
@@ -436,7 +436,7 @@ entry(%u : $NoPayloads2):
 // CHECK:   br i1 [[COND]], label %[[DEFAULT_DEST:[0-9]+]], label %[[U_DEST:[0-9]+]]
   switch_enum %u : $NoPayloads2, case #NoPayloads2.u!enumelt: u_dest, default default_dest
 
-// CHECK: ; <label>:[[U_DEST]]
+// CHECK: [[U_DEST]]:
 u_dest:
 // CHECK:   call swiftcc void @a()
   %a = function_ref @a : $@convention(thin) () -> ()
@@ -444,7 +444,7 @@ u_dest:
 // CHECK:   br label %[[END:[0-9]+]]
   br end
 
-// CHECK: ; <label>:[[DEFAULT_DEST]]
+// CHECK: [[DEFAULT_DEST]]:
 default_dest:
 // CHECK:   call swiftcc void @b()
   %b = function_ref @b : $@convention(thin) () -> ()
@@ -452,7 +452,7 @@ default_dest:
 // CHECK:   br label %[[END]]
   br end
 
-// CHECK: ; <label>:[[END]]
+// CHECK: [[END]]:
 end:
 // CHECK:   ret void
   %x = tuple ()
@@ -499,7 +499,7 @@ sil @single_payload_no_xi_switch : $@convention(thin) (SinglePayloadNoXI2) -> ()
 entry(%u : $SinglePayloadNoXI2):
 // CHECK;   %2 = trunc i8
 // CHECK:   br i1 %2, label %[[TAGS:[0-9]+]], label %[[X_DEST:[0-9]+]]
-// CHECK: ; <label>:[[TAGS]]
+// CHECK: [[TAGS]]:
 // CHECK:   switch [[WORD]] %0, label %[[DFLT:[0-9]+]] [
 // CHECK:     [[WORD]] 0, label %[[Y_DEST:[0-9]+]]
 // CHECK:     [[WORD]] 1, label %[[Z_DEST:[0-9]+]]
@@ -507,12 +507,12 @@ entry(%u : $SinglePayloadNoXI2):
 // CHECK:     [[WORD]] 3, label %[[V_DEST:[0-9]+]]
 // CHECK:     [[WORD]] 4, label %[[U_DEST:[0-9]+]]
 // CHECK:   ]
-// CHECK: ; <label>:[[DFLT]]
+// CHECK: [[DFLT]]:
 // CHECK:   unreachable
   switch_enum %u : $SinglePayloadNoXI2, case #SinglePayloadNoXI2.x!enumelt.1: x_dest, case #SinglePayloadNoXI2.y!enumelt: y_dest, case #SinglePayloadNoXI2.z!enumelt: z_dest, case #SinglePayloadNoXI2.w!enumelt: w_dest, case #SinglePayloadNoXI2.v!enumelt: v_dest, case #SinglePayloadNoXI2.u!enumelt: u_dest
 
 
-// CHECK: ; <label>:[[X_DEST]]
+// CHECK: [[X_DEST]]:
 // CHECK:   call swiftcc void @a()
 // CHECK:   br label %[[END:[0-9]+]]
 x_dest:
@@ -520,7 +520,7 @@ x_dest:
   apply %a() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[Y_DEST]]
+// CHECK: [[Y_DEST]]:
 // CHECK:   call swiftcc void @b()
 // CHECK:   br label %[[END]]
 y_dest:
@@ -528,7 +528,7 @@ y_dest:
   apply %b() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[Z_DEST]]
+// CHECK: [[Z_DEST]]:
 // CHECK:   call swiftcc void @c()
 // CHECK:   br label %[[END]]
 z_dest:
@@ -536,7 +536,7 @@ z_dest:
   apply %c() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[W_DEST]]
+// CHECK: [[W_DEST]]:
 // CHECK:   call swiftcc void @a()
 // CHECK:   br label %[[END:[0-9]+]]
 w_dest:
@@ -544,7 +544,7 @@ w_dest:
   apply %d() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[V_DEST]]
+// CHECK: [[V_DEST]]:
 // CHECK:   call swiftcc void @b()
 // CHECK:   br label %[[END]]
 v_dest:
@@ -552,7 +552,7 @@ v_dest:
   apply %e() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[U_DEST]]
+// CHECK: [[U_DEST]]:
 // CHECK:   call swiftcc void @c()
 // CHECK:   br label %[[END]]
 u_dest:
@@ -560,7 +560,7 @@ u_dest:
   apply %f() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[END]]
+// CHECK: [[END]]:
 // CHECK:   ret void
 end:
   %x = tuple ()
@@ -573,7 +573,7 @@ sil @single_payload_no_xi_switch_arg : $@convention(thin) (SinglePayloadNoXI2) -
 entry(%u : $SinglePayloadNoXI2):
 // CHECK:  %2 = trunc i8
 // CHECK:   br i1 %2, label %[[TAGS:[0-9]+]], label %[[X_PREDEST:[0-9]+]]
-// CHECK: ; <label>:[[TAGS]]
+// CHECK: [[TAGS]]:
 // CHECK:   switch [[WORD]] %0, label %[[DFLT:[0-9]+]] [
 // CHECK:     [[WORD]] 0, label %[[Y_DEST:[0-9]+]]
 // CHECK:     [[WORD]] 1, label %[[Z_DEST:[0-9]+]]
@@ -581,13 +581,13 @@ entry(%u : $SinglePayloadNoXI2):
 // CHECK:     [[WORD]] 3, label %[[SPLITEDGE]]
 // CHECK:     [[WORD]] 4, label %[[SPLITEDGE]]
 // CHECK:   ]
-// CHECK: ; <label>:[[DFLT]]
+// CHECK: [[DFLT]]:
 // CHECK:   unreachable
   switch_enum %u : $SinglePayloadNoXI2, case #SinglePayloadNoXI2.x!enumelt.1: x_dest, case #SinglePayloadNoXI2.y!enumelt: y_dest, case #SinglePayloadNoXI2.z!enumelt: z_dest, default default_dest
 
-// CHECK: ; <label>:[[X_PREDEST]]
+// CHECK: [[X_PREDEST]]:
 // CHECK:   br label %[[X_DEST:[0-9]+]]
-// CHECK: ; <label>:[[X_DEST]]
+// CHECK: [[X_DEST]]:
 // CHECK:   {{%.*}} = phi [[WORD]] [ %0, %[[X_PREDEST]] ]
 x_dest(%u2 : $Builtin.Word):
 // CHECK:   call swiftcc void @a()
@@ -596,7 +596,7 @@ x_dest(%u2 : $Builtin.Word):
   apply %a() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[Y_DEST]]
+// CHECK: [[Y_DEST]]:
 y_dest:
 // CHECK:   call swiftcc void @b()
 // CHECK:   br label %[[END]]
@@ -604,7 +604,7 @@ y_dest:
   apply %b() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[Z_DEST]]
+// CHECK: [[Z_DEST]]:
 z_dest:
 // CHECK:   call swiftcc void @c()
 // CHECK:   br label %[[END]]
@@ -612,12 +612,12 @@ z_dest:
   apply %c() : $@convention(thin) () -> ()
   br end
 
-// CHECK: ; <label>:[[SPLITEDGE]]
+// CHECK: [[SPLITEDGE]]:
 // CHECK:   br label %[[END:[0-9]+]]
 default_dest:
   br end
 
-// CHECK: ; <label>:[[END]]
+// CHECK: [[END]]:
 // CHECK:   ret void
 end:
   %x = tuple ()
@@ -893,15 +893,15 @@ entry(%u : $SinglePayloadSpareBit):
 // CHECK-32:    i32 0, label %[[Y_HIGH:[0-9]+]]
 // CHECK-32:    i32 1, label %[[Z_HIGH:[0-9]+]]
 // CHECK-32:  ]
-// CHECK-32: ; <label>:[[Y_HIGH]]
+// CHECK-32: [[Y_HIGH]]:
 // CHECK-32:  [[IS_Y:%.*]] = icmp eq i32 %1, -2147483648
 // CHECK-32:  br i1 [[IS_Y]], label %[[Y_DEST:[0-9]+]], label %[[X_DEST]]
-// CHECK-32: ; <label>:[[Z_HIGH]]
+// CHECK-32: [[Z_HIGH]]:
 // CHECK-32:  [[IS_Z:%.*]] = icmp eq i32 %1, -2147483648
 // CHECK-32:  br i1 [[IS_Z]], label %[[Z_DEST:[0-9]+]], label %[[X_DEST]]
   switch_enum %u : $SinglePayloadSpareBit, case #SinglePayloadSpareBit.x!enumelt.1: x_dest, case #SinglePayloadSpareBit.y!enumelt: y_dest, case #SinglePayloadSpareBit.z!enumelt: z_dest
 
-// CHECK: ; <label>:[[X_DEST]]
+// CHECK: [[X_DEST]]:
 x_dest:
 // CHECK:   call swiftcc void @a()
   %a = function_ref @a : $@convention(thin) () -> ()
@@ -909,7 +909,7 @@ x_dest:
 // CHECK:   br label %[[END:[0-9]+]]
   br end
 
-// CHECK: ; <label>:[[Y_DEST]]
+// CHECK: [[Y_DEST]]:
 y_dest:
 // CHECK:   call swiftcc void @b()
   %b = function_ref @b : $@convention(thin) () -> ()
@@ -917,7 +917,7 @@ y_dest:
 // CHECK:   br label %[[END]]
   br end
 
-// CHECK: ; <label>:[[Z_DEST]]
+// CHECK: [[Z_DEST]]:
 z_dest:
 // CHECK:   call swiftcc void @c()
   %c = function_ref @c : $@convention(thin) () -> ()
@@ -925,7 +925,7 @@ z_dest:
 // CHECK:   br label %[[END]]
   br end
 
-// CHECK: ; <label>:[[END]]
+// CHECK: [[END]]:
 end:
 // CHECK:   ret void
   %x = tuple ()
@@ -944,10 +944,10 @@ entry(%u : $SinglePayloadSpareBit):
 // CHECK-64:  ]
   switch_enum %u : $SinglePayloadSpareBit, case #SinglePayloadSpareBit.x!enumelt.1: x_dest, case #SinglePayloadSpareBit.y!enumelt: y_dest, case #SinglePayloadSpareBit.z!enumelt: z_dest
 
-// CHECK-64: ; <label>:[[X_PREDEST]]
+// CHECK-64: [[X_PREDEST]]:
 // CHECK-64:   [[TRUNC_PAYLOAD:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   br label %[[X_DEST:[0-9]+]]
-// CHECK-64: ; <label>:[[X_DEST]]
+// CHECK-64: [[X_DEST]]:
 // CHECK-64:   {{%.*}} = phi i63 [ [[TRUNC_PAYLOAD]], %[[X_PREDEST]] ]
 x_dest(%u2 : $Builtin.Int63):
 // CHECK-64:   call swiftcc void @a()
@@ -956,7 +956,7 @@ x_dest(%u2 : $Builtin.Int63):
 // CHECK-64:   br label %[[END:[0-9]+]]
   br end
 
-// CHECK-64: ; <label>:[[Y_DEST]]
+// CHECK-64: [[Y_DEST]]:
 y_dest:
 // CHECK-64:   call swiftcc void @b()
   %b = function_ref @b : $@convention(thin) () -> ()
@@ -964,7 +964,7 @@ y_dest:
 // CHECK-64:   br label %[[END]]
   br end
 
-// CHECK-64: ; <label>:[[Z_DEST]]
+// CHECK-64: [[Z_DEST]]:
 z_dest:
 // CHECK-64:   call swiftcc void @c()
   %c = function_ref @c : $@convention(thin) () -> ()
@@ -972,7 +972,7 @@ z_dest:
 // CHECK-64:   br label %[[END]]
   br end
 
-// CHECK-64: ; <label>:[[END]]
+// CHECK-64: [[END]]:
 end:
 // CHECK-64:   ret void
   %x = tuple ()
@@ -983,10 +983,10 @@ sil @single_payload_spare_bit_switch_indirect : $@convention(thin) (@inout Singl
 entry(%u : $*SinglePayloadSpareBit):
 // CHECK-64:  [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i64*
 // CHECK-64:  [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
-// CHECK-64:  switch i64 [[PAYLOAD]]
+// CHECK-64:  switch i64 [[PAYLOAD]], label %[[DFLT:[0-9]+]] [
   switch_enum_addr %u : $*SinglePayloadSpareBit, case #SinglePayloadSpareBit.x!enumelt.1: x_dest, case #SinglePayloadSpareBit.y!enumelt: y_dest, case #SinglePayloadSpareBit.z!enumelt: z_dest
 
-// CHECK-64: ; <label>:
+// CHECK-64: [[DFLT]]:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i63*
 x_dest:
   %u2 = unchecked_take_enum_data_addr %u : $*SinglePayloadSpareBit, #SinglePayloadSpareBit.x!enumelt.1
@@ -1147,7 +1147,7 @@ enum SinglePayloadClass {
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i64) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   switch i64 %0, label {{%.*}} [
+// CHECK-64:   switch i64 %0, label %[[DFLT:[0-9]+]] [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-objc-64-simulator-false:   i64 2, label {{%.*}}
 // CHECK-objc-64-simulator-false:   i64 4, label {{%.*}}
@@ -1156,17 +1156,17 @@ enum SinglePayloadClass {
 // CHECK-native-64: i64 1, label {{%.*}}
 // CHECK-native-64: i64 2, label {{%.*}}
 // CHECK-64:   ]
-// CHECK-64: ; <label>
+// CHECK-64: [[DFLT]]:
 // CHECK-64:   inttoptr [[WORD]] %0 to %T4enum1CC*
 
 // CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i32) {{.*}} {
 // CHECK-32: entry:
-// CHECK-32:   switch i32 %0, label {{%.*}} [
+// CHECK-32:   switch i32 %0, label %[[DFLT:[0-9]+]] [
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
 // CHECK-32:     i32 2, label {{%.*}}
 // CHECK-32:   ]
-// CHECK-32: ; <label>
+// CHECK-32: [[DFLT]]:
 // CHECK-32:   inttoptr [[WORD]] %0 to %T4enum1CC*
 
 sil @single_payload_class_switch : $(SinglePayloadClass) -> () {
@@ -1386,9 +1386,9 @@ sil @dynamic_single_payload_empty_payload_inject_no_payload : $() -> DynamicSing
 // <rdar://problem/15383966>
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_generic_destroy
 // CHECK:   br i1
-// CHECK: <label>
+// CHECK: {{[0-9]+}}:
 // CHECK:   call void %destroy
-// CHECK: <label>
+// CHECK: {{[0-9]+}}:
 sil @dynamic_single_payload_generic_destroy : $@convention(thin) <T> (@in DynamicSinglePayload<T>) -> () {
 entry(%x : $*DynamicSinglePayload<T>):
   destroy_addr %x : $*DynamicSinglePayload<T>
@@ -1414,59 +1414,59 @@ entry(%u : $MultiPayloadNoSpareBits):
 // CHECK-64:     i8 2, label %[[Z_PREDEST:[0-9]+]]
 // CHECK-64:     i8 3, label %[[EMPTY:[0-9]+]]
 // CHECK-64:   ]
-// CHECK-64: ; <label>:[[EMPTY]]
+// CHECK-64: [[EMPTY]]:
 // CHECK-64:   switch i64 %0, label %[[UNREACHABLE]] [
 // CHECK-64:     i64 0, label %[[A_DEST:[0-9]+]]
 // CHECK-64:     i64 1, label %[[B_DEST:[0-9]+]]
 // CHECK-64:     i64 2, label %[[C_DEST:[0-9]+]]
 // CHECK-64:   ]
-// CHECK-64: ; <label>:[[UNREACHABLE]]
+// CHECK-64: [[UNREACHABLE]]:
 // CHECK-64:   unreachable
   switch_enum %u : $MultiPayloadNoSpareBits, case #MultiPayloadNoSpareBits.x!enumelt.1: x_dest, case #MultiPayloadNoSpareBits.y!enumelt.1: y_dest, case #MultiPayloadNoSpareBits.z!enumelt.1: z_dest, case #MultiPayloadNoSpareBits.a!enumelt: a_dest, case #MultiPayloadNoSpareBits.b!enumelt: b_dest, case #MultiPayloadNoSpareBits.c!enumelt: c_dest
 
-// CHECK-64: ; <label>:[[X_PREDEST]]
+// CHECK-64: [[X_PREDEST]]:
 // CHECK-64:   br label %[[X_DEST:[0-9]+]]
-// CHECK-64: ; <label>:[[Y_PREDEST]]
+// CHECK-64: [[Y_PREDEST]]:
 // CHECK-64:   [[Y_VALUE:%.*]] = trunc i64 %0 to i32
 // CHECK-64:   br label %[[Y_DEST:[0-9]+]]
-// CHECK-64: ; <label>:[[Z_PREDEST]]
+// CHECK-64: [[Z_PREDEST]]:
 // CHECK-64:   [[Z_VALUE:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   br label %[[Z_DEST:[0-9]+]]
 
-// CHECK-64: ; <label>:[[X_DEST]]
+// CHECK-64: [[X_DEST]]:
 // CHECK-64:   phi i64 [ %0, %[[X_PREDEST]] ]
 x_dest(%x : $Builtin.Int64):
   %a = function_ref @a : $@convention(thin) () -> ()
   apply %a() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[Y_DEST]]
+// CHECK-64: [[Y_DEST]]:
 // CHECK-64:   phi i32 [ [[Y_VALUE]], %[[Y_PREDEST]] ]
 y_dest(%y : $Builtin.Int32):
   %b = function_ref @b : $@convention(thin) () -> ()
   apply %b() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[Z_DEST]]
+// CHECK-64: [[Z_DEST]]:
 // CHECK-64:   phi i63 [ [[Z_VALUE]], %[[Z_PREDEST]] ]
 z_dest(%z : $Builtin.Int63):
   %c = function_ref @c : $@convention(thin) () -> ()
   apply %c() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[A_DEST]]
+// CHECK-64: [[A_DEST]]:
 a_dest:
   %d = function_ref @d : $@convention(thin) () -> ()
   apply %d() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[B_DEST]]
+// CHECK-64: [[B_DEST]]:
 b_dest:
   %e = function_ref @e : $@convention(thin) () -> ()
   apply %e() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[C_DEST]]
+// CHECK-64: [[C_DEST]]:
 c_dest:
   %f = function_ref @f : $@convention(thin) () -> ()
   apply %f() : $@convention(thin) () -> ()
@@ -1487,15 +1487,15 @@ entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]]
 // CHECK-64:   switch i8 [[TAG]]
 // CHECK-64:   switch i64 [[PAYLOAD]]
-// CHECK-64: ; <label>:
+// CHECK-64: {{[0-9]+}}:
 // CHECK-64:   unreachable
   switch_enum_addr %u : $*MultiPayloadNoSpareBits, case #MultiPayloadNoSpareBits.x!enumelt.1: x_dest, case #MultiPayloadNoSpareBits.y!enumelt.1: y_dest, case #MultiPayloadNoSpareBits.z!enumelt.1: z_dest, case #MultiPayloadNoSpareBits.a!enumelt: a_dest, case #MultiPayloadNoSpareBits.b!enumelt: b_dest, case #MultiPayloadNoSpareBits.c!enumelt: c_dest
 
-// CHECK-64: ; <label>:[[X_DEST:[0-9]+]]
+// CHECK-64: [[X_DEST:[0-9]+]]:
 // CHECK-64:   bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i64*
-// CHECK-64: ; <label>:[[Y_DEST:[0-9]+]]
+// CHECK-64: [[Y_DEST:[0-9]+]]:
 // CHECK-64:   bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i32*
-// CHECK-64: ; <label>:[[Z_DEST:[0-9]+]]
+// CHECK-64: [[Z_DEST:[0-9]+]]:
 // CHECK-64:   bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i63*
 
 x_dest:
@@ -1653,7 +1653,7 @@ entry(%u : $MultiPayloadOneSpareBit):
 // CHECK-64:     i8 3, label %[[EMPTY_DEST:[0-9]+]]
 // CHECK-64:   ]
 
-// CHECK-64: ; <label>:[[EMPTY_DEST]]
+// CHECK-64: [[EMPTY_DEST]]:
 // CHECK-64:   switch i64 %0, label %[[UNREACHABLE]] [
 // --            0x8000_0000_0000_0000
 // CHECK-64:     i64 -9223372036854775808, label %[[A_DEST:[0-9]+]]
@@ -1663,56 +1663,56 @@ entry(%u : $MultiPayloadOneSpareBit):
 // CHECK-64:     i64 -9223372036854775806, label %[[C_DEST:[0-9]+]]
 // CHECK-64:   ]
 
-// CHECK-64: ; <label>:[[UNREACHABLE]]
+// CHECK-64: [[UNREACHABLE]]:
 // CHECK-64:   unreachable
   switch_enum %u : $MultiPayloadOneSpareBit, case #MultiPayloadOneSpareBit.x!enumelt.1: x_dest, case #MultiPayloadOneSpareBit.y!enumelt.1: y_dest, case #MultiPayloadOneSpareBit.z!enumelt.1: z_dest, case #MultiPayloadOneSpareBit.a!enumelt: a_dest, case #MultiPayloadOneSpareBit.b!enumelt: b_dest, case #MultiPayloadOneSpareBit.c!enumelt: c_dest
 
-// CHECK-64: ; <label>:[[X_PREDEST]]
+// CHECK-64: [[X_PREDEST]]:
 // CHECK-64:   [[X_VALUE:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   br label %[[X_DEST:[0-9]+]]
-// CHECK-64: ; <label>:[[Y_PREDEST]]
+// CHECK-64: [[Y_PREDEST]]:
 // --                                    0x7FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[Y_MASKED:%.*]] = and i64 %0, 9223372036854775807
 // CHECK-64:   [[Y_VALUE:%.*]] = trunc i64 [[Y_MASKED]] to i63
 // CHECK-64:   br label %[[Y_DEST:[0-9]+]]
-// CHECK-64: ; <label>:[[Z_PREDEST]]
+// CHECK-64: [[Z_PREDEST]]:
 // CHECK-64:   [[Z_VALUE:%.*]] = trunc i64 %0 to i61
 // CHECK-64:   br label %[[Z_DEST:[0-9]+]]
 
-// CHECK-64: ; <label>:[[X_DEST]]
+// CHECK-64: [[X_DEST]]:
 // CHECK-64:   phi i62 [ [[X_VALUE]], %[[X_PREDEST]] ]
 x_dest(%x : $Builtin.Int62):
   %a = function_ref @a : $@convention(thin) () -> ()
   apply %a() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[Y_DEST]]
+// CHECK-64: [[Y_DEST]]:
 // CHECK-64:   phi i63 [ [[Y_VALUE]], %[[Y_PREDEST]] ]
 y_dest(%y : $Builtin.Int63):
   %b = function_ref @b : $@convention(thin) () -> ()
   apply %b() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[Z_DEST]]
+// CHECK-64: [[Z_DEST]]:
 // CHECK-64:   phi i61 [ [[Z_VALUE]], %[[Z_PREDEST]] ]
 z_dest(%z : $Builtin.Int61):
   %c = function_ref @c : $@convention(thin) () -> ()
   apply %c() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[A_DEST]]
+// CHECK-64: [[A_DEST]]:
 a_dest:
   %d = function_ref @d : $@convention(thin) () -> ()
   apply %d() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[B_DEST]]
+// CHECK-64: [[B_DEST]]:
 b_dest:
   %e = function_ref @e : $@convention(thin) () -> ()
   apply %e() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[C_DEST]]
+// CHECK-64: [[C_DEST]]:
 c_dest:
   %f = function_ref @f : $@convention(thin) () -> ()
   apply %f() : $@convention(thin) () -> ()
@@ -1732,14 +1732,14 @@ entry(%u : $*MultiPayloadOneSpareBit):
 // CHECK-64:   [[TAG:%.*]] = load i1, i1* [[TAG_ADDR]]
 // CHECK-64:   switch i8 {{%.*}}
 // CHECK-64:   switch i64 [[PAYLOAD]]
-// CHECK-64: ; <label>:
+// CHECK-64: {{[0-9]+}}:
 // CHECK-64:   unreachable
   switch_enum_addr %u : $*MultiPayloadOneSpareBit, case #MultiPayloadOneSpareBit.x!enumelt.1: x_dest, case #MultiPayloadOneSpareBit.y!enumelt.1: y_dest, case #MultiPayloadOneSpareBit.z!enumelt.1: z_dest, case #MultiPayloadOneSpareBit.a!enumelt: a_dest, case #MultiPayloadOneSpareBit.b!enumelt: b_dest, case #MultiPayloadOneSpareBit.c!enumelt: c_dest
 
-// CHECK-64: ; <label>:[[X_PREDEST:[0-9]+]]
+// CHECK-64: [[X_PREDEST:[0-9]+]]:
 // CHECK-64:   bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i62*
 
-// CHECK-64: ; <label>:[[Y_PREDEST:[0-9]+]]
+// CHECK-64: [[Y_PREDEST:[0-9]+]]:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
@@ -1748,7 +1748,7 @@ entry(%u : $*MultiPayloadOneSpareBit):
 // CHECK-64:   store i64 [[PAYLOAD_MASKED]], i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i63*
 
-// CHECK-64: ; <label>:[[Z_PREDEST:[0-9]+]]
+// CHECK-64: [[Z_PREDEST:[0-9]+]]:
 // CHECK-64:   bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i61*
 
 x_dest:
@@ -1946,7 +1946,7 @@ entry(%u : $MultiPayloadTwoSpareBits):
 // CHECK-64:     i8 2, label %[[Z_PREDEST:[0-9]+]]
 // CHECK-64:     i8 3, label %[[EMPTY_DEST:[0-9]+]]
 // CHECK-64:   ]
-// CHECK-64: ; <label>:[[EMPTY_DEST]]
+// CHECK-64: [[EMPTY_DEST]]:
 // CHECK-64:   switch i64 %0, label %[[UNREACHABLE]] [
 // --            0xC000_0000_0000_0000
 // CHECK-64:     i64 -4611686018427387904, label %[[A_DEST:[0-9]+]]
@@ -1955,60 +1955,60 @@ entry(%u : $MultiPayloadTwoSpareBits):
 // --            0xC000_0000_0000_0002
 // CHECK-64:     i64 -4611686018427387902, label %[[C_DEST:[0-9]+]]
 // CHECK-64:   ]
-// CHECK-64: ; <label>:[[UNREACHABLE]]
+// CHECK-64: [[UNREACHABLE]]:
 // CHECK-64:   unreachable
   switch_enum %u : $MultiPayloadTwoSpareBits, case #MultiPayloadTwoSpareBits.x!enumelt.1: x_dest, case #MultiPayloadTwoSpareBits.y!enumelt.1: y_dest, case #MultiPayloadTwoSpareBits.z!enumelt.1: z_dest, case #MultiPayloadTwoSpareBits.a!enumelt: a_dest, case #MultiPayloadTwoSpareBits.b!enumelt: b_dest, case #MultiPayloadTwoSpareBits.c!enumelt: c_dest
 
-// CHECK-64: ; <label>:[[X_PREDEST]]
+// CHECK-64: [[X_PREDEST]]:
 // CHECK-64:   [[X_VALUE:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   br label %[[X_DEST:[0-9]+]]
 
-// CHECK-64: ; <label>:[[Y_PREDEST]]
+// CHECK-64: [[Y_PREDEST]]:
 // --                                    0x3FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[Y_MASKED:%.*]] = and i64 %0, 4611686018427387903
 // CHECK-64:   [[Y_VALUE:%.*]] = trunc i64 [[Y_MASKED]] to i60
 // CHECK-64:   br label %[[Y_DEST:[0-9]+]]
 
-// CHECK-64: ; <label>:[[Z_PREDEST]]
+// CHECK-64: [[Z_PREDEST]]:
 // --                                    0x3FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[Z_MASKED:%.*]] = and i64 %0, 4611686018427387903
 // CHECK-64:   [[Z_VALUE:%.*]] = trunc i64 [[Z_MASKED]] to i61
 // CHECK-64:   br label %[[Z_DEST:[0-9]+]]
 
-// CHECK-64: ; <label>:[[X_DEST]]
+// CHECK-64: [[X_DEST]]:
 // CHECK-64:   phi i62 [ [[X_VALUE]], %[[X_PREDEST]] ]
 x_dest(%x : $Builtin.Int62):
   %a = function_ref @a : $@convention(thin) () -> ()
   apply %a() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[Y_DEST]]
+// CHECK-64: [[Y_DEST]]:
 // CHECK-64:   phi i60 [ [[Y_VALUE]], %[[Y_PREDEST]] ]
 y_dest(%y : $Builtin.Int60):
   %b = function_ref @b : $@convention(thin) () -> ()
   apply %b() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[Z_DEST]]
+// CHECK-64: [[Z_DEST]]:
 // CHECK-64:   phi i61 [ [[Z_VALUE]], %[[Z_PREDEST]] ]
 z_dest(%z : $Builtin.Int61):
   %c = function_ref @c : $@convention(thin) () -> ()
   apply %c() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[A_DEST]]
+// CHECK-64: [[A_DEST]]:
 a_dest:
   %d = function_ref @d : $@convention(thin) () -> ()
   apply %d() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[B_DEST]]
+// CHECK-64: [[B_DEST]]:
 b_dest:
   %e = function_ref @e : $@convention(thin) () -> ()
   apply %e() : $@convention(thin) () -> ()
   br end
 
-// CHECK-64: ; <label>:[[C_DEST]]
+// CHECK-64: [[C_DEST]]:
 c_dest:
   %f = function_ref @f : $@convention(thin) () -> ()
   apply %f() : $@convention(thin) () -> ()
@@ -2247,14 +2247,14 @@ enum MultiPayloadSpareBitAggregates {
 // CHECK-64:     i8 1, label %[[Y_DEST:[0-9]+]]
 // CHECK-64:     i8 2, label %[[Z_DEST:[0-9]+]]
 // CHECK-64:   ]
-// CHECK-64: ; <label>:[[X_DEST]]
+// CHECK-64: [[X_DEST]]:
 // CHECK-64:   [[X_0:%.*]] = trunc i64 %0 to i32
-// CHECK-64: ; <label>:[[Y_DEST]]
+// CHECK-64: [[Y_DEST]]:
 // --                                        0x3fffffffffffffff
 // CHECK-64:   [[Y_MASKED:%.*]] = and i64 %0, 4611686018427387903
 // CHECK-64:   [[Y_0:%.*]] = inttoptr i64 [[Y_MASKED]] to %T4enum1CC*
 // CHECK-64:   [[Y_1:%.*]] = inttoptr i64 %1 to %T4enum1CC*
-// CHECK-64: ; <label>:[[Z_DEST]]
+// CHECK-64: [[Z_DEST]]:
 // --                                        0x3fffffffffffffff
 // CHECK-64:   [[Z_MASKED:%.*]] = and i64 %0, 4611686018427387903
 // CHECK-64:   [[Z_A:%.*]] = trunc i64 [[Z_MASKED]] to i21
@@ -2738,7 +2738,7 @@ entry(%x : $*MyOptional):
 // CHECK:  [[VAL01:%.*]] = icmp uge i32 %tag, 2
 // CHECK:  br i1 [[VAL01]], label %[[TLABEL:.*]], label %[[FLABEL:.*]]
 
-// CHECK: <label>:[[TLABEL]]
+// CHECK: [[TLABEL]]:
 // CHECK:  [[VAL02:%.*]] = sub i32 %tag, 2
 // CHECK:  [[VAL03:%.*]] = trunc i32 [[VAL02]] to i8
 // CHECK:  [[VAL04:%.*]] = bitcast %T4enum40MultiPayloadLessThan32BitsWithEmptyCasesO* [[VAL00]] to i8*
@@ -2748,14 +2748,14 @@ entry(%x : $*MyOptional):
 // CHECK:  store i8 2, i8* [[VAL06]]
 // CHECK:  br label %[[RLABEL:.*]]
 
-// CHECK: <label>:[[FLABEL]]
+// CHECK: [[FLABEL]]:
 // CHECK:  [[VAL09:%.*]] = trunc i32 %tag to i8
 // CHECK:  [[VAL10:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
 // CHECK:  [[VAL11:%.*]] = bitcast [1 x i8]* [[VAL10]] to i8*
 // CHECK:  store i8 [[VAL09]], i8* [[VAL11]]
 // CHECK:  br label %[[RLABEL]]
 
-// CHECK: <label>:[[RLABEL]]
+// CHECK: [[RLABEL]]:
 // CHECK:  ret void
 
 enum MultiPayloadLessThan32BitsWithEmptyCases {

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -58,9 +58,9 @@ entry(%e : $Either<(), ()>):
   %b = unchecked_enum_data %r : $Either<(), ()>, #Either.Right!enumelt.1
 
   // CHECK-NEXT: br i1 {{%.*}}, label %7, label %6
-  // CHECK:      <label>:6
+  // CHECK:      6:
   // CHECK:        br label %8
-  // CHECK:      <label>:7
+  // CHECK:      7:
   // CHECK:        br label %9
   switch_enum %e : $Either<(), ()>,
     case #Either.Left!enumelt.1: left,
@@ -125,9 +125,9 @@ entry(%e : $EitherOr<(), ()>):
     case #EitherOr.Center!enumelt: center,
     case #EitherOr.Right!enumelt.1: right
 
-  // CHECK:      <label>:[[LEFT_PRE]]
+  // CHECK:      [[LEFT_PRE]]:
   // CHECK:        br label [[LEFT:%[0-9]+]]
-  // CHECK:      <label>:[[RIGHT_PRE]]
+  // CHECK:      [[RIGHT_PRE]]:
   // CHECK:        br label [[RIGHT:%[0-9]+]]
 
 left(%x : $()):
@@ -307,22 +307,22 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
     case #EitherOr.Center!enumelt: center,
     case #EitherOr.Right!enumelt.1: right
 
-  // CHECK: <label>:[[LEFT]]
+  // CHECK: [[LEFT]]:
 left:
   %0 = integer_literal $Builtin.Int8, 0
   br next(%0 : $Builtin.Int8)
 
-  // CHECK: <label>:[[MIDDLE]]
+  // CHECK: [[MIDDLE]]:
 middle:
   %1 = integer_literal $Builtin.Int8, 1
   br next(%1 : $Builtin.Int8)
 
-  // CHECK: <label>:[[CENTER]]
+  // CHECK: [[CENTER]]:
 center:
   %2 = integer_literal $Builtin.Int8, 2
   br next(%2 : $Builtin.Int8)
 
-  // CHECK: <label>:[[RIGHT]]
+  // CHECK: [[RIGHT]]:
 right:
   %3 = integer_literal $Builtin.Int8, 3
   br next(%3 : $Builtin.Int8)
@@ -340,23 +340,23 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // -- only the Left branch of this instance needs cleanup
   // CHECK:        [[COND:%.*]] = icmp ne i32 [[TAG]], 0
   // CHECK-NEXT:   br i1 [[COND]], label %[[NOOP:[0-9]+]], label %[[LEFT:[0-9]+]]
-  // CHECK:      <label>:[[LEFT]]
+  // CHECK:      [[LEFT]]:
   // CHECK:        call void %destroy(%swift.opaque* noalias {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[NOOP]]
-  // CHECK:      <label>:[[NOOP]]
+  // CHECK:      [[NOOP]]:
   destroy_addr %a : $*EitherOr<T, Builtin.Int64>
 
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
   // -- only the Left branch of this instance needs nontrivial take
   // CHECK:        [[COND:%.*]] = icmp ne i32 [[TAG]], 0
   // CHECK-NEXT:   br i1 [[COND]], label %[[TRIVIAL:[0-9]+]], label %[[LEFT:[0-9]+]]
-  // CHECK:      <label>:[[LEFT]]
+  // CHECK:      [[LEFT]]:
   // CHECK:        call %swift.opaque* %initializeWithTake(%swift.opaque* noalias {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
-  // CHECK:      <label>:[[TRIVIAL]]
+  // CHECK:      [[TRIVIAL]]:
   // CHECK:        call void @llvm.memcpy
   // CHECK:        br label %[[DONE]]
-  // CHECK:      <label>:[[DONE]]
+  // CHECK:      [[DONE]]:
   copy_addr [take] %a to [initialization] %b : $*EitherOr<T, Builtin.Int64>
 
   copy_addr [take] %a to                  %b : $*EitherOr<T, Builtin.Int64>
@@ -375,25 +375,25 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK-NEXT:     i32 0, label %[[LEFT:[0-9]+]]
   // CHECK-NEXT:     i32 1, label %[[RIGHT:[0-9]+]]
   // CHECK-NEXT:   ]
-  // CHECK:      <label>:[[LEFT]]
+  // CHECK:      [[LEFT]]:
   // CHECK:        call void %destroy(%swift.opaque* noalias {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[NOOP]]
-  // CHECK:      <label>:[[RIGHT]]
+  // CHECK:      [[RIGHT]]:
   // CHECK:        call void {{.*}} @swift_release
-  // CHECK:      <label>:[[NOOP]]
+  // CHECK:      [[NOOP]]:
   destroy_addr %a : $*EitherOr<T, C>
 
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
   // -- only the Left branch of this instance needs cleanup
   // CHECK:        [[COND:%.*]] = icmp ne i32 [[TAG]], 0
   // CHECK-NEXT:   br i1 [[COND]], label %[[TRIVIAL:[0-9]+]], label %[[LEFT:[0-9]+]]
-  // CHECK:      <label>:[[LEFT]]
+  // CHECK:      [[LEFT]]:
   // CHECK:        call %swift.opaque* %initializeWithTake(%swift.opaque* noalias {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
-  // CHECK:      <label>:[[TRIVIAL]]
+  // CHECK:      [[TRIVIAL]]:
   // CHECK:        call void @llvm.memcpy
   // CHECK:        br label %[[DONE]]
-  // CHECK:      <label>:[[DONE]]
+  // CHECK:      [[DONE]]:
   copy_addr [take] %a to [initialization] %b : $*EitherOr<T, C>
 
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
@@ -402,16 +402,16 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK-NEXT:     i32 0, label %[[LEFT:[0-9]+]]
   // CHECK-NEXT:     i32 1, label %[[RIGHT:[0-9]+]]
   // CHECK-NEXT:   ]
-  // CHECK:      <label>:[[LEFT]]
+  // CHECK:      [[LEFT]]:
   // CHECK:        call %swift.opaque* %initializeWithCopy(%swift.opaque* noalias {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
-  // CHECK:      <label>:[[RIGHT]]
+  // CHECK:      [[RIGHT]]:
   // CHECK:        call %swift.refcounted* @swift_retain
   // CHECK:        br label %[[DONE:[0-9]+]]
-  // CHECK:      <label>:[[TRIVIAL]]
+  // CHECK:      [[TRIVIAL]]:
   // CHECK:        call void @llvm.memcpy
   // CHECK:        br label %[[DONE]]
-  // CHECK:      <label>:[[DONE]]
+  // CHECK:      [[DONE]]:
   copy_addr        %a to [initialization] %b : $*EitherOr<T, C>
 
   return undef : $()

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -220,31 +220,31 @@ public func constructResilientEnumPayload(_ s: Size) -> Medium {
 // CHECK:  [[PAMPHLET_CASE:%.*]] = icmp eq i32 [[TAG]], [[PAMPHLET_CASE_TAG]]
 // CHECK:  br i1 [[PAMPHLET_CASE]], label %[[PAMPHLET_CASE_LABEL:.*]], label %[[PAPER_CHECK:.*]]
 
-// CHECK:  <label>:[[PAPER_CHECK]]:
+// CHECK:  [[PAPER_CHECK]]:
 // CHECK:  [[PAPER_CASE_TAG:%.*]] = load i32, i32* @"$s14resilient_enum6MediumO5PaperyA2CmFWC"
 // CHECK:  [[PAPER_CASE:%.*]] = icmp eq i32 [[TAG]], [[PAPER_CASE_TAG]]
 // CHECK:  br i1 [[PAPER_CASE]], label %[[PAPER_CASE_LABEL:.*]], label %[[CANVAS_CHECK:.*]]
 
-// CHECK:  <label>:[[CANVAS_CHECK]]:
+// CHECK:  [[CANVAS_CHECK]]:
 // CHECK:  [[CANVAS_CASE_TAG:%.*]] = load i32, i32* @"$s14resilient_enum6MediumO6CanvasyA2CmFWC"
 // CHECK:  [[CANVAS_CASE:%.*]] = icmp eq i32 [[TAG]], [[CANVAS_CASE_TAG]]
 // CHECK:  br i1 [[CANVAS_CASE]], label %[[CANVAS_CASE_LABEL:.*]], label %[[DEFAULT_CASE:.*]]
 
-// CHECK: ; <label>:[[PAPER_CASE_LABEL]]
+// CHECK: [[PAPER_CASE_LABEL]]:
 // CHECK: br label %[[END:.*]]
 
-// CHECK: ; <label>:[[CANVAS_CASE_LABEL]]
+// CHECK: [[CANVAS_CASE_LABEL]]:
 // CHECK: br label %[[END]]
 
-// CHECK: ; <label>:[[PAMPHLET_CASE_LABEL]]
+// CHECK: [[PAMPHLET_CASE_LABEL]]:
 // CHECK: swift_projectBox
 // CHECK: br label %[[END]]
 
-// CHECK: ; <label>:[[DEFAULT_CASE]]
+// CHECK: [[DEFAULT_CASE]]:
 // CHeCK: call void %destroy
 // CHECK: br label %[[END]]
 
-// CHECK: ; <label>:[[END]]
+// CHECK: [[END]]:
 // CHECK: = phi [[INT]] [ 3, %[[DEFAULT_CASE]] ], [ {{.*}}, %[[PAMPHLET_CASE_LABEL]] ], [ 2, %[[CANVAS_CASE_LABEL]] ], [ 1, %[[PAPER_CASE_LABEL]] ]
 // CHECK: ret
 

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -279,13 +279,13 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-objc-simulator-true:        i64 2, label %[[DONE]]
 // CHECK:      ]
 
-// CHECK:      ; <label>:[[RELEASE_PAYLOAD]]
+// CHECK:      [[RELEASE_PAYLOAD]]:
 // CHECK-NEXT: [[DATA_ADDR:%.*]] = bitcast %T20enum_value_semantics23SinglePayloadNontrivialO* [[ADDR]] to %swift.refcounted**
 // CHECK-NEXT: [[DATA:%.*]] = load %swift.refcounted*, %swift.refcounted** [[DATA_ADDR]], align 8
 // CHECK-NEXT: call void @swift_release(%swift.refcounted* [[DATA]])
 // CHECK-NEXT: br label %[[DONE]]
 
-// CHECK:      ; <label>:[[DONE]]
+// CHECK:      [[DONE]]:
 // CHECK-NEXT: ret void
 
 
@@ -330,7 +330,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[IS_PAYLOAD:%.*]] = icmp uge i32 %tag, 2
 // CHECK-NEXT: br i1 [[IS_PAYLOAD]], label %[[HAS_NO_PAYLOAD:.*]], label %[[HAS_PAYLOAD:.*]]
 
-// CHECK:      ; <label>:[[HAS_NO_PAYLOAD]]
+// CHECK:      [[HAS_NO_PAYLOAD]]:
 
 //   -- Compute the no-payload tag
 // CHECK-NEXT: [[NO_PAYLOAD_TAG:%.*]] = sub i32 %tag, 2
@@ -346,7 +346,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: store i8 2, i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: br label %[[DONE:.*]]
 
-// CHECK:      ; <label>:[[HAS_PAYLOAD]]
+// CHECK:      [[HAS_PAYLOAD]]:
 
 //   -- Store the tag in the extra tag area
 // CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i8
@@ -355,7 +355,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: store i8 [[TAG]], i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: br label %[[DONE]]
 
-// CHECK:      ; <label>:[[DONE]]
+// CHECK:      [[DONE]]:
 // CHECK-NEXT: ret void
 
 
@@ -541,7 +541,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[IS_PAYLOAD:%.*]] = icmp uge i32 %tag, 3
 // CHECK-NEXT: br i1 [[IS_PAYLOAD]], label %[[HAS_NO_PAYLOAD:.*]], label %[[HAS_PAYLOAD:.*]]
 
-// CHECK:      ; <label>:[[HAS_NO_PAYLOAD]]
+// CHECK:      [[HAS_NO_PAYLOAD]]:
 
 //   -- Turn the case index into a no-payload case index
 // CHECK-NEXT: [[NO_PAYLOAD_TAG:%.*]] = sub i32 %tag, 3
@@ -558,7 +558,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: store i64 -4611686018427387904, i64* [[SECOND_ADDR]], align 8
 // CHECK-NEXT: br label %[[END:.*]]
 
-// CHECK:      ; <label>:[[HAS_PAYLOAD]]
+// CHECK:      [[HAS_PAYLOAD]]:
 
 //   -- Not really necessary
 // CHECK-NEXT: [[TAG_TMP:%.*]] = and i32 %tag, 3
@@ -591,7 +591,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: store i64 [[SECOND_NEW]], i64* [[SECOND_ADDR]], align 8
 // CHECK-NEXT: br label %[[END]]
 
-// CHECK:      ; <label>:[[END]]
+// CHECK:      [[END]]:
 // CHECK-NEXT: ret void
 
 

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -138,12 +138,12 @@ enum MultipleEmptyRefcounted {
 // CHECK-objc-simulator-false:     i64 2, label %5
 // CHECK-objc-simulator-true:     i64 1, label %5
 // CHECK:   ]
-// CHECK: ; <label>:3:                                      ; preds = %entry
+// CHECK: 3:                                      ; preds = %entry
 // CHECK:   %4 = bitcast %T34enum_value_semantics_special_cases23MultipleEmptyRefcountedO* %0 to %swift.refcounted**
 // CHECK:   %toDestroy = load %swift.refcounted*, %swift.refcounted** %4, align 8
 // CHECK:   call void @swift_release(%swift.refcounted* %toDestroy)
 // CHECK:   br label %5
-// CHECK: ; <label>:5:                                      ; preds = %3, %entry, %entry
+// CHECK: 5:                                      ; preds = %3, %entry, %entry
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/IRGen/enum_value_semantics_special_cases_objc.sil
+++ b/test/IRGen/enum_value_semantics_special_cases_objc.sil
@@ -87,16 +87,16 @@ enum MixedRefcountedWithIndirect {
 // CHECK:     i8 1, label %6
 // CHECK:   ]
 
-// CHECK: ; <label>:4:
+// CHECK: 4:
 // CHECK:   %5 = inttoptr i64 %0 to %swift.refcounted*
 // CHECK:   call void @swift_release(%swift.refcounted* %5) #1
 // CHECK:   br label %9
 
-// CHECK: ; <label>:6:
+// CHECK: 6:
 // CHECK:   %7 = and i64 %0, 4611686018427387903
 // CHECK:   %8 = inttoptr i64 %7 to %objc_object*
 // CHECK:   call void @swift_unknownObjectRelease(%objc_object* %8) #1
 // CHECK:   br label %9
 
-// CHECK: ; <label>:9:
+// CHECK: 9:
 // CHECK:   ret void

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -17,27 +17,27 @@ func useFoo(_ x: Foo) -> Int32 {
   // CHECK: ]
 
   switch x {
-    // CHECK: <label>:[[CASE_B]]
+    // CHECK: [[CASE_B]]:
     // CHECK-NEXT: br label %[[FINAL:.+]]
   case .B:
     return 11
 
-    // CHECK: <label>:[[CASE_C]]
+    // CHECK: [[CASE_C]]:
     // CHECK-NEXT: br label %[[FINAL]]
   case .C:
     return 15
 
-    // CHECK: <label>:[[CASE_A]]
+    // CHECK: [[CASE_A]]:
     // CHECK-NEXT: br label %[[FINAL]]
   case .A:
     return 10
   }
 
-  // CHECK: <label>:[[DEFAULT]]
+  // CHECK: [[DEFAULT]]:
   // CHECK: call swiftcc void @"$ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(%swift.type* @"$s{{.+}}3FooON", %swift.opaque* noalias nocapture %{{.+}}, %swift.type* @"$ss5Int32VN")
   // CHECK-NEXT: unreachable
 
-  // CHECK: <label>:[[FINAL]]
+  // CHECK: [[FINAL]]:
   // CHECK: %[[RETVAL:.+]] = phi i32 [ 10, %[[CASE_A]] ], [ 15, %[[CASE_C]] ], [ 11, %[[CASE_B]] ]
   // CHECK: ret i32 %[[RETVAL]]
 }
@@ -51,27 +51,27 @@ func useBar(_ x: Bar) -> Int32 {
   // CHECK: ]
 
   switch x {
-  // CHECK: <label>:[[CASE_B]]
+  // CHECK: [[CASE_B]]:
   // CHECK-NEXT: br label %[[FINAL:.+]]
   case .B:
     return 11
 
-  // CHECK: <label>:[[CASE_C]]
+  // CHECK: [[CASE_C]]:
   // CHECK-NEXT: br label %[[FINAL]]
   case .C:
     return 15
 
-  // CHECK: <label>:[[CASE_A]]
+  // CHECK: [[CASE_A]]:
   // CHECK-NEXT: br label %[[FINAL]]
   case .A:
     return 10
   }
 
-  // CHECK: <label>:[[DEFAULT]]
+  // CHECK: [[DEFAULT]]:
   // CHECK: call swiftcc void @"$ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(%swift.type* @"$s{{.+}}3BarON", %swift.opaque* noalias nocapture %{{.+}}, %swift.type* @"$ss5Int32VN")
   // CHECK-NEXT: unreachable
 
-  // CHECK: <label>:[[FINAL]]
+  // CHECK: [[FINAL]]:
   // CHECK: %[[RETVAL:.+]] = phi i32 [ 10, %[[CASE_A]] ], [ 15, %[[CASE_C]] ], [ 11, %[[CASE_B]] ]
   // CHECK: ret i32 %[[RETVAL]]
 }

--- a/test/IRGen/weak_import_native.swift
+++ b/test/IRGen/weak_import_native.swift
@@ -239,15 +239,15 @@ public func test_not_hoist_weakly_linked4() {
 // CHECK:  [[IS_STRONG:%.*]] = icmp eq i32 [[TAG]], [[STRONG_CASE]]
 // CHECK:  br i1 [[IS_STRONG]], label %[[BB0:[0-9]+]], label %[[BB1:[0-9]+]]
 //
-// CHECK:  <label>:[[BB1]]:
+// CHECK:  [[BB1]]:
 // CHECK:  br i1 icmp eq ({{.*}} ptrtoint (i32* @"$s25weak_import_native_helper1EO0A0yA2CmFWC" to {{.*}}), {{.*}} 0), label %[[BB2:[0-9]+]], label %[[BB3:[0-9]+]]
 //
-// CHECK:; <label>:[[BB3]]:
+// CHECK:  [[BB3]]:
 // CHECK:  [[WEAK_CASE:%.*]] = load i32, i32* @"$s25weak_import_native_helper1EO0A0yA2CmFWC"
 // CHECK:  [[IS_WEAK:%.*]] = icmp eq i32 [[TAG]], [[WEAK_CASE]]
 // CHECK:  br label %[[BB2]]
 //
-// CHECK:; <label>:[[BB2]]:
+// CHECK:  [[BB2]]:
 // CHECK:  = phi i1 [ false, %[[BB1]] ], [ [[IS_WEAK]], %[[BB3]] ]
 public func test_weakly_linked_enum_cases(e: E) -> Int {
   switch e {

--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -54,7 +54,7 @@ public func testCount(_ x: UnsafeBufferPointer<UInt>) -> Int {
 // CHECK: .loopexit: ; preds = %[[LOOP]]
 // CHECK: ret float
 //
-// CHECK: ; <label>:[[LOOP]]:
+// CHECK: [[LOOP]]:
 // CHECK: phi float [ 0.000000e+00
 // CHECK: load float, float*
 // CHECK: fadd float
@@ -77,7 +77,7 @@ public func testSubscript(_ ubp: UnsafeBufferPointer<Float>) -> Float {
 // CHECK: [[RET:.*]]: ; preds = %[[LOOP]], %entry
 // CHECK: ret i64
 //
-// CHECK: ; <label>:[[LOOP]]:
+// CHECK: [[LOOP]]:
 // CHECK: phi i64 [ 0
 // CHECK: load i8, i8*
 // CHECK: zext i8 %{{.*}} to i64

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -97,7 +97,7 @@ def main():
     cur_block = None
     sil_block_pattern = re.compile(r'^(\S+)(\(.*\))?: *(\/\/ *Preds:(.*))?$')
     llvm_block_pattern1 = re.compile(r'^"?([^\s"]+)"?: *; *preds =(.*)?$')
-    llvm_block_pattern2 = re.compile(r'^; <label>:(\d+):? *; *preds =(.*)?$')
+    llvm_block_pattern2 = re.compile(r'^(\d+):? *; *preds =(.*)?$')
 
     # Scan the input file.
 


### PR DESCRIPTION
LLVM r356789 changed the format of textual IR to print nameless
blocks with labels instead of comments with "; <label>". Adjust Swift
tests to match. I also updated the utils/viewcfg script to match.
