### PR TITLE
[5.1] Driver changes for TSan libdispatch support on Linux

### DIFF
--- a/include/swift/Basic/Sanitizers.def
+++ b/include/swift/Basic/Sanitizers.def
@@ -1,0 +1,28 @@
+//===--- Sanitizers.def - Swift Sanitizers ß----------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the sanitizers supported by Swift.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SANITIZER
+#error "Define SANITIZER prior to including this file!"
+#endif
+
+// SANITIZER(enum_bit, kind, name, file)
+
+SANITIZER(0, Address,   address,    asan)
+SANITIZER(1, Thread,    thread,     tsan)
+SANITIZER(2, Undefined, undefined,  ubsan)
+SANITIZER(3, Fuzzer,    fuzzer,     fuzzer)
+
+#undef SANITIZER

--- a/include/swift/Basic/Sanitizers.h
+++ b/include/swift/Basic/Sanitizers.h
@@ -17,10 +17,8 @@ namespace swift {
 
 // Enabling bitwise masking.
 enum class SanitizerKind : unsigned {
-  Address = 1 << 1,
-  Thread = 1 << 2,
-  Fuzzer = 1 << 3,
-  Undefined = 1 << 4
+  #define SANITIZER(enum_bit, kind, name, file) kind = (1 << enum_bit),
+  #include "Sanitizers.def"
 };
 
 } // end namespace swift

--- a/include/swift/Option/SanitizerOptions.h
+++ b/include/swift/Option/SanitizerOptions.h
@@ -42,5 +42,8 @@ llvm::SanitizerCoverageOptions parseSanitizerCoverageArgValue(
         const llvm::Triple &Triple,
         DiagnosticEngine &Diag,
         OptionSet<SanitizerKind> sanitizers);
+
+/// Returns the active sanitizers as a comma-separated list.
+std::string getSanitizerList(const OptionSet<SanitizerKind> &Set);
 }
 #endif // SWIFT_OPTIONS_SANITIZER_OPTIONS_H

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -278,6 +278,12 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   if (job.getKind() == LinkKind::Executable && context.OI.SelectedSanitizers) {
     Arguments.push_back(context.Args.MakeArgString(
         "-fsanitize=" + getSanitizerList(context.OI.SelectedSanitizers)));
+
+    // The TSan runtime depends on the blocks runtime and libdispatch.
+    if (context.OI.SelectedSanitizers & SanitizerKind::Thread) {
+      Arguments.push_back("-lBlocksRuntime");
+      Arguments.push_back("-ldispatch");
+    }
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -22,6 +22,7 @@
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
 #include "swift/Option/Options.h"
+#include "swift/Option/SanitizerOptions.h"
 #include "clang/Basic/Version.h"
 #include "clang/Driver/Util.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -36,27 +37,6 @@
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
-
-static void addLinkSanitizerLibArgsForLinux(const ArgList &Args,
-                                            ArgStringList &Arguments,
-                                            StringRef Sanitizer,
-                                            const ToolChain &TC) {
-  TC.addLinkRuntimeLib(Args, Arguments, TC.sanitizerRuntimeLibName(Sanitizer));
-
-  // Code taken from
-  // https://github.com/apple/swift-clang/blob/ab3cbe7/lib/Driver/Tools.cpp#L3264-L3276
-  // There's no libpthread or librt on RTEMS.
-  if (TC.getTriple().getOS() != llvm::Triple::RTEMS) {
-    Arguments.push_back("-lpthread");
-    Arguments.push_back("-lrt");
-  }
-  Arguments.push_back("-lm");
-
-  // There's no libdl on FreeBSD or RTEMS.
-  if (TC.getTriple().getOS() != llvm::Triple::FreeBSD &&
-      TC.getTriple().getOS() != llvm::Triple::RTEMS)
-    Arguments.push_back("-ldl");
-}
 
 std::string
 toolchains::GenericUnix::sanitizerRuntimeLibName(StringRef Sanitizer,
@@ -293,23 +273,11 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   Arguments.push_back(
       context.Args.MakeArgString("--target=" + getTriple().str()));
 
-  if (getTriple().getOS() == llvm::Triple::Linux) {
-    // Make sure we only add SanitizerLibs for executables
-    if (job.getKind() == LinkKind::Executable) {
-      if (context.OI.SelectedSanitizers & SanitizerKind::Address)
-        addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "asan", *this);
-
-      if (context.OI.SelectedSanitizers & SanitizerKind::Thread)
-        addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "tsan", *this);
-
-      if (context.OI.SelectedSanitizers & SanitizerKind::Undefined)
-        addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "ubsan", *this);
-
-      if (context.OI.SelectedSanitizers & SanitizerKind::Fuzzer)
-        addLinkRuntimeLib(context.Args, Arguments,
-                          sanitizerRuntimeLibName("fuzzer"));
-
-    }
+  // Delegate to Clang for sanitizers. It will figure out the correct linker
+  // options.
+  if (job.getKind() == LinkKind::Executable && context.OI.SelectedSanitizers) {
+    Arguments.push_back(context.Args.MakeArgString(
+        "-fsanitize=" + getSanitizerList(context.OI.SelectedSanitizers)));
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -188,3 +188,13 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
 
   return sanitizerSet;
 }
