### PR TITLE
[build-script] Move HostSpecificConfiguration out of main script.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -41,6 +41,8 @@ from swift_build_support.swift_build_support.SwiftBuildSupport import (
     SWIFT_SOURCE_ROOT,
 )
 from swift_build_support.swift_build_support.cmake import CMake
+from swift_build_support.swift_build_support.host_specific_configuration \
+    import HostSpecificConfiguration
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
 from swift_build_support.swift_build_support.toolchain import host_toolchain
@@ -54,143 +56,6 @@ def exit_rejecting_arguments(message, parser=None):
     if parser:
         parser.print_usage(sys.stderr)
     sys.exit(2)  # 2 is the same as `argparse` error exit code.
-
-
-class HostSpecificConfiguration(object):
-
-    """Configuration information for an individual host."""
-
-    def __init__(self, host_target, invocation):
-        """Initialize for the given `host_target`."""
-
-        # Compute the set of deployment targets to configure/build.
-        args = invocation.args
-        if host_target == args.host_target:
-            # This host is the user's desired product, so honor the requested
-            # set of targets to configure/build.
-            stdlib_targets_to_configure = args.stdlib_deployment_targets
-            if "all" in args.build_stdlib_deployment_targets:
-                stdlib_targets_to_build = set(stdlib_targets_to_configure)
-            else:
-                stdlib_targets_to_build = set(
-                    args.build_stdlib_deployment_targets).intersection(
-                    set(args.stdlib_deployment_targets))
-        else:
-            # Otherwise, this is a host we are building as part of
-            # cross-compiling, so we only need the target itself.
-            stdlib_targets_to_configure = [host_target]
-            stdlib_targets_to_build = set(stdlib_targets_to_configure)
-
-        # Compute the lists of **CMake** targets for each use case (configure
-        # vs. build vs. run) and the SDKs to configure with.
-        self.sdks_to_configure = set()
-        self.swift_stdlib_build_targets = []
-        self.swift_test_run_targets = []
-        self.swift_benchmark_build_targets = []
-        self.swift_benchmark_run_targets = []
-        for deployment_target_name in stdlib_targets_to_configure:
-            # Get the target object.
-            deployment_target = StdlibDeploymentTarget.get_target_for_name(
-                deployment_target_name)
-            if deployment_target is None:
-                diagnostics.fatal("unknown target: %r" % (
-                    deployment_target_name,))
-
-            # Add the SDK to use.
-            deployment_platform = deployment_target.platform
-            self.sdks_to_configure.add(deployment_platform.sdk_name)
-
-            # If we aren't actually building this target (only configuring
-            # it), do nothing else.
-            if deployment_target_name not in stdlib_targets_to_build:
-                continue
-
-            # Compute which actions are desired.
-            build = (
-                deployment_platform not in invocation.platforms_to_skip_build)
-            test = (
-                deployment_platform not in invocation.platforms_to_skip_test)
-            test_host_only = None
-            dt_supports_benchmark = deployment_target.supports_benchmark
-            build_benchmarks = build and dt_supports_benchmark
-            build_external_benchmarks = all([build, dt_supports_benchmark,
-                                             args.build_external_benchmarks])
-
-            # FIXME: Note, `build-script-impl` computed a property here
-            # w.r.t. testing, but it was actually unused.
-
-            # For platforms which normally require a connected device to
-            # test, the default behavior is to run tests that only require
-            # the host (i.e., they do not attempt to execute).
-            if deployment_platform.uses_host_tests and \
-                    deployment_platform not in \
-                    invocation.platforms_to_skip_test_host:
-                test_host_only = True
-
-            name = deployment_target.name
-
-            for skip_test_arch in invocation.platforms_archs_to_skip_test:
-                if deployment_target.name == skip_test_arch.name:
-                    test = False
-
-            if build:
-                # Validation, long, and stress tests require building the full
-                # standard library, whereas the other targets can build a
-                # slightly smaller subset which is faster to build.
-                if args.build_swift_stdlib_unittest_extra or \
-                        args.validation_test or args.long_test or \
-                        args.stress_test:
-                    self.swift_stdlib_build_targets.append(
-                        "swift-stdlib-" + name)
-                else:
-                    self.swift_stdlib_build_targets.append(
-                        "swift-test-stdlib-" + name)
-            if build_benchmarks:
-                self.swift_benchmark_build_targets.append(
-                    "swift-benchmark-" + name)
-                if args.benchmark:
-                    self.swift_benchmark_run_targets.append(
-                        "check-swift-benchmark-" + name)
-
-            if build_external_benchmarks:
-                # Add support for the external benchmarks.
-                self.swift_benchmark_build_targets.append(
-                    "swift-benchmark-{}-external".format(name))
-                if args.benchmark:
-                    self.swift_benchmark_run_targets.append(
-                        "check-swift-benchmark-{}-external".format(name))
-            if test:
-                if test_host_only:
-                    suffix = "-only_non_executable"
-                else:
-                    suffix = ""
-                subset_suffix = ""
-                if args.validation_test and args.long_test and \
-                        args.stress_test:
-                    subset_suffix = "-all"
-                elif args.validation_test:
-                    subset_suffix = "-validation"
-                elif args.long_test:
-                    subset_suffix = "-only_long"
-                elif args.stress_test:
-                    subset_suffix = "-only_stress"
-                else:
-                    subset_suffix = ""
-                self.swift_test_run_targets.append("check-swift{}{}-{}".format(
-                    subset_suffix, suffix, name))
-                if args.test_optimized and not test_host_only:
-                    self.swift_test_run_targets.append(
-                        "check-swift{}-optimize-{}".format(
-                            subset_suffix, name))
-                if args.test_optimize_for_size and not test_host_only:
-                    self.swift_test_run_targets.append(
-                        "check-swift{}-optimize_size-{}".format(
-                            subset_suffix, name))
-                if args.test_optimize_none_implicit_dynamic and \
-                        not test_host_only:
-                    self.swift_test_run_targets.append(
-                        "check-swift{}-optimize_none_implicit_dynamic-{}"
-                        .format(subset_suffix, name))
 
 
 class BuildScriptInvocation(object):
