### PR TITLE
Add a test for circular protocol inheritance through a typealias

### DIFF
--- a/test/decl/protocol/conforms/circular_validation.swift
+++ b/test/decl/protocol/conforms/circular_validation.swift
@@ -11,3 +11,8 @@ struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}}
   static var x = 0 // expected-note {{candidate operates on a type, not an instance as required}}
   var x = S.x // expected-note {{candidate references itself}}
 }
+
+// FIXME: Lousy diagnostics on this case.
+protocol SR9224_Foo: SR9224_Foobar {} // expected-error 2 {{protocol 'SR9224_Foo' refines itself}}
+protocol SR9224_Bar: SR9224_Foobar {} // expected-error {{protocol 'SR9224_Bar' refines itself}} expected-note {{protocol 'SR9224_Bar' declared here}}
+typealias SR9224_Foobar = SR9224_Foo & SR9224_Bar


### PR DESCRIPTION
We could do better on the diagnostics here, but it's not that important.

[SR-9224](https://bugs.swift.org/browse/SR-9224)