### PR TITLE
Improve codegen for init(signOf: magnitudeOf:)

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -230,7 +230,6 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   ///     the initializer has the same magnitude as `magnitudeOf`.
   init(signOf: Self, magnitudeOf: Self)
   
-  
   /// Creates a new value, rounded to the closest possible representation.
   ///
   /// If two representable values are equally close, the result is the value

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -973,6 +973,15 @@ extension ${Self}: BinaryFloatingPoint {
 %end
   }
 
+  //  For core standard library floating-point types, LLVM can lower copysign
+  //  for us; this gets somewhat better codegen than the generic implementation,
+  //  but more importantly allows it to participate in other optimizations
+  //  at the LLVM level.
+  @_transparent
+  public init(signOf sign: ${Self}, magnitudeOf mag: ${Self}) {
+    _value = Builtin.int_copysign_FPIEEE${bits}(mag._value, sign._value)
+  }
+
   /// Rounds the value to an integral value using the specified rounding rule.
   ///
   /// The following example rounds a value using four different rounding rules:


### PR DESCRIPTION
This can map straight to the LLVM copysign intrinsic for builtin types, which both gets us better codgen and lets the compiler plug this operation into other LLVM-level optimizations.

Before this change, the specialized codegen for this init on `Float` is:
```
movmskps %xmm1,   %eax
shll     $0x1f,   %eax
movd     %xmm0,   %ecx
andl $0x7fffffff, %ecx
orl      %eax,    %ecx
movd     %ecx,    %xmm0
```
after:
```
andps  0x15(%rip), %xmm1
andps  0x1e(%rip), %xmm0
orps   %xmm1,      %xmm0
```