### PR TITLE
[TestJSONEncoder] Re-enable tests and add a special case for `testEncodingDate`

### DIFF
--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -9,7 +9,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: rdar49161053
 
 import Swift
 import Foundation
@@ -231,11 +230,71 @@ class TestJSONEncoder : TestJSONEncoderSuper {
 
   // MARK: - Date Strategy Tests
   func testEncodingDate() {
+
+    func formattedLength(of value: Double) -> Int {
+        let empty = UnsafeMutablePointer<Int8>.allocate(capacity: 0)
+        defer { empty.deallocate() }
+        let length = snprintf(ptr: empty, 0, "%0.*g", DBL_DECIMAL_DIG, value)
+        return Int(length)
+    }
+
+    // Duplicated to handle a special case
+    func localTestRoundTrip<T: Codable & Equatable>(of value: T) {
+        var payload: Data! = nil
+        do {
+            let encoder = JSONEncoder()
+            payload = try encoder.encode(value)
+        } catch {
+            expectUnreachable("Failed to encode \(T.self) to JSON: \(error)")
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            let decoded = try decoder.decode(T.self, from: payload)
+
+            /// `snprintf`'s `%g`, which `JSONSerialization` uses internally for double values, does not respect
+            /// our precision requests in every case. This bug effects Darwin, FreeBSD, and Linux currently
+            /// causing this test (which uses the current time) to fail occasionally.
+            let evalEdgeCase: (Date, Date) -> () = { decodedDate, expectedDate in
+                if formattedLength(of: decodedDate.timeIntervalSinceReferenceDate) > DBL_DECIMAL_DIG + 2 {
+                    let adjustedTimeIntervalSinceReferenceDate: (Date) -> Double = {
+                        let adjustment = pow(10, Double(DBL_DECIMAL_DIG))
+                        return Double(floor(adjustment * $0.timeIntervalSinceReferenceDate) / adjustment)
+                    }
+
+                    let decodedAprox = adjustedTimeIntervalSinceReferenceDate(decodedDate)
+                    let valueAprox = adjustedTimeIntervalSinceReferenceDate(expectedDate)
+                    expectEqual(decodedAprox, valueAprox, "\(T.self) did not round-trip to an equal value after DBL_DECIMAL_DIG adjustment \(decodedAprox) != \(valueAprox).")
+                }
+            }
+
+            if let decodedDate = (decoded as? TopLevelWrapper<Date>)?.value,
+                let expectedDate = (value as? TopLevelWrapper<Date>)?.value {
+                evalEdgeCase(decodedDate, expectedDate)
+                return
+            }
+
+            if let decodedDate = (decoded as? OptionalTopLevelWrapper<Date>)?.value,
+                let expectedDate = (value as? OptionalTopLevelWrapper<Date>)?.value {
+                evalEdgeCase(decodedDate, expectedDate)
+                return
+            }
+
+            expectEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+        } catch {
+            expectUnreachable("Failed to decode \(T.self) from JSON: \(error)")
+        }
+    }
+
+    // Test the above `snprintf` edge case evaluation with a known triggering case
+    let knownBadDate = Date(timeIntervalSinceReferenceDate: 0.0021413276231263384)
+    localTestRoundTrip(of: TopLevelWrapper(knownBadDate))
+
     // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
-    _testRoundTrip(of: TopLevelWrapper(Date()))
+    localTestRoundTrip(of: TopLevelWrapper(Date()))
 
     // Optional dates should encode the same way.
-    _testRoundTrip(of: OptionalTopLevelWrapper(Date()))
+    localTestRoundTrip(of: OptionalTopLevelWrapper(Date()))
   }
 
   func testEncodingDateSecondsSince1970() {


### PR DESCRIPTION
Handles a rare condition caused by `snprintf`'s `%g` which `JSONSerialization` uses internally for double values. This bug effects Darwin, FreeBSD, and Linux currently.