### PR TITLE
[5.1] SILOptimizer: handle begin_apply in escape analysis

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1216,7 +1216,9 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
                                         int RecursionDepth) {
   ConnectionGraph *ConGraph = &FInfo->Graph;
   FullApplySite FAS = FullApplySite::isa(I);
-  if (FAS) {
+  if (FAS &&
+      // We currently don't support co-routines. In most cases co-routines will be inlined anyway.
+      !isa<BeginApplyInst>(I)) {
     ArraySemanticsCall ASC(FAS.getInstruction());
     switch (ASC.getKind()) {
       case ArrayCallKind::kArrayPropsIsNativeTypeChecked:

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1477,3 +1477,41 @@ bb0:
   return %7 : $()
 }
 
+sil hidden [transparent] @test_modifier : $@yield_once @convention(thin) (@guaranteed Y) -> @yields @inout X {
+bb0(%0 : $Y):
+  %2 = ref_element_addr %0 : $Y, #Y.x
+  yield %2 : $*X, resume bb1, unwind bb2
+
+bb1:
+  %6 = tuple ()
+  return %6 : $()
+
+bb2:
+  unwind
+}
+
+// Currently escape analysis treats co-routines conservatively.
+// Ideally there should be a link from %0 -> %2 -> %4. But for now %2 (the
+// begin_apply result) is just marked as escaping.
+
+// CHECK-LABEL: CG of call_coroutine
+// CHECK:         Val %0 Esc: G, Succ: (%0.1)
+// CHECK:         Con %0.1 Esc: G, Succ: (%0.2)
+// CHECK:         Con %0.2 Esc: G, Succ: 
+// CHECK:         Val %2 Esc: G, Succ: (%2.1)
+// CHECK:         Con %2.1 Esc: G, Succ: %4
+// CHECK:         Val %4 Esc: G, Succ: 
+// CHECK:       End
+sil @call_coroutine : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $Y
+  %1 = function_ref @test_modifier : $@convention(thin) @yield_once (@guaranteed Y) -> (@yields @inout X)
+  (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed Y) -> @yields @inout X
+  %4 = alloc_ref $X
+  store %4 to %2 : $*X
+  end_apply %3
+  strong_release %0 : $Y
+  %7 = tuple ()
+  return %7 : $()
+}
+

--- a/test/SILOptimizer/stack_promotion_crash.swift
+++ b/test/SILOptimizer/stack_promotion_crash.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Check that the compiled code does not crash because of a wrong
+// stack-promoted array.
+// End-to-end test for https://bugs.swift.org/browse/SR-10444
+
+public struct Beta {
+  var gamma: [Int]
+}
+
+class Delta {
+  var epislon: Beta? = Beta(gamma: [])
+
+  func main() {
+    for _ in 1...100 { 
+      crash()
+    }
+  }
+
+  func crash() { 
+    epislon?.gamma = [0]
+  }
+}
+
+func testit() {
+  Delta().main()
+}
+
+testit()
+
+// CHECK: ok
+print("ok")
+


### PR DESCRIPTION
Just treat begin_apply conservatively.
It's probably not worth adding much complexity for begin_apply to the analysis as co-routines are often inlined anyway.

Fixes a miscompile.

https://bugs.swift.org/browse/SR-10444
rdar://problem/49755264
