### PR TITLE
[Sema] Fix getter parameter indices crash.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -780,6 +780,12 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
           C, /*implicit*/ true, SourceLoc(), SourceLoc(), {}, None,
           None, nullptr);
       member->getAttrs().add(diffableAttr);
+      // If getter does not exist, trigger synthesis and compute type.
+      if (!member->getGetter())
+        addExpectedOpaqueAccessorsToStorage(TC, member);
+      if (!member->getGetter()->hasInterfaceType())
+        TC.resolveDeclSignature(member->getGetter());
+      // Compute getter parameter indices.
       auto *getterType =
           member->getGetter()->getInterfaceType()->castTo<AnyFunctionType>();
       AutoDiffParameterIndicesBuilder builder(getterType);

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -251,6 +251,26 @@ struct TF_260<T : Differentiable> : Differentiable & AdditiveArithmetic {
   var x: T.CotangentVector
 }
 
+// TF-269: Test crash when differentiation properties have no getter.
+// Related to access levels and associated type inference.
+public protocol TF_269_Layer: Differentiable & KeyPathIterable
+  where AllDifferentiableVariables: KeyPathIterable {
+
+  associatedtype Input: Differentiable
+  associatedtype Output: Differentiable
+  func applied(to input: Input) -> Output
+}
+
+public struct TF_269 : TF_269_Layer {
+  public var filter: Float
+  public typealias Activation = @differentiable (Output) -> Output
+  @noDerivative public let activation: Activation
+
+  public func applied(to input: Float) -> Float {
+    return input
+  }
+}
+
 // Test errors.
 
 // Test manually customizing vector space types.


### PR DESCRIPTION
During `Differentiable` derived conformances, the stored properties for
differentiation should be marked with `@differentiable`.

Previously, derived conformances crashed for stored properties with no
getter. Now, getter synthesis is triggered.

Resolves [TF-269](https://bugs.swift.org/browse/TF-269).