### PR TITLE
test: add a test for `ll` suffixed types being promoted to ULL

### DIFF
--- a/test/ClangImporter/long-long-promotion.swift
+++ b/test/ClangImporter/long-long-promotion.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+import macros
+
+func verifyIsSigned(_: Int64) { }
+func verifyIsUnsigned(_: UInt64) { }
+
+// Windows will not convert a long long value that overflows into an unsigned
+// long long if it has the `ll` suffix of `i64` suffix.  Ensure that the type is
+// imported appropriately.
+#if os(Windows)
+verifyIsSigned(LL_TO_ULL)
+#else
+verifyIsUnsigned(LL_TO_ULL)
+#endif
+

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -25,6 +25,8 @@
 #define TRUE 1
 #define FALSE 0
 
+#define LL_TO_ULL 0x8000000000000000LL
+
 #define A_PI M_PI
 
 #define VERSION_STRING "Swift 1.0"


### PR DESCRIPTION
This addresses the follow up test case discussed in PR23651.  Windows
will not promote a macro literal suffixed with `ll` or `i64` to an
unsigned long long even upon an overflow.  This tests that the corner
case behaviour for importing a long long literal matches the platform
expectations.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
