### PR TITLE
Update WindowsBuild.md

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -1,35 +1,14 @@
 # Building Swift on Windows
 
-This document describes how to build Swift for Windows natively. See [the
-Windows doc](./Windows.md) for more about what is possible with Swift on
-Windows.
+Visual Studio 2017 or newer is needed to build swift on Windows.
 
-There are two supported ways to build Swift on Windows:
-
-1. Using [`clang-cl`](https://clang.llvm.org/docs/UsersManual.html#clang-cl)
-1. Using the Microsoft Visual C++ compiler (MSVC)
-
-`clang-cl` is recommended over MSVC for building Swift on Windows.
-
-Although it is possible to build the compiler and the standard library with
-MSVC and to use those built products to compile a Swift program, it won't be
-possible to run the binary without separately obtaining the Swift runtime. On
-the other hand, `clang-cl` is able to build the runtime, which makes it
-possible to build and run all the components required for Swift natively on
-Windows.
-
-clang should be 7.0 or newer. Visual Studio 2017 is needed in all cases as
-it provides some of the needed headers and libraries.
-
-## `clang-cl`
-
-### 1. Install dependencies
+## 1. Install dependencies
 1. Latest version of [Visual Studio](https://www.visualstudio.com/downloads/)
 - Make sure to include "Programming Languages|Visual C++" and "Windows and Web
   Development|Universal Windows App Development|Windows SDK" in your
   installation.
 
-### 2. Clone the repositories
+## 2. Clone the repositories
 1. Configure git to work with Unix file endings
 1. Create a folder to contain all the Swift repositories
 1. Clone `apple/swift-cmark` into a folder named `cmark`
@@ -72,7 +51,7 @@ git clone https://github.com/curl/curl.git
 git clone https://gitlab.gnome.org/GNOME/libxml2.git
 ```
 
-### 3. Acquire ICU
+## 3. Acquire ICU
 1. Download ICU from [ICU Project](http://site.icu-project.org) for Windows x64 and extract the binaries.
 1. Add the `bin64` folder to your `Path` environment variable.
 
@@ -80,7 +59,7 @@ git clone https://gitlab.gnome.org/GNOME/libxml2.git
 PATH S:\icu\bin64;%PATH%
 ```
 
-### 4. Fetch SQLite3
+## 4. Fetch SQLite3
 
 ```powershell
 (New-Object System.Net.WebClient).DownloadFile("https://www.sqlite.org/2019/sqlite-amalgamation-3270200.zip", "S:\sqlite-amalgamation-3270200.zip")
@@ -88,7 +67,7 @@ Add-Type -A System.IO.Compression.FileSystem
 [IO.Compression.ZipFile]::ExtractToDirectory("S:\sqlite-amalgamation-3270200.zip", "S:\")
 ```
 
-### 5. Get ready
+## 5. Get ready
 - From within a **developer** command prompt (not PowerShell nor cmd, but the [Visual Studio Developer Command Prompt](https://msdn.microsoft.com/en-us/library/f35ctcxw.aspx)), execute the following command if you have an x64 PC.
 
 ```cmd
@@ -119,7 +98,7 @@ mklink "%VCToolsInstallDir%\include\visualc.apinotes" S:\swift\stdlib\public\Pla
 
 Warning: Creating the above links usually requires administrator privileges. The quick and easy way to do this is to open a second developer prompt by right clicking whatever shortcut you used to open the first one, choosing Run As Administrator, and pasting the above commands into the resulting window. You can then close the privileged prompt; this is the only step which requires elevation.
 
-### 6. Build LLVM/Clang
+## 6. Build LLVM/Clang
 - This must be done from within a developer command prompt. LLVM and Clang are
   large projects, so building might take a few hours. Make sure that the build
   type for LLVM/Clang is compatbile with the build type for Swift. That is,
@@ -147,8 +126,7 @@ cmake --build "S:\b\llvm"
 ```cmd
 path S:\b\llvm\bin;%PATH%
 ```
-
-### 7. Build CMark
+## 7. Build CMark
 - This must be done from within a developer command prompt. CMark is a fairly
   small project and should only take a few minutes to build.
 ```cmd
@@ -163,7 +141,7 @@ popd
 cmake --build "S:\b\cmark"
 ```
 
-### 8. Build Swift
+## 8. Build Swift
 - This must be done from within a developer command prompt
 - Note that Visual Studio vends a 32-bit python 2.7 installation in `C:\Python27` and a 64-bit python in `C:\Python27amd64`.  You may use either one based on your installation.
 
@@ -204,7 +182,7 @@ cmake --build "S:\b\swift"
 cmake -G "Visual Studio 2017" -A x64 -T "host=x64"^ ...
 ```
 
-### 9. Build lldb
+## 9. Build lldb
 - This must be done from within a developer command prompt and could take hours
   depending on your system.
 ```cmd
@@ -225,7 +203,7 @@ popd
 cmake --build S:\b\lldb
 ```
 
-### 10. Running tests on Windows
+## 10. Running tests on Windows
 
 Running the testsuite on Windows has additional external dependencies.  You must have a subset of the GNUWin32 programs installed and available in your path.  The following packages are currently required:
 
@@ -239,7 +217,7 @@ path S:\thirdparty\icu4c-63_1-Win64-MSVC2017\bin64;S:\b\swift\bin;S:\b\swift\lib
 ninja -C S:\b\swift check-swift
 ```
 
-### 11. Build swift-corelibs-libdispatch
+## 11. Build swift-corelibs-libdispatch
 
 ```cmd
 mkdir "S:\b\libdispatch"
@@ -261,7 +239,7 @@ cmake --build S:\b\libdispatch
 path S:\b\libdispatch;S:\b\libdispatch\src;%PATH%
 ```
 
-### 12. Build curl
+## 12. Build curl
 
 ```cmd
 pushd "S:\curl"
@@ -271,7 +249,7 @@ nmake /f Makefile.vc mode=static VC=15 MACHINE=x64
 popd
 ```
 
-### 13. Build libxml2
+## 13. Build libxml2
 
 ```cmd
 pushd "S:\libxml2\win32"
@@ -280,7 +258,7 @@ nmake /f Makefile.msvc
 popd
 ```
 
-### 14. Build swift-corelibs-foundation
+## 14. Build swift-corelibs-foundation
 
 ```cmd
 mkdir "S:\b\foundation"
@@ -307,7 +285,7 @@ cmake -G Ninja^
 path S:\b\foundation;%PATH%
 ```
 
-### 15. Build swift-corelibs-xctest
+## 15. Build swift-corelibs-xctest
 
 ```cmd
 mkdir "S:\b\xctest"
@@ -332,13 +310,13 @@ cmake --build S:\b\xctest
 path S:\b\xctest;%PATH%
 ```
 
-### 16. Test XCTest
+## 16. Test XCTest
 
 ```cmd
 ninja -C S:\b\xctest check-xctest
 ```
 
-### 17. Rebuild Foundation
+## 17. Rebuild Foundation
 
 ```cmd
 mkdir "S:\b\foundation"
@@ -361,14 +339,14 @@ cmake -G Ninja^
  cmake --build S:\b\foundation
 ```
 
-### 18. Test Foundation
+## 18. Test Foundation
 
 ```cmd
 cmake --build S:\b\foundation
 ninja -C S:\b\foundation test 
 ```
 
-### 19. Build SQLite3
+## 19. Build SQLite3
 
 ```cmd
 md S:\b\sqlite
@@ -381,7 +359,7 @@ cl /MD /Ox /Zi /LD /DSQLITE_API=__declspec(dllexport) S:\sqlite-amalgamation-327
 path S:\b\sqlite;%PATH%
 ```
 
-### 20. Build llbuild
+## 20. Build llbuild
 
 ```cmd
 md S:\b\llbuild
@@ -401,7 +379,7 @@ ninja
 path S:\b\llbuild;%PATH%
 ```
 
-### 21. Build swift-package-manager
+## 21. Build swift-package-manager
 
 ```cmd
 md S:\b\spm
@@ -409,7 +387,7 @@ cd S:\b\spm
 C:\Python27\python.exe S:\swift-package-manager\Utilities\bootstrap --foundation S:\b\foundation --libdispatch-build-dir S:\b\libdispatch --libdispatch-source-dir S:\swift-corelibs-libdispatch --llbuild-build-dir S:\b\llbuild --llbuild-source-dir S:\llbuild --sqlite-build-dir S:\b\sqlite --sqlite-source-dir S:\sqlite-amalgamation-3270200
 ```
 
-### 22. Install Swift on Windows
+## 22. Install Swift on Windows
 
 - Run ninja install:
 


### PR DESCRIPTION
Remove prelude as the documentation now covers the use of `cl` to build as it is stable and does a better job overall compared to `clang-cl` (better generated binaries, faster builds, better (working) debug information).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
