### PR TITLE
Support dump hash when skip clone icu on Darwin

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -317,12 +317,17 @@ def dump_repo_hashes(config):
     new_config['branch-schemes'] = {branch_scheme_name: branch_scheme}
     for repo_name, repo_info in sorted(config['repos'].items(),
                                        key=lambda x: x[0]):
-        with shell.pushd(os.path.join(SWIFT_SOURCE_ROOT, repo_name),
-                         dry_run=False,
-                         echo=False):
-            h = shell.capture(["git", "rev-parse", "HEAD"],
-                              echo=False).strip()
-            repos[repo_name] = str(h)
+                                       
+        path = os.path.join(SWIFT_SOURCE_ROOT, repo_name)
+        if os.path.isdir(path):
+            with shell.pushd(path,
+                            dry_run=False,
+                            echo=False):
+                h = shell.capture(["git", "rev-parse", "HEAD"],
+                                echo=False).strip()
+                repos[repo_name] = str(h)
+        if not os.path.isdir(path):
+            repos[repo_name] = "dir not exist"
     json.dump(new_config, sys.stdout, indent=4)
 
 

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -317,17 +317,17 @@ def dump_repo_hashes(config):
     new_config['branch-schemes'] = {branch_scheme_name: branch_scheme}
     for repo_name, repo_info in sorted(config['repos'].items(),
                                        key=lambda x: x[0]):
-                                       
         path = os.path.join(SWIFT_SOURCE_ROOT, repo_name)
-        if os.path.isdir(path):
-            with shell.pushd(path,
-                            dry_run=False,
-                            echo=False):
-                h = shell.capture(["git", "rev-parse", "HEAD"],
-                                echo=False).strip()
-                repos[repo_name] = str(h)
         if not os.path.isdir(path):
-            repos[repo_name] = "dir not exist"
+            repos[repo_name] = "not cloned"
+        continue
+
+        with shell.pushd(path,
+                         dry_run=False,
+                         echo=False):
+            h = shell.capture(["git", "rev-parse", "HEAD"],
+                              echo=False).strip()
+            repos[repo_name] = str(h)
     json.dump(new_config, sys.stdout, indent=4)
 
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
```
➜  swift-source ./swift/utils/update-checkout --dump-hashes            
Traceback (most recent call last):
File "./swift/utils/update-checkout", line 15, in <module>
update_checkout.main()
File "/Volumes/sunny/git-code/swift-collection/swift-source/swift/utils/update_checkout/update_checkout/update_checkout.py", line 511, in main
dump_repo_hashes(config)
File "/Volumes/sunny/git-code/swift-collection/swift-source/swift/utils/update_checkout/update_checkout/update_checkout.py", line 322, in dump_repo_hashes
echo=False):
File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 17, in __enter__
return self.gen.next()
File "/Volumes/sunny/git-code/swift-collection/swift-source/swift/utils/swift_build_support/swift_build_support/shell.py", line 157, in pushd
os.chdir(path)
OSError: [Errno 2] No such file or directory: '/Volumes/sunny/git-code/swift-collection/swift-source/icu'
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

-->
@swift-ci Please smoke test
