### PR TITLE
lit.cfg: move the DYLD_LIBRARY_PATH setting code to the config.substitutions

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1326,6 +1326,47 @@ if platform.system() != 'Darwin':
     config.target_resilience_test = ('%s --no-symbol-diff' %
                                      config.target_resilience_test)
 
+platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
+if run_vendor != 'apple':
+    platform_module_dir = make_path(platform_module_dir, run_cpu)
+lit_config.note('Using platform module dir: ' + platform_module_dir)
+if test_sdk_overlay_dir:
+    platform_sdk_overlay_dir = test_sdk_overlay_dir
+else:
+    platform_sdk_overlay_dir = platform_module_dir
+
+# If static stdlib is present, enable static stdlib tests
+static_stdlib_path = make_path(config.swift_lib_dir, "swift_static", config.target_sdk_name)
+static_libswiftCore_path = make_path(static_stdlib_path, "libswiftCore.a")
+if os.path.exists(static_libswiftCore_path):
+    config.available_features.add("static_stdlib")
+    config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
+    lit_config.note('using static stdlib path: %s' % static_stdlib_path)
+
+# Set up testing with the standard libraries coming from the OS / just-built libraries
+# default Swift tests to use the just-built libraries
+target_stdlib_path = platform_module_dir
+if not kIsWindows:
+	if 'use_os_stdlib' not in lit_config.params:
+		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
+		config.target_run = (
+			"/usr/bin/env "
+			"DYLD_LIBRARY_PATH='{0}' " # Apple option
+			"LD_LIBRARY_PATH='{0}' " # Linux option
+			.format(target_stdlib_path))
+	else:
+		os_stdlib_path = ''
+		if run_vendor == 'apple':
+			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
+			os_stdlib_path = "/usr/lib/swift"
+		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
+		lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
+		config.target_run = (
+			"/usr/bin/env "
+			"DYLD_LIBRARY_PATH='{0}' " # Apple option
+			"LD_LIBRARY_PATH='{0}' " # Linux option
+			.format(all_stdlib_path))
+
 #
 # When changing substitutions, update docs/Testing.rst.
 #
@@ -1416,15 +1457,6 @@ if hasattr(config, 'target_swift_autolink_extract'):
 config.substitutions.append(('%target-swift-modulewrap',
                              config.target_swift_modulewrap))
 
-platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
-if run_vendor != 'apple':
-    platform_module_dir = make_path(platform_module_dir, run_cpu)
-lit_config.note('Using platform module dir: ' + platform_module_dir)
-if test_sdk_overlay_dir:
-    platform_sdk_overlay_dir = test_sdk_overlay_dir
-else:
-    platform_sdk_overlay_dir = platform_module_dir
-
 config.substitutions.insert(0, ('%platform-module-dir', platform_module_dir))
 config.substitutions.insert(0, ('%platform-sdk-overlay-dir', platform_sdk_overlay_dir))
 
@@ -1458,37 +1490,6 @@ config.substitutions.append(('%FileCheck',
         config.filecheck,
         '--enable-windows-compatibility' if kIsWindows else '')))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
-
-# If static stdlib is present, enable static stdlib tests
-static_stdlib_path = make_path(config.swift_lib_dir, "swift_static", config.target_sdk_name)
-libswiftCore_path = make_path(static_stdlib_path, "libswiftCore.a")
-if os.path.exists(libswiftCore_path):
-    config.available_features.add("static_stdlib")
-    config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
-    lit_config.note('using static stdlib path: %s' % static_stdlib_path)
-
-# Set up testing with the standard libraries coming from the OS / just-built libraries
-# default Swift tests to use the just-built libraries
-target_stdlib_path = platform_module_dir
-if 'use_os_stdlib' not in lit_config.params:
-	lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
-	config.target_run = (
-        "/usr/bin/env "
-        "DYLD_LIBRARY_PATH='{0}' " # Apple option
-        "LD_LIBRARY_PATH='{0}' " # Linux option
-        .format(target_stdlib_path))
-else:
-	os_stdlib_path = ''
-	if run_vendor == 'apple':
-		#If we get swift-in-the-OS for non-Apple platforms, add a condition here
-		os_stdlib_path = "/usr/lib/swift"
-	all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
-	lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
-	config.target_run = (
-        "/usr/bin/env "
-        "DYLD_LIBRARY_PATH='{0}' " # Apple option
-        "LD_LIBRARY_PATH='{0}' " # Linux option
-        .format(all_stdlib_path))
 
 if config.lldb_build_root != "":
     config.available_features.add('lldb')


### PR DESCRIPTION
This change the order the configuration file to something that makes more sense: the platform_module_dir value was being set in the middle of the config.substitutions phase.
We needed said value for setting the DYLD_LIBRARY_PATH, so that code was added right after it.

The problem is that by that time config.substitutions.append(('%target-run', config.target_run)) has already happened for local targets

This change moves all said code to just before the substitutions phase, much cleaner and resolves rdar://problem/49835064
