### PR TITLE
[Sema] Derived property access level workaround for LLDB.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -765,6 +765,11 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     newMember->setType(parentDC->mapTypeIntoContext(memberAssocInterfaceType));
     structDecl->addMember(newMember);
     newMember->copyFormalAccessFrom(member, /*sourceIsParentContext*/ true);
+    // NOTE(TF-238): This is a REPL/Jupyter workaround.
+    // Derived properties are not rewritten by LLDB to be public, leading to
+    // cross-cell access level errors.
+    if (nominal->getParentModule()->getNameStr().startswith("__lldb_expr"))
+      newMember->setAccess(AccessLevel::Public);
     newMember->setValidationToChecked();
     newMember->setSetterAccess(member->getFormalAccess());
     C.addSynthesizedDecl(newMember);


### PR DESCRIPTION
LLDB does not rewrite derived properties to have access level public.
This leads to usability problems (access level errors) in LLDB/Jupyter.

Workaround for [TF-238](https://bugs.swift.org/browse/TF-238).
A robust fix is to rewrite derived properties to be public in LLDB (if it's okay).