### PR TITLE
[5.1] Add static and class subscripts

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -139,6 +139,8 @@ enum class DescriptiveDeclKind : uint8_t {
   GenericClass,
   GenericType,
   Subscript,
+  StaticSubscript,
+  ClassSubscript,
   Constructor,
   Destructor,
   LocalFunction,

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -84,6 +84,9 @@ ERROR(class_func_not_in_class,none,
 ERROR(class_var_not_in_class,none,
       "class properties are only allowed within classes; "
       "use 'static' to declare a %select{static|requirement fulfilled by either a static or class}0 property", (bool))
+ERROR(class_subscript_not_in_class,none,
+      "class subscripts are only allowed within classes; "
+      "use 'static' to declare a %select{static|requirement fulfilled by either a static or class}0 subscript", (bool))
 
 // FIXME: Used by both the parser and the type-checker.
 ERROR(func_decl_without_brace,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -392,8 +392,6 @@ ERROR(expected_lbrace_subscript_protocol,PointsToFirstBadToken,
       "{ get set } specifier", ())
 ERROR(subscript_without_get,none,
       "subscript declarations must have a getter", ())
-ERROR(subscript_static,none,
-      "subscript cannot be marked %0", (StaticSpellingKind))
 
 // initializer
 ERROR(invalid_nested_init,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3643,6 +3643,8 @@ ERROR(objc_invalid_on_var,none,
 ERROR(objc_invalid_on_subscript,none,
       "subscript cannot be %" OBJC_ATTR_SELECT "0 because its type "
       "cannot be represented in Objective-C", (unsigned))
+ERROR(objc_invalid_on_static_subscript,none,
+      "%0 cannot be %" OBJC_ATTR_SELECT "1", (DescriptiveDeclKind, unsigned))
 ERROR(objc_invalid_with_generic_params,none,
       "method cannot be %" OBJC_ATTR_SELECT "0 because it has generic "
       "parameters", (unsigned))

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1006,7 +1006,8 @@ public:
                                                DeclAttributes &Attributes);
 
   ParserResult<SubscriptDecl>
-  parseDeclSubscript(ParseDeclOptions Flags, DeclAttributes &Attributes,
+  parseDeclSubscript(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
+                     ParseDeclOptions Flags, DeclAttributes &Attributes,
                      SmallVectorImpl<Decl *> &Decls);
 
   ParserResult<ConstructorDecl>

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2850,6 +2850,9 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
   printAccess(decl);
+  if (!Options.SkipIntroducerKeywords && decl->isStatic() &&
+      Options.PrintStaticKeyword)
+    printStaticKeyword(decl->getCorrectStaticSpelling());
   printContextIfNeeded(decl);
   recordDeclLoc(decl, [&]{
     Printer << "subscript";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -150,7 +150,6 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(GenericTypeParam);
   TRIVIAL_KIND(AssociatedType);
   TRIVIAL_KIND(Protocol);
-  TRIVIAL_KIND(Subscript);
   TRIVIAL_KIND(Constructor);
   TRIVIAL_KIND(Destructor);
   TRIVIAL_KIND(EnumElement);
@@ -185,6 +184,18 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
        return DescriptiveDeclKind::StaticProperty;
      case StaticSpellingKind::KeywordClass:
        return DescriptiveDeclKind::ClassProperty;
+     }
+   }
+
+   case DeclKind::Subscript: {
+     auto subscript = cast<SubscriptDecl>(this);
+     switch (subscript->getCorrectStaticSpelling()) {
+     case StaticSpellingKind::None:
+       return DescriptiveDeclKind::Subscript;
+     case StaticSpellingKind::KeywordStatic:
+       return DescriptiveDeclKind::StaticSubscript;
+     case StaticSpellingKind::KeywordClass:
+       return DescriptiveDeclKind::ClassSubscript;
      }
    }
 
@@ -279,6 +290,8 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(GenericClass, "generic class");
   ENTRY(GenericType, "generic type");
   ENTRY(Subscript, "subscript");
+  ENTRY(StaticSubscript, "static subscript");
+  ENTRY(ClassSubscript, "class subscript");
   ENTRY(Constructor, "initializer");
   ENTRY(Destructor, "deinitializer");
   ENTRY(LocalFunction, "local function");

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1370,6 +1370,12 @@ namespace {
 
       auto &tc = cs.getTypeChecker();
       auto baseTy = cs.getType(base)->getRValueType();
+      
+      bool baseIsInstance = true;
+      if (auto baseMeta = baseTy->getAs<AnyMetatypeType>()) {
+        baseIsInstance = false;
+        baseTy = baseMeta->getInstanceType();
+      }
 
       // Check whether the base is 'super'.
       bool isSuper = base->isSuperExpr();
@@ -1455,9 +1461,22 @@ namespace {
       auto openedBaseType =
           getBaseType(openedFullFnType, /*wantsRValue*/ false);
       auto containerTy = solution.simplifyType(openedBaseType);
-      base = coerceObjectArgumentToType(
-        base, containerTy, subscript, AccessSemantics::Ordinary,
-        locator.withPathElement(ConstraintLocator::MemberRefBase));
+      
+      if (baseIsInstance) {
+        base = coerceObjectArgumentToType(
+          base, containerTy, subscript, AccessSemantics::Ordinary,
+          locator.withPathElement(ConstraintLocator::MemberRefBase));
+      } else {
+        base = coerceToType(base,
+                            MetatypeType::get(containerTy),
+                            locator.withPathElement(
+                              ConstraintLocator::MemberRefBase));
+        
+        if (!base)
+          return nullptr;
+        
+        base = cs.coerceToRValue(base);
+      }
       if (!base)
         return nullptr;
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -431,6 +431,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // Allow references to types as a part of:
       // - member references T.foo, T.Type, T.self, etc.
       // - constructor calls T()
+      // - Subscripts T[]
       if (auto *ParentExpr = Parent.getAsExpr()) {
         // This is an exhaustive list of the accepted syntactic forms.
         if (isa<ErrorExpr>(ParentExpr) ||
@@ -442,7 +443,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
             isa<UnresolvedDotExpr>(ParentExpr) ||
             isa<DotSyntaxBaseIgnoredExpr>(ParentExpr) ||
             isa<UnresolvedSpecializeExpr>(ParentExpr) ||
-            isa<OpenExistentialExpr>(ParentExpr)) {
+            isa<OpenExistentialExpr>(ParentExpr) ||
+            isa<SubscriptExpr>(ParentExpr)) {
           return;
         }
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4073,7 +4073,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     // Member subscripts need some special validation logic.
     if (SD->getDeclContext()->isTypeContext()) {
       // If this is a class member, mark it final if the class is final.
-      inferFinalAndDiagnoseIfNeeded(*this, SD, StaticSpellingKind::None);
+      inferFinalAndDiagnoseIfNeeded(*this, SD, SD->getStaticSpelling());
     }
 
     // Perform accessor-related validation.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -827,6 +827,16 @@ bool swift::isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason) {
   if (checkObjCInForeignClassContext(SD, Reason))
     return false;
 
+  // ObjC doesn't support class subscripts.
+  if (!SD->isInstanceMember()) {
+    if (Diagnose) {
+      SD->diagnose(diag::objc_invalid_on_static_subscript,
+                   SD->getDescriptiveKind(), Reason);
+      describeObjCReason(SD, Reason);
+    }
+    return true;
+  }
+
   if (!SD->hasInterfaceType()) {
     SD->getASTContext().getLazyResolver()->resolveDeclSignature(
                                               const_cast<SubscriptDecl *>(SD));

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1683,6 +1683,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     switch (baseKind) {
     case DescriptiveDeclKind::StaticProperty:
     case DescriptiveDeclKind::StaticMethod:
+    case DescriptiveDeclKind::StaticSubscript:
       override->diagnose(diag::override_static, baseKind);
       break;
     default:

--- a/test/ClangImporter/Inputs/custom-modules/ObjCSubscripts.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCSubscripts.h
@@ -60,3 +60,10 @@
 @interface KeySubscriptReversedOverrideSetter : KeySubscriptReversedBase
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
 @end
+
+@interface NoClassSubscript : NSObject
++ (id)objectAtIndexedSubscript:(int)i;
++ (void)setObject:(id)obj atIndexedSubscript:(int)i;
++ (id)objectForKeyedSubscript:(NSString *)subscript;
++ (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end

--- a/test/ClangImporter/objc_class_subscript.swift
+++ b/test/ClangImporter/objc_class_subscript.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck -I %S/Inputs/custom-modules %s -verify
+
+// REQUIRES: objc_interop
+
+import ObjCSubscripts
+
+func testClass() {
+  _ = NoClassSubscript[0] // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
+  NoClassSubscript[0] = "" // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
+  
+  _ = NoClassSubscript["foo"] // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
+  NoClassSubscript["foo"] = "" // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
+}
+
+func testInstance(x: NoClassSubscript) {
+  _ = x[0] // expected-error{{value of type 'NoClassSubscript' has no subscripts}}
+  x[0] = "" // expected-error{{value of type 'NoClassSubscript' has no subscripts}}
+  
+  _ = x["foo"] // expected-error{{value of type 'NoClassSubscript' has no subscripts}}
+  x["foo"] = "" // expected-error{{value of type 'NoClassSubscript' has no subscripts}}
+}
+
+func testClassMethods() {
+  _ = NoClassSubscript.object(atIndexedSubscript: 0)
+  NoClassSubscript.setObject("", atIndexedSubscript: 0)
+  
+  _ = NoClassSubscript.object(forKeyedSubscript: "foo")
+  NoClassSubscript.setObject("", forKeyedSubscript: "foo")
+}

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -11,7 +11,7 @@ protocol IntToStringSubscript {
   subscript (i : Int) -> String { get }
 }
 
-class LameDictionary {
+class FauxDictionary {
   subscript (i : Int) -> String {
     get {
       return String(i)
@@ -19,7 +19,7 @@ class LameDictionary {
   }
 }
 
-func archetypeSubscript<T : IntToStringSubscript, U : LameDictionary>(_ t: T, u: U)
+func archetypeSubscript<T : IntToStringSubscript, U : FauxDictionary>(_ t: T, u: U)
        -> String {
   // Subscript an archetype.
   if false { return t[17] }
@@ -32,6 +32,39 @@ func archetypeSubscript<T : IntToStringSubscript, U : LameDictionary>(_ t: T, u:
 func existentialSubscript(_ a: IntToStringSubscript) -> String {
   return a[17]
 }
+
+// Static of above:
+
+// Subscript of archetype.
+protocol IntToStringStaticSubscript {
+  static subscript (i : Int) -> String { get }
+}
+
+class FauxStaticDictionary {
+  static subscript (i : Int) -> String {
+    get {
+      return String(i)
+    }
+  }
+}
+
+func archetypeStaticSubscript<
+  T : IntToStringStaticSubscript, U : FauxStaticDictionary
+>(_ t: T.Type, u: U.Type) -> String {
+  // Subscript an archetype.
+  if false { return t[17] }
+  
+  // Subscript an archetype for which the subscript operator is in a base class.
+  return u[17]
+}
+
+// Subscript of existential type.
+func existentialStaticSubscript(
+  _ a: IntToStringStaticSubscript.Type
+) -> String {
+  return a[17]
+}
+
 
 class MyDictionary<Key, Value> {
   subscript (key : Key) -> Value {

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -172,6 +172,13 @@ struct d0100_FooStruct {
     }
   }
 // PASS_COMMON-NEXT: {{^}}  subscript(i: Int, j: Int) -> Double { get }{{$}}
+  
+  static subscript(i: Int) -> Double {
+    get {
+      return Double(i)
+    }
+  }
+// PASS_COMMON-NEXT: {{^}}  static subscript(i: Int) -> Double { get }{{$}}
 
   func bodyNameVoidFunc1(a: Int, b x: Float) {}
 // PASS_COMMON-NEXT: {{^}}  func bodyNameVoidFunc1(a: Int, b x: Float){{$}}

--- a/test/Interpreter/SDK/dictionary_pattern_matching.swift
+++ b/test/Interpreter/SDK/dictionary_pattern_matching.swift
@@ -11,7 +11,7 @@ struct State {
   let abbrev: String
 }
 
-func stateFromPlistLame(_ plist: Dictionary<String, Any>) -> State? {
+func stateFromPlistVerbose(_ plist: Dictionary<String, Any>) -> State? {
   if let name = plist["name"] as? NSString {
     if let population = plist["population"] as? NSNumber {
       if let abbrev = plist["abbrev"] as? NSString {
@@ -62,22 +62,22 @@ let invalidStatePlist3: Dictionary<String, Any> = [
 // CHECK:         name: "California"
 // CHECK:         population: 38040000
 // CHECK:         abbrev: "CA"
-dump(stateFromPlistLame(goodStatePlist))
+dump(stateFromPlistVerbose(goodStatePlist))
 // CHECK-LABEL: some:
 // CHECK:         name: "California"
 // CHECK:         population: 38040000
 // CHECK:         abbrev: "CA"
 dump(stateFromPlistCool(goodStatePlist))
 // CHECK-LABEL: nil
-dump(stateFromPlistLame(invalidStatePlist1))
+dump(stateFromPlistVerbose(invalidStatePlist1))
 // CHECK-LABEL: nil
 dump(stateFromPlistCool(invalidStatePlist1))
 // CHECK-LABEL: nil
-dump(stateFromPlistLame(invalidStatePlist2))
+dump(stateFromPlistVerbose(invalidStatePlist2))
 // CHECK-LABEL: nil
 dump(stateFromPlistCool(invalidStatePlist2))
 // CHECK-LABEL: nil
-dump(stateFromPlistLame(invalidStatePlist3))
+dump(stateFromPlistVerbose(invalidStatePlist3))
 // CHECK-LABEL: nil
 dump(stateFromPlistCool(invalidStatePlist3))
 

--- a/test/Interpreter/generic_subscript_static.swift
+++ b/test/Interpreter/generic_subscript_static.swift
@@ -1,0 +1,197 @@
+//===--- generic_subscript.swift ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+//
+
+import StdlibUnittest
+
+
+var GenericSubscriptTestSuite = TestSuite("GenericSubscriptStatic")
+
+var ts: [ObjectIdentifier: Any] = [:]
+
+struct S<T> : P {
+  typealias Element = T
+  static var t: T {
+    get {
+      return ts[ObjectIdentifier(self)] as! T
+    }
+    set {
+      ts[ObjectIdentifier(self)] = newValue
+    }
+  }
+
+  static subscript<U>(a: (T) -> U, b: (U) -> T) -> U {
+    get {
+      print(T.self)
+      print(U.self)
+
+      return a(t)
+    }
+    set {
+      print(T.self)
+      print(U.self)
+
+      t = b(newValue)
+    }
+  }
+}
+
+protocol P {
+  associatedtype Element
+  static subscript<U>(a: (Element) -> U, b: (U) -> Element) -> U { get set }
+}
+
+func increment<T : P>(p: T.Type) where T.Element == String {
+  p[{Int($0)!}, {String($0)}] += 1
+}
+
+GenericSubscriptTestSuite.test("Basic") {
+  var s = S<String>.self
+  s.t = "0"
+  increment(p: s)
+  expectEqual(s.t, "1")
+}
+
+protocol AnySubscript {
+  static subscript(k: AnyHashable) -> Any? { get set }
+}
+
+struct AnyDictionary : AnySubscript {
+  static var dict: [AnyHashable : Any] = [:]
+
+  static subscript(k: AnyHashable) -> Any? {
+    get {
+      return dict[k]
+    }
+    set {
+      dict[k] = newValue
+    }
+  }
+}
+
+extension AnySubscript {
+  static subscript<K : Hashable, V>(k k: K) -> V? {
+    get {
+      return self[k] as! V?
+    }
+    set {
+      self[k] = newValue
+    }
+  }
+}
+
+GenericSubscriptTestSuite.test("ProtocolExtensionConcrete") {
+  var dict = AnyDictionary.self
+
+  func doIt(dict: AnyDictionary.Type) {
+    dict["a" ] = 0
+    dict[k: "a"]! += 1
+  }
+
+  doIt(dict: dict)
+
+  expectEqual(dict["a"]! as! Int, 1)
+  expectEqual(dict[k: "a"]!, 1)
+}
+
+GenericSubscriptTestSuite.test("ProtocolExtensionAbstract") {
+  var dict = AnyDictionary.self
+
+  func doIt<T : AnySubscript>(dict: T.Type) {
+    dict["a" ] = 0
+    dict[k: "a"]! += 1
+  }
+
+  doIt(dict: dict)
+
+  expectEqual(dict["a"]! as! Int, 1)
+  expectEqual(dict[k: "a"]!, 1)
+}
+
+protocol GenericSubscript : AnySubscript {
+  static subscript<K : Hashable, V>(k k: K) -> V? { get set }
+}
+
+extension AnyDictionary : GenericSubscript { }
+
+GenericSubscriptTestSuite.test("ProtocolExtensionWitness") {
+  var dict = AnyDictionary.self
+
+  func doIt<T : GenericSubscript>(dict: T.Type) {
+    dict["a" ] = 0
+    dict[k: "a"]! += 1
+  }
+
+  doIt(dict: dict)
+
+  expectEqual(dict["a"]! as! Int, 1)
+  expectEqual(dict[k: "a"]!, 1)
+}
+
+class EchoBase<T: SignedNumeric> {
+  // In EchoDerived, subscript(a:) will be overridden.
+  class subscript(a a: T) -> String {
+    get {
+      return "EchoBase.Type.subscript(a: \(a))"
+    }
+  }
+  
+  // In EchoDerived, subscript(b:) will be overridden with a super call.
+  class subscript(b b: T) -> String {
+    get {
+      return "EchoBase.Type.subscript(b: \(b))"
+    }
+  }
+  
+  // In EchoDerived, subscript(c:) will not be overridden.
+  class subscript(c c: T) -> String {
+    get {
+      return "EchoBase.Type.subscript(c: \(c))"
+    }
+  }
+}
+
+class EchoDerived<T: SignedNumeric>: EchoBase<T> {
+  override class subscript(a a: T) -> String {
+    get {
+      return  "EchoDerived.Type.subscript(a: \(a))"
+    }
+  }
+  
+  override class subscript(b b: T) -> String {
+    get {
+      return "\(super[b: -b]) EchoDerived.Type.subscript(b: \(b))"
+    }
+  }
+  
+  class subscript(d d: T) -> String {
+    return  "EchoDerived.Type.subscript(d: \(d))"
+  }
+}
+
+GenericSubscriptTestSuite.test("Overrides") {
+  let base = EchoBase<Int>.self
+  let derived = EchoDerived<Int>.self
+  
+  expectEqual(base[a: 42], "EchoBase.Type.subscript(a: 42)")
+  expectEqual(base[b: 42], "EchoBase.Type.subscript(b: 42)")
+  expectEqual(base[c: 42], "EchoBase.Type.subscript(c: 42)")
+  
+  expectEqual(derived[a: 42], "EchoDerived.Type.subscript(a: 42)")
+  expectEqual(derived[b: 42], "EchoBase.Type.subscript(b: -42) EchoDerived.Type.subscript(b: 42)")
+  expectEqual(derived[c: 42], "EchoBase.Type.subscript(c: 42)")
+  expectEqual(derived[d: 42], "EchoDerived.Type.subscript(d: 42)")
+}
+
+runAllTests()

--- a/test/Interpreter/subscripting.swift
+++ b/test/Interpreter/subscripting.swift
@@ -4,17 +4,28 @@
 // Check that subscripts and functions named subscript can exist side-by-side
 struct Foo {
   subscript() -> String {
-    return "subscript"
+    return "instance subscript"
   }
   
   func `subscript`() -> String {
-    return "func"
+    return "instance func"
+  }
+  
+  static subscript() -> String {
+    return "static subscript"
+  }
+  
+  static func `subscript`() -> String {
+    return "static func"
   }
 }
 
 let f = Foo()
-print(f[]) // CHECK: subscript
-print(f.subscript()) // CHECK: func
+print(f[]) // CHECK: instance subscript
+print(f.subscript()) // CHECK: instance func
+print(Foo[]) // CHECK: static subscript
+print(Foo.subscript()) // CHECK: static func
+
 
 // SR-7418
 
@@ -40,3 +51,19 @@ func foo<T : P>(_ t: inout T) {
 
 var q = Q()
 foo(&q) // CHECK: I survived
+
+protocol PStatic {
+  static subscript<T : Y>(_: T) -> Int { get set }
+}
+
+struct QStatic : PStatic {
+  static subscript<T : X>(_ idx: T) -> Int {
+    get { return 0 } set { idx.foo() }
+  }
+}
+func fooStatic<T : PStatic>(_ t: T.Type) {
+  t[Idx()] += 1
+}
+
+fooStatic(QStatic.self) // CHECK: I survived
+

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -57,6 +57,32 @@ struct X4 {
   }
 }
 
+struct X5 {
+  static var stored: Int = 1
+  
+  static subscript(i: Int) -> Int {
+    get {
+      return stored + i
+    }
+    set {
+      stored = newValue - i
+    }
+  }
+}
+
+class X6 {
+  static var stored: Int = 1
+  
+  class subscript(i: Int) -> Int {
+    get {
+      return stored + i
+    }
+    set {
+      stored = newValue - i
+    }
+  }
+}
+
 struct Y1 {
   var stored: Int
   subscript(_: i, j: Int) -> Int { // expected-error {{use of undeclared type 'i'}}
@@ -155,15 +181,15 @@ struct A6 {
 }
 
 struct A7 {
-  static subscript(a: Int) -> Int { // expected-error {{subscript cannot be marked 'static'}} {{3-10=}}
+  class subscript(a: Float) -> Int { // expected-error {{class subscripts are only allowed within classes; use 'static' to declare a static subscript}} {{3-8=static}}
     get {
       return 42
     }
   }
 }
 
-struct A7b {
-  class subscript(a: Float) -> Int { // expected-error {{subscript cannot be marked 'class'}} {{3-9=}}
+class A7b {
+  class static subscript(a: Float) -> Int { // expected-error {{'static' specified twice}} {{9-16=}}
     get {
       return 42
     }

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -19,6 +19,10 @@ class Foo: Proto {
     get { return native }
     set {}
   }
+  class subscript(nativeType nativeType: Int) -> Int {
+    get { return nativeType }
+    set {}
+  }
 
   // @objc, so it has an ObjC entry point but can also be dispatched
   // by vtable
@@ -48,6 +52,7 @@ protocol Proto {
   func nativeMethod()
   var nativeProp: Int { get set }
   subscript(native native: Int) -> Int { get set }
+  static subscript(nativeType nativeType: Int) -> Int { get set }
 
   func objcMethod()
   var objcProp: Int { get set }
@@ -100,6 +105,10 @@ protocol Proto {
 // CHECK:         class_method {{%.*}} : $Foo, #Foo.subscript!getter.1 :
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s7dynamic3FooCAA5ProtoA2aDP6nativeS2i_tcisTW
 // CHECK:         class_method {{%.*}} : $Foo, #Foo.subscript!setter.1 :
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s7dynamic3FooCAA5ProtoA2aDP10nativeTypeS2i_tcigZTW
+// CHECK:         class_method {{%.*}} : $@thick Foo.Type, #Foo.subscript!getter.1 :
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s7dynamic3FooCAA5ProtoA2aDP10nativeTypeS2i_tcisZTW
+// CHECK:         class_method {{%.*}} : $@thick Foo.Type, #Foo.subscript!setter.1 :
 
 // @objc witnesses use vtable dispatch:
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s7dynamic3FooCAA5ProtoA2aDP10objcMethod{{[_0-9a-zA-Z]*}}FTW
@@ -170,6 +179,15 @@ class Subclass: Foo {
     set { super[native: native] = newValue }
     // CHECK-LABEL: sil hidden [ossa] @$s7dynamic8SubclassC6nativeS2i_tcis
     // CHECK:         function_ref @$s7dynamic3FooC6nativeS2i_tcis : $@convention(method) (Int, Int, @guaranteed Foo) -> ()
+  }
+
+  override class subscript(nativeType nativeType: Int) -> Int {
+    get { return super[nativeType: nativeType] }
+    // CHECK-LABEL: sil hidden [ossa] @$s7dynamic8SubclassC10nativeTypeS2i_tcigZ
+    // CHECK:         function_ref @$s7dynamic3FooC10nativeTypeS2i_tcigZ : $@convention(method) (Int, @thick Foo.Type) -> Int
+    set { super[nativeType: nativeType] = newValue }
+    // CHECK-LABEL: sil hidden [ossa] @$s7dynamic8SubclassC10nativeTypeS2i_tcisZ
+    // CHECK:         function_ref @$s7dynamic3FooC10nativeTypeS2i_tcisZ : $@convention(method) (Int, Int, @thick Foo.Type) -> ()
   }
 
   override init(objc: Int) {
@@ -267,6 +285,10 @@ func nativeMethodDispatch() {
   let y = c[native: 0]
   // CHECK: class_method {{%.*}} : $Foo, #Foo.subscript!setter.1 :
   c[native: 0] = y
+  // CHECK: class_method {{%.*}} : $@thick Foo.Type, #Foo.subscript!getter.1 :
+  let z = type(of: c)[nativeType: 0]
+  // CHECK: class_method {{%.*}} : $@thick Foo.Type, #Foo.subscript!setter.1 :
+  type(of: c)[nativeType: 0] = z
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s7dynamic18objcMethodDispatchyyF : $@convention(thin) () -> ()
@@ -506,6 +528,9 @@ public class ConcreteDerived : GenericBase<Int> {
 // CHECK-NEXT:   #Foo.nativeProp!modify.1:
 // CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} :   @$s7dynamic3FooC6nativeS2i_tcig    // dynamic.Foo.subscript.getter : (native: Swift.Int) -> Swift.Int
 // CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} :   @$s7dynamic3FooC6nativeS2i_tcis    // dynamic.Foo.subscript.setter : (native: Swift.Int) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!modify.1:
+// CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} :   @$s7dynamic3FooC10nativeTypeS2i_tcigZ    // static dynamic.Foo.subscript.getter : (nativeType: Swift.Int) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} :   @$s7dynamic3FooC10nativeTypeS2i_tcisZ    // static dynamic.Foo.subscript.setter : (nativeType: Swift.Int) -> Swift.Int
 // CHECK-NEXT:   #Foo.subscript!modify.1:
 // CHECK-NEXT:   #Foo.init!allocator.1: {{.*}} :   @$s7dynamic3FooC4objcACSi_tcfC
 // CHECK-NEXT:   #Foo.objcMethod!1: {{.*}} :         @$s7dynamic3FooC10objcMethodyyF

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -158,6 +158,8 @@ class subject_class1 { // no-error
 
   @objc
   func subject_instanceFunc() {} // no-error
+  
+  
 }
 
 @objc
@@ -506,7 +508,12 @@ class subject_subscriptGeneric<T> {
   }
 }
 
-
+class subject_subscriptInvalid1 {
+  @objc class subscript(_ i: Int) -> AnyObject? {
+  // expected-error@-1 {{class subscript cannot be marked @objc}}
+    return nil
+  }
+}
 
 class subject_subscriptInvalid2 {
   @objc

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -57,6 +57,25 @@ class A {
     set {
     }
   }
+  
+  // FIXME(SR-10323): The second note is wrong; it should be "potential overridden class subscript 'subscript(_:)' here". This is a preexisting bug.
+  class subscript (i: String) -> String { // expected-note{{overridden declaration is here}} expected-note{{attempt to override subscript here}}
+    get {
+      return "hello"
+    }
+    
+    set {
+    }
+  }
+  
+  class subscript (typeInSuperclass a: [Int]) -> String {
+    get {
+      return "hello"
+    }
+    
+    set {
+    }
+  }
 
   subscript (i: Int8) -> A { // expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get { return self }
@@ -116,6 +135,52 @@ class B : A {
   }
 
   override subscript (f: Float) -> String { // expected-error{{subscript does not override any subscript from its superclass}}
+    get {
+      return "hello"
+    }
+
+    set {
+    }
+  }
+  
+  // FIXME(SR-10323): This error is wrong; it should be "subscript does not override any subscript from its superclass". This is a preexisting bug.
+  override class subscript (i: Int) -> String { // expected-error{{cannot override mutable subscript of type '(Int) -> String' with covariant type '(String) -> String'}}
+    get {
+      return "hello"
+    }
+    
+    set {
+    }
+  }
+  
+  static subscript (i: String) -> String { // expected-error{{overriding declaration requires an 'override' keyword}} {{10-10=override }}
+    get {
+      return "hello"
+    }
+    
+    set {
+    }
+  }
+  
+  static subscript (i: Double) -> String {
+    get {
+      return "hello"
+    }
+    
+    set {
+    }
+  }
+  
+  override class subscript (typeInSuperclass a: [Int]) -> String {
+    get {
+      return "hello"
+    }
+    
+    set {
+    }
+  }
+
+  override subscript (typeInSuperclass a: [Int]) -> String { // expected-error{{subscript does not override any subscript from its superclass}}
     get {
       return "hello"
     }

--- a/test/decl/protocol/req/subscript.swift
+++ b/test/decl/protocol/req/subscript.swift
@@ -38,11 +38,12 @@ struct S1Error : P1 { // expected-error{{type 'S1Error' does not conform to prot
 
 
 protocol SubscriptGet {
-  subscript(a : Int) -> Int { get }
+  subscript(a : Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'; do you want to add a stub?}}
 }
 
 class SubscriptGet_Get : SubscriptGet {
   subscript(a : Int) -> Int { return 0 }  // ok
+  // for static cross-conformance test below: expected-note@-1 {{candidate operates on an instance, not a type as required}}
 }
 
 class SubscriptGet_GetSet : SubscriptGet {
@@ -92,3 +93,35 @@ struct GenericSubscriptWitness : GenericSubscriptProtocol {
 
 struct GenericSubscriptNoWitness : GenericSubscriptProtocol {}
 // expected-error@-1 {{type 'GenericSubscriptNoWitness' does not conform to protocol 'GenericSubscriptProtocol'}}
+
+//===----------------------------------------------------------------------===//
+// Static subscript requirements
+//===----------------------------------------------------------------------===//
+
+protocol StaticSubscriptGet {
+  static subscript(a : Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'; do you want to add a stub?}}
+}
+
+class StaticSubscriptGet_Get : StaticSubscriptGet {
+  static subscript(a : Int) -> Int { return 0 }  // ok
+  // for static cross-conformance test below: expected-note@-1 {{candidate operates on a type, not an instance as required}}
+}
+
+class StaticSubscriptGet_GetSet : StaticSubscriptGet {
+  static subscript(a : Int) -> Int { get { return 42 } set {} }  // ok
+}
+
+protocol StaticSubscriptGetSet {
+  static subscript(a : Int) -> Int { get set }   // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
+}
+
+class StaticSubscriptGetSet_Get : StaticSubscriptGetSet {  // expected-error {{type 'StaticSubscriptGetSet_Get' does not conform to protocol 'StaticSubscriptGetSet'}}
+  static subscript(a : Int) -> Int { return 0 }   // expected-note {{candidate is not settable, but protocol requires it}}
+}
+
+class StaticSubscriptGetSet_GetSet : StaticSubscriptGetSet {
+  static subscript(a : Int) -> Int { get { return 42 } set {} }  // ok
+}
+
+extension SubscriptGet_Get: StaticSubscriptGet {} // expected-error {{type 'SubscriptGet_Get' does not conform to protocol 'StaticSubscriptGet'}}
+extension StaticSubscriptGet_Get: SubscriptGet {} // expected-error {{type 'StaticSubscriptGet_Get' does not conform to protocol 'SubscriptGet'}}

--- a/test/decl/subscript/generic.swift
+++ b/test/decl/subscript/generic.swift
@@ -33,3 +33,33 @@ struct GenericType<T : Collection> {
     return factory.init()
   }
 }
+
+struct StaticConcreteType {
+  static let c: [Int] = []
+  
+  // Generic index type
+  static subscript<C : Collection>(indices: C) -> [Int]
+  where C.Iterator.Element == Int {
+    return indices.map { c[$0] }
+  }
+  
+  // Generic element type
+  static subscript<I : Initable>(factory: I.Type) -> I {
+    return factory.init()
+  }
+}
+
+struct StaticGenericType<T : Collection> {
+  static var c: T { fatalError() }
+  
+  // Generic index type
+  static subscript<C : Collection>(indices: C) -> [T.Iterator.Element]
+  where C.Iterator.Element == T.Index {
+    return indices.map { c[$0] }
+  }
+  
+  // Generic element type
+  static subscript<I : Initable>(factory: I.Type) -> I {
+    return factory.init()
+  }
+}

--- a/test/decl/subscript/static.swift
+++ b/test/decl/subscript/static.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+struct MyStruct {
+  static subscript(_ i: Int) -> String {
+    get { return "get \(i)" }
+    set { print("set \(i) = \(newValue)") }
+  }
+}
+
+func useMyStruct() {
+  print(MyStruct.self[0])
+  print(MyStruct[0])
+
+  MyStruct.self[1] = "zyzyx"
+  MyStruct[2] = "asdfg"
+  
+  MyStruct()[0] // expected-error {{static member 'subscript' cannot be used on instance of type 'MyStruct'}}
+  MyStruct()[1] = "zyzyx" // expected-error {{static member 'subscript' cannot be used on instance of type 'MyStruct'}}
+}
+
+struct BadStruct {
+  static subscript(_ i: Int) -> String {
+    nonmutating get { fatalError() } // expected-error{{static functions must not be declared mutating}}
+    mutating set { fatalError() } // expected-error{{static functions must not be declared mutating}}
+  }
+}
+
+@dynamicMemberLookup
+class Dyn {
+  static subscript(dynamicMember name: String) -> String {
+    return "Dyn.\(name)"
+  }
+}
+
+func useDyn() {
+  _ = Dyn.foo
+  _ = Dyn().bar // expected-error{{static member 'bar' cannot be used on instance of type 'Dyn'}}
+}
+
+class BadBase {
+  static subscript(_ i: Int) -> String { return "Base" } // expected-note{{overridden declaration is here}}
+}
+class BadDerived: BadBase {
+  override static subscript(_ i: Int) -> String { return "DerivedGood" } // expected-error{{cannot override static subscript}}
+}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -56,6 +56,38 @@ struct X4 {
   }
 }
 
+struct X5 {
+  static var stored : Int = 1
+  
+  static subscript (i : Int) -> Int {
+    get {
+      return stored + i
+    }
+    set {
+      stored = newValue - i
+    }
+  }
+}
+
+class X6 {
+  static var stored : Int = 1
+  
+  class subscript (i : Int) -> Int {
+    get {
+      return stored + i
+    }
+    set {
+      stored = newValue - i
+    }
+  }
+}
+
+protocol XP1 {
+  subscript (i : Int) -> Int { get set }
+  static subscript (i : Int) -> Int { get set }
+}
+
+
 // Semantic errors
 struct Y1 {
   var x : X
@@ -80,6 +112,24 @@ struct Y2 {
 class Y3 {
   subscript(idx: Int) -> TypoType { // expected-error {{use of undeclared type 'TypoType'}}
     get { repeat {} while true }
+    set {}
+  }
+}
+
+class Y4 {
+  var x = X()
+  
+  static subscript(idx: Int) -> X {
+    get { return x } // expected-error {{instance member 'x' cannot be used on type 'Y4'}}
+    set {}
+  }
+}
+
+class Y5 {
+  static var x = X()
+  
+  subscript(idx: Int) -> X {
+    get { return x } // expected-error {{static member 'x' cannot be used on instance of type 'Y5'}}
     set {}
   }
 }
@@ -199,6 +249,27 @@ func test_subscript(_ x2: inout X2, i: Int, j: Int, value: inout Int, no: NoSubs
 
   value = ret[i]
   ret[i] = value
+  
+  X5[i] = value
+  value = X5[i]
+}
+
+func test_proto_static<XP1Type: XP1>(
+                                     i: Int, value: inout Int,
+                                     existential: inout XP1,
+                                     generic: inout XP1Type
+                                     ) {
+  existential[i] = value
+  value = existential[i]
+  
+  type(of: existential)[i] = value
+  value = type(of: existential)[i]
+
+  generic[i] = value
+  value = generic[i]
+  
+  XP1Type[i] = value
+  value = XP1Type[i]
 }
 
 func subscript_rvalue_materialize(_ i: inout Int) {


### PR DESCRIPTION
Cherry-pick of #23358 to swift-5.1-branch. Original PR reviewed by @jrose-apple.

Implements [SE-0254](https://github.com/apple/swift-evolution/blob/master/proposals/0254-static-subscripts.md). Resolves rdar://problem/16555559.