### PR TITLE
Implement basic tensor pretty printing, based on NumPy printing.

### DIFF
--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -799,8 +799,39 @@ extension Tensor : Equatable where Scalar : Equatable {
 
 /// String conversion.
 extension Tensor : CustomStringConvertible {
+  /// A textual representation of the tensor.
+  ///
+  /// - Note: use `fullDescription` for a non-pretty-printed representation
+  ///   showing all scalars.
   public var description: String {
     return array.description
+  }
+}
+
+public extension Tensor {
+  /// A textual representation of the tensor. Returns a summarized description
+  /// if `summarize` is true and the element count exceeds twice the
+  /// `edgeElementCount`.
+  ///
+  /// - Parameters:
+  ///   - lineWidth: The max line width for printing. Used to determine number
+  ///     of scalars to print per line.
+  ///   - edgeElementCount: The maximum of elements to print before and after
+  ///     summarization via ellipses (`...`).
+  ///   - summarize: If true, summarize description if element count exceeds
+  ///     twice `edgeElementCount`.
+  func description(
+    lineWidth: Int = 80, edgeElementCount: Int = 3, summarize: Bool = false
+  ) -> String {
+    return array.description(
+      lineWidth: lineWidth, edgeElementCount: edgeElementCount,
+      summarize: summarize)
+  }
+
+  /// A full, non-pretty-printed textual representation of the tensor, showing
+  /// all scalars.
+  var fullDescription: String {
+    return array.fullDescription
   }
 }
 

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -797,12 +797,12 @@ extension Tensor : Equatable where Scalar : Equatable {
 // Description and visualization
 //===----------------------------------------------------------------------===//
 
-/// String conversion.
+// String conversion.
 extension Tensor : CustomStringConvertible {
   /// A textual representation of the tensor.
   ///
-  /// - Note: use `fullDescription` for a non-pretty-printed representation
-  ///   showing all scalars.
+  /// - Note: use `fullDescription` for a non-pretty-printed description showing
+  ///   all scalars.
   public var description: String {
     return array.description
   }
@@ -816,16 +816,16 @@ public extension Tensor {
   /// - Parameters:
   ///   - lineWidth: The max line width for printing. Used to determine number
   ///     of scalars to print per line.
-  ///   - edgeElementCount: The maximum of elements to print before and after
-  ///     summarization via ellipses (`...`).
-  ///   - summarize: If true, summarize description if element count exceeds
+  ///   - edgeElementCount: The maximum number of elements to print before and
+  ///     after summarization via ellipses (`...`).
+  ///   - summarizing: If true, summarize description if element count exceeds
   ///     twice `edgeElementCount`.
   func description(
-    lineWidth: Int = 80, edgeElementCount: Int = 3, summarize: Bool = false
+    lineWidth: Int = 80, edgeElementCount: Int = 3, summarizing: Bool = false
   ) -> String {
     return array.description(
       lineWidth: lineWidth, edgeElementCount: edgeElementCount,
-      summarize: summarize)
+      summarizing: summarizing)
   }
 
   /// A full, non-pretty-printed textual representation of the tensor, showing
@@ -835,14 +835,14 @@ public extension Tensor {
   }
 }
 
-/// Xcode Playground display conversion.
+// Xcode Playground display conversion.
 extension Tensor : CustomPlaygroundDisplayConvertible {
   public var playgroundDescription: Any {
     return description
   }
 }
 
-/// Mirror representation, used by debugger/REPL.
+// Mirror representation, used by debugger/REPL.
 extension Tensor : CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [], displayStyle: .struct)

--- a/test/TensorFlowRuntime/description.swift
+++ b/test/TensorFlowRuntime/description.swift
@@ -1,0 +1,250 @@
+// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Tensor description (`CustomStringConvertible` conformance) tests.
+
+import TensorFlow
+import StdlibUnittest
+
+var DescriptionTests = TestSuite("DescriptionTests")
+
+DescriptionTests.test("Empty") {
+  let empty = Tensor<Float>([] as [Float])
+  expectEqual("[]", empty.description)
+}
+
+DescriptionTests.test("Scalar") {
+  do {
+    let scalar = Tensor<Int32>(1)
+    expectEqual("1", scalar.description)
+  }
+
+  do {
+    let scalar = Tensor<Float>(-3.14)
+    expectEqual("-3.14", scalar.description)
+  }
+}
+
+DescriptionTests.test("Vector") {
+  do {
+    let vector = Tensor<Int32>(ones: [4])
+    expectEqual("[1, 1, 1, 1]", vector.description)
+  }
+
+  do {
+    var vector = Tensor<Float>([1, 2, 3, 4])
+    expectEqual("[1.0, 2.0, 3.0, 4.0]", vector.description)
+    vector[1] = Tensor<Float>(-2)
+    // vector = Tensor<Float>([1, -2, 3, 4])
+    expectEqual("[ 1.0, -2.0,  3.0,  4.0]", vector.description)
+  }
+
+  // Test long vector (above 1000 scalar threshold).
+  do {
+    let vector = Tensor<Float>(repeating: 3, shape: [1001])
+    expectEqual("[3.0, 3.0, 3.0, ..., 3.0, 3.0, 3.0]", vector.description)
+  }
+}
+
+DescriptionTests.test("Matrix") {
+  do {
+    var matrix = Tensor<Int32>(ones: [2, 2])
+    expectEqual("""
+      [[1, 1],
+       [1, 1]]
+      """, matrix.description)
+    // Increase max scalar length.
+    // Check that scalars are still aligned (properly left padded).
+    matrix[0][1] = Tensor(-1)
+    expectEqual("""
+      [[ 1, -1],
+       [ 1,  1]]
+      """, matrix.description)
+  }
+
+  do {
+    var matrix = Tensor<Float>(ones: [2, 2])
+    expectEqual("""
+      [[1.0, 1.0],
+       [1.0, 1.0]]
+      """, matrix.description)
+    // Increase max scalar length.
+    // Check that scalars are still aligned (properly left padded).
+    matrix[0][1] = Tensor(-1)
+    expectEqual("""
+      [[ 1.0, -1.0],
+       [ 1.0,  1.0]]
+      """, matrix.description)
+  }
+}
+
+DescriptionTests.test("HigherRankTensors") {
+  do {
+    let tensor = Tensor<Int32>(ones: [1, 1, 1, 1])
+    expectEqual("[[[[1]]]]", tensor.description)
+  }
+
+  do {
+    let tensor = Tensor<Int32>(ones: [3, 4, 5])
+    expectEqual("""
+      [[[1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1]],
+
+       [[1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1]],
+
+       [[1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1]]]
+      """, tensor.description)
+  }
+
+  // Test large tensor (above 1000 scalar threshold).
+  do {
+    let tensor = Tensor<Int32>(ones: [10, 10, 11])
+    expectEqual("""
+      [[[1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        ...,
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1]],
+
+       [[1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        ...,
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1]],
+
+       [[1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        ...,
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1]],
+
+       ...,
+
+       [[1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        ...,
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1]],
+
+       [[1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        ...,
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1]],
+
+       [[1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        ...,
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1],
+        [1, 1, 1, ..., 1, 1, 1]]]
+      """, tensor.description)
+  }
+}
+
+// Test example random initialization (longer scalars).
+// Hard-coded test tensors generated via `Tensor(randomNormal:)`.
+DescriptionTests.test("RandomScalars") {
+  do {
+    var matrix = Tensor<Float>(
+      [[  1.1621541, -0.39326498],
+       [ -1.5391855,    -1.11794]]
+    )
+    expectEqual("""
+      [[  1.1621541, -0.39326498],
+       [ -1.5391855,    -1.11794]]
+      """, matrix.description)
+    // Use one short scalar.
+    // Check that scalars are still aligned (properly left padded).
+    matrix[0][1] = Tensor(-1)
+    expectEqual("""
+      [[ 1.1621541,       -1.0],
+       [-1.5391855,   -1.11794]]
+      """, matrix.description)
+  }
+
+  do {
+    var matrix = Tensor<Double>(
+      [[  0.3374860907024739,   0.1805635511143933],
+       [  0.1861132028235124, -0.08243178459215775]]
+    )
+    expectEqual("""
+      [[  0.3374860907024739,   0.1805635511143933],
+       [  0.1861132028235124, -0.08243178459215775]]
+      """, matrix.description)
+    // Use one short scalar.
+    // Check that scalars are still aligned (properly left padded).
+    matrix[0][1] = Tensor(-1)
+    expectEqual("""
+      [[  0.3374860907024739,                 -1.0],
+       [  0.1861132028235124, -0.08243178459215775]]
+      """, matrix.description)
+  }
+}
+
+DescriptionTests.test("DescriptionConfiguration") {
+  // Test `lineWidth` configuration.
+  let vector = Tensor<Float>(ones: [10])
+  expectEqual("[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]",
+              vector.description)
+  expectEqual("""
+    [1.0, 1.0,
+     1.0, 1.0,
+     1.0, 1.0,
+     1.0, 1.0,
+     1.0, 1.0]
+    """, vector.description(lineWidth: 6))
+
+  // Test `summarize` configuration.
+  let longVector = Tensor<Float>(ones: [1001])
+  expectTrue(longVector.description.contains("..."))
+  expectFalse(longVector.description(summarize: false).contains("..."))
+
+  // Test `edgeElementCount` configuration.
+  var tallMatrix = Tensor<Float>(ones: [50, 2])
+  expectEqual("""
+    [[1.0, 1.0],
+     [1.0, 1.0],
+     [1.0, 1.0],
+     ...,
+     [1.0, 1.0],
+     [1.0, 1.0],
+     [1.0, 1.0]]
+    """,
+    tallMatrix.description(summarize: true))
+  expectEqual("""
+    [[1.0, 1.0],
+     ...,
+     [1.0, 1.0]]
+    """,
+    tallMatrix.description(edgeElementCount: 1, summarize: true))
+}
+
+DescriptionTests.test("FullDescription") {
+  let vector = Tensor<Float>(ones: [2, 2, 2])
+  expectEqual("[[[1.0, 1.0], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]]",
+              vector.fullDescription)
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -137,15 +137,4 @@ ShapedArrayTests.test("Hashable") {
   checkHashable([ShapedArraySlice(shape: [2, 3], scalars: Array(0..<6))], equalityOracle: { $0 == $1 })
 }
 
-ShapedArrayTests.test("StringDescription") {
-  let scalar = ShapedArray(shape: [], scalars: [1.0])
-  expectEqual("1.0", scalar.description)
-
-  let x = ShapedArray(shape: [2, 3], scalars: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-  expectEqual("[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]", x.description)
-
-  let y = ShapedArraySlice(shape: [2, 3], scalars: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-  expectEqual("[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]", y.description)
-}
-
 runAllTests()

--- a/test/TensorFlowRuntime/string_description.swift
+++ b/test/TensorFlowRuntime/string_description.swift
@@ -220,12 +220,12 @@ StringDescriptionTests.test("DescriptionConfiguration") {
      1.0, 1.0]
     """, vector.description(lineWidth: 6))
 
-  // Test `summarize` configuration.
+  // Test `summarizing` configuration.
   // NOTE: `String.contains(_ substring: String)` requires Foundation.
 #if canImport(Foundation)
   let longVector = Tensor<Float>(ones: [1001])
   expectTrue(longVector.description.contains("..."))
-  expectFalse(longVector.description(summarize: false).contains("..."))
+  expectFalse(longVector.description(summarizing: false).contains("..."))
 #endif // canImport(Foundation)
 
   // Test `edgeElementCount` configuration.
@@ -239,13 +239,13 @@ StringDescriptionTests.test("DescriptionConfiguration") {
      [1.0, 1.0],
      [1.0, 1.0]]
     """,
-    tallMatrix.description(summarize: true))
+    tallMatrix.description(summarizing: true))
   expectEqual("""
     [[1.0, 1.0],
      ...,
      [1.0, 1.0]]
     """,
-    tallMatrix.description(edgeElementCount: 1, summarize: true))
+    tallMatrix.description(edgeElementCount: 1, summarizing: true))
 }
 
 StringDescriptionTests.test("FullDescription") {

--- a/test/TensorFlowRuntime/string_description.swift
+++ b/test/TensorFlowRuntime/string_description.swift
@@ -3,19 +3,24 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //
-// Tensor description (`CustomStringConvertible` conformance) tests.
+// `Tensor` string description tests.
 
 import TensorFlow
 import StdlibUnittest
 
-var DescriptionTests = TestSuite("DescriptionTests")
+// Note: Foundation is needed for `String.contains(_: String)`.
+#if canImport(Foundation)
+import Foundation
+#endif
 
-DescriptionTests.test("Empty") {
+var StringDescriptionTests = TestSuite("StringDescriptionTests")
+
+StringDescriptionTests.test("Empty") {
   let empty = Tensor<Float>([] as [Float])
   expectEqual("[]", empty.description)
 }
 
-DescriptionTests.test("Scalar") {
+StringDescriptionTests.test("Scalar") {
   do {
     let scalar = Tensor<Int32>(1)
     expectEqual("1", scalar.description)
@@ -27,7 +32,7 @@ DescriptionTests.test("Scalar") {
   }
 }
 
-DescriptionTests.test("Vector") {
+StringDescriptionTests.test("Vector") {
   do {
     let vector = Tensor<Int32>(ones: [4])
     expectEqual("[1, 1, 1, 1]", vector.description)
@@ -37,7 +42,6 @@ DescriptionTests.test("Vector") {
     var vector = Tensor<Float>([1, 2, 3, 4])
     expectEqual("[1.0, 2.0, 3.0, 4.0]", vector.description)
     vector[1] = Tensor<Float>(-2)
-    // vector = Tensor<Float>([1, -2, 3, 4])
     expectEqual("[ 1.0, -2.0,  3.0,  4.0]", vector.description)
   }
 
@@ -48,7 +52,7 @@ DescriptionTests.test("Vector") {
   }
 }
 
-DescriptionTests.test("Matrix") {
+StringDescriptionTests.test("Matrix") {
   do {
     var matrix = Tensor<Int32>(ones: [2, 2])
     expectEqual("""
@@ -80,7 +84,7 @@ DescriptionTests.test("Matrix") {
   }
 }
 
-DescriptionTests.test("HigherRankTensors") {
+StringDescriptionTests.test("HigherRankTensors") {
   do {
     let tensor = Tensor<Int32>(ones: [1, 1, 1, 1])
     expectEqual("[[[[1]]]]", tensor.description)
@@ -165,7 +169,7 @@ DescriptionTests.test("HigherRankTensors") {
 
 // Test example random initialization (longer scalars).
 // Hard-coded test tensors generated via `Tensor(randomNormal:)`.
-DescriptionTests.test("RandomScalars") {
+StringDescriptionTests.test("RandomScalars") {
   do {
     var matrix = Tensor<Float>(
       [[  1.1621541, -0.39326498],
@@ -203,7 +207,7 @@ DescriptionTests.test("RandomScalars") {
   }
 }
 
-DescriptionTests.test("DescriptionConfiguration") {
+StringDescriptionTests.test("DescriptionConfiguration") {
   // Test `lineWidth` configuration.
   let vector = Tensor<Float>(ones: [10])
   expectEqual("[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]",
@@ -217,9 +221,12 @@ DescriptionTests.test("DescriptionConfiguration") {
     """, vector.description(lineWidth: 6))
 
   // Test `summarize` configuration.
+  // NOTE: `String.contains(_ substring: String)` requires Foundation.
+#if canImport(Foundation)
   let longVector = Tensor<Float>(ones: [1001])
   expectTrue(longVector.description.contains("..."))
   expectFalse(longVector.description(summarize: false).contains("..."))
+#endif // canImport(Foundation)
 
   // Test `edgeElementCount` configuration.
   var tallMatrix = Tensor<Float>(ones: [50, 2])
@@ -241,7 +248,7 @@ DescriptionTests.test("DescriptionConfiguration") {
     tallMatrix.description(edgeElementCount: 1, summarize: true))
 }
 
-DescriptionTests.test("FullDescription") {
+StringDescriptionTests.test("FullDescription") {
   let vector = Tensor<Float>(ones: [2, 2, 2])
   expectEqual("[[[1.0, 1.0], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]]",
               vector.fullDescription)


### PR DESCRIPTION
Pretty-printing functionality:
* Print element tensors on new lines.
* Truncate long tensors.
  * Summarize overly long contents with `...`.
* Provide configuration options.
  * `lineWidth`: max line width for printing.
  * `edgeElementCount`: max number of elements to print before and after
    summarization via `...`.
  * `summarizing`: if true, summarize description when element count exceeds twice
    `edgeElementCount`.

Todos:
* Add scalar formatting.
* For `ShapedArray`: test aesthetics for custom `Scalar` types.

---

Resolves [TF-420](https://bugs.swift.org/browse/TF-420).
[TF-419](https://bugs.swift.org/browse/TF-419) has more info, including a survey of tensor printing in existing frameworks.