### PR TITLE
[TF] Make whole-tensor reductions safe for tracing (fixed)

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1259,16 +1259,14 @@ public extension Tensor where Scalar : Numeric {
     where Scalar : TensorFlowFloatingPoint
   )
   func sum() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.sum(self, reductionIndices: axes)
+    return Raw.sum(flattened(), reductionIndices: Tensor<Int32>([0]))
   }
 
   // NOTE: This overload is necessary, otherwise `sum()` would refer
   // to the variadic method `sum(squeezingAxes:)` with zero indices.
   @inlinable @inline(__always)
   func product() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.prod(self, reductionIndices: axes)
+    return Raw.prod(flattened(), reductionIndices: Tensor<Int32>([0]))
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer
@@ -1279,8 +1277,7 @@ public extension Tensor where Scalar : Numeric {
   )
   @inlinable @inline(__always)
   func mean() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.mean(self, reductionIndices: axes)
+    return Raw.mean(flattened(), reductionIndices: Tensor<Int32>([0]))
   }
 
   // NOTE: This overload is necessary, otherwise `mean()` would refer


### PR DESCRIPTION
Redoes https://github.com/apple/swift/pull/24009, in a fixed way.

https://github.com/apple/swift/pull/24009 was failing typechecking. But then it decided to proceed to SILGen and crash the compiler instead of printing out a diagnostic. I have filed a bug for the crash: https://bugs.swift.org/browse/TF-432