### PR TITLE
[5.1] Temporarily disable ErrorBridgedStatic.swift.

### DIFF
--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -8,6 +8,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: static_stdlib
 
+// isTypeMetadata is asserting on the 5.1 branch...
+// REQUIRES: rdar49699316
+
 import StdlibUnittest
 
 class Bar: Foo {


### PR DESCRIPTION
This is only failing on the 5.1 branch. I was unable to reproduce the
failure locally, it passes for me when building static stdlib.

Maybe the test should be deleted. Tracking here:
<rdar://problem/49699316> [Swift CI Issue][swift-5.1-branch] TEST 'Swift(iphonesimulator-x86_64) :: stdlib/ErrorBridgedStatic.swift'

