### PR TITLE
[stdlib] Include POSIXError as part of Glibc

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -25,6 +25,7 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_
 
 add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     ${swift_platform_sources}
+    POSIXError.swift
 
     GYB_SOURCES
       ${swift_platform_gyb_sources}


### PR DESCRIPTION
<!-- What's in this pull request? -->
`POSIXErrorCode` is compiled as part of the platform module on Darwin, but not as part of Glibc on Linux and other platforms. This PR makes the platforms consistently define `POSIXErrorCode` which should have been compiling for Linux since https://github.com/apple/swift/commit/8157194e83ea49a3fbadefaf04395b1b15d72474#diff-c86969eead9d9f63ad0faa3e75802e66R268.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10485](https://bugs.swift.org/browse/SR-10485).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->