### PR TITLE
doc-serialization: exclude non-public decls when serializing module group info.

### DIFF
--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -367,10 +367,34 @@ static void writeDeclCommentTable(
       return StringRef(Mem, String.size());
     }
 
+    bool shouldSerializeDoc(Decl *D) {
+      if (auto *VD = dyn_cast<ValueDecl>(D)) {
+        // Skip the decl if it's not visible to clients. The use of
+        // getEffectiveAccess is unusual here; we want to take the testability
+        // state into account and emit documentation if and only if they are
+        // visible to clients (which means public ordinarily, but
+        // public+internal when testing enabled).
+        if (VD->getEffectiveAccess() < swift::AccessLevel::Public)
+          return false;
+      }
+
+      // When building the stdlib we intend to serialize unusual comments.
+      // This situation is represented by GroupContext.isEnable().  In that
+      // case, we perform more serialization to keep track of source order.
+      if (GroupContext.isEnable())
+        return true;
+
+      // Skip the decl if it cannot have a comment.
+      if (!D->canHaveComment())
+        return false;
+
+      // Skip the decl if it does not have a comment.
+      if (D->getRawComment().Comments.empty())
+        return false;
+      return true;
+    }
+
     void writeDocForExtensionDecl(ExtensionDecl *ED) {
-      RawComment Raw = ED->getRawComment();
-      if (Raw.Comments.empty() && !GroupContext.isEnable())
-        return;
       // Compute USR.
       {
         USRBuffer.clear();
@@ -379,12 +403,14 @@ static void writeDeclCommentTable(
           return;
       }
       generator.insert(copyString(USRBuffer.str()),
-                       { ED->getBriefComment(), Raw,
+                       { ED->getBriefComment(), ED->getRawComment(),
                          GroupContext.getGroupSequence(ED),
                          SourceOrder++ });
     }
 
     bool walkToDeclPre(Decl *D) override {
+      if (!shouldSerializeDoc(D))
+        return true;
       if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
         writeDocForExtensionDecl(ED);
         return true;
@@ -393,29 +419,6 @@ static void writeDeclCommentTable(
       auto *VD = dyn_cast<ValueDecl>(D);
       if (!VD)
         return true;
-
-      RawComment Raw = VD->getRawComment();
-      // When building the stdlib we intend to serialize unusual comments.
-      // This situation is represented by GroupContext.isEnable().  In that
-      // case, we perform fewer serialization checks.
-      if (!GroupContext.isEnable()) {
-        // Skip the decl if it cannot have a comment.
-        if (!VD->canHaveComment()) {
-          return true;
-        }
-
-        // Skip the decl if it does not have a comment.
-        if (Raw.Comments.empty())
-          return true;
-
-        // Skip the decl if it's not visible to clients. The use of
-        // getEffectiveAccess is unusual here; we want to take the testability
-        // state into account and emit documentation if and only if they are
-        // visible to clients (which means public ordinarily, but
-        // public+internal when testing enabled).
-        if (VD->getEffectiveAccess() < swift::AccessLevel::Public)
-          return true;
-      }
 
       // Compute USR.
       {
@@ -426,7 +429,7 @@ static void writeDeclCommentTable(
       }
 
       generator.insert(copyString(USRBuffer.str()),
-                       { VD->getBriefComment(), Raw,
+                       { VD->getBriefComment(), D->getRawComment(),
                          GroupContext.getGroupSequence(VD),
                          SourceOrder++ });
       return true;

--- a/test/Serialization/Inputs/group_info.json
+++ b/test/Serialization/Inputs/group_info.json
@@ -1,0 +1,3 @@
+{
+	"group1": ["group_info_diags.swift"]
+}

--- a/test/Serialization/group_info_diags.swift
+++ b/test/Serialization/group_info_diags.swift
@@ -4,7 +4,16 @@
 // RUN: not %target-swift-frontend -emit-module %s -module-name HasArray -o %t -module-cache-path %t/mcp -group-info-path %S/Inputs/corrupted_group_info.json -emit-module-doc &> %t/result.txt
 // RUN: %FileCheck %s -check-prefix=CORRUPTED < %t/result.txt
 
-public protocol P {}
+// RUN: %target-swift-frontend -emit-module %s -module-name HasArray -o %t -module-cache-path %t/mcp -group-info-path %S/Inputs/group_info.json -emit-module-doc &> %t/result.txt
+// RUN: strings %t/HasArray.swiftdoc > %t/doc_strings.txt
+// RUN: %FileCheck %s -check-prefix=INCLUDED < %t/doc_strings.txt
+// RUN: %FileCheck %s -check-prefix=EXCLUDED < %t/doc_strings.txt
+
+public protocol PublicProtocol {}
+
+internal class InternalClass {}
 
 // MISSING: error: cannot find group info file at path
 // CORRUPTED: error: cannot parse group info file at path
+// EXCLUDED-NOT: InternalClass
+// INCLUDED: PublicProtocol


### PR DESCRIPTION
This reduces the size of x86_64.swiftdoc about 10%.

rdar://48689311