### PR TITLE
SourceKit: Account for existing braces when expanding closure placeholders

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -91,3 +91,13 @@ if true {
 
 foo(.foo(<#T##block: () -> Void##() -> Void#>))
 // CHECK: foo(.foo({
+
+braced1(x: {<#T##() -> Void#>})
+// CHECK:   braced1 {
+// CHECK-NEXT:  <#code#>
+// CHECK-NEXT:  }
+
+braced2(x: {<#T##() -> Void#>}, y: Int)
+// CHECK:   braced2(x: {
+// CHECK-NEXT:  <#code#>
+// CHECK-NEXT:  }, y: Int)


### PR DESCRIPTION
[SR-9560](https://bugs.swift.org/browse/SR-9560)

cc @rintaro