### PR TITLE
Undo "Disable TSan in coroutine functions" (0ca3f79).

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1226,10 +1226,7 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
   }
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
     auto declContext = f->getDeclContext();
-    if (f->getLoweredFunctionType()->isCoroutine()) {
-      // Disable TSan in coroutines; the instrumentation currently interferes
-      // with coroutine structural invariants.
-    } else if (declContext && isa<DestructorDecl>(declContext)) {
+    if (declContext && isa<DestructorDecl>(declContext)) {
       // Do not report races in deinit and anything called from it
       // because TSan does not observe synchronization between retain
       // count dropping to '0' and the object deinitialization.

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -1,6 +1,6 @@
 // This test verifies that we add the function attributes used by TSan.
 
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
+// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
 
 // TSan is currently only supported on 64 bit mac and simulators.
 // (We do not test the simulators here.)
@@ -22,5 +22,5 @@ public var x: Int {
 // TSAN-SAME: }
 
 // TSAN: attributes [[COROUTINE_ATTRS]] =
-// TSAN-NOT: sanitize_address
+// TSAN-SAME: sanitize_thread
 // TSAN-SAME: }


### PR DESCRIPTION
This is no longer needed because we now make sure to run the coroutine lowering pass before ASan/TSan instrumentation passes.

Also fixes a typo in the test.
