### PR TITLE
[5.1] [ModuleInterfaces] Rename 'parseable interfaces' to 'module interfaces'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -606,16 +606,16 @@ ERROR(sema_opening_import,Fatal,
 ERROR(serialization_load_failed,Fatal,
       "failed to load module %0", (Identifier))
 ERROR(serialization_malformed_module,Fatal,
-      "malformed module file: %0", (StringRef))
+      "malformed compiled module: %0", (StringRef))
 ERROR(serialization_module_too_new,Fatal,
-      "module file was created by a newer version of the compiler: %0",
+      "compiled module was created by a newer version of the compiler: %0",
       (StringRef))
 ERROR(serialization_module_language_version_mismatch,Fatal,
       "module compiled with Swift %0 cannot be imported by the Swift %1 "
       "compiler: %2",
       (StringRef, StringRef, StringRef))
 ERROR(serialization_module_too_old,Fatal,
-      "module file was created by an older version of the compiler; "
+      "compiled module was created by an older version of the compiler; "
       "rebuild %0 and try again: %1",
       (Identifier, StringRef))
 ERROR(serialization_missing_single_dependency,Fatal,

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -131,7 +131,7 @@ public:
     MergeModules,   ///< Merge modules only
 
     /// Build from a swiftinterface, as close to `import` as possible
-    BuildModuleFromParseableInterface,
+    CompileModuleFromInterface,
 
     EmitSIBGen, ///< Emit serialized AST + raw SIL
     EmitSIB,    ///< Emit serialized AST + canonical SIL
@@ -269,8 +269,8 @@ public:
   bool TrackSystemDeps = false;
 
   /// Should we serialize the hashes of dependencies (vs. the modification
-  /// times) when compiling a parseable module interface?
-  bool SerializeParseableModuleInterfaceDependencyHashes = false;
+  /// times) when compiling a module interface?
+  bool SerializeModuleInterfaceDependencyHashes = false;
 
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -59,13 +59,13 @@ def emit_fixits_path
   : Separate<["-"], "emit-fixits-path">, MetaVarName<"<path>">,
     HelpText<"Output compiler fixits as source edits to <path>">;
 
-// For transition purposes.
-def emit_interface_path
-  : Separate<["-"], "emit-interface-path">,
-    Alias<emit_parseable_module_interface_path>;
+def serialize_module_interface_dependency_hashes
+  : Flag<["-"], "serialize-module-interface-dependency-hashes">,
+    Flags<[HelpHidden]>;
 
 def serialize_parseable_module_interface_dependency_hashes
   : Flag<["-"], "serialize-parseable-module-interface-dependency-hashes">,
+    Alias<serialize_module_interface_dependency_hashes>,
     Flags<[HelpHidden]>;
 
 def tbd_install_name
@@ -153,8 +153,8 @@ def debug_crash_Group : OptionGroup<"<automatic crashing options>">;
 class DebugCrashOpt : Group<debug_crash_Group>;
 
 
-// Flags that are saved into parseable interfaces
-let Flags = [FrontendOption, NoDriverOption, HelpHidden, ParseableInterfaceOption] in {
+// Flags that are saved into module interfaces
+let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOption] in {
 
 def enable_objc_interop :
   Flag<["-"], "enable-objc-interop">,
@@ -512,14 +512,19 @@ def dump_interface_hash : Flag<["-"], "dump-interface-hash">,
    HelpText<"Parse input file(s) and dump interface token hash(es)">,
    ModeOpt;
 
+def compile_module_from_interface :
+  Flag<["-"], "compile-module-from-interface">,
+  HelpText<"Treat the (single) input as a swiftinterface and produce a module">,
+  ModeOpt;
+
 def build_module_from_parseable_interface :
   Flag<["-"], "build-module-from-parseable-interface">,
-  HelpText<"Treat the (single) input as a swiftinterface and produce a module">,
+  Alias<compile_module_from_interface>,
   ModeOpt;
 
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,
-  HelpText<"Directory of prebuilt modules for loading parseable interfaces">;
+  HelpText<"Directory of prebuilt modules for loading module interfaces">;
 def prebuilt_module_cache_path_EQ :
   Joined<["-"], "prebuilt-module-cache-path=">,
   Alias<prebuilt_module_cache_path>;

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -35,7 +35,7 @@ namespace options {
     ModuleWrapOption = (1 << 10),
     SwiftFormatOption = (1 << 11),
     ArgumentIsPath = (1 << 12),
-    ParseableInterfaceOption = (1 << 13),
+    ModuleInterfaceOption = (1 << 13),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -47,9 +47,9 @@ def DoesNotAffectIncrementalBuild : OptionFlag;
 // current working directory.
 def ArgumentIsPath : OptionFlag;
 
-// The option should be written into a .swiftinterface parseable interface file,
+// The option should be written into a .swiftinterface module interface file,
 // and read/parsed from there when reconstituting a .swiftmodule from it.
-def ParseableInterfaceOption : OptionFlag;
+def ModuleInterfaceOption : OptionFlag;
 
 /////////
 // Options
@@ -183,12 +183,12 @@ def j : JoinedOrSeparate<["-"], "j">, Flags<[DoesNotAffectIncrementalBuild]>,
 def sdk : Separate<["-"], "sdk">, Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Compile against <sdk>">, MetaVarName<"<sdk>">;
 
-def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, ParseableInterfaceOption]>,
+def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
 def package_description_version: Separate<["-"], "package-description-version">,
-  Flags<[FrontendOption, HelpHidden, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"The version number to be applied on the input for the PackageDescription availability kind">,
   MetaVarName<"<vers>">;
 
@@ -306,17 +306,17 @@ def module_cache_path : Separate<["-"], "module-cache-path">,
   HelpText<"Specifies the Clang module cache path">;
 
 def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Build the module to allow binary-compatible library evolution">;
 
 def module_name : Separate<["-"], "module-name">,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Name of the module to build">;
 def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
 
 def module_link_name : Separate<["-"], "module-link-name">,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Library to link against when using this module">;
 def module_link_name_EQ : Joined<["-"], "module-link-name=">,
   Flags<[FrontendOption]>, Alias<module_link_name>;
@@ -337,15 +337,25 @@ def emit_module_path_EQ : Joined<["-"], "emit-module-path=">,
          ArgumentIsPath]>,
   Alias<emit_module_path>;
 
-def emit_parseable_module_interface :
-  Flag<["-"], "emit-parseable-module-interface">,
+def emit_module_interface :
+  Flag<["-"], "emit-module-interface">,
   Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Output parseable interface file">;
-def emit_parseable_module_interface_path :
-  Separate<["-"], "emit-parseable-module-interface-path">,
+  HelpText<"Output module interface file">;
+def emit_module_interface_path :
+  Separate<["-"], "emit-module-interface-path">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
          ArgumentIsPath]>,
-  MetaVarName<"<path>">, HelpText<"Output parseable interface file to <path>">;
+  MetaVarName<"<path>">, HelpText<"Output module interface file to <path>">;
+
+def emit_parseable_module_interface :
+  Flag<["-"], "emit-parseable-module-interface">,
+  Alias<emit_module_interface>,
+  Flags<[NoInteractiveOption, HelpHidden, DoesNotAffectIncrementalBuild]>;
+def emit_parseable_module_interface_path :
+  Separate<["-"], "emit-parseable-module-interface-path">,
+  Alias<emit_module_interface_path>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         HelpHidden, ArgumentIsPath]>;
 
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
@@ -492,19 +502,19 @@ def Xlinker : Separate<["-"], "Xlinker">,
 def O_Group : OptionGroup<"<optimization level options>">;
 
 def Onone : Flag<["-"], "Onone">, Group<O_Group>,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile without any optimization">;
 def O : Flag<["-"], "O">, Group<O_Group>,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile with optimizations">;
 def Osize : Flag<["-"], "Osize">, Group<O_Group>,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile with optimizations and target small code size">;
 def Ounchecked : Flag<["-"], "Ounchecked">, Group<O_Group>,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile with optimizations and remove runtime safety checks">;
 def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
