### PR TITLE
[5.1] Undo "Disable ASan in coroutine functions; it interferes with splitting." (3a4185c).

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1218,12 +1218,8 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
   // Apply sanitizer attributes to the function.
   // TODO: Check if the function is supposed to be excluded from ASan either by
   // being in the external file or via annotations.
-  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address) {
-    // Disable ASan in coroutines; stack poisoning is not going to do
-    // reasonable things to the structural invariants.
-    if (!f->getLoweredFunctionType()->isCoroutine())
-      CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
-  }
+  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address)
+    CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
     auto declContext = f->getDeclContext();
     if (f->getLoweredFunctionType()->isCoroutine()) {

--- a/test/IRGen/asan-attributes.swift
+++ b/test/IRGen/asan-attributes.swift
@@ -1,6 +1,6 @@
 // This test verifies that we add the function attributes used by ASan.
 
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -sanitize=address %s | %FileCheck %s -check-prefix=ASAN
+// RUN: %target-swift-frontend -emit-ir -sanitize=address %s | %FileCheck %s -check-prefix=ASAN
 
 // ASAN: define {{.*}} @"$s4main4testyyF"() [[DEFAULT_ATTRS:#[0-9]+]]
 public func test() {
@@ -18,5 +18,5 @@ public var x: Int {
 // ASAN-SAME: }
 
 // ASAN: attributes [[COROUTINE_ATTRS]] =
-// ASAN-NOT: sanitize_address
+// ASAN-SAME: sanitize_address
 // ASAN-SAME: }


### PR DESCRIPTION
5.1 port of https://github.com/apple/swift/pull/23951