### PR TITLE
[build-script] Introduce ProductBuilder. Transform Ninja to use it.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -444,11 +444,12 @@ class BuildScriptInvocation(object):
                 "can't find source directory for ninja "
                 "(tried %s)" % (self.workspace.source_dir("ninja")))
 
-        ninja_build = products.Ninja(
+        ninja_build = products.Ninja.new_builder(
             args=self.args,
             toolchain=self.toolchain,
-            source_dir=self.workspace.source_dir("ninja"),
-            build_dir=self.workspace.build_dir("build", "ninja"))
+            workspace=self.workspace,
+            host=StdlibDeploymentTarget.get_target_for_name(
+                self.args.host_target))
         ninja_build.build()
         self.toolchain.ninja = ninja_build.ninja_bin_path
 

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -28,6 +28,20 @@ class Ninja(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
+    @classmethod
+    def new_builder(cls, args, toolchain, workspace, host):
+        return NinjaBuilder(cls, args, toolchain, workspace)
+
+
+class NinjaBuilder(product.ProductBuilder):
+    def __init__(self, product_class, args, toolchain, workspace):
+        self.source_dir = workspace.source_dir(
+            product_class.product_source_name())
+        self.build_dir = workspace.build_dir('build',
+                                             product_class.product_name())
+        self.args = args
+        self.toolchain = toolchain
+
     @cache_util.reify
     def ninja_bin_path(self):
         return os.path.join(self.build_dir, 'ninja')

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -10,6 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
+import abc
+
 
 class Product(object):
     @classmethod
@@ -58,3 +60,76 @@ class Product(object):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.cmake_options = []
+
+
+class ProductBuilder(object):
+    """
+    Abstract base class for all ProductBuilders.
+
+    An specific ProductBuilder will implement the interface methods depending
+    how the product want to be build. Multiple products can use the same
+    product builder if parametrized right (for example all the products build
+    using CMake).
+
+    Ideally a ProductBuilder will be initialized with references to the
+    invocation arguments, the calculated toolchain, the calculated workspace,
+    and the target host, but the base class doesn't impose those requirements
+    in order to be flexible.
+
+    NOTE: Python doesn't need an explicit abstract base class, but it helps
+    documenting the interface.
+    """
+
+    @abc.abstractmethod
+    def __init__(self, product_class, args, toolchain, workspace):
+        """
+        Create a product builder for the given product class.
+
+        Parameters
+        ----------
+        product_class : class
+            A subtype of `Product` which describes the product being built by
+            this builder.
+        args : `argparse.Namespace`
+            The arguments passed by the user to the invocation of the script. A
+            builder should consider this argument read-only.
+        toolchain : `swift_build_support.toolchain.Toolchain`
+            The toolchain being used to build the product. The toolchain will
+            point to the tools that the builder should use to build (like the
+            compiler or the linker).
+        workspace : `swift_build_support.workspace.Workspace`
+            The workspace where the source code and the build directories have
+            to be located. A builder should use the workspace to access its own
+            source/build directory, as well as other products source/build
+            directories.
+        """
+        pass
+
+    @abc.abstractmethod
+    def build(self):
+        """
+        Perform the build phase for the product.
+
+        This phase might also imply a configuration phase, but each product
+        builder is free to determine how to do it.
+        """
+        pass
+
+    @abc.abstractmethod
+    def test(self):
+        """
+        Perform the test phase for the product.
+
+        This phase might build and execute the product tests.
+        """
+        pass
+
+    @abc.abstractmethod
+    def install(self):
+        """
+        Perform the install phase for the product.
+
+        This phase might copy the artifacts from the previous phases into a
+        destination directory.
+        """
+        pass

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -26,6 +26,7 @@ except ImportError:
 from swift_build_support import shell
 from swift_build_support import xcrun
 from swift_build_support.products import Ninja
+from swift_build_support.targets import StdlibDeploymentTarget
 from swift_build_support.toolchain import host_toolchain
 from swift_build_support.workspace import Workspace
 
@@ -40,6 +41,8 @@ class NinjaTestCase(unittest.TestCase):
 
         self.workspace = Workspace(source_root=tmpdir1,
                                    build_root=tmpdir2)
+
+        self.host = StdlibDeploymentTarget.host_target()
 
         # Setup toolchain
         self.toolchain = host_toolchain()
@@ -71,20 +74,23 @@ class NinjaTestCase(unittest.TestCase):
         self.args = None
 
     def test_ninja_bin_path(self):
-        ninja_build = Ninja(
+        ninja_build = Ninja.new_builder(
             args=self.args,
             toolchain=self.toolchain,
-            source_dir='/path/to/src',
-            build_dir='/path/to/build')
+            workspace=self.workspace,
+            host=self.host)
 
-        self.assertEqual(ninja_build.ninja_bin_path, '/path/to/build/ninja')
+        self.assertEqual(ninja_build.ninja_bin_path,
+                         os.path.join(
+                             self.workspace.build_dir('build', 'ninja'),
+                             'ninja'))
 
     def test_build(self):
-        ninja_build = Ninja(
+        ninja_build = Ninja.new_builder(
             args=self.args,
             toolchain=self.toolchain,
-            source_dir=self.workspace.source_dir('ninja'),
-            build_dir=self.workspace.build_dir('build', 'ninja'))
+            workspace=self.workspace,
+            host=self.host)
 
         ninja_build.build()
 
@@ -113,8 +119,7 @@ class NinjaTestCase(unittest.TestCase):
 + pushd {build_dir}
 + {expect_env}{python} configure.py --bootstrap
 + popd
-""".format(
-            source_dir=os.path.join(self.workspace.source_root, 'ninja'),
-            build_dir=os.path.join(self.workspace.build_root, 'ninja-build'),
-            expect_env=expect_env,
-            python=sys.executable))
+""".format(source_dir=self.workspace.source_dir('ninja'),
+           build_dir=self.workspace.build_dir('build', 'ninja'),
+           expect_env=expect_env,
+           python=sys.executable))


### PR DESCRIPTION
`ProductBuilder` allows us to tackle the different way than the different
products need to be build. The builders follow a very simple interface,
but inside them the details are hidden.

Previously the Ninja product was both a `Product` and also the process to build Ninja. The
methods that did the build have moved into `ProductBuilder` to match the
future `ProductBuilders`.

`Product` and `ProductBuilder` are very close, but the current design of `Product` is not adequate to compile for different hosts and lacks of some access to other parts of the script. Instead of modifying `Product`, I decided to keep separate from it to allow the rest of the script to keep working the same (it will also allow to keep the previous way of doing things and the new way of doing things in parallel, which might made the migration less scary).

Pieces that `ProductBuilder` requires, but weren’t available in `Product` are the target host and the workspace information. The first is needed to generate the right parameters to invoke CMake and other build scripts, while the second is necessary to find out about other product locations (Swift product references LLVM, LLDB references both Swift and LLVM), as well as allowing access to the build results for the current target, and also the tools host target.

Later commits will show how `ProductBuilder` is leveraged to invoke different building scripts and how  flexible is the setup.

This was part of #23257. I’m trying to split the PR in smaller ones to make the reviews easier. Other PRs in this group are #23303, #23803, and #23810 .

/cc @compnerd