-  Flags<[HelpHidden, FrontendOption, ParseableInterfaceOption]>,
+  Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile with optimizations appropriate for a playground">;
 
 def RemoveRuntimeAsserts : Flag<["-"], "remove-runtime-asserts">,
@@ -650,7 +660,7 @@ def parse_sil : Flag<["-"], "parse-sil">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Parse the input file as SIL code, not Swift source">;
 def parse_stdlib : Flag<["-"], "parse-stdlib">,
-  Flags<[FrontendOption, HelpHidden, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"Parse the input file(s) as the Swift standard library">;
 
 def modes_Group : OptionGroup<"<mode options>">, HelpText<"MODES">;
@@ -791,12 +801,12 @@ def resource_dir : Separate<["-"], "resource-dir">,
   HelpText<"The directory that holds the compiler resource files">;
 
 def target : Separate<["-"], "target">,
-  Flags<[FrontendOption, ModuleWrapOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption]>,
   HelpText<"Generate code for the given target">;
 def target_legacy_spelling : Joined<["--"], "target=">,
   Flags<[FrontendOption]>, Alias<target>;
 
-def target_cpu : Separate<["-"], "target-cpu">, Flags<[FrontendOption, ParseableInterfaceOption]>,
+def target_cpu : Separate<["-"], "target-cpu">, Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Generate code for a particular CPU variant">;
 
 def profile_generate : Flag<["-"], "profile-generate">,
@@ -855,7 +865,7 @@ def index_ignore_system_modules : Flag<["-"], "index-ignore-system-modules">,
   HelpText<"Avoid indexing system modules">;
 
 def enforce_exclusivity_EQ : Joined<["-"], "enforce-exclusivity=">,
-  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   MetaVarName<"<enforcement>">,
   HelpText<"Enforce law of exclusivity">;
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -127,8 +127,8 @@ static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
   if (args.hasArgNoClaim(options::OPT_import_underlying_module))
     diags.diagnose({}, diag::error_framework_bridging_header);
 
-  if (args.hasArgNoClaim(options::OPT_emit_parseable_module_interface,
-                         options::OPT_emit_parseable_module_interface_path)) {
+  if (args.hasArgNoClaim(options::OPT_emit_module_interface,
+                         options::OPT_emit_module_interface_path)) {
     diags.diagnose({}, diag::error_bridging_header_parseable_interface);
   }
 }
@@ -1522,8 +1522,8 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     OI.ShouldTreatModuleAsTopLevelOutput = false;
   } else if (Args.hasArg(options::OPT_emit_objc_header,
                          options::OPT_emit_objc_header_path,
-                         options::OPT_emit_parseable_module_interface,
-                         options::OPT_emit_parseable_module_interface_path) &&
+                         options::OPT_emit_module_interface,
+                         options::OPT_emit_module_interface_path) &&
              OI.CompilerMode != OutputInfo::Mode::SingleCompile) {
     // An option has been passed which requires whole-module knowledge, but we
     // don't have that. Generate a module, but treat it as an intermediate
@@ -2509,8 +2509,8 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     chooseSwiftModuleDocOutputPath(C, OutputMap, workingDirectory,
                                    Output.get());
 
-  if (C.getArgs().hasArg(options::OPT_emit_parseable_module_interface,
-                         options::OPT_emit_parseable_module_interface_path))
+  if (C.getArgs().hasArg(options::OPT_emit_module_interface,
+                         options::OPT_emit_module_interface_path))
     chooseParseableInterfacePath(C, JA, workingDirectory, Buf, Output.get());
 
   if (C.getArgs().hasArg(options::OPT_update_code) && isa<CompileJobAction>(JA))
@@ -2829,7 +2829,7 @@ void Driver::chooseParseableInterfacePath(Compilation &C, const JobAction *JA,
 
   StringRef outputPath = *getOutputFilenameFromPathArgOrAsTopLevel(
       C.getOutputInfo(), C.getArgs(),
-      options::OPT_emit_parseable_module_interface_path,
+      options::OPT_emit_module_interface_path,
       file_types::TY_SwiftParseableInterfaceFile,
       /*TreatAsTopLevelOutput*/true, workingDirectory, buffer);
   output->setAdditionalOutputForType(file_types::TY_SwiftParseableInterfaceFile,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -80,8 +80,8 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.TrackSystemDeps |= Args.hasArg(OPT_track_system_dependencies);
 
-  Opts.SerializeParseableModuleInterfaceDependencyHashes |=
-    Args.hasArg(OPT_serialize_parseable_module_interface_dependency_hashes);
+  Opts.SerializeModuleInterfaceDependencyHashes |=
+    Args.hasArg(OPT_serialize_module_interface_dependency_hashes);
 
   computePrintStatsOptions();
   computeDebugTimeOptions();
@@ -380,8 +380,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::REPL;
   if (Opt.matches(OPT_interpret))
     return FrontendOptions::ActionType::Immediate;
-  if (Opt.matches(OPT_build_module_from_parseable_interface))
-    return FrontendOptions::ActionType::BuildModuleFromParseableInterface;
+  if (Opt.matches(OPT_compile_module_from_interface))
+    return FrontendOptions::ActionType::CompileModuleFromInterface;
 
   llvm_unreachable("Unhandled mode option");
 }

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -295,7 +295,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_loaded_module_trace_path);
   auto TBD = getSupplementaryFilenamesFromArguments(options::OPT_emit_tbd_path);
   auto parseableInterfaceOutput = getSupplementaryFilenamesFromArguments(
-      options::OPT_emit_parseable_module_interface_path);
+      options::OPT_emit_module_interface_path);
 
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
@@ -515,7 +515,7 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
         options::OPT_emit_reference_dependencies_path,
         options::OPT_serialize_diagnostics_path,
         options::OPT_emit_loaded_module_trace_path,
