### PR TITLE
[5.1][stdlib] Fix Set/Dictionary casting issues

### DIFF
--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -460,6 +460,28 @@ internal func KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS(
 }
 
 extension _NativeDictionary { // Insertions
+  /// Insert a new element into uniquely held storage.  Storage must be uniquely
+  /// referenced with adequate capacity.  If `allowingDuplicates` is false,
+  /// `element` must not be already present in the dictionary.
+  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
+  internal mutating func insertWithGuaranteedCapacity(
+    key: __owned Key,
+    value: __owned Value,
+    allowingDuplicates: Bool
+  ) {
+    _precondition(count < capacity)
+    if !allowingDuplicates {
+      _unsafeInsertNew(key: key, value: value)
+      return
+    }
+    let (bucket, found) = find(key)
+    if found {
+      (_values + bucket.offset).pointee = value
+    } else {
+      _insert(at: bucket, key: key, value: value)
+    }
+  }
+
   /// Insert a new element into uniquely held storage.
   /// Storage must be uniquely referenced with adequate capacity.
   /// The `key` must not be already present in the Dictionary.

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -362,7 +362,7 @@ extension _NativeSet { // Insertions
   /// The `element` must not be already present in the Set.
   @inlinable
   internal func _unsafeInsertNew(_ element: __owned Element) {
-    _precondition(count < capacity)
+    _internalInvariant(count + 1 <= capacity)
     let hashValue = self.hashValue(for: element)
     if _isDebugAssertConfiguration() {
       // In debug builds, perform a full lookup and trap if we detect duplicate

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3473,6 +3473,21 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.StringEqualityMismatch") {
   expectTrue(v == 42 || v == 23)
 }
 
+DictionaryTestSuite.test("Upcast.StringEqualityMismatch") {
+  // Upcasting from NSString to String keys changes their concept of equality,
+  // resulting in two equal keys, one of which should be discarded by the
+  // downcast. (Along with its associated value.)
+  // rdar://problem/35995647
+  let d: Dictionary<NSString, NSObject> = [
+    "cafe\u{301}": 1 as NSNumber,
+    "café": 2 as NSNumber,
+  ]
+  expectEqual(d.count, 2)
+  let d2 = d as Dictionary<String, NSObject>
+  expectEqual(d2.count, 1)
+}
+
+
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.OptionalDowncastFailure") {
   let nsd = NSDictionary(
     objects: [1 as NSNumber, 2 as NSNumber, 3 as NSNumber],

--- a/validation-test/stdlib/DictionaryTrapsObjC.swift
+++ b/validation-test/stdlib/DictionaryTrapsObjC.swift
@@ -283,7 +283,12 @@ DictionaryTraps.test("ForcedVerbatimBridge.Value")
   }
 }
 
-DictionaryTraps.test("Downcast1") {
+DictionaryTraps.test("Downcast.Verbatim")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
   let d: Dictionary<NSObject, NSObject> = [ TestObjCKeyTy(10): NSObject(),
                                             NSObject() : NSObject() ]
   let d2: Dictionary<TestObjCKeyTy, NSObject> = _dictionaryDownCast(d)
@@ -295,10 +300,11 @@ DictionaryTraps.test("Downcast1") {
   for (_, _) in d2 { }
 }
 
-DictionaryTraps.test("Downcast2")
+DictionaryTraps.test("Downcast.NonVerbatimBridged")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
   .code {
   let d: Dictionary<NSObject, NSObject> = [ TestObjCKeyTy(10): NSObject(),
                                             NSObject() : NSObject() ]

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -4714,4 +4714,116 @@ SetTestSuite.test("ForcedVerbatimBridge.Trap.NSNumber")
 }
 #endif
 
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedVerbatimDowncast.Trap.String")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let s1: Set<NSObject> = [
+    "Gordon" as NSString,
+    "William" as NSString,
+    "Katherine" as NSString,
+    "Lynn" as NSString,
+    "Brian" as NSString,
+    1756 as NSNumber]
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let s2 = s1 as! Set<NSString>
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd numeric value is caught.
+  expectCrashLater()
+  for string in s2 {
+    _ = string
+  }
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedVerbatimDowncast.Trap.Int")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let s1: Set<NSObject> = [
+    4 as NSNumber,
+    8 as NSNumber,
+    15 as NSNumber,
+    16 as NSNumber,
+    23 as NSNumber,
+    42 as NSNumber,
+    "John" as NSString]
+  // With the ObjC runtime, the verbatim downcast is O(1); it performs no
+  // runtime checks.
+  let s2 = s1 as! Set<NSNumber>
+  expectCrashLater()
+  // Element access goes through the bridged path and performs forced downcasts.
+  // This is where the odd string value is caught.
+  for string in s2 {
+    _ = string
+  }
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let s1: Set<NSObject> = [
+    "Gordon" as NSString,
+    "William" as NSString,
+    "Katherine" as NSString,
+    "Lynn" as NSString,
+    "Brian" as NSString,
+    1756 as NSNumber]
+  expectCrashLater()
+  // Nonverbatim downcasts are greedy and they trap immediately.
+  let s2 = s1 as! Set<String>
+  _ = s2.contains("Gordon")
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Could not cast value of type")
+  .code {
+  let s1: Set<NSObject> = [
+    4 as NSNumber,
+    8 as NSNumber,
+    15 as NSNumber,
+    16 as NSNumber,
+    23 as NSNumber,
+    42 as NSNumber,
+    "John" as NSString]
+  expectCrashLater()
+  // Nonverbatim downcasts are greedy and they trap immediately.
+  let s2 = s1 as! Set<Int>
+  _ = s2.contains(23)
+}
+#endif
+
+#if _runtime(_ObjC)
+SetTestSuite.test("Upcast.StringEqualityMismatch") {
+  // Upcasting from NSString to String keys changes their concept of equality,
+  // resulting in two equal keys, one of which should be discarded by the
+  // downcast. (Along with its associated value.)
+  // rdar://problem/35995647
+  let s: Set<NSString> = [
+    "cafe\u{301}",
+    "café"
+  ]
+  expectEqual(s.count, 2)
+  let s2 = s as Set<String>
+  expectEqual(s2.count, 1)
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
(Cherry-picked from https://github.com/apple/swift/pull/23683, reviewed by @Catfish-Man.)

This PR fixes `Set`/`Dictionary` casts to correctly handle casting between `String` and `NSString` keys. (`String` has a more permissive concept of equality than `NSString`, which can lead to duplicate entries when we convert `NSString`-keyed hash tables to `String`.) 

Bridging was fixed to handle this in the Swift 4 era, but the same issue can occur during casting between Swift-native `Set` and `Dictionary` types.

`Set` upcasts have been failing since Swift 4.2:

```swift
import Foundation
let s: Set<NSString> = [
    "cafe\u{301}",
    "café",
]
let s2 = s as Set<String>
```
```
⟹ Fatal error: Duplicate elements of type 'String' were found in a Set.
⟹ This usually means either that the type violates Hashable's requirements, or
⟹ that members of such a set were mutated after insertion.
```

(The trap is not guaranteed to happen immediately, or at all.)

`Dictionary` upcasts worked well up to and including Swift 5.0, but since https://github.com/apple/swift/pull/20911, they have the same issue:

```swift
import Foundation
let d: Dictionary<NSString, NSObject> = [
    "cafe\u{301}": NSObject(),
    "café": NSObject(),
]
let d2 = d as Dictionary<String, NSObject>
```
```
⟹ Fatal error: Duplicate elements of type 'String' were found in a Dictionary.
⟹ This usually means either that the type violates Hashable's requirements, or
⟹ that members of such a set were mutated after insertion.
```

These traps can also occur in downcasting situations, e.g., when casting from `NSObject` to `String` keys.

Additionally, this PR changes the forced-downcast code for sets and dictionaries to fail with a clear runtime error instead of a generic nil unwrap.

```swift
let s1: Set<AnyHashable> = ["Gordon", "William", "Katherine", "Lynn", "Brian", 1756]
let s2 = s1 as! Set<String>
```
```
⟹ before: Fatal error: Unexpectedly found nil while unwrapping an Optional value
⟹ after: Could not cast value of type 'Swift.AnyHashable' (0x110c09c48) to 'Swift.String' (0x110c0c160).
```

rdar://49444002