### PR TITLE
DNM: Revert "Emit the clang.arc.retainAutoreleasedReturnValueMarker as a m…

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -126,10 +126,13 @@ llvm::InlineAsm *IRGenModule::getObjCRetainAutoreleasedReturnValueMarker() {
   // and let the late ARC pass insert it, but don't generate any calls
   // right now.
   if (IRGen.Opts.shouldOptimize()) {
-    const char *markerKey = "clang.arc.retainAutoreleasedReturnValueMarker";
-    if (!Module.getModuleFlag(markerKey)) {
-      auto *str = llvm::MDString::get(LLVMContext, asmString);
-      Module.addModuleFlag(llvm::Module::Error, markerKey, str);
+    llvm::NamedMDNode *metadata =
+      Module.getOrInsertNamedMetadata(
+                            "clang.arc.retainAutoreleasedReturnValueMarker");
+    assert(metadata->getNumOperands() <= 1);
+    if (metadata->getNumOperands() == 0) {
+      auto *string = llvm::MDString::get(LLVMContext, asmString);
+      metadata->addOperand(llvm::MDNode::get(LLVMContext, string));
     }
 
     cache = nullptr;


### PR DESCRIPTION
…odule flag."

This reverts commit 25ad152213f9599cae097d56b5da1b1b230f3988.
