### PR TITLE
Improve `-debug-constraints` output for key path components

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -60,6 +60,7 @@ namespace swift {
   class ParameterList;
   class EnumElementDecl;
   class CallExpr;
+  class KeyPathExpr;
 
 enum class ExprKind : uint8_t {
 #define EXPR(Id, Parent) Id,
@@ -539,6 +540,7 @@ public:
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
   void dump(raw_ostream &OS, llvm::function_ref<Type(const Expr *)> getType,
             llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc,
+            llvm::function_ref<Type(const KeyPathExpr *E, unsigned index)> getTypeOfKeyPathComponent,
             unsigned Indent = 0) const;
   
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2615,88 +2615,94 @@ public:
     printCommon(E, "keypath_expr");
     if (E->isObjC())
       OS << " objc";
+
+    OS << '\n';
+    Indent += 2;
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, ExprColor) << "components";
+    OS.indent(Indent + 2);
     for (unsigned i : indices(E->getComponents())) {
       auto &component = E->getComponents()[i];
       OS << '\n';
       OS.indent(Indent + 2);
-      OS << "(component=";
+      PrintWithColorRAII(OS, ParenthesisColor) << '(';
       switch (component.getKind()) {
       case KeyPathExpr::Component::Kind::Invalid:
-        OS << "invalid ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "invalid";
         break;
 
       case KeyPathExpr::Component::Kind::OptionalChain:
-        OS << "optional_chain ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "optional_chain";
         break;
         
       case KeyPathExpr::Component::Kind::OptionalForce:
-        OS << "optional_force ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "optional_force";
         break;
         
       case KeyPathExpr::Component::Kind::OptionalWrap:
-        OS << "optional_wrap ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "optional_wrap";
         break;
         
       case KeyPathExpr::Component::Kind::Property:
-        OS << "property ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "property";
+        PrintWithColorRAII(OS, DeclColor) << " decl=";
         printDeclRef(component.getDeclRef());
-        OS << " ";
         break;
       
       case KeyPathExpr::Component::Kind::Subscript:
-        OS << "subscript ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "subscript";
+        PrintWithColorRAII(OS, DeclColor) << " decl='";
         printDeclRef(component.getDeclRef());
-        OS << '\n';
-        Indent += 2;
-        printRec(component.getIndexExpr());
-        Indent -= 2;
-        OS.indent(Indent + 4);
+        PrintWithColorRAII(OS, DeclColor) << "'";
         break;
       
       case KeyPathExpr::Component::Kind::UnresolvedProperty:
-        OS << "unresolved_property ";
-        component.getUnresolvedDeclName().print(OS);
-        OS << " ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "unresolved_property";
+        PrintWithColorRAII(OS, IdentifierColor)
+          << " decl_name='" << component.getUnresolvedDeclName() << "'";
         break;
         
       case KeyPathExpr::Component::Kind::UnresolvedSubscript:
-        OS << "unresolved_subscript";
-        OS << '\n';
-        Indent += 2;
-        printRec(component.getIndexExpr());
-        Indent -= 2;
-        OS.indent(Indent + 4);
+        PrintWithColorRAII(OS, ASTNodeColor) << "unresolved_subscript";
+        printArgumentLabels(component.getSubscriptLabels());
         break;
       case KeyPathExpr::Component::Kind::Identity:
-        OS << "identity";
-        OS << '\n';
+        PrintWithColorRAII(OS, ASTNodeColor) << "identity";
         break;
+
       case KeyPathExpr::Component::Kind::TupleElement:
-        OS << "tuple_element ";
-        OS << "#" << component.getTupleIndex();
-        OS << " ";
+        PrintWithColorRAII(OS, ASTNodeColor) << "tuple_element ";
+        PrintWithColorRAII(OS, DiscriminatorColor)
+          << "#" << component.getTupleIndex();
         break;
       }
-      OS << "type=";
-      GetTypeOfKeyPathComponent(E, i).print(OS);
+      PrintWithColorRAII(OS, TypeColor)
+        << " type='" << GetTypeOfKeyPathComponent(E, i) << "'";
+      if (auto indexExpr = component.getIndexExpr()) {
+        OS << '\n';
+        Indent += 2;
+        printRec(indexExpr);
+        Indent -= 2;
+      }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
+
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    Indent -= 2;
+
     if (auto stringLiteral = E->getObjCStringLiteralExpr()) {
       OS << '\n';
-      printRec(stringLiteral);
+      printRecLabeled(stringLiteral, "objc_string_literal");
     }
     if (!E->isObjC()) {
-      OS << "\n";
       if (auto root = E->getParsedRoot()) {
-        printRec(root);
-      } else {
-        OS.indent(Indent + 2) << "<<null>>";
+        OS << "\n";
+        printRecLabeled(root, "parsed_root");
       }
-      OS << "\n";
       if (auto path = E->getParsedPath()) {
-        printRec(path);
-      } else {
-        OS.indent(Indent + 2) << "<<null>>";
+        OS << "\n";
+        printRecLabeled(path, "parsed_path");
       }
     }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3054,6 +3054,10 @@ namespace {
         case KeyPathExpr::Component::Kind::Identity:
           continue;
         }
+
+        // By now, `base` is the result type of this component. Set it in the
+        // constraint system so we can find it later.
+        CS.setType(E, i, base);
       }
       
       // If there was an optional chaining component, the end result must be

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2977,7 +2977,7 @@ namespace {
         auto memberLocator = CS.getConstraintLocator(
             locator, ConstraintLocator::PathElement::getKeyPathComponent(i));
         auto resultLocator = CS.getConstraintLocator(
-            memberLocator, ConstraintLocator::FunctionResult);
+            memberLocator, ConstraintLocator::KeyPathComponentResult);
 
         switch (auto kind = component.getKind()) {
         case KeyPathExpr::Component::Kind::Invalid:

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2974,6 +2974,11 @@ namespace {
       
       for (unsigned i : indices(E->getComponents())) {
         auto &component = E->getComponents()[i];
+        auto memberLocator = CS.getConstraintLocator(
+            locator, ConstraintLocator::PathElement::getKeyPathComponent(i));
+        auto resultLocator = CS.getConstraintLocator(
+            memberLocator, ConstraintLocator::FunctionResult);
+
         switch (auto kind = component.getKind()) {
         case KeyPathExpr::Component::Kind::Invalid:
           break;
@@ -2982,7 +2987,7 @@ namespace {
         // This should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Property: {
-          auto memberTy = CS.createTypeVariable(locator,
+          auto memberTy = CS.createTypeVariable(resultLocator,
                                                 TVO_CanBindToLValue |
                                                 TVO_CanBindToNoEscape);
           auto lookupName = kind == KeyPathExpr::Component::Kind::UnresolvedProperty
@@ -2992,8 +2997,6 @@ namespace {
           auto refKind = lookupName.isSimpleName()
             ? FunctionRefKind::Unapplied
             : FunctionRefKind::Compound;
-          auto memberLocator = CS.getConstraintLocator(E,
-                        ConstraintLocator::PathElement::getKeyPathComponent(i));
           CS.addValueMemberConstraint(base, lookupName,
                                       memberTy,
                                       CurDC,
@@ -3008,11 +3011,8 @@ namespace {
         // Subscript should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Subscript: {
-
-          auto *locator = CS.getConstraintLocator(E,
-                        ConstraintLocator::PathElement::getKeyPathComponent(i));
           base = addSubscriptConstraints(E, base, component.getIndexExpr(),
-                                         /*decl*/ nullptr, locator);
+                                         /*decl*/ nullptr, memberLocator);
           break;
         }
 
@@ -3026,18 +3026,20 @@ namespace {
           
           // We can't assign an optional back through an optional chain
           // today. Force the base to an rvalue.
-          auto rvalueTy = CS.createTypeVariable(locator, TVO_CanBindToNoEscape);
-          CS.addConstraint(ConstraintKind::Equal, base, rvalueTy, locator);
+          auto rvalueTy = CS.createTypeVariable(resultLocator,
+                                                TVO_CanBindToNoEscape);
+          CS.addConstraint(ConstraintKind::Equal, base, rvalueTy,
+                           resultLocator);
           base = rvalueTy;
           LLVM_FALLTHROUGH;
         }
         case KeyPathExpr::Component::Kind::OptionalForce: {
-          auto optionalObjTy = CS.createTypeVariable(locator,
+          auto optionalObjTy = CS.createTypeVariable(resultLocator,
                                                      TVO_CanBindToLValue |
                                                      TVO_CanBindToNoEscape);
           
           CS.addConstraint(ConstraintKind::OptionalObject, base, optionalObjTy,
-                           locator);
+                           resultLocator);
           
           base = optionalObjTy;
           break;
@@ -3078,10 +3080,8 @@ namespace {
       } else {
         // The type of key path depends on the overloads chosen for the key
         // path components.
-        kpTy = CS.createTypeVariable(CS.getConstraintLocator(E),
-                                     TVO_CanBindToNoEscape);
-        CS.addKeyPathConstraint(kpTy, root, rvalueBase,
-                                CS.getConstraintLocator(E));
+        kpTy = CS.createTypeVariable(locator, TVO_CanBindToNoEscape);
+        CS.addKeyPathConstraint(kpTy, root, rvalueBase, locator);
       }
       return kpTy;
     }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1147,21 +1147,9 @@ ConstraintSystem::solveImpl(Expr *&expr,
   }
 
   if (TC.getLangOpts().DebugConstraintSolver) {
-    auto getTypeOfExpr = [&](const Expr *E) -> Type {
-      if (hasType(E))
-        return getType(E);
-      return Type();
-    };
-    auto getTypeOfTypeLoc = [&](const TypeLoc &TL) -> Type {
-      if (hasType(TL))
-        return getType(TL);
-      return Type();
-    };
-
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log << "---Initial constraints for the given expression---\n";
-
-    expr->dump(log, getTypeOfExpr, getTypeOfTypeLoc);
+    print(log, expr);
     log << "\n";
     print(log);
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -81,6 +81,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case SynthesizedArgument:
     case KeyPathRoot:
     case KeyPathValue:
+    case KeyPathComponentResult:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -332,19 +333,23 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       break;
 
     case SynthesizedArgument:
-      out << " synthesized argument #" << llvm::utostr(elt.getValue());
+      out << "synthesized argument #" << llvm::utostr(elt.getValue());
       break;
 
     case KeyPathDynamicMember:
-      out << " keypath dynamic member lookup";
+      out << "key path dynamic member lookup";
       break;
 
     case KeyPathRoot:
-      out << " keypath root";
+      out << "key path root";
       break;
 
     case KeyPathValue:
-      out << " keypath value";
+      out << "key path value";
+      break;
+
+    case KeyPathComponentResult:
+      out << "key path component result";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -133,6 +133,8 @@ public:
     KeyPathRoot,
     /// The value of a keypath
     KeyPathValue,
+    /// The result type of a key path component. Not used for subscripts.
+    KeyPathComponentResult,
   };
 
   /// Determine the number of numeric values used for the given path
@@ -165,6 +167,7 @@ public:
     case ContextualType:
     case KeyPathRoot:
     case KeyPathValue:
+    case KeyPathComponentResult:
       return 0;
 
     case OpenedGeneric:
@@ -233,6 +236,7 @@ public:
     case KeyPathDynamicMember:
     case KeyPathRoot:
     case KeyPathValue:
+    case KeyPathComponentResult:
       return 0;
 
     case FunctionArgument:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1065,6 +1065,8 @@ private:
   llvm::DenseMap<const Expr *, TypeBase *> ExprTypes;
   llvm::DenseMap<const TypeLoc *, TypeBase *> TypeLocTypes;
   llvm::DenseMap<const ParamDecl *, TypeBase *> ParamTypes;
+  llvm::DenseMap<std::pair<const KeyPathExpr *, unsigned>, TypeBase *>
+      KeyPathComponentTypes;
 
   /// Maps closure parameters to type variables.
   llvm::DenseMap<const ParamDecl *, TypeVariableType *>
@@ -1446,6 +1448,11 @@ private:
       if (expr->getType())
         CS.cacheType(expr);
 
+      if (auto kp = dyn_cast<KeyPathExpr>(expr))
+        for (auto i : indices(kp->getComponents()))
+          if (kp->getComponents()[i].getComponentType())
+            CS.cacheType(kp, i);
+
       return expr;
     }
 
@@ -1476,6 +1483,15 @@ private:
       assert(!CS.getType(expr)->hasTypeVariable() &&
              "Should not write type variable into expression!");
       expr->setType(CS.getType(expr));
+
+      if (auto kp = dyn_cast<KeyPathExpr>(expr)) {
+        for (auto i : indices(kp->getComponents())) {
+          Type componentType;
+          if (CS.hasType(kp, i))
+            componentType = CS.getType(kp, i);
+          kp->getMutableComponents()[i].setComponentType(componentType);
+        }
+      }
 
       return expr;
     }
@@ -1757,6 +1773,12 @@ public:
     ParamTypes[P] = T.getPointer();
   }
 
+  void setType(KeyPathExpr *KP, unsigned I, Type T) {
+    assert(KP && "Expected non-null key path parameter!");
+    assert(T && "Expected non-null type!");
+    KeyPathComponentTypes[std::make_pair(KP, I)] = T.getPointer();
+  }
+
   /// Check to see if we have a type for an expression.
   bool hasType(const Expr *E) const {
     assert(E != nullptr && "Expected non-null expression!");
@@ -1770,6 +1792,12 @@ public:
   bool hasType(const ParamDecl *P) const {
     assert(P != nullptr && "Expected non-null parameter!");
     return ParamTypes.find(P) != ParamTypes.end();
+  }
+
+  bool hasType(const KeyPathExpr *KP, unsigned I) const {
+    assert(KP && "Expected non-null key path parameter!");
+    return KeyPathComponentTypes.find(std::make_pair(KP, I))
+              != KeyPathComponentTypes.end();
   }
 
   /// Get the type for an expression.
@@ -1800,12 +1828,26 @@ public:
     return wantInterfaceType ? D->getInterfaceType() : D->getType();
   }
 
+  Type getType(const KeyPathExpr *KP, unsigned I) const {
+    assert(hasType(KP, I) && "Expected type to have been set!");
+    return KeyPathComponentTypes.find(std::make_pair(KP, I))->second;
+  }
+
   /// Cache the type of the expression argument and return that same
   /// argument.
   template <typename T>
   T *cacheType(T *E) {
     assert(E->getType() && "Expected a type!");
     setType(E, E->getType());
+    return E;
+  }
+
+  /// Cache the type of the expression argument and return that same
+  /// argument.
+  KeyPathExpr *cacheType(KeyPathExpr *E, unsigned I) {
+    auto componentTy = E->getComponents()[I].getComponentType();
+    assert(componentTy && "Expected a type!");
+    setType(E, I, componentTy);
     return E;
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3557,6 +3557,7 @@ public:
                             "only for use within the debugger");
 
   void print(raw_ostream &out);
+  void print(raw_ostream &out, Expr *);
 };
 
 /// Compute the shuffle required to map from a given tuple type to

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3408,27 +3408,9 @@ void ConstraintSystem::print(raw_ostream &out, Expr *E) {
     return Type();
   };
   auto getTypeOfKeyPathComponent =
-      [&](const KeyPathExpr *E, unsigned index) -> Type {
-    // CSGen attaches the type var for each key path component to the
-    // "key path component #n -> function result" locator. This is the natural
-    // place subscript result types will end up, and it's otherwise unused by
-    // other components.
-    auto componentLocator = getConstraintLocator(E,
-        ConstraintLocator::PathElement::getKeyPathComponent(index));
-    auto resultLocator = getConstraintLocator(componentLocator,
-        ConstraintLocator::FunctionResult);
-
-    // Find the first type variable with this locator and return it.
-    for (auto &typeVar : TypeVariables) {
-      if ((*typeVar)->getLocator() != resultLocator)
-        continue;
-
-      if (auto fixedTy = (*typeVar)->getFixedType(getSavedBindings()))
-        return fixedTy;
-
-      return typeVar;
-    }
-
+      [&](const KeyPathExpr *KP, unsigned I) -> Type {
+    if (hasType(KP, I))
+      return getType(KP, I);
     return Type();
   };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3407,8 +3407,32 @@ void ConstraintSystem::print(raw_ostream &out, Expr *E) {
       return getType(TL);
     return Type();
   };
+  auto getTypeOfKeyPathComponent =
+      [&](const KeyPathExpr *E, unsigned index) -> Type {
+    // CSGen attaches the type var for each key path component to the
+    // "key path component #n -> function result" locator. This is the natural
+    // place subscript result types will end up, and it's otherwise unused by
+    // other components.
+    auto componentLocator = getConstraintLocator(E,
+        ConstraintLocator::PathElement::getKeyPathComponent(index));
+    auto resultLocator = getConstraintLocator(componentLocator,
+        ConstraintLocator::FunctionResult);
 
-  E->dump(out, getTypeOfExpr, getTypeOfTypeLoc);
+    // Find the first type variable with this locator and return it.
+    for (auto &typeVar : TypeVariables) {
+      if ((*typeVar)->getLocator() != resultLocator)
+        continue;
+
+      if (auto fixedTy = (*typeVar)->getFixedType(getSavedBindings()))
+        return fixedTy;
+
+      return typeVar;
+    }
+
+    return Type();
+  };
+
+  E->dump(out, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent);
 }
 
 void ConstraintSystem::print(raw_ostream &out) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3393,6 +3393,10 @@ void ConstraintSystem::dump() {
 }
 
 void ConstraintSystem::dump(Expr *E) {
+  print(llvm::errs(), E);
+}
+
+void ConstraintSystem::print(raw_ostream &out, Expr *E) {
   auto getTypeOfExpr = [&](const Expr *E) -> Type {
     if (hasType(E))
       return getType(E);
@@ -3404,7 +3408,7 @@ void ConstraintSystem::dump(Expr *E) {
     return Type();
   };
 
-  E->dump(llvm::errs(), getTypeOfExpr, getTypeOfTypeLoc);
+  E->dump(out, getTypeOfExpr, getTypeOfTypeLoc);
 }
 
 void ConstraintSystem::print(raw_ostream &out) {


### PR DESCRIPTION
During constraint debugging, the AST dumper currently shows all `KeyPathExpr` components with `<null>` types because it can't look into the constraint system to find type variables. This PR improves this debugging experience, which should help us fight some of the bugs in key path type-checking.

- [x] Make key path component type variables consistently accessible by constraint locator
- [x] Add callback for ASTDumper to find them
- [x] Colorize, rearrange, and otherwise improve key path component AST dump formatting

**Before**

<img width="1020" alt="Screen Shot 2019-04-16 at 9 22 44 PM" src="https://user-images.githubusercontent.com/931226/56260897-db745400-608d-11e9-9d94-8053e60e0876.png">

**After**

<img width="1020" alt="Screen Shot 2019-04-16 at 9 22 10 PM" src="https://user-images.githubusercontent.com/931226/56260908-e4fdbc00-608d-11e9-9e18-96fdedcb648b.png">