### PR TITLE
Allow non-mutable properties and subscripts returning Self

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2501,6 +2501,8 @@ ERROR(self_in_mutable_subscript,none,
       "'Self' is not available as the type of a mutable subscript", ())
 ERROR(self_in_parameter,none,
       "'Self' cannot be the type of a (contravariant) function argument", ())
+ERROR(self_in_nested_return,none,
+      "'Self' cannot be the type of a nested return value", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2493,6 +2493,14 @@ ERROR(dynamic_self_non_method,none,
 ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
       "method in a class; did you mean '%0'?", (StringRef))
+ERROR(self_in_alias,none,
+      "'Self' is not available in a typealias", ())
+ERROR(self_in_mutable_property,none,
+      "'Self' is not available as the type of a mutable property", ())
+ERROR(self_in_mutable_subscript,none,
+      "'Self' is not available as the type of a mutable subscript", ())
+ERROR(self_in_parameter,none,
+      "'Self' cannot be the type of a (contravariant) function argument", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2500,7 +2500,7 @@ ERROR(self_in_mutable_property,none,
 ERROR(self_in_mutable_subscript,none,
       "'Self' is not available as the type of a mutable subscript", ())
 ERROR(self_in_parameter,none,
-      "'Self' cannot be the type of a (contravariant) function argument", ())
+      "'Self' cannot be the type of a function argument in a class", ())
 ERROR(self_in_nested_return,none,
       "'Self' cannot be the type of a nested return value", ())
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2344,6 +2344,7 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     isStatic = FD->isStatic();
     selfAccess = FD->getSelfAccessKind();
 
+    // `self`s type for subscripts and properties
     if (auto *AD = dyn_cast<AccessorDecl>(AFD)) {
       if (wantDynamicSelf && AD->getStorage()
           ->getValueInterfaceType()->hasDynamicSelfType())

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2344,10 +2344,15 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     isStatic = FD->isStatic();
     selfAccess = FD->getSelfAccessKind();
 
+    if (auto *AD = dyn_cast<AccessorDecl>(AFD)) {
+      if (wantDynamicSelf && AD->getStorage()
+          ->getValueInterfaceType()->hasDynamicSelfType())
+        isDynamicSelf = true;
+    }
     // Methods returning 'Self' have a dynamic 'self'.
     //
     // FIXME: All methods of non-final classes should have this.
-    if (wantDynamicSelf && FD->hasDynamicSelf())
+    else if (wantDynamicSelf && FD->hasDynamicSelf())
       isDynamicSelf = true;
   } else if (auto *CD = dyn_cast<ConstructorDecl>(AFD)) {
     if (isInitializingCtor) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2285,9 +2285,17 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   }
 
   // Class-to-class.
-  if (matchMode.contains(TypeMatchFlags::AllowOverride))
-    if (t2->isExactSuperclassOf(t1))
+  if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
+    if (auto dyn = dyn_cast<DynamicSelfType>(t2
+                                             ->getCanonicalType())) {
+//      dyn->dump();
+//      t1->dump();
+      if (dyn->getSelfType()->isExactSuperclassOf(t1))
+        return true;
+    }
+    else if (t2->isExactSuperclassOf(t1))
       return true;
+  }
 
   if (matchMode.contains(TypeMatchFlags::AllowABICompatible))
     if (isABICompatibleEvenAddingOptional(t1, t2))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2285,15 +2285,9 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   }
 
   // Class-to-class.
-  if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
-    if (auto dyn = dyn_cast<DynamicSelfType>(t2
-                                             ->getCanonicalType())) {
-      if (dyn->getSelfType()->isExactSuperclassOf(t1))
-        return true;
-    }
-    else if (t2->isExactSuperclassOf(t1))
+  if (matchMode.contains(TypeMatchFlags::AllowOverride))
+    if (t2->eraseDynamicSelfType()->isExactSuperclassOf(t1))
       return true;
