### PR TITLE
test: make the ParseableInterface.ModuleCache tests pass on Windows

### DIFF
--- a/test/ParseableInterface/Inputs/make-unreadable.py
+++ b/test/ParseableInterface/Inputs/make-unreadable.py
@@ -1,0 +1,30 @@
+
+import platform
+import subprocess
+import sys
+
+if platform.system() == 'Windows':
+    import ctypes
+    AdvAPI32 = ctypes.windll.Advapi32
+
+    from ctypes.wintypes import POINTER
+
+    UNLEN = 256
+
+    GetUserNameW = AdvAPI32.GetUserNameW
+    GetUserNameW.argtypes = (
+        ctypes.c_wchar_p,           # _In_Out_ lpBuffer
+        POINTER(ctypes.c_uint)      # _In_out_ pcBuffer
+    )
+    GetUserNameW.restype = ctypes.c_uint
+
+    buffer = ctypes.create_unicode_buffer(UNLEN + 1)
+    size = ctypes.c_uint(len(buffer))
+    GetUserNameW(buffer, ctypes.byref(size))
+
+    for path in sys.argv[1:]:
+        subprocess.call(['icacls', path, '/deny',
+                         '{}:(R)'.format(buffer.value)])
+else:
+    for path in sys.argv[1:]:
+        subprocess.call(['chmod', 'a-r', path])

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
@@ -56,7 +56,7 @@
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -I %t %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 
 // 6. Both are present but the module can't be opened.
-// RUN: chmod a-r %t/Lib.swiftmodule/%target-swiftmodule-name
+// RUN: %{python} %S/../Inputs/make-unreadable.py %t/Lib.swiftmodule/%target-swiftmodule-name
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: %empty-directory(%t/MCP)
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
@@ -57,7 +57,7 @@
 // RUN: %empty-directory(%t/MCP)
 
 // 6. Both are present but the module can't be opened.
-// RUN: chmod a-r %t/Lib.framework/Modules/Lib.swiftmodule/%target-swiftmodule-name
+// RUN: %{python} %S/../Inputs/make-unreadable.py %t/Lib.framework/Modules/Lib.swiftmodule/%target-swiftmodule-name
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: %empty-directory(%t/MCP)
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode.swift
@@ -54,7 +54,7 @@
 // RUN: %empty-directory(%t/MCP)
 
 // 6. Both are present but the module can't be opened.
-// RUN: chmod a-r %t/Lib.swiftmodule
+// RUN: %{python} %S/../Inputs/make-unreadable.py %t/Lib.swiftmodule
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: %empty-directory(%t/MCP)
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s

--- a/test/ParseableInterface/ModuleCache/prebuilt-module-cache-forwarding.swift
+++ b/test/ParseableInterface/ModuleCache/prebuilt-module-cache-forwarding.swift
@@ -35,7 +35,7 @@
 // RUN: %empty-directory(%t/MCP)
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1
 // RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/Lib-*.swiftmodule
-// RUN: chmod a-r %t/MCP/Lib-*.swiftmodule
+// RUN: %{python} %S/../Inputs/make-unreadable.py %t/MCP/Lib-*.swiftmodule
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
 // RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/Lib-*.swiftmodule
 


### PR DESCRIPTION
Use a wrapper for invoking chmod a-r or icacls on Windows to make the
files actually unreadable.  This allows the tests to pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
