### PR TITLE
Fix some problems with IRGen lazy metadata emission

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -346,10 +346,6 @@ class LinkEntity {
     /// The pointer is a canonical TypeBase*.
     TypeMetadataLazyCacheVariable,
 
-    /// A foreign type metadata candidate.
-    /// The pointer is a canonical TypeBase*.
-    ForeignTypeMetadataCandidate,
-
     /// A reflection metadata descriptor for a builtin or imported type.
     ReflectionBuiltinDescriptor,
 
@@ -685,12 +681,6 @@ public:
   static LinkEntity forTypeMetadataLazyCacheVariable(CanType type) {
     LinkEntity entity;
     entity.setForType(Kind::TypeMetadataLazyCacheVariable, type);
-    return entity;
-  }
-
-  static LinkEntity forForeignTypeMetadataCandidate(CanType type) {
-    LinkEntity entity;
-    entity.setForType(Kind::ForeignTypeMetadataCandidate, type);
     return entity;
   }
 
@@ -1047,14 +1037,14 @@ public:
            getKind() == Kind::ObjCResilientClassStub);
     return (TypeMetadataAddress)LINKENTITY_GET_FIELD(Data, MetadataAddress);
   }
-  bool isForeignTypeMetadataCandidate() const {
-    return getKind() == Kind::ForeignTypeMetadataCandidate;
-  }
   bool isObjCClassRef() const {
     return getKind() == Kind::ObjCClassRef;
   }
   bool isSILFunction() const {
     return getKind() == Kind::SILFunction;
+  }
+  bool isNominalTypeDescriptor() const {
+    return getKind() == Kind::NominalTypeDescriptor;
   }
 
   /// Determine whether this entity will be weak-imported.

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -930,13 +930,16 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
   auto &resilientLayout =
     classTI.getClassLayout(*this, selfType, /*forBackwardDeployment=*/false);
 
+  // As a matter of policy, class metadata is never emitted lazily for now.
+  assert(!IRGen.hasLazyMetadata(D));
+
   // Emit the class metadata.
   emitClassMetadata(*this, D, fragileLayout, resilientLayout);
+  emitFieldDescriptor(D);
 
   IRGen.addClassForEagerInitialization(D);
 
   emitNestedTypeDecls(D->getMembers());
-  emitFieldMetadataRecord(D);
 }
 
 namespace {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1223,6 +1223,12 @@ void IRGenerator::noteUseOfFieldDescriptor(NominalTypeDecl *type) {
   if (!hasLazyMetadata(type))
     return;
 
+  // Imported classes and protocols do not need field descriptors.
+  if (type->hasClangNode() &&
+      (isa<ClassDecl>(type) ||
+       isa<ProtocolDecl>(type)))
+    return;
+
   if (!LazilyEmittedFieldMetadata.insert(type).second)
     return;
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6703,7 +6703,7 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 }
 
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
-  if (!IRGen.tryEnableLazyTypeMetadata(theEnum))
+  if (!IRGen.hasLazyMetadata(theEnum))
     emitEnumMetadata(*this, theEnum);
 
   emitNestedTypeDecls(theEnum->getMembers());

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6708,11 +6708,6 @@ void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
 
   emitNestedTypeDecls(theEnum->getMembers());
 
-  if (shouldEmitOpaqueTypeMetadataRecord(theEnum)) {
-    emitOpaqueTypeMetadataRecord(theEnum);
-    return;
-  }
-
   emitFieldMetadataRecord(theEnum);
 
   if (!isResilient(theEnum, ResilienceExpansion::Minimal))

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6703,12 +6703,12 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 }
 
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
-  if (!IRGen.hasLazyMetadata(theEnum))
+  if (!IRGen.hasLazyMetadata(theEnum)) {
     emitEnumMetadata(*this, theEnum);
+    emitFieldDescriptor(theEnum);
+  }
 
   emitNestedTypeDecls(theEnum->getMembers());
