### PR TITLE
Fixing PlaygroundTransform/placeholder.swift to pass on Windows.

### DIFF
--- a/test/PlaygroundTransform/Inputs/not.py
+++ b/test/PlaygroundTransform/Inputs/not.py
@@ -7,7 +7,8 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 try:
-    subprocess.check_call(shlex.split(sys.argv[1]))
+    isPosix = (sys.platform != "win32")
+    subprocess.check_call(shlex.split(sys.argv[1], posix=isPosix))
     sys.exit(1)
 except subprocess.CalledProcessError as e:
     sys.exit(0)


### PR DESCRIPTION
Apparently shlex just always assumes posix=True rather than just doing
the right thing.

<!-- What's in this pull request? -->
Change to test/PlaygroundTransform/Inputs/not.py

shlex is wrong by default it seems. 