-        options::OPT_emit_parseable_module_interface_path,
+        options::OPT_emit_module_interface_path,
         options::OPT_emit_tbd_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -178,7 +178,7 @@ static void PrintArg(raw_ostream &OS, const char *Arg, StringRef TempDir) {
   OS << '"';
 }
 
-/// Save a copy of any flags marked as ParseableInterfaceOption, if running
+/// Save a copy of any flags marked as ModuleInterfaceOption, if running
 /// in a mode that is going to emit a .swiftinterface file.
 static void SaveParseableInterfaceArgs(ParseableInterfaceOptions &Opts,
                                        FrontendOptions &FOpts,
@@ -187,7 +187,7 @@ static void SaveParseableInterfaceArgs(ParseableInterfaceOptions &Opts,
     return;
   ArgStringList RenderedArgs;
   for (auto A : Args) {
-    if (A->getOption().hasFlag(options::ParseableInterfaceOption))
+    if (A->getOption().hasFlag(options::ModuleInterfaceOption))
       A->render(Args, RenderedArgs);
   }
   llvm::raw_string_ostream OS(Opts.ParseableInterfaceFlags);

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -48,7 +48,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::EmitSIB:
   case ActionType::EmitModuleOnly:
   case ActionType::MergeModules:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
     return true;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -84,7 +84,7 @@ bool FrontendOptions::isActionImmediate(ActionType action) {
   case ActionType::EmitSIB:
   case ActionType::EmitModuleOnly:
   case ActionType::MergeModules:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
     return false;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -172,7 +172,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
 
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
     return TY_SwiftModuleFile;
 
   case ActionType::Immediate:
@@ -210,7 +210,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -246,7 +246,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -282,7 +282,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -315,7 +315,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -354,7 +354,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -394,7 +394,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
@@ -436,7 +436,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitObject:
   case ActionType::EmitImportedModules:
   case ActionType::MergeModules:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::DumpTypeInfo:
     return true;
 
@@ -456,7 +456,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::EmitSIB:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
   case ActionType::EmitBC:
   case ActionType::EmitObject:
   case ActionType::Immediate:
@@ -499,7 +499,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
-  case ActionType::BuildModuleFromParseableInterface:
+  case ActionType::CompileModuleFromInterface:
     return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -322,7 +322,7 @@ class swift::ParseableInterfaceBuilder {
 
     // Tell the subinvocation to serialize dependency hashes if asked to do so.
     auto &frontendOpts = subInvocation.getFrontendOptions();
-    frontendOpts.SerializeParseableModuleInterfaceDependencyHashes =
+    frontendOpts.SerializeModuleInterfaceDependencyHashes =
       serializeDependencyHashes;
   }
 
@@ -563,7 +563,7 @@ public:
       SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
       SmallVector<FileDependency, 16> Deps;
       if (collectDepsForSerialization(SubInstance, Deps,
-            FEOpts.SerializeParseableModuleInterfaceDependencyHashes)) {
+            FEOpts.SerializeModuleInterfaceDependencyHashes)) {
         SubError = true;
         return;
       }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -588,7 +588,7 @@ static bool buildModuleFromParseableInterface(CompilerInvocation &Invocation,
       Instance.getASTContext(), Invocation.getClangModuleCachePath(),
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
-      FEOpts.SerializeParseableModuleInterfaceDependencyHashes,
+      FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.TrackSystemDeps);
 }
 
@@ -962,7 +962,7 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::ActionType::EmitPCH)
     return precompileBridgingHeader(Invocation, Instance);
 
