### PR TITLE
[silgen] Split off SILGenSILBuilder from SILGenBuilder and have SILGe…

### DIFF
--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenPoly.cpp
   SILGenProlog.cpp
   SILGenStmt.cpp
+  SILGenSILBuilder.cpp
   SILGenThunk.cpp
   SILGenType.cpp)
 target_link_libraries(swiftSILGen PRIVATE

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -33,153 +33,15 @@ SILGenModule &SILGenBuilder::getSILGenModule() const { return SGF.SGM; }
 //===----------------------------------------------------------------------===//
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF)
-    : SILBuilder(SGF.F), SGF(SGF) {}
+    : SILGenSILBuilder(SGF), SGF(SGF) {}
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SmallVectorImpl<SILInstruction *> *insertedInsts)
-    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {}
+    : SILGenSILBuilder(SGF, insertBB, insertedInsts), SGF(SGF) {}
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SILBasicBlock::iterator insertInst)
-    : SILBuilder(insertBB, insertInst), SGF(SGF) {}
-
-//===----------------------------------------------------------------------===//
-//              Instruction Emission + Conformance Endowed APIs
-//===----------------------------------------------------------------------===//
-//
-// This section contains wrappers around SILBuilder SILValue APIs that add extra
-// conformances. These are the only places where we should be accessing
-// SILBuilder APIs directly.
-//
-
-MetatypeInst *SILGenBuilder::createMetatype(SILLocation loc, SILType metatype) {
-  auto theMetatype = metatype.castTo<MetatypeType>();
-  // Getting a nontrivial metatype requires forcing any conformances necessary
-  // to instantiate the type.
-  switch (theMetatype->getRepresentation()) {
-  case MetatypeRepresentation::Thin:
-    break;
-  case MetatypeRepresentation::Thick:
-  case MetatypeRepresentation::ObjC: {
-    // Walk the type recursively to look for substitutions we may need.
-    theMetatype.getInstanceType().findIf([&](Type t) -> bool {
-      auto *decl = t->getAnyNominal();
-      if (!decl)
-        return false;
-
-      if (isa<ProtocolDecl>(decl))
-        return false;
-
-      auto *genericSig = decl->getGenericSignature();
-      if (!genericSig)
-        return false;
-
-      auto subMap = t->getContextSubstitutionMap(getSILGenModule().SwiftModule,
-                                                 decl);
-      getSILGenModule().useConformancesFromSubstitutions(subMap);
-      return false;
-    });
-
-    break;
-  }
-  }
-
-  return SILBuilder::createMetatype(loc, metatype);
-}
-
-ApplyInst *SILGenBuilder::createApply(SILLocation loc, SILValue fn,
-                                      SILType substFnTy, SILType result,
-                                      SubstitutionMap subs,
-                                      ArrayRef<SILValue> args) {
-  getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createApply(loc, fn, subs, args, false);
-}
-
-TryApplyInst *
-SILGenBuilder::createTryApply(SILLocation loc, SILValue fn, SILType substFnTy,
-                              SubstitutionMap subs, ArrayRef<SILValue> args,
-                              SILBasicBlock *normalBB, SILBasicBlock *errorBB) {
-  getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createTryApply(loc, fn, subs, args, normalBB, errorBB);
-}
-
-BeginApplyInst *
-SILGenBuilder::createBeginApply(SILLocation loc, SILValue fn,
-                                SubstitutionMap subs,
-                                ArrayRef<SILValue> args) {
-  getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createBeginApply(loc, fn, subs, args, false);
-}
-
-PartialApplyInst *
-SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
-                                  SILType substFnTy, SubstitutionMap subs,
-                                  ArrayRef<SILValue> args, SILType closureTy) {
-  getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createPartialApply(
-      loc, fn, subs, args,
-      closureTy.getAs<SILFunctionType>()->getCalleeConvention());
-}
-
-
-BuiltinInst *SILGenBuilder::createBuiltin(SILLocation loc, Identifier name,
-                                          SILType resultTy,
-                                          SubstitutionMap subs,
-                                          ArrayRef<SILValue> args) {
-  getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createBuiltin(loc, name, resultTy, subs, args);
-}
-
-InitExistentialAddrInst *SILGenBuilder::createInitExistentialAddr(
-    SILLocation loc, SILValue existential, CanType formalConcreteType,
-    SILType loweredConcreteType,
-    ArrayRef<ProtocolConformanceRef> conformances) {
-  for (auto conformance : conformances)
-    getSILGenModule().useConformance(conformance);
-
-  return SILBuilder::createInitExistentialAddr(
-      loc, existential, formalConcreteType, loweredConcreteType, conformances);
-}
-
-InitExistentialValueInst *SILGenBuilder::createInitExistentialValue(
-    SILLocation Loc, SILType ExistentialType, CanType FormalConcreteType,
-    SILValue Concrete, ArrayRef<ProtocolConformanceRef> Conformances) {
-  for (auto conformance : Conformances)
-    getSILGenModule().useConformance(conformance);
-
-  return SILBuilder::createInitExistentialValue(
-      Loc, ExistentialType, FormalConcreteType, Concrete, Conformances);
-}
-
-InitExistentialMetatypeInst *SILGenBuilder::createInitExistentialMetatype(
-    SILLocation loc, SILValue metatype, SILType existentialType,
-    ArrayRef<ProtocolConformanceRef> conformances) {
-  for (auto conformance : conformances)
-    getSILGenModule().useConformance(conformance);
-
-  return SILBuilder::createInitExistentialMetatype(
-      loc, metatype, existentialType, conformances);
-}
-
-InitExistentialRefInst *SILGenBuilder::createInitExistentialRef(
-    SILLocation loc, SILType existentialType, CanType formalConcreteType,
-    SILValue concreteValue, ArrayRef<ProtocolConformanceRef> conformances) {
-  for (auto conformance : conformances)
-    getSILGenModule().useConformance(conformance);
-
-  return SILBuilder::createInitExistentialRef(
-      loc, existentialType, formalConcreteType, concreteValue, conformances);
-}
-
-AllocExistentialBoxInst *SILGenBuilder::createAllocExistentialBox(
-    SILLocation loc, SILType existentialType, CanType concreteType,
-    ArrayRef<ProtocolConformanceRef> conformances) {
-  for (auto conformance : conformances)
-    getSILGenModule().useConformance(conformance);
-
-  return SILBuilder::createAllocExistentialBox(loc, existentialType,
-                                               concreteType, conformances);
-}
+    : SILGenSILBuilder(SGF, insertBB, insertInst), SGF(SGF) {}
 
 //===----------------------------------------------------------------------===//
 //                             Managed Value APIs
