### PR TITLE
SIL: fix a crash when constructing a debug location in mandatory inlining

### DIFF
--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -687,6 +687,8 @@ private:
       : SILLocation(D, MandatoryInlinedKind, F) {}
   MandatoryInlinedLocation(SourceLoc L, unsigned F)
       : SILLocation(L, MandatoryInlinedKind, F) {}
+  MandatoryInlinedLocation(DebugLoc L, unsigned F)
+      : SILLocation(L, MandatoryInlinedKind, F) {}
 };
 
 /// Used on the instruction performing auto-generated cleanup such as

--- a/lib/SIL/SILLocation.cpp
+++ b/lib/SIL/SILLocation.cpp
@@ -217,6 +217,9 @@ MandatoryInlinedLocation::getMandatoryInlinedLocation(SILLocation L) {
   if (L.isInTopLevel())
     return MandatoryInlinedLocation::getModuleLocation(L.getSpecialFlags());
 
+  if (L.isDebugInfoLoc())
+    return MandatoryInlinedLocation(L.getDebugInfoLoc(), L.getSpecialFlags());
+
   llvm_unreachable("Cannot construct Inlined loc from the given location.");
 }
 


### PR DESCRIPTION
There was one case which was not handled and that's inlining of a compiler intrinsic.
In this case there is a different location type on the function call.

rdar://problem/49651421

Will be tested by un upcoming stdlib change by @Catfish-Man 