### PR TITLE
Sema: Correctly simplify member types with a DynamicSelfType base

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2197,7 +2197,8 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
       // through lvalue, inout and IUO types here
       Type lookupBaseType = newBase->getWithoutSpecifierType();
 
-      if (lookupBaseType->mayHaveMembers()) {
+      if (lookupBaseType->mayHaveMembers() ||
+          lookupBaseType->is<DynamicSelfType>()) {
         auto *proto = assocType->getProtocol();
         auto conformance = cs.DC->getParentModule()->lookupConformance(
           lookupBaseType, proto);

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -320,18 +320,24 @@ func testOptionalSelf(_ y : Y) {
 // Conformance lookup on Self
 
 protocol Runcible {
+  associatedtype Runcer
 }
 
 extension Runcible {
   func runce() {}
+
+  func runced(_: Runcer) {}
 }
 
 func wantsRuncible<T : Runcible>(_: T) {}
 
 class Runce : Runcible {
+  typealias Runcer = Int
+
   func getRunced() -> Self {
     runce()
     wantsRuncible(self)
+    runced(3)
     return self
   }
 }


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-10434>, <rdar://problem/49779783>.
