### PR TITLE
Sema: Fix code completion crash when a ParamDecl hasn't had its type set yet [5.1]

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -593,7 +593,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     void checkNoEscapeParameterUse(DeclRefExpr *DRE, Expr *parent,
                                    OperandKind useKind) {
       // This only cares about declarations of noescape function type.
-      auto AFT = DRE->getDecl()->getInterfaceType()->getAs<AnyFunctionType>();
+      auto AFT = DRE->getType()->getAs<FunctionType>();
       if (!AFT || !AFT->isNoEscape())
         return;
 

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -307,19 +307,16 @@ func doThing1(_ completion: (_ success: Bool) -> ()) {
   // expected-note@-1{{parameter 'completion' is implicitly non-escaping}}
   // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
   escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
-  // expected-error @-1 {{non-escaping value 'escape' may only be called}}
 }
 func doThing2(_ completion: CompletionHandlerNE) {
   // expected-note@-1{{parameter 'completion' is implicitly non-escaping}}
   // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
   escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
-  // expected-error @-1 {{non-escaping value 'escape' may only be called}}
 }
 func doThing3(_ completion: CompletionHandler) {
   // expected-note@-1{{parameter 'completion' is implicitly non-escaping}}
   // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
   escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
-  // expected-error @-1 {{non-escaping value 'escape' may only be called}}
 }
 func doThing4(_ completion: @escaping CompletionHandler) {
   escapeOther = completion

--- a/validation-test/IDE/crashers_2_fixed/rdar42098113.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar42098113.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename %s
+
+func test() {
+  let cl = { arg in
+    let name = arg as String
+    #^A^#
+  }
+}


### PR DESCRIPTION
We set the type of ParamDecls when applying solutions in the normal path, but
sometimes code completion will type check an expression inside a closure without
checking the outer expression. In this case, we may have inferred a type for
the ParamDecl, but we don't write it back.

Instead, just look at the DeclRefExpr's type.

Fixes <rdar://problem/42098113>.