-  }
 
   if (matchMode.contains(TypeMatchFlags::AllowABICompatible))
     if (isABICompatibleEvenAddingOptional(t1, t2))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2288,8 +2288,6 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
     if (auto dyn = dyn_cast<DynamicSelfType>(t2
                                              ->getCanonicalType())) {
-//      dyn->dump();
-//      t1->dump();
       if (dyn->getSelfType()->isExactSuperclassOf(t1))
         return true;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -905,8 +905,8 @@ namespace {
           if (auto dyn = dyn_cast<DynamicSelfType>(sub->getValueInterfaceType()
                                                    ->getCanonicalType())) {
             refTy = refTy->replaceCovariantResultType(containerTy/*or dyn or baseTy or containerTy*/, 1);
-            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
-            dyn.dump();
+//            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
+//            dyn.dump();
             if (!baseTy->isEqual(containerTy)) {
               dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
             }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -878,6 +878,8 @@ namespace {
         openedExistential = true;
       }
 
+//      member->dump();
+
       // If this is a method whose result type is dynamic Self, or a
       // construction, replace the result type with the actual object type.
       Type dynamicSelfFnType;
@@ -887,17 +889,21 @@ namespace {
                cast<FuncDecl>(func)->hasDynamicSelf()) ||
               (isa<ConstructorDecl>(func) &&
                containerTy->getClassOrBoundGenericClass())) {
+            fprintf(stderr, "buildMemberRef FuncDecl !!!!!!!!!!!!!!!!\n");
             refTy = refTy->replaceCovariantResultType(containerTy, 2);
             if (!baseTy->isEqual(containerTy)) {
               dynamicSelfFnType = refTy->replaceCovariantResultType(baseTy, 2);
             }
           }
         }
-        else if (isa<DynamicSelfType>(member->getInterfaceType()
-                                      ->getCanonicalType())) {
-          refTy = refTy->replaceCovariantResultType(containerTy, 1);
-          if (!baseTy->isEqual(containerTy)) {
-            dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
+        else if (auto *decl = dyn_cast<VarDecl>(member)) {
+          fprintf(stderr, "buildMemberRef VarDecl !!!!!!!!!!!!!!!!\n");
+          if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
+            refTy = refTy->replaceCovariantResultType(containerTy, 1);
+            if (!baseTy->isEqual(containerTy)) {
+              fprintf(stderr, "buildMemberRef dynamicSelfFnType !!!!!!!!!!!!!!!!\n");
+              dynamicSelfFnType = refTy->replaceCovariantResultType(baseTy, 1);
+            }
           }
         }
       }
@@ -921,6 +927,7 @@ namespace {
           if (cs.getType(base)->is<LValueType>())
             selfParamTy = InOutType::get(selfTy);
 
+//        cs.setType(base, DynamicSelfType::get(baseTy, context));
         base = coerceObjectArgumentToType(
                  base, selfParamTy, member, semantics,
                  locator.withPathElement(ConstraintLocator::MemberRefBase));
@@ -1029,6 +1036,11 @@ namespace {
         cs.setType(memberRefExpr, simplifyType(openedType));
         Expr *result = memberRefExpr;
         closeExistential(result, locator);
+//        if (dynamicSelfFnType) {
+//          result = new (context) CovariantFunctionConversionExpr(result,
+//                                                              dynamicSelfFnType);
+//          cs.cacheType(result);
+//        }
         return forceUnwrapIfExpected(result, choice, memberLocator);
       }
       
@@ -1069,6 +1081,7 @@ namespace {
         }
       }
 
+      ///openedType->dump();
       return finishApply(apply, openedType, locator);
     }
     
@@ -1235,6 +1248,8 @@ namespace {
                          AccessSemantics semantics,
                          Optional<SelectedOverload> selected = None) {
 
+//      base->dump();
+
       // Determine the declaration selected for this subscript operation.
       if (!selected)
         selected = solution.getOverloadChoiceIfAvailable(
@@ -1298,6 +1313,7 @@ namespace {
                                   locator.withPathElement(locatorKind));
       }
 
+//      newSubscript->dump();
       return newSubscript;
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -893,20 +893,10 @@ namespace {
             }
           }
         }
-//        member->dump();
-//        else if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
-//          fprintf(stderr, "HEREE2!!!!!!!!!!!!!!!!\n");
-//          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
-//                                                   ->getCanonicalType())) {
-//            refTy = refTy->replaceCovariantResultType(dyn, 2);
-//          }
-//        }
-        else if (auto *sub = dyn_cast<VarDecl>(member)) {
-          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getValueInterfaceType()
+        else if (auto decl = dyn_cast<VarDecl>(member)) {
+          if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
                                                    ->getCanonicalType())) {
-            refTy = refTy->replaceCovariantResultType(containerTy/*or dyn or baseTy or containerTy*/, 1);
-//            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
-//            dyn.dump();
+            refTy = refTy->replaceCovariantResultType(containerTy, 1);
             if (!baseTy->isEqual(containerTy)) {
               dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
             }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -893,13 +893,11 @@ namespace {
             }
           }
         }
-        else if (auto decl = dyn_cast<VarDecl>(member)) {
-          if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
-                                                   ->getCanonicalType())) {
-            refTy = refTy->replaceCovariantResultType(containerTy, 1);
-            if (!baseTy->isEqual(containerTy)) {
-              dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
-            }
+        else if (isa<DynamicSelfType>(member->getInterfaceType()
+                                      ->getCanonicalType())) {
+          refTy = refTy->replaceCovariantResultType(containerTy, 1);
+          if (!baseTy->isEqual(containerTy)) {
+            dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
           }
         }
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -894,11 +894,22 @@ namespace {
           }
         }
 //        member->dump();
-        if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
-          printf("HEREE2!!!!!!!!!!!!!!!!\n");
-          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+//        else if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
+//          fprintf(stderr, "HEREE2!!!!!!!!!!!!!!!!\n");
+//          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+//                                                   ->getCanonicalType())) {
+//            refTy = refTy->replaceCovariantResultType(dyn, 2);
+//          }
+//        }
+        else if (auto *sub = dyn_cast<VarDecl>(member)) {
+          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getValueInterfaceType()
                                                    ->getCanonicalType())) {
-            refTy = refTy->replaceCovariantResultType(baseTy, 2);
+            refTy = refTy->replaceCovariantResultType(containerTy/*or dyn or baseTy or containerTy*/, 1);
+            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
+            dyn.dump();
+            if (!baseTy->isEqual(containerTy)) {
+              dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
+            }
           }
         }
       }
