### PR TITLE
runtime: force unaligned start/stop markers

### DIFF
--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -27,10 +27,12 @@
 #define DECLARE_SWIFT_SECTION(name)                                            \
   PRAGMA(section("." #name "$A", long, read))                                  \
   __declspec(allocate("." #name "$A"))                                         \
+  __declspec(align(1))                                                         \
   static uintptr_t __start_##name = 0;                                         \
                                                                                \
   PRAGMA(section("." #name "$C", long, read))                                  \
   __declspec(allocate("." #name "$C"))                                         \
+  __declspec(align(1))                                                         \
   static uintptr_t __stop_##name = 0;
 
 extern "C" {


### PR DESCRIPTION
The sections to which the start/stop symbols are being applied do not
guarantee pointer alignment.  In particular, the field metadata is
aligned to a 4-byte boundary, which is less then the pointer alignment
of `uintptr_t`.  This results in extra padding in the data which is
going to cause the iteration to run off the end.  A similar byte
alignment is forced for the markers in the ELF case as well.  This fixes
one of the reflection tests on Windows where we were attempting to
decode the padding as an entry.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
