### PR TITLE
[5.1] Fix issue with expression patterns in switch exhaustivity checking

### DIFF
--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1176,3 +1176,43 @@ extension Result where T == NoError {
     }
   }
 }
+
+enum SR10301<T,E> {
+  case value(T)
+  case error(E)
+}
+enum SR10301Error: Error {
+  case bad
+}
+
+func sr10301(_ foo: SR10301<String,(Int,Error)>) {
+  switch foo {
+  case .value: return
+  case .error((_, SR10301Error.bad)): return
+  case .error((_, let err)):
+    _ = err
+    return
+  }
+}
+
+func sr10301_is(_ foo: SR10301<String,(Int,Error)>) {
+  switch foo {
+  case .value: return
+  case .error((_, is SR10301Error)): return
+  case .error((_, let err)):
+    _ = err
+    return
+  }
+}
+
+func sr10301_as(_ foo: SR10301<String,(Int,Error)>) {
+  switch foo {
+  case .value: return
+  case .error((_, let err as SR10301Error)):
+    _ = err
+    return
+  case .error((_, let err)):
+    _ = err
+    return
+  }
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1135,3 +1135,43 @@ extension Result where T == NoError {
     }
   }
 }
+
+enum SR10301<T,E> {
+  case value(T)
+  case error(E)
+}
+enum SR10301Error: Error {
+  case bad
+}
+
+func sr10301(_ foo: SR10301<String,(Int,Error)>) {
+  switch foo {
+  case .value: return
+  case .error((_, SR10301Error.bad)): return
+  case .error((_, let err)):
+    _ = err
+    return
+  }
+}
+
+func sr10301_is(_ foo: SR10301<String,(Int,Error)>) {
+  switch foo {
+  case .value: return
+  case .error((_, is SR10301Error)): return
+  case .error((_, let err)):
+    _ = err
+    return
+  }
+}
+
+func sr10301_as(_ foo: SR10301<String,(Int,Error)>) {
+  switch foo {
+  case .value: return
+  case .error((_, let err as SR10301Error)):
+    _ = err
+    return
+  case .error((_, let err)):
+    _ = err
+    return
+  }
+}


### PR DESCRIPTION
Cherry-pick of #23804. Reviewed by @CodaFi.

[SR-10301](https://bugs.swift.org/browse/SR-10301) / rdar://problem/49609445