### PR TITLE
AST: Fix mangling of entities in subscript context

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1595,10 +1595,10 @@ void ASTMangler::appendContext(const DeclContext *ctx) {
     return appendEntity(eed);
   }
 
-  case DeclContextKind::SubscriptDecl:
-    // FIXME: We may need to do something here if subscripts contain any symbols
-    // exposed with linkage names, or if/when they get generic parameters.
-    return appendContext(ctx->getParent());
+  case DeclContextKind::SubscriptDecl: {
+    auto sd = cast<SubscriptDecl>(ctx);
+    return appendEntity(sd);
+  }
       
   case DeclContextKind::Initializer:
     switch (cast<Initializer>(ctx)->getInitializerKind()) {

--- a/test/IDE/print_usrs.swift
+++ b/test/IDE/print_usrs.swift
@@ -67,7 +67,7 @@ class GenericClass {
   }
 
   // CHECK: [[@LINE+2]]:3 s:14swift_ide_test12GenericClassCySfSicip{{$}}
-  // CHECK: [[@LINE+1]]:13 s:14swift_ide_test12GenericClassC1iL_Sivp{{$}}
+  // CHECK: [[@LINE+1]]:13 s:14swift_ide_test12GenericClassCySfSicip1iL_Sivp{{$}}
   subscript(i: Int) -> Float {
     // CHECK: [[@LINE+1]]:5 s:14swift_ide_test12GenericClassCySfSicig{{$}}
     get { return 0.0 }
@@ -212,7 +212,7 @@ class ObjCClass1 {
   class func staticFunc1(_ a: Int) {}
 
   // CHECK: [[@LINE+2]]:10 s:14swift_ide_test10ObjCClass1CyS2icip{{$}}
-  // CHECK: [[@LINE+1]]:20 s:14swift_ide_test10ObjCClass1C1xL_Sivp{{$}}
+  // CHECK: [[@LINE+1]]:20 s:14swift_ide_test10ObjCClass1CyS2icip1xL_Sivp{{$}}
   public subscript(x: Int) -> Int {
 
     // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_test@objc(cs)ObjCClass1(im)objectAtIndexedSubscript:{{$}}
@@ -223,7 +223,7 @@ class ObjCClass1 {
   }
 
   // CHECK: [[@LINE+2]]:10 s:14swift_ide_test10ObjCClass1CySiACcip{{$}}
-  // CHECK: [[@LINE+1]]:20 s:14swift_ide_test10ObjCClass1C1xL_ACvp{{$}}
+  // CHECK: [[@LINE+1]]:20 s:14swift_ide_test10ObjCClass1CySiACcip1xL_ACvp{{$}}
   public subscript(x: ObjCClass1) -> Int {
 
     // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_test@objc(cs)ObjCClass1(im)objectForKeyedSubscript:{{$}}

--- a/test/SourceKit/CursorInfo/cursor_info_param.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_param.swift
@@ -24,16 +24,14 @@ func customSourceLocation(a: Int) {}
 // CHECK-FUNC-THEB-NOT: PARENT OFFSET
 
 // RUN: %sourcekitd-test -req=cursor -pos=4:13 %s -- %s | %FileCheck -check-prefix=CHECK-SUBSCRIPT-A %s
-// FIXME: This USR is wrong; see https://bugs.swift.org/browse/SR-8660.
-// CHECK-SUBSCRIPT-A: s:17cursor_info_param12AccessorTestV1aL_Sivp
+// CHECK-SUBSCRIPT-A: s:17cursor_info_param12AccessorTestV_1bS2i_Sitcip1aL_Sivp
 // CHECK-SUBSCRIPT-A: PARENT OFFSET: 67
 
 // RUN: %sourcekitd-test -req=cursor -pos=4:21 %s -- %s | %FileCheck -check-prefix=CHECK-SUBSCRIPT-B %s
 // CHECK-SUBSCRIPT-B: s:17cursor_info_param12AccessorTestV
 
 // RUN: %sourcekitd-test -req=cursor -pos=4:23 %s -- %s | %FileCheck -check-prefix=CHECK-SUBSCRIPT-THEB %s
-// FIXME: This USR is wrong; see https://bugs.swift.org/browse/SR-8660.
-// CHECK-SUBSCRIPT-THEB: s:17cursor_info_param12AccessorTestV4theBL_Sivp
+// CHECK-SUBSCRIPT-THEB: s:17cursor_info_param12AccessorTestV_1bS2i_Sitcip4theBL_Sivp
 // CHECK-SUBSCRIPT-THEB-NOT: PARENT OFFSET
 
 // RUN: %sourcekitd-test -req=cursor -pos=7:9 %s -- %s | %FileCheck -check-prefix=CHECK-SETTER-V %s


### PR DESCRIPTION
For now, this means USRs of ParamDecls. Soon, default argument generators
for subscripts will need this too.

Fixes <https://bugs.swift.org/browse/SR-8660>, <rdar://problem/44435221>.