### PR TITLE
appendingPathComponent(:isDirectory:) should account for isDirectory

### DIFF
--- a/stdlib/public/Darwin/Foundation/URL.swift
+++ b/stdlib/public/Darwin/Foundation/URL.swift
@@ -827,7 +827,8 @@ public struct URL : ReferenceConvertible, Equatable {
         } else {
             // Now we need to do something more expensive
             if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
-                c.path = (c.path as NSString).appendingPathComponent(pathComponent)
+                let path = (c.path as NSString).appendingPathComponent(pathComponent)
+                c.path = isDirectory ? path + "/" : path
                 
                 if let result = c.url {
                     return result


### PR DESCRIPTION
<!-- What's in this pull request? -->
When `appendingPathComponent(:isDirectory:)` is falling back from an **NSURL**.appendingPathComponent() to an **NSString**.appendingPathComponent(), it's forgetting to take into account the `isDirectory` parameter.