@@ -1009,7 +1020,6 @@ namespace {
 
       // For properties, build member references.
       if (isa<VarDecl>(member)) {
-        assert(!dynamicSelfFnType && "Converted type doesn't make sense here");
         if (!baseIsInstance && member->isInstanceMember()) {
           assert(memberLocator.getBaseLocator() && 
                  cs.UnevaluatedRootExprs.count(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -893,6 +893,14 @@ namespace {
             }
           }
         }
+//        member->dump();
+        if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
+          printf("HEREE2!!!!!!!!!!!!!!!!\n");
+          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+                                                   ->getCanonicalType())) {
+            refTy = refTy->replaceCovariantResultType(baseTy, 2);
+          }
+        }
       }
 
       // References to properties with accessors and storage usually go

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1299,12 +1299,21 @@ ConstraintSystem::getTypeOfMemberReference(
     if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
       if ((isa<FuncDecl>(func) && cast<FuncDecl>(func)->hasDynamicSelf()) ||
           (isa<ConstructorDecl>(func) && !baseObjTy->getOptionalObjectType())) {
+        fprintf(stderr, "getTypeOfMemberReference AbstractFunctionDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-    else if (isa<DynamicSelfType>(value->getInterfaceType()
-                                  ->getCanonicalType())) {
-      openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
+    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
+      if (decl->getElementInterfaceType()->hasDynamicSelfType()) {
+        fprintf(stderr, "getTypeOfMemberReference SubscriptDecl !!!!!!!\n");
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
+      }
+    }
+    else if (auto *decl = dyn_cast<VarDecl>(value)) {
+      if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
+        fprintf(stderr, "getTypeOfMemberReference VarDecl !!!!!!!\n");
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
+      }
     }
   } else {
     // Protocol requirements returning Self have a dynamic Self return

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1302,20 +1302,10 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-//    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
-//      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getElementInterfaceType()
-//                                               ->getCanonicalType())) {
-//        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
-//        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
-//        baseObjTy->dump();
-////        outerDC->dumpContext();
-//      }
-//    }
-    else if (auto *decl = dyn_cast<VarDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getInterfaceType()
+    else if (auto decl = dyn_cast<VarDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
                                                ->getCanonicalType())) {
-//        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
-        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 1);
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
       }
     }
   } else {
@@ -1357,7 +1347,6 @@ ConstraintSystem::getTypeOfMemberReference(
     // For a static member referenced through a metatype or an instance
     // member referenced through an instance, strip off the 'self'.
     type = openedFnType->getResult();
-//    type->dump();
   } else {
     // For an unbound instance method reference, replace the 'Self'
     // parameter with the base type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1306,7 +1306,17 @@ ConstraintSystem::getTypeOfMemberReference(
       if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
                                                ->getCanonicalType())) {
         fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
-        openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
+        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
+//        openedType->dump();
+//        outerDC->dumpContext();
+      }
+    }
+    else if (auto *sub = dyn_cast<VarDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getInterfaceType()
+                                               ->getCanonicalType())) {
+        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
+        dyn.dump();
+        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 1);
 //        openedType->dump();
 //        outerDC->dumpContext();
       }
