### PR TITLE
Move the legacy _branchHint function to LegacyABI.swift

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -301,17 +301,6 @@ func _uncheckedUnsafeAssume(_ condition: Bool) {
   _ = Builtin.assume_Int1(condition._value)
 }
 
-// This function is no longer used but must be kept for ABI compatibility
-// because references to it may have been inlined.
-@usableFromInline
-internal func _branchHint(_ actual: Bool, expected: Bool) -> Bool {
-  // The LLVM intrinsic underlying int_expect_Int1 now requires an immediate
-  // argument for the expected value so we cannot call it here. This should
-  // never be called in cases where performance matters, so just return the
-  // value without any branch hint.
-  return actual
-}
-
 //===--- Runtime shim wrappers --------------------------------------------===//
 
 /// Returns `true` iff the class indicated by `theClass` uses native

--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -60,3 +60,14 @@ extension Substring {
     return try copy.withUTF8(body)
   }
 }
+
+// This function is no longer used but must be kept for ABI compatibility
+// because references to it may have been inlined.
+@usableFromInline
+internal func _branchHint(_ actual: Bool, expected: Bool) -> Bool {
+  // The LLVM intrinsic underlying int_expect_Int1 now requires an immediate
+  // argument for the expected value so we cannot call it here. This should
+  // never be called in cases where performance matters, so just return the
+  // value without any branch hint.
+  return actual
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/23375. The LegacyABI.swift file had not been added at the time.