### PR TITLE
[utils][test] PathSanitizingFileCheck more compatible with Windows.

### DIFF
--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -6,13 +6,13 @@
 // RUN: %target-swift-frontend -emit-pch -o %t.pch %/S/Inputs/chained-unit-test-bridging-header-to-pch.h
 // RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s -import-objc-header %t.pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
-// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.swiftdeps
-// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS --enable-yaml-compatibility %s < %t.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t.swiftdeps
 
 // RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %/S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.persistent.d
-// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.persistent.swiftdeps
-// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.persistent.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS --enable-yaml-compatibility %s < %t.persistent.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t.persistent.swiftdeps
 
 print(app_function(1))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1450,12 +1450,13 @@ config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 
 config.substitutions.append(('%FileCheck',
-                             '%r %r --sanitize BUILD_DIR=%r --sanitize SOURCE_DIR=%r --use-filecheck %r' % (
+                             '%r %r --sanitize BUILD_DIR=%r --sanitize SOURCE_DIR=%r --use-filecheck %r %s' % (
         sys.executable,
         config.PathSanitizingFileCheck,
         swift_obj_root,
         config.swift_src_root,
-        config.filecheck)))
+        config.filecheck,
+        '--enable-windows-compatibility' if kIsWindows else '')))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
 
 # If static stdlib is present, enable static stdlib tests

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -43,12 +43,36 @@ constants.""")
         dest="file_check_path",
         default="FileCheck")
 
+    parser.add_argument(
+        "--enable-windows-compatibility",
+        help="Enable Windows path compatibility, which checks against both "
+             "forward slashes and backward slashes.",
+        action="store_true")
+
+    parser.add_argument(
+        "--enable-yaml-compatibility",
+        help="Enable YAML path compatibility. Since YAML double escapes "
+             "backward slashes, we need to check for them escaped. Only "
+             "available if Windows compatibility is enabled.",
+        action="store_true")
+
     args, unknown_args = parser.parse_known_args()
+
+    if args.enable_windows_compatibility:
+        if args.enable_yaml_compatibility:
+            slashes_re = r'(/|\\\\|\\\\\\\\)'
+        else:
+            slashes_re = r'(/|\\\\)'
+    else:
+        slashes_re = r'/'
 
     stdin = sys.stdin.read()
     for s in args.sanitize_strings:
         replacement, pattern = s.split('=', 1)
-        stdin = re.sub(re.sub(r'/', r'[/\\\\]', pattern), replacement, stdin)
+        # We are replacing the Unix path separators in the paths passed as
+        # arguments with a broader pattern to also allow forward slashes and
+        # double escaped slashes in the result that we are checking. Sigh.
+        stdin = re.sub(re.sub(r'/', slashes_re, pattern), replacement, stdin)
 
     p = subprocess.Popen(
         [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)


### PR DESCRIPTION
In pch-bridging-header-deps test, the PathSanitizingFileCheck is used to
check against YAML escaped paths. This works for Unix paths, since the
slash doesn't need to be escaped, but doesn't work for Windows paths,
because the path separator is escaped, and the replacement done by
PathSanitizingFileCheck only looks for exact matches.

To avoid changes in how Darwin/Linux execute the tests, this commit adds
two options in PathSanitizingFileCheck: Windows compatibility makes the
given paths match both forward and backward slashes; in the additional
YAML compatibility is enabled, escaped backward slashes will also be
matched.

The Windows compatibility is enabled for all the test in case the tests
are running on Windows (change done in lit.cfg), while the YAML
compatibility is only enabled for those tests that might need it (like
the PCH bridging header one). This is in order to not allow possible
empty path components in tests that do not deal with YAML escaped paths.

@compnerd: the reason it was working for you and me was that our `SOURCE_DIR` is simply `S:\swift` and the values on the `.swiftdeps` files was `S:/swift\\foo\\bar`. For some reason the YAML has the first slash forwards, and the rest backwards. When running in CI, the `SOURCE_DIR` is `S:\agent\_1\s\swift` and the values in `.swiftdeps` are `S:/agent\\_1\\s\\swift`. The first double escaped backward slash cannot match the `SOURCE_DIR` pattern we were using. The patch should allow those matches, but only in the situations that are really needed.