-  if (Action == FrontendOptions::ActionType::BuildModuleFromParseableInterface)
+  if (Action == FrontendOptions::ActionType::CompileModuleFromInterface)
     return buildModuleFromParseableInterface(Invocation, Instance);
 
   if (Invocation.getInputKind() == InputFileKind::LLVM)

--- a/test/Driver/imported_modules_bridging_header.swift
+++ b/test/Driver/imported_modules_bridging_header.swift
@@ -4,6 +4,6 @@
 
 // Confirm that the compiler does look for/find the bad overlay during a normal
 // compilation, and thus validate that -emit-imported-modules doesn't.
-// CHECK: malformed module file: {{.*}}InvalidOverlay.swiftmodule
+// CHECK: malformed compiled module: {{.*}}InvalidOverlay.swiftmodule
 
 // REQUIRES: objc_interop

--- a/test/Interpreter/SDK/missing_imports_repl.swift
+++ b/test/Interpreter/SDK/missing_imports_repl.swift
@@ -33,7 +33,7 @@ MKMapRectIsNull(x)
 
 
 import Corrupted_Module
-// CHECK-ERROR: error: malformed module file
+// CHECK-ERROR: error: malformed compiled module
 
 "unreached"
 // CHECK-NOT: unreached

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-archs.swift
@@ -93,7 +93,7 @@
 
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
-// BAD-MODULE: [[@LINE-2]]:8: error: malformed module file: {{.*}}Lib.swiftmodule
+// BAD-MODULE: [[@LINE-2]]:8: error: malformed compiled module: {{.*}}Lib.swiftmodule
 // WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: garbage
 
 struct X {}

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode-framework.swift
@@ -94,7 +94,7 @@
 
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
-// BAD-MODULE: [[@LINE-2]]:8: error: malformed module file: {{.*}}Lib.swiftmodule
+// BAD-MODULE: [[@LINE-2]]:8: error: malformed compiled module: {{.*}}Lib.swiftmodule
 // WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: garbage
 
 struct X {}

