### PR TITLE
[TF] Refactor numeric reduction ops and fix rank issues.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -577,45 +577,6 @@ public extension Tensor where Scalar : FloatingPoint & Equatable {
   }
 }
 
-public extension Tensor where Scalar : TensorFlowFloatingPoint {
-  // TODO: standardDeviation() should handle non floating point Tensors.
-
-  /// Returns the standard deviation of the elements along the specified axes.
-  /// The reduced dimensions are retained with value `1`. Does not apply
-  /// Bessel's correction.
-  ///
-  /// - Parameter axes: The dimensions to reduce.
-  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
-  @differentiable(wrt: self)
-  func standardDeviation() -> Tensor {
-    // Reduce along all dimensions.
-    return standardDeviation(alongAxes: Array(0..<shape.rank))
-  }
-
-  /// Returns the standard deviation of the elements along the specified axes.
-  /// The reduced dimensions are retained with value `1`. Does not apply
-  /// Bessel's correction.
-  ///
-  /// - Parameter axes: The dimensions to reduce.
-  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
-  @differentiable(wrt: self)
-  func standardDeviation(alongAxes axes: Int32...) -> Tensor {
-    return standardDeviation(alongAxes: axes)
-  }
-
-  /// Returns the standard deviation of the elements along the specified axes.
-  /// The reduced dimensions are retained with value `1`. Does not apply
-  /// Bessel's correction.
-  ///
-  /// - Parameter axes: The dimensions to reduce.
-  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
-  @inlinable @inline(__always)
-  @differentiable(wrt: self)
-  func standardDeviation(alongAxes axes: [Int32]) -> Tensor {
-    return sqrt(variance(alongAxes: axes))
-  }
-}
-
 public extension Tensor where Scalar == Bool {
   /// Computes `!self` element-wise.
   @inlinable @inline(__always)
@@ -702,7 +663,6 @@ public extension Tensor {
     return transposed(withPermutations: Tensor<Int32>(defaultPermutations))
   }
 }
-
 
 public extension Tensor {
   /// Concatenates tensors along the specified axis.
@@ -1462,16 +1422,6 @@ public extension Tensor where Scalar : Numeric {
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
-  func variance(alongAxes axes: Int32...) -> Tensor {
-    return variance(alongAxes: axes)
-  }
-
-  /// Returns the variance along the specified axes. The reduced dimensions are
-  /// retained with value 1. Does not apply Bessel's correction.
-  /// - Parameter axes: The dimensions to reduce.
-  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
-  @inlinable @inline(__always)
-  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func variance(alongAxes axes: Tensor<Int32>) -> Tensor {
     let mean = self.mean(alongAxes: axes)
     let squaredDiff = (self - mean).squared()
@@ -1486,6 +1436,101 @@ public extension Tensor where Scalar : Numeric {
   @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func variance(alongAxes axes: [Int32]) -> Tensor {
     return variance(alongAxes: Tensor<Int32>(axes))
+  }
+
+  /// Returns the variance along the specified axes. The reduced dimensions are
+  /// retained with value 1. Does not apply Bessel's correction.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
+  func variance(alongAxes axes: Int32...) -> Tensor {
+    return variance(alongAxes: axes)
+  }
+}
+
+// TODO: Consider making the return type be generic over `FloatingPoint` types
+// so that `self`'s scalar type can be any `Numeric` type.
+public extension Tensor where Scalar : TensorFlowFloatingPoint {
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @differentiable(wrt: self)
+  func standardDeviation() -> Tensor {
+    // Reduce along all dimensions.
+    return standardDeviation(squeezingAxes: Array(0..<shape.rank))
+  }
+
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self)
+  func standardDeviation(squeezingAxes axes: Tensor<Int32>) -> Tensor {
+    return sqrt(variance(squeezingAxes: axes))
+  }
+
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self)
+  func standardDeviation(squeezingAxes axes: [Int32]) -> Tensor {
+    return sqrt(variance(squeezingAxes: axes))
+  }
+
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @differentiable(wrt: self)
+  func standardDeviation(squeezingAxes axes: Int32...) -> Tensor {
+    return standardDeviation(squeezingAxes: axes)
+  }
+
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @differentiable(wrt: self)
+  func standardDeviation(alongAxes axes: Tensor<Int32>) -> Tensor {
+    return sqrt(variance(alongAxes: axes))
+  }
+
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @differentiable(wrt: self)
+  func standardDeviation(alongAxes axes: [Int32]) -> Tensor {
+    return standardDeviation(alongAxes: Tensor<Int32>(axes))
+  }
+
+  /// Returns the standard deviation of the elements along the specified axes.
+  /// The reduced dimensions are retained with value `1`. Does not apply
+  /// Bessel's correction.
+  ///
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  @differentiable(wrt: self)
+  func standardDeviation(alongAxes axes: Int32...) -> Tensor {
+    return sqrt(variance(alongAxes: axes))
   }
 }
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -300,11 +300,9 @@ TensorTests.testAllBackends("SimpleMath") {
 }
 
 TensorTests.testAllBackends("StandardDeviation") {
-  expectEqual(0, Tensor<Float>([1]).standardDeviation().scalarized())
-  expectEqual(
-    0.5,
-    Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0).scalarized())
-  expectEqual(0.5, Tensor<Float>([0, 1]).standardDeviation().scalarized())
+  expectEqual(Tensor(0), Tensor<Float>([1]).standardDeviation())
+  expectEqual(Tensor(0.5), Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0))
+  expectEqual(Tensor(0.5), Tensor<Float>([0, 1]).standardDeviation())
   expectNearlyEqual(
     2.87228132,
     Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).standardDeviation().scalarized(),


### PR DESCRIPTION
Refactor all numeric reduction ops so that they have a "squeezing" version, an "along" version, and a nullary version that performs squeezing on all dimensions.

Also:
* Add `standardDeviation(squeezingAxes:)` APIs.
* Add a variant of `standardDeviation` APIs that take a `Tensor<Int32>` as axes, since `variance` has those.
* Reorder some reduction ops so that their `squeezing` version comes before their nullary version, which then comes before their `along` version. Make sure their polymorphic overloads are ordered as tensor-taking (base implementation), array-taking, and variadics-taking.
* `standardDeviation()` should return a scalar tensor like all other reduction ops. It is fixed in this PR.

Resolves [an issue reported on the fast.ai forum](https://forums.fast.ai/t/standarddeviation-doesnt-return-a-rank-0-tensor/43808/2).