### PR TITLE
add install-tensorflow back to build-presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1847,6 +1847,7 @@ swift-primary-variant-sdk=OSX
 swift-primary-variant-arch=x86_64
 # Enable TensorFlow support.
 enable-tensorflow
+install-tensorflow
 
 [preset: tensorflow_osx]
 mixin-preset=tensorflow_osx_base
@@ -1875,18 +1876,22 @@ darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 [preset: tensorflow_linux]
 mixin-preset=buildbot_linux
 enable-tensorflow
+install-tensorflow
 
 [preset: tensorflow_linux,no_test]
 mixin-preset=buildbot_linux,no_test
 enable-tensorflow
+install-tensorflow
 
 [preset: tensorflow_linux,gpu]
 mixin-preset=tensorflow_linux
 enable-tensorflow-gpu
+install-tensorflow
 
 [preset: tensorflow_linux,gpu,no_test]
 mixin-preset=tensorflow_linux,no_test
 enable-tensorflow-gpu
+install-tensorflow
 
 #===------------------------------------------------------------------------===#
 # Swift for TensorFlow Preset
@@ -1896,6 +1901,7 @@ enable-tensorflow-gpu
 [preset: tensorflow_linux,tools=DA,stdlib=DA]
 mixin-preset=mixin_linux_installation
 enable-tensorflow
+install-tensorflow
 
 ### From: buildbot_linux
 build-subdir=buildbot_linux


### PR DESCRIPTION
I don't know if this will actually work. I ran `SWIFT_PACKAGE=tensorflow_linux,no_test swift/utils/build-toolchain local.swift` on my workstation to check, and I'll report back tomorrow morning when I wake up if that succeeded.

I think that `install-tensorflow` accidentally got removed a long time ago. `install-tensorflow` is responsible for copying the tensorflow libs into the toolchain:

https://github.com/apple/swift/blob/02351479c5423a78f46c5f65bfb3abac57123831/utils/build-script-impl#L3831.

I have an unverified guess about why this didn't cause problems earlier: Some other step is copying all ".so" files into the toolchain, and the tensorflow libs used to be "libtensorflow.so" and "libtensorflow_framework.so". But recent tensorflow changes added some ".so.VERSION" files that don't get copied by the other step. So we need to bring "install-tensorflow" back.