--- a/test/ParseableInterface/ModuleCache/force-module-loading-mode.swift
+++ b/test/ParseableInterface/ModuleCache/force-module-loading-mode.swift
@@ -69,7 +69,7 @@
 
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
-// BAD-MODULE: [[@LINE-2]]:8: error: malformed module file: {{.*}}Lib.swiftmodule
+// BAD-MODULE: [[@LINE-2]]:8: error: malformed compiled module: {{.*}}Lib.swiftmodule
 
 struct X {}
 let _: X = Lib.testValue

--- a/test/Serialization/load-arch-fallback-framework.swift
+++ b/test/Serialization/load-arch-fallback-framework.swift
@@ -15,4 +15,4 @@
 // REQUIRES: CPU=armv7 || CPU=armv7k || CPU=armv7s
 
 import empty
-// CHECK: :[[@LINE-1]]:8: error: malformed module file: {{.*}}arm.swiftmodule
+// CHECK: :[[@LINE-1]]:8: error: malformed compiled module: {{.*}}arm.swiftmodule

--- a/test/Serialization/load-arch-fallback.swift
+++ b/test/Serialization/load-arch-fallback.swift
@@ -15,4 +15,4 @@
 // REQUIRES: CPU=armv7 || CPU=armv7k || CPU=armv7s
 
 import empty