@@ -209,8 +71,8 @@ SILGenBuilder::createConvertFunction(SILLocation loc, ManagedValue fn,
                                      SILType resultTy,
                                      bool withoutActuallyEscaping) {
   CleanupCloner cloner(*this, fn);
-  SILValue result = SILBuilder::createConvertFunction(
-      loc, fn.forward(getSILGenFunction()), resultTy, withoutActuallyEscaping);
+  SILValue result = createConvertFunction(loc, fn.forward(getSILGenFunction()),
+                                          resultTy, withoutActuallyEscaping);
   return cloner.clone(result);
 }
 
@@ -741,7 +603,7 @@ ManagedValue SILGenBuilder::createUncheckedBitCast(SILLocation loc,
   CleanupCloner cloner(*this, value);
   SILValue cast = createUncheckedBitCast(loc, value.getValue(), type);
 
-  // Currently SILBuilder::createUncheckedBitCast only produces these
+  // Currently createUncheckedBitCast only produces these
   // instructions. We assert here to make sure if this changes, this code is
   // updated.
   assert((isa<UncheckedTrivialBitCastInst>(cast) ||
@@ -962,14 +824,14 @@ void SILGenBuilder::emitDestructureValueOperation(
     SILLocation loc, ManagedValue value,
     llvm::function_ref<void(unsigned, ManagedValue)> func) {
   CleanupCloner cloner(*this, value);
-  SILBuilder::emitDestructureValueOperation(
-      loc, value.forward(SGF), [&](unsigned index, SILValue subValue) {
-        return func(index, cloner.clone(subValue));
-      });
+  emitDestructureValueOperation(loc, value.forward(SGF),
+                                [&](unsigned index, SILValue subValue) {
+                                  return func(index, cloner.clone(subValue));
+                                });
 }
 
 ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
                                              unsigned index) {
-  auto *pbi = SILBuilder::createProjectBox(loc, mv.getValue(), index);
+  auto *pbi = createProjectBox(loc, mv.getValue(), index);
   return ManagedValue::forUnmanaged(pbi);
 }

--- a/lib/SILGen/SILGenSILBuilder.cpp
+++ b/lib/SILGen/SILGenSILBuilder.cpp
@@ -1,0 +1,174 @@
+//===--- SILGenSILBuilder.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SILGenSILBuilder.h"
+#include "SILGenFunction.h"
+
+using namespace swift;
+using namespace Lowering;
+
+//===----------------------------------------------------------------------===//
+//                              Utility Methods
+//===----------------------------------------------------------------------===//
+
+SILGenModule &SILGenSILBuilder::getSILGenModule() const { return SGF.SGM; }
+
+//===----------------------------------------------------------------------===//
+//                                Constructors
+//===----------------------------------------------------------------------===//
+
+SILGenSILBuilder::SILGenSILBuilder(SILGenFunction &SGF)
+    : SILBuilder(SGF.F), SGF(SGF) {}
+
+SILGenSILBuilder::SILGenSILBuilder(
+    SILGenFunction &SGF, SILBasicBlock *insertBB,
+    SmallVectorImpl<SILInstruction *> *insertedInsts)
+    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {}
+
+SILGenSILBuilder::SILGenSILBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
+                                   SILBasicBlock::iterator insertInst)
+    : SILBuilder(insertBB, insertInst), SGF(SGF) {}
+
+//===----------------------------------------------------------------------===//
+//              Instruction Emission + Conformance Endowed APIs
+//===----------------------------------------------------------------------===//
+//
+// This section contains wrappers around SILBuilder SILValue APIs that add extra
+// conformances. These are the only places where we should be accessing
+// SILBuilder APIs directly.
+//
+
+MetatypeInst *SILGenSILBuilder::createMetatype(SILLocation loc,
+                                               SILType metatype) {
+  auto theMetatype = metatype.castTo<MetatypeType>();
+  // Getting a nontrivial metatype requires forcing any conformances necessary
+  // to instantiate the type.
+  switch (theMetatype->getRepresentation()) {
+  case MetatypeRepresentation::Thin:
+    break;
+  case MetatypeRepresentation::Thick:
+  case MetatypeRepresentation::ObjC: {
+    // Walk the type recursively to look for substitutions we may need.
+    theMetatype.getInstanceType().findIf([&](Type t) -> bool {
+      auto *decl = t->getAnyNominal();
+      if (!decl)
+        return false;
+
+      if (isa<ProtocolDecl>(decl))
+        return false;
+
+      auto *genericSig = decl->getGenericSignature();
+      if (!genericSig)
+        return false;
+
+      auto subMap =
+          t->getContextSubstitutionMap(getSILGenModule().SwiftModule, decl);
+      getSILGenModule().useConformancesFromSubstitutions(subMap);
+      return false;
+    });
+
+    break;
+  }
+  }
+
+  return SILBuilder::createMetatype(loc, metatype);
+}
+
+ApplyInst *SILGenSILBuilder::createApply(SILLocation loc, SILValue fn,
+                                         SILType substFnTy, SILType result,
+                                         SubstitutionMap subs,
+                                         ArrayRef<SILValue> args) {
+  getSILGenModule().useConformancesFromSubstitutions(subs);
+  return SILBuilder::createApply(loc, fn, subs, args, false);
+}
+
+TryApplyInst *SILGenSILBuilder::createTryApply(
+    SILLocation loc, SILValue fn, SILType substFnTy, SubstitutionMap subs,
+    ArrayRef<SILValue> args, SILBasicBlock *normalBB, SILBasicBlock *errorBB) {
+  getSILGenModule().useConformancesFromSubstitutions(subs);
+  return SILBuilder::createTryApply(loc, fn, subs, args, normalBB, errorBB);
+}
+
+BeginApplyInst *SILGenSILBuilder::createBeginApply(SILLocation loc, SILValue fn,
+                                                   SubstitutionMap subs,
+                                                   ArrayRef<SILValue> args) {
+  getSILGenModule().useConformancesFromSubstitutions(subs);
+  return SILBuilder::createBeginApply(loc, fn, subs, args, false);
+}
+
+PartialApplyInst *SILGenSILBuilder::createPartialApply(
+    SILLocation loc, SILValue fn, SILType substFnTy, SubstitutionMap subs,
+    ArrayRef<SILValue> args, SILType closureTy) {
+  getSILGenModule().useConformancesFromSubstitutions(subs);
+  return SILBuilder::createPartialApply(
+      loc, fn, subs, args,
+      closureTy.getAs<SILFunctionType>()->getCalleeConvention());
+}
+
+BuiltinInst *SILGenSILBuilder::createBuiltin(SILLocation loc, Identifier name,
+                                             SILType resultTy,
+                                             SubstitutionMap subs,
+                                             ArrayRef<SILValue> args) {
+  getSILGenModule().useConformancesFromSubstitutions(subs);
+  return SILBuilder::createBuiltin(loc, name, resultTy, subs, args);
+}
+
+InitExistentialAddrInst *SILGenSILBuilder::createInitExistentialAddr(
+    SILLocation loc, SILValue existential, CanType formalConcreteType,
+    SILType loweredConcreteType,
+    ArrayRef<ProtocolConformanceRef> conformances) {
+  for (auto conformance : conformances)
+    getSILGenModule().useConformance(conformance);
+
+  return SILBuilder::createInitExistentialAddr(
+      loc, existential, formalConcreteType, loweredConcreteType, conformances);
+}
+
+InitExistentialValueInst *SILGenSILBuilder::createInitExistentialValue(
+    SILLocation Loc, SILType ExistentialType, CanType FormalConcreteType,
+    SILValue Concrete, ArrayRef<ProtocolConformanceRef> Conformances) {
+  for (auto conformance : Conformances)
+    getSILGenModule().useConformance(conformance);
+
+  return SILBuilder::createInitExistentialValue(
+      Loc, ExistentialType, FormalConcreteType, Concrete, Conformances);
+}
+
+InitExistentialMetatypeInst *SILGenSILBuilder::createInitExistentialMetatype(
+    SILLocation loc, SILValue metatype, SILType existentialType,
+    ArrayRef<ProtocolConformanceRef> conformances) {
+  for (auto conformance : conformances)
+    getSILGenModule().useConformance(conformance);
+
+  return SILBuilder::createInitExistentialMetatype(
+      loc, metatype, existentialType, conformances);
+}
+
+InitExistentialRefInst *SILGenSILBuilder::createInitExistentialRef(
+    SILLocation loc, SILType existentialType, CanType formalConcreteType,
+    SILValue concreteValue, ArrayRef<ProtocolConformanceRef> conformances) {
+  for (auto conformance : conformances)
+    getSILGenModule().useConformance(conformance);
+
+  return SILBuilder::createInitExistentialRef(
+      loc, existentialType, formalConcreteType, concreteValue, conformances);
+}
+
+AllocExistentialBoxInst *SILGenSILBuilder::createAllocExistentialBox(
+    SILLocation loc, SILType existentialType, CanType concreteType,
+    ArrayRef<ProtocolConformanceRef> conformances) {
+  for (auto conformance : conformances)
+    getSILGenModule().useConformance(conformance);
+
+  return SILBuilder::createAllocExistentialBox(loc, existentialType,
+                                               concreteType, conformances);
+}

--- a/lib/SILGen/SILGenSILBuilder.h
+++ b/lib/SILGen/SILGenSILBuilder.h
@@ -1,0 +1,102 @@
+//===--- SILGenSILBuilder.h -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILGEN_SILGENSILBUILDER_H
+#define SWIFT_SILGEN_SILGENSILBUILDER_H
+
+#include "swift/SIL/SILBuilder.h"
+
+namespace swift {
+namespace Lowering {
+
+class SILGenFunction;
+
+class SILGenSILBuilder : public SILBuilder {
+  SILGenFunction &SGF;
+
+public:
+  SILGenSILBuilder(SILGenFunction &SGF);
+  SILGenSILBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
+                   SmallVectorImpl<SILInstruction *> *insertedInsts = nullptr);
+  SILGenSILBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
+                   SILBasicBlock::iterator insertInst);
+
+  // Create a new builder, inheriting the given builder's context and debug
+  // scope.
+  SILGenSILBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
+                   const SILDebugScope *debugScope,
+                   SILBuilderContext &builderCtx)
+      : SILBuilder(insertBB, debugScope, builderCtx), SGF(SGF) {}
+
+  SILGenModule &getSILGenModule() const;
+
+  // Metatype instructions use the conformances necessary to instantiate the
+  // type.
+
+  MetatypeInst *createMetatype(SILLocation loc, SILType metatype);
+  // Generic apply instructions use the conformances necessary to form the call.
+
+  using SILBuilder::createApply;
+
+  ApplyInst *createApply(SILLocation loc, SILValue fn, SILType SubstFnTy,
+                         SILType result, SubstitutionMap subs,
+                         ArrayRef<SILValue> args);
+
+  TryApplyInst *createTryApply(SILLocation loc, SILValue fn, SILType substFnTy,
+                               SubstitutionMap subs, ArrayRef<SILValue> args,
+                               SILBasicBlock *normalBB, SILBasicBlock *errorBB);
+
+  BeginApplyInst *createBeginApply(SILLocation loc, SILValue fn,
+                                   SubstitutionMap subs,
+                                   ArrayRef<SILValue> args);
+
+  PartialApplyInst *createPartialApply(SILLocation loc, SILValue fn,
+                                       SILType substFnTy, SubstitutionMap subs,
+                                       ArrayRef<SILValue> args,
+                                       SILType closureTy);
+  BuiltinInst *createBuiltin(SILLocation loc, Identifier name, SILType resultTy,
+                             SubstitutionMap subs, ArrayRef<SILValue> args);
+
+  // Existential containers use the conformances needed by the existential
+  // box.
+
+  InitExistentialAddrInst *
+  createInitExistentialAddr(SILLocation loc, SILValue existential,
+                            CanType formalConcreteType,
+                            SILType loweredConcreteType,
+                            ArrayRef<ProtocolConformanceRef> conformances);
+
+  InitExistentialValueInst *
+  createInitExistentialValue(SILLocation loc, SILType existentialType,
+                             CanType formalConcreteType, SILValue concrete,
+                             ArrayRef<ProtocolConformanceRef> conformances);
+
+  InitExistentialMetatypeInst *
+  createInitExistentialMetatype(SILLocation loc, SILValue metatype,
+                                SILType existentialType,
+                                ArrayRef<ProtocolConformanceRef> conformances);
+
+  InitExistentialRefInst *
+  createInitExistentialRef(SILLocation loc, SILType existentialType,
+                           CanType formalConcreteType, SILValue concreteValue,
+                           ArrayRef<ProtocolConformanceRef> conformances);
+
+  AllocExistentialBoxInst *
+  createAllocExistentialBox(SILLocation loc, SILType existentialType,
+                            CanType concreteType,
+                            ArrayRef<ProtocolConformanceRef> conformances);
+};
+
+} // namespace Lowering
+} // namespace swift
+
+#endif


### PR DESCRIPTION
…nBuilder inherit from it.

This prevents ManagedValue APIs on SILGenBuilder from by mistake accesing
non-conformance tracking APIs on SILBuilder.

NOTE: Eventually, we should make SILGenBuilder compose with SILGenSILBuilder and
then rename SILGenBuilder to ManagedValueBuilder. I did not do that in this PR
since it becomes very disruptive since there is still a lot of code in SILGen
that uses SILValue APIs and I have not found a concise way to write such
code. But this patch at least defines away this error which has bitten us
before.
