### PR TITLE
[upstream-update] Add to SwiftAAResult a getModRefInfo entrypoint tha…

### DIFF
--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -31,7 +31,13 @@ namespace swift {
 
     using AAResultBase::getModRefInfo;
     llvm::ModRefInfo getModRefInfo(const llvm::CallBase *Call,
-                                   const llvm::MemoryLocation &Loc);
+                                   const llvm::MemoryLocation &Loc) {
+      llvm::AAQueryInfo AAQI;
+      return getModRefInfo(Call, Loc, AAQI);
+    }
+    llvm::ModRefInfo getModRefInfo(const llvm::CallBase *Call,
+                                   const llvm::MemoryLocation &Loc,
+                                   llvm::AAQueryInfo &AAQI);
   };
 
   class SwiftAAWrapperPass : public llvm::ImmutablePass {

--- a/lib/LLVMPasses/LLVMSwiftAA.cpp
+++ b/lib/LLVMPasses/LLVMSwiftAA.cpp
@@ -33,7 +33,8 @@ static ModRefInfo getConservativeModRefForKind(const llvm::Instruction &I) {
 }
 
 ModRefInfo SwiftAAResult::getModRefInfo(const llvm::CallBase *Call,
-                                        const llvm::MemoryLocation &Loc) {
+                                        const llvm::MemoryLocation &Loc,
+                                        llvm::AAQueryInfo &AAQI) {
   // We know at compile time that certain entry points do not modify any
   // compiler-visible state ever. Quickly check if we have one of those
   // instructions and return if so.
@@ -41,7 +42,6 @@ ModRefInfo SwiftAAResult::getModRefInfo(const llvm::CallBase *Call,
     return ModRefInfo::NoModRef;
 
   // Otherwise, delegate to the rest of the AA ModRefInfo machinery.
-  AAQueryInfo AAQI;
   return AAResultBase::getModRefInfo(Call, Loc, AAQI);
 }
 


### PR DESCRIPTION
…t takes an llvm::AAQueryInfo.

I left in the old entrypoint as well that doesn't take the AAQueryInfo by having
it delegate to the AAQueryInfo entrypoint passing a default constructed
AAQueryInfo. This matches how people upstream have handled this.

rdar://49450147