### PR TITLE
AST: Start returning SelfProtocolConformances from ModuleDecl::lookupConformance()

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -1147,9 +1147,9 @@ ConformanceLookupTable::getSatisfiedProtocolRequirementsForMember(
       if (conf->isInvalid())
         continue;
 
-      auto normal = conf->getRootNormalConformance();
-      normal->forEachValueWitness(nullptr,
-                                  [&](ValueDecl *req, Witness witness) {
+      auto root = conf->getRootConformance();
+      root->forEachValueWitness(nullptr,
+                                [&](ValueDecl *req, Witness witness) {
         if (witness.getDecl() == member)
           reqs.push_back(req);
       });

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1055,12 +1055,12 @@ SpecializedProtocolConformance::getTypeWitnessAndDecl(
 
   // Local function to determine whether we will end up referring to a
   // tentative witness that may not be chosen.
-  auto normal = GenericConformance->getRootNormalConformance();
+  auto root = GenericConformance->getRootConformance();
   auto isTentativeWitness = [&] {
-    if (normal->getState() != ProtocolConformanceState::CheckingTypeWitnesses)
+    if (root->getState() != ProtocolConformanceState::CheckingTypeWitnesses)
       return false;
 
-    return !normal->hasTypeWitness(assocType, nullptr);
+    return !root->hasTypeWitness(assocType, nullptr);
   };
 
   auto genericWitnessAndDecl

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -664,33 +664,20 @@ void SubstitutionMap::verify() const {
     if (conformance.isInvalid())
       continue;
 
-    // An existential type can have an abstract conformance to
-    // AnyObject or an @objc protocol.
-    if (conformance.isAbstract() &&
-        substType->isExistentialType()) {
-      auto *proto = conformance.getRequirement();
-      if (!proto->isObjC()) {
-        llvm::dbgs() << "Existential type conforms to something:\n";
-        substType->dump();
-        llvm::dbgs() << "SubstitutionMap:\n";
-        dump(llvm::dbgs());
-        llvm::dbgs() << "\n";
-      }
-
-      assert(proto->isObjC() &&
-             "an existential type can conform only to an "
-             "@objc-protocol");
-      continue;
-    }
     // All of the conformances should be concrete.
     if (!conformance.isConcrete()) {
-      llvm::dbgs() << "Concrete substType type:\n";
+      llvm::dbgs() << "Concrete type cannot have abstract conformance:\n";
       substType->dump(llvm::dbgs());
       llvm::dbgs() << "SubstitutionMap:\n";
       dump(llvm::dbgs());
       llvm::dbgs() << "\n";
     }
     assert(conformance.isConcrete() && "Conformance should be concrete");
+
+    if (substType->isExistentialType()) {
+      assert(isa<SelfProtocolConformance>(conformance.getConcrete()) &&
+              "Existential type cannot have normal conformance");
+    }
 
     ++conformanceIndex;
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1612,8 +1612,8 @@ bool TypeBase::isBindableTo(Type b) {
           if (origConf.isConcrete()) {
             if (!substConf.isConcrete())
               return false;
-            if (origConf.getConcrete()->getRootNormalConformance()
-                  != substConf.getConcrete()->getRootNormalConformance())
+            if (origConf.getConcrete()->getRootConformance()
+                  != substConf.getConcrete()->getRootConformance())
               return false;
           }
         }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4252,13 +4252,12 @@ public:
       auto Proto = Conformance->getProtocol();
       if (!Proto->isAccessibleFrom(CurrDeclContext))
         continue;
-      auto NormalConformance = Conformance->getRootNormalConformance();
       for (auto Member : Proto->getMembers()) {
         auto *ATD = dyn_cast<AssociatedTypeDecl>(Member);
         if (!ATD)
           continue;
         // FIXME: Also exclude the type alias that has already been specified.
-        if (!NormalConformance->hasTypeWitness(ATD) ||
+        if (!Conformance->hasTypeWitness(ATD) ||
             !ATD->getDefaultDefinitionLoc().isNull())
           continue;
         addTypeAlias(ATD,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1509,16 +1509,6 @@ void WitnessTableBuilder::defineAssociatedTypeWitnessTableAccessFunction(
 
   const ConformanceInfo *conformanceI = nullptr;
 
-  // Rewrite (abstract) self conformances to the concrete conformance.
-  if (associatedConformance.isAbstract() && !hasArchetype) {
-    // This must be a self conformance.
-    auto proto = associatedConformance.getRequirement();
-    assert(proto->requiresSelfConformanceWitnessTable());
-    assert(cast<ProtocolType>(associatedType)->getDecl() == proto);
-    auto concreteConformance = IGF.IGM.Context.getSelfConformance(proto);
-    associatedConformance = ProtocolConformanceRef(concreteConformance);
-  }
-
   if (associatedConformance.isConcrete()) {
     assert(associatedType->isEqual(associatedConformance.getConcrete()->getType()));
 
@@ -2750,13 +2740,8 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
   // requirements of the archetype. Look at what's locally bound.
   ProtocolConformance *concreteConformance;
   if (conformance.isAbstract()) {
-    if (auto archetype = dyn_cast<ArchetypeType>(srcType))
-      return emitArchetypeWitnessTableRef(IGF, archetype, proto);
-
-    // Otherwise, this must be a self-conformance.
-    assert(proto->requiresSelfConformanceWitnessTable());
-    assert(cast<ProtocolType>(srcType)->getDecl() == proto);
-    concreteConformance = IGF.IGM.Context.getSelfConformance(proto);
+    auto archetype = cast<ArchetypeType>(srcType);
+    return emitArchetypeWitnessTableRef(IGF, archetype, proto);
 
   // All other source types should be concrete enough that we have
   // conformance info for them.  However, that conformance info might be

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -192,7 +192,7 @@ static bool mustDeserializeProtocolConformance(SILModule &M,
                                                ProtocolConformanceRef c) {
   if (!c.isConcrete())
     return false;
-  auto conformance = c.getConcrete()->getRootNormalConformance();
+  auto conformance = c.getConcrete()->getRootConformance();
   return M.Types.protocolRequiresWitnessTable(conformance->getProtocol())
     && isa<ClangModuleUnit>(conformance->getDeclContext()
                                        ->getModuleScopeContext());

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1513,15 +1513,18 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
     return;
 
   auto conformance = conformanceRef.getConcrete();
-  auto root = conformance->getRootNormalConformance();
+  auto normal = dyn_cast<NormalProtocolConformance>(
+      conformance->getRootConformance());
+  if (normal == nullptr)
+    return;
 
   // If we already emitted this witness table, we don't need to track the fact
   // we need it.
-  if (emittedWitnessTables.count(root))
+  if (emittedWitnessTables.count(normal))
     return;
 
   // If we delayed emitting this witness table, force it.
-  auto foundDelayed = delayedConformances.find(root);
+  auto foundDelayed = delayedConformances.find(normal);
   if (foundDelayed != delayedConformances.end()) {
     forcedConformances.push_back(*foundDelayed);
     delayedConformances.erase(foundDelayed);
@@ -1529,7 +1532,7 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
   }
 
   // Otherwise, just remember the fact we used this conformance.
-  usedConformances.insert(root);
+  usedConformances.insert(normal);
 }
 
 void SILGenModule::useConformancesFromSubstitutions(

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -58,7 +58,7 @@ public:
   /// Mapping from SILDeclRefs to emitted SILFunctions.
   llvm::DenseMap<SILDeclRef, SILFunction*> emittedFunctions;
   /// Mapping from ProtocolConformances to emitted SILWitnessTables.
-  llvm::DenseMap<ProtocolConformance*, SILWitnessTable*> emittedWitnessTables;
+  llvm::DenseMap<NormalProtocolConformance*, SILWitnessTable*> emittedWitnessTables;
 
   struct DelayedFunction {
     /// Insert the entity after the given function when it's emitted.
@@ -78,7 +78,7 @@ public:
   SILDeclRef lastEmittedFunction;
 
   /// Set of used conformances for which witness tables need to be emitted.
-  llvm::DenseSet<NormalProtocolConformance *> usedConformances;
+  llvm::DenseSet<RootProtocolConformance *> usedConformances;
 
   struct DelayedWitnessTable {
     NormalProtocolConformance *insertAfter;
@@ -272,7 +272,7 @@ public:
   void emitExternalDefinition(Decl *d);
 
   /// Emit SIL related to a Clang-imported declaration.
-  void emitExternalWitnessTable(ProtocolConformance *d);
+  void emitExternalWitnessTable(NormalProtocolConformance *d);
 
   /// Emit the ObjC-compatible entry point for a method.
   void emitObjCMethodThunk(FuncDecl *method);
@@ -287,7 +287,7 @@ public:
   void emitObjCDestructorThunk(DestructorDecl *destructor);
 
   /// Get or emit the witness table for a protocol conformance.
-  SILWitnessTable *getWitnessTable(ProtocolConformance *conformance);
+  SILWitnessTable *getWitnessTable(NormalProtocolConformance *conformance);
 
   /// Emit a protocol witness entry point.
   SILFunction *

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1391,16 +1391,15 @@ CleanupHandle SILGenFunction::enterDeinitExistentialCleanup(
   return Cleanups.getTopCleanup();
 }
 
-void SILGenModule::emitExternalWitnessTable(ProtocolConformance *c) {
-  auto root = c->getRootNormalConformance();
+void SILGenModule::emitExternalWitnessTable(NormalProtocolConformance *c) {
   // Emit the witness table right now if we used it.
-  if (usedConformances.count(root)) {
+  if (usedConformances.count(c)) {
     getWitnessTable(c);
     return;
   }
   // Otherwise, remember it for later.
-  delayedConformances.insert({root, {lastEmittedConformance}});
-  lastEmittedConformance = root;
+  delayedConformances.insert({c, {lastEmittedConformance}});
+  lastEmittedConformance = c;
 }
 
 static bool isDeclaredInPrimaryFile(SILModule &M, Decl *d) {
@@ -1443,7 +1442,7 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
       if (Lowering::TypeConverter::protocolRequiresWitnessTable(proto) &&
           isa<NormalProtocolConformance>(c) &&
           c->isComplete())
-        emitExternalWitnessTable(c);
+        emitExternalWitnessTable(cast<NormalProtocolConformance>(c));
     }
     break;
   }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -382,8 +382,7 @@ public:
   IsSerialized_t Serialized;
 
   SILGenConformance(SILGenModule &SGM, NormalProtocolConformance *C)
-    // We only need to emit witness tables for base NormalProtocolConformances.
-    : SGM(SGM), Conformance(C->getRootNormalConformance()),
+    : SGM(SGM), Conformance(C),
       Linkage(getLinkageForProtocolConformance(Conformance,
                                                ForDefinition)),
       Serialized(isConformanceSerialized(Conformance))
@@ -454,11 +453,11 @@ public:
     });
 
     // Emit the witness table for the base conformance if it is shared.
-    if (getLinkageForProtocolConformance(
-                                        conformance->getRootNormalConformance(),
-                                        NotForDefinition)
+    auto *normal = conformance->getRootNormalConformance();
+
+    if (getLinkageForProtocolConformance(normal, NotForDefinition)
           == SILLinkage::Shared)
-      SGM.getWitnessTable(conformance->getRootNormalConformance());
+      SGM.getWitnessTable(normal);
   }
 
   Witness getWitness(ValueDecl *decl) {
@@ -571,20 +570,18 @@ getWitnessTableToInsertAfter(SILGenModule &SGM,
 }
 
 SILWitnessTable *
-SILGenModule::getWitnessTable(ProtocolConformance *conformance) {
-  auto normal = conformance->getRootNormalConformance();
-
+SILGenModule::getWitnessTable(NormalProtocolConformance *conformance) {
   // If we've already emitted this witness table, return it.
-  auto found = emittedWitnessTables.find(normal);
+  auto found = emittedWitnessTables.find(conformance);
   if (found != emittedWitnessTables.end())
     return found->second;
 
-  SILWitnessTable *table = SILGenConformance(*this, normal).emit();
-  emittedWitnessTables.insert({normal, table});
+  SILWitnessTable *table = SILGenConformance(*this, conformance).emit();
+  emittedWitnessTables.insert({conformance, table});
 
   // If we delayed emission of this witness table, move it to its rightful
   // place within the module.
-  auto foundDelayed = delayedConformances.find(normal);
+  auto foundDelayed = delayedConformances.find(conformance);
   if (foundDelayed != delayedConformances.end()) {
     M.witnessTables.remove(table);
     auto insertAfter = getWitnessTableToInsertAfter(*this,
@@ -597,7 +594,7 @@ SILGenModule::getWitnessTable(ProtocolConformance *conformance) {
   } else {
     // We would have marked a delayed conformance as "last emitted" when it
     // was delayed.
-    lastEmittedConformance = normal;
+    lastEmittedConformance = conformance;
   }
   return table;
 }
@@ -978,9 +975,10 @@ public:
     // are existential and do not have witness tables.
     for (auto *conformance : theType->getLocalConformances(
                                ConformanceLookupKind::All, nullptr)) {
-      if (conformance->isComplete() &&
-          isa<NormalProtocolConformance>(conformance))
-        SGM.getWitnessTable(conformance);
+      if (conformance->isComplete()) {
+        if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
+          SGM.getWitnessTable(normal);
+      }
     }
   }
 
@@ -1085,9 +1083,10 @@ public:
       for (auto *conformance : e->getLocalConformances(
                                  ConformanceLookupKind::All,
                                  nullptr)) {
-        if (conformance->isComplete() &&
-            isa<NormalProtocolConformance>(conformance))
-          SGM.getWitnessTable(conformance);
+        if (conformance->isComplete()) {
+          if (auto *normal =dyn_cast<NormalProtocolConformance>(conformance))
+            SGM.getWitnessTable(normal);
+        }
       }
     }
   }

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -905,7 +905,7 @@ getWitnessMethodSubstitutions(
   auto baseSubMap = conformance->getSubstitutions(mod);
 
   unsigned baseDepth = 0;
-  auto *rootConformance = conformance->getRootNormalConformance();
+  auto *rootConformance = conformance->getRootConformance();
   if (auto *witnessSig = rootConformance->getGenericSignature())
     baseDepth = witnessSig->getGenericParams().back()->getDepth() + 1;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5355,7 +5355,8 @@ void TypeChecker::synthesizeMemberForLookup(NominalTypeDecl *target,
                         (ConformanceCheckFlags::Used|
                          ConformanceCheckFlags::SkipConditionalRequirements),
                          SourceLoc())) {
-      if (auto *conformance = ref->getConcrete()->getRootNormalConformance()) {
+      if (auto *conformance = dyn_cast<NormalProtocolConformance>(
+            ref->getConcrete()->getRootConformance())) {
         if (conformance->getState() == ProtocolConformanceState::Incomplete) {
           checkConformance(conformance);
         }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3600,15 +3600,16 @@ void ConformanceChecker::addUsedConformances(
   if (!visited.insert(conformance).second)
     return;
 
-  auto normalConf = conformance->getRootNormalConformance();
+  if (auto normalConf = dyn_cast<NormalProtocolConformance>(
+        conformance->getRootConformance())) {;
+    if (normalConf->isIncomplete())
+      TC.UsedConformances.insert(normalConf);
 
-  if (normalConf->isIncomplete())
-    TC.UsedConformances.insert(normalConf);
-
-  // Mark each conformance in the signature as used.
-  for (auto sigConformance : normalConf->getSignatureConformances()) {
-    if (sigConformance.isConcrete())
-      addUsedConformances(sigConformance.getConcrete(), visited);
+    // Mark each conformance in the signature as used.
+    for (auto sigConformance : normalConf->getSignatureConformances()) {
+      if (sigConformance.isConcrete())
+        addUsedConformances(sigConformance.getConcrete(), visited);
+    }
   }
 }
 
@@ -4274,17 +4275,18 @@ void TypeChecker::markConformanceUsed(ProtocolConformanceRef conformance,
                                       DeclContext *dc) {
   if (conformance.isAbstract()) return;
 
-  auto normalConformance =
-    conformance.getConcrete()->getRootNormalConformance();
+  if (auto normalConformance =
+        dyn_cast<NormalProtocolConformance>(
+          conformance.getConcrete()->getRootConformance())) {;
+    // Make sure that the type checker completes this conformance.
+    if (normalConformance->isIncomplete())
+      UsedConformances.insert(normalConformance);
 
-  // Make sure that the type checker completes this conformance.
-  if (normalConformance->isIncomplete())
-    UsedConformances.insert(normalConformance);
-
-  // Record the usage of this conformance in the enclosing source
-  // file.
-  if (auto sf = dc->getParentSourceFile()) {
-    sf->addUsedConformance(normalConformance);
+    // Record the usage of this conformance in the enclosing source
+    // file.
+    if (auto sf = dc->getParentSourceFile()) {
+      sf->addUsedConformance(normalConformance);
+    }
   }
 }
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -974,7 +974,7 @@ Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
                           baseTy, assocType->getProtocol(), dc,
                           ConformanceCheckFlags::SkipConditionalRequirements);
       if (!localConformance || localConformance->isAbstract() ||
-          (localConformance->getConcrete()->getRootNormalConformance()
+          (localConformance->getConcrete()->getRootConformance()
              != conformance)) {
         return nullptr;
       }

--- a/test/IRGen/error_self_conformance.sil
+++ b/test/IRGen/error_self_conformance.sil
@@ -17,3 +17,11 @@ entry(%0 : $*Error):
   %ret = tuple ()
   return %ret : $()
 }
+
+sil @partial_apply_test : $@convention(thin) (@in Error) -> () {
+entry(%0 : $*Error):
+  %take = function_ref @take_any_error : $@convention(thin) <T: Error> (@in T) -> ()
+  %fn = partial_apply %take<Error>(%0) : $@convention(thin) <T: Error> (@in T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
Fixes <rdar://problem/49241923>, <https://bugs.swift.org/browse/SR-10015>.