### PR TITLE
[build-script] Move some calculations into independent methods.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -322,87 +322,98 @@ class BuildScriptInvocation(object):
         # FIXME: We should move the platform-derived arguments to be entirely
         # data driven, so that we can eliminate this code duplication and just
         # iterate over all supported platforms.
+        self.platforms_to_skip_build = self.__platforms_to_skip_build(args)
+        self.platforms_to_skip_test = self.__platforms_to_skip_test(args)
+        self.platforms_archs_to_skip_test = \
+            self.__platforms_archs_to_skip_test(args)
+        self.platforms_to_skip_test_host = \
+            self.__platforms_to_skip_test_host(args)
 
-        self.platforms_to_skip_build = set()
+        self.build_libparser_only = args.build_libparser_only
+
+    def __platforms_to_skip_build(self, args):
+        platforms_to_skip_build = set()
         if not args.build_linux:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
         if not args.build_freebsd:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
         if not args.build_cygwin:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
         if not args.build_osx:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
         if not args.build_ios_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
         if not args.build_ios_simulator:
-            self.platforms_to_skip_build.add(
-                StdlibDeploymentTarget.iOSSimulator)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.iOSSimulator)
         if not args.build_tvos_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
         if not args.build_tvos_simulator:
-            self.platforms_to_skip_build.add(
+            platforms_to_skip_build.add(
                 StdlibDeploymentTarget.AppleTVSimulator)
         if not args.build_watchos_device:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
         if not args.build_watchos_simulator:
-            self.platforms_to_skip_build.add(
+            platforms_to_skip_build.add(
                 StdlibDeploymentTarget.AppleWatchSimulator)
         if not args.build_android:
-            self.platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
+            platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
+        return platforms_to_skip_build
 
-        self.platforms_to_skip_test = set()
-        self.platforms_archs_to_skip_test = set()
+    def __platforms_to_skip_test(self, args):
+        platforms_to_skip_test = set()
         if not args.test_linux:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
         if not args.test_freebsd:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
         if not args.test_cygwin:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
         if not args.test_osx:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
         if not args.test_ios_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
         else:
             exit_rejecting_arguments("error: iOS device tests are not " +
                                      "supported in open-source Swift.")
         if not args.test_ios_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.iOSSimulator)
-        if not args.test_ios_32bit_simulator:
-            self.platforms_archs_to_skip_test.add(
-                StdlibDeploymentTarget.iOSSimulator.i386)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.iOSSimulator)
         if not args.test_tvos_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
         else:
             exit_rejecting_arguments("error: tvOS device tests are not " +
                                      "supported in open-source Swift.")
         if not args.test_tvos_simulator:
-            self.platforms_to_skip_test.add(
-                StdlibDeploymentTarget.AppleTVSimulator)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTVSimulator)
         if not args.test_watchos_host:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
         else:
             exit_rejecting_arguments("error: watchOS device tests are not " +
                                      "supported in open-source Swift.")
         if not args.test_watchos_simulator:
-            self.platforms_to_skip_test.add(
+            platforms_to_skip_test.add(
                 StdlibDeploymentTarget.AppleWatchSimulator)
         if not args.test_android:
-            self.platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
+            platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
 
-        self.platforms_to_skip_test_host = set()
+        return platforms_to_skip_test
+
+    def __platforms_archs_to_skip_test(self, args):
+        platforms_archs_to_skip_test = set()
+        if not args.test_ios_32bit_simulator:
+            platforms_archs_to_skip_test.add(
+                StdlibDeploymentTarget.iOSSimulator.i386)
+        return platforms_archs_to_skip_test
+
+    def __platforms_to_skip_test_host(self, args):
+        platforms_to_skip_test_host = set()
         if not args.test_android_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.Android)
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.Android)
         if not args.test_ios_host:
-            self.platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
         if not args.test_tvos_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.AppleTV)
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleTV)
         if not args.test_watchos_host:
-            self.platforms_to_skip_test_host.add(
-                StdlibDeploymentTarget.AppleWatch)
-        self.build_libparser_only = args.build_libparser_only
+            platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleWatch)
+        return platforms_to_skip_test_host
 
     def initialize_runtime_environment(self):
         """Change the program environment for building."""


### PR DESCRIPTION
Move the calculations of platforms_to_skip_build, platforms_to_skip_test, platforms_archs_to_skip_test, and platforms_to_skip_test_host to their own independent functions. Each function deal with one of them and they are pure functions, which should improve readability a little.

This commit is part of #23810 which was reverted in #23861. This commit only deals with a split of a large method into smaller function in the context of `BuildScriptInvocation`.

This was part of #23257. I’m trying to split the PR in smaller ones to make the reviews easier. Other PRs in this group are #23303, #23803, #23810, and #23822.