### PR TITLE
[Build System: CMake] Install the layouts-*.yaml files in the compiler component.

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -143,7 +143,7 @@ foreach(sdk ${SWIFT_SDKS})
         "swift-stdlib-${platform}-${arch}"
         "copy-legacy-layouts-${platform}-${arch}")
 
-      swift_install_in_component(stdlib
+      swift_install_in_component(compiler
           FILES ${input}
           DESTINATION "lib/swift/${platform}/")
     else()


### PR DESCRIPTION
These new `layouts-*.yaml` files should really be installed along-side the compiler in the resource dir when building toolchains, even if you disable the standard library.