-// CHECK: :[[@LINE-1]]:8: error: malformed module file: {{.*}}arm.swiftmodule
+// CHECK: :[[@LINE-1]]:8: error: malformed compiled module: {{.*}}arm.swiftmodule

--- a/test/Serialization/load-invalid-doc.swift
+++ b/test/Serialization/load-invalid-doc.swift
@@ -14,4 +14,4 @@
 // RUN: echo -n 'abcde' > %t/empty.swiftdoc
 // RUN: %target-swift-frontend -typecheck -I %t %s -verify -show-diagnostics-after-fatal
 
-import empty // expected-error{{malformed module file}}
+import empty // expected-error{{malformed compiled module}}

--- a/test/Serialization/load-invalid.swift
+++ b/test/Serialization/load-invalid.swift
@@ -12,7 +12,7 @@
 // RUN: echo -n 'abcde' > %t/new_module.swiftmodule
 // RUN: %target-swift-frontend %s -typecheck -I %t -verify -show-diagnostics-after-fatal
 
-import new_module // expected-error{{malformed module file}}
+import new_module // expected-error{{malformed compiled module}}
 
 // malformed module files produce an empty module to avoid further errors.
 new_module.foo() // expected-error {{module 'new_module' has no member named 'foo'}}

--- a/test/Serialization/load-wrong-name-doc.swift
+++ b/test/Serialization/load-wrong-name-doc.swift
@@ -6,4 +6,4 @@
 // RUN: mv %t/empty.swiftdoc %t/empty2.swiftdoc
 // RUN: %target-swift-frontend -typecheck -I %t %s -verify -show-diagnostics-after-fatal
 
-import empty2 // expected-error{{malformed module file}}
+import empty2 // expected-error{{malformed compiled module}}

--- a/test/Serialization/swiftdoc-versions.swift
+++ b/test/Serialization/swiftdoc-versions.swift
@@ -17,4 +17,4 @@
 // RUN: cp %S/Inputs/swiftdoc-versions/empty-0.7.swiftdoc %t/empty.swiftdoc
 // RUN: %target-swift-frontend -typecheck -I %t %s -verify -show-diagnostics-after-fatal
 
-import empty // expected-error{{malformed module file}}
+import empty // expected-error{{malformed compiled module}}

--- a/test/Serialization/version-mismatches.swift
+++ b/test/Serialization/version-mismatches.swift
@@ -8,8 +8,8 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
 
 import Library
-// TOO-OLD: :[[@LINE-1]]:8: error: module file was created by an older version of the compiler; rebuild 'Library' and try again: {{.*}}too-old/Library.swiftmodule{{$}}
-// TOO-NEW: :[[@LINE-2]]:8: error: module file was created by a newer version of the compiler: {{.*}}too-new/Library.swiftmodule{{$}}
+// TOO-OLD: :[[@LINE-1]]:8: error: compiled module was created by an older version of the compiler; rebuild 'Library' and try again: {{.*}}too-old/Library.swiftmodule{{$}}
+// TOO-NEW: :[[@LINE-2]]:8: error: compiled module was created by a newer version of the compiler: {{.*}}too-new/Library.swiftmodule{{$}}
 
 // Update this line when the compiler version changes.
 // LANGUAGE: :[[@LINE-5]]:8: error: module compiled with Swift X.Y cannot be imported by the Swift 5.{{.+}} compiler: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}


### PR DESCRIPTION
Cherry-pick of #23969 to 5.1.