### PR TITLE
test: make DebugInfo.debug_prefix_map pass on Windows

### DIFF
--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -9,4 +9,4 @@ func square(_ n: Int) -> Int {
 }
 
 // CHECK: !DIFile(filename: "/var/empty/debug_prefix_map.swift"
-// CHECK: !DIModule(scope: null, name: "Globals", includePath: "/var/empty/Globals.swiftmodule"
+// CHECK: !DIModule(scope: null, name: "Globals", includePath: "/var/empty{{(/|\\5C)}}Globals.swiftmodule"


### PR DESCRIPTION
The separator that is inserted is the native type, so permit both types
of path separators.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
