### PR TITLE
Fix response file support for batch jobs.

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -209,6 +209,14 @@ protected:
   /// set to match the behavior of Clang.
   virtual bool shouldStoreInvocationInDebugInfo() const { return false; }
 
+  /// Gets the response file path and command line argument for an invocation
+  /// if the tool supports response files and if the command line length would
+  /// exceed system limits.
+  Optional<Job::ResponseFileInfo>
+  getResponseFileInfo(const Compilation &C, const char *executablePath,
+                      const InvocationInfo &invocationInfo,
+                      const JobContext &context) const;
+
 public:
   virtual ~ToolChain() = default;
 

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -363,7 +363,7 @@ void Job::printCommandLine(raw_ostream &os, StringRef Terminator) const {
   escapeAndPrintString(os, Executable);
   os << ' ';
   if (hasResponseFile()) {
-    printArguments(os, {ResponseFileArg});
+    printArguments(os, {ResponseFile->argString});
     os << " # ";
   }
   printArguments(os, Arguments);
@@ -419,8 +419,9 @@ void Job::printSummary(raw_ostream &os) const {
 }
 
 bool Job::writeArgsToResponseFile() const {
+  assert(hasResponseFile());
   std::error_code EC;
-  llvm::raw_fd_ostream OS(ResponseFilePath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OS(ResponseFile->path, EC, llvm::sys::fs::F_None);
   if (EC) {
     return true;
   }
@@ -438,9 +439,10 @@ BatchJob::BatchJob(const JobAction &Source,
                    const char *Executable, llvm::opt::ArgStringList Arguments,
                    EnvironmentVector ExtraEnvironment,
                    std::vector<FilelistInfo> Infos,
-                   ArrayRef<const Job *> Combined, int64_t &NextQuasiPID)
+                   ArrayRef<const Job *> Combined, int64_t &NextQuasiPID,
+                   Optional<ResponseFileInfo> ResponseFile)
     : Job(Source, std::move(Inputs), std::move(Output), Executable, Arguments,
-          ExtraEnvironment, Infos),
+          ExtraEnvironment, Infos, ResponseFile),
       CombinedJobs(Combined.begin(), Combined.end()),
       QuasiPIDBase(NextQuasiPID) {
 

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -62,6 +62,27 @@ ToolChain::JobContext::getTemporaryFilePath(const llvm::Twine &name,
   return C.getArgs().MakeArgString(buffer.str());
 }
 
+Optional<Job::ResponseFileInfo>
+ToolChain::getResponseFileInfo(const Compilation &C, const char *executablePath,
+                               const ToolChain::InvocationInfo &invocationInfo,
+                               const ToolChain::JobContext &context) const {
+  const bool forceResponseFiles =
+      C.getArgs().hasArg(options::OPT_driver_force_response_files);
+  assert((invocationInfo.allowsResponseFiles || !forceResponseFiles) &&
+         "Cannot force response file if platform does not allow it");
+
+  if (forceResponseFiles || (invocationInfo.allowsResponseFiles &&
+                             !llvm::sys::commandLineFitsWithinSystemLimits(
+                                 executablePath, invocationInfo.Arguments))) {
+    const char *responseFilePath =
+        context.getTemporaryFilePath("arguments", "resp");
+    const char *responseFileArg =
+        C.getArgs().MakeArgString(Twine("@") + responseFilePath);
+    return {{responseFilePath, responseFileArg}};
+  }
+  return None;
+}
+
 std::unique_ptr<Job> ToolChain::constructJob(
     const JobAction &JA, Compilation &C, SmallVectorImpl<const Job *> &&inputs,
     ArrayRef<const Action *> inputActions,
@@ -114,28 +135,16 @@ std::unique_ptr<Job> ToolChain::constructJob(
     }
   }
 
-  const char *responseFilePath = nullptr;
-  const char *responseFileArg = nullptr;
+  // Determine if the argument list is so long that it needs to be written into
+  // a response file.
+  auto responseFileInfo =
+      getResponseFileInfo(C, executablePath, invocationInfo, context);
 
-  const bool forceResponseFiles =
-      C.getArgs().hasArg(options::OPT_driver_force_response_files);
-  assert((invocationInfo.allowsResponseFiles || !forceResponseFiles) &&
-         "Cannot force response file if platform does not allow it");
-
-  if (forceResponseFiles || (invocationInfo.allowsResponseFiles &&
-                             !llvm::sys::commandLineFitsWithinSystemLimits(
-                                 executablePath, invocationInfo.Arguments))) {
-    responseFilePath = context.getTemporaryFilePath("arguments", "resp");
-    responseFileArg = C.getArgs().MakeArgString(Twine("@") + responseFilePath);
-  }
-
-  return llvm::make_unique<Job>(JA, std::move(inputs), std::move(output),
-                                executablePath,
-                                std::move(invocationInfo.Arguments),
-                                std::move(invocationInfo.ExtraEnvironment),
-                                std::move(invocationInfo.FilelistInfos),
-                                responseFilePath,
-                                responseFileArg);
+  return llvm::make_unique<Job>(
+      JA, std::move(inputs), std::move(output), executablePath,
+      std::move(invocationInfo.Arguments),
+      std::move(invocationInfo.ExtraEnvironment),
+      std::move(invocationInfo.FilelistInfos), responseFileInfo);
 }
 
 std::string
@@ -345,10 +354,12 @@ ToolChain::constructBatchJob(ArrayRef<const Job *> unsortedJobs,
                      *output, OI};
   auto invocationInfo = constructInvocation(*batchCJA, context);
   // Batch mode can produce quite long command lines; in almost every case these
-  // will trigger use of supplementary output file maps, but in some rare corner
-  // cases (very few files, very long paths) they might not. However, in those
-  // cases we _should_ degrade to using response files to pass arguments to the
-  // frontend, which is done automatically by code elsewhere.
+  // will trigger use of supplementary output file maps. However, if the driver
+  // command line is long for reasons unrelated to the number of input files,
+  // such as passing a large number of flags, then the individual batch jobs are
+  // also likely to overflow. We have to check for that explicitly here, because
+  // the BatchJob created here does not go through the same code path in
+  // constructJob above.
   //
   // The `allowsResponseFiles` flag on the `invocationInfo` we have here exists
   // only to model external tools that don't know about response files, such as
@@ -356,9 +367,13 @@ ToolChain::constructBatchJob(ArrayRef<const Job *> unsortedJobs,
   // should always be true. But double check with an assert here in case someone
   // failed to set it in `constructInvocation`.
   assert(invocationInfo.allowsResponseFiles);
+  auto responseFileInfo =
+      getResponseFileInfo(C, executablePath, invocationInfo, context);
+
   return llvm::make_unique<BatchJob>(
       *batchCJA, inputJobs.takeVector(), std::move(output), executablePath,
       std::move(invocationInfo.Arguments),
       std::move(invocationInfo.ExtraEnvironment),
-      std::move(invocationInfo.FilelistInfos), sortedJobs, NextQuasiPID);
+      std::move(invocationInfo.FilelistInfos), sortedJobs, NextQuasiPID,
+      responseFileInfo);
 }

