### PR TITLE
restrict set of copied libtensorflow files

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2444,12 +2444,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     # problematic for overwriting/stripping symbols. Thus, write
                     # permission is added here.
                     for lib_name in tensorflow tensorflow_framework; do
-                        lib="lib${lib_name}.so*"
-                        dylib="lib${lib_name}*.dylib"
-                        rm -f "${TF_LIB_DIR}/${lib}"
-                        rm -f "${TF_LIB_DIR}/${dylib}"
-                        find "${TENSORFLOW_HOST_LIB_DIR}" \( -name "${lib}" -o -name "${dylib}" \) -exec chmod +w {} +
-                        find "${TENSORFLOW_HOST_LIB_DIR}" \( -name "${lib}" -o -name "${dylib}" \) -exec cp -p {} "${TF_LIB_DIR}" \;
+                        lib=".*lib${lib_name}.so[0-9.]*"
+                        dylib=".*lib${lib_name}[0-9.]*.dylib"
+                        find "${TF_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec rm -f {} \;
+                        find "${TENSORFLOW_HOST_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec chmod +w {} +
+                        find "${TENSORFLOW_HOST_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec cp -p {} "${TF_LIB_DIR}" \;
                     done
 
                     if [[ ! "${TENSORFLOW_TARGET_LIB_DIR}" ]] ; then
@@ -3830,10 +3829,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 mkdir -p "${TF_DEST_DIR}"
                 for lib_name in tensorflow tensorflow_framework
                 do
-                    lib="lib${lib_name}.so*"
-                    dylib="lib${lib_name}*.dylib"
-                    echo "${TF_LIBDIR}/${lib} => ${TF_DEST_DIR}"
-                    find "${TF_LIBDIR}" \( -name "${lib}" -o -name "${dylib}" \) -exec cp -a {} "${TF_DEST_DIR}" \;
+                    lib=".*lib${lib_name}.so[0-9.]*"
+                    dylib=".*lib${lib_name}[0-9.]*.dylib"
+                    find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec echo "{} => ${TF_DEST_DIR}" \;
+                    find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec cp -a {} "${TF_DEST_DIR}" \;
                 done
                 continue
                 ;;


### PR DESCRIPTION
https://github.com/apple/swift/pull/23895 accidentally started copying spurious files named "libtensorflow_framework.so.runfiles_manifest" and "libtensorflow.so.runfiles_manifest" into the toolchain, confusing a step that expected to only see libraries.

This uses a regex to only copy the files that we do want to copy (e.g. libtensorflow.so.1.13, libtensorflow1.13.dylib).

I have verified that a toolchain build succeeds on my macbook and on my linux workstation.