### PR TITLE
Add a test for using a nested type for a base class generic argument

### DIFF
--- a/test/Generics/non_generic_derived_class.swift
+++ b/test/Generics/non_generic_derived_class.swift
@@ -9,3 +9,10 @@ class Base<T> {
 class Derived : Base<Int> {}
 
 var a = Derived.f(42)
+
+protocol SR9160_EmptyProtocol {}
+class SR9160_AbstractFoobar<Foo> {}
+// This used to cause the swift compiler to never finish compiling.
+final class SR9160_SomeFoobar: SR9160_AbstractFoobar<SR9160_SomeFoobar.Foo> {
+    enum Foo: SR9160_EmptyProtocol {}
+}


### PR DESCRIPTION
This used to cause an infinite loop in the compiler but now works fine.

[SR-9160](https://bugs.swift.org/browse/SR-9160)