### PR TITLE
Add `mean` and `variance` that take a Tensor<Int32> for `axes`.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -581,15 +581,6 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   }
 
   @inlinable
-  func _vjpMean(alongAxes axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
-    let value = mean(alongAxes: axes)
-    return (value, { [shape = shapeTensor,
-                      count = axes.map { shape[$0] }.reduce(1, *)] in
-      $0.broadcast(toShape: shape) / Tensor(Scalar(count))
-    })
-  }
-
-  @inlinable
   func _vjpMean(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
     let value = mean(alongAxes: axes)
     let count = Raw.gather(params: shapeTensor, indices: axes).product()

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -585,7 +585,7 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
     let value = mean(alongAxes: axes)
     let count = Raw.gather(params: shapeTensor, indices: axes).product()
     return (value, { [shape = shapeTensor] in
-       $0.broadcast(toShape: shape) / Tensor(count)
+      $0.broadcast(toShape: shape) / Tensor(count)
     })
   }
 

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -590,6 +590,15 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   }
 
   @inlinable
+  func _vjpMean(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    let value = mean(alongAxes: axes)
+    return (value, { [shape = shapeTensor,
+            count = Raw.gather(params: shapeTensor, indices: axes).product()] in
+       $0.broadcast(toShape: shape) / Tensor(count)
+    })
+  }
+
+  @inlinable
   func _vjpSum(alongAxes axes: [Int32]) -> (Tensor, (Tensor) -> Tensor) {
     let value = sum(alongAxes: axes)
     return (value, { [shape = shapeTensor] in $0.broadcast(toShape: shape) })

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -592,8 +592,8 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   @inlinable
   func _vjpMean(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
     let value = mean(alongAxes: axes)
-    return (value, { [shape = shapeTensor,
-            count = Raw.gather(params: shapeTensor, indices: axes).product()] in
+    let count = Raw.gather(params: shapeTensor, indices: axes).product()
+    return (value, { [shape = shapeTensor] in
        $0.broadcast(toShape: shape) / Tensor(count)
     })
   }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1310,12 +1310,9 @@ public extension Tensor where Scalar : Numeric {
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
-  @differentiable(
-    wrt: self, vjp: _vjpMean(alongAxes:)
-    where Scalar : TensorFlowFloatingPoint
-  )
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func mean(alongAxes axes: [Int32]) -> Tensor {
-    return Raw.mean(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
+    return mean(alongAxes: Tensor<Int32>(axes))
   }
 
   /// Returns the arithmetic mean along the specified axes. The reduced

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1301,6 +1301,19 @@ public extension Tensor where Scalar : Numeric {
     wrt: self, vjp: _vjpMean(alongAxes:)
     where Scalar : TensorFlowFloatingPoint
   )
+  func mean(alongAxes axes: Tensor<Int32>) -> Tensor {
+    return Raw.mean(self, reductionIndices: axes, keepDims: true)
+  }
+
+  /// Returns the arithmetic mean along the specified axes. The reduced
+  /// dimensions are retained with value 1.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(
+    wrt: self, vjp: _vjpMean(alongAxes:)
+    where Scalar : TensorFlowFloatingPoint
+  )
   func mean(alongAxes axes: [Int32]) -> Tensor {
     return Raw.mean(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
   }
@@ -1346,6 +1359,18 @@ public extension Tensor where Scalar : Numeric {
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func variance(alongAxes axes: Int32...) -> Tensor {
     return variance(alongAxes: axes)
+  }
+
+  /// Returns the variance along the specified axes. The reduced dimensions are
+  /// retained with value 1. Does not apply Bessel's correction.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  func variance(alongAxes axes: Tensor<Int32>) -> Tensor {
+    let mean = self.mean(alongAxes: axes)
+    let squaredDiff = (self - mean).squared()
+    return squaredDiff.mean(alongAxes: axes)
   }
 
   /// Returns the variance along the specified axes. The reduced dimensions are

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1377,9 +1377,7 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func variance(alongAxes axes: [Int32]) -> Tensor {
-    let mean = self.mean(alongAxes: axes)
-    let squaredDiff = (self - mean).squared()
-    return squaredDiff.mean(alongAxes: axes)
+    return variance(alongAxes: Tensor<Int32>(axes))
   }
 
   /// Returns the product along the specified axes. The reduced dimensions are


### PR DESCRIPTION
This is needed to get tracing to work with batch norm.  See https://bugs.swift.org/browse/TF-406.