### PR TITLE
[build-script] Move call_without_sleeping into the shell module

### DIFF
--- a/utils/build-parser-lib
+++ b/utils/build-parser-lib
@@ -42,20 +42,6 @@ from swift_build_support.swift_build_support.toolchain import host_toolchain
 
 isMac = platform.system() == 'Darwin'
 
-def call_without_sleeping(command, env=None, dry_run=False, echo=False):
-    """
-    Execute a command during which system sleep is disabled.
-
-    By default, this ignores the state of the `shell.dry_run` flag.
-    """
-
-    # Disable system sleep, if possible.
-    if platform.system() == 'Darwin':
-        # Don't mutate the caller's copy of the arguments.
-        command = ["caffeinate"] + list(command)
-
-    shell.call(command, env=env, dry_run=dry_run, echo=echo)
-
 class Builder(object):
     def __init__(self, toolchain, args):
         self.toolchain = toolchain
@@ -76,7 +62,7 @@ class Builder(object):
 
     def call(self, command, env=None, without_sleeping=False):
         if without_sleeping:
-            call_without_sleeping(command, env=env, dry_run=self.dry_run, echo=self.verbose)
+            shell.call_without_sleeping(command, env=env, dry_run=self.dry_run, echo=self.verbose)
         else:
             shell.call(command, env=env, dry_run=self.dry_run, echo=self.verbose)
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -56,21 +56,6 @@ def exit_rejecting_arguments(message, parser=None):
     sys.exit(2)  # 2 is the same as `argparse` error exit code.
 
 
-def call_without_sleeping(command, env=None, dry_run=False, echo=False):
-    """
-    Execute a command during which system sleep is disabled.
-
-    By default, this ignores the state of the `shell.dry_run` flag.
-    """
-
-    # Disable system sleep, if possible.
-    if platform.system() == 'Darwin':
-        # Don't mutate the caller's copy of the arguments.
-        command = ["caffeinate"] + list(command)
-
-    shell.call(command, env=env, dry_run=dry_run, echo=echo)
-
-
 class HostSpecificConfiguration(object):
 
     """Configuration information for an individual host."""
@@ -906,8 +891,8 @@ class BuildScriptInvocation(object):
         # `build-script-impl`.
         if self.args.legacy_impl:
             # Execute the underlying build script implementation.
-            call_without_sleeping([build_script_impl] + impl_args,
-                                  env=impl_env, echo=True)
+            shell.call_without_sleeping([build_script_impl] + impl_args,
+                                        env=impl_env, echo=True)
             return
 
         # Otherwise, we compute and execute the individual actions ourselves.
@@ -924,7 +909,7 @@ class BuildScriptInvocation(object):
                 assert name is not None, "invalid action"
                 action_name = "{}-{}-{}".format(
                     host.name, product_class.product_name(), name)
-            call_without_sleeping(
+            shell.call_without_sleeping(
                 [build_script_impl] + impl_args + [
                     "--only-execute", action_name],
                 env=impl_env, echo=self.args.verbose_build)
@@ -1143,7 +1128,7 @@ def main_preset():
     if args.expand_build_script_invocation:
         return 0
 
-    call_without_sleeping(build_script_args)
+    shell.call_without_sleeping(build_script_args)
     return 0
 
 

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 import os
 import pipes
+import platform
 import shutil
 import subprocess
 import sys
@@ -91,6 +92,21 @@ def call(command, stderr=None, env=None, dry_run=None, echo=True):
         diagnostics.fatal(
             "could not execute '" + quote_command(command) +
             "': " + e.strerror)
+
+
+def call_without_sleeping(command, env=None, dry_run=False, echo=False):
+    """
+    Execute a command during which system sleep is disabled.
+
+    By default, this ignores the state of the `shell.dry_run` flag.
+    """
+
+    # Disable system sleep, if possible.
+    if platform.system() == 'Darwin':
+        # Don't mutate the caller's copy of the arguments.
+        command = ["caffeinate"] + list(command)
+
+    call(command, env=env, dry_run=dry_run, echo=echo)
 
 
 def capture(command, stderr=None, env=None, dry_run=None, echo=True,


### PR DESCRIPTION
Move duplicated code from `call_without_sleeping` in `build-script` and `build-parser-lib` into the `swift_build_support.shell` module, so it is accessible from a common place. This will allow using that function from other modules, instead of duplicating the code.

The code has been copied without modifications. The calling sites has been prefixed with `shell.`. An `import platform` has been added to the `shell` module.

This was part of #23257. I’m trying to split the PR in smaller ones to make the reviews easier. Other PRs in this group are #23303.