### PR TITLE
Add an api to trace an function and run it with XLA compilation.

### DIFF
--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -129,6 +129,16 @@ TracerTests.testAllBackends("TraceWithNoResult") {
   expectNearlyEqualWithScalarTensor(8.0, tracedAdd(Tensor<Float>(5.0), three))
 }
 
+TracerTests.testAllBackends("TracerWithInOut") {
+  func addOne(state: Tensor<Int32>) -> (Tensor<Int32>) {
+    return state + 1
+  }
+  let addOneGraph = _graph(addOne)
+  expectEqual(addOneGraph(Tensor<Int32>(5)), Tensor<Int32>(6))
+  expectEqual(addOneGraph(Tensor<Int32>(0)), Tensor<Int32>(1))
+  expectEqual(addOneGraph(Tensor<Int32>(-1)), Tensor<Int32>(0))
+}
+
 TracerTests.testAllBackends("Basic_IntermediateTensors") {
   func tracee(state: Tensor<Float>, data: Data) -> (Tensor<Float>, Result) {
     // Create an intermediate tensor value, which the tracing infra needs to


### PR DESCRIPTION
This PR adds an API to trace a function that takes a `TensorGroup` and returns a `TensorGroup`. The new API also takes an optional `useXLA` argument that enables XLA compilation when executing the traced graph. 

This is one of the several PRs needed for https://bugs.swift.org/browse/TF-406