### PR TITLE
master-next: adjust expected test output for IRGen/ordering_x86.sil

### DIFF
--- a/test/IRGen/ordering_x86.sil
+++ b/test/IRGen/ordering_x86.sil
@@ -41,4 +41,4 @@ bb0:
 // the order of features differs.
 
 // X86_64: define{{( protected)?}} swiftcc void @baz{{.*}}#0
-// X86_64: #0 = {{.*}}"target-features"="+cx16,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+ssse3,+x87"
+// X86_64: #0 = {{.*}}"target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+ssse3,+x87"


### PR DESCRIPTION
Clang r356709 added the new cx8 feature flag for generic x86 targets.
Adjust the expected output of this test to match.