@@ -1350,6 +1360,7 @@ ConstraintSystem::getTypeOfMemberReference(
     // For a static member referenced through a metatype or an instance
     // member referenced through an instance, strip off the 'self'.
     type = openedFnType->getResult();
+//    type->dump();
   } else {
     // For an unbound instance method reference, replace the 'Self'
     // parameter with the base type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1299,19 +1299,16 @@ ConstraintSystem::getTypeOfMemberReference(
     if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
       if ((isa<FuncDecl>(func) && cast<FuncDecl>(func)->hasDynamicSelf()) ||
           (isa<ConstructorDecl>(func) && !baseObjTy->getOptionalObjectType())) {
-        fprintf(stderr, "getTypeOfMemberReference AbstractFunctionDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
     else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
       if (decl->getElementInterfaceType()->hasDynamicSelfType()) {
-        fprintf(stderr, "getTypeOfMemberReference SubscriptDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
     else if (auto *decl = dyn_cast<VarDecl>(value)) {
       if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
-        fprintf(stderr, "getTypeOfMemberReference VarDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1302,6 +1302,15 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
+    else if (auto *sub = dyn_cast<SubscriptDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+                                               ->getCanonicalType())) {
+        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
+//        openedType->dump();
+//        outerDC->dumpContext();
+      }
+    }
   } else {
     // Protocol requirements returning Self have a dynamic Self return
     // type. Erase the dynamic Self since it only comes into play during

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1302,23 +1302,20 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-    else if (auto *sub = dyn_cast<SubscriptDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+//    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
+//      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getElementInterfaceType()
+//                                               ->getCanonicalType())) {
+//        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
+//        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
+//        baseObjTy->dump();
+////        outerDC->dumpContext();
+//      }
+//    }
+    else if (auto *decl = dyn_cast<VarDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getInterfaceType()
                                                ->getCanonicalType())) {
-        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
-        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
-//        openedType->dump();
-//        outerDC->dumpContext();
-      }
-    }
-    else if (auto *sub = dyn_cast<VarDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getInterfaceType()
-                                               ->getCanonicalType())) {
-        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
-        dyn.dump();
+//        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 1);
-//        openedType->dump();
-//        outerDC->dumpContext();
       }
     }
   } else {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1445,12 +1445,10 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
 
       if (doesStorageProduceLValue(subscript, overload.getBaseType(), useDC))
         elementTy = LValueType::get(elementTy);
-      else {
+      else if (elementTy->hasDynamicSelfType()) {
         Type selfType = overload.getBaseType()->getRValueType()
-            ->getMetatypeInstanceType()
-            ->lookThroughAllOptionalTypes();
-        if (elementTy->hasDynamicSelfType())
-          elementTy = elementTy->replaceCovariantResultType(selfType, 0);
+            ->getMetatypeInstanceType()->lookThroughAllOptionalTypes();
+        elementTy = elementTy->replaceCovariantResultType(selfType, 0);
       }
 
       // See ConstraintSystem::resolveOverload() -- optional and dynamic

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1445,6 +1445,13 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
 
       if (doesStorageProduceLValue(subscript, overload.getBaseType(), useDC))
         elementTy = LValueType::get(elementTy);
+      else {
+        Type selfType = overload.getBaseType()->getRValueType()
+            ->getMetatypeInstanceType()
+            ->lookThroughAllOptionalTypes();
+        if (elementTy->hasDynamicSelfType())
+          elementTy = elementTy->replaceCovariantResultType(selfType, 0);
+      }
 
       // See ConstraintSystem::resolveOverload() -- optional and dynamic
       // subscripts are a special case, because the optionality is

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1302,11 +1302,9 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-    else if (auto decl = dyn_cast<VarDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
-                                               ->getCanonicalType())) {
-        openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
-      }
+    else if (isa<DynamicSelfType>(value->getInterfaceType()
+                                  ->getCanonicalType())) {
+      openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
     }
   } else {
     // Protocol requirements returning Self have a dynamic Self return

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2237,13 +2237,16 @@ public:
   /// Diagnose instances of (Dynamic)Self as the type of a function arugument.
   void diagnoseSelfTypedParameters(Type Ty, SourceLoc Loc, int level = 0) {
     if (auto func = dyn_cast<FunctionType>(Ty->getCanonicalType())) {
-      if (level > 0 && isDynamicSelf(func->getResult()))
-        TC.diagnose(Loc, diag::self_in_nested_return);
       for (auto &param : func->getParams()) {
         if (isDynamicSelf(param.getParameterType())) {
           TC.diagnose(Loc, diag::self_in_parameter);
           diagnoseSelfTypedParameters(param.getParameterType(), Loc, level + 1);
         }
+      }
+      if (Type returnTy = func->getResult()) {
+        if (level > 0 && isDynamicSelf(returnTy))
+          TC.diagnose(Loc, diag::self_in_nested_return);
+        diagnoseSelfTypedParameters(returnTy, Loc, level + 1);
       }
     }
   }
@@ -3149,13 +3152,16 @@ public:
 
     if (isDeclaredInClass(FD)) {
       for (auto *Param : *FD->getParameters()) {
-        auto TyLoc = Param->getTypeLoc();
-        auto Loc = TyLoc.hasLocation() ? TyLoc.getLoc() : Param->getLoc();
+        TypeLoc TyLoc = Param->getTypeLoc();
+        SourceLoc Loc = TyLoc.hasLocation() ? TyLoc.getLoc() : Param->getLoc();
         if (isDynamicSelf(Param->getInterfaceType()))
           TC.diagnose(Loc, diag::self_in_parameter);
         else
           diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc, 1);
       }
+      TypeLoc RTyLoc = FD->getBodyResultTypeLoc();
+      if (RTyLoc.getType())
+        diagnoseSelfTypedParameters(RTyLoc.getType(), RTyLoc.getLoc(), 1);
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3135,6 +3135,15 @@ public:
     }
 
     TC.checkParameterAttributes(FD->getParameters());
+
+    for (auto *Param : *FD->getParameters()) {
+      auto TL = Param->getTypeLoc();
+      auto Loc = TL.hasLocation() ? TL.getLoc() : Param->getLoc();
+      if (Param->getInterfaceType()->hasDynamicSelfType())
+        TC.diagnose(Loc, diag::self_in_parameter);
+      else
+        diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc);
+    }
   }
 
   void visitModuleDecl(ModuleDecl *) { }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2225,16 +2225,23 @@ public:
     }
   }
 
