### PR TITLE
[5.1] SILGen: Only set the external decl of a key path component if the accessor is public

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3360,8 +3360,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
                                 bool forPropertyDescriptor) {
   /// Returns true if a key path component for the given property or
   /// subscript should be externally referenced.
-  auto shouldUseExternalKeyPathComponent =
-    [&]() -> bool {
+  auto shouldUseExternalKeyPathComponent = [&]() -> bool {
     return (!forPropertyDescriptor &&
             (storage->getModuleContext() != SwiftModule ||
              storage->isResilient(SwiftModule, expansion)) &&
@@ -3370,11 +3369,15 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
             // Properties that only dispatch via ObjC lookup do not have nor
             // need property descriptors, since the selector identifies the
             // storage.
+            // Properties that are not public don't need property descriptors
+            // either.
             (!storage->hasAnyAccessors() ||
-             !getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage))
-             .isForeign));
-    };
-  
+             (!getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage))
+                   .isForeign &&
+              getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage))
+                      .getLinkage(ForDefinition) <= SILLinkage::PublicNonABI)));
+  };
+
   auto strategy = storage->getAccessStrategy(AccessSemantics::Ordinary,
                                              storage->supportsMutation()
                                                ? AccessKind::ReadWrite

--- a/test/IRGen/Inputs/keypaths_c_types.h
+++ b/test/IRGen/Inputs/keypaths_c_types.h
@@ -1,0 +1,5 @@
+union c_union {
+  struct some_struct {
+    void* data;
+  } some_field;
+};

--- a/test/IRGen/keypaths_c_types.swift
+++ b/test/IRGen/keypaths_c_types.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -import-objc-header %S/Inputs/keypaths_c_types.h
+
+// This used to crash while trying to emit a reference to the property
+// descriptor for the some_field property.
+
+struct Foo {
+  static let somePath: WritableKeyPath<c_union, some_struct>? = \c_union.some_field
+}

--- a/test/SILGen/Inputs/keypaths_objc.h
+++ b/test/SILGen/Inputs/keypaths_objc.h
@@ -5,3 +5,9 @@
 @property(readonly) NSString *_Nonnull objcProp;
 
 @end
+
+union c_union {
+  struct some_struct {
+    void* data;
+  } some_field;
+};

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -96,3 +96,9 @@ func externalObjCProperty() {
   // CHECK-NOT: external #NSObject.description
   _ = \NSObject.description
 }
+
+func sharedCProperty() {
+  // CHECK:  keypath $WritableKeyPath<c_union, some_struct>
+  // CHECK-NOT: external #c_union.some_field
+  let dataKeyPath: WritableKeyPath<c_union, some_struct>? = \c_union.some_field
+}


### PR DESCRIPTION

rdar://49064011
