### PR TITLE
[build-script] Rename all do_* methods to simply *.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -440,7 +440,7 @@ class BuildScriptInvocation(object):
             toolchain=self.toolchain,
             source_dir=self.workspace.source_dir("ninja"),
             build_dir=self.workspace.build_dir("build", "ninja"))
-        ninja_build.do_build()
+        ninja_build.build()
         self.toolchain.ninja = ninja_build.ninja_bin_path
 
     def convert_to_impl_arguments(self):
@@ -980,8 +980,8 @@ class BuildScriptInvocation(object):
                     source_dir=self.workspace.source_dir(product_source),
                     build_dir=self.workspace.build_dir(
                         host_target, product_name))
-                product.do_build(host_target)
-                product.do_test(host_target)
+                product.build(host_target)
+                product.test(host_target)
 
         # Extract symbols...
         for host_target in all_hosts:

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -28,10 +28,10 @@ class ToolchainBenchmarks(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def do_build(self, host_target):
+    def build(self, host_target):
         run_build_script_helper(host_target, self, self.args)
 
-    def do_test(self, host_target):
+    def test(self, host_target):
         """Just run a single instance of the command for both .debug and
            .release.
         """

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -27,10 +27,10 @@ class IndexStoreDB(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def do_build(self, host_target):
+    def build(self, host_target):
         run_build_script_helper('build', host_target, self, self.args)
 
-    def do_test(self, host_target):
+    def test(self, host_target):
         if self.args.test and self.args.test_indexstoredb:
             run_build_script_helper('test', host_target, self, self.args)
 

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -32,7 +32,7 @@ class Ninja(product.Product):
     def ninja_bin_path(self):
         return os.path.join(self.build_dir, 'ninja')
 
-    def do_build(self):
+    def build(self):
         if os.path.exists(self.ninja_bin_path):
             return
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -38,15 +38,15 @@ class Product(object):
         """
         return True
 
-    def do_build(self, host_target):
-        """do_build() -> void
+    def build(self, host_target):
+        """build() -> void
 
         Perform the build, for a non-build-script-impl product.
         """
         raise NotImplementedError
 
-    def do_test(self, host_target):
-        """do_build() -> void
+    def test(self, host_target):
+        """test() -> void
 
         Run the tests, for a non-build-script-impl product.
         """

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -23,11 +23,11 @@ class SourceKitLSP(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def do_build(self, host_target):
+    def build(self, host_target):
         indexstoredb.run_build_script_helper(
             'build', host_target, self, self.args)
 
-    def do_test(self, host_target):
+    def test(self, host_target):
         if self.args.test and self.args.test_sourcekitlsp:
             indexstoredb.run_build_script_helper(
                 'test', host_target, self, self.args)

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -79,14 +79,14 @@ class NinjaTestCase(unittest.TestCase):
 
         self.assertEqual(ninja_build.ninja_bin_path, '/path/to/build/ninja')
 
-    def test_do_build(self):
+    def test_build(self):
         ninja_build = Ninja(
             args=self.args,
             toolchain=self.toolchain,
             source_dir=self.workspace.source_dir('ninja'),
             build_dir=self.workspace.build_dir('build', 'ninja'))
 
-        ninja_build.do_build()
+        ninja_build.build()
 
         expect_env = ""
         if platform.system() == "Darwin":


### PR DESCRIPTION
As proposed in #23822, the do_* methods should only be using the * parts. Because all building should have the same names, this commit removes the prefix from all the method instances.

