### PR TITLE
[silgenpattern] Fix ownership error which could result in a use-after…

### DIFF
--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -249,8 +249,8 @@ enum SR7799 {
 // CHECK: bb0(%0 : $Optional<SR7799>):
 // CHECK-NEXT:  debug_value %0 : $Optional<SR7799>, let, name "bar", argno 1
 // CHECK-NEXT:  switch_enum %0 : $Optional<SR7799>, case #Optional.some!enumelt.1: bb1, default bb4
-// CHECK: bb1(%3 : $SR7799):
-// CHECK-NEXT:  switch_enum %3 : $SR7799, case #SR7799.one!enumelt: bb2, case #SR7799.two!enumelt: bb3
+// CHECK: bb1([[PHI_ARG:%.*]] : $SR7799):
+// CHECK-NEXT:  switch_enum [[PHI_ARG]] : $SR7799, case #SR7799.one!enumelt: bb2, case #SR7799.two!enumelt: bb3
 func sr7799(bar: SR7799?) {
   switch bar {
   case .one: print("one")

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -12,6 +12,7 @@ import resilient_enum
 // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience15resilientSwitchyy0c1_A06MediumOF : $@convention(thin) (@in_guaranteed Medium) -> ()
 // CHECK:         [[BOX:%.*]] = alloc_stack $Medium
 // CHECK-NEXT:    copy_addr %0 to [initialization] [[BOX]]
+// CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt.1: bb3, case #Medium.Postcard!enumelt.1: bb4, default bb5
 // CHECK:       bb1:
 // CHECK-NEXT:    dealloc_stack [[BOX]]
@@ -32,7 +33,6 @@ import resilient_enum
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb5:
-// CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$ss27_diagnoseUnexpectedEnumCase
 // CHECK-NEXT:    = apply [[DIAGNOSE]]<Medium>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -17,6 +17,7 @@
 // CHECK-LABEL: sil hidden [ossa] @$s24enum_resilience_testable15resilientSwitchyy0d1_A06MediumOF : $@convention(thin) (@in_guaranteed Medium) -> ()
 // CHECK:         [[BOX:%.*]] = alloc_stack $Medium
 // CHECK-NEXT:    copy_addr %0 to [initialization] [[BOX]]
+// CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt.1: bb3, case #Medium.Postcard!enumelt.1: bb4, default bb5
 // CHECK:       bb1:
 // CHECK-NEXT:    dealloc_stack [[BOX]]
@@ -37,7 +38,6 @@
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb5:
-// CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$ss27_diagnoseUnexpectedEnumCase
 // CHECK-NEXT:    = apply [[DIAGNOSE]]<Medium>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -1029,8 +1029,8 @@ func testOptionalEnumMix(_ a : Int?) -> Int {
   case let x?:
     return 0
 
-  // CHECK: [[SOMEBB]](%3 : $Int):
-  // CHECK-NEXT: debug_value %3 : $Int, let, name "x"
+  // CHECK: [[SOMEBB]]([[X:%.*]] : $Int):
+  // CHECK-NEXT: debug_value [[X]] : $Int, let, name "x"
   // CHECK: integer_literal $Builtin.IntLiteral, 0
 
   case .none:
@@ -1051,8 +1051,8 @@ func testOptionalEnumMixWithNil(_ a : Int?) -> Int {
   case let x?:
     return 0
 
-  // CHECK: [[SOMEBB]](%3 : $Int):
-  // CHECK-NEXT: debug_value %3 : $Int, let, name "x"
+  // CHECK: [[SOMEBB]]([[X:%.*]] : $Int):
+  // CHECK-NEXT: debug_value [[X]] : $Int, let, name "x"
   // CHECK: integer_literal $Builtin.IntLiteral, 0
 
   case nil:

--- a/test/SILGen/switch_objc.swift
+++ b/test/SILGen/switch_objc.swift
@@ -25,3 +25,30 @@ func matchesEither(input: Hive, a: Hive, b: Hive) -> Bool {
     return false
   }
 }
+
+@objc enum ObjCEnum : UInt8 {
+case first
+case second
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11switch_objc44checkObjCEnumUnhandledCaseDiagnosticEmission1xyAA0dE0O_tF : $@convention(thin) (ObjCEnum) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[METATYPE:%.*]] = metatype $@thick ObjCEnum.Type
+// CHECK:   [[ARG_INT_REPR:%.*]] = unchecked_trivial_bit_cast [[ARG]]
+// CHECK:   switch_enum [[ARG]] : $ObjCEnum, {{.*}}, default [[DEFAULT_BB:bb[0-9]+]]
+//
+// CHECK: [[DEFAULT_BB]](
+// CHECK:   [[STACK_SLOT:%.*]] = alloc_stack $UInt8
+// CHECK:   store [[ARG_INT_REPR]] to [trivial] [[STACK_SLOT]]
+// CHECK:   [[DIAGNOSE_FUNC:%.*]] = function_ref @$ss32_diagnoseUnexpectedEnumCaseValue4type03rawE0s5NeverOxm_q_tr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@thick τ_0_0.Type, @in_guaranteed τ_0_1) -> Never
+// CHECK:   apply [[DIAGNOSE_FUNC]]<ObjCEnum, UInt8>([[METATYPE]], [[STACK_SLOT]])
+// CHECK:   unreachable
+// CHECK: } // end sil function '$s11switch_objc44checkObjCEnumUnhandledCaseDiagnosticEmission1xyAA0dE0O_tF'
+func checkObjCEnumUnhandledCaseDiagnosticEmission(x: ObjCEnum) {
+  switch x {
+  case .first:
+    break
+  case .second:
+    break
+  }
+}


### PR DESCRIPTION
…-free.

Specifically, in order to generate runtime errors when we do not handle an enum
appropriately, we form a metatype from the input of the switch. The problem is
that by the time we get to the leaf of the emission tree where this metatype is
created, the input of the switch may have already been consumed. This means
creating the metatype could be a use after free.

This patch fixes the problem by stashing the insertion point /after/ we emit
(the potentially empty) of instructions for the switch input but before we emit
the switch itself. Then if we find out in the leafs of the pattern emission tree
that we need the metatype, we are able to backtrack and create it before it is
possible for the input to be consumed by the switch.

rdar://49562761
