### PR TITLE
[ParseableInterfaces] Stop explicitly optimizing cached modules

### DIFF
--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -520,10 +520,6 @@ public:
         return;
       }
 
-      // Optimize emitted modules. This has to happen after we parse arguments,
-      // because parseSILOpts would override the current optimization mode.
-      subInvocation.getSILOptions().OptMode = OptimizationMode::ForSpeed;
-
       // Build the .swiftmodule; this is a _very_ abridged version of the logic
       // in performCompile in libFrontendTool, specialized, to just the one
       // module-serialization task we're trying to do here.

--- a/test/ParseableInterface/optimization-level.swift
+++ b/test/ParseableInterface/optimization-level.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/Lib.swiftinterface %s -O
+// RUN: %target-swift-frontend -build-module-from-parseable-interface %t/Lib.swiftinterface -Xllvm -sil-print-pass-name -o /dev/null 2>&1 | %FileCheck --check-prefix OPT %s
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/Lib.swiftinterface %s -Onone
+// RUN: %target-swift-frontend -build-module-from-parseable-interface %t/Lib.swiftinterface -Xllvm -sil-print-pass-name -o /dev/null 2>&1 | %FileCheck --check-prefix UNOPT %s
+
+// This is a bit of an implementation detail, but we want to make sure
+// optimization passes don't run when compiling a .swiftinterface that was
+// generated with -Onone.
+
+// OPT: EagerSpecializer
+// UNOPT-NOT: EagerSpecializer
+public func f() {}
+

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -30,6 +30,6 @@ func f(s : inout [Int]) {
 // Test we can generate the interface of a module loaded via a .swiftinterface file correctly
 
 // RUN: %empty-directory(%t.mod)
-// RUN: %swift -emit-module -o /dev/null -emit-parseable-module-interface-path %t.mod/swift_mod.swiftinterface %S/Inputs/swift_mod.swift -parse-as-library
+// RUN: %swift -emit-module -o /dev/null -emit-parseable-module-interface-path %t.mod/swift_mod.swiftinterface -O %S/Inputs/swift_mod.swift -parse-as-library
 // RUN: %sourcekitd-test -req=interface-gen -module swift_mod -- -I %t.mod -module-cache-path %t.mod/mcp > %t.response
 // RUN: diff -u %s.from_swiftinterface.response %t.response


### PR DESCRIPTION
Previously, we always optimized cached modules. Now, use the flag we're
already preserving to optimize them.

Fixes rdar://46358840