### PR TITLE
[Foundation] Data: Hash the entire contents, not just an arbitrary subset

### DIFF
--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -1046,9 +1046,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         func hash(into hasher: inout Hasher) {
             hasher.combine(count)
 
-            // At most, hash the first 80 bytes of this data.
-            let range = startIndex ..< Swift.min(startIndex + 80, endIndex)
-            storage.withUnsafeBytes(in: range) {
+            // To ensure strong hashing, all bytes must be fed into the hasher.
+            withUnsafeBytes {
                 hasher.combine(bytes: $0)
             }
         }
@@ -1250,9 +1249,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         func hash(into hasher: inout Hasher) {
             hasher.combine(count)
 
-            // Hash at most the first 80 bytes of this data.
-            let range = startIndex ..< Swift.min(startIndex + 80, endIndex)
-            storage.withUnsafeBytes(in: range) {
+            // To ensure strong hashing, all bytes must be fed into the hasher.
+            withUnsafeBytes {
                 hasher.combine(bytes: $0)
             }
         }

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -974,6 +974,59 @@ class TestData : TestDataSuper {
         expectTrue(d.classForKeyedArchiver == expected)
     }
 
+    func test_Hashing() {
+        func bridgedData(_ bytes: [UInt8]) -> Data {
+            return bytes.withUnsafeBytes { buffer in
+                NSData(bytes: buffer.baseAddress, length: buffer.count) as Data
+            }
+        }
+
+    let simpleTests: [[Data]] = [
+            [
+                Data(),
+                bridgedData([]),
+            ],
+            [
+                Data([1]),
+                bridgedData([1]),
+            ],
+            [
+                Data([1, 2]),
+                bridgedData([1, 2]),
+            ],
+            [
+                Data([1, 2, 3]),
+                Data([1, 2, 3]),
+                bridgedData([1, 2, 3]),
+                bridgedData([1, 2, 3]),
+            ],
+            [
+                Data([2, 1, 3]),
+                bridgedData([2, 1, 3]),
+            ],
+        ]
+        checkHashableGroups(simpleTests)
+
+        // To ensure strong hashing, all bytes must be fed into the hasher.
+        let longTest: [Data] = [
+            Data([1]) + Data(UInt8.min ... UInt8.max),
+            Data([2]) + Data(UInt8.min ... UInt8.max),
+            Data(UInt8.min ... UInt8.max) + Data([1]),
+            Data(UInt8.min ... UInt8.max) + Data([2]),
+            Data(UInt8.min ..< 128) + Data([1]) + Data(128 ... UInt8.max),
+            Data(UInt8.min ..< 128) + Data([2]) + Data(128 ... UInt8.max),
+        ]
+        checkHashable(longTest, equalityOracle: { $0 == $1 })
+
+        let concatenationTest: [[Data]] = [
+            [Data([1, 2, 3]), Data()],
+            [Data([1, 2]), Data([3])],
+            [Data([1]), Data([2, 3])],
+            [Data(), Data([1, 2, 3])],
+        ]
+        checkHashable(concatenationTest, equalityOracle: { $0 == $1 })
+    }
+
     func test_AnyHashableContainingData() {
         let values: [Data] = [
             Data(base64Encoded: "AAAA")!,
@@ -3708,13 +3761,14 @@ class TestData : TestDataSuper {
         let base2 = Data(bytes: [0, 0xFF, 0xFF, 0])
         let base3 = Data(bytes: [0xFF, 0xFF, 0xFF, 0])
         let sliceEmulation = Data(bytes: [0xFF, 0xFF])
-        expectEqual(base1.hashValue, base2.hashValue)
         let slice1 = base1[base1.startIndex.advanced(by: 1)..<base1.endIndex.advanced(by: -1)]
         let slice2 = base2[base2.startIndex.advanced(by: 1)..<base2.endIndex.advanced(by: -1)]
         let slice3 = base3[base3.startIndex.advanced(by: 1)..<base3.endIndex.advanced(by: -1)]
-        expectEqual(slice1.hashValue, sliceEmulation.hashValue)
-        expectEqual(slice1.hashValue, slice2.hashValue)
-        expectEqual(slice2.hashValue, slice3.hashValue)
+        checkHashableGroups([
+            [base1, base2],
+            [base3],
+            [sliceEmulation, slice1, slice2, slice3],
+        ])
     }
 
     func test_slice_resize_growth() {
@@ -3725,16 +3779,10 @@ class TestData : TestDataSuper {
 
     func test_hashEmptyData() {
         let d1 = Data()
-        let h1 = d1.hashValue
-
         let d2 = NSData() as Data
-        let h2 = d2.hashValue
-        expectEqual(h1, h2)
-
         let data = Data(bytes: [0, 1, 2, 3, 4, 5, 6])
         let d3 = data[4..<4]
-        let h3 = d3.hashValue
-        expectEqual(h1, h3)
+        checkHashableGroups([[d1, d2, d3]])
     }
     
     func test_validateMutation_slice_withUnsafeMutableBytes_lengthLessThanLowerBound() {
@@ -3847,6 +3895,7 @@ DataTests.test("test_basicMutableDataMutation") { TestData().test_basicMutableDa
 DataTests.test("test_passing") { TestData().test_passing() }
 DataTests.test("test_bufferSizeCalculation") { TestData().test_bufferSizeCalculation() }
 DataTests.test("test_classForCoder") { TestData().test_classForCoder() }
+DataTests.test("test_Hashing") { TestData().test_Hashing() }
 DataTests.test("test_AnyHashableContainingData") { TestData().test_AnyHashableContainingData() }
 DataTests.test("test_AnyHashableCreatedFromNSData") { TestData().test_AnyHashableCreatedFromNSData() }
 DataTests.test("test_noCopyBehavior") { TestData().test_noCopyBehavior() }


### PR DESCRIPTION
This was cherry picked from commit b711ed9f90222302cebc6ae6e36ba7eb755a7d83 in https://github.com/apple/swift/pull/23832. `Data` already implements `hash(into:)`, so arguably this change doesn't belong in that PR anyway.

This is one case where the existing hashing implementation deliberately fails to feed all relevant information into the hasher. This makes it trivial to induce an arbitrary number of collisions, despite all the effort that went into implementing a high-quality universal hash function.

This seems like a particularly bad idea for `Data`, which is the standard type for safely exchanging byte buffers across module boundaries. It is reasonable to expect `Data` to implement the same high quality hashing as `Array` does; silently doing otherwise is not a good idea.

We previously discussed this issue in #21754.