### PR TITLE
SILGen: Only set the external decl of a key path component if the accessor is public

### DIFF
--- a/test/IRGen/Inputs/keypaths_c_types.h
+++ b/test/IRGen/Inputs/keypaths_c_types.h
@@ -1,0 +1,5 @@
+union c_union {
+  struct some_struct {
+    void* data;
+  } some_field;
+};

--- a/test/IRGen/keypaths_c_types.swift
+++ b/test/IRGen/keypaths_c_types.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -import-objc-header %S/Inputs/keypaths_c_types.h
+
+// This used to crash while trying to emit a reference to the property
+// descriptor for the some_field property.
+
+struct Foo {
+  static let somePath: WritableKeyPath<c_union, some_struct>? = \c_union.some_field
+}

--- a/test/SILGen/Inputs/keypaths_objc.h
+++ b/test/SILGen/Inputs/keypaths_objc.h
@@ -5,3 +5,9 @@
 @property(readonly) NSString *_Nonnull objcProp;
 
 @end
+
+union c_union {
+  struct some_struct {
+    void* data;
+  } some_field;
+};

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -96,3 +96,9 @@ func externalObjCProperty() {
   // CHECK-NOT: external #NSObject.description
   _ = \NSObject.description
 }
+
+func sharedCProperty() {
+  // CHECK:  keypath $WritableKeyPath<c_union, some_struct>
+  // CHECK-NOT: external #c_union.some_field
+  let dataKeyPath: WritableKeyPath<c_union, some_struct>? = \c_union.some_field
+}


### PR DESCRIPTION

rdar://49064011
