### PR TITLE
[5.1] Fix a data race on _swiftEmptyArrayStorage reported by TSan #21627

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1162,7 +1162,10 @@ extension Array: RangeReplaceableCollection {
       "newElements.underestimatedCount was an overestimate")
     // can't check for overflow as sequences can underestimate
 
-    _buffer.count += writtenCount
+    // This check prevents a data race writting to _swiftEmptyArrayStorage
+    if writtenCount > 0 {
+      _buffer.count += writtenCount
+    }
 
     if writtenUpTo == buf.endIndex {
       // there may be elements that didn't fit in the existing buffer,

--- a/test/Sanitizers/tsan-emptyarraystorage.swift
+++ b/test/Sanitizers/tsan-emptyarraystorage.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread -o %t_tsan-binary
+// RUN: %target-codesign %t_tsan-binary
+// RUN: %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: tsan_runtime
+// UNSUPPORTED: OS=tvos
+
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
+import Foundation
+
+let sem = DispatchSemaphore(value: 0)
+
+class T1: Thread {
+  override func main() {
+    var oneEmptyArray: [[String:String]] = []
+    oneEmptyArray.append(contentsOf: [])
+    sem.signal()
+  }
+}
+let t1 = T1()
+t1.start()
+
+class T2: Thread {
+  override func main() {
+    var aCompletelyUnrelatedOtherEmptyArray: [[Double:Double]] = []
+    aCompletelyUnrelatedOtherEmptyArray.append(contentsOf: [])
+    sem.signal()
+  }
+}
+let t2 = T2()
+t2.start()
+
+sem.wait()
+sem.wait()
+print("Done!")
+
+// CHECK: Done!


### PR DESCRIPTION
Cherry picking to 5.1. May be too late, sorry about that if so!

Fixes rdar://problem/45738939