### PR TITLE
Provide inotify from glibc

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -407,6 +407,10 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/shm.h"
         export *
       }
+      module inotify {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/inotify.h"
+        export *
+      }
 % end
       module statvfs {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/statvfs.h"


### PR DESCRIPTION
Inotify is provided by glibc and bionic and it would be nice to have it included. Specifically, I want to be able to remove [an inotify import](https://github.com/apple/swift-package-manager/blob/master/Sources/clibc/include/clibc.h) in swiftpm.
