### PR TITLE
[utils] Remove unused method.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -31,11 +31,6 @@ class Product(object):
         return cls.product_name()
 
     @classmethod
-    def get_build_directory_name(cls, host_target):
-        return "{}-{}".format(cls.product_name(),
-                              host_target.name)
-
-    @classmethod
     def is_build_script_impl_product(cls):
         """is_build_script_impl_product -> bool
 


### PR DESCRIPTION
The method was not used anywhere, and Workspace provides a better alternative which gives the full path instead of just the directory name.

This was part of #23257. I’m trying to split the PR in smaller ones to make the reviews easier. Other PRs in this group are #23303, #23803, #23810, and #23822.
