### PR TITLE
[5.1] [ParseableInterfaces] Short-circuit module loading in the PIML

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -51,6 +51,18 @@ protected:
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                   bool &isFramework);
 
+  /// Attempts to search the provided directory for a loadable serialized
+  /// .swiftmodule with the provided `ModuleFilename`. Subclasses must
+  /// override this method to perform their custom module lookup behavior.
+  ///
+  /// If such a module could not be loaded, the subclass must return a
+  /// `std::error_code` indicating the failure. There are two specific error
+  /// codes that will be treated specially:
+  /// - `errc::no_such_file_or_directory`: The module loader will stop looking
+  ///   for loadable modules and will diagnose the lookup failure.
+  /// - `errc::not_supported`: The module loader will stop looking for loadable
+  ///   modules and will defer to the remaining module loaders to look up this
+  ///   module.
   virtual std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -218,6 +218,8 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
                         moduleBuffer, moduleDocBuffer);
       if (!result) {
         return true;
+      } else if (result == std::errc::not_supported) {
+        return false;
       } else if (result != std::errc::no_such_file_or_directory) {
         return None;
       }
@@ -251,6 +253,8 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
                                                moduleBuffer, moduleDocBuffer);
       if (!result)
         return true;
+      else if (result == std::errc::not_supported)
+        return false;
     }
   }
 
@@ -320,6 +324,8 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
                                                moduleBuffer, moduleDocBuffer);
       if (!result)
         return true;
+      else if (result == std::errc::not_supported)
+        return false;
     }
   }
 

--- a/test/ParseableInterface/ModuleCache/prefer-local-module-to-sdk.swift
+++ b/test/ParseableInterface/ModuleCache/prefer-local-module-to-sdk.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t/BuildDir)
+// RUN: %empty-directory(%t/SecondBuildDir/Lib.swiftmodule)
+// RUN: %empty-directory(%t/ModuleCache)
+
+// RUN: echo 'public func showsUpInBothPlaces() {}' > %t/Lib.swift
+
+// 1. Create a .swiftinterface file containing just one API, and put it inside a second build dir (without a .swiftmodule)
+// RUN: %target-swift-frontend -typecheck %t/Lib.swift -emit-parseable-module-interface-path %t/SecondBuildDir/Lib.swiftmodule/%target-cpu.swiftinterface
+
+// 2. Add a new API to the module, and compile just the serialized version in the build dir.
+// RUN: echo 'public func onlyInTheCompiledModule() {}' >> %t/Lib.swift
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/BuildDir/Lib.swiftmodule -emit-parseable-module-interface-path %t/BuildDir/Lib.swiftinterface
+
+// 3. Make sure when we compile this test file, we can access both APIs since we'll
+//    load the compiled .swiftmodule instead of the .swiftinterface in the SDK.
+// RUN: %target-swift-frontend -typecheck %s -I %t/BuildDir -I %t/SecondBuildDir -module-cache-path %t/ModuleCache
+
+// 4. Make sure we didn't compile any .swiftinterfaces into the module cache.
+// RUN: ls %t/ModuleCache | not grep 'swiftmodule'
+
+import Lib
+
+showsUpInBothPlaces()
+onlyInTheCompiledModule()


### PR DESCRIPTION
Previously, the ParseableInterfaceModuleLoader relied on the assumption
that, if it returned `errc::not_supported`, it would fall through the
search paths and then move on to the SerializedModuleLoader. This did
not anticipate the possibility of a valid .swiftinterface coming later
in the search paths, which can cause issues for the standard library
which is in the resource-dir and should always be loaded from there.

Instead, make the module loading explicitly short-circuit when seeing
`errc::not_supported`, and document it.

Also add some more logging throughout `discoverLoadableModule` so we can
more easily catch issues like this in the future.

Fixes rdar://49479386

(Cherry-pick of #23857 to 5.1)