### PR TITLE
[ParseableInterfaces] Find inherited default arg for initializer params

### DIFF
--- a/test/ParseableInterface/Inputs/InitInheritanceTest.swift
+++ b/test/ParseableInterface/Inputs/InitInheritanceTest.swift
@@ -1,0 +1,3 @@
+open class OpenClassWithDefaultArg {
+  public init(value: Int = 9999) {}
+}

--- a/test/ParseableInterface/initializer-inheritance.swift
+++ b/test/ParseableInterface/initializer-inheritance.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/InitInheritanceTest.swiftinterface %S/Inputs/InitInheritanceTest.swift -module-name InitInheritanceTest -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck %s -I %t -emit-parseable-module-interface-path - | %FileCheck %s
+
+import InitInheritanceTest
+
+// CHECK: public class SubclassOfOpenClassWithDefaultArg : OpenClassWithDefaultArg {
+public class SubclassOfOpenClassWithDefaultArg: OpenClassWithDefaultArg {
+// CHECK-NEXT: override public init(value: Swift.Int = 9999)
+// CHECK-NEXT: @objc deinit
+// CHECK-NEXT: }
+}


### PR DESCRIPTION
Since we try not to synthesize inherited initializers, we want to be
explicit and print them in subclasses. Since the default argument kind
was `Inherited`, though, they would print as

```swift
override public init(value: Swift.Int = super)
```

...which doesn't parse.

Instead, try to walk up the override chain for these methods and pull
out the default argument string.

Fixes rdar://49789274