### PR TITLE
[benchmarks] Test that we can keep on building the benchmarks against…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -748,6 +748,9 @@ build-swift-stdlib-unittest-extra
 
 test-installable-package
 
+# Build the benchmarks against the toolchain.
+toolchain-benchmarks
+
 # Path to the root of the installation filesystem.
 install-destdir=%(install_destdir)s
 
@@ -953,6 +956,9 @@ skip-test-lldb
 # FIXME: Disabled until a home for the swift-snapshot-tests can be found.
 #test-installable-package
 
+# Make sure we can build the benchmarks against the toolchain.
+toolchain-benchmarks
+
 # Path to the root of the installation filesystem.
 install-destdir=%(install_destdir)s
 
@@ -1125,6 +1131,9 @@ install-prefix=%(install_toolchain_dir)s/usr
 # Assumes the swift-integration-tests repo is checked out
 
 test-installable-package
+
+# Make sure that we can build the benchmarks with swiftpm against the toolchain
+toolchain-benchmarks
 
 # If someone uses this for incremental builds, force reconfiguration.
 reconfigure


### PR DESCRIPTION
… toolchains by using build-script instead of via the integration tests.

This will ensure that I can put this down for now and things do not break.

In a subsequent commit to the integration test suite I am going to remove that
test.
