### PR TITLE
test: adjust for Windows file extensions

### DIFF
--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -41,7 +41,7 @@
 // watchOS: {{(bin/)?ld(.exe)?"? }}
 // watchOS: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}darwin{{(\\\\|/)}}libclang_rt.profile_watchos.a
 
-// watchOS_SIM: {{(bin/)?ld"? }}
+// watchOS_SIM: {{(bin/)?ld(.exe)?"? }}
 // watchOS_SIM: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}darwin{{(\\\\|/)}}libclang_rt.profile_watchossim.a
 
 // LINUX: clang++{{(\.exe)?"? }}


### PR DESCRIPTION
Windows tools have the `.exe` suffix which may or may not be present.
Adjust the test to account for that.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
