### PR TITLE
[windows] Add build script for Windows.

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -1,0 +1,323 @@
+:: build-windows.bat
+::
+:: This source file is part of the Swift.org open source project
+::
+:: Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+:: Licensed under Apache License v2.0 with Runtime Library Exception
+::
+:: See https://swift.org/LICENSE.txt for license information
+:: See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+:: REQUIRED ENVIRONMENT VARIABLES
+:: This script requires to be executed inside one Visual Studio command line,
+:: in order for many of the tools and environment variables to be available.
+:: Additionally, it needs the following variables:
+:: - CMAKE_BUILD_TYPE: Kind of build: Release, RelWithDebInfo, Debug.
+:: - PYTHON_HOME: The Python installation directory.
+
+:: REQUIRED PERMISSIONS
+:: Practically, it is easier to be in the Adminstrators group to run the
+:: script, but it should be possible to execute as a normal user.
+:: The user will need permission to write files into the Windows SDK and the
+:: VisualC++ folder.
+
+@echo off
+
+setlocal enableextensions enabledelayedexpansion
+
+set icu_version=63_1
+
+set "exitOnError=|| (exit /b)"
+set current_directory=%~dp0
+set current_directory=%current_directory:~0,-1%
+set source_root=%current_directory%\..\..
+
+:: Resetting source_root with %CD% removes the ..\.. from the paths, and makes
+:: the output easier to read.
+cd %source_root%
+set source_root=%CD%
+
+set build_root=%source_root%\build
+set install_directory=%build_root%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
+
+mkdir %build_root%
+
+call :clone_repositories %exitOnError%
+call :download_icu %exitOnError%
+:: TODO: Disabled until we need LLBuild/SwiftPM in this build script.
+:: call :download_sqlite3
+
+call :build_llvm %exitOnError%
+path %PATH%;%install_directory%\bin
+
+call :build_cmark %exitOnError%
+
+call :prepare_platform_modules %exitOnError%
+call :build_swift %exitOnError%
+
+call :build_lldb %exitOnError%
+
+path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
+call :test_swift %exitOnError%
+
+goto :end
+endlocal
+
+:clone_repositories
+:: Clones the repositories used by the Windows build.
+:: It supposes that the swift repository is already cloned by CI.
+:: It supposes the %CD% is the source root.
+setlocal enableextensions enabledelayedexpansion
+
+git config --global core.autocrlf false
+git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %exitOnError%
+git clone --depth 1 --single-branch https://github.com/apple/swift-clang clang %exitOnError%
+git clone --depth 1 --single-branch https://github.com/apple/swift-llvm llvm %exitOnError%
+git clone --depth 1 --single-branch https://github.com/apple/swift-lldb lldb %exitOnError%
+git clone --depth 1 --single-branch https://github.com/apple/swift-compiler-rt compiler-rt %exitOnError%
+git clone --depth 1 --single-branch https://github.com/apple/swift-corelibs-libdispatch %exitOnError%
+
+goto :eof
+endlocal
+
+
+:download_icu
+:: Downloads ICU, which will be used as a dependency for the Swift Standard
+:: Library and Foundation.
+setlocal enableextensions enabledelayedexpansion
+
+set file_name=icu4c-%icu_version%-Win64-MSVC2017.zip
+curl -L -O -z %file_name% "http://download.icu-project.org/files/icu4c/63.1/%file_name%" %exitOnError%
+:: unzip warns about the paths in the zip using slashes, which raises the
+:: errorLevel to 1. We cannot use exitOnError, and have to ignore errors.
+unzip -o %file_name% -d "%source_root%\icu-%icu_version%"
+exit /b 0
+
+goto :eof
+endlocal
+
+
+:download_sqlite3
+:: Downloads SQLite3, which will be used as a dependency for llbuild and
+:: Swift Package Manager.
+setlocal enableextensions enabledelayedexpansion
+
+set file_name=sqlite-amalgamation-3270200.zip
+curl -L -O "https://www.sqlite.org/2019/%file_name%" %exitOnError%
+unzip -o %file_name% %exitOnError%
+
+goto :eof
+endlocal
+
+
+:prepare_platform_modules
+:: Create files into the right places of the Windows SDK to the files in the
+:: swift repository, in order to consider the headers of the Windows SDK a
+:: module to compile Swift code against them.
+setlocal enableextensions enabledelayedexpansion
+
+copy /y "%source_root%\swift\stdlib\public\Platform\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" %exitOnError%
+copy /y "%source_root%\swift\stdlib\public\Platform\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" %exitOnError%
+copy /y "%source_root%\swift\stdlib\public\Platform\visualc.modulemap" "%VCToolsInstallDir%\include\module.modulemap" %exitOnError%
+copy /y "%source_root%\swift\stdlib\public\Platform\visualc.apinotes" "%VCToolsInstallDir%\include\visualc.apinotes" %exitOnError%
+
+goto :eof
+endlocal
+
+
+:build_llvm
+:: Configures, builds, and installs LLVM
+setlocal enableextensions enabledelayedexpansion
+
+mkdir "%build_root%\llvm" %exitOnError%
+pushd "%build_root%\llvm"
+
+cmake "%source_root%\llvm"^
+    -G Ninja^
+    -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
+    -DCMAKE_C_COMPILER=cl^
+    -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_INSTALL_PREFIX=%install_directory%^
+    -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc^
+    -DLLVM_ENABLE_PDB:BOOL=YES^
+    -DLLVM_ENABLE_ASSERTIONS:BOOL=YES^
+    -DLLVM_ENABLE_PROJECTS:STRING=clang^
+    -DLLVM_TARGETS_TO_BUILD:STRING="AArch64;ARM;X86"^
+    -DLLVM_INCLUDE_BENCHMARKS:BOOL=NO^
+    -DLLVM_INCLUDE_DOCS:BOOL=NO^
+    -DLLVM_INCLUDE_EXAMPLES:BOOL=NO^
+    -DLLVM_INCLUDE_GO_TESTS:BOOL=NO^
+    -DLLVM_TOOL_GOLD_BUILD:BOOL=NO^
+    -DLLVM_ENABLE_OCAMLDOC:BOOL=NO^
+    -DLLVM_ENABLE_LIBXML2:BOOL=NO^
+    -DLLVM_ENABLE_ZLIB:BOOL=NO^
+    -DENABLE_X86_RELAX_RELOCATIONS:BOOL=YES^
+    -DLLVM_INSTALL_BINUTILS_SYMLINKS:BOOL=YES^
+    -DLLVM_INSTALL_TOOLCHAIN_ONLY:BOOL=YES^
+    -DLLVM_TOOLCHAIN_TOOLS:STRING="addr2line;ar;c++filt;dsymutil;dwp;llvm-ar;llvm-cov;llvm-cvtres;llvm-cxxfilt;llvm-dlltool;llvm-dwp;llvm-ranlib;llvm-lib;llvm-mt;llvm-nm;llvm-objdump;llvm-pdbutil;llvm-profdata;llvm-rc;llvm-readelf;llvm-readobj;llvm-size;llvm-strip;llvm-symbolizer;llvm-undname;nm;objcopy;objdump;ranlib;readelf;size;strings"^
+    -DCLANG_TOOLS="clang;clang-format;clang-headers;clang-tidy"^
+    -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
+    -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
+
+popd
+
+cmake --build "%build_root%\llvm" %exitOnError%
+cmake --build "%build_root%\llvm" --target install %exitOnError%
+
+goto :eof
+endlocal
+
+
+:build_cmark
+:: Configures and builds CMark
+setlocal enableextensions enabledelayedexpansion
+
+mkdir "%build_root%\cmark" %exitOnError%
+pushd "%build_root%\cmark"
+
+cmake "%source_root%\cmark"^
+    -G Ninja^
+    -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
+    -DCMAKE_C_COMPILER=cl^
+    -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
+    -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
+
+popd
+
+cmake --build "%build_root%\cmark" %exitOnError%
+
+goto :eof
+endlocal
+
+
+:build_swift
+:: Configures, builds, and installs Swift and the Swift Standard Library
+setlocal enableextensions enabledelayedexpansion
+
+mkdir "%build_root%\swift" %exitOnError%
+pushd "%build_root%\swift"
+
+:: SWIFT_PARALLEL_LINK_JOBS=8 allows the build machine to use as many CPU as
+:: possible, while not exhausting the RAM.
+cmake "%source_root%\swift"^
+    -G Ninja^
+    -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
+    -DCMAKE_C_COMPILER=cl^
+    -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_INSTALL_PREFIX=%install_directory%^
+    -DClang_DIR=%build_root%\llvm\lib\cmake\clang^
+    -DSWIFT_PATH_TO_CMARK_BUILD=%build_root%\cmark^
+    -DSWIFT_PATH_TO_CMARK_SOURCE=%source_root%\cmark^
+    -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=%source_root%\swift-corelibs-libdispatch^
+    -DLLVM_DIR=%build_root%\llvm\lib\cmake\llvm^
+    -DSWIFT_INCLUDE_DOCS=NO^
+    -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=%source_root%\icu-%icu_version%\include\unicode^
+    -DSWIFT_WINDOWS_x86_64_ICU_UC=%source_root%\icu-%icu_version%\lib64\icuuc.lib^
+    -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=%source_root%\icu-%icu_version%\include^
+    -DSWIFT_WINDOWS_x86_64_ICU_I18N=%source_root%\icu-%icu_version%\lib64\icuin.lib^
+    -DSWIFT_BUILD_DYNAMIC_STDLIB=YES^
+    -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES^
+    -DSWIFT_BUILD_STATIC_STDLIB=NO^
+    -DSWIFT_BUILD_STATIC_SDK_OVERLAY=NO^
+    -DLLVM_INSTALL_TOOLCHAIN_ONLY=YES^
+    -DSWIFT_BUILD_SOURCEKIT=YES^
+    -DSWIFT_ENABLE_SOURCEKIT_TESTS=NO^
+    -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
+    -DSWIFT_PARALLEL_LINK_JOBS=8^
+    -DPYTHON_EXECUTABLE=%PYTHON_HOME%\python.exe^
+    -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
+    -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
+
+popd
+
+cmake --build "%build_root%\swift" %exitOnError%
+cmake --build "%build_root%\swift" --target install %exitOnError%
+
+goto :eof
+endlocal
+
+
+:test_swift
+:: Tests the Swift compiler and the Swift Standard Library
+setlocal enableextensions enabledelayedexpansion
+
+cmake --build "%build_root%\swift" --target check-swift %exitOnError%
+
+goto :eof
+endlocal
+
+
+:build_lldb
+:: Configures, builds, and installs LLDB
+setlocal enableextensions enabledelayedexpansion
+
+mkdir "%build_root%\lldb" %exitOnError%
+pushd "%build_root%\lldb"
+
+cmake "%source_root%\lldb"^
+    -G Ninja^
+    -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
+    -DCMAKE_C_COMPILER=clang-cl^
+    -DCMAKE_CXX_COMPILER=clang-cl^
+    -DCMAKE_INSTALL_PREFIX=%install_directory%^
+    -DLLDB_PATH_TO_CMARK_SOURCE=%source_root%\cmark^
+    -DLLDB_PATH_TO_CLANG_SOURCE=%source_root%\clang^
+    -DLLDB_PATH_TO_LLVM_SOURCE=%source_root%\llvm^
+    -DLLDB_PATH_TO_SWIFT_SOURCE=%source_root%\swift^
+    -DLLDB_PATH_TO_CMARK_BUILD=%build_root%\cmark^
+    -DLLDB_PATH_TO_CLANG_BUILD=%build_root%\llvm^
+    -DLLDB_PATH_TO_LLVM_BUILD=%build_root%\llvm^
+    -DLLDB_PATH_TO_SWIFT_BUILD=%build_root%\swift^
+    -DLLVM_ENABLE_ASSERTIONS=YES^
+    -DLLVM_ALLOW_STATIC_BINDINGS=YES^
+    -DPYTHON_HOME=%PYTHON_HOME%^
+    -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
+    -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
+
+popd
+
+cmake --build "%build_root%\lldb" %exitOnError%
+cmake --build "%build_root%\lldb" --target install %exitOnError%
+
+goto :eof
+endlocal
+
+
+:build_lldb
+:: Configures, builds, and installs Dispatch
+setlocal enableextensions enabledelayedexpansion
+
+mkdir "%build_root%\swift-corelibs-libdispatch" %exitOnError%
+pushd "%build_root%\swift-corelibs-libdispatch"
+
+cmake "%source_root%\swift-corelibs-libdispatch"^
+    -G Ninja^
+    -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
+    -DCMAKE_C_COMPILER=clang-cl^
+    -DCMAKE_CXX_COMPILER=clang-cl^
+    -DCMAKE_SWIFT_COMPILER=%install_directory%\bin\swiftc.exe^
+    -DSwift_DIR=%build_root%\swift\lib\cmake\swift^
+    -DCMAKE_INSTALL_PREFIX=%install_directory%^
+    -DBUILD_SHARED_LIBS=YES^
+    -DENABLE_TESTING=NO^
+    -DCMAKE_C_COMPILER_TARGET=x86_64-unknown-windows-msvc^
+    -DENABLE_SWIFT=YES^
+    -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
+    -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
+
+popd
+
+cmake --build "%build_root%\swift-corelibs-libdispatch" %exitOnError%
+cmake --build "%build_root%\swift-corelibs-libdispatch" --target install %exitOnError%
+
+goto :eof
+endlocal
+
+
+:end


### PR DESCRIPTION
This is a build script for Windows, intended for CI, not really for
final users.

The script mixes bits from WindowsBuild.md, and the Azure YAML script.
It only builds up to libdispatch, including LLDB. If more products are
ready, we can improve the script, but keeping in mind this should be a
temporary solution.

The script needs a couple of environment variables from the build
machine (the Python installation path and the type of build), and also
needs Visual Studio tools in path and its environment variables. Besides
that, it should be self-contained.

We should be able to add something like the following as a Batch script for Jenkins (I suppose Jenkins downloads `swift` into the work directory):

```batch
%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=amd64
:: I don't know if the environment variables are typed elsewhere, but anything that set environment variables work for us.
set CMAKE_BUILD_TYPE=Release
set PYTHON_HOME=C:\Python27
%WORKSPACE%\swift\utils\build-windows.bat
```
