### PR TITLE
Revert "Temporarily disable stdlib tests depending on autorelease elision."

### DIFF
--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -988,16 +988,7 @@ ArrayTestSuite.test("BridgedToObjC/Custom/ObjectEnumerator/FastEnumeration/UseFr
   expectEqual(3, TestBridgedValueTy.bridgeOperations)
 }
 
-ArrayTestSuite.test("BridgedToObjC/Custom/BridgeBack/Cast")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+ArrayTestSuite.test("BridgedToObjC/Custom/BridgeBack/Cast") {
   let a = getBridgedNSArrayOfValueTypeCustomBridged(numElements: 3)
 
   var v: AnyObject = a[0] as AnyObject

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3222,16 +3222,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
 }
 
 
-DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_ParallelArray")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_ParallelArray") {
 autoreleasepoolIfUnoptimizedReturnAutoreleased {
   // Add an autorelease pool because ParallelArrayDictionary autoreleases
   // values in objectForKey.
@@ -4292,16 +4283,7 @@ DictionaryTestSuite.test("DictionaryUpcastBridged") {
 // Dictionary downcasts
 //===---
 
-DictionaryTestSuite.test("DictionaryDowncastEntryPoint")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+DictionaryTestSuite.test("DictionaryDowncastEntryPoint") {
   var d = Dictionary<NSObject, AnyObject>(minimumCapacity: 32)
   d[TestObjCKeyTy(10)] = TestObjCValueTy(1010)
   d[TestObjCKeyTy(20)] = TestObjCValueTy(1020)
@@ -4322,16 +4304,7 @@ DictionaryTestSuite.test("DictionaryDowncastEntryPoint")
   expectAutoreleasedKeysAndValues(unopt: (0, 3))
 }
 
-DictionaryTestSuite.test("DictionaryDowncast")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+DictionaryTestSuite.test("DictionaryDowncast") {
   var d = Dictionary<NSObject, AnyObject>(minimumCapacity: 32)
   d[TestObjCKeyTy(10)] = TestObjCValueTy(1010)
   d[TestObjCKeyTy(20)] = TestObjCValueTy(1020)

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2646,16 +2646,7 @@ SetTestSuite.test("SetUpcastBridged") {
 // Set downcasts
 //
 
-SetTestSuite.test("SetDowncastEntryPoint")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+SetTestSuite.test("SetDowncastEntryPoint") {
   var s = Set<NSObject>(minimumCapacity: 32)
   for i in [1010, 2020, 3030] {
       s.insert(TestObjCKeyTy(i))
@@ -2671,16 +2662,7 @@ SetTestSuite.test("SetDowncastEntryPoint")
   expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
 
-SetTestSuite.test("SetDowncast")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+SetTestSuite.test("SetDowncast") {
   var s = Set<NSObject>(minimumCapacity: 32)
   for i in [1010, 2020, 3030] {
       s.insert(TestObjCKeyTy(i))
@@ -2756,16 +2738,7 @@ SetTestSuite.test("SetBridgeFromObjectiveCEntryPoint") {
   }
 }
 
-SetTestSuite.test("SetBridgeFromObjectiveC")
-  .skip(.custom(
-    {
-#if os(iOS)
-      return true
-#else
-      return false
-#endif
-    }, reason: "Autorelease Failure. rdar://49791522"))
-.code {
+SetTestSuite.test("SetBridgeFromObjectiveC") {
   var s = Set<NSObject>(minimumCapacity: 32)
   for i in [1010, 2020, 3030] {
       s.insert(TestObjCKeyTy(i))


### PR DESCRIPTION
Reverts apple/swift#24049

The tests should work after apple/swift#23911

rdar://49791522