### PR TITLE
Check access control for the generic requirements of subscripts and typealiases

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -162,29 +162,30 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     llvm::function_ref<CheckTypeAccessCallback> diagnose) {
   if (TC.Context.isAccessControlDisabled())
     return;
-  if (!type)
-    return;
   // Don't spend time checking local declarations; this is always valid by the
   // time we get to this point.
   if (!contextAccessScope.isPublic() &&
       contextAccessScope.getDeclContext()->isLocalContext())
     return;
 
-  Optional<AccessScope> typeAccessScope =
-      TypeAccessScopeChecker::getAccessScope(type, useDC,
-                                             checkUsableFromInline);
+  AccessScope problematicAccessScope = AccessScope::getPublic();
+  if (type) {
+    Optional<AccessScope> typeAccessScope =
+        TypeAccessScopeChecker::getAccessScope(type, useDC,
+                                               checkUsableFromInline);
+
+    // Note: This means that the type itself is invalid for this particular
+    // context, because it references declarations from two incompatible scopes.
+    // In this case we should have diagnosed the bad reference already.
+    if (!typeAccessScope.hasValue())
+      return;
+    problematicAccessScope = *typeAccessScope;
+  }
+
   auto downgradeToWarning = DowngradeToWarning::No;
 
-  // Note: This means that the type itself is invalid for this particular
-  // context, because it references declarations from two incompatible scopes.
-  // In this case we should have diagnosed the bad reference already.
-  if (!typeAccessScope.hasValue())
-    return;
-
-  AccessScope problematicAccessScope = *typeAccessScope;
-
-  if (contextAccessScope.hasEqualDeclContextWith(*typeAccessScope) ||
-      contextAccessScope.isChildOf(*typeAccessScope)) {
+  if (contextAccessScope.hasEqualDeclContextWith(problematicAccessScope) ||
+      contextAccessScope.isChildOf(problematicAccessScope)) {
 
     // /Also/ check the TypeRepr, if present. This can be important when we're
     // unable to preserve typealias sugar that's present in the TypeRepr.
@@ -194,7 +195,9 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     Optional<AccessScope> typeReprAccessScope =
         TypeReprAccessScopeChecker::getAccessScope(typeRepr, useDC,
                                                    checkUsableFromInline);
-    assert(typeReprAccessScope && "valid Type but not valid TypeRepr?");
+    if (!typeReprAccessScope.hasValue())
+      return;
+
     if (contextAccessScope.hasEqualDeclContextWith(*typeReprAccessScope) ||
         contextAccessScope.isChildOf(*typeReprAccessScope)) {
       // Only if both the Type and the TypeRepr follow the access rules can
@@ -365,8 +368,8 @@ void AccessControlCheckerBase::checkGenericParamAccess(
   if (minAccessScope.isPublic())
     return;
 
-  // FIXME: Promote this to an error in the next -swift-version break.
-  if (isa<SubscriptDecl>(owner))
+  // FIXME: Promote these to an error in the next -swift-version break.
+  if (isa<SubscriptDecl>(owner) || isa<TypeAliasDecl>(owner))
     downgradeToWarning = DowngradeToWarning::Yes;
 
   if (checkUsableFromInline) {
@@ -542,6 +545,8 @@ public:
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
+    checkGenericParamAccess(TAD->getGenericParams(), TAD);
+
     checkTypeAccess(TAD->getUnderlyingTypeLoc(), TAD, /*mayBeInferred*/false,
                     [&](AccessScope typeAccessScope,
                         const TypeRepr *complainRepr,
@@ -1128,6 +1133,8 @@ public:
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
+    checkGenericParamAccess(TAD->getGenericParams(), TAD);
+
     checkTypeAccess(TAD->getUnderlyingTypeLoc(), TAD, /*mayBeInferred*/false,
                     [&](AccessScope typeAccessScope,
                         const TypeRepr *complainRepr,

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1375,5 +1375,5 @@ public typealias MyPairI<B> = MyPair<Int, B>
 // PASS_PRINT_AST: public typealias MyPairI<B> = MyPair<Int, B>
 public typealias MyPairAlias<T, U> = MyPair<T, U>
 // PASS_PRINT_AST: public typealias MyPairAlias<T, U> = MyPair<T, U>
-public typealias MyPairAlias2<T: FooProtocol, U> = MyPair<T, U> where U: BarProtocol
-// PASS_PRINT_AST: public typealias MyPairAlias2<T, U> = MyPair<T, U> where T : FooProtocol, U : BarProtocol
+typealias MyPairAlias2<T: FooProtocol, U> = MyPair<T, U> where U: BarProtocol
+// PASS_PRINT_AST: typealias MyPairAlias2<T, U> = MyPair<T, U> where T : FooProtocol, U : BarProtocol

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -876,3 +876,6 @@ public struct TestGenericSubscripts {
   public subscript<T: PrivateProto>(_: T) -> Int { return 0 } // expected-warning {{subscript should not be declared public because its generic parameter uses a private type}} {{none}}
   public subscript<T>(where _: T) -> Int where T: PrivateProto { return 0 } // expected-warning {{subscript should not be declared public because its generic requirement uses a private type}} {{none}}
 }
+
+public typealias TestGenericAlias<T: PrivateProto> = T // expected-warning {{type alias should not be declared public because its generic parameter uses a private type}}
+public typealias TestGenericAliasWhereClause<T> = T where T: PrivateProto // expected-warning {{type alias should not be declared public because its generic requirement uses a private type}}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -869,3 +869,10 @@ public extension ObjCSub {
     set {}
   }
 }
+
+public struct TestGenericSubscripts {
+  // We'd like these to be errors in a future version of Swift, but they weren't
+  // in Swift 5.0.
+  public subscript<T: PrivateProto>(_: T) -> Int { return 0 } // expected-warning {{subscript should not be declared public because its generic parameter uses a private type}} {{none}}
+  public subscript<T>(where _: T) -> Int where T: PrivateProto { return 0 } // expected-warning {{subscript should not be declared public because its generic requirement uses a private type}} {{none}}
+}

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -152,3 +152,6 @@ public struct TestGenericSubscripts {
   @usableFromInline subscript<T: InternalProtocol>(_: T) -> Int { return 0 } // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
   @usableFromInline subscript<T>(where _: T) -> Int where T: InternalProtocol { return 0 } // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
 }
+
+@usableFromInline typealias TestGenericAlias<T: InternalProtocol> = T // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' type alias should be '@usableFromInline' or public}}
+@usableFromInline typealias TestGenericAliasWhereClause<T> = T where T: InternalProtocol // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' type alias should be '@usableFromInline' or public}}

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -87,7 +87,7 @@ internal struct InternalStruct {}
 // expected-error@-1 {{type referenced from the underlying type of a '@usableFromInline' type alias must be '@usableFromInline' or public}}
 
 protocol InternalProtocol {
-  // expected-note@-1 4{{type declared here}}
+  // expected-note@-1 * {{type declared here}}
   associatedtype T
 }
 
@@ -147,3 +147,8 @@ enum BadEnum {
 @usableFromInline
 class BadClass : InternalClass {}
 // expected-error@-1 {{type referenced from the superclass of a '@usableFromInline' class must be '@usableFromInline' or public}}
+
+public struct TestGenericSubscripts {
+  @usableFromInline subscript<T: InternalProtocol>(_: T) -> Int { return 0 } // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
+  @usableFromInline subscript<T>(where _: T) -> Int where T: InternalProtocol { return 0 } // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
+}


### PR DESCRIPTION
Oops.

This is a little more involved than it should have been because the requirements on a generic typealias don't always carry a Type anymore; sometimes all you have is the TypeRepr. That should still be okay in practice as long as we don't start doing that for var/let, which can have part of a type be inferred but not all of it.

We don't have an idiom for "this should be an error in the *next* `-swift-version`" yet. Maybe it should be 9999, like we're using in the standard library for Apple OS availability?