### PR TITLE
Allow Swift String to conform to NSString functions

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -969,72 +969,101 @@ internal func _fastWithNormalizedCodeUnitsImpl(
   }
 }
 
-// Allow for Swift String class to convert itself to int/float/double using dot notation
-// This will allow for an easier time when casting a string to various types of numbers
-// Since it returns a non-optional value, unwrapping isn't necessary
-// Before we would have to do Float(value) ?? 0.0, where as now it would be simply value.intValue etc.
+/* Conforms String class to NSString functions, "integerValue", "doubleValue", "floatValue"
+ * Allow for dot notation string to number conversion
+ * Currently to transform a string to a number we must cast using Float(string) which returns an optional
+ * In Obj-c the same conversoin would return 0.0, which may be much more convenient for a more swift development process
+ */
 extension String {
-    func intValue() -> Int {
-        if let value = Int(self) {
-            return value;
-        }
-        else {
-            return 0;
+    
+    // Returns an integer value of the string
+    //  If the value can not be an integer returns 0 instead
+    public var intValue: Int {
+        get {
+            if let value = Int(self) {
+                return value;
+            }
+            else {
+                return 0;
+            }
         }
     }
     
-    func int8Value() -> Int8 {
-        if let value = Int8(self) {
-            return value;
-        }
-        else {
-            return 0;
-        }
-    }
-    
-    func int16Value() -> Int16 {
-        if let value = Int16(self) {
-            return value;
-        }
-        else {
-            return 0;
+    // Returns a short value of the string
+    //  If the value can not be a short returns 0 instead
+    public var int8Value: Int8 {
+        get {
+            if let value = Int8(self) {
+                return value;
+            }
+            else {
+                return 0;
+            }
         }
     }
     
-    func int32Value() -> Int32 {
-        if let value = Int32(self) {
-            return value;
-        }
-        else {
-            return 0;
-        }
-    }
-    
-    func int64Value() -> Int64 {
-        if let value = Int64(self) {
-            return value;
-        }
-        else {
-            return 0;
+    // Returns a int16 value of the string
+    //  If the value can not be an int16 returns 0 instead
+    public var int16Value: Int16 {
+        get {
+            if let value = Int16(self) {
+                return value;
+            }
+            else {
+                return 0;
+            }
         }
     }
     
-    
-    func doubleValue() -> Double {
-        if let value = Double(self) {
-            return value;
-        }
-        else {
-            return 0.0;
+    // Returns a int32 value of the string
+    //  If the value can not be an int32 returns 0 instead
+    public var int32Value: Int32 {
+        get {
+            if let value = Int32(self) {
+                return value;
+            }
+            else {
+                return 0;
+            }
         }
     }
     
-    func floatValue() -> Float {
-        if let float = Float(self) {
-            return float;
+    // Returns a int64 value of the string
+    //  If the value can not be an int64 returns 0 instead
+    public var int64Value: Int64 {
+        get {
+            if let value = Int64(self) {
+                return value;
+            }
+            else {
+                return 0;
+            }
         }
-        else {
-            return 0.0;
+    }
+    
+    // Returns a Double value of the string
+    //  If the value can not be a Double returns 0 instead
+    public var doubleValue: Double {
+        get {
+            if let value = Double(self) {
+                return value;
+            }
+            else {
+                return 0.0;
+            }
+        }
+    }
+    
+    // Returns a Float value of the string
+    //  If the value can not be a Float returns 0 instead
+    public var floatValue: Float {
+        get {
+            if let float = Float(self) {
+                return float;
+            }
+            else {
+                return 0.0;
+            }
         }
     }
 }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -989,7 +989,7 @@ extension String {
     
     /// Returns an int8 (short) version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an int8:
     ///
     ///     let five = "5"
     ///     print(five.int8Value)
@@ -1004,7 +1004,7 @@ extension String {
     
     /// Returns an int16 version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an int16:
     ///
     ///     let five = "5"
     ///     print(five.int16Value)
@@ -1019,7 +1019,7 @@ extension String {
     
     /// Returns an int32 version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an int32:
     ///
     ///     let five = "5"
     ///     print(five.int32Value)
@@ -1035,7 +1035,7 @@ extension String {
         
     /// Returns an int64 version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an int64:
     ///
     ///     let five = "5"
     ///     print(five.int64Value)
@@ -1051,7 +1051,7 @@ extension String {
         
     /// Returns an double version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an double:
     ///
     ///     let five = "5"
     ///     print(five.doubleValue)
@@ -1067,7 +1067,7 @@ extension String {
         
     /// Returns an float version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an float:
     ///
     ///     let five = "5"
     ///     print(five.floatValue)
@@ -1082,7 +1082,7 @@ extension String {
     
     /// Returns a bool version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an bool:
     ///
     ///     let five = "5"
     ///     print(five.boolValue)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -969,120 +969,112 @@ internal func _fastWithNormalizedCodeUnitsImpl(
   }
 }
 
-/// The following convenience methods allow for dot notation string to number conversion without dealing with optional values
+/// The following convenience properties provide the value of the string in various numeric representations, such as Int and Double.
 extension String {
     
-    /// Returns an integer version of the string.
+    /// Returns an `Int` version of the string.
     ///
-    /// The following example transforms a string to an integer:
+    /// The following example transforms a string to an `Int`:
     ///
     ///     let five = "5"
     ///     print(five.intValue)
     ///     // Prints "5"
     ///
+    /// - Note: Returns 0 for invalid strings
     /// - Returns: An integer copy of the string.
     public var intValue: Int {
-        get {
-            return Int(self) ?? 0
-        }
+        return Int(self) ?? 0
     }
     
-    /// Returns an int8 (short) version of the string.
+    /// Returns an `Int8` (short) version of the string.
     ///
-    /// The following example transforms a string to an int8:
+    /// The following example transforms a string to an `Int8`:
     ///
     ///     let five = "5"
     ///     print(five.int8Value)
     ///     // Prints "5"
     ///
+    /// - Note: Returns 0 for invalid strings
     /// - Returns: An int8 (short) copy of the string.
     public var int8Value: Int8 {
-        get {
-            return Int8(self) ?? 0
-        }
+        return Int8(self) ?? 0
     }
     
-    /// Returns an int16 version of the string.
+    /// Returns an `Int16` version of the string.
     ///
-    /// The following example transforms a string to an int16:
+    /// The following example transforms a string to an `Int16`:
     ///
     ///     let five = "5"
     ///     print(five.int16Value)
     ///     // Prints "5"
     ///
+    /// - Note: Returns 0 for invalid strings
     /// - Returns: An int16 copy of the string.
     public var int16Value: Int16 {
-        get {
-            return Int16(self) ?? 0
-        }
+        return Int16(self) ?? 0
     }
     
-    /// Returns an int32 version of the string.
+    /// Returns an `Int32` version of the string.
     ///
-    /// The following example transforms a string to an int32:
+    /// The following example transforms a string to an `Int32`:
     ///
     ///     let five = "5"
     ///     print(five.int32Value)
     ///     // Prints "5"
     ///
+    /// - Note: Returns 0 for invalid strings
     /// - Returns: An int32 copy of the string.
     public var int32Value: Int32 {
-        get {
-            return Int32(self) ?? 0
-        }
+        return Int32(self) ?? 0
     }
     
-        
-    /// Returns an int64 version of the string.
+    
+    /// Returns an `Int64` version of the string.
     ///
-    /// The following example transforms a string to an int64:
+    /// The following example transforms a string to an `Int64`:
     ///
     ///     let five = "5"
     ///     print(five.int64Value)
     ///     // Prints "5"
     ///
+    /// - Note: Returns 0 for invalid strings
     /// - Returns: An int64 copy of the string.
     public var int64Value: Int64 {
-        get {
-            return Int64(self) ?? 0
-        }
+        return Int64(self) ?? 0
     }
     
-        
-    /// Returns an double version of the string.
+    
+    /// Returns a `Double` version of the string.
     ///
-    /// The following example transforms a string to an double:
+    /// The following example transforms a string to a `Double`:
     ///
     ///     let five = "5"
     ///     print(five.doubleValue)
     ///     // Prints "5.0"
     ///
+    /// - Note: Returns 0.0 for invalid strings
     /// - Returns: A double copy of the string.
     public var doubleValue: Double {
-        get {
-            return Double(self) ?? 0
-        }
+        return Double(self) ?? 0
     }
     
-        
-    /// Returns an float version of the string.
+    
+    /// Returns a `Float` version of the string.
     ///
-    /// The following example transforms a string to an float:
+    /// The following example transforms a string to a `Float`:
     ///
     ///     let five = "5"
     ///     print(five.floatValue)
-    ///     // Prints "5"
-    ///
+    ///     // Prints "5"///
+    /// - Note: Returns 0.0 for invalid strings
     /// - Returns: A float copy of the string.
     public var floatValue: Float {
-        get {
-            return Float(self) ?? 0
-        }
+        return Float(self) ?? 0
     }
     
-    /// Returns a bool version of the string.
+    /// Returns a `Bool` version of the string.
     ///
-    /// The following example transforms a string to an bool:
+    /// The following example transforms a string to a `Bool`:
     ///
     ///     let five = "5"
     ///     print(five.boolValue)
@@ -1092,10 +1084,10 @@ extension String {
     ///     print(zero.boolValue)
     ///     // Prints "false"
     ///
+    /// - Note: Returns false for invalid strings
     /// - Returns: A bool copy of the string.
     public var boolValue: Bool {
-        get {
-            return NSString(string: self).boolValue
-        }
+        return NSString(string: self).boolValue
     }
 }
+

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1001,7 +1001,7 @@ extension String {
         }
     }
     
-    func int16Value() -> Int32 {
+    func int32Value() -> Int32 {
         if let value = Int32(self) {
             return value;
         }
@@ -1010,7 +1010,7 @@ extension String {
         }
     }
     
-    func int16Value() -> Int64 {
+    func int64Value() -> Int64 {
         if let value = Int64(self) {
             return value;
         }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -969,101 +969,133 @@ internal func _fastWithNormalizedCodeUnitsImpl(
   }
 }
 
-/* Conforms String class to NSString functions, "integerValue", "doubleValue", "floatValue"
- * Allow for dot notation string to number conversion
- * Currently to transform a string to a number we must cast using Float(string) which returns an optional
- * In Obj-c the same conversoin would return 0.0, which may be much more convenient for a more swift development process
- */
+/// The following convenience methods allow for dot notation string to number conversion without dealing with optional values
 extension String {
     
-    // Returns an integer value of the string
-    //  If the value can not be an integer returns 0 instead
+    /// Returns an integer version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.intValue)
+    ///     // Prints "5"
+    ///
+    /// - Returns: An integer copy of the string.
     public var intValue: Int {
         get {
-            if let value = Int(self) {
-                return value;
-            }
-            else {
-                return 0;
-            }
+            return Int(self) ?? 0
         }
     }
     
-    // Returns a short value of the string
-    //  If the value can not be a short returns 0 instead
+    /// Returns an int8 (short) version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.int8Value)
+    ///     // Prints "5"
+    ///
+    /// - Returns: An int8 (short) copy of the string.
     public var int8Value: Int8 {
         get {
-            if let value = Int8(self) {
-                return value;
-            }
-            else {
-                return 0;
-            }
+            return Int8(self) ?? 0
         }
     }
     
-    // Returns a int16 value of the string
-    //  If the value can not be an int16 returns 0 instead
+    /// Returns an int16 version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.int16Value)
+    ///     // Prints "5"
+    ///
+    /// - Returns: An int16 copy of the string.
     public var int16Value: Int16 {
         get {
-            if let value = Int16(self) {
-                return value;
-            }
-            else {
-                return 0;
-            }
+            return Int16(self) ?? 0
         }
     }
     
-    // Returns a int32 value of the string
-    //  If the value can not be an int32 returns 0 instead
+    /// Returns an int32 version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.int32Value)
+    ///     // Prints "5"
+    ///
+    /// - Returns: An int32 copy of the string.
     public var int32Value: Int32 {
         get {
-            if let value = Int32(self) {
-                return value;
-            }
-            else {
-                return 0;
-            }
+            return Int32(self) ?? 0
         }
     }
     
-    // Returns a int64 value of the string
-    //  If the value can not be an int64 returns 0 instead
+        
+    /// Returns an int64 version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.int64Value)
+    ///     // Prints "5"
+    ///
+    /// - Returns: An int64 copy of the string.
     public var int64Value: Int64 {
         get {
-            if let value = Int64(self) {
-                return value;
-            }
-            else {
-                return 0;
-            }
+            return Int64(self) ?? 0
         }
     }
     
-    // Returns a Double value of the string
-    //  If the value can not be a Double returns 0 instead
+        
+    /// Returns an double version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.doubleValue)
+    ///     // Prints "5.0"
+    ///
+    /// - Returns: A double copy of the string.
     public var doubleValue: Double {
         get {
-            if let value = Double(self) {
-                return value;
-            }
-            else {
-                return 0.0;
-            }
+            return Double(self) ?? 0
         }
     }
     
-    // Returns a Float value of the string
-    //  If the value can not be a Float returns 0 instead
+        
+    /// Returns an float version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.floatValue)
+    ///     // Prints "5"
+    ///
+    /// - Returns: A float copy of the string.
     public var floatValue: Float {
         get {
-            if let float = Float(self) {
-                return float;
-            }
-            else {
-                return 0.0;
-            }
+            return Float(self) ?? 0
+        }
+    }
+    
+    /// Returns a bool version of the string.
+    ///
+    /// The following example transforms a string to an integer:
+    ///
+    ///     let five = "5"
+    ///     print(five.boolValue)
+    ///     // Prints "true"
+    ///
+    ///     let zero = "0"
+    ///     print(zero.boolValue)
+    ///     // Prints "false"
+    ///
+    /// - Returns: A float copy of the string.
+    public var boolValue: Bool {
+        get {
+            return NSString(string: self).boolValue
         }
     }
 }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -968,3 +968,73 @@ internal func _fastWithNormalizedCodeUnitsImpl(
     }
   }
 }
+
+// Allow for Swift String class to convert itself to int/float/double using dot notation
+// This will allow for an easier time when casting a string to various types of numbers
+// Since it returns a non-optional value, unwrapping isn't necessary
+// Before we would have to do Float(value) ?? 0.0, where as now it would be simply value.intValue etc.
+extension String {
+    func intValue() -> Int {
+        if let value = Int(self) {
+            return value;
+        }
+        else {
+            return 0;
+        }
+    }
+    
+    func int8Value() -> Int8 {
+        if let value = Int8(self) {
+            return value;
+        }
+        else {
+            return 0;
+        }
+    }
+    
+    func int16Value() -> Int16 {
+        if let value = Int16(self) {
+            return value;
+        }
+        else {
+            return 0;
+        }
+    }
+    
+    func int16Value() -> Int32 {
+        if let value = Int32(self) {
+            return value;
+        }
+        else {
+            return 0;
+        }
+    }
+    
+    func int16Value() -> Int64 {
+        if let value = Int64(self) {
+            return value;
+        }
+        else {
+            return 0;
+        }
+    }
+    
+    
+    func doubleValue() -> Double {
+        if let value = Double(self) {
+            return value;
+        }
+        else {
+            return 0.0;
+        }
+    }
+    
+    func floatValue() -> Float {
+        if let float = Float(self) {
+            return float;
+        }
+        else {
+            return 0.0;
+        }
+    }
+}

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1092,7 +1092,7 @@ extension String {
     ///     print(zero.boolValue)
     ///     // Prints "false"
     ///
-    /// - Returns: A float copy of the string.
+    /// - Returns: A bool copy of the string.
     public var boolValue: Bool {
         get {
             return NSString(string: self).boolValue


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request will add functionality to the String class to conform to NSString functions integerValue, doubleValue, floatValue.

Before we would have to do Float(value) ?? 0.0, where as now it would be simply value.intValue etc.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
