### PR TITLE
Revert "[TF] Make whole-tensor reductions safe for tracing"

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1259,14 +1259,16 @@ public extension Tensor where Scalar : Numeric {
     where Scalar : TensorFlowFloatingPoint
   )
   func sum() -> Tensor {
-    return Raw.sum(flattened(), reductionIndices: [0])
+    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
+    return Raw.sum(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
   func product() -> Tensor {
-    return Raw.prod(flattened(), reductionIndices: [0])
+    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
+    return Raw.prod(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer
@@ -1277,7 +1279,8 @@ public extension Tensor where Scalar : Numeric {
   )
   @inlinable @inline(__always)
   func mean() -> Tensor {
-    return Raw.mean(flattened(), reductionIndices: [0])
+    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
+    return Raw.mean(self, reductionIndices: axes)
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -179,7 +179,6 @@ TensorTests.testAllBackends("Reduction") {
   // 2 x 5
   let x = Tensor<Float>([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
   expectEqual(Tensor(30), x.sum().toHost(shape: []))
-  expectEqual(0, x.rank)
   expectEqual(Tensor(shape: [5], scalars: [2, 4, 6, 8, 10]),
               x.sum(squeezingAxes: 0).toHost(shape: []))
   expectEqual(Tensor(shape: [1, 5], scalars: [2, 4, 6, 8, 10]),


### PR DESCRIPTION
Reverts apple/swift#24009 since it broke builds.