### PR TITLE
Sema: move `is_convertible` outside of class decl

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1494,11 +1494,11 @@ class ImplementationOnlyImportChecker
                               offendingType->getFullName(), M->getName());
       highlightOffendingType(TC, diag, complainRepr);
     }
-
-    static_assert(std::is_convertible<DiagnoseGenerically,
-                                      CheckImplementationOnlyCallback>::value,
-                  "DiagnoseGenerically has wrong call signature");
   };
+
+  static_assert(std::is_convertible<DiagnoseGenerically,
+                                    CheckImplementationOnlyCallback>::value,
+                "DiagnoseGenerically has wrong call signature");
 
   DiagnoseGenerically getDiagnoseCallback(const Decl *D) {
     return DiagnoseGenerically(TC, D);


### PR DESCRIPTION
Ensure the class is fully defined before performing the `is_convertible`
check which may trigger a compiler builtin.  Before the class is
complete, the compiler can not technically perform the check on it.
This fixes the build with `cl`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
