### PR TITLE
[docs] Fix typo in ErrorHandlingRationale.rst

### DIFF
--- a/docs/ErrorHandlingRationale.rst
+++ b/docs/ErrorHandlingRationale.rst
@@ -1180,7 +1180,7 @@ Haskell
 Haskell provides three different common error-propagation mechanisms.
 
 The first is that, like many other functional languages, it supports
-manual propagation with a ``Maybe`` type.  A function can return ``None``
+manual propagation with a ``Maybe`` type.  A function can return ``Nothing``
 to indicate that it couldn't produce a more useful result.  This is
 the most common failure method for functions in the functional subset
 of the library.


### PR DESCRIPTION
This fixes a minor mix-up in the error handling rationale document; the error case of Haskell's Maybe type is called `Nothing`, not `None`.

https://hackage.haskell.org/package/base-4.12.0.0/docs/Prelude.html#t:Maybe