### PR TITLE
Fix range relative(to:)

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -461,7 +461,7 @@ extension PartialRangeUpTo: RangeExpression {
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
-    return collection.startIndex..<self.upperBound
+    return collection.startIndex..<Swift.max(collection.startIndex, self.upperBound)
   }
   
   @_transparent
@@ -517,7 +517,7 @@ extension PartialRangeThrough: RangeExpression {
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
-    return collection.startIndex..<collection.index(after: self.upperBound)
+    return collection.startIndex..<Swift.max(collection.startIndex, collection.index(after: self.upperBound))
   }
   @_transparent
   public func contains(_ element: Bound) -> Bool {
@@ -633,7 +633,7 @@ extension PartialRangeFrom: RangeExpression {
   public func relative<C: Collection>(
     to collection: C
   ) -> Range<Bound> where C.Index == Bound {
-    return self.lowerBound..<collection.endIndex
+    return Swift.min(self.lowerBound, collection.endIndex)..<collection.endIndex
   }
   @inlinable // trivial-implementation
   public func contains(_ element: Bound) -> Bool {

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -797,5 +797,42 @@ MiscTestSuite.test("Compatibility typealiases") {
   let _: CountableClosedRange = MinimalStrideableValue(3)...MinimalStrideableValue(3)
 }
 
+MiscTestSuite.test("relative(to:)/partialRangeFrom") {
+  let emptyCollection = [Int]()
+  let partialRangeFrom = 1...
+
+  var rangeFromPartialRangeFrom = partialRangeFrom.relative(to: emptyCollection)
+  expectType(Range<Int>.self, &rangeFromPartialRangeFrom)
+  expectEqual(0, rangeFromPartialRangeFrom.lowerBound)
+  expectEqual(0, rangeFromPartialRangeFrom.upperBound)
+  expectEqual(true, rangeFromPartialRangeFrom.isEmpty)
+}
+
+MiscTestSuite.test("relative(to:)/partialRangeUpTo") {
+  let nonEmptyCollection = (0..<20).map { $0 }
+  let arraySlice = nonEmptyCollection[5...]
+
+  let partialRangeUpTo = ..<1
+
+  var rangeFromPartialRangeUpTo = partialRangeUpTo.relative(to: arraySlice)
+  expectType(Range<Int>.self, &rangeFromPartialRangeUpTo)
+  expectEqual(5, rangeFromPartialRangeUpTo.lowerBound)
+  expectEqual(5, rangeFromPartialRangeUpTo.upperBound)
+  expectEqual(true, rangeFromPartialRangeUpTo.isEmpty)
+}
+
+MiscTestSuite.test("relative(to:)/partialRangeThrough") {
+  let nonEmptyCollection = (0..<20).map { $0 }
+  let arraySlice = nonEmptyCollection[5...]
+
+  let partialRangeThrough = ...1
+
+  var rangeFromPartialRangeThrough = partialRangeThrough.relative(to: arraySlice)
+  expectType(Range<Int>.self, &rangeFromPartialRangeThrough)
+  expectEqual(5, rangeFromPartialRangeThrough.lowerBound)
+  expectEqual(5, rangeFromPartialRangeThrough.upperBound)
+  expectEqual(true, rangeFromPartialRangeThrough.isEmpty)
+}
+
 runAllTests()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
I noticed that if you have a partial range and you call `relative(to:)` with a collection that does not contain the range's specified bound you get a fatalError

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10299](https://bugs.swift.org/browse/SR-10299).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
