### PR TITLE
 Record parseable interface imports in the debug info.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -827,6 +827,10 @@ public:
     return getParentModule()->getName().str();
   }
 
+  /// If this is a module imported from a parseable interface, return the path
+  /// to the interface file, otherwise an empty StringRef.
+  virtual StringRef getParseableInterface() const { return {}; }
+
   /// Traverse the decls within this file.
   ///
   /// \returns true if traversal was aborted, false if it completed

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -643,7 +643,8 @@ namespace input_block {
     IMPORTED_HEADER_CONTENTS,
     MODULE_FLAGS, // [unused]
     SEARCH_PATH,
-    FILE_DEPENDENCY
+    FILE_DEPENDENCY,
+    PARSEABLE_INTERFACE_PATH
   };
 
   using ImportedModuleLayout = BCRecordLayout<
@@ -690,6 +691,12 @@ namespace input_block {
     BCFixed<1>,                    // SDK-relative?
     BCBlob                         // path
   >;
+
+  using ParseableInterfaceLayout = BCRecordLayout<
+    PARSEABLE_INTERFACE_PATH,
+    BCBlob // file path
+  >;
+
 }
 
 /// The record types within the "decls-and-types" block.

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -33,6 +33,7 @@ namespace swift {
     StringRef GroupInfoPath;
     StringRef ImportedHeader;
     StringRef ModuleLinkName;
+    StringRef ParseableInterface;
     ArrayRef<std::string> ExtraClangOptions;
 
     /// Describes a single-file dependency for this module, along with the

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -186,6 +186,11 @@ class SerializedASTFile final : public LoadedFile {
   friend class ModuleFile;
 
   ModuleFile &File;
+
+  /// The parseable interface this module was generated from if any.
+  /// Used for debug info.
+  std::string ParseableInterface;
+
   bool IsSIB;
 
   ~SerializedASTFile() = default;
@@ -277,6 +282,13 @@ public:
 
   virtual const clang::Module *getUnderlyingClangModule() const override;
 
+  /// If this is a module imported from a parseable interface, return the path
+  /// to the interface file, otherwise an empty StringRef.
+  virtual StringRef getParseableInterface() const override {
+    return ParseableInterface;
+  }
+  void setParseableInterface(StringRef PI) { ParseableInterface = PI; }
+  
   virtual bool getAllGenericSignatures(
                    SmallVectorImpl<GenericSignature*> &genericSignatures)
                 override;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -92,6 +92,7 @@ struct ValidationInfo {
 class ExtendedValidationInfo {
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
   StringRef SDKPath;
+  StringRef ParseableInterface;
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
@@ -113,6 +114,8 @@ public:
   void addExtraClangImporterOption(StringRef option) {
     ExtraClangImporterOpts.push_back(option);
   }
+  StringRef getParseableInterface() const { return ParseableInterface; }
+  void setParseableInterface(StringRef PI) { ParseableInterface = PI; }
 
   bool isSIB() const { return Bits.IsSIB; }
   void setIsSIB(bool val) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1134,6 +1134,10 @@ StringRef ModuleDecl::getModuleFilename() const {
   // per-file names. Modules can consist of more than one file.
   StringRef Result;
   for (auto F : getFiles()) {
+    Result = F->getParseableInterface();
+    if (!Result.empty())
+      return Result;
+
     if (auto SF = dyn_cast<SourceFile>(F)) {
       if (!Result.empty())
         return StringRef();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -124,9 +124,8 @@ CompilerInvocation::getParseableInterfaceOutputPathForWholeModule() const {
       .SupplementaryOutputs.ParseableInterfaceOutputPath;
 }
 
-SerializationOptions
-CompilerInvocation::computeSerializationOptions(const SupplementaryOutputPaths &outs,
-                                                bool moduleIsPublic) {
+SerializationOptions CompilerInvocation::computeSerializationOptions(
+    const SupplementaryOutputPaths &outs, bool moduleIsPublic) {
   const FrontendOptions &opts = getFrontendOptions();
 
   SerializationOptions serializationOpts;

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -582,6 +582,12 @@ public:
       std::string OutPathStr = OutPath;
       SerializationOpts.OutputPath = OutPathStr.c_str();
       SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
+
+      // Record any non-SDK parseable interface files for the debug info.
+      StringRef SDKPath = SubInstance.getASTContext().SearchPathOpts.SDKPath;
+      if (!getRelativeDepPath(InPath, SDKPath))
+        SerializationOpts.ParseableInterface = InPath;
+
       SmallVector<FileDependency, 16> Deps;
       if (collectDepsForSerialization(SubInstance, Deps,
             FEOpts.SerializeParseableModuleInterfaceDependencyHashes)) {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -191,14 +191,13 @@ public:
 
 private:
   static StringRef getFilenameFromDC(const DeclContext *DC) {
-    if (auto LF = dyn_cast<LoadedFile>(DC))
+    if (auto *LF = dyn_cast<LoadedFile>(DC))
       return LF->getFilename();
-    if (auto SF = dyn_cast<SourceFile>(DC))
+    if (auto *SF = dyn_cast<SourceFile>(DC))
       return SF->getFilename();
-    else if (auto M = dyn_cast<ModuleDecl>(DC))
+    if (auto *M = dyn_cast<ModuleDecl>(DC))
       return M->getModuleFilename();
-    else
-      return StringRef();
+    return {};
   }
 
   using DebugLoc = SILLocation::DebugLoc;
@@ -717,7 +716,6 @@ private:
     ModuleDecl *M = IM.second;
     if (Optional<ASTSourceDescriptor> ModuleDesc = getClangModule(*M))
       return getOrCreateModule(*ModuleDesc, ModuleDesc->getModuleOrNull());
-
     StringRef Path = getFilenameFromDC(M);
     StringRef Name = M->getName().str();
     return getOrCreateModule(M, TheCU, Name, Path);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1332,6 +1332,11 @@ ModuleFile::ModuleFile(
           SearchPaths.push_back({blobData, isFramework, isSystem});
           break;
         }
+        case input_block::PARSEABLE_INTERFACE_PATH: {
+          if (extInfo)
+            extInfo->setParseableInterface(blobData);
+          break;
+        }
         default:
           // Unknown input kind, possibly for use by a future version of the
           // module format.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -833,6 +833,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(input_block, MODULE_FLAGS);
   BLOCK_RECORD(input_block, SEARCH_PATH);
   BLOCK_RECORD(input_block, FILE_DEPENDENCY);
+  BLOCK_RECORD(input_block, PARSEABLE_INTERFACE_PATH);
 
   BLOCK(DECLS_AND_TYPES_BLOCK);
 #define RECORD(X) BLOCK_RECORD(decls_block, X);
@@ -1059,6 +1060,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   input_block::ImportedHeaderContentsLayout ImportedHeaderContents(Out);
   input_block::SearchPathLayout SearchPath(Out);
   input_block::FileDependencyLayout FileDependency(Out);
+  input_block::ParseableInterfaceLayout ParseableInterface(Out);
 
   if (options.SerializeOptionsForDebugging) {
     const SearchPathOptions &searchPathOpts = M->getASTContext().SearchPathOpts;
@@ -1079,6 +1081,9 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
                         dep.isSDKRelative(),
                         dep.getPath());
   }
+
+  if (!options.ParseableInterface.empty())
+    ParseableInterface.emit(ScratchRecord, options.ParseableInterface);
 
   ModuleDecl::ImportFilter allImportFilter;
   allImportFilter |= ModuleDecl::ImportFilterKind::Public;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -394,6 +394,7 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
     // We've loaded the file. Now try to bring it into the AST.
     auto fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile,
                                                 extendedInfo.isSIB());
+    fileUnit->setParseableInterface(extendedInfo.getParseableInterface());
     M.addFile(*fileUnit);
     if (extendedInfo.isTestable())
       M.setTestingEnabled();

--- a/test/DebugInfo/ParseableInterfaceImports.swift
+++ b/test/DebugInfo/ParseableInterfaceImports.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-typecheck %S/basic.swift \
+// RUN:    -emit-parseable-module-interface-path %t/basic.swiftinterface
+// RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
+// RUN:    | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
+// RUN:    -sdk %t | %FileCheck %s --check-prefix=SDK
+
+import basic
+
+// CHECK: !DIModule(scope: null, name: "basic", includePath: "
+// CHECK-SAME:      basic.swiftinterface"
+
+// We don;t record any parseable interfaces from the SDK.
+// They're in the SDK after all.
+// SDK:   !DIModule(scope: null, name: "basic", includePath: "
+// SDK-SAME:        basic{{.*}}.swiftmodule"
+
+
+func markUsed<T>(_ t: T) {}
+markUsed(basic.foo(1, 2))
+


### PR DESCRIPTION
When a Swift module built with debug info imports a library without
debug info from a textual interface, the textual interface is
necessary to reconstruct types defined in the library's interface.  By
recording the Swift interface files in DWARF dsymutil can collect them
and LLDB can find them.

rdar://problem/49751363


