### PR TITLE
[AutoDiff] Propagate '@nondiff' from AST function types to SIL function types.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -396,6 +396,8 @@ NOTE(autodiff_protocol_member_not_differentiable,none,
 NOTE(autodiff_protocol_member_subset_indices_not_differentiable,none,
      "member is differentiable only with respect to a smaller subset of "
      "arguments", ())
+NOTE(autodiff_function_nondiff_parameter_not_differentiable,none,
+     "cannot differentiate with respect to a '@nondiff' parameter", ())
 NOTE(autodiff_function_assoc_func_requirements_unmet,none,
      "function call is not differentiable because generic requirements are not "
      "met", ())

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3093,6 +3093,7 @@ public:
     return getExtInfo().getRepresentation();
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
   /// Given `indices`, `differentiationOrder`, and `kind`, calculates the type
   /// of the corresponding autodiff associated function.
   ///
@@ -3104,6 +3105,8 @@ public:
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
       LookupConformanceFn lookupConformance,
       GenericSignature *whereClauseGenericSignature = nullptr);
+
+  AnyFunctionType *getWithoutDifferentiability() const;
 
   /// \brief True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -547,7 +547,6 @@ public:
         theFunction));
   }
 
-
   AutoDiffFunctionExtractInst *createAutoDiffFunctionExtractOriginal(
       SILLocation loc, SILValue theFunction) {
     return insert(new (getModule()) AutoDiffFunctionExtractInst(

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2338,7 +2338,7 @@ static void printParameterFlags(ASTPrinter &printer, PrintOptions options,
     printer << "@escaping ";
   // SWIFT_ENABLE_TENSORFLOW
   if (!options.excludeAttrKind(TAK_nondiff) && flags.isNonDifferentiable())
-    printer << "@nondiff";
+    printer << "@nondiff ";
 
   switch (flags.getValueOwnership()) {
   case ValueOwnership::Default:

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -254,15 +254,12 @@ AutoDiffParameterIndices::getLowered(AnyFunctionType *functionType) const {
 }
 
 static unsigned getNumAutoDiffParameterIndices(AnyFunctionType *fnTy) {
-  unsigned numAutoDiffParameterIndices = 0;
-  // FIXME: Compute the exact parameter count.
-  // Do not loop ad-infinitum; loop either 1 or 2 iterations, depending on
-  // whether the function is a free function/static method/instance method.
-  while (fnTy != nullptr) {
-    numAutoDiffParameterIndices += fnTy->getNumParams();
-    fnTy = fnTy->getResult()->getAs<AnyFunctionType>();
-  }
-  return numAutoDiffParameterIndices;
+  // TODO: For more correct counting, we still need to know whether it's a
+  // method or not.
+  unsigned numParameters = fnTy->getNumParams();
+  if (auto *innerFn = fnTy->getResult()->getAs<AnyFunctionType>())
+    numParameters += innerFn->getNumParams();
+  return numParameters;
 }
 
 /// Returns true if the given type conforms to `Differentiable` in the given

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1075,8 +1075,8 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
   // of the associated function type.
   auto *origFnTy =
       firstArgGen.build(builder)->castTo<AnyFunctionType>();
-  origFnTy = origFnTy->withExtInfo(
-      origFnTy->getExtInfo().withDifferentiable(false).withNoEscape(false));
+  origFnTy = origFnTy->getWithoutDifferentiability()->withExtInfo(
+      origFnTy->getExtInfo().withNoEscape(false));
   auto autodiffBuilder = AutoDiffParameterIndicesBuilder::inferParameters(
       origFnTy, Context.getStdlibModule());
   auto *paramIndices = autodiffBuilder.build(Context);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4304,3 +4304,18 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
 
   return associatedFunction;
 }
+
+AnyFunctionType *AnyFunctionType::getWithoutDifferentiability() const {
+  SmallVector<Param, 8> newParams;
+  for (auto &param : getParams()) {
+    Param newParam(param.getPlainType(), param.getLabel(),
+                   param.getParameterFlags().withNonDifferentiable(false));
+    newParams.push_back(newParam);
+  }
+  auto nonDiffExtInfo = getExtInfo().withDifferentiable(false);
+  if (isa<FunctionType>(this))
+    return FunctionType::get(newParams, getResult(), nonDiffExtInfo);
+  assert(isa<GenericFunctionType>(this));
+  return GenericFunctionType::get(getOptGenericSignature(), newParams,
+                                  getResult(), nonDiffExtInfo);
+}

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -67,7 +67,7 @@ public:
     auto differentiationOrder = std::get<1>(Index);
     auto kind = *std::get<0>(Index).getExtracteeAsAssociatedFunction();
     auto assocTy = origFnTy->getAutoDiffAssociatedFunctionType(
-        SmallBitVector(origFnTy->getNumParameters(), true), /*resultIndex*/ 0,
+        origFnTy->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
         differentiationOrder, kind, IGM.getSILModule(),
         LookUpConformanceInModule(IGM.getSwiftModule()));
     return SILType::getPrimitiveObjectType(assocTy);
@@ -159,7 +159,7 @@ public:
     auto differentiationOrder = std::get<1>(field);
     auto kind = *std::get<0>(field).getExtracteeAsAssociatedFunction();
     auto assocTy = origFnTy->getAutoDiffAssociatedFunctionType(
-        SmallBitVector(origFnTy->getNumParameters(), true), /*resultIndex*/ 0,
+        origFnTy->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
         differentiationOrder, kind, IGM.getSILModule(),
         LookUpConformanceInModule(IGM.getSwiftModule()));
     return SILType::getPrimitiveObjectType(assocTy);

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -38,11 +38,15 @@ using DiffFuncIndex =
 namespace {
 class DiffFuncFieldInfo final : public RecordField<DiffFuncFieldInfo> {
 public:
-  DiffFuncFieldInfo(DiffFuncIndex index, const TypeInfo &type)
-      : RecordField(type), Index(index) {}
+  DiffFuncFieldInfo(DiffFuncIndex index, const TypeInfo &type,
+                    const SmallBitVector &parameterIndices)
+      : RecordField(type), Index(index), ParameterIndices(parameterIndices) {}
 
   /// The field index.
   const DiffFuncIndex Index;
+
+  /// The parameter indices.
+  SmallBitVector ParameterIndices;
 
   std::string getFieldName() const {
     auto extractee = std::get<0>(Index);
@@ -67,9 +71,8 @@ public:
     auto differentiationOrder = std::get<1>(Index);
     auto kind = *std::get<0>(Index).getExtracteeAsAssociatedFunction();
     auto assocTy = origFnTy->getAutoDiffAssociatedFunctionType(
-        origFnTy->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
-        differentiationOrder, kind, IGM.getSILModule(),
-        LookUpConformanceInModule(IGM.getSwiftModule()));
+        ParameterIndices, /*resultIndex*/ 0, differentiationOrder, kind,
+        IGM.getSILModule(), LookUpConformanceInModule(IGM.getSwiftModule()));
     return SILType::getPrimitiveObjectType(assocTy);
   }
 };
@@ -118,14 +121,13 @@ class DiffFuncTypeBuilder
                                DiffFuncIndex> {
 
   SILFunctionType *origFnTy;
+  SmallBitVector parameterIndices;
 
 public:
   DiffFuncTypeBuilder(IRGenModule &IGM, SILFunctionType *fnTy)
-      : RecordTypeBuilder(IGM) {
+      : RecordTypeBuilder(IGM), origFnTy(fnTy->getWithoutDifferentiability()),
+        parameterIndices(fnTy->getDifferentiationParameterIndices()) {
     assert(fnTy->isDifferentiable());
-    auto extInfo = fnTy->getExtInfo();
-    auto nondiffExtInfo = extInfo.withDifferentiable(false);
-    origFnTy = fnTy->getWithExtInfo(nondiffExtInfo);
   }
 
   TypeInfo *createFixed(ArrayRef<DiffFuncFieldInfo> fields,
@@ -150,7 +152,7 @@ public:
 
   DiffFuncFieldInfo getFieldInfo(unsigned index, DiffFuncIndex field,
                                  const TypeInfo &fieldTI) {
-    return DiffFuncFieldInfo(field, fieldTI);
+    return DiffFuncFieldInfo(field, fieldTI, parameterIndices);
   }
 
   SILType getType(DiffFuncIndex field) {
@@ -159,9 +161,8 @@ public:
     auto differentiationOrder = std::get<1>(field);
     auto kind = *std::get<0>(field).getExtracteeAsAssociatedFunction();
     auto assocTy = origFnTy->getAutoDiffAssociatedFunctionType(
-        origFnTy->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
-        differentiationOrder, kind, IGM.getSILModule(),
-        LookUpConformanceInModule(IGM.getSwiftModule()));
+        parameterIndices, /*resultIndex*/ 0, differentiationOrder, kind,
+        IGM.getSILModule(), LookUpConformanceInModule(IGM.getSwiftModule()));
     return SILType::getPrimitiveObjectType(assocTy);
   }
 

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -63,9 +63,7 @@ public:
 
   SILType getType(IRGenModule &IGM, SILType t) const {
     auto fnTy = t.castTo<SILFunctionType>();
-    auto extInfo = fnTy->getExtInfo();
-    auto nondiffExtInfo = extInfo.withDifferentiable(false);
-    auto origFnTy = fnTy->getWithExtInfo(nondiffExtInfo);
+    auto origFnTy = fnTy->getWithoutDifferentiability();
     if (std::get<0>(Index) == AutoDiffFunctionExtractInst::Extractee::Original)
       return SILType::getPrimitiveObjectType(origFnTy);
     auto differentiationOrder = std::get<1>(Index);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3580,10 +3580,8 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     (void)adFnExp.claimAll();
     tmpCalleeLV = LoweredValue(e);
 
-    origCalleeType = origCalleeType->getWithExtInfo(
-        origCalleeType->getExtInfo().withDifferentiable(false));
-    substCalleeType = substCalleeType->getWithExtInfo(
-        substCalleeType->getExtInfo().withDifferentiable(false));
+    origCalleeType = origCalleeType->getWithoutDifferentiability();
+    substCalleeType = substCalleeType->getWithoutDifferentiability();
   }
   const LoweredValue &calleeLV =
       tmpCalleeLV ? *tmpCalleeLV : getLoweredValue(site.getCallee());

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -153,6 +153,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
     AutoDiffAssociatedFunctionKind kind, SILModule &module,
     LookupConformanceFn lookupConformance,
     GenericSignature *whereClauseGenSig) {
+
   // JVP: (T...) -> ((R...),
   //                 (T.TangentVector...) -> (R.TangentVector...))
   // VJP: (T...) -> ((R...),
@@ -294,7 +295,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
         result.getType()->getCanonicalType(whereClauseGenSig));
     newResults.push_back(mappedResult);
   }
-  newResults.push_back({closureType, ResultConvention::Owned});
+  newResults.push_back({closureType->getCanonicalType(whereClauseGenSig),
+                        ResultConvention::Owned});
   return SILFunctionType::get(whereClauseGenSig, getExtInfo(),
                               getCoroutineKind(), getCalleeConvention(),
                               getParameters(), getYields(), newResults,

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -215,12 +215,10 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   // Calculate WRT parameter infos, in the order that they appear in the
   // AST-level parameter lists.
   SmallVector<SILParameterInfo, 4> wrtParams;
-  for (auto valueAndIndex : enumerate(getParameters())) {
-    llvm::errs() << "Parameter " << valueAndIndex.value() << '\n';
+  for (auto valueAndIndex : enumerate(getParameters()))
     if (valueAndIndex.index() < parameterIndices.size() &&
         parameterIndices[valueAndIndex.index()])
       wrtParams.push_back(valueAndIndex.value());
-  }
 
   CanSILFunctionType closureType;
   switch (kind) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -99,35 +99,14 @@ CanType SILFunctionType::getSelfInstanceType() const {
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-llvm::SmallBitVector
+SmallBitVector
 SILFunctionType::getDifferentiationParameterIndices() const {
   assert(isDifferentiable());
-
-  // Unwrap curry levels.
-  SmallVector<const SILFunctionType *, 2> curryLevels;
-  auto *currentLevel = this;
-  unsigned numParameters = 0;
-  while (currentLevel != nullptr) {
-    curryLevels.push_back(currentLevel);
-    numParameters += currentLevel->getNumParameters();
-    if (currentLevel->getNumResults() != 1)
-      break;
-    currentLevel =
-        currentLevel->getSingleResult().getType()->getAs<SILFunctionType>();
-  }
-
-  SmallBitVector result(numParameters);
-  unsigned currentOffset = 0;
-  for (auto *curryLevel : reversed(curryLevels)) {
-    for (auto paramAndIndex : enumerate(curryLevel->getParameters())) {
-      auto &param = paramAndIndex.value();
-      unsigned index = paramAndIndex.index();
-      if (param.getDifferentiability() ==
-              SILParameterDifferentiability::DifferentiableOrNotApplicable)
-        result.set(currentOffset + index);
-    }
-    currentOffset += curryLevel->getNumParameters();
-  }
+  SmallBitVector result(NumParameters, true);
+  for (auto valueAndIndex : enumerate(getParameters()))
+    if (valueAndIndex.value().getDifferentiability() ==
+            SILParameterDifferentiability::NotDifferentiable)
+      result.reset(valueAndIndex.index());
   return result;
 }
 
@@ -183,10 +162,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   auto &typeConverter = module.Types;
   Lowering::GenericContextScope
       genericContextScope(module.Types, getGenericSignature());
-
-  auto testParamIndex = [&](unsigned index) -> bool {
-    return index < parameterIndices.size() && parameterIndices[index];
-  };
+  if (!whereClauseGenSig)
+    whereClauseGenSig = getGenericSignature();
 
   // Given a type, returns its formal SIL parameter info.
   auto getCotangentParameterInfoForOriginalResult = [&](
@@ -235,144 +212,78 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
     return {cotanType, conv};
   };
 
-  // Unwrap curry levels.
-  SmallVector<SILFunctionType *, 2> curryLevels;
-  auto *currentLevel = this;
-  while (currentLevel != nullptr) {
-    curryLevels.push_back(currentLevel);
-    if (currentLevel->getNumResults() != 1)
-      break;
-    currentLevel =
-        currentLevel->getSingleResult().getType()->getAs<SILFunctionType>();
-  }
-
-  SmallVector<unsigned, 2> curryLevelParameterIndexOffsets(curryLevels.size());
-  unsigned currentOffset = 0;
-  for (unsigned curryLevelIndex : reversed(indices(curryLevels))) {
-    curryLevelParameterIndexOffsets[curryLevelIndex] = currentOffset;
-    currentOffset += curryLevels[curryLevelIndex]->getNumParameters();
-  }
-
   // Calculate WRT parameter infos, in the order that they appear in the
   // AST-level parameter lists.
   SmallVector<SILParameterInfo, 4> wrtParams;
-  for (unsigned curryLevelIndex : indices(curryLevels)) {
-    auto *curryLevel = curryLevels[curryLevelIndex];
-    unsigned parameterIndexOffset =
-        curryLevelParameterIndexOffsets[curryLevelIndex];
-    unsigned numParamsWithoutSelf = curryLevel->getNumParameters() -
-        (curryLevel->hasSelfParam() ? 1 : 0);
-    if (curryLevel->hasSelfParam() &&
-        testParamIndex(parameterIndexOffset + numParamsWithoutSelf))
-      wrtParams.push_back(curryLevel->getSelfParameter());
-    for (unsigned paramIndex : range(numParamsWithoutSelf)) {
-      if (testParamIndex(parameterIndexOffset + paramIndex)) {
-        wrtParams.push_back(curryLevel->getParameters()[paramIndex]);
-      }
-    }
-  }
-
-  auto withNewResults = [&](SILFunctionType *base,
-                            ArrayRef<SILResultInfo> newResults,
-                            GenericSignature *genericSignature)
-      -> CanSILFunctionType {
-    if (!genericSignature)
-      genericSignature = base->getGenericSignature();
-    // If generic signature is specified, use it to canonical result types.
-    // This is important for consistent typing for types like:
-    //     <T : Differentiable, T == T.CotangentVector> (...) ->
-    //         (@out T.CotangentVector)
-    // Which should be canonicalized to:
-    //     <T : Differentiable, T == T.CotangentVector> (...) ->
-    //         (@out T)
-    ArrayRef<SILResultInfo> results =
-        genericSignature
-            ? map<SmallVector<SILResultInfo, 4>>(
-                  newResults, [&](SILResultInfo resInfo) {
-                    return resInfo.getWithType(
-                        resInfo.getType()->getCanonicalType(genericSignature));
-                  })
-            : newResults;
-    return SILFunctionType::get(genericSignature,
-                                base->getExtInfo(),
-                                base->getCoroutineKind(),
-                                base->getCalleeConvention(),
-                                base->getParameters(), base->getYields(),
-                                results, base->getOptionalErrorResult(), ctx,
-                                base->getWitnessMethodConformanceOrNone());
-  };
+  for (auto valueAndIndex : enumerate(getParameters()))
+    if (parameterIndices[valueAndIndex.index()])
+      wrtParams.push_back(valueAndIndex.value());
 
   CanSILFunctionType closureType;
   switch (kind) {
   case AutoDiffAssociatedFunctionKind::JVP: {
-    SmallVector<SILParameterInfo, 8> tangentParams;
-    for (auto &param : wrtParams)
-      tangentParams.push_back(
-          {param.getType()
-               ->getAutoDiffAssociatedVectorSpace(
-                   AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
-               ->getCanonicalType(),
+    SmallVector<SILParameterInfo, 8> differentialParams;
+    for (auto &param : wrtParams) {
+      differentialParams.push_back(
+          {param.getType()->getAutoDiffAssociatedVectorSpace(
+               AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
+                   ->getCanonicalType(),
            param.getConvention()});
-    SmallVector<SILResultInfo, 8> tangentResults;
-    auto &result = curryLevels.back()->getResults()[resultIndex];
-    tangentResults.push_back(
-        {result.getType()
-             ->getAutoDiffAssociatedVectorSpace(
-                 AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
-             ->getCanonicalType(),
+    }
+    SmallVector<SILResultInfo, 8> differentialResults;
+    auto &result = getResults()[resultIndex];
+    differentialResults.push_back(
+        {result.getType()->getAutoDiffAssociatedVectorSpace(
+             AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
+                 ->getCanonicalType(),
          result.getConvention()});
     closureType = SILFunctionType::get(
         /*genericSignature*/ nullptr, ExtInfo(), SILCoroutineKind::None,
-        ParameterConvention::Direct_Guaranteed, tangentParams, {},
-        tangentResults, None, ctx);
+        ParameterConvention::Direct_Guaranteed, differentialParams, {},
+        differentialResults, None, ctx);
     break;
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
-    SmallVector<SILParameterInfo, 8> cotangentParams;
-    auto &origRes = curryLevels.back()->getResults()[resultIndex];
+    SmallVector<SILParameterInfo, 8> pullbackParams;
+    auto &origRes = getResults()[resultIndex];
     auto cotangentAssocTy =
-        origRes.getType()
-            ->getAutoDiffAssociatedVectorSpace(
-                AutoDiffAssociatedVectorSpaceKind::Cotangent, lookupConformance)
-            ->getCanonicalType();
-    cotangentParams.push_back(
+        origRes.getType()->getAutoDiffAssociatedVectorSpace(
+            AutoDiffAssociatedVectorSpaceKind::Cotangent, lookupConformance)
+                ->getCanonicalType();
+    pullbackParams.push_back(
         getCotangentParameterInfoForOriginalResult(cotangentAssocTy,
-                                          origRes.getConvention()));
-    SmallVector<SILResultInfo, 8> cotangentResults;
+                                                   origRes.getConvention()));
+    SmallVector<SILResultInfo, 8> pullbackResults;
     for (auto &param : wrtParams) {
       auto paramCotangentTy =
-          param.getType()
-              ->getAutoDiffAssociatedVectorSpace(
-                  AutoDiffAssociatedVectorSpaceKind::Cotangent,
-                  lookupConformance)
-              ->getCanonicalType();
-      cotangentResults.push_back(
+          param.getType()->getAutoDiffAssociatedVectorSpace(
+              AutoDiffAssociatedVectorSpaceKind::Cotangent, lookupConformance)
+                  ->getCanonicalType();
+      pullbackResults.push_back(
           getCotangentResultInfoForOriginalParameter(paramCotangentTy,
-                                            param.getConvention()));
+                                                     param.getConvention()));
     }
     closureType = SILFunctionType::get(
         /*genericSignature*/ nullptr, ExtInfo(), SILCoroutineKind::None,
-        ParameterConvention::Direct_Guaranteed, cotangentParams, {},
-        cotangentResults, {}, ctx);
+        ParameterConvention::Direct_Guaranteed, pullbackParams, {},
+        pullbackResults, {}, ctx);
     break;
   }
   }
 
-  SmallVector<SILResultInfo, 8> results(
-      curryLevels.back()->getResults().begin(),
-      curryLevels.back()->getResults().end());
-  results.push_back({closureType, ResultConvention::Owned});
-  CanSILFunctionType associatedFunction =
-      withNewResults(curryLevels.back(), results,
-                     whereClauseGenSig);
-
-  auto curryLevelsWithoutLast =
-      ArrayRef<SILFunctionType *>(curryLevels).drop_back(1);
-  for (auto *curryLevel : reversed(curryLevelsWithoutLast))
-    associatedFunction = withNewResults(
-        curryLevel, {{associatedFunction, ResultConvention::Owned}},
-        whereClauseGenSig);
-  return associatedFunction;
+  SmallVector<SILResultInfo, 4> newResults;
+  newResults.reserve(getNumResults() + 1);
+  for (auto &result : getResults()) {
+    auto mappedResult = result.getWithType(
+        result.getType()->getCanonicalType(whereClauseGenSig));
+    newResults.push_back(mappedResult);
+  }
+  newResults.push_back({closureType, ResultConvention::Owned});
+  return SILFunctionType::get(whereClauseGenSig, getExtInfo(),
+                              getCoroutineKind(), getCalleeConvention(),
+                              getParameters(), getYields(), newResults,
+                              getOptionalErrorResult(), ctx,
+                              getWitnessMethodConformanceOrNone());
 }
 
 ProtocolDecl *
@@ -906,9 +817,11 @@ private:
     auto loweredType = substTL.getLoweredType().getASTType();
 
     // SWIFT_ENABLE_TENSORFLOW
-    Inputs.push_back(SILParameterInfo(loweredType, convention)
-        .getWithDifferentiability(
-            SILParameterDifferentiability::NotDifferentiable));
+    SILParameterInfo param(loweredType, convention);
+    if (isNonDifferentiable)
+      param.getWithDifferentiability(
+          SILParameterDifferentiability::NotDifferentiable);
+    Inputs.push_back(param);
 
     maybeAddForeignParameters();
   }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -215,9 +215,12 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   // Calculate WRT parameter infos, in the order that they appear in the
   // AST-level parameter lists.
   SmallVector<SILParameterInfo, 4> wrtParams;
-  for (auto valueAndIndex : enumerate(getParameters()))
-    if (parameterIndices[valueAndIndex.index()])
+  for (auto valueAndIndex : enumerate(getParameters())) {
+    llvm::errs() << "Parameter " << valueAndIndex.value() << '\n';
+    if (valueAndIndex.index() < parameterIndices.size() &&
+        parameterIndices[valueAndIndex.index()])
       wrtParams.push_back(valueAndIndex.value());
+  }
 
   CanSILFunctionType closureType;
   switch (kind) {
@@ -819,7 +822,7 @@ private:
     // SWIFT_ENABLE_TENSORFLOW
     SILParameterInfo param(loweredType, convention);
     if (isNonDifferentiable)
-      param.getWithDifferentiability(
+      param = param.getWithDifferentiability(
           SILParameterDifferentiability::NotDifferentiable);
     Inputs.push_back(param);
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -153,7 +153,6 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
     AutoDiffAssociatedFunctionKind kind, SILModule &module,
     LookupConformanceFn lookupConformance,
     GenericSignature *whereClauseGenSig) {
-
   // JVP: (T...) -> ((R...),
   //                 (T.TangentVector...) -> (R.TangentVector...))
   // VJP: (T...) -> ((R...),

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -832,7 +832,8 @@ private:
       auto flags = params[i].getParameterFlags();
 
       visit(flags.getValueOwnership(), /*forSelf=*/false,
-            eltPattern, ty, silRepresentation);
+            // SWIFT_ENABLE_TENSORFLOW
+            eltPattern, ty, silRepresentation, flags.isNonDifferentiable());
     }
 
     // Process the self parameter.  Note that we implicitly drop self
@@ -853,7 +854,9 @@ private:
 
   void visit(ValueOwnership ownership, bool forSelf,
              AbstractionPattern origType, CanType substType,
-             SILFunctionTypeRepresentation rep) {
+             // SWIFT_ENABLE_TENSORFLOW
+             SILFunctionTypeRepresentation rep,
+             bool isNonDifferentiable = false) {
     assert(!isa<InOutType>(substType));
 
     // Tuples get handled specially, in some cases:
@@ -902,7 +905,10 @@ private:
     }
     auto loweredType = substTL.getLoweredType().getASTType();
 
-    Inputs.push_back(SILParameterInfo(loweredType, convention));
+    // SWIFT_ENABLE_TENSORFLOW
+    Inputs.push_back(SILParameterInfo(loweredType, convention)
+        .getWithDifferentiability(
+            SILParameterDifferentiability::NotDifferentiable));
 
     maybeAddForeignParameters();
   }

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -678,19 +678,7 @@ getExtracteeType(SILValue function, Extractee extractee,
                  unsigned differentiationOrder, SILModule &module) {
   auto fnTy = function->getType().castTo<SILFunctionType>();
   assert(fnTy->getExtInfo().isDifferentiable());
-
-  auto originalFnExtInfo = fnTy->getExtInfo().withDifferentiable(false);
-  SmallVector<SILParameterInfo, 4> originalFnParameters;
-  for (auto &param : fnTy->getParameters())
-    originalFnParameters.push_back(SILParameterInfo(
-        param.getType(), param.getConvention(),
-        SILParameterDifferentiability::DifferentiableOrNotApplicable));
-  auto originalFnTy = SILFunctionType::get(
-      fnTy->getGenericSignature(), originalFnExtInfo, fnTy->getCoroutineKind(),
-      fnTy->getCalleeConvention(), originalFnParameters, fnTy->getYields(),
-      fnTy->getResults(), fnTy->getOptionalErrorResult(), fnTy->getASTContext(),
-      fnTy->getWitnessMethodConformanceOrNone());
-
+  auto originalFnTy = fnTy->getWithoutDifferentiability();
   auto kindOpt = extractee.getExtracteeAsAssociatedFunction();
   if (!kindOpt) {
     assert(extractee == Extractee::Original);

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -247,6 +247,7 @@ namespace {
     }
     
     RetTy visitSILFunctionType(CanSILFunctionType type) {
+      llvm::errs() << "visit FnTy: " << type << '\n';
       // SWIFT_ENABLE_TENSORFLOW
       if (type->isDifferentiable())
         return asImpl().visitDifferentiableSILFunctionType(type);
@@ -895,8 +896,7 @@ namespace {
       auto maxOrder = 1;
       auto numAssocFns = autodiff::getNumAutoDiffAssociatedFunctions(maxOrder);
       children.reserve(numAssocFns + 1);
-      auto origFnTy = fnTy->getWithExtInfo(
-          fnTy->getExtInfo().withDifferentiable(false));
+      auto origFnTy = fnTy->getWithoutDifferentiability();
       auto paramIndices = fnTy->getDifferentiationParameterIndices();
       children.push_back(Child{
         {AutoDiffFunctionExtractee::Original, 0},

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -247,7 +247,6 @@ namespace {
     }
     
     RetTy visitSILFunctionType(CanSILFunctionType type) {
-      llvm::errs() << "visit FnTy: " << type << '\n';
       // SWIFT_ENABLE_TENSORFLOW
       if (type->isDifferentiable())
         return asImpl().visitDifferentiableSILFunctionType(type);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5369,19 +5369,12 @@ RValue RValueEmitter::visitUnevaluatedInstanceExpr(UnevaluatedInstanceExpr *E,
 // SWIFT_ENABLE_TENSORFLOW
 RValue RValueEmitter::visitAutoDiffFunctionExpr(AutoDiffFunctionExpr *E,
                                                 SGFContext C) {
-  std::function<unsigned(Type)> countParams;
-  countParams = [&](Type type) -> unsigned {
-    auto *fnTy = type->getAs<AnyFunctionType>();
-    if (!fnTy)
-      return 0;
-    return fnTy->getNumParams() + countParams(fnTy->getResult());
-  };
-
-  // TODO(rxwei): Use the parameter indices and order specified in E's function
-  // type.
   auto orig = SGF.emitRValueAsSingleValue(E->getSubExpr());
-  auto *diffFunc = SGF.B.createAutoDiffFunction(E,
-      SmallBitVector(countParams(E->getType()), true), 1, orig.forward(SGF));
+  auto origFnTy = orig.getType().castTo<SILFunctionType>();
+  // TODO(rxwei): Use the order specified in E's function type.
+  auto *diffFunc = SGF.B.createAutoDiffFunction(
+      E, origFnTy->getDifferentiationParameterIndices(), /*order*/ 1,
+      orig.forward(SGF));
   return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(diffFunc));
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5370,10 +5370,10 @@ RValue RValueEmitter::visitUnevaluatedInstanceExpr(UnevaluatedInstanceExpr *E,
 RValue RValueEmitter::visitAutoDiffFunctionExpr(AutoDiffFunctionExpr *E,
                                                 SGFContext C) {
   auto orig = SGF.emitRValueAsSingleValue(E->getSubExpr());
-  auto origFnTy = orig.getType().castTo<SILFunctionType>();
+  auto destTy = SGF.getLoweredType(E->getType()).castTo<SILFunctionType>();
   // TODO(rxwei): Use the order specified in E's function type.
   auto *diffFunc = SGF.B.createAutoDiffFunction(
-      E, origFnTy->getDifferentiationParameterIndices(), /*order*/ 1,
+      E, destTy->getDifferentiationParameterIndices(), /*order*/ 1,
       orig.forward(SGF));
   return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(diffFunc));
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3218,10 +3218,6 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
   // value without disabling cleanup.
   auto fnValue = fn.getValue();
 
-  auto withoutDifferentiableType = [](CanAnyFunctionType type)
-      -> CanAnyFunctionType {
-    return type.withExtInfo(type->getExtInfo().withDifferentiable(false));
-  };
   auto withoutDifferentiablePattern = [](AbstractionPattern pattern)
       -> AbstractionPattern {
     auto patternType = cast<AnyFunctionType>(pattern.getType());
@@ -3232,9 +3228,11 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
     return pattern;
   };
 
-  auto inputSubstTypeNotDiff = withoutDifferentiableType(inputSubstType);
+  CanAnyFunctionType inputSubstTypeNotDiff(
+      inputSubstType->getWithoutDifferentiability());
   auto inputOrigTypeNotDiff = withoutDifferentiablePattern(inputOrigType);
-  auto outputSubstTypeNotDiff = withoutDifferentiableType(outputSubstType);
+  CanAnyFunctionType outputSubstTypeNotDiff(
+      outputSubstType->getWithoutDifferentiability());
   auto outputOrigTypeNotDiff = withoutDifferentiablePattern(outputOrigType);
   auto &expectedTLNotDiff = SGF.getTypeLowering(outputOrigTypeNotDiff,
                                                 outputSubstTypeNotDiff);
@@ -3246,11 +3244,12 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
       SGF, loc, managedOriginal, inputOrigTypeNotDiff, inputSubstTypeNotDiff,
       outputOrigTypeNotDiff, outputSubstTypeNotDiff, expectedTLNotDiff);
 
-  // TODO: Use parameter indices specified in the function type.
-  auto autodiffBuilder = AutoDiffParameterIndicesBuilder::inferParameters(
-      inputSubstType, SGF.getModule().getSwiftModule());
+  AutoDiffParameterIndicesBuilder paramIndicesBuilder(inputSubstType);
+  for (auto i : range(inputSubstType->getNumParams()))
+    if (!inputSubstType->getParams()[i].isNonDifferentiable())
+      paramIndicesBuilder.setParameter(i);
   auto *parameterIndices =
-      autodiffBuilder.build(inputSubstType->getASTContext());
+      paramIndicesBuilder.build(inputSubstType->getASTContext());
 
   auto getAssocFnTy =
       [&](CanAnyFunctionType fnTy, AutoDiffAssociatedFunctionKind kind)

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3223,8 +3223,7 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
     auto patternType = cast<AnyFunctionType>(pattern.getType());
     pattern.rewriteType(
         pattern.getGenericSignature(),
-        patternType.withExtInfo(
-            patternType->getExtInfo().withDifferentiable(false)));
+        patternType->getWithoutDifferentiability()->getCanonicalType());
     return pattern;
   };
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6831,9 +6831,12 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       maybeDiagnoseUnsupportedFunctionConversion(cs, expr, toFunc);
 
       // SWIFT_ENABLE_TENSORFLOW
-      auto toEINoAdConversion =
+      auto toEINoADConversion =
           toEI.withDifferentiable(fromEI.isDifferentiable());
-      auto toFuncNoADConversion = toFunc->withExtInfo(toEINoAdConversion);
+      auto toFuncNoADConversion = toFunc->withExtInfo(toEINoADConversion);
+      if (toEI.isDifferentiable() && !fromEI.isDifferentiable())
+        toFuncNoADConversion =
+            toFuncNoADConversion->getWithoutDifferentiability();
       expr = cs.cacheType(new (tc.Context)
                               FunctionConversionExpr(expr,
                                                      toFuncNoADConversion));
@@ -6842,10 +6845,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // because some of the other conversions are not currently supported on
       // @differentiable functions. (e.g. escape_to_noescape).
       // After we do support those conversions, the order will no longer matter.
-      if (!fromEI.isDifferentiable() && toEI.isDifferentiable()) {
+      if (!fromEI.isDifferentiable() && toEI.isDifferentiable())
         expr = cs.cacheType(new (tc.Context)
-                            AutoDiffFunctionExpr(expr, toFunc));
-      }
+                                AutoDiffFunctionExpr(expr, toFunc));
 
       return expr;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6778,8 +6778,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       auto fromEI = fromFunc->getExtInfo();
       // Handle implicit conversion from @differentiable.
       if (fromEI.isDifferentiable() && !toEI.isDifferentiable()) {
-        fromFunc = fromFunc->withExtInfo(fromEI.withDifferentiable(false))
-                ->castTo<FunctionType>();
+        fromFunc = fromFunc->getWithoutDifferentiability()
+            ->castTo<FunctionType>();
         expr = cs.cacheType(new (tc.Context)
             AutoDiffFunctionExtractOriginalExpr(expr, fromFunc));
       }

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -254,3 +254,14 @@ func nonVariedResult(_ x: Float) -> Float {
   // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to add '.withoutDerivative()'?}} {{15-15=.withoutDerivative()}}
   return one()
 }
+
+//===----------------------------------------------------------------------===//
+// Subset parameters
+//===----------------------------------------------------------------------===//
+
+func nondiff(_ f: @differentiable (Float, @nondiff Float) -> Float) -> Float {
+  // expected-note @+3 {{expression is not differentiable}}
+  // expected-note @+2 {{cannot differentiate with respect to a '@nondiff' parameter}}
+  // expected-error @+1 {{function is not differentiable}}
+  return gradient(at: 2) { x in f(x * x, x) }
+}

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -36,4 +36,9 @@ struct TF30 : Differentiable {
   @noDerivative var y: @differentiable (Float) -> Float
 }
 // Make sure this passes SIL verification.
-let _: @autodiff (TF30) -> Float = { x in x.x }
+let _: @differentiable (TF30) -> Float = { x in x.x }
+
+// Make sure `@nondiff` gets propagated through SIL.
+let _: @differentiable (Float, @nondiff Float) -> Float = { x, y in x }
+// Make sure `@nondiff` with non-`Differentiable` also works.
+let _: @differentiable (Float, @nondiff Int) -> Float = { x, y in x }

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -39,6 +39,8 @@ struct TF30 : Differentiable {
 let _: @differentiable (TF30) -> Float = { x in x.x }
 
 // Make sure `@nondiff` gets propagated through SIL.
-let _: @differentiable (Float, @nondiff Float) -> Float = { x, y in x }
 // Make sure `@nondiff` with non-`Differentiable` also works.
-let _: @differentiable (Float, @nondiff Int) -> Float = { x, y in x }
+public func nondiffs(_ f: @differentiable (Float, @nondiff Float) -> Float,
+                     _ g: @differentiable (Float, @nondiff Int) -> Float) {
+}
+nondiffs({ x, y in x }, { x, y in x })

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -42,5 +42,7 @@ let _: @differentiable (TF30) -> Float = { x in x.x }
 // Make sure `@nondiff` with non-`Differentiable` also works.
 public func nondiffs(_ f: @differentiable (Float, @nondiff Float) -> Float,
                      _ g: @differentiable (Float, @nondiff Int) -> Float) {
+  _ = gradient(at: 0) { f($0, 1) }
+  _ = gradient(at: 0) { g($0, 1) }
 }
 nondiffs({ x, y in x }, { x, y in x })

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -251,7 +251,7 @@ SimpleMathTests.test("StructSideEffects") {
   }
 
   func double(_ input: Float) -> Point {
-    var point = Point(x: input, y: input, z: input)
+    let point = Point(x: input, y: input, z: input)
     return point + point
   }
   expectEqual(6, pullback(at: 4, in: double)(Point(x: 1, y: 1, z: 1)))
@@ -309,11 +309,15 @@ SimpleMathTests.test("StructGeneric") {
 }
 
 SimpleMathTests.test("SubsetIndices") {
-  func train(_ lossFunction: @differentiable (Float, Float) -> Float) {
-    let y = Float(0)
-    _ = gradient(at: 0) { x in lossFunction(x, y) }
+  func grad(_ lossFunction: @differentiable (Float, Float) -> Float) -> Float {
+    return gradient(at: 1) { x in lossFunction(x * x, 10.0) }
   }
-  train { x, y in x + y }
+  expectEqual(2, grad { x, y in x + y })
+
+  func gradWRTNonDiff(_ lossFunction: @differentiable (Float, @nondiff Int) -> Float) -> Float {
+    return gradient(at: 2) { x in lossFunction(x * x, 10) }
+  }
+  expectEqual(4, gradWRTNonDiff { x, y in x + Float(y) })
 }
 
 runAllTests()


### PR DESCRIPTION
This is to unblock `@differentiable` functions with `@nondiff` parameters. 

- Propagate `@nondiff` from AST to SIL.
- Add `AnyFunctionType::getWithoutDifferentiability`, which drops all `@differentiable` and `@nondiff` attributes from a function type.
- Use autodiff parameter indices from function types now that `@nondiff` has been propagated.
- Replace currying logic from `SILFunctionType::getAssociatedFunctionType` with lightweight logic that handles methods, which is needed for differentiable protocol requirements.
- Emit an error when a `@nondiff` parameter is being differentiated with respect to.
- Fix `@nondiff` AST printing.

Note: 
- Once `SILDifferentiableFunctionType` in #23482 lands, `@nondiff` should be nuked from SIL.
- Before merging, pull from the `tensorflow` branch to make sure #23887 is merged.

Resolves [TF-421](https://bugs.swift.org/browse/TF-421).