### PR TITLE
[Python] Extends unit testing infra to support several python versions

### DIFF
--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -238,6 +238,12 @@ private extension PythonLibrary {
   }
 }
 
+public extension PythonLibrary {
+  static func isPythonLibraryLoadable() -> Bool {
+    return loadPythonLibrary() != nil
+  }
+}
+
 // Methods of `PythonLibrary` used for logging messages.
 private extension PythonLibrary {
   static func log(_ message: String) {

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1371,6 +1371,18 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
+    config.target_run_simple_swift_python2_interop = (
+        '%%empty-directory(%%t) && '
+        '%s %%s -o %%t/a.out -module-name main && '
+        '%s %%t/a.out && '
+        'env PYTHON_VERSION=2 %s %%t/a.out'
+        % (config.target_build_swift, config.target_codesign, config.target_run))
+    config.target_run_simple_swift_python3_interop = (
+        '%%empty-directory(%%t) && '
+        '%s %%s -o %%t/a.out -module-name main && '
+        '%s %%t/a.out && '
+        'env PYTHON_VERSION=3 %s %%t/a.out'
+        % (config.target_build_swift, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
@@ -1426,6 +1438,8 @@ config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.targe
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))
 config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdlib_swift))
+config.substitutions.append(('%target-run-python2-interop-simple-swift', config.target_run_simple_swift_python2_interop))
+config.substitutions.append(('%target-run-python3-interop-simple-swift', config.target_run_simple_swift_python3_interop))
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))
 config.substitutions.append(('%target-run', config.target_run))
 config.substitutions.append(('%target-jit-run', subst_target_jit_run))


### PR DESCRIPTION
In order to run the tests using different Python versions, two new
lit-directives were added: target-run-python2-interop-simple-swift and
target-run-python3-interop-simple-swift. Each of them behave exactly
like target-run-simple-swift only that they set the env variable
PYTHON_VERSION with the desired major python version to be loaded.

As well, within `python_runtime.swift` there is logic to check
if a given PYTHON_VERSION is loadable. All tests in the file
are short-circuited if the desired python library wasn't. Downside
is that this not play nice with lit failing error's reporting.

In this solution there is no duplication of logic in `lit.cfg`
to search for paths to different versions of the Python library
files as it only provides directives that set `PYTHON_VERSION`
before running tests.

~~This moves all tests present in test/Python/python_runtime.swift
into a private module within the stdlib: PythonUnittest, so that
they can be reused to run them against different Python versions.~~

~~In order to run the tests using different Python versions, two new
lit-directives were added: target-run-python2-interop-simple-swift and
target-run-python3-interop-simple-swift. Each of them behave exactly
like target-run-simple-swift only that they set the env variable
PYTHON_LIBRARY with the desired python library file path before
executing the produced test's binary. Now, lit.cfg has functionality
to look for python2 and python3 library file paths.~~

~~As well, two new lit-requirements were added: python2 and python3.
This way, tests for either version will be run only when the feature
is available.~~

----

Notes:

~~* I left the "Errors" test duplicated in python2_runtime and python3_runtime b/c when
moving it into the private module in the stdlib the compiler was crashing. I would prefer
to first merge this and then investigate the reason of the crash.~~
* In my local machine, the tests for python3 fail due to the checks for memory usage.
I raised the issue here https://github.com/apple/swift/pull/23316#issuecomment-476834100.
I would like to see if this tests fail as well in the CI when using python3.

Resolves [TF-336](https://bugs.swift.org/browse/TF-336).
