### PR TITLE
Disable semantic arc opts for MichaelI benchmark run.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -461,6 +461,7 @@ namespace {
 // configuration.
 struct SemanticARCOpts : SILFunctionTransform {
   void run() override {
+    return;
     SILFunction &f = *getFunction();
 
     // Make sure we are running with ownership verification enabled.


### PR DESCRIPTION
Just for benchmarking to answer MichaelI's question.