### PR TITLE
`allSatisfy` was added in Swift 4.2

### DIFF
--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -558,7 +558,7 @@ extension ShapedArray where Scalar : TensorFlowScalar {
       precondition(rank <= Int32.max, """
         Conversion to TensorHandle is undefined when rank exceeds Int32.max.
         """)
-      precondition(shape.forAll { $0 <= Int32.max }, """
+      precondition(shape.allSatisfy { $0 <= Int32.max }, """
         Conversion to TensorHandle is undefined when shape dimensions exceed \
         Int32.max.
         """)
@@ -718,7 +718,7 @@ public struct ShapedArraySlice<Scalar> : _ShapedArrayProtocol {
   ) {
     precondition(indices.count <= base.rank,
                  "Number of base indices exceeds base rank")
-    precondition(zip(base.shape, indices).forAll { $1 >= 0 && $1 < $0 },
+    precondition(zip(base.shape, indices).allSatisfy { $1 >= 0 && $1 < $0 },
                  "Base indices are out of range")
     self.base = base
     self.baseIndices = indices

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -22,18 +22,6 @@ import Glibc
 import CTensorFlow
 
 //===----------------------------------------------------------------------===//
-// Standard library extensions
-//===----------------------------------------------------------------------===//
-
-public extension Sequence {
-  /// Returns true if all elements satisfy the predicate.
-  @available(*, deprecated, renamed: "allSatisfy(_:)")
-  func forAll(_ predicate: (Element) throws -> Bool) rethrows -> Bool {
-    return try first(where: { try !predicate($0) }) == nil
-  }
-}
-
-//===----------------------------------------------------------------------===//
 // Runtime checkers
 //===----------------------------------------------------------------------===//
 

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -27,6 +27,7 @@ import CTensorFlow
 
 public extension Sequence {
   /// Returns true if all elements satisfy the predicate.
+  @available(*, deprecated, renamed: "allSatisfy(_:)")
   func forAll(_ predicate: (Element) throws -> Bool) rethrows -> Bool {
     return try first(where: { try !predicate($0) }) == nil
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
I noticed `forAll(_:)` existed here, even though it was merged added to Swift 4.2 as `allSatisfy(_:)`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: 
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->