### PR TITLE
Parse: XFAIL Parse.enum on Windows

### DIFF
--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -5,6 +5,9 @@
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 
+// Windows does not support FP80
+// XFAIL: OS=windows-msvc
+
 enum Empty {}
 
 enum Boolish {


### PR DESCRIPTION
Windows does not support FP80, only FP64.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
