### PR TITLE
Temporarily disable stdlib tests depending on autorelease elision.

### DIFF
--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -988,7 +988,16 @@ ArrayTestSuite.test("BridgedToObjC/Custom/ObjectEnumerator/FastEnumeration/UseFr
   expectEqual(3, TestBridgedValueTy.bridgeOperations)
 }
 
-ArrayTestSuite.test("BridgedToObjC/Custom/BridgeBack/Cast") {
+ArrayTestSuite.test("BridgedToObjC/Custom/BridgeBack/Cast")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
   let a = getBridgedNSArrayOfValueTypeCustomBridged(numElements: 3)
 
   var v: AnyObject = a[0] as AnyObject

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3222,7 +3222,16 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
 }
 
 
-DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_ParallelArray") {
+DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_ParallelArray")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
 autoreleasepoolIfUnoptimizedReturnAutoreleased {
   // Add an autorelease pool because ParallelArrayDictionary autoreleases
   // values in objectForKey.
@@ -4283,7 +4292,16 @@ DictionaryTestSuite.test("DictionaryUpcastBridged") {
 // Dictionary downcasts
 //===---
 
-DictionaryTestSuite.test("DictionaryDowncastEntryPoint") {
+DictionaryTestSuite.test("DictionaryDowncastEntryPoint")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
   var d = Dictionary<NSObject, AnyObject>(minimumCapacity: 32)
   d[TestObjCKeyTy(10)] = TestObjCValueTy(1010)
   d[TestObjCKeyTy(20)] = TestObjCValueTy(1020)
@@ -4304,7 +4322,16 @@ DictionaryTestSuite.test("DictionaryDowncastEntryPoint") {
   expectAutoreleasedKeysAndValues(unopt: (0, 3))
 }
 
-DictionaryTestSuite.test("DictionaryDowncast") {
+DictionaryTestSuite.test("DictionaryDowncast")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
   var d = Dictionary<NSObject, AnyObject>(minimumCapacity: 32)
   d[TestObjCKeyTy(10)] = TestObjCValueTy(1010)
   d[TestObjCKeyTy(20)] = TestObjCValueTy(1020)

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2646,7 +2646,16 @@ SetTestSuite.test("SetUpcastBridged") {
 // Set downcasts
 //
 
-SetTestSuite.test("SetDowncastEntryPoint") {
+SetTestSuite.test("SetDowncastEntryPoint")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
   var s = Set<NSObject>(minimumCapacity: 32)
   for i in [1010, 2020, 3030] {
       s.insert(TestObjCKeyTy(i))
@@ -2662,7 +2671,16 @@ SetTestSuite.test("SetDowncastEntryPoint") {
   expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
 
-SetTestSuite.test("SetDowncast") {
+SetTestSuite.test("SetDowncast")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
   var s = Set<NSObject>(minimumCapacity: 32)
   for i in [1010, 2020, 3030] {
       s.insert(TestObjCKeyTy(i))
@@ -2738,7 +2756,16 @@ SetTestSuite.test("SetBridgeFromObjectiveCEntryPoint") {
   }
 }
 
-SetTestSuite.test("SetBridgeFromObjectiveC") {
+SetTestSuite.test("SetBridgeFromObjectiveC")
+  .skip(.custom(
+    {
+#if os(iOS)
+      return true
+#else
+      return false
+#endif
+    }, reason: "Autorelease Failure. rdar://49791522"))
+.code {
   var s = Set<NSObject>(minimumCapacity: 32)
   for i in [1010, 2020, 3030] {
       s.insert(TestObjCKeyTy(i))


### PR DESCRIPTION
Until the issue is fixed. Tracked by:
<rdar://problem/49791522> Swift CI Test failures: IRGen/autorelease_optimized_armv7/aarch64.
https://bugs.swift.org/browse/SR-10474