### PR TITLE
TF-404: Add `.std()` to `Tensor`.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -577,6 +577,38 @@ public extension Tensor where Scalar : FloatingPoint & Equatable {
   }
 }
 
+public extension Tensor where Scalar : FloatingPoint {
+  // TODO: std() should handle non floating point Tensors.
+
+  /// Returns the standard deviation along the specified axes. The reduced
+  /// dimensions are retained with value 1. Does not apply Bessel's correction.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  func std() -> Tensor {
+    return std(alongAxes: Array(0..<shape.rank))  // Reduce along all dimensions
+  }
+
+  /// Returns the standard deviation along the specified axes. The reduced
+  /// dimensions are retained with value 1. Does not apply Bessel's correction.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  func std(alongAxes axes: Int32...) -> Tensor {
+    return std(alongAxes: axes)
+  }
+
+  /// Returns the standard deviation along the specified axes. The reduced
+  /// dimensions are retained with value 1. Does not apply Bessel's correction.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  func std(alongAxes axes: [Int32]) -> Tensor {
+    return sqrt(variance(alongAxes: axes))
+  }
+}
+
 public extension Tensor where Scalar == Bool {
   /// Computes `!self` element-wise.
   @inlinable @inline(__always)

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -583,17 +583,19 @@ public extension Tensor where Scalar : TensorFlowFloatingPoint {
   /// Returns the standard deviation of the elements along the specified axes.
   /// The reduced dimensions are retained with value `1`. Does not apply
   /// Bessel's correction.
+  ///
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @differentiable(wrt: self)
   func standardDeviation() -> Tensor {
-    // Reduce along all dimensions
+    // Reduce along all dimensions.
     return standardDeviation(alongAxes: Array(0..<shape.rank))
   }
 
   /// Returns the standard deviation of the elements along the specified axes.
   /// The reduced dimensions are retained with value `1`. Does not apply
   /// Bessel's correction.
+  ///
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @differentiable(wrt: self)
@@ -604,6 +606,7 @@ public extension Tensor where Scalar : TensorFlowFloatingPoint {
   /// Returns the standard deviation of the elements along the specified axes.
   /// The reduced dimensions are retained with value `1`. Does not apply
   /// Bessel's correction.
+  ///
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -578,33 +578,36 @@ public extension Tensor where Scalar : FloatingPoint & Equatable {
 }
 
 public extension Tensor where Scalar : FloatingPoint {
-  // TODO: std() should handle non floating point Tensors.
+  // TODO: standardDeviation() should handle non floating point Tensors.
 
-  /// Returns the standard deviation along the specified axes. The reduced
-  /// dimensions are retained with value 1. Does not apply Bessel's correction.
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value 1. Does not apply Bessel's
+  /// correction.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
-  func std() -> Tensor {
-    return std(alongAxes: Array(0..<shape.rank))  // Reduce along all dimensions
+  func standardDeviation() -> Tensor {
+    return standardDeviation(alongAxes: Array(0..<shape.rank))  // Reduce along all dimensions
   }
 
-  /// Returns the standard deviation along the specified axes. The reduced
-  /// dimensions are retained with value 1. Does not apply Bessel's correction.
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value 1. Does not apply Bessel's
+  /// correction.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
-  func std(alongAxes axes: Int32...) -> Tensor {
-    return std(alongAxes: axes)
+  func standardDeviation(alongAxes axes: Int32...) -> Tensor {
+    return standardDeviation(alongAxes: axes)
   }
 
-  /// Returns the standard deviation along the specified axes. The reduced
-  /// dimensions are retained with value 1. Does not apply Bessel's correction.
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value 1. Does not apply Bessel's
+  /// correction.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
-  func std(alongAxes axes: [Int32]) -> Tensor {
+  func standardDeviation(alongAxes axes: [Int32]) -> Tensor {
     return sqrt(variance(alongAxes: axes))
   }
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -577,36 +577,37 @@ public extension Tensor where Scalar : FloatingPoint & Equatable {
   }
 }
 
-public extension Tensor where Scalar : FloatingPoint {
+public extension Tensor where Scalar : TensorFlowFloatingPoint {
   // TODO: standardDeviation() should handle non floating point Tensors.
 
   /// Returns the standard deviation of the elements along the specified axes.
-  /// The reduced dimensions are retained with value 1. Does not apply Bessel's
-  /// correction.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
-  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  @differentiable(wrt: self)
   func standardDeviation() -> Tensor {
-    return standardDeviation(alongAxes: Array(0..<shape.rank))  // Reduce along all dimensions
+    // Reduce along all dimensions
+    return standardDeviation(alongAxes: Array(0..<shape.rank))
   }
 
   /// Returns the standard deviation of the elements along the specified axes.
-  /// The reduced dimensions are retained with value 1. Does not apply Bessel's
-  /// correction.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
-  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  @differentiable(wrt: self)
   func standardDeviation(alongAxes axes: Int32...) -> Tensor {
     return standardDeviation(alongAxes: axes)
   }
 
   /// Returns the standard deviation of the elements along the specified axes.
-  /// The reduced dimensions are retained with value 1. Does not apply Bessel's
-  /// correction.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
-  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  @differentiable(wrt: self)
   func standardDeviation(alongAxes axes: [Int32]) -> Tensor {
     return sqrt(variance(alongAxes: axes))
   }

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -279,21 +279,21 @@ TensorTests.testAllBackends("SimpleMath") {
 TensorTests.testAllBackends("StandardDeviation") {
   expectEqual(0, Tensor<Float>([1]).standardDeviation().scalarized())
   expectEqual(
-      0.5,
-      Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0).scalarized())
+    0.5,
+    Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0).scalarized())
   expectEqual(0.5, Tensor<Float>([0, 1]).standardDeviation().scalarized())
   expectNearlyEqual(
-      2.87228132,
-      Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).standardDeviation().scalarized(),
-      byError: 0.001)
+    2.87228132,
+    Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).standardDeviation().scalarized(),
+    byError: 0.001)
   let matrix = Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).reshaped(to: [2, 5])
   expectNearlyEqual(2.87228132,
                     matrix.standardDeviation().scalarized(),
                     byError: 0.001)
   expectPointwiseNearlyEqual(
-      [1.4142, 1.4142],
-      matrix.standardDeviation(alongAxes: 1).array.scalars,
-      byError: 0.001)
+    [1.4142, 1.4142],
+    matrix.standardDeviation(alongAxes: 1).array.scalars,
+    byError: 0.001)
 }
 
 TensorTests.testAllBackends("ReductionToScalar") {

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -276,6 +276,22 @@ TensorTests.testAllBackends("SimpleMath") {
                              byError: 0.0001)
 }
 
+TensorTests.testAllBackends("StandardDeviation") {
+  expectEqual(0, Tensor<Float>([1]).std().scalarized())
+  expectEqual(0.5, Tensor<Float>([0, 1]).std(alongAxes: 0).scalarized())
+  expectEqual(0.5, Tensor<Float>([0, 1]).std().scalarized())
+  expectNearlyEqual(2.87228132,
+                    Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).std().scalarized(),
+                    byError: 0.001)
+  let matrix = Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).reshaped(to: [2, 5])
+  expectNearlyEqual(2.87228132,
+                    matrix.std().scalarized(),
+                    byError: 0.001)
+  expectPointwiseNearlyEqual([1.4142, 1.4142],
+                             matrix.std(alongAxes: 1).array.scalars,
+                             byError: 0.001)
+}
+
 TensorTests.testAllBackends("ReductionToScalar") {
   let _: Tensor<Float> = [1, 2, 3, 4, 5]
   // expectEqual(x.mean(), 3)

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -277,19 +277,23 @@ TensorTests.testAllBackends("SimpleMath") {
 }
 
 TensorTests.testAllBackends("StandardDeviation") {
-  expectEqual(0, Tensor<Float>([1]).std().scalarized())
-  expectEqual(0.5, Tensor<Float>([0, 1]).std(alongAxes: 0).scalarized())
-  expectEqual(0.5, Tensor<Float>([0, 1]).std().scalarized())
-  expectNearlyEqual(2.87228132,
-                    Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).std().scalarized(),
-                    byError: 0.001)
+  expectEqual(0, Tensor<Float>([1]).standardDeviation().scalarized())
+  expectEqual(
+      0.5,
+      Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0).scalarized())
+  expectEqual(0.5, Tensor<Float>([0, 1]).standardDeviation().scalarized())
+  expectNearlyEqual(
+      2.87228132,
+      Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).standardDeviation().scalarized(),
+      byError: 0.001)
   let matrix = Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).reshaped(to: [2, 5])
   expectNearlyEqual(2.87228132,
-                    matrix.std().scalarized(),
+                    matrix.standardDeviation().scalarized(),
                     byError: 0.001)
-  expectPointwiseNearlyEqual([1.4142, 1.4142],
-                             matrix.std(alongAxes: 1).array.scalars,
-                             byError: 0.001)
+  expectPointwiseNearlyEqual(
+      [1.4142, 1.4142],
+      matrix.standardDeviation(alongAxes: 1).array.scalars,
+      byError: 0.001)
 }
 
 TensorTests.testAllBackends("ReductionToScalar") {


### PR DESCRIPTION
This change adds `std()` to compute the standard deviation of a Tensor.
It supports optionally specifying the `alongAxes` parameter, which allows
users to reduce only along specified axes.

Resolves [TF-404](https://bugs.swift.org/browse/TF-404).
