### PR TITLE
[sil] Replace some nstances of SILBuilder(...) with SILBuilderWithSco…

### DIFF
--- a/lib/SIL/BasicBlockUtils.cpp
+++ b/lib/SIL/BasicBlockUtils.cpp
@@ -220,7 +220,7 @@ SILBasicBlock *swift::splitEdge(TermInst *T, unsigned edgeIdx,
   SmallVector<SILValue, 16> args;
   getEdgeArgs(T, edgeIdx, edgeBB, args);
 
-  SILBuilder(edgeBB).createBranch(T->getLoc(), destBB, args);
+  SILBuilderWithScope(edgeBB, T).createBranch(T->getLoc(), destBB, args);
 
   // Strip the arguments and rewire the branch in the source block.
   changeBranchTarget(T, edgeIdx, edgeBB, /*PreserveArgs=*/false);

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -239,18 +239,18 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
       auto *CondBr = cast<CondBranchInst>(
           Latch->getSinglePredecessorBlock()->getTerminator());
       if (CondBr->getTrueBB() != Latch)
-        SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getTrueBB(),
-                                        CondBr->getTrueArgs());
+        SILBuilderWithScope(CondBr).createBranch(
+            CondBr->getLoc(), CondBr->getTrueBB(), CondBr->getTrueArgs());
       else
-        SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getFalseBB(),
-                                        CondBr->getFalseArgs());
+        SILBuilderWithScope(CondBr).createBranch(
+            CondBr->getLoc(), CondBr->getFalseBB(), CondBr->getFalseArgs());
       CondBr->eraseFromParent();
       return;
     }
 
     // Otherwise, branch to the next iteration's header.
-    SILBuilder(Br).createBranch(Br->getLoc(), NextIterationsHeader,
-                                Br->getArgs());
+    SILBuilderWithScope(Br).createBranch(Br->getLoc(), NextIterationsHeader,
+                                         Br->getArgs());
     Br->eraseFromParent();
     return;
   }
@@ -261,12 +261,12 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
   // one.
   if (CurLoopIter == LastLoopIter) {
     if (CondBr->getTrueBB() == CurrentHeader) {
-      SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getFalseBB(),
-                                      CondBr->getFalseArgs());
+      SILBuilderWithScope(CondBr).createBranch(
+          CondBr->getLoc(), CondBr->getFalseBB(), CondBr->getFalseArgs());
     } else {
       assert(CondBr->getFalseBB() == CurrentHeader);
-      SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getTrueBB(),
-                                      CondBr->getTrueArgs());
+      SILBuilderWithScope(CondBr).createBranch(
+          CondBr->getLoc(), CondBr->getTrueBB(), CondBr->getTrueArgs());
     }
     CondBr->eraseFromParent();
     return;
@@ -274,12 +274,12 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
 
   // Otherwise, branch to the next iteration's header.
   if (CondBr->getTrueBB() == CurrentHeader) {
-    SILBuilder(CondBr).createCondBranch(
+    SILBuilderWithScope(CondBr).createCondBranch(
         CondBr->getLoc(), CondBr->getCondition(), NextIterationsHeader,
         CondBr->getTrueArgs(), CondBr->getFalseBB(), CondBr->getFalseArgs());
   } else {
     assert(CondBr->getFalseBB() == CurrentHeader);
-    SILBuilder(CondBr).createCondBranch(
+    SILBuilderWithScope(CondBr).createCondBranch(
         CondBr->getLoc(), CondBr->getCondition(), CondBr->getTrueBB(),
         CondBr->getTrueArgs(), NextIterationsHeader, CondBr->getFalseArgs());
   }

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -233,8 +233,8 @@ void CheckedCastBrJumpThreading::Edit::modifyCFGForUnknownPreds() {
   if (auto *CMI = dyn_cast<ClassMethodInst>(Inst)) {
     if (CMI->getOperand() == stripClassCasts(CCBI->getOperand())) {
       // Replace checked_cast_br by branch to FailureBB.
-      SILBuilder(CCBI->getParent()).createBranch(CCBI->getLoc(),
-                                                 CCBI->getFailureBB());
+      SILBuilderWithScope(CCBI).createBranch(CCBI->getLoc(),
+                                             CCBI->getFailureBB());
       CCBI->eraseFromParent();
     }
   }
@@ -275,8 +275,8 @@ modifyCFGForSuccessPreds(Optional<BasicBlockCloner> &Cloner) {
   auto *CCBI = cast<CheckedCastBranchInst>(CCBBlock->getTerminator());
 
   if (InvertSuccess) {
-    SILBuilder B(CCBBlock);
-    B.createBranch(CCBI->getLoc(), CCBI->getFailureBB());
+    SILBuilderWithScope(CCBI).createBranch(CCBI->getLoc(),
+                                           CCBI->getFailureBB());
     CCBI->eraseFromParent();
     return;
   }
@@ -313,8 +313,8 @@ modifyCFGForSuccessPreds(Optional<BasicBlockCloner> &Cloner) {
 
   // Add an unconditional jump at the end of the block.
   // Take argument value from the dominating BB
-  SILBuilder(CCBBlock).createBranch(CCBI->getLoc(), CCBI->getSuccessBB(),
-                              {SuccessArg});
+  SILBuilderWithScope(CCBI).createBranch(CCBI->getLoc(), CCBI->getSuccessBB(),
+                                         {SuccessArg});
   CCBI->eraseFromParent();
 }
 


### PR DESCRIPTION
…pe(...).

The main thing to notice about these changes is that I always picked the debug
scope associated with the location we were using. They should always be in
sync.
