### PR TITLE
[Build System: CMake] Add back the missing install_name_dir for the standard library (5.1 03-18-2019 branch).

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1010,6 +1010,10 @@ function(_add_swift_library_single target name)
   if(SWIFTLIB_SINGLE_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
     set(install_name_dir "@rpath")
 
+    if(SWIFTLIB_SINGLE_IS_STDLIB)
+      set(install_name_dir "${SWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR}")
+    endif()
+
     # Always use @rpath for XCTest
     if(module_name STREQUAL "XCTest")
       set(install_name_dir "@rpath")


### PR DESCRIPTION
Copy of #23711 for the 5.1 03-18-2019 branch.