### PR TITLE
[ParseableInterfaces] Always load valid modules from the PIML

### DIFF
--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -864,13 +864,25 @@ class ParseableInterfaceModuleLoaderImpl {
       if (isForwardingModule) {
         if (auto forwardingModule = ForwardingModule::load(*buf)) {
           std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
-          if (forwardingModuleIsUpToDate(*forwardingModule, deps, moduleBuffer))
+          if (forwardingModuleIsUpToDate(*forwardingModule, deps,
+                                         moduleBuffer)) {
+            LLVM_DEBUG(llvm::dbgs() << "Found up-to-date forwarding module at "
+                                    << cachedOutputPath << "\n");
             return DiscoveredModule::forwarded(
               forwardingModule->underlyingModulePath, std::move(moduleBuffer));
+          }
+
+          LLVM_DEBUG(llvm::dbgs() << "Found out-of-date forwarding module at "
+                     << cachedOutputPath << "\n");
         }
       // Otherwise, check if the AST buffer itself is up to date.
       } else if (serializedASTBufferIsUpToDate(*buf, deps)) {
+        LLVM_DEBUG(llvm::dbgs() << "Found up-to-date cached module at "
+                                << cachedOutputPath << "\n");
         return DiscoveredModule::normal(cachedOutputPath, std::move(buf));
+      } else {
+        LLVM_DEBUG(llvm::dbgs() << "Found out-of-date cached module at "
+                   << cachedOutputPath << "\n");
       }
     }
 
@@ -883,14 +895,22 @@ class ParseableInterfaceModuleLoaderImpl {
       llvm::SmallString<256> scratch;
       std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
       auto path = computePrebuiltModulePath(scratch);
-      if (path && swiftModuleIsUpToDate(*path, deps, moduleBuffer))
-        return DiscoveredModule::prebuilt(*path, std::move(moduleBuffer));
+      if (path) {
+        if (swiftModuleIsUpToDate(*path, deps, moduleBuffer)) {
+          LLVM_DEBUG(llvm::dbgs() << "Found up-to-date prebuilt module at "
+                                  << path->str() << "\n");
+          return DiscoveredModule::prebuilt(*path, std::move(moduleBuffer));
+        } else {
+          LLVM_DEBUG(llvm::dbgs() << "Found out-of-date prebuilt module at "
+                     << modulePath << "\n");
+        }
+      }
     }
 
     // Finally, if there's a module adjacent to the .swiftinterface that we can
-    // _likely_ load (it validates OK and is up to date), bail early with
-    // errc::not_supported, so the next (serialized) loader in the chain will
-    // load it. Alternately, if there's a .swiftmodule present but we can't even
+    // _likely_ load (it validates OK and is up to date), return its buffer and
+    // continue loading it.
+    // Alternately, if there's a .swiftmodule present but we can't even
     // read it (for whatever reason), we should let the other module loader
     // diagnose it.
     if (!shouldLoadAdjacentModule)
@@ -898,8 +918,15 @@ class ParseableInterfaceModuleLoaderImpl {
 
     auto adjacentModuleBuffer = fs.getBufferForFile(modulePath);
     if (adjacentModuleBuffer) {
-      if (serializedASTBufferIsUpToDate(*adjacentModuleBuffer.get(), deps))
-        return std::make_error_code(std::errc::not_supported);
+      if (serializedASTBufferIsUpToDate(*adjacentModuleBuffer.get(), deps)) {
+        LLVM_DEBUG(llvm::dbgs() << "Found up-to-date module at "
+                                << modulePath << "\n");
+        return DiscoveredModule::normal(modulePath,
+                                        std::move(*adjacentModuleBuffer));
+      } else {
+        LLVM_DEBUG(llvm::dbgs() << "Found out-of-date module at "
+                   << modulePath << "\n");
+      }
     } else if (adjacentModuleBuffer.getError() != notFoundError) {
       return std::make_error_code(std::errc::not_supported);
     }
@@ -1053,8 +1080,14 @@ std::error_code ParseableInterfaceModuleLoader::findModuleFilesInDirectory(
   auto Ext = file_types::getExtension(file_types::TY_SwiftParseableInterfaceFile);
   InPath = ModPath;
   path::replace_extension(InPath, Ext);
-  if (!fs.exists(InPath))
+  if (!fs.exists(InPath)) {
+    if (fs.exists(ModPath)) {
+      LLVM_DEBUG(llvm::dbgs()
+        << "No .swiftinterface file found adjacent to module file "
+        << ModPath.str() << "\n");
+    }
     return std::make_error_code(std::errc::no_such_file_or_directory);
+  }
 
   // Create an instance of the Impl to do the heavy lifting.
   ParseableInterfaceModuleLoaderImpl Impl(

--- a/test/ParseableInterface/ModuleCache/prefer-local-module-to-sdk.swift
+++ b/test/ParseableInterface/ModuleCache/prefer-local-module-to-sdk.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t/BuildDir)
+// RUN: %empty-directory(%t/SecondBuildDir/Lib.swiftmodule)
+// RUN: %empty-directory(%t/ModuleCache)
+
+// RUN: echo 'public func showsUpInBothPlaces() {}' > %t/Lib.swift
+
+// 1. Create a .swiftinterface file containing just one API, and put it inside a second build dir (without a .swiftmodule)
+// RUN: %target-swift-frontend -typecheck %t/Lib.swift -emit-parseable-module-interface-path %t/SecondBuildDir/Lib.swiftmodule/%target-cpu.swiftinterface
+
+// 2. Add a new API to the module, and compile just the serialized version in the build dir.
+// RUN: echo 'public func onlyInTheCompiledModule() {}' >> %t/Lib.swift
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/BuildDir/Lib.swiftmodule -emit-parseable-module-interface-path %t/BuildDir/Lib.swiftinterface
+
+// 3. Make sure when we compile this test file, we can access both APIs since we'll
+//    load the compiled .swiftmodule instead of the .swiftinterface in the SDK.
+// RUN: %target-swift-frontend -typecheck %s -I %t/BuildDir -I %t/SecondBuildDir -module-cache-path %t/ModuleCache
+
+// 4. Make sure we didn't compile any .swiftinterfaces into the module cache.
+// RUN: ls %t/ModuleCache | not grep 'swiftmodule'
+
+import Lib
+
+showsUpInBothPlaces()
+onlyInTheCompiledModule()


### PR DESCRIPTION
Previously, we would return `errc::not_supported` when there was a
valid .swiftmodule that we could load instead of compiling from an
interface. This worked great, when there was only one place in the
search paths where there's a .swiftmodule or .swiftinterface we could
load. We'd skip all the valid ones and then let the
SerializedModuleLoader load them instead.

However, when there's a valid .swiftinterface anywhere in the search
paths, suddenly we'll load from that instead of the valid .swiftmodule
we saw previously. Instead of returning `not_supported` and possibly
searching the rest of the paths for something that might not be right
for a local build, just pass up the module we've already loaded,
validated, and made sure is up-to-date.

Also add some more logging throughout `discoverLoadableModule` so we can
more easily catch/debug issues in the future.

Fixes rdar://49479386