### PR TITLE
[ownership] Fix a corner case in the linear lifetime checker.

### DIFF
--- a/lib/SIL/LinearLifetimeChecker.cpp
+++ b/lib/SIL/LinearLifetimeChecker.cpp
@@ -486,6 +486,25 @@ LinearLifetimeError swift::valueHasLinearLifetime(
   // have been detected by initializing our consuming uses. So we are done.
   if (consumingUses.size() == 1 &&
       consumingUses[0].getParent() == value->getParentBlock()) {
+    // Check if any of our non consuming uses are not in the parent block. We
+    // flag those as additional use after frees. Any in the same block, we would
+    // have flagged.
+    if (llvm::any_of(nonConsumingUses, [&](BranchPropagatedUser user) {
+          return user.getParent() != value->getParentBlock();
+        })) {
+      state.error.handleUseAfterFree([&] {
+        llvm::errs() << "Function: '" << value->getFunction()->getName()
+                     << "'\n"
+                     << "Found use after free due to unvisited non lifetime "
+                        "ending uses?!\n"
+                     << "Value: " << *value << "    Remaining Users:\n";
+        for (const auto &user : nonConsumingUses) {
+          llvm::errs() << "User: " << *user.getInst();
+        }
+        llvm::errs() << "\n";
+      });
+    }
+
     return state.error;
   }
 

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -22,6 +22,13 @@ case some(T)
 case none
 }
 
+protocol Error {}
+
+struct NativeObjectPair {
+  var obj1 : Builtin.NativeObject
+  var obj2 : Builtin.NativeObject
+}
+
 class SuperKlass {
   func doSomething()
 }
@@ -484,4 +491,36 @@ bb0(%0 : @guaranteed $ClassProtConformingRef, %1 : @owned $ClassProtConformingRe
   %4 = init_existential_ref %1 : $ClassProtConformingRef : $ClassProtConformingRef, $ClassProt
   %5 = tuple(%3 : $ClassProt, %4 : $ClassProt)
   return %5 : $(ClassProt, ClassProt)
+}
+
+sil [ossa] @eliminate_copy_try_apple_callee : $@convention(thin) (@owned Builtin.NativeObject) -> @error Error {
+entry(%0 : @owned $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+
+// CHECK-LABEL: Function: 'use_after_free_consume_in_same_block'
+// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Value:   %3 = copy_value %2 : $Builtin.NativeObject
+// CHECK:     Remaining Users:
+// CHECK: User:   %10 = apply %7(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+sil [ossa] @use_after_free_consume_in_same_block : $@convention(thin) (@owned NativeObjectPair) -> @error Error {
+bb0(%0 : @owned $NativeObjectPair):
+  %1 = begin_borrow %0 : $NativeObjectPair
+  %2 = struct_extract %1 : $NativeObjectPair, #NativeObjectPair.obj1
+  %3 = copy_value %2 : $Builtin.NativeObject
+  end_borrow %1 : $NativeObjectPair
+  destroy_value %0 : $NativeObjectPair
+  %4 = function_ref @eliminate_copy_try_apple_callee : $@convention(thin) (@owned Builtin.NativeObject) -> @error Error
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  try_apply %4(%3) : $@convention(thin) (@owned Builtin.NativeObject) -> @error Error, normal bb1, error bb2
+
+bb1(%errorEmptyTup: $()):
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2(%error : @owned $Error):
+  throw %error : $Error
 }


### PR DESCRIPTION
Specifically, if we had a value that was consumed in the same block that it was
produced in, we ignored use-after-frees in subsequent blocks. We did check for
use-after-frees in the same block though. The general case was handled
correctly, this was just an incorrect early exit.

On master, this only found one problem (namely the one fixed in:
14d39c0cf951aaca3b8d782b0738bf55bf6672ab). I do not expect this corner case to
have more impact after cherry-picking to 5.1.

rdar://49794321
