### PR TITLE
[AutoDiff] Register derivative for `AnyDerivative.init`.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -678,6 +678,7 @@ public struct AnyDerivative : Differentiable & AdditiveArithmetic {
   }
 
   /// Creates a type-erased derivative from the given derivative.
+  @differentiable(vjp: _vjpInit(_:))
   public init<T>(_ base: T)
     where T : Differentiable, T.TangentVector == T,
           T.AllDifferentiableVariables == T,
@@ -686,6 +687,18 @@ public struct AnyDerivative : Differentiable & AdditiveArithmetic {
           T.CotangentVector == T.CotangentVector.AllDifferentiableVariables
   {
     self._box = _ConcreteDerivativeBox<T>(base)
+  }
+
+  @usableFromInline internal static func _vjpInit<T>(
+    _ base: T
+  ) -> (AnyDerivative, (AnyDerivative) -> T.CotangentVector)
+    where T : Differentiable, T.TangentVector == T,
+          T.AllDifferentiableVariables == T,
+          // NOTE: The requirement below should be defined on `Differentiable`.
+          // But it causes a crash due to generic signature minimization bug.
+          T.CotangentVector == T.CotangentVector.AllDifferentiableVariables
+  {
+    return (AnyDerivative(base), { v in v.base as! T.CotangentVector })
   }
 
   public typealias TangentVector = AnyDerivative


### PR DESCRIPTION
`AnyDerivative.init` has type `(T) -> AnyDerivative`.
Its pullback has type `(AnyDerivative) -> T.CotangentVector`.