### PR TITLE
Temporarily remove the global min(a,b) and max(a,b) SIMD functions.

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -467,15 +467,17 @@ extension SIMD where Scalar: Comparable {
     return lhs .> Self(repeating: rhs)
   }
   
+  /*  Temporarily removed pending plan for Swift.min / Swift.max
   @_alwaysEmitIntoClient
   public mutating func clamp(lowerBound: Self, upperBound: Self) {
     self = self.clamped(lowerBound: lowerBound, upperBound: upperBound)
   }
-  
+
   @_alwaysEmitIntoClient
   public func clamped(lowerBound: Self, upperBound: Self) -> Self {
     return Swift.min(upperBound, Swift.max(lowerBound, self))
   }
+  */
 }
 
 extension SIMD where Scalar: FixedWidthInteger {
@@ -1341,6 +1343,10 @@ public func all<Storage>(_ mask: SIMDMask<Storage>) -> Bool {
   return mask._storage.max() < 0
 }
 
+/*
+Temporarily removed while we investigate compile-time regressions caused by
+introducing these global functions.
+ 
 /// The lanewise minimum of two vectors.
 ///
 /// Each element of the result is the minimum of the corresponding elements
@@ -1397,3 +1403,4 @@ where V: SIMD, V.Scalar: FloatingPoint {
   }
   return result
 }
+*/


### PR DESCRIPTION
These are triggering a bad compile-time regression for some expressions; that's a bug that should be fixed, but we don't know how to fix it yet, so we'll need to remove these in the short-term, and possibly spell them differently in the medium term.

<rdar://problem/49787922>