### PR TITLE
[5.1] Various improvements to the variable-is-never-mutated diagnostic.

### DIFF
--- a/test/Constraints/anyhashable-collection-cast.swift
+++ b/test/Constraints/anyhashable-collection-cast.swift
@@ -18,6 +18,6 @@ func test() {
 
 func testLValueCoerce() {
 	var lvalue = "lvalue"
-	var map: [AnyHashable : Any] = [lvalue: lvalue]
+	let map: [AnyHashable : Any] = [lvalue: lvalue]
 	lvalue = map[lvalue] as! String
 }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -96,8 +96,24 @@ func testInOut(_ x : inout Int) {  // Ok.
 
 struct TestStruct {
   var property = 42
-}
 
+  var mutatingProperty: Int {
+    mutating get { return 0 }
+    mutating set {}
+  }
+  var nonmutatingProperty: Int {
+    nonmutating get { return 0 }
+    nonmutating set {}
+  }
+  subscript(mutating index: Int) -> Int {
+    mutating get { return 0 }
+    mutating set {}
+  }
+  subscript(nonmutating index: Int) -> Int {
+    nonmutating get { return 0 }
+    nonmutating set {}
+  }
+}
 
 func testStructMember() -> TestStruct {
   var x = TestStruct()  // ok
@@ -105,6 +121,53 @@ func testStructMember() -> TestStruct {
   return x
 }
 
+func testMutatingProperty_get() -> TestStruct {
+  var x = TestStruct()  // ok
+  _ = x.mutatingProperty
+  return x
+}
+
+func testMutatingProperty_set() -> TestStruct {
+  var x = TestStruct()  // ok
+  x.mutatingProperty = 17
+  return x
+}
+
+func testNonmutatingProperty_get() -> TestStruct {
+  var x = TestStruct()  // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  _ = x.nonmutatingProperty
+  return x
+}
+
+func testNonmutatingProperty_set() -> TestStruct {
+  var x = TestStruct()  // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  x.nonmutatingProperty = 17
+  return x
+}
+
+func testMutatingSubscript_get() -> TestStruct {
+  var x = TestStruct()  // ok
+  _ = x[mutating: 4]
+  return x
+}
+
+func testMutatingSubscript_set() -> TestStruct {
+  var x = TestStruct()  // ok
+  x[mutating: 4] = 17
+  return x
+}
+
+func testNonmutatingSubscript_get() -> TestStruct {
+  var x = TestStruct()  // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  _ = x[nonmutating: 4]
+  return x
+}
+
+func testNonmutatingSubscript_set() -> TestStruct {
+  var x = TestStruct()  // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  x[nonmutating: 4] = 17
+  return x
+}
 
 func testSubscript() -> [Int] {
   var x = [1,2,3] // ok
@@ -112,6 +175,11 @@ func testSubscript() -> [Int] {
   return x
 }
 
+func testSubscriptNeverMutated() -> [Int] {
+  var x = [1,2,3] // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  _ = x[1]
+  return x
+}
 
 func testTuple(_ x : Int) -> Int {
   var x = x
@@ -178,7 +246,10 @@ func testBuildConfigs() {
 protocol Fooable {
   mutating func mutFoo()
   func immutFoo()
+  var mutatingProperty: Int { mutating get mutating set }
+  var nonmutatingProperty: Int { nonmutating get nonmutating set }
 }
+
 func testOpenExistential(_ x: Fooable,
                          y: Fooable) {
   var x = x
@@ -187,6 +258,25 @@ func testOpenExistential(_ x: Fooable,
   y.immutFoo()
 }
 
+func testOpenExistential_mutatingProperty_get(p: Fooable) {
+  var x = p
+  _ = x.mutatingProperty
+}
+
+func testOpenExistential_mutatingProperty_set(p: Fooable) {
+  var x = p
+  x.mutatingProperty = 4
+}
+
+func testOpenExistential_nonmutatingProperty_get(p: Fooable) {
+  var x = p // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  _ = x.nonmutatingProperty
+}
+
+func testOpenExistential_nonmutatingProperty_set(p: Fooable) {
+  var x = p // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  x.nonmutatingProperty = 4
+}
 
 func couldThrow() throws {}
 

--- a/test/multifile/lazy.swift
+++ b/test/multifile/lazy.swift
@@ -9,3 +9,9 @@ func test1(s: Test1) {
 func test2(s: Test2) {
   _ = s.property
 }
+
+// rdar://49482742 - shouldn't warn about 's' never being mutated
+func test3() {
+  var s = Test1()
+  _ = s.property
+}

--- a/test/stdlib/StringCompatibilityDiagnostics4.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics4.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %s -verify
 
 func testPopFirst() {
-  var str = "abc"
+  let str = "abc"
   var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String directly}}
   charView = str.characters // expected-warning{{'characters' is deprecated: Please use String directly}}
   dump(charView)

--- a/test/type/infer/local_variables.swift
+++ b/test/type/infer/local_variables.swift
@@ -20,11 +20,11 @@ func infer_type(_ i: Int, f: Float) {
 
 func infer_generic_args() {
   // Simple types
-  var x : Dictionary = ["Hello" : 1]
+  let x : Dictionary = ["Hello" : 1]
   var i : Int = x["Hello"]!
 
   // Tuples
-  var (d, s) : (Dictionary, Array) = ( ["Hello" : 1], [1, 2, 3] )
+  let (d, s) : (Dictionary, Array) = ( ["Hello" : 1], [1, 2, 3] )
   i = d["Hello"]!
   i = s[i]
 


### PR DESCRIPTION
The main fixes here are:
- we weren't looking through open-existentials in the l-value
- we weren't handling mutating gets correctly unless CSApply wrapped
  the base in an InOutExpr, which seems to be multifile-sensitive
- we were missing diagnostics in some cases involving subscripts

A better fix would be to re-introduce LValueAccessKind, but I wanted
a workable short-term fix that I could try to get into 5.1.

Fixes rdar://49482742, which is specific to the lazy-getter problem.

This is the 5.1 version of #23867.