@@ -317,91 +182,6 @@ class BuildScriptInvocation(object):
             source_root=SWIFT_SOURCE_ROOT,
             build_root=os.path.join(SWIFT_BUILD_ROOT, args.build_subdir))
 
-        # Compute derived information from the arguments.
-        #
-        # FIXME: We should move the platform-derived arguments to be entirely
-        # data driven, so that we can eliminate this code duplication and just
-        # iterate over all supported platforms.
-
-        self.platforms_to_skip_build = set()
-        if not args.build_linux:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
-        if not args.build_freebsd:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
-        if not args.build_cygwin:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
-        if not args.build_osx:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
-        if not args.build_ios_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
-        if not args.build_ios_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.iOSSimulator)
-        if not args.build_tvos_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
-        if not args.build_tvos_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.AppleTVSimulator)
-        if not args.build_watchos_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
-        if not args.build_watchos_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.AppleWatchSimulator)
-        if not args.build_android:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
-
-        self.platforms_to_skip_test = set()
-        self.platforms_archs_to_skip_test = set()
-        if not args.test_linux:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
-        if not args.test_freebsd:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
-        if not args.test_cygwin:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
-        if not args.test_osx:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
-        if not args.test_ios_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
-        else:
-            exit_rejecting_arguments("error: iOS device tests are not " +
-                                     "supported in open-source Swift.")
-        if not args.test_ios_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.iOSSimulator)
-        if not args.test_ios_32bit_simulator:
-            self.platforms_archs_to_skip_test.add(
-                StdlibDeploymentTarget.iOSSimulator.i386)
-        if not args.test_tvos_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
-        else:
-            exit_rejecting_arguments("error: tvOS device tests are not " +
-                                     "supported in open-source Swift.")
-        if not args.test_tvos_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.AppleTVSimulator)
-        if not args.test_watchos_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
-        else:
-            exit_rejecting_arguments("error: watchOS device tests are not " +
-                                     "supported in open-source Swift.")
-        if not args.test_watchos_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.AppleWatchSimulator)
-        if not args.test_android:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
-
-        self.platforms_to_skip_test_host = set()
-        if not args.test_android_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.Android)
-        if not args.test_ios_host:
-            self.platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
-        if not args.test_tvos_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.AppleTV)
-        if not args.test_watchos_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.AppleWatch)
         self.build_libparser_only = args.build_libparser_only
 
     def initialize_runtime_environment(self):
@@ -821,7 +601,10 @@ class BuildScriptInvocation(object):
         options = {}
         for host_target in [args.host_target] + args.cross_compile_hosts:
             # Compute the host specific configuration.
