### PR TITLE
Driver: Win32 support for Driver.batch_mode_parseable_output_cancella…

### DIFF
--- a/test/Driver/batch_mode_parseable_output_cancellation.swift
+++ b/test/Driver/batch_mode_parseable_output_cancellation.swift
@@ -2,13 +2,23 @@
 // RUN: touch %t/file-01.swift
 // RUN: echo 'public func main() { help_an_error_happened() }' >%t/main.swift
 //
-// RUN: not %swiftc_driver -enable-batch-mode -parseable-output -serialize-diagnostics -c -emit-module -module-name main -j 1 %t/file-01.swift %t/main.swift 2>&1 | %FileCheck %s
+// RUN: not %swiftc_driver -enable-batch-mode -parseable-output -serialize-diagnostics -c -emit-module -module-name main -j 1 %t/file-01.swift %t/main.swift 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-os
 //
 //      CHECK:   "kind": "signalled",
 // CHECK-NEXT:   "name": "compile",
 // CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
 // CHECK-NEXT:   "process": {
 // CHECK-NEXT:   	"real_pid": {{[1-9][0-9]*}}
+//
+// This information is not available on POSIX systems where the child is
+// signalled, but it is available on Windows.  We simply report it there since
+// we already have the information.
+// CHECK-windows-msvc-NEXT:     "usage": {
+// CHECK-windows-msvc-NEXT:       "utime":
+// CHECK-windows-msvc-NEXT:       "stime":
+// CHECK-windows-msvc-NEXT:       "maxrss":
+// CHECK-windows-msvc-NEXT:     }
+//
 // CHECK-NEXT:   },
 // CHECK-NEXT:   "error-message": "{{.*}}",
 // CHECK-NEXT:   "signal": 2


### PR DESCRIPTION
…tion

We now emit memory usage information upon the completion of a job.
Adjust the emission expectations.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