--- a/test/Driver/batch_mode_response_files.swift
+++ b/test/Driver/batch_mode_response_files.swift
@@ -1,0 +1,10 @@
+// Batch jobs go through a different code path than other jobs, so make sure
+// that they also use response files correctly when their argument lists are
+// too long.
+
+// RUN: %{python} -c 'for i in range(500001): print "-DTEST_" + str(i)' > %t.resp
+// RUN: %swiftc_driver -driver-print-jobs -module-name batch -enable-batch-mode -j 1 -c %S/Inputs/main.swift %S/Inputs/lib.swift @%t.resp 2>&1 > %t.jobs.txt
+// RUN: %FileCheck %s < %t.jobs.txt -check-prefix=BATCH
+
+// BATCH: bin{{/|\\\\}}swift{{c?}}
+// BATCH: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp{{"?}} # -frontend -c -primary-file {{[^ ]+}}/Inputs/main.swift{{"?}} -primary-file {{[^ ]+}}/Inputs/lib.swift

--- a/test/Driver/force-response-files.swift
+++ b/test/Driver/force-response-files.swift
@@ -4,3 +4,7 @@
 // RUN: %swiftc_driver -driver-force-response-files -typecheck %S/../Inputs/empty.swift -### 2>&1 | %FileCheck %s
 // CHECK: @
 // CHECK: .resp
+
+// RUN: %swiftc_driver -enable-batch-mode -driver-force-response-files -typecheck %S/../Inputs/empty.swift -### 2>&1 | %FileCheck %s -check-prefix=BATCH
+// BATCH: @
+// BATCH: .resp


### PR DESCRIPTION
This fixes an issue where batch jobs don't recompute whether they need response files due to command line length limits, because `BatchJob`s are added directly to the task queue and don't go through the same code path in `constructJob` that checks the length (the comment in `constructBatchJob` was incorrect).

I've verified that the test added in this PR fails when this patch is not present (the batch frontend job doesn't use a response file) and succeeds when it is.