### PR TITLE
[build-script] Rename ToolchainBenchmarks -> Benchmarks.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -897,7 +897,7 @@ class BuildScriptInvocation(object):
         if self.args.build_sourcekitlsp:
             product_classes.append(products.SourceKitLSP)
         if self.args.build_toolchainbenchmarks:
-            product_classes.append(products.ToolchainBenchmarks)
+            product_classes.append(products.Benchmarks)
         return product_classes
 
     def execute(self):

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -10,7 +10,7 @@
 #
 # ----------------------------------------------------------------------------
 
-from .benchmarks import ToolchainBenchmarks
+from .benchmarks import Benchmarks
 from .cmark import CMark
 from .foundation import Foundation
 from .indexstoredb import IndexStoreDB
@@ -48,5 +48,5 @@ __all__ = [
     'SwiftEvolve',
     'IndexStoreDB',
     'SourceKitLSP',
-    'ToolchainBenchmarks',
+    'Benchmarks',
 ]

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -19,7 +19,7 @@ from .. import targets
 
 
 # Build against the current installed toolchain.
-class ToolchainBenchmarks(product.Product):
+class Benchmarks(product.Product):
     @classmethod
     def product_source_name(cls):
         return "benchmarks"


### PR DESCRIPTION
This is a better name for the internal interface. The outside option is still
--toolchain-benchmarks to distinguish it from the normal --benchmarks which is
part of swift's cmake.
