### PR TITLE
[5.1] Deprecate -disable-reflection-metadata

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -278,6 +278,10 @@ ERROR(unknown_forced_module_loading_mode,none,
       "unknown value for SWIFT_FORCE_MODULE_LOADING variable: '%0'",
       (StringRef))
 
+WARNING(disable_reflection_metadata_unsupported, none,
+      "'-disable-reflection-metadata' is no longer supported "
+      "and has no effects", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -162,9 +162,6 @@ public:
   unsigned HasValueNamesSetting : 1;
   unsigned ValueNames : 1;
 
-  /// Emit nominal type field metadata.
-  unsigned EnableReflectionMetadata : 1;
-
   /// Emit names of struct stored properties and enum cases.
   unsigned EnableReflectionNames : 1;
 
@@ -237,7 +234,7 @@ public:
         DisableLLVMSLPVectorizer(false), DisableFPElim(true), Playground(false),
         EmitStackPromotionChecks(false), PrintInlineTree(false),
         EmbedMode(IRGenEmbedMode::None), HasValueNamesSetting(false),
-        ValueNames(false), EnableReflectionMetadata(true),
+        ValueNames(false),
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
         ForcePublicLinkage(false), LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1075,10 +1075,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.SanitizeCoverage.CoverageType = llvm::SanitizerCoverageOptions::SCK_Edge;
   }
 
-  if (Args.hasArg(OPT_disable_reflection_metadata)) {
-    Opts.EnableReflectionMetadata = false;
-    Opts.EnableReflectionNames = false;
-  }
+  if (Args.hasArg(OPT_disable_reflection_metadata))
+    Diags.diagnose(SourceLoc(), diag::disable_reflection_metadata_unsupported);
 
   if (Args.hasArg(OPT_enable_anonymous_context_mangled_names))
     Opts.EnableAnonymousContextMangledNames = true;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1284,8 +1284,7 @@ namespace {
     void addReflectionFieldDescriptor() {
       // Structs are reflectable unless we emit them with opaque reflection
       // metadata.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata
-          || IGM.shouldEmitOpaqueTypeMetadataRecord(getType())) {
+      if (IGM.shouldEmitOpaqueTypeMetadataRecord(getType())) {
         B.addInt32(0);
         return;
       }
@@ -1358,13 +1357,12 @@ namespace {
     void addReflectionFieldDescriptor() {
       // Some enum layout strategies (viz. C compatible layout) aren't
       // supported by reflection.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata
-          || IGM.shouldEmitOpaqueTypeMetadataRecord(getType())
-          || !Strategy.isReflectable()) {
+      if (IGM.shouldEmitOpaqueTypeMetadataRecord(getType()) ||
+          !Strategy.isReflectable()) {
         B.addInt32(0);
         return;
       }
-    
+
       B.addRelativeAddress(IGM.getAddrOfReflectionFieldDescriptor(
         getType()->getDeclaredType()->getCanonicalType()));
     }
@@ -1477,13 +1475,12 @@ namespace {
     void addReflectionFieldDescriptor() {
       // Classes are always reflectable, unless reflection is disabled or this
       // is a foreign class.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata
-          || IGM.shouldEmitOpaqueTypeMetadataRecord(getType())
-          || getType()->isForeign()) {
+      if (IGM.shouldEmitOpaqueTypeMetadataRecord(getType()) ||
+          getType()->isForeign()) {
         B.addInt32(0);
         return;
       }
-    
+
       B.addRelativeAddress(IGM.getAddrOfReflectionFieldDescriptor(
         getType()->getDeclaredType()->getCanonicalType()));
     }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -927,9 +927,6 @@ llvm::Constant *IRGenModule::getAddrOfFieldName(StringRef Name) {
 
 llvm::Constant *
 IRGenModule::getAddrOfBoxDescriptor(CanType BoxedType) {
-  if (!IRGen.Opts.EnableReflectionMetadata)
-    return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);
-
   BoxDescriptorBuilder builder(*this, BoxedType);
   auto var = builder.emit();
 
@@ -942,9 +939,6 @@ IRGenModule::getAddrOfCaptureDescriptor(SILFunction &Caller,
                                         CanSILFunctionType SubstCalleeType,
                                         SubstitutionMap Subs,
                                         const HeapLayout &Layout) {
-  if (!IRGen.Opts.EnableReflectionMetadata)
-    return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);
-
   if (CaptureDescriptorBuilder::hasOpenedExistential(OrigCalleeType, Layout))
     return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);
 
@@ -959,9 +953,6 @@ void IRGenModule::
 emitAssociatedTypeMetadataRecord(const RootProtocolConformance *conformance) {
   auto normalConf = dyn_cast<NormalProtocolConformance>(conformance);
   if (!normalConf)
-    return;
-
-  if (!IRGen.Opts.EnableReflectionMetadata)
     return;
 
   SmallVector<std::pair<StringRef, CanType>, 2> AssociatedTypes;
@@ -1026,9 +1017,6 @@ void IRGenerator::emitBuiltinReflectionMetadata() {
 }
 
 void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
-  if (!IRGen.Opts.EnableReflectionMetadata)
-    return;
-
   // @objc enums never have generic parameters or payloads,
   // and lower as their raw type.
   if (auto *ED = dyn_cast<EnumDecl>(Decl))

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 // RUN: %target-swift-frontend -disable-reflection-names -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
-// RUN: %target-swift-frontend -disable-reflection-metadata -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
+// RUN: %target-swift-frontend -disable-reflection-metadata -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-reflection-metadata -emit-ir %s 2>&1 | %FileCheck %s --check-prefix=WARNING
+
+// WARNING: warning: '-disable-reflection-metadata' is no longer supported and has no effects
 
 // STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_reflect|.sw5rfst\$B}}
 // STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}
@@ -12,12 +15,6 @@
 
 // STRIP_REFLECTION_NAMES-DAG: @"$s19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}
 
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_reflect|.sw5rfst\$B}}
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_assocty|.sw5asty\$B}}
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_capture|.sw5cptr\$B}}
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_reflstr|.sw5rfst\$B}}
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_builtin|.sw5bltn\$B}}
 
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
 // CHECK-DAG: private constant [2 x i8] c"i\00", section "{{[^"]*swift5_reflstr|.sw5rfst\$B}}


### PR DESCRIPTION
Reflection metadata use by compiled Swift code has increased. This
option is untested and does not reliably work.

rdar://49742144