### PR TITLE
[TF-425] Update swift-apis dependency to latest version.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -242,7 +242,7 @@
                 "icu": "release-61-1",
                 "tensorflow": "5e8df789cc30098d791475c14a623ec68b50b4ed",
                 "tensorflow-swift-bindings": "0957744551614e433dbabc725cba29ff5ddb91d3",
-                "tensorflow-swift-apis": "18f937191bdc9ddbe5df8f99f0dc64e1a4c0ffab"
+                "tensorflow-swift-apis": "5caa4600e0796cc04dc755f7d7c4befe7bd336cd"
             }
         }
     }


### PR DESCRIPTION
Resolves [TF-425](https://bugs.swift.org/browse/TF-425).
