### PR TITLE
build: do not search for native LLVM when not building tools

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -62,32 +62,34 @@ macro(swift_common_standalone_build_config_llvm product)
     set(${product}_NATIVE_LLVM_TOOLS_PATH "${LLVM_TOOLS_BINARY_DIR}")
   endif()
 
-  if(CMAKE_CROSSCOMPILING)
-    set(LLVM_NATIVE_BUILD_DIR "${LLVM_BINARY_DIR}/NATIVE")
-    if(NOT EXISTS "${LLVM_NATIVE_BUILD_DIR}")
-      message(FATAL_ERROR
-        "Attempting to cross-compile swift standalone but no native LLVM build
-        found.  Please cross-compile LLVM as well.")
-    endif()
+  if(SWIFT_INCLUDE_TOOLS)
+    if(CMAKE_CROSSCOMPILING)
+      set(LLVM_NATIVE_BUILD_DIR "${LLVM_BINARY_DIR}/NATIVE")
+      if(NOT EXISTS "${LLVM_NATIVE_BUILD_DIR}")
+        message(FATAL_ERROR
+          "Attempting to cross-compile swift standalone but no native LLVM build
+          found.  Please cross-compile LLVM as well.")
+      endif()
 
-    if(CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
-      set(HOST_EXECUTABLE_SUFFIX ".exe")
-    endif()
+      if(CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
+        set(HOST_EXECUTABLE_SUFFIX ".exe")
+      endif()
 
-    if(NOT CMAKE_CONFIGURATION_TYPES)
-      set(LLVM_TABLEGEN_EXE
-        "${LLVM_NATIVE_BUILD_DIR}/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
+      if(NOT CMAKE_CONFIGURATION_TYPES)
+        set(LLVM_TABLEGEN_EXE
+          "${LLVM_NATIVE_BUILD_DIR}/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
+      else()
+        # NOTE: LLVM NATIVE build is always built Release, as is specified in
+        # CrossCompile.cmake
+        set(LLVM_TABLEGEN_EXE
+          "${LLVM_NATIVE_BUILD_DIR}/Release/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
+      endif()
     else()
-      # NOTE: LLVM NATIVE build is always built Release, as is specified in
-      # CrossCompile.cmake
-      set(LLVM_TABLEGEN_EXE
-        "${LLVM_NATIVE_BUILD_DIR}/Release/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
-    endif()
-  else()
-    find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" HINTS ${LLVM_TOOLS_BINARY_DIR}
-      NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-    if(LLVM_TABLEGEN_EXE STREQUAL "LLVM_TABLEGEN_EXE-NOTFOUND")
-      message(FATAL_ERROR "Failed to find tablegen in ${LLVM_TOOLS_BINARY_DIR}")
+      find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" HINTS ${LLVM_TOOLS_BINARY_DIR}
+        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+      if(LLVM_TABLEGEN_EXE STREQUAL "LLVM_TABLEGEN_EXE-NOTFOUND")
+        message(FATAL_ERROR "Failed to find tablegen in ${LLVM_TOOLS_BINARY_DIR}")
+      endif()
     endif()
   endif()
 


### PR DESCRIPTION
The standard library does not depend on the LLVM libraries at runtime.  Do not
perform the search for the LLVM configuration when the tools are not being
built.  This is needed to permit cross-compiling the standard library standalone
for android on a Linux host without building LLVM and Clang for android.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
