### PR TITLE
Shims: include `math.h` on Windows

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -214,6 +214,7 @@ float _swift_stdlib_log1pf(float x) {
 static inline SWIFT_ALWAYS_INLINE
 float _swift_stdlib_hypotf(float x, float y) {
 #if defined(_WIN32)
+  extern float _hypotf(float, float);
   return _hypotf(x, y);
 #else
   return __builtin_hypotf(x, y);


### PR DESCRIPTION
Since we use `_hypotf` on Windows rather than `__builtin_hyptof` due to
a bug in LLVM with the TLI lowering to the wrong builtin, include the
math header to get the proper declaration.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
