### PR TITLE
Implementation-only import checking for types used in decls

### DIFF
--- a/include/swift/AST/AccessScopeChecker.h
+++ b/include/swift/AST/AccessScopeChecker.h
@@ -23,47 +23,79 @@
 
 namespace swift {
 
-class AbstractStorageDecl;
-class ExtensionDecl;
+class BoundGenericType;
+class ComponentIdentTypeRepr;
+class NominalType;
 class SourceFile;
-class ValueDecl;
+class TypeAliasType;
 
 class AccessScopeChecker {
   const SourceFile *File;
   bool TreatUsableFromInlineAsPublic;
 
-protected:
-  ASTContext &Context;
   Optional<AccessScope> Scope = AccessScope::getPublic();
 
   AccessScopeChecker(const DeclContext *useDC,
                      bool treatUsableFromInlineAsPublic);
-  bool visitDecl(ValueDecl *VD);
-};
-
-class TypeReprAccessScopeChecker : private ASTWalker, AccessScopeChecker {
-  TypeReprAccessScopeChecker(const DeclContext *useDC,
-                             bool treatUsableFromInlineAsPublic);
-
-  bool walkToTypeReprPre(TypeRepr *TR) override;
-  bool walkToTypeReprPost(TypeRepr *TR) override;
+  bool visitDecl(const ValueDecl *VD);
 
 public:
   static Optional<AccessScope>
   getAccessScope(TypeRepr *TR, const DeclContext *useDC,
                  bool treatUsableFromInlineAsPublic = false);
-};
-
-class TypeAccessScopeChecker : private TypeWalker, AccessScopeChecker {
-  TypeAccessScopeChecker(const DeclContext *useDC,
-                         bool treatUsableFromInlineAsPublic);
-
-  Action walkToTypePre(Type T);
-
-public:
   static Optional<AccessScope>
   getAccessScope(Type T, const DeclContext *useDC,
                  bool treatUsableFromInlineAsPublic = false);
+};
+
+/// Walks a Type to find all NominalTypes, BoundGenericTypes, and
+/// TypeAliasTypes.
+class TypeDeclFinder : public TypeWalker {
+  Action walkToTypePre(Type T) override;
+
+public:
+  virtual Action visitNominalType(const NominalType *ty) {
+    return Action::Continue;
+  }
+  virtual Action visitBoundGenericType(const BoundGenericType *ty) {
+    return Action::Continue;
+  }
+  virtual Action visitTypeAliasType(const TypeAliasType *ty) {
+    return Action::Continue;
+  }
+};
+
+/// A TypeDeclFinder for use cases where all types should be treated
+/// equivalently and where generic arguments can be walked to separately from
+/// the generic type.
+class SimpleTypeDeclFinder : public TypeDeclFinder {
+  /// The function to call when a ComponentIdentTypeRepr is seen.
+  llvm::function_ref<Action(const TypeDecl *)> Callback;
+
+  Action visitNominalType(const NominalType *ty) override;
+  Action visitBoundGenericType(const BoundGenericType *ty) override;
+  Action visitTypeAliasType(const TypeAliasType *ty) override;
+
+public:
+  explicit SimpleTypeDeclFinder(
+      llvm::function_ref<Action(const TypeDecl *)> callback)
+    : Callback(callback) {}
+};
+
+/// Walks a TypeRepr to find all ComponentIdentTypeReprs with bound TypeDecls.
+///
+/// Subclasses can either override #visitTypeDecl if they only care about
+/// types on their own, or #visitComponentIdentTypeRepr if they want to keep
+/// the TypeRepr around.
+class TypeReprIdentFinder : public ASTWalker {
+  /// The function to call when a ComponentIdentTypeRepr is seen.
+  llvm::function_ref<bool(const ComponentIdentTypeRepr *)> Callback;
+
+  bool walkToTypeReprPost(TypeRepr *TR) override;
+public:
+  explicit TypeReprIdentFinder(
+      llvm::function_ref<bool(const ComponentIdentTypeRepr *)> callback)
+    : Callback(callback) {}
 };
 
 }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2392,6 +2392,11 @@ NOTE(enum_raw_value_incrementing_from_zero,none,
 NOTE(construct_raw_representable_from_unwrapped_value,none,
      "construct %0 from unwrapped %1 value", (Type, Type))
 
+ERROR(decl_from_implementation_only_module,none,
+      "cannot use %0 here; %1 has been imported as "
+      "'@_implementationOnly'",
+      (DeclName, Identifier))
+
 // Derived conformances
 ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
       "implementation of %0 for non-final class cannot be automatically "

--- a/lib/AST/AccessScopeChecker.cpp
+++ b/lib/AST/AccessScopeChecker.cpp
@@ -24,11 +24,10 @@ using namespace swift;
 AccessScopeChecker::AccessScopeChecker(const DeclContext *useDC,
                                        bool treatUsableFromInlineAsPublic)
   : File(useDC->getParentSourceFile()),
-    TreatUsableFromInlineAsPublic(treatUsableFromInlineAsPublic),
-    Context(File->getASTContext()) {}
+    TreatUsableFromInlineAsPublic(treatUsableFromInlineAsPublic) {}
 
 bool
-AccessScopeChecker::visitDecl(ValueDecl *VD) {
+AccessScopeChecker::visitDecl(const ValueDecl *VD) {
   if (!VD || isa<GenericTypeParamDecl>(VD))
     return true;
 
@@ -37,55 +36,64 @@ AccessScopeChecker::visitDecl(ValueDecl *VD) {
   return Scope.hasValue();
 }
 
-TypeReprAccessScopeChecker::TypeReprAccessScopeChecker(const DeclContext *useDC,
-                                                       bool treatUsableFromInlineAsPublic)
-  : AccessScopeChecker(useDC, treatUsableFromInlineAsPublic) {
-}
-
-bool
-TypeReprAccessScopeChecker::walkToTypeReprPre(TypeRepr *TR) {
-  if (auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR))
-    return visitDecl(CITR->getBoundDecl());
-  return true;
-}
-
-bool
-TypeReprAccessScopeChecker::walkToTypeReprPost(TypeRepr *TR) {
-  return Scope.hasValue();
+bool TypeReprIdentFinder::walkToTypeReprPost(TypeRepr *TR) {
+  auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR);
+  if (!CITR || !CITR->getBoundDecl())
+    return true;
+  return Callback(CITR);
 }
 
 Optional<AccessScope>
-TypeReprAccessScopeChecker::getAccessScope(TypeRepr *TR, const DeclContext *useDC,
-                                           bool treatUsableFromInlineAsPublic) {
-  TypeReprAccessScopeChecker checker(useDC, treatUsableFromInlineAsPublic);
-  TR->walk(checker);
+AccessScopeChecker::getAccessScope(TypeRepr *TR, const DeclContext *useDC,
+                                   bool treatUsableFromInlineAsPublic) {
+  AccessScopeChecker checker(useDC, treatUsableFromInlineAsPublic);
+  TR->walk(TypeReprIdentFinder([&](const ComponentIdentTypeRepr *typeRepr) {
+    return checker.visitDecl(typeRepr->getBoundDecl());
+  }));
   return checker.Scope;
 }
 
-TypeAccessScopeChecker::TypeAccessScopeChecker(const DeclContext *useDC,
-                                               bool treatUsableFromInlineAsPublic)
-  : AccessScopeChecker(useDC, treatUsableFromInlineAsPublic) {}
+TypeWalker::Action TypeDeclFinder::walkToTypePre(Type T) {
+  if (auto *TAT = dyn_cast<TypeAliasType>(T.getPointer()))
+    return visitTypeAliasType(TAT);
 
-TypeWalker::Action
-TypeAccessScopeChecker::walkToTypePre(Type T) {
-  ValueDecl *VD;
-  if (auto *BNAD = dyn_cast<TypeAliasType>(T.getPointer()))
-    VD = BNAD->getDecl();
-  else if (auto *NTD = T->getAnyNominal())
-    VD = NTD;
-  else
-    VD = nullptr;
-
-  if (!visitDecl(VD))
-    return Action::Stop;
+  // FIXME: We're looking through sugar here so that we visit, e.g.,
+  // Swift.Array when we see `[Int]`. But that means we do redundant work when
+  // we see sugar that's purely structural, like `(Int)`. Fortunately, paren
+  // types are the only such purely structural sugar at the time this comment
+  // was written, and they're not so common in the first place.
+  if (auto *BGT = T->getAs<BoundGenericType>())
+    return visitBoundGenericType(BGT);
+  if (auto *NT = T->getAs<NominalType>())
+    return visitNominalType(NT);
 
   return Action::Continue;
 }
 
+TypeWalker::Action
+SimpleTypeDeclFinder::visitNominalType(const NominalType *ty) {
+  return Callback(ty->getDecl());
+}
+
+TypeWalker::Action
+SimpleTypeDeclFinder::visitBoundGenericType(const BoundGenericType *ty) {
+  return Callback(ty->getDecl());
+}
+
+TypeWalker::Action
+SimpleTypeDeclFinder::visitTypeAliasType(const TypeAliasType *ty) {
+  return Callback(ty->getDecl());
+}
+
+
 Optional<AccessScope>
-TypeAccessScopeChecker::getAccessScope(Type T, const DeclContext *useDC,
-                                       bool treatUsableFromInlineAsPublic) {
-  TypeAccessScopeChecker checker(useDC, treatUsableFromInlineAsPublic);
-  T.walk(checker);
+AccessScopeChecker::getAccessScope(Type T, const DeclContext *useDC,
+                                   bool treatUsableFromInlineAsPublic) {
+  AccessScopeChecker checker(useDC, treatUsableFromInlineAsPublic);
+  T.walk(SimpleTypeDeclFinder([&](const ValueDecl *VD) {
+    if (checker.visitDecl(VD))
+      return TypeWalker::Action::Continue;
+    return TypeWalker::Action::Stop;
+  }));
   return checker.Scope;
 }

--- a/lib/AST/AccessScopeChecker.cpp
+++ b/lib/AST/AccessScopeChecker.cpp
@@ -28,7 +28,7 @@ AccessScopeChecker::AccessScopeChecker(const DeclContext *useDC,
 
 bool
 AccessScopeChecker::visitDecl(const ValueDecl *VD) {
-  if (!VD || isa<GenericTypeParamDecl>(VD))
+  if (isa<GenericTypeParamDecl>(VD))
     return true;
 
   auto AS = VD->getFormalAccessScope(File, TreatUsableFromInlineAsPublic);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1517,10 +1517,10 @@ public:
 
     // Is this a stored property in a non-resilient struct or class?
     auto *property = dyn_cast<VarDecl>(VD);
-    if (!property || !property->hasStorage())
+    if (!property || !property->hasStorage() || property->isStatic())
       return true;
     auto *parentNominal = dyn_cast<NominalTypeDecl>(property->getDeclContext());
-    if (!parentNominal || !parentNominal->isResilient())
+    if (!parentNominal || parentNominal->isResilient())
       return true;
 
     // Is that struct or class part of the module's API or ABI?

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -171,8 +171,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
   AccessScope problematicAccessScope = AccessScope::getPublic();
   if (type) {
     Optional<AccessScope> typeAccessScope =
-        TypeAccessScopeChecker::getAccessScope(type, useDC,
-                                               checkUsableFromInline);
+      AccessScopeChecker::getAccessScope(type, useDC, checkUsableFromInline);
 
     // Note: This means that the type itself is invalid for this particular
     // context, because it references declarations from two incompatible scopes.
@@ -193,8 +192,8 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
       return;
 
     Optional<AccessScope> typeReprAccessScope =
-        TypeReprAccessScopeChecker::getAccessScope(typeRepr, useDC,
-                                                   checkUsableFromInline);
+        AccessScopeChecker::getAccessScope(typeRepr, useDC,
+                                           checkUsableFromInline);
     if (!typeReprAccessScope.hasValue())
       return;
 
@@ -221,8 +220,8 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
       //
       // Downgrade the error to a warning in this case for source compatibility.
       Optional<AccessScope> typeReprAccessScope =
-          TypeReprAccessScopeChecker::getAccessScope(typeRepr, useDC,
-                                                     checkUsableFromInline);
+          AccessScopeChecker::getAccessScope(typeRepr, useDC,
+                                             checkUsableFromInline);
       assert(typeReprAccessScope && "valid Type but not valid TypeRepr?");
       if (contextAccessScope.hasEqualDeclContextWith(*typeReprAccessScope) ||
           contextAccessScope.isChildOf(*typeReprAccessScope)) {

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -439,6 +439,8 @@ public:
   UNREACHABLE(PrecedenceGroup, "cannot appear in a type context")
   UNREACHABLE(Module, "cannot appear in a type context")
 
+  UNREACHABLE(IfConfig, "does not have access control")
+  UNREACHABLE(PoundDiagnostic, "does not have access control")
   UNREACHABLE(Param, "does not have access control")
   UNREACHABLE(GenericTypeParam, "does not have access control")
   UNREACHABLE(MissingMember, "does not have access control")
@@ -447,8 +449,6 @@ public:
 #define UNINTERESTING(KIND) \
   void visit##KIND##Decl(KIND##Decl *D) {}
 
-  UNINTERESTING(IfConfig) // Does not have access control.
-  UNINTERESTING(PoundDiagnostic) // Does not have access control.
   UNINTERESTING(EnumCase) // Handled at the EnumElement level.
   UNINTERESTING(Var) // Handled at the PatternBinding level.
   UNINTERESTING(Destructor) // Always correct.
@@ -1399,16 +1399,382 @@ public:
     }
   }
 };
+
+class ImplementationOnlyImportChecker
+    : public DeclVisitor<ImplementationOnlyImportChecker> {
+  using CheckImplementationOnlyCallback =
+      llvm::function_ref<void(const TypeDecl *, const TypeRepr *)>;
+
+  TypeChecker &TC;
+
+  void checkTypeImpl(Type type, const TypeRepr *typeRepr, const SourceFile *SF,
+                     CheckImplementationOnlyCallback diagnose) {
+    // Don't bother checking errors.
+    if (type && type->hasError())
+      return;
+
+    bool foundAnyIssues = false;
+
+    // Check the TypeRepr first (if present), because that will give us a
+    // better diagonstic.
+    if (typeRepr) {
+      const_cast<TypeRepr *>(typeRepr)->walk(TypeReprIdentFinder(
+          [&](const ComponentIdentTypeRepr *component) {
+        ModuleDecl *M = component->getBoundDecl()->getModuleContext();
+        if (!SF->isImportedImplementationOnly(M))
+          return true;
+
+        diagnose(component->getBoundDecl(), component);
+        foundAnyIssues = true;
+        // We still continue even in the diagnostic case to report multiple
+        // violations.
+        return true;
+      }));
+    }
+
+    // FIXME: Are there places where we can be sure the TypeRepr fully accounts
+    // for the type, and therefore we could skip this extra work?
+    if (!foundAnyIssues && type) {
+      type.walk(SimpleTypeDeclFinder([&](const TypeDecl *typeDecl) {
+        ModuleDecl *M = typeDecl->getModuleContext();
+        if (!SF->isImportedImplementationOnly(M))
+          return TypeWalker::Action::Continue;
+
+        diagnose(typeDecl, /*typeRepr*/nullptr);
+        // We still continue even in the diagnostic case to report multiple
+        // violations.
+        return TypeWalker::Action::Continue;
+      }));
+    }
+  }
+
+  void checkType(Type type, const TypeRepr *typeRepr, const Decl *context,
+                 CheckImplementationOnlyCallback diagnose) {
+    auto *SF = context->getDeclContext()->getParentSourceFile();
+    assert(SF && "checking a non-source declaration?");
+    return checkTypeImpl(type, typeRepr, SF, diagnose);
+  }
+
+  void checkType(const TypeLoc &TL, const Decl *context,
+                 CheckImplementationOnlyCallback diagnose) {
+    checkType(TL.getType(), TL.getTypeRepr(), context, diagnose);
+  }
+
+  void checkGenericParams(const GenericParamList *params,
+                          const Decl *owner) {
+    if (!params)
+      return;
+
+    for (auto param : *params) {
+      if (param->getInherited().empty())
+        continue;
+      assert(param->getInherited().size() == 1);
+      checkType(param->getInherited().front(), owner,
+                getDiagnoseCallback(owner));
+    }
+
+    forAllRequirementTypes(WhereClauseOwner(
+                             owner->getInnermostDeclContext(),
+                             const_cast<GenericParamList *>(params)),
+                           [&](Type type, TypeRepr *typeRepr) {
+      checkType(type, typeRepr, owner, getDiagnoseCallback(owner));
+    });
+  }
+
+  class DiagnoseGenerically {
+    TypeChecker &TC;
+    const Decl *D;
+  public:
+    DiagnoseGenerically(TypeChecker &TC, const Decl *D) : TC(TC), D(D) {}
+
+    void operator()(const TypeDecl *offendingType,
+                    const TypeRepr *complainRepr) {
+      ModuleDecl *M = offendingType->getModuleContext();
+      auto diag = TC.diagnose(D, diag::decl_from_implementation_only_module,
+                              offendingType->getFullName(), M->getName());
+      highlightOffendingType(TC, diag, complainRepr);
+    }
+
+    static_assert(std::is_convertible<DiagnoseGenerically,
+                                      CheckImplementationOnlyCallback>::value,
+                  "DiagnoseGenerically has wrong call signature");
+  };
+
+  DiagnoseGenerically getDiagnoseCallback(const Decl *D) {
+    return DiagnoseGenerically(TC, D);
+  }
+
+public:
+  explicit ImplementationOnlyImportChecker(TypeChecker &TC) : TC(TC) {}
+
+  static bool shouldSkipChecking(const ValueDecl *VD) {
+    // Is this part of the module's API or ABI?
+    AccessScope accessScope =
+        VD->getFormalAccessScope(nullptr,
+                                 /*treatUsableFromInlineAsPublic*/true);
+    if (accessScope.isPublic())
+      return false;
+
+    // Is this a stored property in a non-resilient struct or class?
+    auto *property = dyn_cast<VarDecl>(VD);
+    if (!property || !property->hasStorage())
+      return true;
+    auto *parentNominal = dyn_cast<NominalTypeDecl>(property->getDeclContext());
+    if (!parentNominal || !parentNominal->isResilient())
+      return true;
+
+    // Is that struct or class part of the module's API or ABI?
+    AccessScope parentAccessScope = parentNominal->getFormalAccessScope(
+        nullptr, /*treatUsableFromInlineAsPublic*/true);
+    if (parentAccessScope.isPublic())
+      return false;
+
+    return true;
+  }
+
+  void visit(Decl *D) {
+    if (D->isInvalid() || D->isImplicit())
+      return;
+
+    if (auto *VD = dyn_cast<ValueDecl>(D))
+      if (shouldSkipChecking(VD))
+        return;
+
+    DeclVisitor<ImplementationOnlyImportChecker>::visit(D);
+
+    if (auto *extension = dyn_cast<ExtensionDecl>(D->getDeclContext())) {
+      checkType(extension->getExtendedTypeLoc(), extension,
+                getDiagnoseCallback(extension));
+      checkConstrainedExtensionRequirements(extension);
+    }
+  }
+
+  // Force all kinds to be handled at a lower level.
+  void visitDecl(Decl *D) = delete;
+  void visitValueDecl(ValueDecl *D) = delete;
+
+#define UNREACHABLE(KIND, REASON) \
+  void visit##KIND##Decl(KIND##Decl *D) { \
+    llvm_unreachable(REASON); \
+  }
+  UNREACHABLE(Import, "not applicable")
+  UNREACHABLE(TopLevelCode, "not applicable")
+  UNREACHABLE(Module, "not applicable")
+
+  UNREACHABLE(Param, "handled by the enclosing declaration")
+  UNREACHABLE(GenericTypeParam, "handled by the enclosing declaration")
+  UNREACHABLE(MissingMember, "handled by the enclosing declaration")
+#undef UNREACHABLE
+
+#define UNINTERESTING(KIND) \
+  void visit##KIND##Decl(KIND##Decl *D) {}
+
+  UNINTERESTING(PrefixOperator) // Does not reference other decls.
+  UNINTERESTING(PostfixOperator) // Does not reference other decls.
+  UNINTERESTING(IfConfig) // Not applicable.
+  UNINTERESTING(PoundDiagnostic) // Not applicable.
+  UNINTERESTING(EnumCase) // Handled at the EnumElement level.
+  UNINTERESTING(Destructor) // Always correct.
+  UNINTERESTING(Accessor) // Handled by the Var or Subscript.
+
+  // Handled at the PatternBinding level; if the pattern has a simple
+  // "name: TheType" form, we can get better results by diagnosing the TypeRepr.
+  UNINTERESTING(Var)
+
+  /// \see visitPatternBindingDecl
+  void checkNamedPattern(const NamedPattern *NP,
+                         const llvm::DenseSet<const VarDecl *> &seenVars) {
+    const VarDecl *theVar = NP->getDecl();
+    if (shouldSkipChecking(theVar))
+      return;
+    // Only check individual variables if we didn't check an enclosing
+    // TypedPattern.
+    if (seenVars.count(theVar) || theVar->isInvalid())
+      return;
+
+    checkType(theVar->getInterfaceType(), /*typeRepr*/nullptr, theVar,
+              getDiagnoseCallback(theVar));
+  }
+
+  /// \see visitPatternBindingDecl
+  void checkTypedPattern(const TypedPattern *TP,
+                         llvm::DenseSet<const VarDecl *> &seenVars) {
+    // FIXME: We need to figure out if this is a stored or computed property,
+    // so we pull out some random VarDecl in the pattern. They're all going to
+    // be the same, but still, ick.
+    const VarDecl *anyVar = nullptr;
+    TP->forEachVariable([&](VarDecl *V) {
+      seenVars.insert(V);
+      anyVar = V;
+    });
+    if (!anyVar)
+      return;
+    if (shouldSkipChecking(anyVar))
+      return;
+
+    checkType(TP->getTypeLoc(), anyVar, getDiagnoseCallback(anyVar));
+  }
+
+  void visitPatternBindingDecl(PatternBindingDecl *PBD) {
+    llvm::DenseSet<const VarDecl *> seenVars;
+    for (auto entry : PBD->getPatternList()) {
+      entry.getPattern()->forEachNode([&](const Pattern *P) {
+        if (auto *NP = dyn_cast<NamedPattern>(P)) {
+          checkNamedPattern(NP, seenVars);
+          return;
+        }
+
+        auto *TP = dyn_cast<TypedPattern>(P);
+        if (!TP)
+          return;
+        checkTypedPattern(TP, seenVars);
+      });
+      seenVars.clear();
+    }
+  }
+
+  void visitTypeAliasDecl(TypeAliasDecl *TAD) {
+    checkGenericParams(TAD->getGenericParams(), TAD);
+    checkType(TAD->getUnderlyingTypeLoc(), TAD, getDiagnoseCallback(TAD));
+  }
+
+  void visitAssociatedTypeDecl(AssociatedTypeDecl *assocType) {
+    llvm::for_each(assocType->getInherited(),
+                   [&](TypeLoc requirement) {
+      checkType(requirement, assocType, getDiagnoseCallback(assocType));
+    });
+    checkType(assocType->getDefaultDefinitionLoc(), assocType,
+              getDiagnoseCallback(assocType));
+
+    if (assocType->getTrailingWhereClause()) {
+      forAllRequirementTypes(assocType,
+                             [&](Type type, TypeRepr *typeRepr) {
+        checkType(type, typeRepr, assocType, getDiagnoseCallback(assocType));
+      });
+    }
+  }
+
+  void visitNominalTypeDecl(const NominalTypeDecl *nominal) {
+    checkGenericParams(nominal->getGenericParams(), nominal);
+
+    llvm::for_each(nominal->getInherited(),
+                   [&](TypeLoc nextInherited) {
+      checkType(nextInherited, nominal, getDiagnoseCallback(nominal));
+    });
+  }
+
+  void visitProtocolDecl(ProtocolDecl *proto) {
+    llvm::for_each(proto->getInherited(),
+                  [&](TypeLoc requirement) {
+      checkType(requirement, proto, getDiagnoseCallback(proto));
+    });
+
+    if (proto->getTrailingWhereClause()) {
+      forAllRequirementTypes(proto, [&](Type type, TypeRepr *typeRepr) {
+        checkType(type, typeRepr, proto, getDiagnoseCallback(proto));
+      });
+    }
+  }
+
+  void visitSubscriptDecl(SubscriptDecl *SD) {
+    checkGenericParams(SD->getGenericParams(), SD);
+
+    for (auto &P : *SD->getIndices())
+      checkType(P->getTypeLoc(), SD, getDiagnoseCallback(SD));
+    checkType(SD->getElementTypeLoc(), SD, getDiagnoseCallback(SD));
+  }
+
+  void visitAbstractFunctionDecl(AbstractFunctionDecl *fn) {
+    checkGenericParams(fn->getGenericParams(), fn);
+
+    for (auto *P : *fn->getParameters())
+      checkType(P->getTypeLoc(), fn, getDiagnoseCallback(fn));
+  }
+
+  void visitFuncDecl(FuncDecl *FD) {
+    visitAbstractFunctionDecl(FD);
+    checkType(FD->getBodyResultTypeLoc(), FD, getDiagnoseCallback(FD));
+  }
+
+  void visitEnumElementDecl(EnumElementDecl *EED) {
+    if (!EED->hasAssociatedValues())
+      return;
+    for (auto &P : *EED->getParameterList())
+      checkType(P->getTypeLoc(), EED, getDiagnoseCallback(EED));
+  }
+
+  void checkConstrainedExtensionRequirements(ExtensionDecl *ED) {
+    if (!ED->getTrailingWhereClause())
+      return;
+    forAllRequirementTypes(ED, [&](Type type, TypeRepr *typeRepr) {
+      checkType(type, typeRepr, ED, getDiagnoseCallback(ED));
+    });
+  }
+
+  void visitExtensionDecl(ExtensionDecl *ED) {
+    if (shouldSkipChecking(ED->getExtendedNominal()))
+      return;
+
+    // FIXME: We should allow conforming to implementation-only protocols,
+    // but just hide that from interfaces.
+    llvm::for_each(ED->getInherited(),
+                   [&](TypeLoc nextInherited) {
+      checkType(nextInherited, ED, getDiagnoseCallback(ED));
+    });
+
+    if (!ED->getInherited().empty())
+      checkConstrainedExtensionRequirements(ED);
+  }
+
+  void checkPrecedenceGroup(const PrecedenceGroupDecl *PGD,
+                            const Decl *refDecl, SourceLoc diagLoc,
+                            SourceRange refRange) {
+    const SourceFile *SF = refDecl->getDeclContext()->getParentSourceFile();
+    ModuleDecl *M = PGD->getModuleContext();
+    if (!SF->isImportedImplementationOnly(M))
+      return;
+
+    auto diag = TC.diagnose(diagLoc, diag::decl_from_implementation_only_module,
+                            PGD->getName(), M->getName());
+    if (refRange.isValid())
+      diag.highlight(refRange);
+    diag.flush();
+    TC.diagnose(PGD, diag::decl_declared_here, PGD->getName());
+  }
+
+  void visitInfixOperatorDecl(InfixOperatorDecl *IOD) {
+    // FIXME: Handle operator designated types (which also applies to prefix
+    // and postfix operators).
+    if (auto *precedenceGroup = IOD->getPrecedenceGroup()) {
+      if (!IOD->getIdentifierLocs().empty()) {
+        checkPrecedenceGroup(precedenceGroup, IOD, IOD->getLoc(),
+                             IOD->getIdentifierLocs().front());
+      }
+    }
+  }
+
+  void visitPrecedenceGroupDecl(PrecedenceGroupDecl *PGD) {
+    llvm::for_each(PGD->getLowerThan(),
+                   [&](const PrecedenceGroupDecl::Relation &relation) {
+      checkPrecedenceGroup(relation.Group, PGD, PGD->getLowerThanLoc(),
+                           relation.NameLoc);
+    });
+    llvm::for_each(PGD->getHigherThan(),
+                   [&](const PrecedenceGroupDecl::Relation &relation) {
+      checkPrecedenceGroup(relation.Group, PGD, PGD->getHigherThanLoc(),
+                           relation.NameLoc);
+    });
+  }
+};
 } // end anonymous namespace
 
-void swift::checkAccessControl(TypeChecker &TC, Decl *D) {
-  AccessControlChecker(TC).visit(D);
-  UsableFromInlineChecker(TC).visit(D);
-}
+static void checkExtensionGenericParamAccess(TypeChecker &TC,
+                                             const ExtensionDecl *ED) {
+  auto *AA = ED->getAttrs().getAttribute<AccessControlAttr>();
+  if (!AA)
+    return;
+  AccessLevel userSpecifiedAccess = AA->getAccess();
 
-void swift::checkExtensionGenericParamAccess(TypeChecker &TC,
-                                             const ExtensionDecl *ED,
-                                             AccessLevel userSpecifiedAccess) {
   AccessScope desiredAccessScope = AccessScope::getPublic();
   switch (userSpecifiedAccess) {
   case AccessLevel::Private:
@@ -1433,4 +1799,15 @@ void swift::checkExtensionGenericParamAccess(TypeChecker &TC,
   AccessControlChecker(TC).checkGenericParamAccess(ED->getGenericParams(), ED,
                                                    desiredAccessScope,
                                                    userSpecifiedAccess);
+}
+
+void swift::checkAccessControl(TypeChecker &TC, Decl *D) {
+  if (isa<ValueDecl>(D) || isa<PatternBindingDecl>(D)) {
+    AccessControlChecker(TC).visit(D);
+    UsableFromInlineChecker(TC).visit(D);
+  } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+    checkExtensionGenericParamAccess(TC, ED);
+  }
+
+  ImplementationOnlyImportChecker(TC).visit(D);
 }

--- a/lib/Sema/TypeCheckAccess.h
+++ b/lib/Sema/TypeCheckAccess.h
@@ -22,17 +22,12 @@ namespace swift {
 class Decl;
 class TypeChecker;
 
-/// Checks the given declaration's signature does not reference any other
-/// declarations that are less visible than the declaration itself.
+/// Performs access-related checks for \p D.
 ///
-/// \p D must be a ValueDecl or a Decl that can appear in a type context.
+/// At a high level, this checks the given declaration's signature does not
+/// reference any other declarations that are less visible than the declaration
+/// itself. Related checks may also be performed.
 void checkAccessControl(TypeChecker &TC, Decl *D);
-
-/// Checks that the generic parameters of the given extension do not reference
-/// any other declarations that are less visible than the user-specified access
-/// on the extension.
-void checkExtensionGenericParamAccess(TypeChecker &TC, const ExtensionDecl *ED,
-                                      AccessLevel userSpecifiedAccess);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2085,10 +2085,12 @@ public:
 
   void visitOperatorDecl(OperatorDecl *OD) {
     TC.validateDecl(OD);
+    checkAccessControl(TC, OD);
   }
 
   void visitPrecedenceGroupDecl(PrecedenceGroupDecl *PGD) {
     TC.validateDecl(PGD);
+    checkAccessControl(TC, PGD);
   }
 
   void visitMissingMemberDecl(MissingMemberDecl *MMD) {
@@ -2992,8 +2994,7 @@ public:
     if (!ED->isInvalid())
       TC.checkDeclAttributes(ED);
 
-    if (auto *AA = ED->getAttrs().getAttribute<AccessControlAttr>())
-      checkExtensionGenericParamAccess(TC, ED, AA->getAccess());
+    checkAccessControl(TC, ED);
 
     // Trigger the creation of all of the conformances associated with this
     // nominal type.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2523,8 +2523,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
         // when the underlying type has sufficient access, but only in
         // non-resilient modules.
         Optional<AccessScope> underlyingTypeScope =
-            TypeAccessScopeChecker::getAccessScope(type, DC,
-                                                   /*usableFromInline*/false);
+            AccessScopeChecker::getAccessScope(type, DC,
+                                               /*usableFromInline*/false);
         assert(underlyingTypeScope.hasValue() &&
                "the type is already invalid and we shouldn't have gotten here");
 

--- a/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
+++ b/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
@@ -1,0 +1,9 @@
+public struct BadStruct {}
+public protocol BadProto {}
+open class BadClass {}
+
+public struct IntLike: ExpressibleByIntegerLiteral, Equatable {
+  public init(integerLiteral: Int) {}
+}
+
+precedencegroup BadPrecedence {}

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -115,3 +115,36 @@ precedencegroup TestLowerThan {
 precedencegroup TestHigherThan {
   higherThan: BadPrecedence // expected-error {{cannot use 'BadPrecedence' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
 }
+
+public struct PublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private let letIsLikeVar = [BadStruct]() // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@usableFromInline internal struct UFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private let letIsLikeVar = [BadStruct]() // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public class PublicClassStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private let letIsLikeVar = [BadStruct]() // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -1,0 +1,117 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift
+
+// RUN: %target-typecheck-verify-swift -I %t
+
+@_implementationOnly import BADLibrary
+
+public struct TestConformance: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+@usableFromInline struct TestConformanceUFI: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+struct TestConformanceOkay: BadProto {} // ok
+
+public class TestConformanceClass: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public enum TestConformanceEnum: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+
+public struct TestGenericParams<T: BadProto> {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public struct TestGenericParamsWhereClause<T> where T: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public enum TestCase {
+  case x(BadStruct) // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  case y(Int, BadStruct) // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public func testGenericParams<T: BadProto>(_: T) {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public func testGenericParamsWhereClause<T>(_: T) where T: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public func testParams(_: BadStruct, _: BadProto) {}
+// expected-error@-1 {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+// expected-error@-2 {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public func testResult() -> BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public struct TestSubscript {
+  public subscript<T: BadProto>(_: T) -> Int { return 0 } // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public subscript<T>(where _: T) -> Int where T: BadProto { return 0 } // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public subscript(_: BadStruct) -> Int { return 0 } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public subscript(_: Int) -> BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public struct TestInit {
+  public init(_: BadStruct) {} // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public init<T: BadProto>(_: T) {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public init<T>(where _: T) where T: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public protocol TestInherited: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public protocol TestConstraintBase {
+  associatedtype Assoc
+}
+public protocol TestConstraint: TestConstraintBase where Assoc: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public protocol TestConstraintEq: TestConstraintBase where Assoc == BadStruct {} // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public protocol TestAssocType {
+  associatedtype Assoc: BadProto // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public protocol TestAssocTypeWhereClause {
+  associatedtype Assoc: Collection where Assoc.Element: BadProto // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public enum TestRawType: IntLike { // expected-error {{cannot use 'IntLike' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  case x = 1
+}
+
+public class TestSubclass: BadClass { // expected-error {{cannot use 'BadClass' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public typealias TestUnderlying = BadStruct // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public typealias TestGenericParamsAliasWhereClause<T> = T where T: BadProto // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public typealias TestGenericParamsAlias<T: BadProto> = T // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public var testBadType: BadStruct? = nil // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var testBadTypeInferred = Optional<BadStruct>.none // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var testBadTypePartiallyInferred: Optional = Optional<BadStruct>.none // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var (testBadTypeTuple1, testBadTypeTuple2): (BadStruct?, BadClass?) = (nil, nil)
+// expected-error@-1 {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+// expected-error@-2 {{cannot use 'BadClass' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var (testBadTypeTuplePartlyInferred1, testBadTypeTuplePartlyInferred2): (Optional, Optional) = (Optional<Int>.none, Optional<BadStruct>.none) // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var (testBadTypeTuplePartlyInferred3, testBadTypeTuplePartlyInferred4): (Optional, Optional) = (Optional<BadStruct>.none, Optional<Int>.none) // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var testMultipleBindings1: Int? = nil, testMultipleBindings2: BadStruct? = nil // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public var testMultipleBindings3: BadStruct? = nil, testMultipleBindings4: Int? = nil // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+extension BadStruct { // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func testExtensionOfBadType() {} // FIXME: Should complain here instead of at the extension decl.
+}
+extension BadStruct {
+  func testExtensionOfOkayType() {}
+}
+
+extension Array where Element == BadStruct { // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func testExtensionWithBadRequirement() {} // FIXME: Should complain here instead of at the extension decl.
+}
+
+extension Array where Element == BadStruct {
+  func testExtensionWithOkayRequirement() {} // okay
+}
+
+extension Int: BadProto {} // expected-error {{cannot use 'BadProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+struct TestExtensionConformanceOkay {}
+extension TestExtensionConformanceOkay: BadProto {} // okay
+
+public protocol TestConstrainedExtensionProto {}
+extension Array: TestConstrainedExtensionProto where Element == BadStruct { // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+
+infix operator !!!!!!: BadPrecedence // expected-error {{cannot use 'BadPrecedence' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+precedencegroup TestLowerThan {
+  lowerThan: BadPrecedence // expected-error {{cannot use 'BadPrecedence' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+precedencegroup TestHigherThan {
+  higherThan: BadPrecedence // expected-error {{cannot use 'BadPrecedence' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}

--- a/test/Sema/implementation-only-import-library-evolution.swift
+++ b/test/Sema/implementation-only-import-library-evolution.swift
@@ -1,0 +1,77 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift
+
+// RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution
+
+@_implementationOnly import BADLibrary
+
+public struct PublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // okay
+  private var privatelyBad: BadStruct? // okay
+  private let letIsLikeVar = [BadStruct]() // okay
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@usableFromInline internal struct UFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // okay
+  private var privatelyBad: BadStruct? // okay
+  private let letIsLikeVar = [BadStruct]() // okay
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+public class PublicClassStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // okay
+  private var privatelyBad: BadStruct? // okay
+  private let letIsLikeVar = [BadStruct]() // okay
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+// MARK: Frozen types
+
+@_fixed_layout
+public struct FrozenPublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@_fixed_layout
+@usableFromInline internal struct FrozenUFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@_fixed_layout
+public class FrozenPublicClassStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use 'BadStruct' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}


### PR DESCRIPTION
Builds on John's #23702 to handle checking of types in decls, the same way we do for access control. Contains more duplicated code than I like, but appears to work, and may provide refactoring hints in the future.

Part of rdar://problem/48991061