### PR TITLE
[TF-76][Python Interop] add PythonConvertible conformance to TensorShape

### DIFF
--- a/stdlib/public/TensorFlow/TensorShape.swift
+++ b/stdlib/public/TensorFlow/TensorShape.swift
@@ -163,10 +163,13 @@ extension TensorShape : Codable {
 
 extension TensorShape: PythonConvertible {
   public var pythonObject: PythonObject {
-    return self.dimensions.pythonObject
+    return dimensions.pythonObject
   }
 
   public init?(_ pythonObject: PythonObject) {
-    self.init(Array<Int32>(pythonObject)!)
+    guard let array = [Int32](pythonObject) else {
+      return nil
+    }
+    self.init(array)
   }
 }

--- a/stdlib/public/TensorFlow/TensorShape.swift
+++ b/stdlib/public/TensorFlow/TensorShape.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Python
+
 // NOTE: it may be possible to edit `TensorShape` to support "labeled tensors".
 // Dimensions may be either an Int32 or an enum representing a label.
 
@@ -156,5 +158,15 @@ extension TensorShape : Codable {
     let container = try decoder.singleValueContainer()
     let dimensions = try container.decode([Int32].self)
     self.init(dimensions)
+  }
+}
+
+extension TensorShape: PythonConvertible {
+  public var pythonObject: PythonObject {
+    return self.dimensions.pythonObject
+  }
+
+  public init?(_ pythonObject: PythonObject) {
+    self.init(Array<Int32>(pythonObject)!)
   }
 }

--- a/stdlib/public/TensorFlow/TensorShape.swift
+++ b/stdlib/public/TensorFlow/TensorShape.swift
@@ -161,15 +161,19 @@ extension TensorShape : Codable {
   }
 }
 
