### PR TITLE
test: make Frontend.vfs pass on Windows

### DIFF
--- a/test/Frontend/vfs.swift
+++ b/test/Frontend/vfs.swift
@@ -3,24 +3,24 @@
 // RUN: sed -e "s|INPUT_DIR|%/S/Inputs|g" -e "s|OUT_DIR|%/t|g" %S/Inputs/vfs/secondary-vfsoverlay.yaml > %t/secondary-overlay.yaml
 // RUN: sed -e "s|INPUT_DIR|%/S/Inputs|g" -e "s|OUT_DIR|%/t|g" %S/Inputs/vfs/tertiary-vfsoverlay.yaml > %t/tertiary-overlay.yaml
 
-// RUN: not %target-swift-frontend -vfsoverlay %t/overlay.yaml -typecheck %s %t/mapped-file.swift -serialize-diagnostics-path %t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
-// RUN: c-index-test -read-diagnostics %t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
+// RUN: not %target-swift-frontend -vfsoverlay %/t/overlay.yaml -typecheck %s %/t/mapped-file.swift -serialize-diagnostics-path %/t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
+// RUN: c-index-test -read-diagnostics %/t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
 
 // BASIC_MAPPING_ERROR: {{.*}}/mapped-file.swift:2:17: error:
 
-// RUN: not %target-swift-frontend -vfsoverlay %t/overlay.yaml -vfsoverlay %t/secondary-overlay.yaml -vfsoverlay %t/tertiary-overlay.yaml -typecheck %s %t/triple-mapped-swift-file.swift -serialize-diagnostics-path %t/complex.dia 2>&1 | %FileCheck -check-prefix=COMPLEX_MAPPING_ERROR %s
-// RUN: c-index-test -read-diagnostics %t/complex.dia 2>&1 | %FileCheck -check-prefix=COMPLEX_MAPPING_ERROR %s
+// RUN: not %target-swift-frontend -vfsoverlay %/t/overlay.yaml -vfsoverlay %/t/secondary-overlay.yaml -vfsoverlay %/t/tertiary-overlay.yaml -typecheck %/s %/t/triple-mapped-swift-file.swift -serialize-diagnostics-path %/t/complex.dia 2>&1 | %FileCheck -check-prefix=COMPLEX_MAPPING_ERROR %s
+// RUN: c-index-test -read-diagnostics %/t/complex.dia 2>&1 | %FileCheck -check-prefix=COMPLEX_MAPPING_ERROR %s
 
 // COMPLEX_MAPPING_ERROR: {{.*}}/triple-mapped-swift-file.swift:2:17: error:
 
 // The Clang Importer should inherit Swift's VFS
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -DTEST_VFS_CLANG_IMPORTER -vfsoverlay %t/overlay.yaml -typecheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -vfsoverlay %/t//overlay.yaml -typecheck %/s
 
 // Just -Xcc -ivfsoverlay should work fine too
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -DTEST_VFS_CLANG_IMPORTER -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -typecheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -Xcc -ivfsoverlay -Xcc %/t/overlay.yaml -typecheck %/s
 
 // If we see -ivfsoverlay and -vfsoverlay, we'll clobber Clang's VFS with our own.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -DTEST_VFS_CLANG_IMPORTER -vfsoverlay %t/overlay.yaml -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -typecheck %s  2>&1 | %FileCheck -check-prefix=WARN_VFS_CLOBBERED %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -vfsoverlay %/t/overlay.yaml -Xcc -ivfsoverlay -Xcc %/t/overlay.yaml -typecheck %/s  2>&1 | %FileCheck -check-prefix=WARN_VFS_CLOBBERED %s
 
 // WARN_VFS_CLOBBERED: warning: ignoring '-ivfsoverlay' options provided to '-Xcc' in favor of '-vfsoverlay'
 


### PR DESCRIPTION
Ensure that we convert the path to the correct separator for the mapping
to take effect.  This makes the last Frontend test pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
