### PR TITLE
[stdlib] Add _getBool back as ABI

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -170,6 +170,11 @@ extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLitera
   }
 }
 
+@available(swift, obsoleted: 5.0)
+@usableFromInline
+internal // used to be COMPILER_INTRINSIC, now just ABI cruft
+func _getBool(_ v: Builtin.Int1) -> Bool { return Bool(v) }		
+
 extension Bool : CustomStringConvertible {
   /// A textual representation of the Boolean value.
   @inlinable


### PR DESCRIPTION
This was removed as part of #21872 but that didn't ship with 5.0, so adding it back just in case this gets referenced somehow.