### PR TITLE
[ConstraintSystem] Overload choice should not be required to refer to…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4232,13 +4232,13 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
              DeclName memberName, const OverloadChoice &choice,
              ConstraintLocator *locator,
              Optional<MemberLookupResult::UnviableReason> reason = None) {
-  if (!choice.isDecl())
-    return nullptr;
-
-  auto *decl = choice.getDecl();
-  if (auto *CD = dyn_cast<ConstructorDecl>(decl)) {
-    if (auto *fix = validateInitializerRef(cs, CD, locator))
-      return fix;
+  // Not all of the choices handled here are going
+  // to refer to a declaration.
+  if (choice.isDecl()) {
+    if (auto *CD = dyn_cast<ConstructorDecl>(choice.getDecl())) {
+      if (auto *fix = validateInitializerRef(cs, CD, locator))
+        return fix;
+    }
   }
 
   if (reason) {
@@ -4248,7 +4248,8 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
       return AllowTypeOrInstanceMember::create(cs, baseTy, memberName, locator);
 
     case MemberLookupResult::UR_Inaccessible:
-      return AllowInaccessibleMember::create(cs, decl, locator);
+      assert(choice.isDecl());
+      return AllowInaccessibleMember::create(cs, choice.getDecl(), locator);
 
     case MemberLookupResult::UR_MutatingMemberOnRValue:
     case MemberLookupResult::UR_MutatingGetterOnRValue:


### PR DESCRIPTION
… declaration to have a fix

We should be able to attach fixes to overload choices that don't
refer to declarations e.g. keypath applications which refer to
`AnyObject` is a base type.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
