### PR TITLE
[5.1][stdlib] Change the signature of Dictionary’s bulk initializer

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSDictionary.swift
+++ b/stdlib/public/Darwin/Foundation/NSDictionary.swift
@@ -238,7 +238,7 @@ extension Dictionary : _ObjectiveCBridgeable {
       let handleDuplicates = (Key.self == String.self)
       
       result = Dictionary(_unsafeUninitializedCapacity: numElems,
-        allowingDuplicates: handleDuplicates) { (keys, vals, outCount) in
+        allowingDuplicates: handleDuplicates) { keys, vals in
         
         let objectKeys = UnsafeMutableRawPointer(mutating:
           keys.baseAddress!).assumingMemoryBound(to: AnyObject.self)
@@ -253,7 +253,7 @@ extension Dictionary : _ObjectiveCBridgeable {
         _forceBridge(objectKeys, count: numElems, to: Key.self)
         _forceBridge(objectVals, count: numElems, to: Value.self)
         
-        outCount = numElems
+        return numElems
       }
     }
   }
@@ -293,7 +293,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     let handleDuplicates = (Key.self == String.self)
     
     let tmpResult = Dictionary(_unsafeUninitializedCapacity: numElems,
-      allowingDuplicates: handleDuplicates) { (keys, vals, outCount) in
+      allowingDuplicates: handleDuplicates) { keys, vals in
       
       let objectKeys = UnsafeMutableRawPointer(mutating:
         keys.baseAddress!).assumingMemoryBound(to: AnyObject.self)
@@ -314,7 +314,7 @@ extension Dictionary : _ObjectiveCBridgeable {
             Key.self)).deinitialize(count: numElems)
         }
       }
-      outCount = success ? numElems : 0
+      return success ? numElems : 0
     }
     
     result = success ? tmpResult : nil

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -72,16 +72,14 @@ extension Dictionary {
   ///     closure must return the count of the initialized elements, starting at
   ///     the beginning of the buffer.
   @_alwaysEmitIntoClient // Introduced in 5.1
-  @inlinable
   public // SPI(Foundation)
   init(
     _unsafeUninitializedCapacity capacity: Int,
     allowingDuplicates: Bool,
     initializingWith initializer: (
       _ keys: UnsafeMutableBufferPointer<Key>,
-      _ values: UnsafeMutableBufferPointer<Value>,
-      _ initializedCount: inout Int
-    ) -> Void
+      _ values: UnsafeMutableBufferPointer<Value>
+    ) -> Int
   ) {
     self.init(_native: _NativeDictionary(
         _unsafeUninitializedCapacity: capacity,
@@ -92,23 +90,19 @@ extension Dictionary {
 
 extension _NativeDictionary {
   @_alwaysEmitIntoClient // Introduced in 5.1
-  @inlinable
   internal init(
     _unsafeUninitializedCapacity capacity: Int,
     allowingDuplicates: Bool,
     initializingWith initializer: (
       _ keys: UnsafeMutableBufferPointer<Key>,
-      _ values: UnsafeMutableBufferPointer<Value>,
-      _ initializedCount: inout Int
-    ) -> Void
+      _ values: UnsafeMutableBufferPointer<Value>
+    ) -> Int
   ) {
     self.init(capacity: capacity)
-    var initializedCount = 0
-    initializer(
+    let initializedCount = initializer(
       UnsafeMutableBufferPointer(start: _keys, count: capacity),
-      UnsafeMutableBufferPointer(start: _values, count: capacity),
-      &initializedCount)
-    _precondition(count >= 0 && count <= capacity)
+      UnsafeMutableBufferPointer(start: _values, count: capacity))
+    _precondition(initializedCount >= 0 && initializedCount <= capacity)
     _storage._count = initializedCount
 
     // Hash initialized elements and move each of them into their correct

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5700,14 +5700,14 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Unique") {
     let d1 = Dictionary<TestKeyTy, TestEquatableValueTy>(
       _unsafeUninitializedCapacity: c,
       allowingDuplicates: false
-    ) { keys, values, count in
+    ) { keys, values in
       let k = keys.baseAddress!
       let v = values.baseAddress!
       for i in 0 ..< c {
         (k + i).initialize(to: TestKeyTy(i))
         (v + i).initialize(to: TestEquatableValueTy(i))
-        count += 1
       }
+      return c
     }
 
     let d2 = Dictionary(
@@ -5727,14 +5727,14 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Nonunique") {
     let d1 = Dictionary<TestKeyTy, TestEquatableValueTy>(
       _unsafeUninitializedCapacity: c,
       allowingDuplicates: true
-    ) { keys, values, count in
+    ) { keys, values in
       let k = keys.baseAddress!
       let v = values.baseAddress!
       for i in 0 ..< c {
         (k + i).initialize(to: TestKeyTy(i / 2))
         (v + i).initialize(to: TestEquatableValueTy(i / 2))
-        count += 1
       }
+      return c
     }
 
     let d2 = Dictionary(


### PR DESCRIPTION
(cherry picked from commit e72e328a4f3747335fc40e9388e4e751240bbc7a in https://github.com/apple/swift/pull/23758)

The initializer was originally introduced without proper availability; in https://github.com/apple/swift/pull/23643, we fixed this by applying the `@_alwaysEmitIntoClient` attribute. However, this had the unfortunate side-effect that the symbol disappeared from `libswiftCore.dylib`, which somehow confuses some simulator builds.

Try to figure out what’s happening by replacing the third closure argument with an integer return value. This changes the mangled name of the bulk initializer, which should make it more obvious how/why these builds fail.

rdar://problem/49479386
