### PR TITLE
Revert "SR-10294: convertBoolToDarwinBool and friends should be inlined"

### DIFF
--- a/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
@@ -27,30 +27,26 @@ import _SwiftObjectiveCOverlayShims
 public struct ObjCBool : ExpressibleByBooleanLiteral {
 #if os(macOS) || (os(iOS) && (arch(i386) || arch(arm)))
   // On OS X and 32-bit iOS, Objective-C's BOOL type is a "signed char".
-  @usableFromInline var _value: Int8
+  var _value: Int8
 
-  @_transparent
   init(_ value: Int8) {
     self._value = value
   }
 
-  @_transparent
   public init(_ value: Bool) {
     self._value = value ? 1 : 0
   }
 
 #else
   // Everywhere else it is C/C++'s "Bool"
-  @usableFromInline var _value: Bool
+  var _value: Bool
 
-  @_transparent
   public init(_ value: Bool) {
     self._value = value
   }
 #endif
 
   /// The value of `self`, expressed as a `Bool`.
-  @_transparent
   public var boolValue: Bool {
 #if os(macOS) || (os(iOS) && (arch(i386) || arch(arm)))
     return _value != 0
@@ -82,13 +78,11 @@ extension ObjCBool : CustomStringConvertible {
 
 // Functions used to implicitly bridge ObjCBool types to Swift's Bool type.
 
-@_transparent
 public // COMPILER_INTRINSIC
 func _convertBoolToObjCBool(_ x: Bool) -> ObjCBool {
   return ObjCBool(x)
 }
 
-@_transparent
 public // COMPILER_INTRINSIC
 func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
   return x.boolValue

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -30,15 +30,13 @@ public var noErr: OSStatus { return 0 }
 /// The C type is a typedef for `unsigned char`.
 @_fixed_layout
 public struct DarwinBoolean : ExpressibleByBooleanLiteral {
-  @usableFromInline var _value: UInt8
+  var _value: UInt8
 
-  @_transparent
   public init(_ value: Bool) {
     self._value = value ? 1 : 0
   }
 
   /// The value of `self`, expressed as a `Bool`.
-  @_transparent
   public var boolValue: Bool {
     return _value != 0
   }
@@ -65,19 +63,15 @@ extension DarwinBoolean : CustomStringConvertible {
 }
 
 extension DarwinBoolean : Equatable {
-  @_transparent
   public static func ==(lhs: DarwinBoolean, rhs: DarwinBoolean) -> Bool {
     return lhs.boolValue == rhs.boolValue
   }
 }
 
-@_transparent
 public // COMPILER_INTRINSIC
 func _convertBoolToDarwinBoolean(_ x: Bool) -> DarwinBoolean {
   return DarwinBoolean(x)
 }
-
-@_transparent
 public // COMPILER_INTRINSIC
 func _convertDarwinBooleanToBool(_ x: DarwinBoolean) -> Bool {
   return x.boolValue

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -95,27 +95,21 @@ class Cat : FakeNSObject {
     // CHECK:      store %2 to [[SELF_BOX]] : $*Cat
     // CHECK-NEXT: [[COND:%.+]] = struct_extract %0 : $Bool, #Bool._value
     // CHECK-NEXT: cond_br [[COND]], bb1, bb2
-  
+
   // CHECK: bb1:
-    // CHECK-NEXT: br bb8
-    
-  // CHECK: bb3:
-    // CHECK: br bb5
-  
-  // CHECK: bb4:
-    // CHECK: br bb5
-  
-  // CHECK: bb5
+    // CHECK-NEXT: br bb5
+
+  // CHECK: bb2:
     // CHECK: [[SELF_INIT:%.+]] = objc_method %2 : $Cat, #Cat.init!initializer.1.foreign : (Cat.Type) -> (Int, Bool) -> Cat?
     // CHECK: [[NEW_OPT_SELF:%.+]] = apply [[SELF_INIT]]({{%.+}}, {{%.+}}, %2) : $@convention(objc_method) (Int, ObjCBool, @owned Cat) -> @owned Optional<Cat>
     // CHECK: [[COND:%.+]] = select_enum [[NEW_OPT_SELF]] : $Optional<Cat>
-    // CHECK-NEXT: cond_br [[COND]], bb7, bb6
+    // CHECK-NEXT: cond_br [[COND]], bb4, bb3
 
-  // CHECK: bb6:
+  // CHECK: bb3:
     // CHECK-NEXT: release_value [[NEW_OPT_SELF]]
-    // CHECK-NEXT: br bb8
+    // CHECK-NEXT: br bb5
 
-  // CHECK: bb7:
+  // CHECK: bb4:
     // CHECK-NEXT: [[NEW_SELF:%.+]] = unchecked_enum_data [[NEW_OPT_SELF]] : $Optional<Cat>, #Optional.some!enumelt.1
     // CHECK-NEXT: store [[NEW_SELF]] to [[SELF_BOX]] : $*Cat
     // TODO: Once we re-enable arbitrary take promotion, this retain and the associated destroy_addr will go away.
@@ -123,26 +117,26 @@ class Cat : FakeNSObject {
     // CHECK-NEXT: [[RESULT:%.+]] = enum $Optional<Cat>, #Optional.some!enumelt.1, [[NEW_SELF]] : $Cat
     // CHECK-NEXT: destroy_addr [[SELF_BOX]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
-    // CHECK-NEXT: br bb12([[RESULT]] : $Optional<Cat>)
+    // CHECK-NEXT: br bb9([[RESULT]] : $Optional<Cat>)
 
-  // CHECK: bb8:
+  // CHECK: bb5:
     // CHECK-NEXT: [[COND:%.+]] = load [[HAS_RUN_INIT_BOX]] : $*Builtin.Int1
-    // CHECK-NEXT: cond_br [[COND]], bb9, bb10
+    // CHECK-NEXT: cond_br [[COND]], bb6, bb7
 
-  // CHECK: bb9:
-    // CHECK-NEXT: br bb11
+  // CHECK: bb6:
+    // CHECK-NEXT: br bb8
 
-  // CHECK: bb10:
+  // CHECK: bb7:
     // CHECK-NEXT: [[MOST_DERIVED_TYPE:%.+]] = value_metatype $@thick Cat.Type, %2 : $Cat
     // CHECK-NEXT: dealloc_partial_ref %2 : $Cat, [[MOST_DERIVED_TYPE]] : $@thick Cat.Type
-    // CHECK-NEXT: br bb11
+    // CHECK-NEXT: br bb8
 
-  // CHECK: bb11:
+  // CHECK: bb8:
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
     // CHECK-NEXT: [[NIL_RESULT:%.+]] = enum $Optional<Cat>, #Optional.none!enumelt
-    // CHECK-NEXT: br bb12([[NIL_RESULT]] : $Optional<Cat>)
+    // CHECK-NEXT: br bb9([[NIL_RESULT]] : $Optional<Cat>)
 
-  // CHECK: bb12([[RESULT:%.+]] : $Optional<Cat>):
+  // CHECK: bb9([[RESULT:%.+]] : $Optional<Cat>):
     // CHECK-NEXT: dealloc_stack [[HAS_RUN_INIT_BOX]] : $*Builtin.Int1
     // CHECK-NEXT: return [[RESULT]] : $Optional<Cat>
 


### PR DESCRIPTION
Reverts apple/swift#23802

This broke PR testing (it never passed `@swift-ci test`).