### PR TITLE
utils: be more flexible about path separators

### DIFF
--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -12,6 +12,7 @@
 from __future__ import print_function
 
 import argparse
+import re
 import subprocess
 import sys
 
@@ -47,7 +48,7 @@ constants.""")
     stdin = sys.stdin.read()
     for s in args.sanitize_strings:
         replacement, pattern = s.split('=', 1)
-        stdin = stdin.replace(pattern, replacement)
+        stdin = re.sub(re.sub(r'/', r'[/\\\\]', pattern), replacement, stdin)
 
     p = subprocess.Popen(
         [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)


### PR DESCRIPTION
The path separator on Windows is `\` and the path separator on Linux,
android, macOS is `/`.   Permit both sets of path separators.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
