### PR TITLE
[SR-8246] set linux-fatal-backtrace as UNSUPPORTED for Linux aarch64

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -4,7 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
-// UNSUPPORTED: CPU=aarch64
+// XFAIL: CPU=aarch64
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
+// UNSUPPORTED: CPU=aarch64
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Linux on AArch64 CPU does not output a `stack trace` using the existing test methods.
The following are the outputs from running the `backtrace.swift` test file.

#### x86 
````
(lldb) target create backtrace
Current executable set to 'backtrace' (x86_64).
(lldb) r
Process 3130 launched: '/backtrace' (x86_64)
Fatal error: Unexpectedly found nil while unwrapping an Optional value
Current stack trace:
0    libswiftCore.so                    0x00007ffff7cce050 _swift_stdlib_reportFatalError + 69
1    libswiftCore.so                    0x00007ffff7bdbdc6 <unavailable> + 3280326
2    libswiftCore.so                    0x00007ffff7bdc145 <unavailable> + 3281221
3    libswiftCore.so                    0x00007ffff7a03bd0 _fatalErrorMessage(_:_:file:line:flags:) + 19
4    backtrace                          0x00005555555550eb <unavailable> + 4331
5    backtrace                          0x0000555555554ff4 <unavailable> + 4084
6    libc.so.6                          0x00007ffff6c70740 __libc_start_main + 240
7    backtrace                          0x0000555555554d79 <unavailable> + 3449
Process 3130 stopped
* thread #1, name = 'backtrace', stop reason = Fatal error: Unexpectedly found nil while unwrapping an Optional value
    frame #0: 0x00007ffff7c707c0 libswiftCore.so`_swift_runtime_on_report
libswiftCore.so`_swift_runtime_on_report:
->  0x7ffff7c707c0 <+0>: retq
    0x7ffff7c707c1:      nopw   %cs:(%rax,%rax)
libswiftCore.so`_swift_reportToDebugger:
    0x7ffff7c707d0 <+0>: jmp    0x7ffff7c707c0            ; _swift_runtime_on_report
    0x7ffff7c707d5:      nopw   %cs:(%rax,%rax)
Target 0: (backtrace) stopped.
(lldb)
````
#### aarch64
````
(lldb) target create backtrace
Current executable set to 'backtrace' (aarch64).
(lldb) r
Process 1085 launched: '/backtrace' (aarch64)
Fatal error: Unexpectedly found nil while unwrapping an Optional value
Current stack trace:
Process 1085 stopped
* thread #1, name = 'backtrace', stop reason = Fatal error: Unexpectedly found nil while unwrapping an Optional value
    frame #0: 0x0000007fb7e297b4 libswiftCore.so`_swift_runtime_on_report
libswiftCore.so`_swift_runtime_on_report:
->  0x7fb7e297b4 <+0>: ret

libswiftCore.so`_swift_reportToDebugger:
    0x7fb7e297b8 <+0>: b      0x7fb7e297b4              ; _swift_runtime_on_report

libswiftCore.so`_swift_shouldReportFatalErrorsToDebugger:
    0x7fb7e297bc <+0>: adrp   x8, 292
    0x7fb7e297c0 <+4>: ldrb   w0, [x8, #0x490]
Target 0: (backtrace) stopped.
(lldb)
````
As there is no `stack trace` produced, this test should be changed to `UNSUPPORTED` for `CPU=aarch64`.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8246](https://bugs.swift.org/browse/SR-8246).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
