### PR TITLE
Diagnose typealiases of non-public types in inlinable functions

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -309,7 +309,8 @@ bool DeclContext::isGenericContext() const {
 /// domains, this ensures that only sufficiently-conservative access patterns
 /// are used.
 ResilienceExpansion DeclContext::getResilienceExpansion() const {
-  for (const auto *dc = this; dc->isLocalContext(); dc = dc->getParent()) {
+  for (const auto *dc = getLocalContext(); dc && dc->isLocalContext();
+       dc = dc->getParent()) {
     // Default argument initializer contexts have their resilience expansion
     // set when they're type checked.
     if (isa<DefaultArgumentInitializer>(dc)) {

--- a/test/attr/attr_inlinable_typealias.swift
+++ b/test/attr/attr_inlinable_typealias.swift
@@ -5,6 +5,7 @@ private typealias PrivateAlias = Int
 
 internal typealias InternalAlias = Int
 // expected-note@-1 {{type alias 'InternalAlias' is not '@usableFromInline' or public}}
+// expected-note@-2 * {{type alias 'InternalAlias' is not '@usableFromInline' or public}}
 
 @usableFromInline typealias UsableFromInlineAlias = Int
 
@@ -20,4 +21,9 @@ public typealias PublicAlias = Int
   _ = UsableFromInlineAlias.self
 
   _ = PublicAlias.self
+}
+
+@inlinable public func localTypealiases() {
+  typealias LocalAlias = InternalAlias // expected-warning {{type alias 'InternalAlias' is internal and should not be referenced from an '@inlinable' function}}
+  typealias GenericAlias<T> = (T, InternalAlias) // expected-warning {{type alias 'InternalAlias' is internal and should not be referenced from an '@inlinable' function}}
 }


### PR DESCRIPTION
...as a warning, since we didn't check this correctly in Swift 5. For parseable interfaces, these typealiases won't work at all.