-extension TensorShape: PythonConvertible {
+extension TensorShape : PythonConvertible {
   public var pythonObject: PythonObject {
     return dimensions.pythonObject
   }
 
   public init?(_ pythonObject: PythonObject) {
-    guard let array = [Int32](pythonObject) else {
-      return nil
+    let hasLen = Bool(Python.hasattr(pythonObject, "__len__"))
+    if(hasLen == true) {
+      guard let array = [Int32](pythonObject) else { return nil }
+      self.init(array)
+    } else {
+      guard let num = Int32(pythonObject) else { return nil }
+      self.init(num)
     }
-    self.init(array)
   }
 }

--- a/test/Python/numpy_conversion.swift
+++ b/test/Python/numpy_conversion.swift
@@ -4,7 +4,6 @@
 // `numpy.ndarray` conversion tests.
 
 import Python
-import struct TensorFlow.TensorShape
 import StdlibUnittest
 
 var NumpyConversionTests = TestSuite("NumpyConversion")
@@ -35,17 +34,6 @@ NumpyConversionTests.test("array-conversion") {
 
   let numpyArray2D = np.ones([2, 3])
   expectNil(Array<Float>(numpy: numpyArray2D))
-
-  let reshaped = np.reshape(numpyArray2D, 6)
-  if let array = expectNotNil(Array<Double>(numpy: reshaped)) {
-    expectEqual([1.0, 1.0, 1.0, 1.0, 1.0, 1.0], array)
-  }
-
-  let numpyArray1D = np.ones(28)
-  let reshaped3D = np.reshape(numpyArray1D, [2, 7, 2] as TensorShape)
-  expectEqual(TensorShape(reshaped3D.shape), [2, 7, 2])
-  let reshaped2D = np.reshape(reshaped3D, [14, 2] as TensorShape)
-  expectEqual(TensorShape(reshaped2D.shape), [14, 2])
 
   let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
       Python.slice(Python.None), 1]

--- a/test/Python/numpy_conversion.swift
+++ b/test/Python/numpy_conversion.swift
@@ -35,6 +35,17 @@ NumpyConversionTests.test("array-conversion") {
   let numpyArray2D = np.ones([2, 3])
   expectNil(Array<Float>(numpy: numpyArray2D))
 
+  let reshaped = np.reshape(numpyArray2D, 6)
+  if let array = expectNotNil(Array<Double>(numpy: reshaped)) {
+    expectEqual([1.0, 1.0, 1.0, 1.0, 1.0, 1.0], array)
+  }
+
+  let numpyArray1D = np.ones(28)
+  let reshaped3D = np.reshape(numpyArray1D, [2, 7, 2])
+  expectEqual(Array(reshaped3D.shape), [2, 7, 2])
+  let reshaped2D = np.reshape(reshaped3D, [14, 2])
+  expectEqual(Array(reshaped2D.shape), [14, 2])
+
   let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
       Python.slice(Python.None), 1]
   // Assert that the array has a stride, so that we're certainly testing a

--- a/test/Python/numpy_conversion.swift
+++ b/test/Python/numpy_conversion.swift
@@ -4,6 +4,7 @@
 // `numpy.ndarray` conversion tests.
 
 import Python
+import struct TensorFlow.TensorShape
 import StdlibUnittest
 
 var NumpyConversionTests = TestSuite("NumpyConversion")
@@ -41,10 +42,10 @@ NumpyConversionTests.test("array-conversion") {
   }
 
   let numpyArray1D = np.ones(28)
-  let reshaped3D = np.reshape(numpyArray1D, [2, 7, 2])
-  expectEqual(Array(reshaped3D.shape), [2, 7, 2])
-  let reshaped2D = np.reshape(reshaped3D, [14, 2])
-  expectEqual(Array(reshaped2D.shape), [14, 2])
+  let reshaped3D = np.reshape(numpyArray1D, [2, 7, 2] as TensorShape)
+  expectEqual(TensorShape(reshaped3D.shape), [2, 7, 2])
+  let reshaped2D = np.reshape(reshaped3D, [14, 2] as TensorShape)
+  expectEqual(TensorShape(reshaped2D.shape), [14, 2])
 
   let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
       Python.slice(Python.None), 1]

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -5,6 +5,7 @@
 
 import Python
 import StdlibUnittest
+import struct TensorFlow.TensorShape
 
 /// The gc module is an interface to the Python garbage collector.
 let gc = Python.import("gc")
@@ -258,6 +259,8 @@ PythonRuntimeTestSuite.testWithLeakChecking("ConvertibleFromPython") {
   let five: PythonObject = 5
   let half: PythonObject = 0.5
   let string: PythonObject = "abc"
+  let intArray: PythonObject = [2, 3]
+  let dict: PythonObject = ["abc": 97]
 
   expectEqual(-1, Int(minusOne))
   expectEqual(-1, Int8(minusOne))
@@ -285,6 +288,10 @@ PythonRuntimeTestSuite.testWithLeakChecking("ConvertibleFromPython") {
 
   expectEqual("abc", String(string))
 
+  expectEqual([2, 3], Array(intArray))
+  expectEqual(TensorShape(2, 3), TensorShape(intArray))
+  expectEqual(["abc": 97], Dictionary<String, Int32>(dict))
+
   expectNil(String(zero))
   expectNil(Int(string))
   expectNil(Double(string))
@@ -293,6 +300,8 @@ PythonRuntimeTestSuite.testWithLeakChecking("ConvertibleFromPython") {
 PythonRuntimeTestSuite.testWithLeakChecking("PythonConvertible") {
   let minusOne: PythonObject = -1
   let five: PythonObject = 5
+  let intArray: PythonObject = [2, 3]
+  let dict: PythonObject = ["abc": 7]
 
   expectEqual(minusOne, Int(-1).pythonObject)
   expectEqual(minusOne, Int8(-1).pythonObject)
@@ -309,6 +318,11 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonConvertible") {
   expectEqual(five, UInt64(5).pythonObject)
   expectEqual(five, Float(5).pythonObject)
   expectEqual(five, Double(5).pythonObject)
+
+  expectEqual(intArray, Array([2, 3]).pythonObject)
+  expectEqual(dict, Dictionary<String, Int32>(["abc": 7]).pythonObject)
+
+  expectEqual(intArray, TensorShape(2, 3).pythonObject)
 }
 
 PythonRuntimeTestSuite.testWithLeakChecking("Optional") {

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -5,7 +5,6 @@
 
 import Python
 import StdlibUnittest
-import struct TensorFlow.TensorShape
 
 /// The gc module is an interface to the Python garbage collector.
 let gc = Python.import("gc")
@@ -289,7 +288,6 @@ PythonRuntimeTestSuite.testWithLeakChecking("ConvertibleFromPython") {
   expectEqual("abc", String(string))
 
   expectEqual([2, 3], Array(intArray))
-  expectEqual(TensorShape(2, 3), TensorShape(intArray))
   expectEqual(["abc" : 97], Dictionary<String, Int32>(dict))
 
   expectNil(String(zero))
@@ -321,8 +319,6 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonConvertible") {
 
   expectEqual(intArray, [2, 3].pythonObject)
   expectEqual(dict, ["abc" : 7].pythonObject)
-
-  expectEqual(intArray, TensorShape(2, 3).pythonObject)
 }
 
 PythonRuntimeTestSuite.testWithLeakChecking("Optional") {

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -67,7 +67,7 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonList") {
 }
 
 PythonRuntimeTestSuite.testWithLeakChecking("PythonDict") {
-  let dict: PythonObject = ["a": 1, 1: 0.5]
+  let dict: PythonObject = ["a" : 1, 1 : 0.5]
   expectEqual(2, Python.len(dict))
   expectEqual(1, dict["a"])
   expectEqual(0.5, dict[1])
@@ -211,7 +211,7 @@ PythonRuntimeTestSuite.testWithLeakChecking("Tuple") {
   let element1: PythonObject = 0
   let element2: PythonObject = "abc"
   let element3: PythonObject = [0, 0]
-  let element4: PythonObject = ["a": 0, "b": "c"]
+  let element4: PythonObject = ["a" : 0, "b" : "c"]
   let pair = PythonObject(tupleOf: element1, element2)
   let (pair1, pair2) = pair.tuple2
   expectEqual(element1, pair1)
@@ -260,7 +260,7 @@ PythonRuntimeTestSuite.testWithLeakChecking("ConvertibleFromPython") {
   let half: PythonObject = 0.5
   let string: PythonObject = "abc"
   let intArray: PythonObject = [2, 3]
-  let dict: PythonObject = ["abc": 97]
+  let dict: PythonObject = ["abc" : 97]
 
   expectEqual(-1, Int(minusOne))
   expectEqual(-1, Int8(minusOne))
@@ -290,7 +290,7 @@ PythonRuntimeTestSuite.testWithLeakChecking("ConvertibleFromPython") {
 
   expectEqual([2, 3], Array(intArray))
   expectEqual(TensorShape(2, 3), TensorShape(intArray))
-  expectEqual(["abc": 97], Dictionary<String, Int32>(dict))
+  expectEqual(["abc" : 97], Dictionary<String, Int32>(dict))
 
   expectNil(String(zero))
   expectNil(Int(string))
@@ -301,7 +301,7 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonConvertible") {
   let minusOne: PythonObject = -1
   let five: PythonObject = 5
   let intArray: PythonObject = [2, 3]
-  let dict: PythonObject = ["abc": 7]
+  let dict: PythonObject = ["abc" : 7]
 
   expectEqual(minusOne, Int(-1).pythonObject)
   expectEqual(minusOne, Int8(-1).pythonObject)
@@ -319,8 +319,8 @@ PythonRuntimeTestSuite.testWithLeakChecking("PythonConvertible") {
   expectEqual(five, Float(5).pythonObject)
   expectEqual(five, Double(5).pythonObject)
 
-  expectEqual(intArray, Array([2, 3]).pythonObject)
-  expectEqual(dict, Dictionary<String, Int32>(["abc": 7]).pythonObject)
+  expectEqual(intArray, [2, 3].pythonObject)
+  expectEqual(dict, ["abc" : 7].pythonObject)
 
   expectEqual(intArray, TensorShape(2, 3).pythonObject)
 }

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -377,7 +377,7 @@ public func testResourceAndVariants() {
     // expected-error @+1 {{op named 'TensorDataSet' is not registered in TensorFlow}}
     #tfop("TensorDataSet", values,
           Toutput_types$dtype: [Float.tensorFlowDataType],
-          output_shapes: [TensorShape(1)])
+          output_shapes: [TensorShape([1])])
 
   // REGISTER_OP("Iterator")
   //     .Output("handle: resource")
@@ -388,7 +388,7 @@ public func testResourceAndVariants() {
   //     .SetShapeFn(shape_inference::ScalarShape);
   let iterator: ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-          output_types$dtype: [Float.tensorFlowDataType], output_shapes: [TensorShape(1)])
+          output_types$dtype: [Float.tensorFlowDataType], output_shapes: [TensorShape([1])])
 
   // REGISTER_OP("MakeIterator")
   //     .Input("dataset: variant")

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -58,6 +58,12 @@ NumpyConversionTests.test("shaped-array-conversion") {
                 array)
   }
 
+  let numpyArray1D = np.ones(28)
+  let reshaped3D = np.reshape(numpyArray1D, [2, 7, 2] as TensorShape)
+  expectEqual(TensorShape(reshaped3D.shape), [2, 7, 2])
+  let reshaped2D = np.reshape(reshaped3D, [14, 2] as TensorShape)
+  expectEqual(TensorShape(reshaped2D.shape), [14, 2])
+
   let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
       Python.slice(Python.None), 1]
   // Assert that the array has a stride, so that we're certainly testing a

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -52,7 +52,7 @@ NumpyConversionTests.test("shaped-array-conversion") {
                 array)
   }
 
-  let reshaped = np.reshape(numpyArrayInt32, [2, 3])
+  let reshaped = np.reshape(numpyArrayInt32, [2, 3] as TensorShape)
   if let array = expectNotNil(ShapedArray<Int32>(numpy: reshaped)) {
     expectEqual(ShapedArray(shape: [2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 array)
@@ -101,7 +101,7 @@ NumpyConversionTests.test("tensor-conversion") {
                 tensor.array)
   }
 
-  let reshaped = np.reshape(numpyArrayInt32, [2, 3])
+  let reshaped = np.reshape(numpyArrayInt32, [2, 3] as TensorShape)
   if let tensor = expectNotNil(Tensor<Int32>(numpy: reshaped)) {
     expectEqual(ShapedArray(shape: [2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 tensor.array)

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -52,6 +52,12 @@ NumpyConversionTests.test("shaped-array-conversion") {
                 array)
   }
 
+  let reshaped = np.reshape(numpyArrayInt32, [2, 3])
+  if let array = expectNotNil(ShapedArray<Int32>(numpy: reshaped)) {
+    expectEqual(ShapedArray(shape: [2, 3], scalars: [1, 2, 3, 4, 5, 6]),
+                array)
+  }
+
   let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
       Python.slice(Python.None), 1]
   // Assert that the array has a stride, so that we're certainly testing a
@@ -92,6 +98,12 @@ NumpyConversionTests.test("tensor-conversion") {
   expectNil(Tensor<UInt32>(numpy: numpyArrayInt32))
   if let tensor = expectNotNil(Tensor<Int32>(numpy: numpyArrayInt32)) {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
+                tensor.array)
+  }
+
+  let reshaped = np.reshape(numpyArrayInt32, [2, 3])
+  if let tensor = expectNotNil(Tensor<Int32>(numpy: reshaped)) {
+    expectEqual(ShapedArray(shape: [2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 tensor.array)
   }
 

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -136,6 +136,12 @@ NumpyConversionTests.test("tensor-round-trip") {
   let t3 = Tensor<Int32>(repeating: 30, shape: [8,5,4])
   expectEqual(t3, Tensor<Int32>(numpy: t3.makeNumpyArray())!)
 }
+
+NumpyConversionTests.test("tensor-shape") {
+  let pyArray = [2, 3].pythonObject
+  expectEqual(pyArray, TensorShape(2, 3).pythonObject)
+  expectEqual(TensorShape(2, 3), TensorShape(pyArray))
+}
 #endif
 
 runAllTests()


### PR DESCRIPTION
This makes TensorShape conform to PythonConvertible per [TF-76](https://bugs.swift.org/browse/TF-76).

Couple small notes:
- It looks like we can essentially delegate to the implementation in [```Array```](https://github.com/apple/swift/blob/tensorflow/stdlib/public/Python/Python.swift#L998)
- I noticed that there were no tests for ```Array``` and ```Dictionary```'s existing ```PythonConvertible``` conformance so I added those as well.