### PR TITLE
[TF] Fix `ShapedArraySlice` index subscript.

### DIFF
--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -901,7 +901,7 @@ extension ShapedArraySlice : RandomAccessCollection, MutableCollection {
                    "ShapeArraySlice index is out of range (before startIndex)")
       return ShapedArraySlice(base: base,
                               baseIndices: baseIndices + [index],
-                              bounds: bounds)
+                              bounds: nil)
     }
     set {
       precondition(!isScalar,

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -41,14 +41,23 @@ ShapedArrayTests.test("Initializers") {
 ShapedArrayTests.test("Indexing") {
   let tensor = ShapedArray(shape: [3, 4, 5], scalars: Array(0..<60))
 
-  /// Test shapes
+  /// Test shapes.
   expectEqual([4, 5], tensor[0].shape)
   expectEqual([5], tensor[0][0].shape)
   expectEqual([], tensor[0][0][0].shape)
   expectEqual([2, 4, 5], tensor[0..<2].shape)
   expectEqual([3, 5], tensor[0][0..<3].shape)
+  expectEqual([4, 5], tensor[0..<3][0].shape)
 
-  /// Test element tensor scalars
+  /// Test indices.
+  expectEqual(0..<4, tensor[0].indices)
+  expectEqual(0..<5, tensor[0][0].indices)
+  expectEqual(0..<0, tensor[0][0][0].indices)
+  expectEqual(0..<2, tensor[0..<2].indices)
+  expectEqual(0..<3, tensor[0][0..<3].indices)
+  expectEqual(0..<4, tensor[0..<3][0].indices)
+
+  /// Test element tensor scalars.
   expectEqual(Array(0..<20), tensor[0].scalars)
   expectEqual(Array(40..<60), tensor[2].scalars)
   expectEqual(Array(0..<5), tensor[0][0].scalars)
@@ -56,7 +65,7 @@ ShapedArrayTests.test("Indexing") {
   expectEqual([43], tensor[2][0][3].scalars)
   expectEqual([37], tensor[1][3][2].scalars)
 
-  /// Test subtensor scalars
+  /// Test subtensor scalars.
   expectEqual(Array(20..<40), tensor[1..<2].scalars)
   expectEqual(Array(20..<30), tensor[1][0..<2].scalars)
   expectEqual(Array(45..<50), tensor[2][1..<2].scalars)


### PR DESCRIPTION
Subscripting `ShapedArraySlice` at an index should creating an element
slice with `bounds` reset to `nil`.

Example:
```swift
let array = ShapedArray(repeating: 1, shape: [4, 4])
let slice = array[0..<2] // bounds: .some(0..<2), indices: 0..<2
let element = slice[0]   // bounds: nil, indices: 0..<4
```