-
-  emitFieldMetadataRecord(theEnum);
 
   if (!isResilient(theEnum, ResilienceExpansion::Minimal))
     return;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1269,7 +1269,8 @@ namespace {
 
       // For any nominal type metadata required for reflection.
       for (auto *prop : properties)
-        IGM.IRGen.noteUseOfTypeMetadata(prop->getValueInterfaceType());
+        IGM.IRGen.noteUseOfTypeMetadata(prop->getValueInterfaceType()
+                                          ->getCanonicalType());
     }
     
     uint16_t getKindSpecificFlags() {
@@ -1342,7 +1343,8 @@ namespace {
 
       // For any nominal type metadata required for reflection.
       for (auto elt : Strategy.getElementsWithPayload())
-        IGM.IRGen.noteUseOfTypeMetadata(elt.decl->getArgumentInterfaceType());
+        IGM.IRGen.noteUseOfTypeMetadata(elt.decl->getArgumentInterfaceType()
+                                          ->getCanonicalType());
     }
     
     uint16_t getKindSpecificFlags() {
@@ -1663,7 +1665,8 @@ namespace {
 
       // For any nominal type metadata required for reflection.
       for (auto *prop : properties)
-        IGM.IRGen.noteUseOfTypeMetadata(prop->getValueInterfaceType());
+        IGM.IRGen.noteUseOfTypeMetadata(prop->getValueInterfaceType()
+                                          ->getCanonicalType());
     }
   };
 } // end anonymous namespace

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1282,10 +1282,8 @@ namespace {
     void maybeAddResilientSuperclass() { }
 
     void addReflectionFieldDescriptor() {
-      // Structs are reflectable unless we emit them with opaque reflection
-      // metadata.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata
-          || IGM.shouldEmitOpaqueTypeMetadataRecord(getType())) {
+      // Structs are reflectable unless reflection is disabled.
+      if (!IGM.IRGen.Opts.EnableReflectionMetadata) {
         B.addInt32(0);
         return;
       }
@@ -1358,9 +1356,8 @@ namespace {
     void addReflectionFieldDescriptor() {
       // Some enum layout strategies (viz. C compatible layout) aren't
       // supported by reflection.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata
-          || IGM.shouldEmitOpaqueTypeMetadataRecord(getType())
-          || !Strategy.isReflectable()) {
+      if (!IGM.IRGen.Opts.EnableReflectionMetadata ||
+          !Strategy.isReflectable()) {
         B.addInt32(0);
         return;
       }
@@ -1477,9 +1474,8 @@ namespace {
     void addReflectionFieldDescriptor() {
       // Classes are always reflectable, unless reflection is disabled or this
       // is a foreign class.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata
-          || IGM.shouldEmitOpaqueTypeMetadataRecord(getType())
-          || getType()->isForeign()) {
+      if (!IGM.IRGen.Opts.EnableReflectionMetadata ||
+          getType()->isForeign()) {
         B.addInt32(0);
         return;
       }

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -71,6 +71,10 @@ namespace irgen {
   /// generated definitions.
   void emitLazyTypeMetadata(IRGenModule &IGM, NominalTypeDecl *type);
 
+
+  /// Emit metadata for a foreign struct, enum or class.
+  void emitForeignTypeMetadata(IRGenModule &IGM, NominalTypeDecl *decl);
+
   /// Emit the metadata associated with the given struct declaration.
   void emitStructMetadata(IRGenModule &IGM, StructDecl *theStruct);
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2164,11 +2164,8 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   // Record this conformance descriptor.
   addProtocolConformance(std::move(description));
 
-  // Trigger the lazy emission of the foreign type metadata.
-  CanType conformingType = conf->getType()->getCanonicalType();
-  if (requiresForeignTypeMetadata(conformingType)) {
-    (void)getAddrOfForeignTypeMetadataCandidate(conformingType);
-  }
+  IRGen.noteUseOfTypeContextDescriptor(conf->getType()->getAnyNominal(),
+                                       RequireMetadata);
 }
 
 /// True if a function's signature in LLVM carries polymorphic parameters.

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -168,15 +168,16 @@ llvm::Constant *IRGenModule::getTypeRef(CanType type, MangledTypeRefRole role) {
   switch (role) {
   case MangledTypeRefRole::DefaultAssociatedTypeWitness:
   case MangledTypeRefRole::Metadata:
-    // Note that we're using all of the nominal types referenced by this type.
-    type.findIf([&](CanType type) -> bool {
-      if (auto nominal = type.getAnyNominal())
-        this->IRGen.noteUseOfTypeMetadata(nominal);
-      return false;
-    });
+    // Note that we're using all of the nominal types referenced by this type,
+    // ensuring that we can always reconstruct type metadata from a mangled name
+    // in-process.
+    IRGen.noteUseOfTypeMetadata(type);
     break;
 
   case MangledTypeRefRole::Reflection:
+    // For reflection records only used for out-of-process reflection, we do not
+    // need to force emission of runtime type metadata.
+    IRGen.noteUseOfFieldDescriptors(type);
     break;
   }
 
@@ -264,46 +265,46 @@ protected:
   
   // Collect any builtin types referenced from this type.
   void addBuiltinTypeRefs(CanType type) {
-    type.visit([&](CanType t) {
-      if (IGM.getSwiftModule()->isStdlibModule() && isa<BuiltinType>(t))
-        IGM.BuiltinTypes.insert(t);
-
-      // We need size/alignment information for imported structs and
-      // enums, so emit builtin descriptors for them.
-      //
-      // In effect they're treated like an opaque blob, which is OK
-      // for now, at least until we want to import C++ types or
-      // something like that.
-      if (auto Nominal = t->getAnyNominal())
-        if (Nominal->hasClangNode()) {
-          if (isa<StructDecl>(Nominal) ||
-              isa<EnumDecl>(Nominal))
-            IGM.OpaqueTypes.insert(Nominal);
-        }
-    });
+    if (IGM.getSwiftModule()->isStdlibModule()) {
+      type.visit([&](CanType t) {
+        if (isa<BuiltinType>(t))
+          IGM.BuiltinTypes.insert(t);
+      });
+    }
   }
 
   /// Add a 32-bit relative offset to a mangled typeref string
   /// in the typeref reflection section.
-  void addTypeRef(CanType type) {
-    B.addRelativeAddress(IGM.getTypeRef(type, MangledTypeRefRole::Reflection));
+  ///
+  /// By default, we use MangledTypeRefRole::Reflection, which does not
+  /// force emission of any type metadata referenced from the typeref.
+  ///
+  /// For reflection records which are demangled to produce type metadata
+  /// in-process, pass MangledTypeRefRole::Metadata instead.
+  void addTypeRef(CanType type,
+                  MangledTypeRefRole role =
+                      MangledTypeRefRole::Reflection) {
+    B.addRelativeAddress(IGM.getTypeRef(type, role));
+    addBuiltinTypeRefs(type);
   }
 
   /// Add a 32-bit relative offset to a mangled nominal type string
   /// in the typeref reflection section.
-  void addNominalRef(const NominalTypeDecl *nominal) {
+  ///
+  /// See above comment about 'role'.
+  void addNominalRef(const NominalTypeDecl *nominal,
+                     MangledTypeRefRole role =
+                      MangledTypeRefRole::Reflection) {
     if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
       IRGenMangler mangler;
       SymbolicMangling mangledStr;
       mangledStr.String = mangler.mangleBareProtocol(proto);
       auto mangledName =
-        IGM.getAddrOfStringForTypeRef(mangledStr,
-                                      MangledTypeRefRole::Reflection);
+        IGM.getAddrOfStringForTypeRef(mangledStr, role);
       B.addRelativeAddress(mangledName);
     } else {
       CanType type = nominal->getDeclaredType()->getCanonicalType();
-      B.addRelativeAddress(
-        IGM.getTypeRef(type, MangledTypeRefRole::Reflection));
+      addTypeRef(type, role);
     }
   }
 
@@ -372,7 +373,7 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
     PrettyStackTraceDecl DebugStack("emitting associated type metadata",
                                     Nominal);
 
-    addTypeRef(Nominal->getDeclaredType()->getCanonicalType());
+    addNominalRef(Nominal);
     addNominalRef(Conformance->getProtocol());
 
     B.addInt32(AssociatedTypes.size());
@@ -381,7 +382,6 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
     for (auto AssocTy : AssociatedTypes) {
       auto NameGlobal = IGM.getAddrOfFieldName(AssocTy.first);
       B.addRelativeAddress(NameGlobal);
-      addBuiltinTypeRefs(AssocTy.second);
       addTypeRef(AssocTy.second);
     }
   }
@@ -419,8 +419,10 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
     if (!type) {
       B.addInt32(0);
     } else {
-      addTypeRef(type);
-      addBuiltinTypeRefs(type);
+      // The standard library's Mirror demangles metadata from field
+      // descriptors, so use MangledTypeRefRole::Metadata to ensure
+      // runtime metadata is available.
+      addTypeRef(type, MangledTypeRefRole::Metadata);
     }
 
     if (IGM.IRGen.Opts.EnableReflectionNames) {
@@ -463,13 +465,9 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
 
     auto kind = FieldDescriptorKind::Enum;
 
-    // If this is a fixed-size multi-payload enum, we have to emit a descriptor
-    // with the size and alignment of the type, because the reflection library
-    // cannot derive this information at runtime.
     if (strategy.getElementsWithPayload().size() > 1 &&
         !strategy.needsPayloadSizeInMetadata()) {
       kind = FieldDescriptorKind::MultiPayloadEnum;
-      IGM.OpaqueTypes.insert(enumDecl);
     }
 
     B.addInt16(uint16_t(kind));
@@ -610,11 +608,6 @@ void IRGenModule::emitBuiltinTypeMetadataRecord(CanType builtinType) {
   builder.emit();
 }
 
-void IRGenModule::emitOpaqueTypeMetadataRecord(const NominalTypeDecl *nominalDecl) {
-  FixedTypeMetadataBuilder builder(*this, nominalDecl);
-  builder.emit();
-}
-
 /// Builds a constant LLVM struct describing the layout of a fixed-size
 /// SIL @box. These look like closure contexts, but without any necessary
 /// bindings or metadata sources, and only a single captured value.
@@ -630,7 +623,6 @@ public:
     B.addInt32(0); // Number of generic bindings
 
     addTypeRef(BoxedType);
-    addBuiltinTypeRefs(BoxedType);
   }
 
   llvm::GlobalVariable *emit() {
@@ -642,6 +634,11 @@ public:
 /// Builds a constant LLVM struct describing the layout of a heap closure,
 /// the types of its captures, and the sources of metadata if any of the
 /// captures are generic.
+///
+/// For now capture descriptors are only used by out-of-process reflection.
+///
+/// If the standard library's Mirror type ever gains the ability to reflect
+/// closure contexts, we should use MangledTypeRefRole::Metadata below.
 class CaptureDescriptorBuilder : public ReflectionMetadataBuilder {
   swift::reflection::MetadataSourceBuilder SourceBuilder;
   CanSILFunctionType OrigCalleeType;
@@ -673,7 +670,7 @@ public:
       Encoder.visit(Source);
 
       auto EncodedSource =
-        IGM.getAddrOfStringForTypeRef(OS.str(), MangledTypeRefRole::Metadata);
+        IGM.getAddrOfStringForTypeRef(OS.str(), MangledTypeRefRole::Reflection);
       B.addRelativeAddress(EncodedSource);
     }
   }
@@ -1000,9 +997,6 @@ void IRGenModule::emitBuiltinReflectionMetadata() {
 
   for (auto builtinType : BuiltinTypes)
     emitBuiltinTypeMetadataRecord(builtinType);
-
-  for (auto nominalDecl : OpaqueTypes)
-    emitOpaqueTypeMetadataRecord(nominalDecl);
 }
 
 void IRGenerator::emitBuiltinReflectionMetadata() {
@@ -1017,13 +1011,31 @@ void IRGenModule::emitFieldDescriptor(const NominalTypeDecl *D) {
 
   auto T = D->getDeclaredTypeInContext()->getCanonicalType();
 
+  bool needsOpaqueDescriptor = false;
+  bool needsFieldDescriptor = true;
+
   if (auto *ED = dyn_cast<EnumDecl>(D)) {
+    auto &strategy = getEnumImplStrategy(*this, T);
+
     // @objc enums never have generic parameters or payloads,
     // and lower as their raw type.
-    if (!getEnumImplStrategy(*this, T).isReflectable()) {
-      OpaqueTypes.insert(D);
-      return;
+    if (!strategy.isReflectable()) {
+      needsOpaqueDescriptor = true;
+      needsFieldDescriptor = false;
     }
+
+    // If this is a fixed-size multi-payload enum, we have to emit a descriptor
+    // with the size and alignment of the type, because the reflection library
+    // cannot derive this information at runtime.
+    if (strategy.getElementsWithPayload().size() > 1 &&
+        !strategy.needsPayloadSizeInMetadata()) {
+      needsOpaqueDescriptor = true;
+    }
+  }
+
+  if (auto *SD = dyn_cast<StructDecl>(D)) {
+    if (SD->hasClangNode())
+      needsOpaqueDescriptor = true;
   }
 
   // If the type has custom @_alignment, emit a fixed record with the
@@ -1035,12 +1047,19 @@ void IRGenModule::emitFieldDescriptor(const NominalTypeDecl *D) {
   if (D->getAttrs().hasAttribute<AlignmentAttr>()) {
     auto &TI = getTypeInfoForUnlowered(T);
     if (isa<FixedTypeInfo>(TI)) {
-      OpaqueTypes.insert(D);
+      needsOpaqueDescriptor = true;
     }
   }
 
-  FieldTypeMetadataBuilder builder(*this, D);
-  FieldDescriptors.push_back(builder.emit());
+  if (needsOpaqueDescriptor) {
+    FixedTypeMetadataBuilder builder(*this, D);
+    builder.emit();
+  }
+
+  if (needsFieldDescriptor) {
+    FieldTypeMetadataBuilder builder(*this, D);
+    FieldDescriptors.push_back(builder.emit());
+  }
 }
 
 void IRGenModule::emitReflectionMetadataVersion() {

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -998,9 +998,6 @@ void IRGenModule::emitBuiltinReflectionMetadata() {
     BuiltinTypes.insert(anyMetatype);
   }
 
-  for (auto SD : ImportedStructs)
-    emitFieldMetadataRecord(SD);
-
   for (auto builtinType : BuiltinTypes)
     emitBuiltinTypeMetadataRecord(builtinType);
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1011,7 +1011,7 @@ void IRGenerator::emitBuiltinReflectionMetadata() {
   }
 }
 
-void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *D) {
+void IRGenModule::emitFieldDescriptor(const NominalTypeDecl *D) {
   if (!IRGen.Opts.EnableReflectionMetadata)
     return;
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -871,7 +871,7 @@ Optional<unsigned> irgen::getPhysicalStructFieldIndex(IRGenModule &IGM,
 }
 
 void IRGenModule::emitStructDecl(StructDecl *st) {
-  if (!IRGen.tryEnableLazyTypeMetadata(st))
+  if (!IRGen.hasLazyMetadata(st))
     emitStructMetadata(*this, st);
 
   emitNestedTypeDecls(st->getMembers());

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -876,11 +876,7 @@ void IRGenModule::emitStructDecl(StructDecl *st) {
 
   emitNestedTypeDecls(st->getMembers());
 
-  if (shouldEmitOpaqueTypeMetadataRecord(st)) {
-    emitOpaqueTypeMetadataRecord(st);
-  } else {
-    emitFieldMetadataRecord(st);
-  }  
+  emitFieldMetadataRecord(st);
 }
 
 namespace {

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -871,12 +871,12 @@ Optional<unsigned> irgen::getPhysicalStructFieldIndex(IRGenModule &IGM,
 }
 
 void IRGenModule::emitStructDecl(StructDecl *st) {
-  if (!IRGen.hasLazyMetadata(st))
+  if (!IRGen.hasLazyMetadata(st)) {
     emitStructMetadata(*this, st);
+    emitFieldDescriptor(st);
+  }
 
   emitNestedTypeDecls(st->getMembers());
-
-  emitFieldMetadataRecord(st);
 }
 
 namespace {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -793,6 +793,7 @@ void IRGenerator::addLazyWitnessTable(const ProtocolConformance *Conf) {
     // Add it to the queue if it hasn't already been put there.
     if (canEmitWitnessTableLazily(wt) &&
         LazilyEmittedWitnessTables.insert(wt).second) {
+      assert(!FinishedEmittingLazyDefinitions);
       LazyWitnessTables.push_back(wt);
     }
   }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -380,8 +380,6 @@ public:
     noteUseOfTypeGlobals(type, false, requireMetadata);
   }
 
-  void noteUseOfAnyParentTypeMetadata(NominalTypeDecl *type);
-
   void noteUseOfFieldDescriptor(NominalTypeDecl *type);
 
   void noteUseOfFieldDescriptors(CanType type) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -228,6 +228,9 @@ private:
     bool IsLazy = false;
   };
 
+  /// If this is true, adding anything to the below queues is an error.
+  bool FinishedEmittingLazyDefinitions = false;
+
   /// The set of type metadata that have been enqueued for lazy emission.
   ///
   /// It can also contain some eagerly emitted metadata. Those are ignored in

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1031,9 +1031,6 @@ public:
   /// without knowledge of their contents. This includes imported structs
   /// and fixed-size multi-payload enums.
   llvm::SetVector<const NominalTypeDecl *> OpaqueTypes;
-  /// Imported structs referenced by types in this module when emitting
-  /// reflection metadata.
-  llvm::SetVector<const StructDecl *> ImportedStructs;
 
   llvm::Constant *getTypeRef(CanType type, MangledTypeRefRole role);
   llvm::Constant *getMangledAssociatedConformance(
@@ -1273,7 +1270,6 @@ public:
                                              ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfTypeMetadataLazyCacheVariable(CanType type,
                                                ForDefinition_t forDefinition);
-  llvm::Constant *getAddrOfForeignTypeMetadataCandidate(CanType concreteType);
 
   llvm::Constant *getAddrOfClassMetadataBounds(ClassDecl *D,
                                                ForDefinition_t forDefinition);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1946,9 +1946,6 @@ llvm::Function *irgen::getOrCreateTypeMetadataAccessFunction(IRGenModule &IGM,
 
   switch (getTypeMetadataAccessStrategy(type)) {
   case MetadataAccessStrategy::ForeignAccessor:
-    // Force the foreign candidate to exist.
-    (void) IGM.getAddrOfForeignTypeMetadataCandidate(type);
-    LLVM_FALLTHROUGH;
   case MetadataAccessStrategy::PublicUniqueAccessor:
   case MetadataAccessStrategy::HiddenUniqueAccessor:
   case MetadataAccessStrategy::PrivateAccessor:

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -17,7 +17,7 @@ protocol Assocked {
 struct Universal : P, Q {}
 
 
-// CHECK-LABEL: @"symbolic _____ 23associated_type_witness12OuterPrivate{{.*}}V" = linkonce_odr hidden constant
+// CHECK-LABEL: @"symbolic _____ 23associated_type_witness12OuterPrivate{{.*}}InnermostV" = linkonce_odr hidden constant
 // CHECK-SAME: @"$s23associated_type_witness12OuterPrivate{{.*}}5InnerE0V9InnermostVMn"
 private struct OuterPrivate {
   struct InnerPrivate: HasSimpleAssoc {

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -9,7 +9,22 @@
 // CHECK: [[MUTABLE_REFRIGERATOR:%TSo24CCMutableRefrigeratorRefa]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 
-// CHECK: @"$sSo17CCRefrigeratorRefaN" = linkonce_odr hidden
+// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [52 x i8] c"CCMutableRefrigerator\00NCCMutableRefrigeratorRef\00St\00\00"
+
+// CHECK: @"$sSo24CCMutableRefrigeratorRefaMn" = linkonce_odr hidden constant
+// -- is imported, foreign init, is class, is nonunique
+// CHECK-SAME: <i32 0x0006_0010>
+// CHECK-SAME: [[MUTABLE_REFRIGERATOR_NAME]]
+// CHECK-SAME: @"$sSo24CCMutableRefrigeratorRefaMa"
+// CHECK-SAME: @"$sSo24CCMutableRefrigeratorRefaMr"
+
+// CHECK: @"$sSo24CCMutableRefrigeratorRefaMf" = linkonce_odr hidden global <{ {{.*}} }> <{
+// -- value witness table
+// CHECK-DIRECT-SAME: i8** @"$sBOWV",
+// CHECK-INDIRECT-SAME: i8** null,
+// CHECK-64-SAME: i64 515, {{.*}}"$sSo24CCMutableRefrigeratorRefaMn", %swift.type* null, i8* null }>
+
+// CHECK: @"$sSo17CCRefrigeratorRefaMf" = linkonce_odr hidden
 // CHECK-DIRECT-SAME: constant
 // CHECK-INDIRECT-SAME: global
 // CHECK-SAME: <{ {{.*}} }> <{
@@ -17,21 +32,6 @@
 // CHECK-DIRECT-SAME: i8** @"$sBOWV",
 // CHECK-INDIRECT-SAME: i8** null,
 // CHECK-SAME: [[INT]] 515, {{.*}}"$sSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null }>
-
-// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [52 x i8] c"CCMutableRefrigerator\00NCCMutableRefrigeratorRef\00St\00\00"
-
-// CHECK-64: @"$sSo24CCMutableRefrigeratorRefaMn" = linkonce_odr hidden constant
-// -- is imported, foreign init, is class, is nonunique
-// CHECK-64-SAME: <i32 0x0006_0010>
-// CHECK-64-SAME: [[MUTABLE_REFRIGERATOR_NAME]]
-// CHECK-64-SAME: @"$sSo24CCMutableRefrigeratorRefaMa"
-// CHECK-64-SAME: @"$sSo24CCMutableRefrigeratorRefaMr"
-
-// CHECK-64: @"$sSo24CCMutableRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
-// -- value witness table
-// CHECK-DIRECT-64-SAME: i8** @"$sBOWV",
-// CHECK-INDIRECT-64-SAME: i8** null,
-// CHECK-64-SAME: i64 515, {{.*}}"$sSo24CCMutableRefrigeratorRefaMn", %swift.type* null, i8* null }>
 
 sil_stage canonical
 
@@ -61,9 +61,9 @@ bb0(%0 : $CCRefrigerator, %1: $CCMutableRefrigerator):
 // CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T2]])
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL:    define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo17CCRefrigeratorRefaMa"(
-// CHECK-32:      call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, [[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$sSo17CCRefrigeratorRefaN" to i8*), [[INT]] 4) to [[TYPE]]*))
-// CHECK-64:      call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, [[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$sSo17CCRefrigeratorRefaN" to i8*), [[INT]] 8) to [[TYPE]]*))
+// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo17CCRefrigeratorRefaMa"(
+// CHECK:      call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0,
+// CHECK-SAME: @"$sSo17CCRefrigeratorRefaMf"
 
 // CHECK-LABEL:    define internal swiftcc %swift.metadata_response @"$sSo24CCMutableRefrigeratorRefaMr"(%swift.type*, i8*, i8**)
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$sSo17CCRefrigeratorRefaMa"([[INT]] 255)

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -3,19 +3,19 @@
 sil_stage canonical
 import c_layout
 
-// CHECK: [[HAS_NESTED_UNION_NAME:@.*]] = private constant [15 x i8] c"HasNestedUnion\00"
-
-// CHECK-LABEL: @"$sSo14HasNestedUnionVMn" = linkonce_odr hidden constant
-// CHECK-SAME: [[HAS_NESTED_UNION_NAME]]
-// CHECK-SAME: @"$sSo14HasNestedUnionVMa"
-
 // CHECK: [[AMAZING_COLOR_NAME:@.*]] = private constant [13 x i8] c"AmazingColor\00"
 
 // CHECK-LABEL: @"$sSo12AmazingColorVMn" = linkonce_odr hidden constant
 // CHECK-SAME: [[AMAZING_COLOR_NAME]]
 // CHECK-SAME: @"$sSo12AmazingColorVMa"
 
-// CHECK-LABEL: @"$sSo14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden constant
+// CHECK: [[HAS_NESTED_UNION_NAME:@.*]] = private constant [15 x i8] c"HasNestedUnion\00"
+
+// CHECK-LABEL: @"$sSo14HasNestedUnionVMn" = linkonce_odr hidden constant
+// CHECK-SAME: [[HAS_NESTED_UNION_NAME]]
+// CHECK-SAME: @"$sSo14HasNestedUnionVMa"
+
+// CHECK-LABEL: @"$sSo14HasNestedUnionV18__Unnamed_struct_sVMf" = linkonce_odr hidden constant
 // CHECK-SAME:  @"$sSo14HasNestedUnionV18__Unnamed_struct_sVWV"
 // CHECK-SAME:  [[INT]] 512,
 // CHECK-SAME:  @"$sSo14HasNestedUnionV18__Unnamed_struct_sVMn"
@@ -23,8 +23,8 @@ import c_layout
 // CHECK-SAME:  i32 4 }
 
 // CHECK-LABEL: @"\01l_type_metadata_table" = private constant
-// CHECK-SAME: @"$sSo14HasNestedUnionVMn"
 // CHECK-SAME: @"$sSo12AmazingColorVMn"
+// CHECK-SAME: @"$sSo14HasNestedUnionVMn"
 // CHECK-SAME: @"$sSo14HasNestedUnionV18__Unnamed_struct_sVMn"
 
 sil @test0 : $() -> () {
@@ -37,7 +37,7 @@ bb0:
 }
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo14HasNestedUnionVMa"(
-// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}}$sSo14HasNestedUnionVN
+// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}}@"$sSo14HasNestedUnionVMf"
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo12AmazingColorVMa"(
-// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}}@"$sSo12AmazingColorVN"
+// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}}@"$sSo12AmazingColorVMf"

--- a/test/IRGen/lazy_metadata.swift
+++ b/test/IRGen/lazy_metadata.swift
@@ -10,14 +10,14 @@
 // CHECK-DAG: @"$s4test7StructAVMF" =
 // CHECK-DAG: @"$s4test7StructBVMF" =
 // CHECK-DAG: @"$s4test7StructCVMF" =
-// CHECK-DAG: @"$s4test7StructDVMF" =
+// CHECK-DEAD-NOT: @"$s4test7StructDVMF" =
 // CHECK-DAG: @"$s4test7StructEVMF" =
 
 // nominal type descriptors
 // CHECK-DAG: @"$s4test7StructAVMn" =
 // CHECK-DAG: @"$s4test7StructBVMn" =
 // CHECK-DAG: @"$s4test7StructCVMn" =
-// CHECK-DAG: @"$s4test7StructDVMn"
+// CHECK-DEAD-NOT: @"$s4test7StructDVMn"
 // CHECK-DAG: @"$s4test7StructEVMn" =
 
 // full type metadata

--- a/test/IRGen/lazy_metadata_no_reflection.swift
+++ b/test/IRGen/lazy_metadata_no_reflection.swift
@@ -1,11 +1,37 @@
-// RUN: %target-swift-frontend -parse-as-library -module-name=test -O %s -emit-ir -disable-reflection-metadata | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -module-name=test -O %s -emit-ir -disable-reflection-metadata > %t/out.txt
+// RUN: %FileCheck %s < %t/out.txt
+// RUN: %FileCheck %s --check-prefix=NEGATIVE < %t/out.txt
 
+// We have an unused conformance. It should not crash.
+//
+// FIXME: Actually stop emitting the conformance.
 struct S { }
 
 extension S: Equatable {
   static func ==(lhs: S, rhs: S) -> Bool {
     return false
   }
+}
+
+// We should only emit metadata for the second type, even though it has a
+// field whose type is the first.
+struct TypeOfProperty {
+  var x: Int
+}
+
+struct HasPropertyType {
+  var p: TypeOfProperty
+}
+
+// NEGATIVE-NOT: @"$s4test14TypeOfPropertyVMn"
+// CHECK-LABEL: @"$s4test15HasPropertyTypeVMn"
+
+@_optimize(none)
+public func takeMetadata<T>(_: T.Type) {}
+
+public func forceMetadata() {
+  takeMetadata(HasPropertyType.self)
 }
 
 // CHECK-LABEL: @"$s4test1SVMn" = hidden constant

--- a/test/IRGen/lazy_metadata_no_reflection.swift
+++ b/test/IRGen/lazy_metadata_no_reflection.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -parse-as-library -module-name=test -O %s -emit-ir -disable-reflection-metadata | %FileCheck %s
+
+struct S { }
+
+extension S: Equatable {
+  static func ==(lhs: S, rhs: S) -> Bool {
+    return false
+  }
+}
+
+// CHECK-LABEL: @"$s4test1SVMn" = hidden constant
+// CHECK-LABEL: @"$s4test1SVSQAAMc" = hidden constant

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -22,12 +22,12 @@ import gizmo
 // CHECK: @"\01L_selector_data(bar)" = private global [4 x i8] c"bar\00", section "__TEXT,__objc_methname,cstring_literals", align 1
 // CHECK: @"\01L_selector(bar)" = private externally_initialized global i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(bar)", i64 0, i64 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip", align 8
 
-// CHECK: @"$sSo4RectVMn" = linkonce_odr hidden constant
-// CHECK: @"$sSo4RectVN" = linkonce_odr hidden constant
-
 // CHECK: @"\01L_selector_data(acquiesce)"
 // CHECK-NOT: @"\01L_selector_data(disharmonize)"
 // CHECK: @"\01L_selector_data(eviscerate)"
+
+// CHECK: @"$sSo4RectVMn" = linkonce_odr hidden constant
+// CHECK: @"$sSo4RectVMf" = linkonce_odr hidden constant
 
 struct id {
   var data : AnyObject
@@ -130,7 +130,7 @@ func test10(_ g: Gizmo, r: Rect) {
 func test11_helper<T>(_ t: T) {}
 // NSRect's metadata needs to be uniqued at runtime using getForeignTypeMetadata.
 // CHECK-LABEL: define hidden swiftcc void @"$s4objc6test11yySo4RectVF"
-// CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata(i64 %0, {{.*}} @"$sSo4RectVN"
+// CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata(i64 %0, {{.*}} @"$sSo4RectVMf"
 func test11(_ r: Rect) { test11_helper(r) }
 
 class WeakObjC {

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir > %t/out.txt
+// RUN: %FileCheck %s -DINT=i%target-ptrsize < %t/out.txt
+// RUN: %FileCheck %s --check-prefix=NEGATIVE < %t/out.txt
+
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
@@ -9,10 +12,11 @@ import Foundation
 import gizmo
 
 // CHECK: @"$sSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
-// CHECK: @"$sSo16NSRuncingOptionsVN" = linkonce_odr hidden constant
+// CHECK: @"$sSo16NSRuncingOptionsVMf" = linkonce_odr hidden constant
 //   CHECK-SAME: @"$sBi{{[0-9]+}}_WV"
 // CHECK: @"$sSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant
-// CHECK-NOT: @"$sSo28NeverActuallyMentionedByNameVSQSCWp" = linkonce_odr hidden constant
+
+// NEGATIVE-NOT: @"$sSo28NeverActuallyMentionedByNameVSQSCWp" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main
 // CHECK:         call swiftcc %swift.metadata_response @"$sSo16NSRuncingOptionsVMa"(i64 0)
@@ -87,7 +91,9 @@ func use_metadata<T: Equatable>(_ t:T){}
 use_metadata(NSRuncingOptions.mince)
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo16NSRuncingOptionsVMa"(i64)
-// CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}} @"$sSo16NSRuncingOptionsVN" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0,
+// CHECK-SAME:    @"$sSo16NSRuncingOptionsVMf"
+// CHECK-SAME:    [[NOUNWIND_READNONE:#[0-9]+]]
 
 @objc enum ExportedToObjC: Int {
   case Foo = -1, Bar, Bas

--- a/test/IRGen/related_entity.sil
+++ b/test/IRGen/related_entity.sil
@@ -13,35 +13,39 @@ sil @use_metatypes : $@convention(thin) () -> () {
 bb0:
   %take = function_ref @take_metatype : $@convention(thin) <T> (@thick T.Type) -> ()
 
-// CHECK:         [[TagError1_NAME:@[0-9]+]] = private constant [14 x i8] c"TagError1\00Re\00\00"
-// CHECK:         @"$sSC9TagError1LeVMn" = linkonce_odr hidden constant
-// CHECK-SAME:    <i32 0x0006_0011>
-// CHECK-SAME:    @"$sSCMXM"
-// CHECK-SAME:    [14 x i8]* [[TagError1_NAME]]
-  %0 = metatype $@thick TagError1.Type
-  apply %take<TagError1>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
-
-// CHECK:         [[TagError2_NAME:@[0-9]+]] = private constant [17 x i8] c"Code\00NTagError2\00\00"
-// CHECK:         @"$sSo9TagError2VMn" = linkonce_odr hidden constant
+// CHECK:         [[TypedefError2Code_NAME:@[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
+// CHECK:         @"$sSo13TypedefError2aMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
-// CHECK-SAME:    [17 x i8]* [[TagError2_NAME]]
-  %1 = metatype $@thick TagError2.Code.Type
-  apply %take<TagError2.Code>(%1) : $@convention(thin) <T> (@thick T.Type) -> ()
+// CHECK-SAME:    [24 x i8]* [[TypedefError2Code_NAME]]
 
 // CHECK:         [[TypedefError1_NAME:@[0-9]+]] = private constant [18 x i8] c"TypedefError1\00RE\00\00"
 // CHECK:         @"$sSC13TypedefError1LEVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"
 // CHECK-SAME:    [18 x i8]* [[TypedefError1_NAME]]
+
+// CHECK:         [[TagError2_NAME:@[0-9]+]] = private constant [17 x i8] c"Code\00NTagError2\00\00"
+// CHECK:         @"$sSo9TagError2VMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x0006_0012>
+// CHECK-SAME:    @"$sSoMXM"
+// CHECK-SAME:    [17 x i8]* [[TagError2_NAME]]
+
+// CHECK:         [[TagError1_NAME:@[0-9]+]] = private constant [14 x i8] c"TagError1\00Re\00\00"
+// CHECK:         @"$sSC9TagError1LeVMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x0006_0011>
+// CHECK-SAME:    @"$sSCMXM"
+// CHECK-SAME:    [14 x i8]* [[TagError1_NAME]]
+
+  %0 = metatype $@thick TagError1.Type
+  apply %take<TagError1>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+  %1 = metatype $@thick TagError2.Code.Type
+  apply %take<TagError2.Code>(%1) : $@convention(thin) <T> (@thick T.Type) -> ()
+
   %2 = metatype $@thick TypedefError1.Type
   apply %take<TypedefError1>(%2) : $@convention(thin) <T> (@thick T.Type) -> ()
 
-// CHECK:         [[TypedefError2Code_NAME:@[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
-// CHECK:         @"$sSo13TypedefError2aMn" = linkonce_odr hidden constant
-// CHECK-SAME:    <i32 0x0006_0012>
-// CHECK-SAME:    @"$sSoMXM"
-// CHECK-SAME:    [24 x i8]* [[TypedefError2Code_NAME]]
   %3 = metatype $@thick TypedefError2.Code.Type
   apply %take<TypedefError2.Code>(%3) : $@convention(thin) <T> (@thick T.Type) -> ()
 

--- a/test/IRGen/symbolic_references.swift
+++ b/test/IRGen/symbolic_references.swift
@@ -4,13 +4,14 @@
 protocol P {
   associatedtype A
 }
-// CHECK: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV9InnermostV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1,
-// CHECK: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
-// CHECK: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+// CHECK-DAG: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV9InnermostV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1,
+// CHECK-DAG: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+// CHECK-DAG: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
 
-// PRIVATE: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV9InnermostV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 2
-// PRIVATE: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
-// PRIVATE: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+// PRIVATE-DAG: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV9InnermostV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 2
+// PRIVATE-DAG: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V5InnerV" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+// PRIVATE-DAG: @"symbolic _____ 19symbolic_references3Foo016_{{.*}}V" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1
+
 fileprivate struct Foo {
   fileprivate struct Inner: P {
     fileprivate struct Innermost { }

--- a/test/IRGen/unusedtype.swift
+++ b/test/IRGen/unusedtype.swift
@@ -1,11 +1,7 @@
-// RUN: %target-swift-frontend -parse-as-library -O %s -emit-ir > %t.ll
-// RUN: %FileCheck %s < %t.ll
-// RUN: %FileCheck -check-prefix=CHECK-REFLECTION %s < %t.ll
+// RUN: %target-swift-frontend -parse-as-library -O %s -emit-ir | %FileCheck %s
 
-// No global metadata, witness tables, etc. Only reflection metadata should not be optimized away
-// CHECK-NOT: @"$s{{.*[^F] =}}"
-// CHECK-REFLECTION: @[[C:.*]] = linkonce_odr hidden constant {{.*}} @"$s10unusedtype13MicroSequenceVMn"
-// CHECK-REFLECTION: @"$s10unusedtype13MicroSequenceVMF" = {{.*}} @[[C]]
+// No global metadata, witness tables, or reflection field descriptor, etc.
+// CHECK-NOT: @"$s{{.* =}}"
 
 // No conformance records
 // CHECK-NOT: protocol_conformances

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -92,11 +92,6 @@
 // CHECK:  (result
 // CHECK:    (tuple))
 
-// CHECK: TypesToReflect.S.NestedS
-// CHECK: ------------------------
-// CHECK: aField: Swift.Int
-// CHECK: (struct Swift.Int)
-
 // CHECK: TypesToReflect.S
 // CHECK: ----------------
 // CHECK: aClass: TypesToReflect.C
@@ -140,6 +135,11 @@
 // CHECK: aFunctionWithCRepresentation: @convention(c) () -> ()
 // CHECK: (function convention=c
 // CHECK:   (tuple))
+
+// CHECK: TypesToReflect.S.NestedS
+// CHECK: ------------------------
+// CHECK: aField: Swift.Int
+// CHECK: (struct Swift.Int)
 
 // CHECK: TypesToReflect.E
 // CHECK: ----------------

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -92,11 +92,6 @@
 // CHECK:  (result
 // CHECK:    (tuple))
 
-// CHECK: TypesToReflect.S.NestedS
-// CHECK: ------------------------
-// CHECK: aField: Swift.Int
-// CHECK: (struct Swift.Int)
-
 // CHECK: TypesToReflect.S
 // CHECK: ----------------
 // CHECK: aClass: TypesToReflect.C
@@ -140,6 +135,11 @@
 // CHECK: aFunctionWithCRepresentation: @convention(c) () -> ()
 // CHECK: (function convention=c
 // CHECK:   (tuple))
+
+// CHECK: TypesToReflect.S.NestedS
+// CHECK: ------------------------
+// CHECK: aField: Swift.Int
+// CHECK: (struct Swift.Int)
 
 // CHECK: TypesToReflect.E
 // CHECK: ----------------

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -1833,4 +1833,22 @@ mirrors.test("GenericNestedWithSameTypeConstraints") {
   expectEqual(expected, output)
 }
 
+@_alignment(16) struct CustomAlignment {
+  var x: Int
+  var y: Int
+}
+
+mirrors.test("CustomAlignment") {
+  let value = CustomAlignment(x: 123, y: 321)
+  var output = ""
+  dump(value, to: &output)
+
+  let expected =
+    "▿ Mirror.CustomAlignment\n" +
+    "  - x: 123\n" +
+    "  - y: 321\n"
+
+  expectEqual(expected, output)
+}
+
 runAllTests()


### PR DESCRIPTION
- Fix a bug where a conformance could reference a nominal type descriptor that was not yet emitted, because conformance descriptors are emitted after the lazy queues have already been drained. Add some assertions preventing this from happening again.

- Lazily emit reflection field descriptors -- they can be dropped if we know the type won't ever appear as a member of a type with metadata (meaning its part of a class instance and can be reflected remotely, or something that's used generically and can be reflected in-process). Previously we would emit field descriptors even for completely unused types, which in turn forced emission of unnecessary nominal type descriptors from symbolic references, etc.

- Don't force emission of metadata referenced by field types if reflection metadata is off. This was a completely unnecessary waste of space.

- Fix a bug where we weren't emitting field descriptors for types with `@_alignment`, preventing them from being reflected by the stdlib Mirror type (remote mirrors still cannot reflect them).

Fixes rdar://49710077