### PR TITLE
IRGen: Fix missing nominal type descriptor when emitting lazy conformances

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2164,11 +2164,10 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   // Record this conformance descriptor.
   addProtocolConformance(std::move(description));
 
-  // Trigger the lazy emission of the foreign type metadata.
+  // Trigger lazy emission of the nominal type descriptor.
   CanType conformingType = conf->getType()->getCanonicalType();
-  if (requiresForeignTypeMetadata(conformingType)) {
-    (void)getAddrOfForeignTypeMetadataCandidate(conformingType);
-  }
+  IRGen.noteUseOfTypeContextDescriptor(conformingType->getAnyNominal(),
+                                       DontRequireMetadata);
 }
 
 /// True if a function's signature in LLVM carries polymorphic parameters.

--- a/test/IRGen/lazy_metadata_no_reflection.swift
+++ b/test/IRGen/lazy_metadata_no_reflection.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -parse-as-library -module-name=test -O %s -emit-ir -disable-reflection-metadata | %FileCheck %s
+
+struct S { }
+
+extension S: Equatable {
+  static func ==(lhs: S, rhs: S) -> Bool {
+    return false
+  }
+}
+
+// CHECK-LABEL: @"$s4test1SVMn" = hidden constant
+// CHECK-LABEL: @"$s4test1SVSQAAMc" = hidden constant


### PR DESCRIPTION
Conformance descriptors are emitted after the lazy emission queues are
drained, so need to queue up anything referenced from a conformance
descriptor before we queue up the conformance descriptor itself.

The existing logic was only forcing foreign type metadata, which is
wrong. We only ever need the nominal type descriptor and not the
metadata; and we need it for all types.

Note that a better fix for this specific test case would be to not
emit the conformance at all; if the conforming type or the protocol
is not referenced there's no way to reference the conformance either.
But that would be a bigger change.

Fixes <rdar://problem/49710077>.