-            config = HostSpecificConfiguration(host_target, self)
+            try:
+                config = HostSpecificConfiguration(self.args, host_target)
+            except argparse.ArgumentError as e:
+                exit_rejecting_arguments(e.message)
 
             # Convert into `build-script-impl` style variables.
             options[host_target] = {
@@ -934,7 +717,10 @@ class BuildScriptInvocation(object):
         # Build...
         for host_target in all_hosts:
             # FIXME: We should only compute these once.
-            config = HostSpecificConfiguration(host_target.name, self)
+            try:
+                config = HostSpecificConfiguration(self.args, host_target.name)
+            except argparse.ArgumentError as e:
+                exit_rejecting_arguments(e.message)
             print("Building the standard library for: {}".format(
                 " ".join(config.swift_stdlib_build_targets)))
             if config.swift_test_run_targets and (

--- a/utils/swift_build_support/swift_build_support/__init__.py
+++ b/utils/swift_build_support/swift_build_support/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "cmake",
     "debug",
     "diagnostics",
+    "host_specific_configuration",
     "migration",
     "tar",
     "targets",

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -1,0 +1,250 @@
+# swift_build_support/host_configuration_support.py -------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from argparse import ArgumentError
+
+import diagnostics
+
+from .targets import StdlibDeploymentTarget
+
+
+class HostSpecificConfiguration(object):
+
+    """Configuration information for an individual host."""
+
+    def __init__(self, args, host_target):
+        """Initialize for the given `host_target`."""
+
+        # Compute the set of deployment targets to configure/build.
+        if host_target == args.host_target:
+            # This host is the user's desired product, so honor the requested
+            # set of targets to configure/build.
+            stdlib_targets_to_configure = args.stdlib_deployment_targets
+            if "all" in args.build_stdlib_deployment_targets:
+                stdlib_targets_to_build = set(stdlib_targets_to_configure)
+            else:
+                stdlib_targets_to_build = set(
+                    args.build_stdlib_deployment_targets).intersection(
+                    set(args.stdlib_deployment_targets))
+        else:
+            # Otherwise, this is a host we are building as part of
+            # cross-compiling, so we only need the target itself.
+            stdlib_targets_to_configure = [host_target]
+            stdlib_targets_to_build = set(stdlib_targets_to_configure)
+
+        # Compute derived information from the arguments.
+        #
+        # FIXME: We should move the platform-derived arguments to be entirely
+        # data driven, so that we can eliminate this code duplication and just
+        # iterate over all supported platforms.
+        platforms_to_skip_build = self.__platforms_to_skip_build(args)
+        platforms_to_skip_test = self.__platforms_to_skip_test(args)
+        platforms_archs_to_skip_test = \
+            self.__platforms_archs_to_skip_test(args)
+        platforms_to_skip_test_host = self.__platforms_to_skip_test_host(args)
+
+        # Compute the lists of **CMake** targets for each use case (configure
+        # vs. build vs. run) and the SDKs to configure with.
+        self.sdks_to_configure = set()
+        self.swift_stdlib_build_targets = []
+        self.swift_test_run_targets = []
+        self.swift_benchmark_build_targets = []
+        self.swift_benchmark_run_targets = []
+        for deployment_target_name in stdlib_targets_to_configure:
+            # Get the target object.
+            deployment_target = StdlibDeploymentTarget.get_target_for_name(
+                deployment_target_name)
+            if deployment_target is None:
+                diagnostics.fatal("unknown target: %r" % (
+                    deployment_target_name,))
+
+            # Add the SDK to use.
+            deployment_platform = deployment_target.platform
+            self.sdks_to_configure.add(deployment_platform.sdk_name)
+
+            # If we aren't actually building this target (only configuring
+            # it), do nothing else.
+            if deployment_target_name not in stdlib_targets_to_build:
+                continue
+
+            # Compute which actions are desired.
+            build = (
+                deployment_platform not in platforms_to_skip_build)
+            test = (
+                deployment_platform not in platforms_to_skip_test)
+            test_host_only = None
+            dt_supports_benchmark = deployment_target.supports_benchmark
+            build_benchmarks = build and dt_supports_benchmark
+            build_external_benchmarks = all([build, dt_supports_benchmark,
+                                             args.build_external_benchmarks])
+
+            # FIXME: Note, `build-script-impl` computed a property here
+            # w.r.t. testing, but it was actually unused.
+
+            # For platforms which normally require a connected device to
+            # test, the default behavior is to run tests that only require
+            # the host (i.e., they do not attempt to execute).
+            if deployment_platform.uses_host_tests and \
+                    deployment_platform not in platforms_to_skip_test_host:
+                test_host_only = True
+
+            name = deployment_target.name
+
+            for skip_test_arch in platforms_archs_to_skip_test:
+                if deployment_target.name == skip_test_arch.name:
+                    test = False
+
+            if build:
+                # Validation, long, and stress tests require building the full
+                # standard library, whereas the other targets can build a
+                # slightly smaller subset which is faster to build.
+                if args.build_swift_stdlib_unittest_extra or \
+                        args.validation_test or args.long_test or \
+                        args.stress_test:
+                    self.swift_stdlib_build_targets.append(
+                        "swift-stdlib-" + name)
+                else:
+                    self.swift_stdlib_build_targets.append(
+                        "swift-test-stdlib-" + name)
+            if build_benchmarks:
+                self.swift_benchmark_build_targets.append(
+                    "swift-benchmark-" + name)
+                if args.benchmark:
+                    self.swift_benchmark_run_targets.append(
+                        "check-swift-benchmark-" + name)
+
+            if build_external_benchmarks:
+                # Add support for the external benchmarks.
+                self.swift_benchmark_build_targets.append(
+                    "swift-benchmark-{}-external".format(name))
+                if args.benchmark:
+                    self.swift_benchmark_run_targets.append(
+                        "check-swift-benchmark-{}-external".format(name))
+            if test:
+                if test_host_only:
+                    suffix = "-only_non_executable"
+                else:
+                    suffix = ""
+                subset_suffix = ""
+                if args.validation_test and args.long_test and \
+                        args.stress_test:
+                    subset_suffix = "-all"
+                elif args.validation_test:
+                    subset_suffix = "-validation"
+                elif args.long_test:
+                    subset_suffix = "-only_long"
+                elif args.stress_test:
+                    subset_suffix = "-only_stress"
+                else:
+                    subset_suffix = ""
+                self.swift_test_run_targets.append("check-swift{}{}-{}".format(
+                    subset_suffix, suffix, name))
+                if args.test_optimized and not test_host_only:
+                    self.swift_test_run_targets.append(
+                        "check-swift{}-optimize-{}".format(
+                            subset_suffix, name))
+                if args.test_optimize_for_size and not test_host_only:
+                    self.swift_test_run_targets.append(
+                        "check-swift{}-optimize_size-{}".format(
+                            subset_suffix, name))
+                if args.test_optimize_none_implicit_dynamic and \
+                        not test_host_only:
+                    self.swift_test_run_targets.append(
+                        "check-swift{}-optimize_none_implicit_dynamic-{}"
+                        .format(subset_suffix, name))
+
+    def __platforms_to_skip_build(self, args):
+        platforms_to_skip_build = set()
+        if not args.build_linux:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
+        if not args.build_freebsd:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
+        if not args.build_cygwin:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
+        if not args.build_osx:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
+        if not args.build_ios_device:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
+        if not args.build_ios_simulator:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.iOSSimulator)
+        if not args.build_tvos_device:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
+        if not args.build_tvos_simulator:
+            platforms_to_skip_build.add(
+                StdlibDeploymentTarget.AppleTVSimulator)
+        if not args.build_watchos_device:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
+        if not args.build_watchos_simulator:
+            platforms_to_skip_build.add(
+                StdlibDeploymentTarget.AppleWatchSimulator)
+        if not args.build_android:
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
+        return platforms_to_skip_build
+
+    def __platforms_to_skip_test(self, args):
+        platforms_to_skip_test = set()
+        if not args.test_linux:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
+        if not args.test_freebsd:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
+        if not args.test_cygwin:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
+        if not args.test_osx:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
+        if not args.test_ios_host:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
+        else:
+            raise ArgumentError(None,
+                                "error: iOS device tests are not " +
+                                "supported in open-source Swift.")
+        if not args.test_ios_simulator:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.iOSSimulator)
+        if not args.test_tvos_host:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
+        else:
+            raise ArgumentError(None,
+                                "error: tvOS device tests are not " +
+                                "supported in open-source Swift.")
+        if not args.test_tvos_simulator:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTVSimulator)
+        if not args.test_watchos_host:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
+        else:
+            raise ArgumentError(None,
+                                "error: watchOS device tests are not " +
+                                "supported in open-source Swift.")
+        if not args.test_watchos_simulator:
+            platforms_to_skip_test.add(
+                StdlibDeploymentTarget.AppleWatchSimulator)
+        if not args.test_android:
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
+
+        return platforms_to_skip_test
+
+    def __platforms_archs_to_skip_test(self, args):
+        platforms_archs_to_skip_test = set()
+        if not args.test_ios_32bit_simulator:
+            platforms_archs_to_skip_test.add(
+                StdlibDeploymentTarget.iOSSimulator.i386)
+        return platforms_archs_to_skip_test
+
+    def __platforms_to_skip_test_host(self, args):
+        platforms_to_skip_test_host = set()
+        if not args.test_android_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.Android)
+        if not args.test_ios_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
+        if not args.test_tvos_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleTV)
+        if not args.test_watchos_host:
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleWatch)
+        return platforms_to_skip_test_host

