### PR TITLE
[stdlib] Make Dictionary's KeyPathIterable conformance use indices.

### DIFF
--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -107,6 +107,6 @@ extension Array : KeyPathIterable {
 extension Dictionary : KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Dictionary>]
   public var allKeyPaths: [PartialKeyPath<Dictionary>] {
-    return keys.map { \Dictionary[$0]! }
+    return values.indices.map { \Dictionary.values[$0] }
   }
 }

--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -107,6 +107,6 @@ extension Array : KeyPathIterable {
 extension Dictionary : KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Dictionary>]
   public var allKeyPaths: [PartialKeyPath<Dictionary>] {
-    return values.indices.map { \Dictionary.values[$0] }
+    return values.indices.map { \Dictionary[$0].value }
   }
 }


### PR DESCRIPTION
No bangs should be used!