### PR TITLE
Avoid O(n) copies when bridgable NSData objects are available

### DIFF
--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -1989,7 +1989,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inlinable // This is @inlinable as a convenience initializer.
     public init(contentsOf url: __shared URL, options: Data.ReadingOptions = []) throws {
         let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
-        self.init(bytes: d.bytes, count: d.length)
+        self.init(referencing: d)
     }
     
     /// Initialize a `Data` from a Base-64 encoded String using the given options.
@@ -2000,7 +2000,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inlinable // This is @inlinable as a convenience initializer.
     public init?(base64Encoded base64String: __shared String, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
-            self.init(bytes: d.bytes, count: d.length)
+            self.init(referencing: d)
         } else {
             return nil
         }
@@ -2015,7 +2015,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inlinable // This is @inlinable as a convenience initializer.
     public init?(base64Encoded base64Data: __shared Data, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
-            self.init(bytes: d.bytes, count: d.length)
+            self.init(referencing: d)
         } else {
             return nil
         }

--- a/stdlib/public/Darwin/Foundation/NSData+DataProtocol.swift
+++ b/stdlib/public/Darwin/Foundation/NSData+DataProtocol.swift
@@ -43,9 +43,11 @@ extension NSData : DataProtocol {
     @nonobjc
     public subscript(position: Int) -> UInt8 {
         var byte = UInt8(0)
+        var offset = position
         enumerateBytes { (ptr, range, stop) in
-            if range.location <= position && position < range.upperBound {
-                byte = ptr.load(fromByteOffset: range.location - position, as: UInt8.self)
+            offset -= range.lowerBound
+            if range.contains(position) {
+                byte = ptr.load(fromByteOffset: offset, as: UInt8.self)
                 stop.pointee = true
             }
         }

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -3807,6 +3807,34 @@ class TestData : TestDataSuper {
         let range = slice.range(of: "a".data(using: .ascii)!)
         expectEqual(range, Range<Data.Index>(4..<5))
     }
+
+    func test_nsdataSequence() {
+        let bytes: [UInt8] = Array(0x00...0xFF)
+        let data = bytes.withUnsafeBytes { NSData(bytes: $0.baseAddress, length: $0.count) }
+
+        for byte in bytes {
+            expectEqual(data[Int(byte)], byte)
+        }
+    }
+
+    func test_dispatchSequence() {
+        let bytes1: [UInt8] = Array(0x00..<0xF0)
+        let bytes2: [UInt8] = Array(0xF0..<0xFF)
+        var data = DispatchData.empty
+        bytes1.withUnsafeBytes {
+            data.append($0)
+        }
+        bytes2.withUnsafeBytes {
+            data.append($0)
+        }
+
+        for byte in bytes1 {
+            expectEqual(data[Int(byte)], byte)
+        }
+        for byte in bytes2 {
+            expectEqual(data[Int(byte)], byte)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -4126,6 +4154,9 @@ DataTests.test("test_validateMutation_slice_customBacking_withUnsafeMutableBytes
 DataTests.test("test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
 DataTests.test("test_byte_access_of_discontiguousData") { TestData().test_byte_access_of_discontiguousData() }
 DataTests.test("test_rangeOfSlice") { TestData().test_rangeOfSlice() }
+DataTests.test("test_nsdataSequence") { TestData().test_nsdataSequence() }
+DataTests.test("test_dispatchSequence") { TestData().test_dispatchSequence() }
+
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
Data created with .mappedIfSafe or .alwaysMapped would inappropriately cause O(n) copies of that NSData when read. 
