### PR TITLE
Implementation-only import checking for conformances

### DIFF
--- a/include/swift/AST/AccessScopeChecker.h
+++ b/include/swift/AST/AccessScopeChecker.h
@@ -54,13 +54,13 @@ class TypeDeclFinder : public TypeWalker {
   Action walkToTypePre(Type T) override;
 
 public:
-  virtual Action visitNominalType(const NominalType *ty) {
+  virtual Action visitNominalType(NominalType *ty) {
     return Action::Continue;
   }
-  virtual Action visitBoundGenericType(const BoundGenericType *ty) {
+  virtual Action visitBoundGenericType(BoundGenericType *ty) {
     return Action::Continue;
   }
-  virtual Action visitTypeAliasType(const TypeAliasType *ty) {
+  virtual Action visitTypeAliasType(TypeAliasType *ty) {
     return Action::Continue;
   }
 };
@@ -72,9 +72,9 @@ class SimpleTypeDeclFinder : public TypeDeclFinder {
   /// The function to call when a ComponentIdentTypeRepr is seen.
   llvm::function_ref<Action(const TypeDecl *)> Callback;
 
-  Action visitNominalType(const NominalType *ty) override;
-  Action visitBoundGenericType(const BoundGenericType *ty) override;
-  Action visitTypeAliasType(const TypeAliasType *ty) override;
+  Action visitNominalType(NominalType *ty) override;
+  Action visitBoundGenericType(BoundGenericType *ty) override;
+  Action visitTypeAliasType(TypeAliasType *ty) override;
 
 public:
   explicit SimpleTypeDeclFinder(

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2391,6 +2391,10 @@ ERROR(decl_from_implementation_only_module,none,
       "cannot use %0 here; %1 has been imported as "
       "'@_implementationOnly'",
       (DeclName, Identifier))
+ERROR(conformance_from_implementation_only_module,none,
+      "cannot use conformance of %0 to %1 here; %2 has been imported as "
+      "'@_implementationOnly'",
+      (Type, DeclName, Identifier))
 
 // Derived conformances
 ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2395,6 +2395,10 @@ ERROR(conformance_from_implementation_only_module,none,
       "cannot use conformance of %0 to %1 here; %2 has been imported as "
       "'@_implementationOnly'",
       (Type, DeclName, Identifier))
+ERROR(assoc_conformance_from_implementation_only_module,none,
+      "cannot use conformance of %0 to %1 in associated type %3 (inferred as "
+      "%4); %2 has been imported as '@_implementationOnly'",
+      (Type, DeclName, Identifier, Type, Type))
 
 // Derived conformances
 ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,

--- a/lib/AST/AccessScopeChecker.cpp
+++ b/lib/AST/AccessScopeChecker.cpp
@@ -71,17 +71,17 @@ TypeWalker::Action TypeDeclFinder::walkToTypePre(Type T) {
 }
 
 TypeWalker::Action
-SimpleTypeDeclFinder::visitNominalType(const NominalType *ty) {
+SimpleTypeDeclFinder::visitNominalType(NominalType *ty) {
   return Callback(ty->getDecl());
 }
 
 TypeWalker::Action
-SimpleTypeDeclFinder::visitBoundGenericType(const BoundGenericType *ty) {
+SimpleTypeDeclFinder::visitBoundGenericType(BoundGenericType *ty) {
   return Callback(ty->getDecl());
 }
 
 TypeWalker::Action
-SimpleTypeDeclFinder::visitTypeAliasType(const TypeAliasType *ty) {
+SimpleTypeDeclFinder::visitTypeAliasType(TypeAliasType *ty) {
   return Callback(ty->getDecl());
 }
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -15,10 +15,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
+#include "TypeCheckAvailability.h"
+#include "swift/AST/AccessScopeChecker.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Initializer.h"
 #include "swift/AST/DeclContext.h"
+#include "swift/AST/Initializer.h"
+#include "swift/AST/ProtocolConformance.h"
 
 using namespace swift;
 using FragileFunctionKind = TypeChecker::FragileFunctionKind;
@@ -106,10 +109,6 @@ bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
   const ValueDecl *D = declRef.getDecl();
   // Do some important fast-path checks that apply to all cases.
 
-  // Local declarations are OK.
-  if (D->getDeclContext()->isLocalContext())
-    return false;
-
   // Type parameters are OK.
   if (isa<AbstractTypeParamDecl>(D))
     return false;
@@ -120,7 +119,7 @@ bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
     return true;
 
   // Check whether the declaration comes from a publically-imported module.
-  if (diagnoseDeclRefExportability(loc, D, DC))
+  if (diagnoseDeclRefExportability(loc, declRef, DC))
     return true;
 
   return false;
@@ -131,6 +130,10 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
                                            const DeclContext *DC,
                                            FragileFunctionKind Kind,
                                            bool TreatUsableFromInlineAsPublic) {
+  // Local declarations are OK.
+  if (D->getDeclContext()->isLocalContext())
+    return false;
+
   // Public declarations are OK.
   if (D->getFormalAccessScope(/*useDC=*/nullptr,
                               TreatUsableFromInlineAsPublic).isPublic())
@@ -204,8 +207,89 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   return (downgradeToWarning == DowngradeToWarning::No);
 }
 
+static bool diagnoseDeclExportability(SourceLoc loc, const ValueDecl *D,
+                                      const SourceFile &userSF) {
+  auto definingModule = D->getModuleContext();
+  if (!userSF.isImportedImplementationOnly(definingModule))
+    return false;
+
+  // TODO: different diagnostics
+  ASTContext &ctx = definingModule->getASTContext();
+  ctx.Diags.diagnose(loc, diag::inlinable_decl_ref_implementation_only,
+                     D->getDescriptiveKind(), D->getFullName());
+  return true;
+}
+
+static bool
+diagnoseGenericArgumentsExportability(SourceLoc loc,
+                                      const SubstitutionMap &subs,
+                                      const SourceFile &userSF) {
+  bool hadAnyIssues = false;
+  for (ProtocolConformanceRef conformance : subs.getConformances()) {
+    if (!conformance.isConcrete())
+      continue;
+    const ProtocolConformance *concreteConf = conformance.getConcrete();
+
+    SubstitutionMap subConformanceSubs =
+        concreteConf->getSubstitutions(userSF.getParentModule());
+    diagnoseGenericArgumentsExportability(loc, subConformanceSubs, userSF);
+
+    const RootProtocolConformance *rootConf =
+        concreteConf->getRootConformance();
+    ModuleDecl *M = rootConf->getDeclContext()->getParentModule();
+    if (!userSF.isImportedImplementationOnly(M))
+      continue;
+
+    ASTContext &ctx = M->getASTContext();
+    ctx.Diags.diagnose(loc, diag::conformance_from_implementation_only_module,
+                       rootConf->getType(),
+                       rootConf->getProtocol()->getFullName(), M->getName());
+    hadAnyIssues = true;
+  }
+  return hadAnyIssues;
+}
+
+void TypeChecker::diagnoseGenericTypeExportability(const TypeLoc &TL,
+                                                   const DeclContext *DC) {
+  class GenericTypeFinder : public TypeDeclFinder {
+    using Callback = llvm::function_ref<void(SubstitutionMap)>;
+
+    const SourceFile &SF;
+    Callback callback;
+  public:
+    GenericTypeFinder(const SourceFile &SF, Callback callback)
+        : SF(SF), callback(callback) {}
+
+    Action visitBoundGenericType(BoundGenericType *ty) override {
+      ModuleDecl *useModule = SF.getParentModule();
+      SubstitutionMap subs = ty->getContextSubstitutionMap(useModule,
+                                                           ty->getDecl());
+      callback(subs);
+      return Action::Continue;
+    }
+
+    Action visitTypeAliasType(TypeAliasType *ty) override {
+      callback(ty->getSubstitutionMap());
+      return Action::Continue;
+    }
+  };
+
+  assert(TL.getType() && "type not validated yet");
+
+  const SourceFile *SF = DC->getParentSourceFile();
+  if (!SF)
+    return;
+
+  TL.getType().walk(GenericTypeFinder(*SF, [&](SubstitutionMap subs) {
+    // FIXME: It would be nice to highlight just the part of the type that's
+    // problematic, but unfortunately the TypeRepr doesn't have the
+    // information we need and the Type doesn't easily map back to it.
+    (void)diagnoseGenericArgumentsExportability(TL.getLoc(), subs, *SF);
+  }));
+}
+
 bool TypeChecker::diagnoseDeclRefExportability(SourceLoc loc,
-                                               const ValueDecl *D,
+                                               ConcreteDeclRef declRef,
                                                const DeclContext *DC) {
   // We're only interested in diagnosing uses from source files.
   auto userSF = DC->getParentSourceFile();
@@ -220,22 +304,12 @@ bool TypeChecker::diagnoseDeclRefExportability(SourceLoc loc,
   if (!userSF->hasImplementationOnlyImports())
     return false;
 
-  auto userModule = userSF->getParentModule();
-  auto definingModule = D->getModuleContext();
-
-  // Nothing to diagnose in the very common case of the same module.
-  if (userModule == definingModule)
-    return false;
-
-  // Nothing to diagnose in the very common case that the module is
-  // imported for use in signatures.
-  if (!userSF->isImportedImplementationOnly(definingModule))
-    return false;
-
-  // TODO: different diagnostics
-  diagnose(loc, diag::inlinable_decl_ref_implementation_only,
-           D->getDescriptiveKind(), D->getFullName());
-
-  // TODO: notes explaining why
-  return true;
+  const ValueDecl *D = declRef.getDecl();
+  if (diagnoseDeclExportability(loc, D, *userSF))
+    return true;
+  if (diagnoseGenericArgumentsExportability(loc, declRef.getSubstitutions(),
+                                            *userSF)) {
+    return true;
+  }
+  return false;
 }

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -99,10 +99,11 @@ enum class DowngradeToWarning: bool {
 };
 
 bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
-                                           const ValueDecl *D,
+                                           ConcreteDeclRef declRef,
                                            const DeclContext *DC,
                                            FragileFunctionKind Kind,
                                            bool TreatUsableFromInlineAsPublic) {
+  const ValueDecl *D = declRef.getDecl();
   // Do some important fast-path checks that apply to all cases.
 
   // Local declarations are OK.

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2293,7 +2293,7 @@ public:
         // DerivedConformanceRawRepresentable will do the right thing.
         flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailable;
 
-      diagAvailability(DR->getDecl(), DR->getSourceRange(),
+      diagAvailability(DR->getDeclRef(), DR->getSourceRange(),
                        getEnclosingApplyExpr(), flags);
       maybeDiagStorageAccess(DR->getDecl(), DR->getSourceRange(), DC);
     }
@@ -2302,18 +2302,18 @@ public:
       return skipChildren();
     }
     if (auto OCDR = dyn_cast<OtherConstructorDeclRefExpr>(E))
-      diagAvailability(OCDR->getDecl(),
+      diagAvailability(OCDR->getDeclRef(),
                        OCDR->getConstructorLoc().getSourceRange(),
                        getEnclosingApplyExpr());
     if (auto DMR = dyn_cast<DynamicMemberRefExpr>(E))
-      diagAvailability(DMR->getMember().getDecl(),
+      diagAvailability(DMR->getMember(),
                        DMR->getNameLoc().getSourceRange(),
                        getEnclosingApplyExpr());
     if (auto DS = dyn_cast<DynamicSubscriptExpr>(E))
-      diagAvailability(DS->getMember().getDecl(), DS->getSourceRange());
+      diagAvailability(DS->getMember(), DS->getSourceRange());
     if (auto S = dyn_cast<SubscriptExpr>(E)) {
       if (S->hasDecl()) {
-        diagAvailability(S->getDecl().getDecl(), S->getSourceRange());
+        diagAvailability(S->getDecl(), S->getSourceRange());
         maybeDiagStorageAccess(S->getDecl().getDecl(), S->getSourceRange(), DC);
       }
     }
@@ -2328,7 +2328,7 @@ public:
       walkInOutExpr(IO);
       return skipChildren();
     }
-    
+
     return visitChildren();
   }
 
@@ -2339,16 +2339,16 @@ public:
     return E;
   }
 
-  bool diagAvailability(const ValueDecl *D, SourceRange R,
+  bool diagAvailability(ConcreteDeclRef declRef, SourceRange R,
                         const ApplyExpr *call = nullptr,
-                        DeclAvailabilityFlags flags = None);
+                        DeclAvailabilityFlags flags = None) const;
 
 private:
   bool diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
-                             const AvailableAttr *Attr);
+                             const AvailableAttr *Attr) const;
   bool diagnoseMemoryLayoutMigration(const ValueDecl *D, SourceRange R,
                                      const AvailableAttr *Attr,
-                                     const ApplyExpr *call);
+                                     const ApplyExpr *call) const;
 
   /// Walks up from a potential callee to the enclosing ApplyExpr.
   const ApplyExpr *getEnclosingApplyExpr() const {
@@ -2502,10 +2502,7 @@ private:
                                 DeclAvailabilityFlags Flags) const {
     Flags &= DeclAvailabilityFlag::ForInout;
     Flags |= DeclAvailabilityFlag::ContinueOnPotentialUnavailability;
-    if (diagnoseDeclAvailability(D, TC,
-                                 const_cast<DeclContext*>(ReferenceDC),
-                                 ReferenceRange,
-                                 Flags))
+    if (diagAvailability(D, ReferenceRange, /*call*/nullptr, Flags))
       return;
   }
 };
@@ -2514,11 +2511,12 @@ private:
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
 bool
-AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
+AvailabilityWalker::diagAvailability(ConcreteDeclRef declRef, SourceRange R,
                                      const ApplyExpr *call,
-                                     DeclAvailabilityFlags Flags) {
-  if (!D)
+                                     DeclAvailabilityFlags Flags) const {
+  if (!declRef)
     return false;
+  const ValueDecl *D = declRef.getDecl();
 
   if (auto *attr = AvailableAttr::isUnavailable(D)) {
     if (diagnoseIncDecRemoval(D, R, attr))
@@ -2539,7 +2537,7 @@ AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
 
   if (FragileKind)
     if (R.isValid())
-      if (TC.diagnoseInlinableDeclRef(R.Start, D, DC, *FragileKind,
+      if (TC.diagnoseInlinableDeclRef(R.Start, declRef, DC, *FragileKind,
                                       TreatUsableFromInlineAsPublic))
         return true;
 
@@ -2602,9 +2600,9 @@ static bool isIntegerOrFloatingPointType(Type ty, DeclContext *DC,
 
 /// If this is a call to an unavailable ++ / -- operator, try to diagnose it
 /// with a fixit hint and return true.  If not, or if we fail, return false.
-bool AvailabilityWalker::diagnoseIncDecRemoval(const ValueDecl *D,
-                                               SourceRange R,
-                                               const AvailableAttr *Attr) {
+bool
+AvailabilityWalker::diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
+                                          const AvailableAttr *Attr) const {
   // We can only produce a fixit if we're talking about ++ or --.
   bool isInc = D->getBaseName() == "++";
   if (!isInc && D->getBaseName() != "--")
@@ -2664,10 +2662,11 @@ bool AvailabilityWalker::diagnoseIncDecRemoval(const ValueDecl *D,
 
 /// If this is a call to an unavailable sizeof family function, diagnose it
 /// with a fixit hint and return true. If not, or if we fail, return false.
-bool AvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
-                                                       SourceRange R,
-                                                       const AvailableAttr *Attr,
-                                                       const ApplyExpr *call) {
+bool
+AvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
+                                                  SourceRange R,
+                                                  const AvailableAttr *Attr,
+                                                  const ApplyExpr *call) const {
 
   if (!D->getModuleContext()->isStdlibModule())
     return false;
@@ -2750,5 +2749,5 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *Decl,
                                      DeclAvailabilityFlags Flags)
 {
   AvailabilityWalker AW(TC, DC);
-  return AW.diagAvailability(Decl, R, nullptr, Flags);
+  return AW.diagAvailability(const_cast<ValueDecl *>(Decl), R, nullptr, Flags);
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3643,23 +3643,70 @@ void ConformanceChecker::ensureRequirementsAreSatisfied(
   std::function<void(ProtocolConformanceRef)> writer
     = Conformance->populateSignatureConformances();
 
+  SourceFile *fileForCheckingImplementationOnlyUse = nullptr;
+  if (getRequiredAccessScope().isPublic() || isUsableFromInlineRequired())
+    fileForCheckingImplementationOnlyUse = DC->getParentSourceFile();
+
   class GatherConformancesListener : public GenericRequirementsCheckListener {
-    NormalProtocolConformance *conformance;
+    NormalProtocolConformance *conformanceBeingChecked;
+    SourceFile *SF;
     std::function<void(ProtocolConformanceRef)> &writer;
+
+    void checkForImplementationOnlyUse(Type depTy, Type replacementTy,
+                                       const ProtocolConformance *conformance) {
+      if (!SF)
+        return;
+
+      SubstitutionMap subs =
+          conformance->getSubstitutions(SF->getParentModule());
+      for (auto &subConformance : subs.getConformances()) {
+        if (!subConformance.isConcrete())
+          continue;
+        checkForImplementationOnlyUse(depTy, replacementTy,
+                                      subConformance.getConcrete());
+      }
+
+      const RootProtocolConformance *rootConformance =
+          conformance->getRootConformance();
+      ModuleDecl *M = rootConformance->getDeclContext()->getParentModule();
+      if (!SF->isImportedImplementationOnly(M))
+        return;
+
+      ASTContext &ctx = M->getASTContext();
+
+      Type selfTy = rootConformance->getProtocol()->getProtocolSelfType();
+      if (depTy->isEqual(selfTy)) {
+        ctx.Diags.diagnose(
+            conformanceBeingChecked->getLoc(),
+            diag::conformance_from_implementation_only_module,
+            rootConformance->getType(),
+            rootConformance->getProtocol()->getName(), M->getName());
+      } else {
+        ctx.Diags.diagnose(
+            conformanceBeingChecked->getLoc(),
+            diag::assoc_conformance_from_implementation_only_module,
+            rootConformance->getType(),
+            rootConformance->getProtocol()->getName(), M->getName(),
+            depTy, replacementTy->getCanonicalType());
+      }
+    }
+
   public:
     GatherConformancesListener(
         NormalProtocolConformance *conformance,
-        std::function<void(ProtocolConformanceRef)> &writer)
-      : conformance(conformance), writer(writer) { }
+        std::function<void(ProtocolConformanceRef)> &writer,
+        SourceFile *fileForCheckingImplementationOnlyUse)
+      : conformanceBeingChecked(conformance),
+        SF(fileForCheckingImplementationOnlyUse), writer(writer) { }
 
     void satisfiedConformance(Type depTy, Type replacementTy,
                               ProtocolConformanceRef conformance) override {
       // The conformance will use contextual types, but we want the
       // interface type equivalent.
-      if (conformance.isConcrete() &&
-          conformance.getConcrete()->getType()->hasArchetype()) {
+      if (conformance.isConcrete()) {
         auto concreteConformance = conformance.getConcrete();
 
+        if (conformance.getConcrete()->getType()->hasArchetype()) {
         // Map the conformance.
         concreteConformance = concreteConformance->subst(
             [](SubstitutableType *type) -> Type {
@@ -3669,7 +3716,12 @@ void ConformanceChecker::ensureRequirementsAreSatisfied(
             },
             MakeAbstractConformanceForGenericType());
 
-        conformance = ProtocolConformanceRef(concreteConformance);
+
+          conformance = ProtocolConformanceRef(concreteConformance);
+        }
+
+        checkForImplementationOnlyUse(depTy, replacementTy,
+                                      concreteConformance);
       }
 
       writer(conformance);
@@ -3679,13 +3731,13 @@ void ConformanceChecker::ensureRequirementsAreSatisfied(
                       const Requirement &req, Type first, Type second,
                       ArrayRef<ParentConditionalConformance> parents) override {
       // Invalidate the conformance to suppress further diagnostics.
-      if (conformance->getLoc().isValid()) {
-        conformance->setInvalid();
+      if (conformanceBeingChecked->getLoc().isValid()) {
+        conformanceBeingChecked->setInvalid();
       }
 
       return false;
     }
-  } listener(Conformance, writer);
+  } listener(Conformance, writer, fileForCheckingImplementationOnlyUse);
 
   auto result = TC.checkGenericArguments(
       DC, Loc, Loc,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1742,6 +1742,13 @@ bool TypeChecker::validateType(TypeLoc &Loc, TypeResolution resolution,
   }
 
   Loc.setType(type);
+  if (!type->hasError()) {
+    const DeclContext *DC = resolution.getDeclContext();
+    if (options.isAnyExpr() || DC->getParent()->isLocalContext())
+      if (DC->getResilienceExpansion() == ResilienceExpansion::Minimal)
+        diagnoseGenericTypeExportability(Loc, DC);
+  }
+
   return type->hasError();
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1876,7 +1876,7 @@ public:
     PropertyInitializer
   };
 
-  bool diagnoseInlinableDeclRef(SourceLoc loc, const ValueDecl *D,
+  bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
                                 const DeclContext *DC,
                                 FragileFunctionKind Kind,
                                 bool TreatUsableFromInlineAsPublic);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1887,12 +1887,22 @@ private:
                                       FragileFunctionKind Kind,
                                       bool TreatUsableFromInlineAsPublic);
 
-public:
   /// Given that a declaration is used from a particular context which
   /// exposes it in the interface of the current module, diagnose if it cannot
   /// reasonably be shared.
-  bool diagnoseDeclRefExportability(SourceLoc loc, const ValueDecl *D,
+  bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
                                     const DeclContext *DC);
+
+public:
+  /// Given that a type is used from a particular context which
+  /// exposes it in the interface of the current module, diagnose if its
+  /// generic arguments require the use of conformances that cannot reasonably
+  /// be shared.
+  ///
+  /// This method \e only checks how generic arguments are used; it is assumed
+  /// that the declarations involved have already been checked elsewhere.
+  void diagnoseGenericTypeExportability(const TypeLoc &TL,
+                                        const DeclContext *DC);
 
   /// Given that \p DC is within a fragile context for some reason, describe
   /// why.

--- a/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
+++ b/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
@@ -1,3 +1,15 @@
+import NormalLibrary
+
+extension NormalStruct: NormalProto {
+  public typealias Assoc = Int
+}
+extension GenericStruct: NormalProto {
+  public typealias Assoc = Int
+}
+extension NormalClass: NormalProto {
+  public typealias Assoc = Int
+}
+
 public struct BadStruct {}
 public protocol BadProto {}
 open class BadClass {}

--- a/test/Sema/Inputs/implementation-only-import-in-decls-public-helper.swift
+++ b/test/Sema/Inputs/implementation-only-import-in-decls-public-helper.swift
@@ -1,0 +1,6 @@
+public struct NormalStruct {}
+public struct GenericStruct<T> {}
+public protocol NormalProto {
+  associatedtype Assoc
+}
+open class NormalClass {}

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -64,6 +64,7 @@ public protocol TestAssocTypeWhereClause {
 
 public enum TestRawType: IntLike { // expected-error {{cannot use 'IntLike' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
   case x = 1
+  // FIXME: expected-error@-1 {{cannot use conformance of 'IntLike' to 'Equatable' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
 }
 
 public class TestSubclass: BadClass { // expected-error {{cannot use 'BadClass' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
@@ -245,3 +246,13 @@ public struct RequirementsHandleSpecializationsToo: SlightlyMoreComplicatedRequi
 public struct ClassConstrainedGenericArg<T: NormalClass>: PublicInferredAssociatedType { // expected-error {{cannot use conformance of 'NormalClass' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'T'); 'BADLibrary' has been imported as '@_implementationOnly'}}
   public func takesAssoc(_: T) {}
 }
+
+
+public protocol RecursiveRequirements {
+  associatedtype Other: RecursiveRequirements
+}
+extension GenericStruct: RecursiveRequirements {
+  public typealias Other = GenericStruct<T>
+}
+public struct RecursiveRequirementsHolder<T: RecursiveRequirements> {}
+public func makeSureRecursiveRequirementsDontBreakEverything(_: RecursiveRequirementsHolder<GenericStruct<Int>>) {}

--- a/test/Sema/implementation-only-import-inlinable-conformances.swift
+++ b/test/Sema/implementation-only-import-inlinable-conformances.swift
@@ -1,0 +1,263 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t
+
+// RUN: %target-typecheck-verify-swift -I %t
+
+@_implementationOnly import BADLibrary
+import NormalLibrary
+
+@available(*, unavailable)
+public typealias X = Int
+
+public typealias NormalProtoAssoc<T: NormalProto> = T.Assoc
+@inlinable func testConformanceInTypealias() {
+  let x: NormalProtoAssoc<NormalStruct>? = nil // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  _ = x
+  _ = NormalProtoAssoc<NormalStruct>() // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+func internalConformanceInTypealias() {
+  let x: NormalProtoAssoc<NormalStruct>? = nil // okay
+  _ = x
+  _ = NormalProtoAssoc<NormalStruct>() // okay
+}
+
+public struct NormalProtoAssocHolder<T: NormalProto> {
+  public var value: T.Assoc?
+  public init() {}
+  public init(_ value: T?) {}
+}
+@inlinable func testConformanceInBoundGeneric() {
+  let x: NormalProtoAssocHolder<NormalStruct>? = nil // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  _ = x
+  // FIXME: We get this error twice: once for the TypeExpr and once for the implicit init.
+  _ = NormalProtoAssocHolder<NormalStruct>() // expected-error 2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  _ = NormalProtoAssocHolder(nil as NormalStruct?) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+func internalConformanceInBoundGeneric() {
+  let x: NormalProtoAssocHolder<NormalStruct>? = nil // okay
+  _ = x
+  _ = NormalProtoAssocHolder<NormalStruct>() // okay
+  _ = NormalProtoAssocHolder(nil as NormalStruct?) // okay
+}
+
+@inlinable func testDowncast(_ x: Any) -> Bool {
+  let normal = x is NormalProtoAssocHolder<NormalStruct> // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  let alias = x is NormalProtoAssoc<NormalStruct> // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  return normal || alias
+}
+
+func internalDowncast(_ x: Any) -> Bool {
+  let normal = x is NormalProtoAssocHolder<NormalStruct> // okay
+  let alias = x is NormalProtoAssoc<NormalStruct> // okay
+  return normal || alias
+}
+
+@inlinable func testSwitch(_ x: Any) {
+  switch x {
+  case let holder as NormalProtoAssocHolder<NormalStruct>: // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+    _ = holder
+    break
+  case is NormalProtoAssoc<NormalStruct>: // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+    break
+  default:
+    break
+  }
+}
+
+func internalSwitch(_ x: Any) {
+  switch x {
+  case let holder as NormalProtoAssocHolder<NormalStruct>: // okay
+    _ = holder
+    break
+  case is NormalProtoAssoc<NormalStruct>: // okay
+    break
+  default:
+    break
+  }
+}
+
+public enum NormalProtoEnumUser<T: NormalProto> {
+  case a
+}
+
+@inlinable func testEnum() {
+  // FIXME: We get this error twice: once for the pattern and once for the implicit TypeExpr.
+  let x: NormalProtoEnumUser<NormalStruct> = .a // expected-error 2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  _ = x
+  // FIXME: We get this error twice: once for the TypeExpr and once for the case.
+  _ = NormalProtoEnumUser<NormalStruct>.a // expected-error 2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+func internalEnum() {
+  let x: NormalProtoEnumUser<NormalStruct> = .a // okay
+  _ = x
+  _ = NormalProtoEnumUser<NormalStruct>.a // okay
+}
+
+@usableFromInline func testFuncImpl<T: NormalProto>(_: T.Type) {}
+
+@inlinable func testFunc() {
+  testFuncImpl(NormalStruct.self) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+func internalFunc() {
+  testFuncImpl(NormalStruct.self) // okay
+}
+
+public struct ForTestingMembers {
+  public init() {}
+  public init<T: NormalProto>(_: T.Type) {}
+
+  public subscript<T: NormalProto>(_: T.Type) -> Int {
+    get { return 0 }
+    set {}
+  }
+
+  public func method<T: NormalProto>(_: T.Type) {}
+}
+
+@inlinable func testMembers() {
+  _ = ForTestingMembers(NormalStruct.self) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  _ = ForTestingMembers.init(NormalStruct.self) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+  _ = ForTestingMembers()[NormalStruct.self] // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  var instance = ForTestingMembers()
+  instance[NormalStruct.self] = 1 // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+  ForTestingMembers().method(NormalStruct.self) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+extension NormalProtoAssocHolder {
+  public static func testAnotherConformance<U: NormalProto>(_: U.Type) {}
+}
+
+@inlinable func testMultipleConformances() {
+  _ = NormalProtoAssocHolder<NormalStruct>.testAnotherConformance(NormalClass.self)
+ // expected-error@-1 2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  // expected-error@-2 {{cannot use conformance of 'NormalClass' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@inlinable func localTypeAlias() {
+  typealias LocalUser = NormalProtoAssocHolder<NormalStruct> // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  typealias LocalGenericUser<T> = (T, NormalProtoAssocHolder<NormalStruct>) // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+  typealias LocalProtoAssoc<T: NormalProto> = T.Assoc
+  _ = LocalProtoAssoc<NormalStruct>() // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@inlinable func localFunctions() {
+  func local(_: NormalProtoAssocHolder<NormalStruct>) {} // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  func localReturn() -> NormalProtoAssocHolder<NormalStruct> { fatalError() } // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  let _ = { (_: NormalProtoAssocHolder<NormalStruct>) in return } // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  let _ = { () -> NormalProtoAssocHolder<NormalStruct> in fatalError() } // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+}
+
+@inlinable public func signatureOfInlinable(_: NormalProtoAssocHolder<NormalStruct>) {} // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public func testDefaultArgument(_: Int = NormalProtoAssoc<NormalStruct>()) {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+
+public class SubclassOfNormalClass: NormalClass {}
+
+public func testInheritedConformance(_: NormalProtoAssocHolder<SubclassOfNormalClass>) {} // expected-error {{cannot use conformance of 'NormalClass' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+public func testSpecializedConformance(_: NormalProtoAssocHolder<GenericStruct<Int>>) {} // expected-error {{cannot use conformance of 'GenericStruct<T>' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+extension Array where Element == NormalProtoAssocHolder<NormalStruct> { // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func testConstrainedExtensionUsingBadConformance() {}
+}
+
+public struct ConditionalGenericStruct<T> {}
+extension ConditionalGenericStruct: NormalProto where T: NormalProto {
+  public typealias Assoc = Int
+}
+public func testConditionalGeneric(_: NormalProtoAssocHolder<ConditionalGenericStruct<NormalStruct>>) {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public protocol PublicInferredAssociatedType {
+  associatedtype Assoc: NormalProto
+  func takesAssoc(_: Assoc)
+}
+@usableFromInline protocol UFIInferredAssociatedType {
+  associatedtype Assoc: NormalProto
+  func takesAssoc(_: Assoc)
+}
+protocol InternalInferredAssociatedType {
+  associatedtype Assoc: NormalProto
+  func takesAssoc(_: Assoc)
+}
+
+public struct PublicInferredAssociatedTypeImpl {
+  public func takesAssoc(_: NormalStruct) {}
+}
+extension PublicInferredAssociatedTypeImpl: PublicInferredAssociatedType {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'NormalStruct'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+extension PublicInferredAssociatedTypeImpl: UFIInferredAssociatedType {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'NormalStruct'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+extension PublicInferredAssociatedTypeImpl: InternalInferredAssociatedType {} // okay
+
+@usableFromInline struct UFIInferredAssociatedTypeImpl {
+  public func takesAssoc(_: NormalStruct) {}
+}
+extension UFIInferredAssociatedTypeImpl: PublicInferredAssociatedType {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'NormalStruct'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+extension UFIInferredAssociatedTypeImpl: UFIInferredAssociatedType {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'NormalStruct'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+extension UFIInferredAssociatedTypeImpl: InternalInferredAssociatedType {} // okay
+
+struct InternalInferredAssociatedTypeImpl {
+  public func takesAssoc(_: NormalStruct) {}
+}
+extension InternalInferredAssociatedTypeImpl: PublicInferredAssociatedType {} // okay
+extension InternalInferredAssociatedTypeImpl: UFIInferredAssociatedType {} // okay
+extension InternalInferredAssociatedTypeImpl: InternalInferredAssociatedType {} // okay
+
+
+public protocol BaseProtoWithNoRequirement {
+  associatedtype Assoc
+  func takesAssoc(_: Assoc)
+}
+public protocol RefinedProto: BaseProtoWithNoRequirement where Assoc: NormalProto {
+}
+
+public struct RefinedProtoImpl: RefinedProto { // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'NormalStruct'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func takesAssoc(_: NormalStruct) {}
+}
+
+public protocol RefinedSelfProto where Self: NormalProto {}
+extension NormalStruct: RefinedSelfProto {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+public protocol RefinedSelfProtoInheritance: NormalProto {}
+extension NormalStruct: RefinedSelfProtoInheritance {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as '@_implementationOnly'}}
+
+
+public protocol SlightlyMoreComplicatedRequirement {
+  associatedtype Assoc: Collection where Assoc.Element: NormalProto
+  func takesAssoc(_: Assoc)
+}
+public struct SlightlyMoreComplicatedRequirementImpl: SlightlyMoreComplicatedRequirement { // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc.Element' (inferred as 'NormalStruct'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func takesAssoc(_: [NormalStruct]) {}
+}
+public struct RequirementsHandleSubclassesToo: SlightlyMoreComplicatedRequirement { // expected-error {{cannot use conformance of 'NormalClass' to 'NormalProto' in associated type 'Self.Assoc.Element' (inferred as 'SubclassOfNormalClass'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func takesAssoc(_: [SubclassOfNormalClass]) {}
+}
+
+public struct RequirementsHandleSpecializationsToo: SlightlyMoreComplicatedRequirement { // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in associated type 'Self.Assoc.Element' (inferred as 'ConditionalGenericStruct<NormalStruct>'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func takesAssoc(_: [ConditionalGenericStruct<NormalStruct>]) {}
+}
+
+public struct ClassConstrainedGenericArg<T: NormalClass>: PublicInferredAssociatedType { // expected-error {{cannot use conformance of 'NormalClass' to 'NormalProto' in associated type 'Self.Assoc' (inferred as 'T'); 'BADLibrary' has been imported as '@_implementationOnly'}}
+  public func takesAssoc(_: T) {}
+}
+
+
+public protocol RecursiveRequirements {
+  associatedtype Other: RecursiveRequirements
+}
+extension GenericStruct: RecursiveRequirements {
+  public typealias Other = GenericStruct<T>
+}
+public struct RecursiveRequirementsHolder<T: RecursiveRequirements> {}
+public func makeSureRecursiveRequirementsDontBreakEverything(_: RecursiveRequirementsHolder<GenericStruct<Int>>) {}
+
+
+@inlinable func testFunctionBody() {
+  
+}

--- a/test/Sema/implementation-only-import-library-evolution.swift
+++ b/test/Sema/implementation-only-import-library-evolution.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift
+// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t
 
 // RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution
 


### PR DESCRIPTION
Continues building on John's #23702 and my #23722 to start checking the use of conformances. These also create a dependency on the implementation module, even if both the type and the protocol are public. As John puts it, a conformance is basically a declaration that we name as part of another declaration.

More rdar://problem/48991061