### PR TITLE
[android] Allow BlocksRuntimeStub to compile for Android

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -467,12 +467,14 @@ function(_add_variant_link_flags)
   endif()
 
   if(NOT "${SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_UC}" STREQUAL "")
-    get_filename_component(SWIFT_${sdk}_${arch}_ICU_UC_LIBDIR "${SWIFT_${sdk}_${arch}_ICU_UC}" DIRECTORY)
-    list(APPEND library_search_directories "${SWIFT_${sdk}_${arch}_ICU_UC_LIBDIR}")
+    get_filename_component(SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_UC_LIBDIR
+      "${SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_UC}" DIRECTORY)
+    list(APPEND library_search_directories "${SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_UC_LIBDIR}")
   endif()
   if(NOT "${SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_I18N}" STREQUAL "")
-    get_filename_component(SWIFT_${sdk}_${arch}_ICU_I18N_LIBDIR "${SWIFT_${sdk}_${arch}_ICU_I18N}" DIRECTORY)
-    list(APPEND library_search_directories "${SWIFT_${sdk}_${arch}_ICU_I18N_LIBDIR}")
+    get_filename_component(SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_I18N_LIBDIR
+      "${SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_I18N}" DIRECTORY)
+    list(APPEND library_search_directories "${SWIFT_${LFLAGS_SDK}_${LFLAGS_ARCH}_ICU_I18N_LIBDIR}")
   endif()
 
   if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,13 +204,16 @@ foreach(SDK ${SWIFT_SDKS})
 __declspec(dllexport)
 #endif
 _Block_release(void) { }\n")
-    add_library(BlocksRuntimeStub-${SDK}-${ARCH} SHARED
+    _add_swift_library_single(
+      BlocksRuntimeStub-${SDK}-${ARCH}
+      BlocksRuntimeStub
+      SHARED
+      DONT_EMBED_BITCODE
+      NOSWIFTRT
+      ARCHITECTURE ${ARCH}
+      SDK ${SDK}
+      INSTALL_IN_COMPONENT dev
       ${test_bin_dir}/BlocksRuntime.c)
-    if(CMAKE_C_COMPILER_ID STREQUAL Clang AND
-        NOT CMAKE_C_COMPILER_SIMULATE_ID STREQUAL MSVC)
-      target_compile_options(BlocksRuntimeStub-${SDK}-${ARCH} PRIVATE
-        -target;${SWIFT_SDK_${SDK}_ARCH_${ARCH}_TRIPLE})
-    endif()
     set_target_properties(BlocksRuntimeStub-${SDK}-${ARCH} PROPERTIES
       ARCHIVE_OUTPUT_DIRECTORY ${test_bin_dir}
       LIBRARY_OUTPUT_DIRECTORY ${test_bin_dir}


### PR DESCRIPTION
The target was correctly set for compiling, but was missing for linking,
so the Android was trying to be link against the host tools machine.

The solution uses _add_swift_library_single from AddSwift.cmake, which should handle all the
supported SDK/Archs.