### PR TITLE
build: remove unnecessary CoreFoundation path passing

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2646,8 +2646,6 @@ for host in "${ALL_HOSTS[@]}"; do
 
                     -DXCTEST_PATH_TO_FOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}
 
-                    -DXCTEST_PATH_TO_COREFOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix
-
                     -DCMAKE_PREFIX_PATH:PATH=$(build_directory ${host} llvm)
 
                     -DENABLE_TESTING=YES
@@ -3092,7 +3090,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
                     DOTEST_EXTRA="-I${FOUNDATION_BUILD_DIR}"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -Xcc -F${FOUNDATION_BUILD_DIR}"
-                    DOTEST_EXTRA="${DOTEST_EXTRA} -Xcc -F${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix/System/Library/Frameworks"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -I${FOUNDATION_BUILD_DIR}/swift"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -I${LIBDISPATCH_SOURCE_DIR}"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -L${FOUNDATION_BUILD_DIR}"


### PR DESCRIPTION
Passing these paths around is no longer needed.  Simplify the build
rules.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