+  bool isDynamicSelf(Type Ty) {
+    return Ty->lookThroughAllOptionalTypes()->hasDynamicSelfType();
+  }
+
   /// diagnoseSelfTypedParameters()
   /// Diagnose instances of (Dynamic)Self as the type of a function arugument.
-  void diagnoseSelfTypedParameters(Type Ty, SourceLoc Loc) {
-    if (auto func = dyn_cast<FunctionType>(Ty->getCanonicalType()))
+  void diagnoseSelfTypedParameters(Type Ty, SourceLoc Loc, int level = 0) {
+    if (auto func = dyn_cast<FunctionType>(Ty->getCanonicalType())) {
+      if (level > 0 && isDynamicSelf(func->getResult()))
+        TC.diagnose(Loc, diag::self_in_nested_return);
       for (auto &param : func->getParams()) {
-        if (param.getParameterType()->hasDynamicSelfType()) {
+        if (isDynamicSelf(param.getParameterType())) {
           TC.diagnose(Loc, diag::self_in_parameter);
-          diagnoseSelfTypedParameters(param.getParameterType(), Loc);
+          diagnoseSelfTypedParameters(param.getParameterType(), Loc, level + 1);
         }
       }
+    }
   }
 
   //===--------------------------------------------------------------------===//
@@ -2594,8 +2601,7 @@ public:
     TC.checkParameterAttributes(SD->getIndices());
     TC.checkDefaultArguments(SD->getIndices(), SD);
 
-    if (SD->isSettable() &&
-        SD->getElementInterfaceType()->hasDynamicSelfType())
+    if (SD->isSettable() && isDynamicSelf(SD->getElementInterfaceType()))
       TC.diagnose(SD->getLoc(), diag::self_in_mutable_subscript);
 
     diagnoseSelfTypedParameters(SD->getElementInterfaceType(),
@@ -2610,11 +2616,11 @@ public:
 
     checkAccessControl(TC, TAD);
 
-    TypeLoc &TL = TAD->getUnderlyingTypeLoc();
-    if (TL.getType()->hasDynamicSelfType())
-      TC.diagnose(TL.getLoc(), diag::self_in_alias);
+    TypeLoc &TyLoc = TAD->getUnderlyingTypeLoc();
+    if (isDynamicSelf(TyLoc.getType()))
+      TC.diagnose(TyLoc.getLoc(), diag::self_in_alias);
 
-    diagnoseSelfTypedParameters(TL.getType(), TL.getLoc());
+    diagnoseSelfTypedParameters(TyLoc.getType(), TyLoc.getLoc());
   }
   
   void visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
@@ -3051,8 +3057,7 @@ public:
     // Delay type-checking on VarDecls until we see the corresponding
     // PatternBindingDecl.
 
-    if (VD->isSettable(nullptr) &&
-        VD->getValueInterfaceType()->hasDynamicSelfType())
+    if (VD->isSettable(nullptr) && isDynamicSelf(VD->getValueInterfaceType()))
       TC.diagnose(VD->getLoc(), diag::self_in_mutable_property);
 
     diagnoseSelfTypedParameters(VD->getValueInterfaceType(),
@@ -3137,12 +3142,12 @@ public:
     TC.checkParameterAttributes(FD->getParameters());
 
     for (auto *Param : *FD->getParameters()) {
-      auto TL = Param->getTypeLoc();
-      auto Loc = TL.hasLocation() ? TL.getLoc() : Param->getLoc();
-      if (Param->getInterfaceType()->hasDynamicSelfType())
+      auto TyLoc = Param->getTypeLoc();
+      auto Loc = TyLoc.hasLocation() ? TyLoc.getLoc() : Param->getLoc();
+      if (isDynamicSelf(Param->getInterfaceType()))
         TC.diagnose(Loc, diag::self_in_parameter);
       else
-        diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc);
+        diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc, 1);
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2229,6 +2229,10 @@ public:
     return Ty->lookThroughAllOptionalTypes()->hasDynamicSelfType();
   }
 
+  bool isDeclaredInClass(Decl *decl) {
+    return decl->getDeclContext()->getSelfClassDecl() != nullptr;
+  }
+
   /// diagnoseSelfTypedParameters()
   /// Diagnose instances of (Dynamic)Self as the type of a function arugument.
   void diagnoseSelfTypedParameters(Type Ty, SourceLoc Loc, int level = 0) {
@@ -3057,11 +3061,13 @@ public:
     // Delay type-checking on VarDecls until we see the corresponding
     // PatternBindingDecl.
 
-    if (VD->isSettable(nullptr) && isDynamicSelf(VD->getValueInterfaceType()))
-      TC.diagnose(VD->getLoc(), diag::self_in_mutable_property);
-
-    diagnoseSelfTypedParameters(VD->getValueInterfaceType(),
-                                VD->getTypeLoc().getLoc());
+    if (isDeclaredInClass(VD)) {
+      if (VD->isSettable(nullptr) && isDynamicSelf(VD->getValueInterfaceType()))
+        TC.diagnose(VD->getLoc(), diag::self_in_mutable_property);
+      else
+        diagnoseSelfTypedParameters(VD->getValueInterfaceType(),
+                                    VD->getTypeLoc().getLoc());
+    }
   }
 
   /// Determine whether the given declaration requires a definition.
@@ -3141,13 +3147,15 @@ public:
 
     TC.checkParameterAttributes(FD->getParameters());
 
-    for (auto *Param : *FD->getParameters()) {
-      auto TyLoc = Param->getTypeLoc();
-      auto Loc = TyLoc.hasLocation() ? TyLoc.getLoc() : Param->getLoc();
-      if (isDynamicSelf(Param->getInterfaceType()))
-        TC.diagnose(Loc, diag::self_in_parameter);
-      else
-        diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc, 1);
+    if (isDeclaredInClass(FD)) {
+      for (auto *Param : *FD->getParameters()) {
+        auto TyLoc = Param->getTypeLoc();
+        auto Loc = TyLoc.hasLocation() ? TyLoc.getLoc() : Param->getLoc();
+        if (isDynamicSelf(Param->getInterfaceType()))
+          TC.diagnose(Loc, diag::self_in_parameter);
+        else
+          diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc, 1);
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2225,6 +2225,18 @@ public:
     }
   }
 
