### PR TITLE
[AST] Mark two more dump() methods as LLVM_ATTRIBUTE_USED

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -221,7 +221,9 @@ public:
   
   void print(llvm::raw_ostream &OS,
              const PrintOptions &Options = PrintOptions()) const;
-  void dump() const;
+  LLVM_ATTRIBUTE_DEPRECATED(
+      void dump() const LLVM_ATTRIBUTE_USED,
+      "only for use within the debugger");
   
   /// walk - This recursively walks the AST rooted at this pattern.
   Pattern *walk(ASTWalker &walker);

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -160,7 +160,9 @@ public:
 
   void print(raw_ostream &OS, const PrintOptions &Opts = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;
-  void dump() const;
+  LLVM_ATTRIBUTE_DEPRECATED(
+      void dump() const LLVM_ATTRIBUTE_USED,
+      "only for use within the debugger");
 
   /// Clone the given type representation.
   TypeRepr *clone(const ASTContext &ctx) const;


### PR DESCRIPTION
...so that they don't get dead-code-stripped and become unusable from the debugger.