+
+std::string swift::getSanitizerList(const OptionSet<SanitizerKind> &Set) {
+  std::string list;
+  if (Set & SanitizerKind::Address) list += "address,";
+  if (Set & SanitizerKind::Thread) list += "thread,";
+  if (Set & SanitizerKind::Fuzzer) list += "fuzzer,";
+  if (Set & SanitizerKind::Undefined) list += "undefined,";
+  if (!list.empty()) list.pop_back(); // Remove last comma
+  return list;
+}

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -31,30 +31,27 @@ using namespace swift;
 
 static StringRef toStringRef(const SanitizerKind kind) {
   switch (kind) {
-  case SanitizerKind::Address:
-    return "address";
-  case SanitizerKind::Thread:
-    return "thread";
-  case SanitizerKind::Fuzzer:
-    return "fuzzer";
-  case SanitizerKind::Undefined:
-    return "undefined";
+    #define SANITIZER(_, kind, name, file) \
+        case SanitizerKind::kind: return #name;
+    #include "swift/Basic/Sanitizers.def"
   }
-  llvm_unreachable("Unsupported sanitizer");
+  llvm_unreachable("Unknown sanitizer");
 }
 
-static const char* toFileName(const SanitizerKind kind) {
+static StringRef toFileName(const SanitizerKind kind) {
   switch (kind) {
-  case SanitizerKind::Address:
-    return "asan";
-  case SanitizerKind::Thread:
-    return "tsan";
-  case SanitizerKind::Fuzzer:
-    return "fuzzer";
-  case SanitizerKind::Undefined:
-    return "ubsan";
+    #define SANITIZER(_, kind, name, file) \
+        case SanitizerKind::kind: return #file;
+    #include "swift/Basic/Sanitizers.def"
   }
-  llvm_unreachable("Unsupported sanitizer");
+  llvm_unreachable("Unknown sanitizer");
+}
+
+static Optional<SanitizerKind> parse(const char* arg) {
+  return llvm::StringSwitch<Optional<SanitizerKind>>(arg)
+      #define SANITIZER(_, kind, name, file) .Case(#name, SanitizerKind::kind)
+      #include "swift/Basic/Sanitizers.def"
+      .Default(None);
 }
 
 llvm::SanitizerCoverageOptions swift::parseSanitizerCoverageArgValue(
@@ -133,35 +130,34 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
   OptionSet<SanitizerKind> sanitizerSet;
 
   // Find the sanitizer kind.
-  for (int i = 0, n = A->getNumValues(); i != n; ++i) {
-    auto kind = llvm::StringSwitch<Optional<SanitizerKind>>(A->getValue(i))
-        .Case("address", SanitizerKind::Address)
-        .Case("thread", SanitizerKind::Thread)
-        .Case("fuzzer", SanitizerKind::Fuzzer)
-        .Case("undefined", SanitizerKind::Undefined)
-        .Default(None);
-    bool isShared = kind && *kind != SanitizerKind::Fuzzer;
-    if (!kind) {
+  for (const char *arg : A->getValues()) {
+    Optional<SanitizerKind> optKind = parse(arg);
+
+    // Unrecognized sanitizer option
+    if (!optKind.hasValue()) {
       Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
-          A->getOption().getPrefixedName(), A->getValue(i));
+          A->getOption().getPrefixedName(), arg);
+      continue;
+    }
+    SanitizerKind kind = optKind.getValue();
+
+    // Support is determined by existance of the sanitizer library.
+    auto fileName = toFileName(kind);
+    bool isShared = (kind != SanitizerKind::Fuzzer);
+    bool sanitizerSupported = sanitizerRuntimeLibExists(fileName, isShared);
+
+    // TSan is explicitly not supported for 32 bits.
+    if (kind == SanitizerKind::Thread && !Triple.isArch64Bit())
+      sanitizerSupported = false;
+
+    if (!sanitizerSupported) {
+      SmallString<128> b;
+      Diags.diagnose(SourceLoc(), diag::error_unsupported_opt_for_target,
+                      (A->getOption().getPrefixedName() + toStringRef(kind))
+                          .toStringRef(b),
+                      Triple.getTriple());
     } else {
-      // Support is determined by existance of the sanitizer library.
-      bool sanitizerSupported =
-          sanitizerRuntimeLibExists(toFileName(*kind), isShared);
-
-      // TSan is explicitly not supported for 32 bits.
-      if (*kind == SanitizerKind::Thread && !Triple.isArch64Bit())
-        sanitizerSupported = false;
-
-      if (!sanitizerSupported) {
-        SmallString<128> b;
-        Diags.diagnose(SourceLoc(), diag::error_unsupported_opt_for_target,
-                       (A->getOption().getPrefixedName() + toStringRef(*kind))
-                           .toStringRef(b),
-                       Triple.getTriple());
-      } else {
-        sanitizerSet |= *kind;
-      }
+      sanitizerSet |= kind;
     }
   }
 
@@ -191,10 +187,12 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
 
 std::string swift::getSanitizerList(const OptionSet<SanitizerKind> &Set) {
   std::string list;
-  if (Set & SanitizerKind::Address) list += "address,";
-  if (Set & SanitizerKind::Thread) list += "thread,";
-  if (Set & SanitizerKind::Fuzzer) list += "fuzzer,";
-  if (Set & SanitizerKind::Undefined) list += "undefined,";
-  if (!list.empty()) list.pop_back(); // Remove last comma
+  #define SANITIZER(_, kind, name, file) \
+      if (Set & SanitizerKind::kind) list += #name ",";
+  #include "swift/Basic/Sanitizers.def"
+
+  if (!list.empty())
+    list.pop_back(); // Remove last comma
+
   return list;
 }

--- a/test/Driver/fuzzer.swift
+++ b/test/Driver/fuzzer.swift
@@ -1,8 +1,11 @@
 // UNSUPPORTED: windows
 // UNSUPPORTED: CPU=powerpc64le
-// RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER_OSX %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -target x86_64-unknown-linux-gnu -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER_LINUX %s
 
-// LIBFUZZER: libclang_rt.fuzzer
+// LIBFUZZER_OSX: libclang_rt.fuzzer
+// LIBFUZZER_LINUX: -fsanitize=address,fuzzer
+
 @_cdecl("LLVMFuzzerTestOneInput") public func fuzzOneInput(Data: UnsafePointer<CChar>, Size: CLong) -> CInt {
   return 0;
 }

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -106,7 +106,7 @@
 
 // UBSAN: -rpath @executable_path
 
-// MULTIPLE_SAN_LINUX: -fsanitize=address,fuzzer,undefined
+// MULTIPLE_SAN_LINUX: -fsanitize=address,undefined,fuzzer
 
 // BADARG: unsupported argument 'unknown' to option '-sanitize='
 // INCOMPATIBLESANITIZERS: argument '-sanitize=address' is not allowed with '-sanitize=thread'

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -39,6 +39,10 @@
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=UBSAN_LINUX %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=UBSAN_WINDOWS %s
 
+/*
+ * Multiple Sanitizers At Once
+ */
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,undefined,fuzzer -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MULTIPLE_SAN_LINUX %s
 
 /*
  * Bad Argument Tests
@@ -65,7 +69,7 @@
 // ASAN_tvOS: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.asan_tvos_dynamic.dylib
 // ASAN_watchOS_SIM: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.asan_watchossim_dynamic.dylib
 // ASAN_watchOS: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.asan_watchos_dynamic.dylib
-// ASAN_LINUX: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}libclang_rt.asan-x86_64.a
+// ASAN_LINUX: -fsanitize=address
 // ASAN_WINDOWS: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}windows{{/|\\\\}}clang_rt.asan-x86_64.lib
 
 // ASAN: -rpath @executable_path
@@ -82,7 +86,7 @@
 // TSAN_watchOS_SIM: unsupported option '-sanitize=thread' for target 'i386-apple-watchos2.0'
 // TSAN_watchOS: unsupported option '-sanitize=thread' for target 'armv7k-apple-watchos2.0'
 // FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
-// TSAN_LINUX: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}libclang_rt.tsan-x86_64.a
+// TSAN_LINUX: -fsanitize=thread
 // TSAN_WINDOWS: unsupported option '-sanitize=thread' for target 'x86_64-unknown-windows-msvc'
 
 // TSAN: -rpath @executable_path
@@ -97,10 +101,12 @@
 // UBSAN_tvOS: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.ubsan_tvos_dynamic.dylib
 // UBSAN_watchOS_SIM: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.ubsan_watchossim_dynamic.dylib
 // UBSAN_watchOS: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.ubsan_watchos_dynamic.dylib
-// UBSAN_LINUX: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}libclang_rt.ubsan-x86_64.a
+// UBSAN_LINUX: -fsanitize=undefined
 // UBSAN_WINDOWS: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}windows{{/|\\\\}}clang_rt.ubsan-x86_64.lib
 
 // UBSAN: -rpath @executable_path
+
+// MULTIPLE_SAN_LINUX: -fsanitize=address,fuzzer,undefined
 
 // BADARG: unsupported argument 'unknown' to option '-sanitize='
 // INCOMPATIBLESANITIZERS: argument '-sanitize=address' is not allowed with '-sanitize=thread'

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -86,7 +86,7 @@
 // TSAN_watchOS_SIM: unsupported option '-sanitize=thread' for target 'i386-apple-watchos2.0'
 // TSAN_watchOS: unsupported option '-sanitize=thread' for target 'armv7k-apple-watchos2.0'
 // FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
-// TSAN_LINUX: -fsanitize=thread
+// TSAN_LINUX: -fsanitize=thread -lBlocksRuntime -ldispatch
 // TSAN_WINDOWS: unsupported option '-sanitize=thread' for target 'x86_64-unknown-windows-msvc'
 
 // TSAN: -rpath @executable_path

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -641,10 +641,6 @@ if run_vendor == 'apple':
         { 'macosx': 'macos', 'darwin': 'macos' }.get(run_os, run_os)
     )
 
-    config.available_features.add('libdispatch')
-    config.available_features.add('foundation')
-    config.available_features.add('objc_interop')
-
     config.target_object_format = "macho"
     config.target_shared_library_prefix = 'lib'
     config.target_shared_library_suffix = ".dylib"
@@ -1459,5 +1455,26 @@ if platform.system() == 'Linux':
     if distributor != '' and release != '':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))
+
+if run_vendor == 'apple':
+    config.available_features.add('libdispatch')
+    config.available_features.add('foundation')
+    config.available_features.add('objc_interop')
+else:
+    # TODO(yln): Works with the packaged swift distribution, but not during build.
+    #            We need to make libdispatch/foundation available in the test resource directory
+    #            or pass along the proper library include paths in the compiler invocations that are used
+    #            to build the tests.
+    def has_lib(name):
+        return False
+
+    if has_lib('dispatch'):
+        config.available_features.add('libdispatch')
+    else:
+        # TSan runtime requires libdispatch on non-Apple platforms
+        config.available_features.remove('tsan_runtime')
+
+    if has_lib('Foundation'):
+        config.available_features.add('foundation')
 
 lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2173,6 +2173,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
+                    -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
                     "${llvm_cmake_options[@]}"
                 )
 


### PR DESCRIPTION
- Build LLVM with `-DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON`
- Delegate to Clang for passing `-fsanitize=thread` during linking
- Add `-lBlocksRuntime -ldispatch` to satisfy newly introduced sanitizer runtime link dependency
- Keep sanitizer enum/string mapping in one place
- Some preparation for running `import Dispatch` tests on Linux

rdar://49177600