+  /// diagnoseSelfTypedParameters()
+  /// Diagnose instances of (Dynamic)Self as the type of a function arugument.
+  void diagnoseSelfTypedParameters(Type Ty, SourceLoc Loc) {
+    if (auto func = dyn_cast<FunctionType>(Ty->getCanonicalType()))
+      for (auto &param : func->getParams()) {
+        if (param.getParameterType()->hasDynamicSelfType()) {
+          TC.diagnose(Loc, diag::self_in_parameter);
+          diagnoseSelfTypedParameters(param.getParameterType(), Loc);
+        }
+      }
+  }
+
   //===--------------------------------------------------------------------===//
   // Visit Methods.
   //===--------------------------------------------------------------------===//
@@ -2581,6 +2593,13 @@ public:
 
     TC.checkParameterAttributes(SD->getIndices());
     TC.checkDefaultArguments(SD->getIndices(), SD);
+
+    if (SD->isSettable() &&
+        SD->getElementInterfaceType()->hasDynamicSelfType())
+      TC.diagnose(SD->getLoc(), diag::self_in_mutable_subscript);
+
+    diagnoseSelfTypedParameters(SD->getElementInterfaceType(),
+                                SD->getElementTypeLoc().getLoc());
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
@@ -2590,6 +2609,12 @@ public:
     TC.checkDeclAttributes(TAD);
 
     checkAccessControl(TC, TAD);
+
+    TypeLoc &TL = TAD->getUnderlyingTypeLoc();
+    if (TL.getType()->hasDynamicSelfType())
+      TC.diagnose(TL.getLoc(), diag::self_in_alias);
+
+    diagnoseSelfTypedParameters(TL.getType(), TL.getLoc());
   }
   
   void visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
@@ -3025,6 +3050,13 @@ public:
   void visitVarDecl(VarDecl *VD) {
     // Delay type-checking on VarDecls until we see the corresponding
     // PatternBindingDecl.
+
+    if (VD->isSettable(nullptr) &&
+        VD->getValueInterfaceType()->hasDynamicSelfType())
+      TC.diagnose(VD->getLoc(), diag::self_in_mutable_property);
+
+    diagnoseSelfTypedParameters(VD->getValueInterfaceType(),
+                                VD->getTypeLoc().getLoc());
   }
 
   /// Determine whether the given declaration requires a definition.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1061,6 +1061,13 @@ static Type SelfAllowedBySE0068(TypeResolution resolution,
     bool isTypeAliasInClass = insideClass &&
       options.is(TypeResolverContext::TypeAliasDecl);
 
