### PR TITLE
[Build System: CMake] Install the Swift shims in the stdlib component (5.1 branch).

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -105,7 +105,7 @@ add_custom_command_target(unused_var
     COMMENT "Symlinking Clang resource headers into ${SWIFTLIB_DIR}/clang")
 add_dependencies(copy_shim_headers symlink_clang_headers)
 
-swift_install_in_component(compiler
+swift_install_in_component(stdlib
     FILES ${sources}
     DESTINATION "lib/swift/shims")
 


### PR DESCRIPTION
Copy of #23903 for the 5.1 branch.