### PR TITLE
platform: correct case for WinSDK module (NFC)

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -19,7 +19,7 @@ module WinSDK [system] [extern_c] {
 
   module core {
     module acl {
-      header "aclapi.h"
+      header "AclAPI.h"
       export *
     }
 


### PR DESCRIPTION
This adjusts the case so that it can build on case sensitive file
systems (e.g. ext4).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
