### PR TITLE
[stdlib] fix prototype declaration in RuntimeShims.h

### DIFF
--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -57,7 +57,7 @@ SWIFT_RUNTIME_STDLIB_API
 int _swift_stdlib_putc_stderr(int C);
 
 SWIFT_RUNTIME_STDLIB_API
-__swift_size_t _swift_stdlib_getHardwareConcurrency();
+__swift_size_t _swift_stdlib_getHardwareConcurrency(void);
 
 /// Manually allocated memory is at least 16-byte aligned in Swift.
 ///


### PR DESCRIPTION
_swift_stdlib_getHardwareConcurrency's declaration isn't a proper prototype: it's missing `void` inside the brackets.

Found while compiling the stdlib to WebAssembly, which fails with:

`Functions with 'no-prototype' attribute must take varargs: _swift_stdlib_getHardwareConcurrency`

This shouldn't impact existing platforms.