### PR TITLE
GSB(SR-10483): Prioritize synthetic superclass requirements

### DIFF
--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -174,6 +174,7 @@ RequirementEnvironment::RequirementEnvironment(
   if (covariantSelf) {
     auto paramTy = GenericTypeParamType::get(/*depth=*/0, /*index=*/0, ctx);
     Requirement reqt(RequirementKind::Superclass, paramTy, substConcreteType);
+
     requirements.push_back(reqt);
   }
 

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -352,3 +352,12 @@ func usesProtoRefinesClass2<T : ProtoRefinesClassComposition>(_ t: T) {
   t.genericMethod((1, 2))
   let _: BaseProto = t
 }
+
+// SR-10483(Fixed)
+class A: P {}
+protocol P: A {
+  func foo()
+}
+extension P {
+  func foo() {}
+}


### PR DESCRIPTION
Resolves [SR-10483](https://bugs.swift.org/browse/SR-10483).

### Why was this happening?
```swift
class A: P {} // error: type 'A' does not conform to protocol 'P'
protocol P: A {
  func foo()
}
extension P {
  func foo() {}
}
```
For any conformer `B` :  `B: A`, the `RequirementEnvironment` initializer adds a synthetic `t_0_0: B` constraint with an explicit requirement source kind and the GSB naturally *derives* `t_0_0: A` from `t_0_0: P` later on. This works fine when `A != B` because the derived `t_0_0: A` requirement gets filtered out, leaving us with the desired `t_0_0: B`. As for `A == B` , we get 2 `t_0_0: A` constraints that end up killing each other: 
* a derived requirement is always preferred over an explicit one when the *types involved match*.
* the remaining derived requirement gets filtered out during enumeration.

This patch introduces a `syntheticRequirement` flag for `*RequirementSource` to allow for prioritizing requirement sources for synthetic constraints.

cc @slavapestov