+    if (isMutablePropertyOrSubscriptOfClass) {
+      if (auto prop = dyn_cast_or_null<ValueDecl>
+          (dc->getInnermostDeclarationDeclContext()))
+        if (!prop->isSettable(dc))
+          isMutablePropertyOrSubscriptOfClass = false;
+    }
+
     if (((!insideClass || !declaringMethod) &&
          !isMutablePropertyOrSubscriptOfClass && !isTypeAliasInClass &&
          !options.is(TypeResolverContext::GenericRequirement)) ||

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1053,29 +1053,9 @@ static Type SelfAllowedBySE0068(TypeResolution resolution,
       (nominal = nominalDC->getSelfNominalTypeDecl())) {
     assert(!isa<ProtocolDecl>(nominal) && "Cannot be a protocol");
 
-    bool insideClass = nominalDC->getSelfClassDecl() != nullptr;
-    AbstractFunctionDecl *methodDecl = dc->getInnermostMethodContext();
-    bool declaringMethod = methodDecl &&
-      methodDecl->getDeclContext() == dc->getParentForLookup();
-    bool isMutablePropertyOrSubscriptOfClass = insideClass &&
-      (options.is(TypeResolverContext::PatternBindingDecl) ||
-       options.is(TypeResolverContext::FunctionResult));
-    bool isTypeAliasInClass = insideClass &&
-      options.is(TypeResolverContext::TypeAliasDecl);
-
-    if (isMutablePropertyOrSubscriptOfClass) {
-      if (auto prop = dyn_cast_or_null<ValueDecl>
-          (dc->getInnermostDeclarationDeclContext()))
-        if (!prop->isSettable(dc))
-          isMutablePropertyOrSubscriptOfClass = false;
-    }
-
-    if (((!insideClass || !declaringMethod) &&
-         !isMutablePropertyOrSubscriptOfClass && !isTypeAliasInClass &&
-         !options.is(TypeResolverContext::GenericRequirement)) ||
-        options.is(TypeResolverContext::ExplicitCastExpr)) {
+    if (!options.is(TypeResolverContext::GenericRequirement)) {
       Type SelfType = nominal->getSelfInterfaceType();
-      if (insideClass)
+      if (nominalDC->getSelfClassDecl() != nullptr)
         SelfType = DynamicSelfType::get(SelfType, ctx);
       return resolution.mapTypeIntoContext(SelfType);
     }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1039,6 +1039,8 @@ static std::string getDeclNameFromContext(DeclContext *dc,
 
 //
 // SE-0068 is "Expanding Swift Self to class members and value types"
+// Returns a Type if 'Self' is available in the current implementation.
+//
 // https://github.com/apple/swift-evolution/blob/master/proposals/0068-universal-self.md
 //
 static Type SelfAllowedBySE0068(TypeResolution resolution,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1040,6 +1040,8 @@ static std::string getDeclNameFromContext(DeclContext *dc,
 //
 // SE-0068 is "Expanding Swift Self to class members and value types"
 // Returns a Type if 'Self' is available in the current implementation.
+// Errs on the side of returning `Self` in most circumstances which is
+// subsequently validated in the various vistors in TypeCheckDecl.cpp.
 //
 // https://github.com/apple/swift-evolution/blob/master/proposals/0068-universal-self.md
 //

--- a/test/Interpreter/dynamic_self.swift
+++ b/test/Interpreter/dynamic_self.swift
@@ -192,5 +192,104 @@ print((Derived() as Base).returnsNewInstance())
 print((Derived() as Base).returnsNewInstanceTransparent())
 print((Derived() as Base).returnsNewInstanceTransparentProtocol())
 
+
+// Read-only properties and subscripts returning Self
+
+open class A1<T> {
+  let i: Int
+  public required init(i: Int) {
+    self.i = i
+  }
+  func copy() -> Self {
+    let copy = Self.init(i: 81)
+    return copy
+  }
+
+  open var copied: Self {
+    let copy = Self.init(i: 82)
+    return copy
+  }
+  open subscript (i: Int) -> Self {
+    return Self.init(i: 80+i)
+  }
+}
+
+class B1: A1<Int> {
+  let j = 88
+  override func copy() -> Self {
+    let copy = super.copy() as! Self // supported
+    return copy
+  }
+  override var copied: Self {
+    let copy = Self.init(i: 99)
+    return copy
+  }
+  //  override subscript (i: Int) -> Self {
+  //    return Self.init(i: i+1000)
+  //  }
+}
+
+// CHECK: 181
+// CHECK: 88
+// CHECK: 88
+// CHECK: 82
+// CHECK: 99
+print(A1<Int>(i: 100)[101].i)
+print(B1(i: 100)[101].j)
+print(B1(i: 100).copy().j)
+print(A1<Int>(i: 100).copied.i)
+print(B1(i: 100).copied.i)
+
+class A0<T, S> {
+  var i = "Base"
+  required init() {}
+  var foo: (Self) -> () { return { (a: Self) in } }
+
+  func copy() -> Self {
+    let copy = Self.init()
+    return copy
+  }
+
+  var copied: Self {
+    get {
+      let copy = Self.init()
+      return copy
+    }
+  }
+  open subscript (i: Int) -> Self {
+    get {
+      return Self.init()
+    }
+  }
+}
+
+protocol Prot3 {
+  static func +(x: Self, y: Self) -> String
+}
+
+class B: A0<Int, Double>, Prot3 {
+  var j = "Derived"
+  static func + (x: B, y: B) -> String {
+    return x.j + x.j
+  }
+  override func copy() -> Self {
+    let copy = Self.init()
+    return copy
+  }
+  override var copied: Self {
+    get {
+      return copy() as! Self
+    }
+  }
+  //  override subscript (i: Int) -> Self {
+  //    return Self.init()
+  //  }
+}
+
+// CHECK: DerivedDerived
+// CHECK: DerivedDerived
+print(B()[0][0].j + B().copied.copied.j)
+print(B()[0][0] + B().copied.copied)
+
 // CHECK-NEXT: Done
 print("Done")

--- a/test/Interpreter/dynamic_self.swift
+++ b/test/Interpreter/dynamic_self.swift
@@ -243,7 +243,6 @@ print(B1(i: 100).copied.i)
 class A0<T, S> {
   var i = "Base"
   required init() {}
-  var foo: (Self) -> () { return { (a: Self) in } }
 
   func copy() -> Self {
     let copy = Self.init()

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -24,9 +24,9 @@ enum E0 {
 class C0 {
   func f() -> Self { } // okay
 
-  func g(_ ds: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{16-20=C0}}
+  func g(_ ds: Self) { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
 
-  func h(_ ds: Self) -> Self { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{16-20=C0}}
+  func h(_ ds: Self) -> Self { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
 }
 
 protocol P0 {
@@ -72,8 +72,8 @@ class C1 {
     // One can use `type(of:)` to attempt to construct an object of type Self.
     if !b { return type(of: self).init(int: 5) }
 
-    // Can't utter Self within the body of a method.
-    var _: Self = self // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C1'?}} {{12-16=C1}}
+    // Can utter Self within the body of a method.
+    var _: Self = self
 
     // Okay to return 'self', because it has the appropriate type.
     return self // okay

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -119,12 +119,60 @@ class B: A<Int> {
 class C {
   required init() {
   }
+
   func f() {
     func g(_: Self) {}
   }
   func g() {
     _ = Self.init() as? Self
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
+  }
+  func h(j: () -> Self) -> () -> Self {
+    // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
+    // expected-error@-2 {{'Self' cannot be the type of a nested return value}}
+    return { return self }
+    // expected-error@-1 {{cannot convert value of type 'C' to closure result type 'Self'}}
+  }
+
+  let p0: Self?
+  var p1: Self? // expected-error {{'Self' is not available as the type of a mutable property}}
+  // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
+  // expected-error@-2 {{'Self' cannot be the type of a function argument in a class}}
+
+  var prop: Self { // expected-error {{'Self' is not available as the type of a mutable property}}
+    get {
+      return self
+    }
+    set (newValue) { // expected-error {{'Self' cannot be the type of a function argument in a class}}
+    }
+  }
+  subscript (i: Int) -> Self { // expected-error {{'Self' is not available as the type of a mutable subscript}}
+    get {
+      return self
+    }
+    set (newValue) { // expected-error {{'Self' cannot be the type of a function argument in a class}}
+    }
+  }
+}
+
+struct S1 {
+  typealias _SELF = Self
+  let j = 99.1
+  subscript (i: Int) -> Self {
+    get {
+      return self
+    }
+    set(newValue) {
+    }
+  }
+  var foo: Self {
+    get {
+      return self// as! Self
+    }
+    set (newValue) {
+    }
+  }
+  func x(y: () -> Self, z: Self) {
   }
 }
 
@@ -143,7 +191,7 @@ struct S2 {
     }
     func foo(a: [Self]) -> Self? {
       Self.x()
-      return Self.init() as? Self
+      return self as? Self
       // expected-warning@-1 {{conditional cast from 'S2.S3<T>' to 'S2.S3<T>' always succeeds}}
     }
   }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -77,7 +77,7 @@ class A<T> {
     return copy
   }
 
-  var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  var copied: Self {
     let copy = Self.init(a: 11)
     return copy
   }
@@ -110,7 +110,7 @@ class B: A<Int> {
     let copy = super.copy() as! Self // supported
     return copy
   }
-  override var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'B'?}}
+  override var copied: Self {
     let copy = super.copied as! Self // unsupported
     return copy
   }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -5,7 +5,7 @@ struct S0<T> {
 }
 
 class C0<T> {
-  func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{21-25=C0}}
+  func foo(_ other: Self) { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
 }
 
 enum E0<T> {
@@ -47,7 +47,7 @@ final class FinalMario : Mario {
 
 class A<T> {
   typealias _Self = Self
-  // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  // expected-error@-1 {{'Self' is not available in a typealias}}
   let b: Int
   required init(a: Int) {
     print("\(Self.self).\(#function)")
@@ -55,7 +55,7 @@ class A<T> {
     b = a
   }
   static func z(n: Self? = nil) {
-    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+    // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
     print("\(Self.self).\(#function)")
   }
   class func y() {
@@ -67,7 +67,6 @@ class A<T> {
     Self.y()
     Self.z()
     let _: Self = Self.init(a: 66)
-    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
     return Self.init(a: 77) as? Self as? A
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
     // expected-warning@-2 {{conditional downcast from 'Self?' to 'A<T>' is equivalent to an implicit conversion to an optional 'A<T>'}}
@@ -81,11 +80,12 @@ class A<T> {
     let copy = Self.init(a: 11)
     return copy
   }
-  subscript (i: Int) -> Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  subscript (i: Int) -> Self { // expected-error {{'Self' is not available as the type of a mutable subscript}}
     get {
       return Self.init(a: i)
     }
     set(newValue) {
+      // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
     }
   }
 }


### PR DESCRIPTION
Hi Apple,

further eases restrictions on recent PRs https://github.com/apple/swift/pull/22863 and https://github.com/apple/swift/pull/23485 to allow properties and subscripts that return Self, provided they are not settable. Will need to be cherrypicked into 5.1 cc @slavapestov.

Resolves #52726.