### PR TITLE
[build-script] Add to default LLDB CMake variables on MacOS

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2534,6 +2534,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options+=(
                       -DLLDB_BUILD_FRAMEWORK:BOOL=TRUE
                       -DLLDB_CODESIGN_IDENTITY=""
+                      -DLLDB_USE_SYSTEM_DEBUGSERVER:BOOL=TRUE
+                      -DLLDB_FRAMEWORK_TOOLS="darwin-debug;lldb-argdumper;lldb-server;repl_swift"
                     )
                   fi
                 fi


### PR DESCRIPTION
LLDB's CMake build forces these values when building on MacOS. I would like to change LLDB to not force these values for these variables, so setting them in the build invocation seems like the right thing to do.

cc @weliveindetail @dcci @compnerd 