### PR TITLE
Re-enable tests with 'REQUIRES: shell'

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -170,9 +170,12 @@ kIsWindows = platform.system() == 'Windows'
 
 # Choose between lit's internal shell pipeline runner and a real shell.  If
 # LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
-use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', not kIsWindows)
+use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', kIsWindows)
+if not use_lit_shell:
+    config.available_features.add('shell')
+
 config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode,
-                                          execute_external=use_lit_shell)
+                                          execute_external=not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.swiftinterface',


### PR DESCRIPTION
At least on my local machine, a bunch of tests were never being run:

```
test/Driver/Dependencies/bindings-build-record.swift:// REQUIRES: shell
test/Driver/Dependencies/dependencies-preservation.swift:// REQUIRES: shell
test/Driver/Dependencies/driver-show-incremental-arguments.swift:// REQUIRES: shell
test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift:// REQUIRES: shell
test/Driver/Dependencies/driver-show-incremental-inputs.swift:// REQUIRES: shell
test/Driver/Dependencies/driver-show-incremental-malformed.swift:// REQUIRES: shell
test/Driver/Dependencies/driver-show-incremental-swift-version.swift:// REQUIRES: shell
test/Driver/linker.swift:// REQUIRES: shell
test/Driver/subcommands.swift:// REQUIRES: shell
test/remote-run/dry-run.test-sh:REQUIRES: shell
test/remote-run/env.test-sh:REQUIRES: shell
test/remote-run/exit-code.test-sh:REQUIRES: shell
test/remote-run/run-only.test-sh:REQUIRES: shell
test/remote-run/stderr.test-sh:REQUIRES: shell
test/stdlib/Mirror.swift:// REQUIRES: shell
test/stdlib/WeakMirror.swift:// REQUIRES: shell
validation-test/Driver/many-inputs.swift:// REQUIRES: shell
```

It looks like this problem was introduced in 7ca074bd07cc7bbf027e3d95b0dd6d1ba213da98.