### PR TITLE
[build-script] Rename is_build_script_impl_product to needs_toolchain.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -521,7 +521,7 @@ class BuildScriptInvocation(object):
 
         # Compute any product specific cmake arguments.
         for product_class in self.compute_product_classes():
-            if not product_class.is_build_script_impl_product():
+            if product_class.needs_toolchain():
                 continue
 
             product_name = product_class.product_name()
@@ -930,8 +930,8 @@ class BuildScriptInvocation(object):
         # matches that of `build-script-impl`.
         product_classes = self.compute_product_classes()
 
-        impl_product_classes = [cls for cls in product_classes
-                                if cls.is_build_script_impl_product()]
+        standalone_product_classes = [cls for cls in product_classes
+                                      if not cls.needs_toolchain()]
 
         # Execute each "pass".
 
@@ -949,24 +949,24 @@ class BuildScriptInvocation(object):
                 print("Running Swift benchmarks for: {}".format(
                     " ".join(config.swift_benchmark_run_targets)))
 
-            for product_class in impl_product_classes:
+            for product_class in standalone_product_classes:
                 self._execute_build_action(host_target, product_class)
 
         # Test...
         for host_target in all_hosts:
-            for product_class in impl_product_classes:
+            for product_class in standalone_product_classes:
                 self._execute_test_action(host_target, product_class)
 
         # Install...
         for host_target in all_hosts:
-            for product_class in impl_product_classes:
+            for product_class in standalone_product_classes:
                 self._execute_install_action(host_target, product_class)
 
         # Non-build-script-impl products...
         # Note: currently only supports building for the host.
         for host_target in [self.args.host_target]:
             for product_class in product_classes:
-                if product_class.is_build_script_impl_product():
+                if not product_class.needs_toolchain():
                     continue
                 product_source = product_class.product_source_name()
                 product_name = product_class.product_name()

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -25,8 +25,8 @@ class Benchmarks(product.Product):
         return "benchmarks"
 
     @classmethod
-    def is_build_script_impl_product(cls):
-        return False
+    def needs_toolchain(cls):
+        return True
 
     def build(self, host_target):
         run_build_script_helper(host_target, self, self.args)

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -24,8 +24,8 @@ class IndexStoreDB(product.Product):
         return "indexstore-db"
 
     @classmethod
-    def is_build_script_impl_product(cls):
-        return False
+    def needs_toolchain(cls):
+        return True
 
     def build(self, host_target):
         run_build_script_helper('build', host_target, self, self.args)

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -24,9 +24,6 @@ from .. import shell
 
 
 class Ninja(product.Product):
-    @classmethod
-    def is_build_script_impl_product(cls):
-        return False
 
     @classmethod
     def new_builder(cls, args, toolchain, workspace, host):

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -33,12 +33,12 @@ class Product(object):
         return cls.product_name()
 
     @classmethod
-    def is_build_script_impl_product(cls):
-        """is_build_script_impl_product -> bool
+    def needs_toolchain(cls):
+        """needs_toolchain -> bool
 
-        Whether this product is produced by build-script-impl.
+        Whether this product needs a toolchain installed to be built.
         """
-        return True
+        return False
 
     def build(self, host_target):
         """build() -> void

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -20,8 +20,8 @@ class SourceKitLSP(product.Product):
         return "sourcekit-lsp"
 
     @classmethod
-    def is_build_script_impl_product(cls):
-        return False
+    def needs_toolchain(cls):
+        return True
 
     def build(self, host_target):
         indexstoredb.run_build_script_helper(

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -26,8 +26,8 @@ class TSanLibDispatch(product.Product):
         return "tsan-libdispatch-test"
 
     @classmethod
-    def is_build_script_impl_product(cls):
-        return False
+    def needs_toolchain(cls):
+        return True
 
     def build(self, host_target):
         """Build TSan runtime (compiler-rt)."""


### PR DESCRIPTION
While the previous name is factual at the moment, I think needs_toolchain
describes better why those products are special.

Sadly Ninja has to be always a special product, and it doesn't fit
needs_toolchain, but it also doesn't need to be handled with the other
products, so answering False for it is fine.

The rest of the changes are mechanical, and flipping the logic around.

With all the work I'm trying to do to remove `build-script-impl`, the name of the property was always bugging me, because it will lie the moment I start implementing the first builders that bypass `build-script-impl`. When I saw #23849 I found that Michael has found the perfect replacement: all this product need a toolchain to build. This change will allow to keep the name during the transition and will be less confusing.

This was part of #23257. I’m trying to split the PR in smaller ones to make the reviews easier. Other PRs in this group are #23303, #23803, #23810, #23822, #23865, #23915 and #23917.