### PR TITLE
[TF] Make whole-tensor reductions safe for tracing

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1259,16 +1259,16 @@ public extension Tensor where Scalar : Numeric {
     where Scalar : TensorFlowFloatingPoint
   )
   func sum() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.sum(self, reductionIndices: axes)
+    let flat = reshaped(to: [-1])
+    return Raw.sum(flat, reductionIndices: [0])
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
   func product() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.prod(self, reductionIndices: axes)
+    let flat = reshaped(to: [-1])
+    return Raw.prod(flat, reductionIndices: [0])
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer
@@ -1279,8 +1279,8 @@ public extension Tensor where Scalar : Numeric {
   )
   @inlinable @inline(__always)
   func mean() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.mean(self, reductionIndices: axes)
+    let flat = reshaped(to: [-1])
+    return Raw.mean(flat, reductionIndices: [0])
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1259,16 +1259,14 @@ public extension Tensor where Scalar : Numeric {
     where Scalar : TensorFlowFloatingPoint
   )
   func sum() -> Tensor {
-    let flat = reshaped(to: [-1])
-    return Raw.sum(flat, reductionIndices: [0])
+    return Raw.sum(flattened(), reductionIndices: [0])
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
   func product() -> Tensor {
-    let flat = reshaped(to: [-1])
-    return Raw.prod(flat, reductionIndices: [0])
+    return Raw.prod(flattened(), reductionIndices: [0])
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer
@@ -1279,8 +1277,7 @@ public extension Tensor where Scalar : Numeric {
   )
   @inlinable @inline(__always)
   func mean() -> Tensor {
-    let flat = reshaped(to: [-1])
-    return Raw.mean(flat, reductionIndices: [0])
+    return Raw.mean(flattened(), reductionIndices: [0])
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -179,6 +179,7 @@ TensorTests.testAllBackends("Reduction") {
   // 2 x 5
   let x = Tensor<Float>([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
   expectEqual(Tensor(30), x.sum().toHost(shape: []))
+  expectEqual(0, x.rank)
   expectEqual(Tensor(shape: [5], scalars: [2, 4, 6, 8, 10]),
               x.sum(squeezingAxes: 0).toHost(shape: []))
   expectEqual(Tensor(shape: [1, 5], scalars: [2, 4, 6, 8, 10]),


### PR DESCRIPTION
Currently global reductions like `sum` try to access the `rank` property, which is dynamically unavailable on abstractified tensors. Switch to a `reshape` then single-axis reduction.