### PR TITLE
[android] Check for Android-specific ARMv7 SIMD generated code.

### DIFF
--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s --check-prefix=%target-cpu
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s --check-prefix=%target-cpu --check-prefix=%target-cpu-%target-sdk-name
 
 import Swift
 import simd
@@ -34,7 +34,10 @@ entry(%x : $float4):
 // aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7-ios-LABEL: define <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7-linux-LABEL: define protected <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7-windows-LABEL: define dllexport <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7-android-LABEL: define protected <3 x float> @simd_c_args_float3(<3 x float>)
 // armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)


### PR DESCRIPTION
In my testing, it seems that Android default target-attributes/data
layout doesn't seem to match those of iOS in ARMv7 (or Linux or
Windows). This commit introduces `target-sdk-name` into the checks, and
does a different check depending on the SDK: iOS stays the same; Linux
and Windows use the iOS approach; Android is a different beast.

To check my assumptions, I used the following small C program and
compiled it with Clang from the tree and different targets
(armv7-none-ios, armv7-none-linux-gnueabi, armv7-none-windows-msvc).

```c
typedef float __attribute__((ext_vector_type(3))) float3;
float3 simd_c_args_float3(float3 x) {
  return x;
}
```