--- a/utils/swift_build_support/tests/test_host_specific_configuration.py
+++ b/utils/swift_build_support/tests/test_host_specific_configuration.py
@@ -1,0 +1,623 @@
+# -*- python -*-
+# test_host_specific_configuration.py - Unit tests for
+# swift_build_support.host_specific_configuration
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import unittest
+from argparse import Namespace
+
+from swift_build_support.host_specific_configuration import \
+    HostSpecificConfiguration
+
+
+class ToolchainTestCase(unittest.TestCase):
+
+    def test_should_configure_and_build_when_deployment_is_all(self):
+        host_target = 'macosx-x86_64'
+        args = self.default_args()
+        args.build_osx = True
+        args.build_ios_device = True
+        args.host_target = host_target
+        args.stdlib_deployment_targets = [host_target, 'iphoneos-arm64']
+        args.build_stdlib_deployment_targets = 'all'
+
+        hsc = HostSpecificConfiguration(args, host_target)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 2)
+        self.assertIn('OSX', hsc.sdks_to_configure)
+        self.assertIn('IOS', hsc.sdks_to_configure)
+
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 2)
+        self.assertIn('swift-test-stdlib-macosx-x86_64',
+                      hsc.swift_stdlib_build_targets)
+        self.assertIn('swift-test-stdlib-iphoneos-arm64',
+                      hsc.swift_stdlib_build_targets)
+
+    def test_should_only_deployment_if_specified(self):
+        host_target = 'macosx-x86_64'
+        args = self.default_args()
+        args.build_osx = True
+        args.build_ios_device = True
+        args.host_target = host_target
+        args.stdlib_deployment_targets = [host_target, 'iphoneos-arm64']
+        args.build_stdlib_deployment_targets = ['iphoneos-arm64']
+
+        hsc = HostSpecificConfiguration(args, host_target)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 2)
+        self.assertIn('OSX', hsc.sdks_to_configure)
+        self.assertIn('IOS', hsc.sdks_to_configure)
+
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 1)
+        self.assertIn('swift-test-stdlib-iphoneos-arm64',
+                      hsc.swift_stdlib_build_targets)
+
+    def test_should_configure_and_build_when_cross_compiling(self):
+        args = self.default_args()
+        args.build_ios_device = True
+        args.host_target = 'macosx-x86_64'
+
+        hsc = HostSpecificConfiguration(args, 'iphoneos-arm64')
+
+        self.assertEqual(len(hsc.sdks_to_configure), 1)
+        self.assertIn('IOS', hsc.sdks_to_configure)
+
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 1)
+        self.assertIn('swift-test-stdlib-iphoneos-arm64',
+                      hsc.swift_stdlib_build_targets)
+
+    def generate_should_skip_building_platform(
+            host_target, sdk_name, build_target, build_arg_name):
+        def test(self):
+            args = self.default_args()
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertIn(sdk_name, before.sdks_to_configure)
+            self.assertNotIn(build_target, before.swift_stdlib_build_targets)
+
+            setattr(args, build_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn(sdk_name, after.sdks_to_configure)
+            self.assertIn(build_target, after.swift_stdlib_build_targets)
+        return test
+
+    test_should_skip_building_android =\
+        generate_should_skip_building_platform(
+            'android-armv7',
+            'ANDROID',
+            'swift-test-stdlib-android-armv7',
+            'build_android')
+    test_should_skip_building_cygwin =\
+        generate_should_skip_building_platform(
+            'cygwin-x86_64',
+            'CYGWIN',
+            'swift-test-stdlib-cygwin-x86_64',
+            'build_cygwin')
+    test_should_skip_building_freebsd =\
+        generate_should_skip_building_platform(
+            'freebsd-x86_64',
+            'FREEBSD',
+            'swift-test-stdlib-freebsd-x86_64',
+            'build_freebsd')
+    test_should_skip_building_ios =\
+        generate_should_skip_building_platform(
+            'iphoneos-arm64',
+            'IOS',
+            'swift-test-stdlib-iphoneos-arm64',
+            'build_ios_device')
+    test_should_skip_building_ios_sim =\
+        generate_should_skip_building_platform(
+            'iphonesimulator-x86_64',
+            'IOS_SIMULATOR',
+            'swift-test-stdlib-iphonesimulator-x86_64',
+            'build_ios_simulator')
+    test_should_skip_building_linux =\
+        generate_should_skip_building_platform(
+            'linux-x86_64',
+            'LINUX',
+            'swift-test-stdlib-linux-x86_64',
+            'build_linux')
+    test_should_skip_building_osx =\
+        generate_should_skip_building_platform(
+            'macosx-x86_64',
+            'OSX',
+            'swift-test-stdlib-macosx-x86_64',
+            'build_osx')
+    test_should_skip_building_tvos =\
+        generate_should_skip_building_platform(
+            'appletvos-arm64',
+            'TVOS',
+            'swift-test-stdlib-appletvos-arm64',
+            'build_tvos_device')
+    test_should_skip_building_tvos_sim =\
+        generate_should_skip_building_platform(
+            'appletvsimulator-x86_64', 'TVOS_SIMULATOR',
+            'swift-test-stdlib-appletvsimulator-x86_64',
+            'build_tvos_simulator')
+    test_should_skip_building_watchos =\
+        generate_should_skip_building_platform(
+            'watchos-armv7k',
+            'WATCHOS',
+            'swift-test-stdlib-watchos-armv7k',
+            'build_watchos_device')
+    test_should_skip_building_watchos_sim =\
+        generate_should_skip_building_platform(
+            'watchsimulator-i386',
+            'WATCHOS_SIMULATOR',
+            'swift-test-stdlib-watchsimulator-i386',
+            'build_watchos_simulator')
+
+    def generate_should_build_full_targets_when_test(test_arg_name):
+        def test(self):
+            host_target = 'macosx-x86_64'
+            args = self.default_args()
+            args.build_osx = True
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertIn('swift-test-stdlib-macosx-x86_64',
+                          before.swift_stdlib_build_targets)
+            self.assertNotIn('swift-stdlib-macosx-x86_64',
+                             before.swift_stdlib_build_targets)
+
+            setattr(args, test_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn('swift-stdlib-macosx-x86_64',
+                          after.swift_stdlib_build_targets)
+            self.assertNotIn('swift-test-stdlib-macosx-x86_64',
+                             after.swift_stdlib_build_targets)
+        return test
+
+    test_should_build_full_targets_when_unittest_extra =\
+        generate_should_build_full_targets_when_test(
+            'build_swift_stdlib_unittest_extra')
+    test_should_build_full_targets_when_validation_test =\
+        generate_should_build_full_targets_when_test(
+            'validation_test')
+    test_should_build_full_targets_when_long_test =\
+        generate_should_build_full_targets_when_test(
+            'long_test')
+    test_should_build_full_targets_when_stress_test =\
+        generate_should_build_full_targets_when_test(
+            'stress_test')
+
+    def generate_should_skip_testing_platform(
+            host_target, build_arg_name, test_arg_name):
+        def test(self):
+            args = self.default_args()
+            setattr(args, build_arg_name, True)
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertEqual(len(before.swift_test_run_targets), 0)
+
+            setattr(args, test_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn('check-swift-{}'.format(host_target),
+                          after.swift_test_run_targets)
+        return test
+
+    test_should_skip_testing_android =\
+        generate_should_skip_testing_platform(
+            'android-armv7',
+            'build_android',
+            'test_android')
+    test_should_skip_testing_cygwin =\
+        generate_should_skip_testing_platform(
+            'cygwin-x86_64',
+            'build_cygwin',
+            'test_cygwin')
+    test_should_skip_testing_freebsd =\
+        generate_should_skip_testing_platform(
+            'freebsd-x86_64',
+            'build_freebsd',
+            'test_freebsd')
+    # NOTE: test_ios_host is not supported in open-source Swift
+    test_should_skip_testing_ios_sim =\
+        generate_should_skip_testing_platform(
+            'iphonesimulator-x86_64',
+            'build_ios_simulator',
+            'test_ios_simulator')
+    test_should_skip_testing_linux =\
+        generate_should_skip_testing_platform(
+            'linux-x86_64',
+            'build_linux',
+            'test_linux')
+    test_should_skip_testing_osx =\
+        generate_should_skip_testing_platform(
+            'macosx-x86_64',
+            'build_osx',
+            'test_osx')
+    # NOTE: test_tvos_host is not supported in open-source Swift
+    test_should_skip_testing_tvos_sim =\
+        generate_should_skip_testing_platform(
+            'appletvsimulator-x86_64',
+            'build_tvos_simulator',
+            'test_tvos_simulator')
+    # NOTE: test_watchos_host is not supported in open-source Swift
+    test_should_skip_testing_watchos_sim =\
+        generate_should_skip_testing_platform(
+            'watchsimulator-i386',
+            'build_watchos_simulator',
+            'test_watchos_simulator')
+
+    def test_should_skip_testing_32bit_ios(self):
+        host_target = 'iphonesimulator-i386'
+        args = self.default_args()
+        args.build_ios_simulator = True
+        args.test_ios_simulator = True
+        args.host_target = host_target
+        args.stdlib_deployment_targets = [host_target]
+        args.build_stdlib_deployment_targets = 'all'
+
+        before = HostSpecificConfiguration(args, host_target)
+        self.assertEqual(len(before.swift_test_run_targets), 0)
+
+        args.test_ios_32bit_simulator = True
+        after = HostSpecificConfiguration(args, host_target)
+        self.assertIn('check-swift-iphonesimulator-i386',
+                      after.swift_test_run_targets)
+
+    def generate_should_allow_testing_only_host(
+            host_target, build_arg_name, test_arg_name, host_test_arg_name):
+        def test(self):
+            args = self.default_args()
+            setattr(args, build_arg_name, True)
+            setattr(args, test_arg_name, True)
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertIn('check-swift-{}'.format(host_target),
+                          before.swift_test_run_targets)
+
+            setattr(args, host_test_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn(
+                'check-swift-only_non_executable-{}'.format(host_target),
+                after.swift_test_run_targets)
+        return test
+
+    test_should_allow_testing_only_host_android =\
+        generate_should_allow_testing_only_host(
+            'android-armv7',
+            'build_android',
+            'test_android',
+            'test_android_host')
+    # NOTE: test_ios_host is not supported in open-source Swift
+    # NOTE: test_tvos_host is not supported in open-source Swift
+    # NOTE: test_watchos_host is not supported in open-source Swift
+
+    def generate_should_build_benchmarks(host_target, build_arg_name):
+        def test(self):
+            args = self.default_args()
+            setattr(args, build_arg_name, True)
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            with_benchmark = HostSpecificConfiguration(args, host_target)
+            self.assertIn('swift-benchmark-{}'.format(host_target),
+                          with_benchmark.swift_benchmark_build_targets)
+            self.assertNotIn('check-swift-benchmark-{}'.format(host_target),
+                             with_benchmark.swift_benchmark_run_targets)
+
+            args.benchmark = True
+            running_benchmarks = HostSpecificConfiguration(args, host_target)
+            self.assertIn('swift-benchmark-{}'.format(host_target),
+                          running_benchmarks.swift_benchmark_build_targets)
+            self.assertIn('check-swift-benchmark-{}'.format(host_target),
+                          running_benchmarks.swift_benchmark_run_targets)
+
+            args.build_external_benchmarks = True
+            with_external_benchmarks = HostSpecificConfiguration(args,
+                                                                 host_target)
+            self.assertIn(
+                'swift-benchmark-{}'.format(host_target),
+                with_external_benchmarks.swift_benchmark_build_targets)
+            self.assertIn(
+                'swift-benchmark-{}-external'.format(host_target),
+                with_external_benchmarks.swift_benchmark_build_targets)
+            self.assertIn('check-swift-benchmark-{}'.format(host_target),
+                          with_external_benchmarks.swift_benchmark_run_targets)
+            self.assertIn(
+                'check-swift-benchmark-{}-external'.format(host_target),
+                with_external_benchmarks.swift_benchmark_run_targets)
+
+            args.benchmark = False
+            not_running_benchmarks = HostSpecificConfiguration(args,
+                                                               host_target)
+            self.assertIn('swift-benchmark-{}'.format(host_target),
+                          not_running_benchmarks.swift_benchmark_build_targets)
+            self.assertIn('swift-benchmark-{}-external'.format(host_target),
+                          not_running_benchmarks.swift_benchmark_build_targets)
+            self.assertNotIn(
+                'check-swift-benchmark-{}'.format(host_target),
+                not_running_benchmarks.swift_benchmark_run_targets)
+            self.assertNotIn(
+                'check-swift-benchmark-{}-external'.format(host_target),
+                not_running_benchmarks.swift_benchmark_run_targets)
+        return test
+
+    test_should_build_and_run_benchmarks_osx_x86_64 =\
+        generate_should_build_benchmarks(
+            'macosx-x86_64',
+            'build_osx')
+    test_should_build_and_run_benchmarks_ios_armv7 =\
+        generate_should_build_benchmarks(
+            'iphoneos-armv7',
+            'build_ios_device')
+    test_should_build_and_run_benchmarks_ios_arm64 =\
+        generate_should_build_benchmarks(
+            'iphoneos-arm64',
+            'build_ios_device')
+    test_should_build_and_run_benchmarks_tvos_arm64 =\
+        generate_should_build_benchmarks(
+            'appletvos-arm64',
+            'build_tvos_device')
+    test_should_build_and_run_benchmarks_watchos_armv7k =\
+        generate_should_build_benchmarks(
+            'watchos-armv7k',
+            'build_watchos_device')
+    # NOTE: other platforms/architectures do not support benchmarks
+
+    def generate_should_test_only_subset(subset_name, subset_arg_name):
+        def test(self):
+            host_target = 'macosx-x86_64'
+            args = self.default_args()
+            args.build_osx = True
+            args.test_osx = True
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            all = 'check-swift-macosx-x86_64'
+            subset = 'check-swift-{}-macosx-x86_64'.format(subset_name)
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertIn(all, before.swift_test_run_targets)
+            self.assertNotIn(subset, before.swift_test_run_targets)
+
+            setattr(args, subset_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn(subset, after.swift_test_run_targets)
+            self.assertNotIn(all, after.swift_test_run_targets)
+        return test
+
+    test_should_test_only_subset_validation =\
+        generate_should_test_only_subset('validation', 'validation_test')
+    test_should_test_only_subset_long =\
+        generate_should_test_only_subset('only_long', 'long_test')
+    test_should_test_only_subset_stress =\
+        generate_should_test_only_subset('only_stress', 'stress_test')
+
+    def test_should_test_all_when_validation_long_and_stress(self):
+        host_target = 'macosx-x86_64'
+        args = self.default_args()
+        args.build_osx = True
+        args.test_osx = True
+        args.host_target = host_target
+        args.stdlib_deployment_targets = [host_target]
+        args.build_stdlib_deployment_targets = 'all'
+
+        all = 'check-swift-macosx-x86_64'
+        subset = 'check-swift-all-macosx-x86_64'
+
+        before = HostSpecificConfiguration(args, host_target)
+        self.assertIn(all, before.swift_test_run_targets)
+        self.assertNotIn(subset, before.swift_test_run_targets)
+
+        args.validation_test = True
+        args.long_test = True
+        args.stress_test = True
+        after = HostSpecificConfiguration(args, host_target)
+        self.assertIn(subset, after.swift_test_run_targets)
+        self.assertNotIn(all, after.swift_test_run_targets)
+
+    def generate_should_test_only_subset_for_host_only_tests(
+            subset_name, subset_arg_name):
+        def test(self):
+            host_target = 'android-armv7'
+            args = self.default_args()
+            args.build_android = True
+            args.test_android = True
+            args.test_android_host = True
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            all = 'check-swift-only_non_executable-android-armv7'
+            subset = 'check-swift-{}-only_non_executable-android-armv7'\
+                .format(subset_name)
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertIn(all, before.swift_test_run_targets)
+            self.assertNotIn(subset, before.swift_test_run_targets)
+
+            setattr(args, subset_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn(subset, after.swift_test_run_targets)
+            self.assertNotIn(all, after.swift_test_run_targets)
+        return test
+
+    test_should_test_only_subset_for_host_only_tests_validation =\
+        generate_should_test_only_subset_for_host_only_tests(
+            'validation',
+            'validation_test')
+    test_should_test_only_subset_for_host_only_tests_long =\
+        generate_should_test_only_subset_for_host_only_tests(
+            'only_long',
+            'long_test')
+    test_should_test_only_subset_for_host_only_tests_stress =\
+        generate_should_test_only_subset_for_host_only_tests(
+            'only_stress',
+            'stress_test')
+
+    def test_should_test_all_when_validation_long_and_stress_with_host_only(
+            self):
+        host_target = 'android-armv7'
+        args = self.default_args()
+        args.build_android = True
+        args.test_android = True
+        args.test_android_host = True
+        args.host_target = host_target
+        args.stdlib_deployment_targets = [host_target]
+        args.build_stdlib_deployment_targets = 'all'
+
+        all = 'check-swift-only_non_executable-android-armv7'
+        subset = 'check-swift-all-only_non_executable-android-armv7'
+
+        before = HostSpecificConfiguration(args, host_target)
+        self.assertIn(all, before.swift_test_run_targets)
+        self.assertNotIn(subset, before.swift_test_run_targets)
+
+        args.validation_test = True
+        args.long_test = True
+        args.stress_test = True
+        after = HostSpecificConfiguration(args, host_target)
+        self.assertIn(subset, after.swift_test_run_targets)
+        self.assertNotIn(all, after.swift_test_run_targets)
+
+    def generate_should_test_optimizations(
+            optimize_name, optimize_arg_name):
+        def test(self):
+            host_target = 'macosx-x86_64'
+            args = self.default_args()
+            args.build_osx = True
+            args.test_osx = True
+            args.host_target = host_target
+            args.stdlib_deployment_targets = [host_target]
+            args.build_stdlib_deployment_targets = 'all'
+
+            target = 'check-swift-{}-macosx-x86_64'.format(optimize_name)
+
+            before = HostSpecificConfiguration(args, host_target)
+            self.assertNotIn(target, before.swift_test_run_targets)
+
+            setattr(args, optimize_arg_name, True)
+            after = HostSpecificConfiguration(args, host_target)
+            self.assertIn(target, after.swift_test_run_targets)
+        return test
+
+    test_should_test_optimizations =\
+        generate_should_test_optimizations(
+            'optimize',
+            'test_optimized')
+    test_should_test_optimizations_size =\
+        generate_should_test_optimizations(
+            'optimize_size',
+            'test_optimize_for_size')
+    test_should_test_optimizations_none_implicit_dynamic =\
+        generate_should_test_optimizations(
+            'optimize_none_implicit_dynamic',
+            'test_optimize_none_implicit_dynamic')
+
+    def test_should_not_test_optimizations_when_testing_only_host(self):
+        host_target = 'android-armv7'
+        args = self.default_args()
+        args.host_target = host_target
+        args.build_android = True
+        args.test_android = True
+        args.stdlib_deployment_targets = [host_target]
+        args.build_stdlib_deployment_targets = 'all'
+        args.test_optimized = True
+        args.test_optimize_for_size = True
+        args.test_optimize_none_implicit_dynamic = True
+
+        before = HostSpecificConfiguration(args, host_target)
+        self.assertIn('check-swift-optimize-android-armv7',
+                      before.swift_test_run_targets)
+        self.assertIn('check-swift-optimize_size-android-armv7',
+                      before.swift_test_run_targets)
+        self.assertIn(
+            'check-swift-optimize_none_implicit_dynamic-android-armv7',
+            before.swift_test_run_targets)
+
+        args.test_android_host = True
+        after = HostSpecificConfiguration(args, host_target)
+        self.assertNotIn('check-swift-optimize-android-armv7',
+                         after.swift_test_run_targets)
+        self.assertNotIn(
+            'check-swift-optimize_size-android-armv7',
+            after.swift_test_run_targets)
+        self.assertNotIn(
+            'check-swift-optimize_none_implicit_dynamic-android-armv7',
+            after.swift_test_run_targets)
+
+    def test_should_test_optimizations_with_subsets(self):
+        host_target = 'android-armv7'
+        args = self.default_args()
+        args.host_target = host_target
+        args.build_android = True
+        args.test_android = True
+        args.stdlib_deployment_targets = [host_target]
+        args.build_stdlib_deployment_targets = 'all'
+        args.test_optimized = True
+        args.test_optimize_for_size = True
+        args.test_optimize_none_implicit_dynamic = True
+        args.long_test = True
+
+        target_name = 'check-swift-only_long-{}-android-armv7'
+
+        before = HostSpecificConfiguration(args, host_target)
+        self.assertIn(target_name.format('optimize'),
+                      before.swift_test_run_targets)
+        self.assertIn(target_name.format('optimize_size'),
+                      before.swift_test_run_targets)
+        self.assertIn(target_name.format('optimize_none_implicit_dynamic'),
+                      before.swift_test_run_targets)
+
+    def default_args(self):
+        return Namespace(
+            benchmark=False,
+            build_android=False,
+            build_cygwin=False,
+            build_external_benchmarks=False,
+            build_freebsd=False,
+            build_ios_device=False,
+            build_ios_simulator=False,
+            build_linux=False,
+            build_osx=False,
+            build_swift_stdlib_unittest_extra=False,
+            build_tvos_device=False,
+            build_tvos_simulator=False,
+            build_watchos_device=False,
+            build_watchos_simulator=False,
+            long_test=False,
+            stress_test=False,
+            test_android=False,
+            test_android_host=False,
+            test_cygwin=False,
+            test_freebsd=False,
+            test_ios_host=False,
+            test_ios_simulator=False,
+            test_ios_32bit_simulator=False,
+            test_linux=False,
+            test_optimize_for_size=False,
+            test_optimize_none_implicit_dynamic=False,
+            test_optimized=False,
+            test_osx=False,
+            test_tvos_host=False,
+            test_tvos_simulator=False,
+            test_watchos_host=False,
+            test_watchos_simulator=False,
+            validation_test=False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This will allow using `HostSpecificConfiguration` from other parts that
are not the main script in the future. This is interesting because the information is mostly useful when building Swift. The rest of the products are not really interested in the results of this calculations.

Additionally, a lot of code that was part of `BuildScriptInvocation` has
been moved into `HostSpecificConfiguration` because nobody else needed it,
and `HostSpecificConfiguration` was highly coupled with the Invocation
object (through one of its arguments). This should make the
`HostSpecificConfiguration` object a better citizen in other scenarios.

Includes a suite of tests that check the implementation correctly calculates the right targets to build under diverse circumstances. 

This was part of #23257. I’m trying to split the PR in smaller ones to make the reviews easier. Other PRs in this group are #23303, and #23803.

/cc @compnerd 