### PR TITLE
Ban Self in typealias for now

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1065,8 +1065,11 @@ static Type diagnoseUnknownType(TypeResolution resolution,
           methodDecl->getDeclContext() == dc->getParentForLookup();
         bool isPropertyOfClass = insideClass &&
           options.is(TypeResolverContext::PatternBindingDecl);
+        bool isTypeAliasInClass = insideClass &&
+          options.is(TypeResolverContext::TypeAliasDecl);
 
-        if (((!insideClass || !declaringMethod) && !isPropertyOfClass &&
+        if (((!insideClass || !declaringMethod) &&
+             !isPropertyOfClass && !isTypeAliasInClass &&
              !options.is(TypeResolverContext::GenericRequirement)) ||
             options.is(TypeResolverContext::ExplicitCastExpr)) {
           Type SelfType = nominal->getSelfInterfaceType();

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -46,6 +46,8 @@ final class FinalMario : Mario {
 // These references to Self are now possible (SE-0068)
 
 class A<T> {
+  typealias _Self = Self
+  // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
   let b: Int
   required init(a: Int) {
     print("\(Self.self).\(#function)")

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -81,6 +81,13 @@ class A<T> {
     let copy = Self.init(a: 11)
     return copy
   }
+  subscript (i: Int) -> Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+    get {
+      return Self.init(a: i)
+    }
+    set(newValue) {
+    }
+  }
 }
 
 class B: A<Int> {
@@ -165,6 +172,13 @@ extension S2 {
     Self.x()
     return Self.init() as? Self
     // expected-warning@-1 {{conditional cast from 'S2' to 'S2' always succeeds}}
+  }
+  subscript (i: Int) -> Self {
+    get {
+      return Self.init()
+    }
+    set(newValue) {
+    }
   }
 }
 


### PR DESCRIPTION
Hi Apple,

A further followup to https://github.com/apple/swift/pull/22863, temporally ban ingenious attempts to "leak" type Self from a class using a typealias statement. Will need to be cherrypicked into 5.1-branch cc @slavapestov 

Resolves #52734.