### PR TITLE
[CodeCompletion] Always print empty tuple type as 'Void'

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -377,6 +377,9 @@ struct PrintOptions {
   /// for optionals that are nested within other optionals.
   bool PrintOptionalAsImplicitlyUnwrapped = false;
 
+  /// When printing empty tuple type. Print them as 'Void' instead of '()'.
+  bool PrintEmptyTupleTypeAsVoid = false;
+
   /// Replaces the name of private and internal properties of types with '_'.
   bool OmitNameOfInaccessibleProperties = false;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3637,12 +3637,17 @@ public:
   }
 
   void visitTupleType(TupleType *T) {
+    auto Fields = T->getElements();
+    if (Fields.empty() && Options.PrintEmptyTupleTypeAsVoid) {
+      Printer << "Void";
+      return;
+    }
+
     Printer.callPrintStructurePre(PrintStructureKind::TupleType);
     SWIFT_DEFER { Printer.printStructurePost(PrintStructureKind::TupleType); };
 
     Printer << "(";
 
-    auto Fields = T->getElements();
     for (unsigned i = 0, e = Fields.size(); i != e; ++i) {
       if (i)
         Printer << ", ";

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -375,6 +375,7 @@ public:
     PO.PrintOptionalAsImplicitlyUnwrapped = IsIUO;
     PO.OpaqueReturnTypePrinting =
         PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword;
+    PO.PrintEmptyTupleTypeAsVoid = true;
     std::string TypeName = Ty->getString(PO);
     addChunkWithText(CodeCompletionString::Chunk::ChunkKind::CallParameterType,
                      TypeName);
@@ -389,6 +390,7 @@ public:
       PO.SkipAttributes = true;
       PO.OpaqueReturnTypePrinting =
           PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword;
+      PO.PrintEmptyTupleTypeAsVoid = true;
       addChunkWithText(
           CodeCompletionString::Chunk::ChunkKind::CallParameterClosureType,
           AFT->getString(PO));

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -608,8 +608,8 @@ class TestImplicitlyCurriedSelf {
     TestImplicitlyCurriedSelf.foo(#^CURRIED_SELF_3^#
 
 // CURRIED_SELF_1: Begin completions, 2 items
-// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int) -> ()#]{{; name=.+$}}
-// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int, Int) -> ()#]{{; name=.+$}}
+// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int) -> Void#]{{; name=.+$}}
+// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int, Int) -> Void#]{{; name=.+$}}
 // CURRIED_SELF_1: End completions
   }
 }

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -300,7 +300,7 @@ func test_28188259(x: ((Int) -> Void) -> Void) {
 }
 // RDAR_28188259: Begin completions
 // RDAR_28188259-DAG: Pattern/CurrModule:                 ({#Int#})[#Void#]; name=(Int)
-// RDAR_28188259-DAG: Keyword[self]/CurrNominal:          .self[#(Int) -> ()#]; name=self
+// RDAR_28188259-DAG: Keyword[self]/CurrNominal:          .self[#(Int) -> Void#]; name=self
 // RDAR_28188259: End completions
 
 // rdar://problem/40956846

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -301,12 +301,12 @@ func testInfix17(x: Void) {
 }
 
 // VOID_OPERATORS: Begin completions
-// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  != {#()#}[#Bool#]; name=!= ()
-// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  == {#()#}[#Bool#]; name=== ()
-// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  <= {#()#}[#Bool#]; name=<= ()
-// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  >= {#()#}[#Bool#]; name=>= ()
-// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  < {#()#}[#Bool#]; name=< ()
-// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  > {#()#}[#Bool#]; name=> ()
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  != {#Void#}[#Bool#]; name=!= Void
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  == {#Void#}[#Bool#]; name=== Void
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  <= {#Void#}[#Bool#]; name=<= Void
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  >= {#Void#}[#Bool#]; name=>= Void
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  < {#Void#}[#Bool#]; name=< Void
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  > {#Void#}[#Bool#]; name=> Void
 // VOID_OPERATORS: End completions
 
 func testInfix18(x: (S2, S2) {

--- a/test/IDE/complete_trailing_closure.swift
+++ b/test/IDE/complete_trailing_closure.swift
@@ -43,12 +43,12 @@ func test1() {
 // GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global2 {|}[#Void#]
 // GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global3 {|}[' rethrows'][#Void#]
 // GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global4 {|}[#Void#]
-// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global1({#() -> ()##() -> ()#})[#Void#]
-// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global2({#label: () -> ()##() -> ()#})[#Void#]
-// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global3({#() throws -> ()##() throws -> ()#})[' rethrows'][#Void#]
-// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global4({#() -> ()##() -> ()#})[#Void#]
-// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global4({#x: Int#}, {#y: Int#}, {#() -> ()##() -> ()#})[#Void#]
-// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      nonTrivial1({#(Int) -> ()##(Int) -> ()#})[#Void#]
+// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global1({#() -> Void##() -> Void#})[#Void#]
+// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global2({#label: () -> Void##() -> Void#})[#Void#]
+// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global3({#() throws -> Void##() throws -> Void#})[' rethrows'][#Void#]
+// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global4({#() -> Void##() -> Void#})[#Void#]
+// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      global4({#x: Int#}, {#y: Int#}, {#() -> Void##() -> Void#})[#Void#]
+// GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      nonTrivial1({#(Int) -> Void##(Int) -> Void#})[#Void#]
 // GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      nonTrivial2({#() -> Int##() -> Int#})[#Void#]
 // GLOBAL_1-DAG: Decl[FreeFunction]/CurrModule:      nonTrivial3({#x: Int#}, {#() -> Int##() -> Int#})[#Void#]
 // GLOBAL_1: End completions
@@ -63,9 +63,9 @@ struct S {
   }
 // METHOD_1: Begin completions
 // METHOD_1: Decl[InstanceMethod]/CurrNominal:   method1 {|}[#Void#]
-// METHOD_1: Decl[InstanceMethod]/CurrNominal:   method1({#() -> ()##() -> ()#})[#Void#]
-// METHOD_1: Decl[InstanceMethod]/CurrNominal:   nonTrivial1({#(Int) -> ()##(Int) -> ()#})[#Void#]
-// METHOD_1: Decl[InstanceMethod]/CurrNominal:   nonTrivial2({#()#})[#Void#]
+// METHOD_1: Decl[InstanceMethod]/CurrNominal:   method1({#() -> Void##() -> Void#})[#Void#]
+// METHOD_1: Decl[InstanceMethod]/CurrNominal:   nonTrivial1({#(Int) -> Void##(Int) -> Void#})[#Void#]
+// METHOD_1: Decl[InstanceMethod]/CurrNominal:   nonTrivial2({#Void#})[#Void#]
 // METHOD_1: End completions
 
   func test3() {
@@ -93,8 +93,8 @@ class C {
   }
 // METHOD_4: Begin completions
 // METHOD_4: Decl[InstanceMethod]/CurrNominal:   method1 {|}[#Void#]
-// METHOD_4: Decl[InstanceMethod]/CurrNominal:   method1({#() -> ()##() -> ()#})[#Void#]
-// METHOD_4: Decl[InstanceMethod]/CurrNominal:   nonTrivial1({#(Int) -> ()##(Int) -> ()#})[#Void#]
+// METHOD_4: Decl[InstanceMethod]/CurrNominal:   method1({#() -> Void##() -> Void#})[#Void#]
+// METHOD_4: Decl[InstanceMethod]/CurrNominal:   nonTrivial1({#(Int) -> Void##(Int) -> Void#})[#Void#]
 // METHOD_4: End completions
 
   func test7() {

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -568,37 +568,37 @@ func testImplicitlyCurriedFunc(_ fs: inout FooStruct) {
   FooStruct.instanceFunc0(&fs)#^IMPLICITLY_CURRIED_FUNC_0^#
 // IMPLICITLY_CURRIED_FUNC_0: Begin completions
 // IMPLICITLY_CURRIED_FUNC_0-NEXT: Decl[InstanceMethod]/CurrNominal: ()[#Void#]{{; name=.+$}}
-// IMPLICITLY_CURRIED_FUNC_0-NEXT: Keyword[self]/CurrNominal: .self[#() -> ()#]; name=self
+// IMPLICITLY_CURRIED_FUNC_0-NEXT: Keyword[self]/CurrNominal: .self[#() -> Void#]; name=self
 // IMPLICITLY_CURRIED_FUNC_0-NEXT: End completions
 
   FooStruct.instanceFunc1(&fs)#^IMPLICITLY_CURRIED_FUNC_1^#
 // IMPLICITLY_CURRIED_FUNC_1: Begin completions
 // IMPLICITLY_CURRIED_FUNC_1-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Int#})[#Void#]{{; name=.+$}}
-// IMPLICITLY_CURRIED_FUNC_1-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> ()#]; name=self
+// IMPLICITLY_CURRIED_FUNC_1-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> Void#]; name=self
 // IMPLICITLY_CURRIED_FUNC_1-NEXT: End completions
 
   FooStruct.instanceFunc2(&fs)#^IMPLICITLY_CURRIED_FUNC_2^#
 // IMPLICITLY_CURRIED_FUNC_2: Begin completions
 // IMPLICITLY_CURRIED_FUNC_2-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Int#}, {#b: &Double#})[#Void#]{{; name=.+$}}
-// IMPLICITLY_CURRIED_FUNC_2-NEXT: Keyword[self]/CurrNominal: .self[#(Int, inout Double) -> ()#]; name=self
+// IMPLICITLY_CURRIED_FUNC_2-NEXT: Keyword[self]/CurrNominal: .self[#(Int, inout Double) -> Void#]; name=self
 // IMPLICITLY_CURRIED_FUNC_2-NEXT: End completions
 
   FooStruct.varargInstanceFunc0(&fs)#^IMPLICITLY_CURRIED_VARARG_FUNC_0^#
 // IMPLICITLY_CURRIED_VARARG_FUNC_0: Begin completions
 // IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(v): Int...#})[#Void#]{{; name=.+$}}
-// IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: Keyword[self]/CurrNominal: .self[#(Int...) -> ()#]; name=self
+// IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: Keyword[self]/CurrNominal: .self[#(Int...) -> Void#]; name=self
 // IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: End completions
 
   FooStruct.varargInstanceFunc1(&fs)#^IMPLICITLY_CURRIED_VARARG_FUNC_1^#
 // IMPLICITLY_CURRIED_VARARG_FUNC_1: Begin completions
 // IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Float#}, {#v: Int...#})[#Void#]{{; name=.+$}}
-// IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: Keyword[self]/CurrNominal: .self[#(Float, Int...) -> ()#]; name=self
+// IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: Keyword[self]/CurrNominal: .self[#(Float, Int...) -> Void#]; name=self
 // IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: End completions
 
   FooStruct.varargInstanceFunc2(&fs)#^IMPLICITLY_CURRIED_VARARG_FUNC_2^#
 // IMPLICITLY_CURRIED_VARARG_FUNC_2: Begin completions
 // IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Float#}, {#b: Double#}, {#v: Int...#})[#Void#]{{; name=.+$}}
-// IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: Keyword[self]/CurrNominal: .self[#(Float, Double, Int...) -> ()#]; name=self
+// IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: Keyword[self]/CurrNominal: .self[#(Float, Double, Int...) -> Void#]; name=self
 // IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: End completions
 
   // This call is ambiguous, and the expression is invalid.
@@ -1157,7 +1157,7 @@ func testFuncParenPattern3(_ fpp: inout FuncParenPattern) {
   fpp.instanceFunc#^FUNC_PAREN_PATTERN_3^#
 // FUNC_PAREN_PATTERN_3: Begin completions
 // FUNC_PAREN_PATTERN_3-NEXT: Decl[InstanceMethod]/CurrNominal: ({#Int#})[#Void#]{{; name=.+$}}
-// FUNC_PAREN_PATTERN_3-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> ()#]; name=self
+// FUNC_PAREN_PATTERN_3-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> Void#]; name=self
 // FUNC_PAREN_PATTERN_3-NEXT: End completions
 }
 
@@ -1951,7 +1951,7 @@ func testThrows002() {
   globalFuncRethrows#^THROWS2^#
 
 // THROWS2: Begin completions
-// THROWS2: Decl[FreeFunction]/CurrModule: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
+// THROWS2: Decl[FreeFunction]/CurrModule: ({#(x): () throws -> Void##() throws -> Void#})[' rethrows'][#Void#]; name=(x: () throws -> Void) rethrows
 // THROWS2: End completions
 }
 func testThrows003(_ x: HasThrowingMembers) {
@@ -1959,7 +1959,7 @@ func testThrows003(_ x: HasThrowingMembers) {
 // MEMBER_THROWS1: Begin completions
 // MEMBER_THROWS1-DAG: Decl[InstanceMethod]/CurrNominal:   memberThrows()[' throws'][#Void#]
 // MEMBER_THROWS1-DAG: Decl[InstanceMethod]/CurrNominal:   memberRethrows {|}[' rethrows'][#Void#]
-// MEMBER_THROWS1-DAG: Decl[InstanceMethod]/CurrNominal:   memberRethrows({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]
+// MEMBER_THROWS1-DAG: Decl[InstanceMethod]/CurrNominal:   memberRethrows({#(x): () throws -> Void##() throws -> Void#})[' rethrows'][#Void#]
 // MEMBER_THROWS1: End completions
 }
 func testThrows004(_ x: HasThrowingMembers) {
@@ -1971,13 +1971,13 @@ func testThrows004(_ x: HasThrowingMembers) {
 func testThrows005(_ x: HasThrowingMembers) {
   x.memberRethrows#^MEMBER_THROWS3^#
 // MEMBER_THROWS3: Begin completions
-// MEMBER_THROWS3: Decl[InstanceMethod]/CurrNominal: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
+// MEMBER_THROWS3: Decl[InstanceMethod]/CurrNominal: ({#(x): () throws -> Void##() throws -> Void#})[' rethrows'][#Void#]; name=(x: () throws -> Void) rethrows
 // MEMBER_THROWS3: End completions
 }
 func testThrows006() {
   HasThrowingMembers(#^INIT_THROWS1^#
 // INIT_THROWS1: Begin completions
-// INIT_THROWS1: Decl[Constructor]/CurrNominal:      ['(']{#x: () throws -> ()##() throws -> ()#}[')'][' rethrows'][#HasThrowingMembers#]
+// INIT_THROWS1: Decl[Constructor]/CurrNominal:      ['(']{#x: () throws -> Void##() throws -> Void#}[')'][' rethrows'][#HasThrowingMembers#]
 // INIT_THROWS1: End completions
 }
 

--- a/test/SourceKit/CodeComplete/complete_structure.swift
+++ b/test/SourceKit/CodeComplete/complete_structure.swift
@@ -42,7 +42,7 @@ func test1(_ x: S1) {
 // S1_DOT: {name:method5}({params:{t:&Int}, {n:b:}{t: &Int}})
 // FIXME: put throws in a range!
 // S1_DOT: {name:method6}({params:{l:c:}{t: Int}}){throws: throws}
-// S1_DOT: {name:method7}({params:{l:callback:}{t: () throws -> ()}}){throws: rethrows}
+// S1_DOT: {name:method7}({params:{l:callback:}{t: () throws -> Void}}){throws: rethrows}
 // S1_DOT: {name:method8}({params:{l:d:}{t: (T, U) -> T}, {n:e:}{t: (T) -> U}})
 // S1_DOT: {name:v1}
 // S1_DOT: {name:v2}


### PR DESCRIPTION
We generally prefer `Void` to `()`.
Added `PrintEmptyTupleTypeAsVoid` print option to `ASTPrinter`.
