### PR TITLE
[TF] Introduce callables.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -122,7 +122,8 @@ DECL_ATTR(available, Available,
   AllowMultipleAttributes | LongAttribute,
   1)
 CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
-  OnClass | OnFunc | OnAccessor | OnVar | OnSubscript |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnClass | OnFunc | OnAccessor | OnCall | OnVar | OnSubscript |
   DeclModifier,
   2)
 DECL_ATTR(objc, ObjC,
@@ -134,7 +135,8 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(required, Required,
   DeclModifier,
   4)
 CONTEXTUAL_SIMPLE_DECL_ATTR(optional, Optional,
-  OnConstructor | OnFunc | OnAccessor | OnVar | OnSubscript |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnConstructor | OnFunc | OnAccessor | OnCall | OnVar | OnSubscript |
   DeclModifier,
   5)
 SIMPLE_DECL_ATTR(dynamicCallable, DynamicCallable,
@@ -190,7 +192,8 @@ DECL_ATTR(_semantics, Semantics,
   AllowMultipleAttributes | UserInaccessible,
   21)
 CONTEXTUAL_SIMPLE_DECL_ATTR(dynamic, Dynamic,
-  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnVar | OnSubscript | OnConstructor |
   DeclModifier,
   22)
 CONTEXTUAL_SIMPLE_DECL_ATTR(infix, Infix,
@@ -206,13 +209,16 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(postfix, Postfix,
   DeclModifier,
   25)
 SIMPLE_DECL_ATTR(_transparent, Transparent,
-  OnFunc | OnAccessor | OnConstructor | OnVar | UserInaccessible,
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnConstructor | OnVar | UserInaccessible,
   26)
 SIMPLE_DECL_ATTR(requires_stored_property_inits, RequiresStoredPropertyInits,
   OnClass,
   27)
 SIMPLE_DECL_ATTR(nonobjc, NonObjC,
-  OnExtension | OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor,
+  // SWIFT_ENABLE_TENSORFLOW
+  OnExtension | OnFunc | OnAccessor | OnCall | OnVar | OnSubscript |
+  OnConstructor,
   30)
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
   OnVar | OnClass | OnStruct |
@@ -222,23 +228,27 @@ SIMPLE_DECL_ATTR(inlinable, Inlinable,
   OnVar | OnSubscript | OnAbstractFunction,
   32)
 DECL_ATTR(_specialize, Specialize,
-  OnConstructor | OnFunc | OnAccessor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnConstructor | OnFunc | OnAccessor | OnCall |
   AllowMultipleAttributes | LongAttribute | UserInaccessible,
   33)
 SIMPLE_DECL_ATTR(objcMembers, ObjCMembers,
   OnClass,
   34)
 CONTEXTUAL_SIMPLE_DECL_ATTR(__consuming, Consuming,
-  OnFunc | OnAccessor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall |
   DeclModifier |
   UserInaccessible |
   NotSerialized, 40)
 CONTEXTUAL_SIMPLE_DECL_ATTR(mutating, Mutating,
-  OnFunc | OnAccessor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall |
   DeclModifier |
   NotSerialized, 41)
 CONTEXTUAL_SIMPLE_DECL_ATTR(nonmutating, NonMutating,
-  OnFunc | OnAccessor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall |
   DeclModifier |
   NotSerialized, 42)
 CONTEXTUAL_SIMPLE_DECL_ATTR(convenience, Convenience,
@@ -246,7 +256,9 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(convenience, Convenience,
   DeclModifier |
   NotSerialized, 43)
 CONTEXTUAL_SIMPLE_DECL_ATTR(override, Override,
-  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor | OnAssociatedType |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnVar | OnSubscript | OnConstructor |
+  OnAssociatedType |
   DeclModifier |
   NotSerialized, 44)
 SIMPLE_DECL_ATTR(_hasStorage, HasStorage,
@@ -254,8 +266,9 @@ SIMPLE_DECL_ATTR(_hasStorage, HasStorage,
   UserInaccessible |
   NotSerialized, 45)
 DECL_ATTR(private, AccessControl,
-  OnFunc | OnAccessor | OnExtension | OnGenericType | OnVar | OnSubscript |
-  OnConstructor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnExtension | OnGenericType | OnVar |
+  OnSubscript | OnConstructor |
   DeclModifier |
   NotSerialized, 46)
 DECL_ATTR_ALIAS(fileprivate, AccessControl)
@@ -303,7 +316,8 @@ DECL_ATTR(_alignment, Alignment,
   UserInaccessible,
   56)
 SIMPLE_DECL_ATTR(rethrows, Rethrows,
-  OnFunc | OnAccessor | OnConstructor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnConstructor |
   RejectByParser,
   57)
 DECL_ATTR(_swift_native_objc_runtime_base, SwiftNativeObjCRuntimeBase,
@@ -330,14 +344,16 @@ SIMPLE_DECL_ATTR(usableFromInline, UsableFromInline,
   LongAttribute,
   64)
 SIMPLE_DECL_ATTR(discardableResult, DiscardableResult,
-  OnFunc | OnAccessor | OnConstructor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnConstructor |
   LongAttribute,
   65)
 SIMPLE_DECL_ATTR(GKInspectable, GKInspectable,
   OnVar,
   66)
 DECL_ATTR(_implements, Implements,
-  OnFunc | OnAccessor | OnVar | OnSubscript | OnTypeAlias |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnVar | OnSubscript | OnTypeAlias |
   UserInaccessible |
   NotSerialized, 67)
 DECL_ATTR(_objcRuntimeName, ObjCRuntimeName,
@@ -353,7 +369,8 @@ DECL_ATTR(_restatedObjCConformance, RestatedObjCConformance,
   NotSerialized, 70)
 // NOTE: 71 is unused
 SIMPLE_DECL_ATTR(_implicitly_unwrapped_optional, ImplicitlyUnwrappedOptional,
-  OnFunc | OnAccessor | OnVar | OnParam | OnSubscript | OnConstructor |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnVar | OnParam | OnSubscript | OnConstructor |
   RejectByParser,
   72)
 DECL_ATTR(_optimize, Optimize,
@@ -365,7 +382,8 @@ DECL_ATTR(_clangImporterSynthesizedType, ClangImporterSynthesizedType,
   LongAttribute | RejectByParser | UserInaccessible |
   NotSerialized, 74)
 SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
-  OnNominalType | OnAssociatedType | OnFunc | OnAccessor | OnVar |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnNominalType | OnAssociatedType | OnFunc | OnAccessor | OnCall | OnVar |
   OnSubscript | OnConstructor | OnEnumElement | UserInaccessible,
   75)
 SIMPLE_DECL_ATTR(_frozen, Frozen,
@@ -381,7 +399,9 @@ SIMPLE_DECL_ATTR(_hasInitialValue, HasInitialValue,
   UserInaccessible,
   78)
 SIMPLE_DECL_ATTR(_nonoverride, NonOverride,
-  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor | OnAssociatedType |
+  // SWIFT_ENABLE_TENSORFLOW
+  OnFunc | OnAccessor | OnCall | OnVar | OnSubscript | OnConstructor |
+  OnAssociatedType |
   UserInaccessible | NotSerialized,
   79)
 DECL_ATTR(_dynamicReplacement, DynamicReplacement,
@@ -397,8 +417,8 @@ DECL_ATTR(_private, PrivateImport,
 
 // SWIFT_ENABLE_TENSORFLOW
 DECL_ATTR(differentiable, Differentiable,
-  OnAccessor | OnConstructor | OnFunc | OnVar | OnSubscript | LongAttribute |
-  AllowMultipleAttributes,
+  OnAccessor | OnConstructor | OnFunc | OnCall | OnVar | OnSubscript |
+  LongAttribute | AllowMultipleAttributes,
   83)
 DECL_ATTR(differentiating, Differentiating,
   OnFunc | LongAttribute | AllowMultipleAttributes |

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -53,6 +53,8 @@ namespace swift {
   struct ASTNode;
   class ASTPrinter;
   class ASTWalker;
+  // SWIFT_ENABLE_TENSORFLOW
+  class CallDecl;
   class ConstructorDecl;
   class DestructorDecl;
   class DiagnosticEngine;
@@ -136,6 +138,8 @@ enum class DescriptiveDeclKind : uint8_t {
   GenericStruct,
   GenericClass,
   GenericType,
+  // SWIFT_ENABLE_TENSORFLOW
+  Call,
   Subscript,
   Constructor,
   Destructor,
@@ -5727,7 +5731,9 @@ public:
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Func ||
-           D->getKind() == DeclKind::Accessor;
+           D->getKind() == DeclKind::Accessor ||
+           // SWIFT_ENABLE_TENSORFLOW
+           D->getKind() == DeclKind::Call;
   }
   static bool classof(const AbstractFunctionDecl *D) {
     return classof(static_cast<const Decl*>(D));
@@ -5880,7 +5886,54 @@ AbstractStorageDecl::AccessorRecord::getAccessor(AccessorKind kind) const {
   }
   return nullptr;
 }
-  
+
+// SWIFT_ENABLE_TENSORFLOW
+/// CallDecl - Declares a callable method for a type. For example:
+///
+/// \code
+/// struct Adder {
+///   var base: Int
+///   call(_ x: Int) -> Int {
+///      return base + x
+///   }
+/// }
+/// \endcode
+class CallDecl final : public FuncDecl {
+  CallDecl(DeclName fullName, SourceLoc declLoc, bool throws,
+           SourceLoc throwsLoc, unsigned numParameterLists,
+           GenericParamList *genericParams, DeclContext *parent)
+    : FuncDecl(DeclKind::Call,
+               /*staticLoc*/ SourceLoc(), StaticSpellingKind::None,
+               /*func loc*/ declLoc, /*name*/ fullName, /*name loc*/ declLoc,
+               throws, throwsLoc, numParameterLists, genericParams, parent) {}
+
+  static CallDecl *createImpl(ASTContext &ctx, DeclName fullName,
+                              SourceLoc declLoc, bool throws,
+                              SourceLoc throwsLoc,
+                              GenericParamList *genericParams,
+                              DeclContext *parent, ClangNode clangNode);
+
+public:
+  static CallDecl *create(ASTContext &ctx, DeclName fullName, SourceLoc declLoc,
+                          bool throws, SourceLoc throwsLoc,
+                          GenericParamList *genericParams,
+                          ParameterList *parameterList,
+                          TypeLoc fnRetType, DeclContext *parent,
+                          ClangNode clangNode = ClangNode());
+
+  static bool classof(const Decl *D) {
+    return D->getKind() == DeclKind::Call;
+  }
+  static bool classof(const AbstractFunctionDecl *D) {
+    return classof(static_cast<const Decl*>(D));
+  }
+  static bool classof(const DeclContext *DC) {
+    if (auto D = DC->getAsDecl())
+      return classof(D);
+    return false;
+  }
+};
+
 /// \brief This represents a 'case' declaration in an 'enum', which may declare
 /// one or more individual comma-separated EnumElementDecls.
 class EnumCaseDecl final : public Decl,
@@ -6793,6 +6846,8 @@ inline ParamDecl **AbstractFunctionDecl::getImplicitSelfDeclStorage() {
     return cast<DestructorDecl>(this)->getImplicitSelfDeclStorage();
   case DeclKind::Func:
   case DeclKind::Accessor:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call:
     return cast<FuncDecl>(this)->getImplicitSelfDeclStorage();
   }
 }
@@ -6801,11 +6856,13 @@ inline ParamDecl **FuncDecl::getImplicitSelfDeclStorage() {
   if (!hasImplicitSelfDecl())
     return nullptr;
 
-  if (!isa<AccessorDecl>(this)) {
-    assert(getKind() == DeclKind::Func && "no new kinds of functions");
-    return reinterpret_cast<ParamDecl **>(this+1);
-  }
-  return reinterpret_cast<ParamDecl **>(static_cast<AccessorDecl*>(this)+1);
+  if (isa<AccessorDecl>(this))
+    return reinterpret_cast<ParamDecl **>(static_cast<AccessorDecl *>(this)+1);
+  // SWIFT_ENABLE_TENSORFLOW
+  else if (isa<CallDecl>(this))
+    return reinterpret_cast<ParamDecl **>(static_cast<CallDecl *>(this)+1);
+  assert(getKind() == DeclKind::Func && "no new kinds of functions");
+  return reinterpret_cast<ParamDecl **>(this+1);
 }
 
 inline DeclIterator &DeclIterator::operator++() {

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -170,7 +170,9 @@ ABSTRACT_DECL(Value, Decl)
     ABSTRACT_FUNCTION_DECL(Destructor, AbstractFunctionDecl)
     ABSTRACT_FUNCTION_DECL(Func, AbstractFunctionDecl)
       ABSTRACT_FUNCTION_DECL(Accessor, FuncDecl)
-    DECL_RANGE(AbstractFunction, Constructor, Accessor)
+      // SWIFT_ENABLE_TENSORFLOW
+      ABSTRACT_FUNCTION_DECL(Call, FuncDecl)
+    DECL_RANGE(AbstractFunction, Constructor, Call)
   VALUE_DECL(EnumElement, ValueDecl)
   DECL_RANGE(Value, Enum, EnumElement)
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -398,6 +398,19 @@ ERROR(subscript_without_get,none,
 ERROR(subscript_static,none,
       "subscript cannot be marked %0", (StaticSpellingKind))
 
+// SWIFT_ENABLE_TENSORFLOW
+// `call` method
+ERROR(call_decl_static,none,
+      "'call' method cannot be marked %0", (StaticSpellingKind))
+ERROR(call_decl_wrong_scope,none,
+      "'call' methods may only be declared within a type", ())
+ERROR(expected_lparen_call,PointsToFirstBadToken,
+      "expected '(' for 'call' member parameters", ())
+ERROR(call_decl_cannot_have_name,PointsToFirstBadToken,
+      "'call' method cannot have a name", ())
+ERROR(call_decl_expected_func_keyword,PointsToFirstBadToken,
+      "'call' must be followed by 'func'", ())
+
 // initializer
 ERROR(invalid_nested_init,none,
       "missing '%select{super.|self.}0' at initializer invocation", (bool))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1052,6 +1052,7 @@ NOTE(archetype_declared_in_type,none,
 NOTE(unbound_generic_parameter_explicit_fix,none,
      "explicitly specify the generic arguments to fix this issue", ())
 
+// SWIFT_ENABLE_TENSORFLOW
 ERROR(invalid_dynamic_callable_type,none,
       "@dynamicCallable attribute requires %0 to have either a valid "
       "'dynamicallyCall(withArguments:)' method or "
@@ -1689,15 +1690,17 @@ ERROR(witness_requires_class_implementation,none,
       (DeclName, Type))
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
-      "|subscript%select{| setter}2}0 must be declared "
+      // SWIFT_ENABLE_TENSORFLOW
+      "|subscript%select{| setter}2|'call' method}0 must be declared "
       "%select{%error|fileprivate|internal|public|%error}3 because it matches a "
       "requirement in %select{private|fileprivate|internal|public|%error}4 protocol "
       "%5",
       (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, DeclName))
 ERROR(witness_not_accessible_type,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
-      "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
-      "type because it matches a requirement in protocol %5",
+      // SWIFT_ENABLE_TENSORFLOW
+      "|subscript%select{| setter}2|'call' method}0 must be as accessible as "
+      "its enclosing type because it matches a requirement in protocol %5",
       (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, DeclName))
 ERROR(type_witness_not_accessible_proto,none,
       "%0 %1 must be declared %select{%error|fileprivate|internal|public|%error}2 "
@@ -1761,19 +1764,24 @@ NOTE(inherited_protocol_does_not_conform,none,
      "type %0 does not conform to inherited protocol %1", (Type, Type))
 NOTE(no_witnesses,none,
      "protocol requires "
-     "%select{initializer %1|function %1|property %1|subscript}0 with type %2"
-     "%select{|; do you want to add a stub?}3",
+      // SWIFT_ENABLE_TENSORFLOW
+     "%select{initializer %1|function %1|property %1|subscript|'call' method}0 "
+     "with type %2%select{|; do you want to add a stub?}3",
      (RequirementKind, DeclName, Type, bool))
 NOTE(missing_witnesses_general,none, "do you want to add protocol stubs?",
      ())
 NOTE(ambiguous_witnesses,none,
      "multiple matching "
      "%select{initializers named %1|functions named %1|properties named %1|"
-     "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
+      // SWIFT_ENABLE_TENSORFLOW
+     "subscript operators|'call' method}0 with type %2",
+     (RequirementKind, DeclName, Type))
 NOTE(ambiguous_witnesses_wrong_name,none,
      "multiple matching "
      "%select{initializers named %1|functions named %1|properties named %1|"
-     "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
+      // SWIFT_ENABLE_TENSORFLOW
+     "subscript operators|'call' method}0 with type %2",
+     (RequirementKind, DeclName, Type))
 NOTE(no_witnesses_type,none,
      "protocol requires nested type %0; do you want to add it?", (Identifier))
 NOTE(default_associated_type_req_fail,none,
@@ -1837,7 +1845,8 @@ NOTE(protocol_witness_renamed,none,
      "rename to %0 to satisfy this requirement%1", (DeclName, StringRef))
 NOTE(protocol_witness_kind_conflict,none,
      "candidate is not %select{an initializer|a function|a variable|"
-     "a subscript}0", (RequirementKind))
+      // SWIFT_ENABLE_TENSORFLOW
+     "a subscript|a 'call' method}0", (RequirementKind))
 NOTE(protocol_witness_type_conflict,none,
      "candidate has non-matching type %0%1", (Type, StringRef))
 NOTE(protocol_witness_missing_requirement,none,

--- a/include/swift/AST/DiagnosticsSema.h
+++ b/include/swift/AST/DiagnosticsSema.h
@@ -29,7 +29,9 @@ namespace swift {
       Constructor,
       Func,
       Var,
-      Subscript
+      Subscript,
+      // SWIFT_ENABLE_TENSORFLOW
+      Call
     };
 
   // Declare common diagnostics objects with their appropriate types.

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -42,6 +42,8 @@ NODE(BoundGenericOtherNominalType)
 NODE(BoundGenericTypeAlias)
 NODE(BoundGenericFunction)
 NODE(BuiltinTypeName)
+// SWIFT_ENABLE_TENSORFLOW
+CONTEXT_NODE(CallDeclaration)
 NODE(CFunctionPointer)
 CONTEXT_NODE(Class)
 NODE(ClassMetadataBaseOffset)

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -398,6 +398,8 @@ enum class CodeCompletionDeclKind {
   Constructor,
   Destructor,
   Subscript,
+  // SWIFT_ENABLE_TENSORFLOW
+  Call,
   StaticMethod,
   InstanceMethod,
   PrefixOperatorFunction,

--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -97,6 +97,8 @@ enum class SyntaxStructureKind : uint8_t {
   EnumElement,
   TypeAlias,
   Subscript,
+  // SWIFT_ENABLE_TENSORFLOW
+  Call,
   AssociatedType,
   GenericTypeParam,
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -457,7 +457,9 @@ public:
   }
 
   SourceLoc consumeIdentifier(Identifier *Result = nullptr) {
-    assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));
+    // SWIFT_ENABLE_TENSORFLOW
+    assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self,
+                     tok::kw_call));
     if (Result)
       *Result = Context.getIdentifier(Tok.getText());
     return consumeToken();
@@ -959,6 +961,9 @@ public:
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  ParserResult<CallDecl>
+  parseDeclCall(ParseDeclOptions Flags, DeclAttributes &Attributes);
   ParserResult<SubscriptDecl>
   parseDeclSubscript(ParseDeclOptions Flags, DeclAttributes &Attributes,
                      SmallVectorImpl<Decl *> &Decls);
@@ -1119,6 +1124,9 @@ public:
     Closure,
     /// A subscript.
     Subscript,
+    // SWIFT_ENABLE_TENSORFLOW
+    /// A callable method.
+    Call,
     /// A curried argument clause.
     Curried,
     /// An enum element.
@@ -1157,6 +1165,8 @@ public:
                                       DefaultArgumentInfo &defaultArgs);
   ParserStatus parseFunctionSignature(Identifier functionName,
                                       DeclName &fullName,
+                                      // SWIFT_ENABLE_TENSORFLOW
+                                      ParameterContextKind paramContext,
                                       ParameterList *&bodyParams,
                                       DefaultArgumentInfo &defaultArgs,
                                       SourceLoc &throws,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 472; // Last change: `@differentiating` wrt
+const uint16_t SWIFTMODULE_VERSION_MINOR = 473; // Last change: `call` declarations
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1057,6 +1057,13 @@ namespace {
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
+    void visitCallDecl(CallDecl *CD) {
+      printCommonFD(CD, "call_decl");
+      printAbstractFunctionDecl(CD);
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
+
     void visitAccessorDecl(AccessorDecl *AD) {
       printCommonFD(AD, "accessor_decl");
       OS << " " << getAccessorKindString(AD->getAccessorKind());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2240,6 +2240,23 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
         accessor->getStorage(), accessor->isStatic());
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  // Handle call declarations specially.
+  if (auto callDecl = dyn_cast<CallDecl>(decl)) {
+    appendContextOf(decl);
+    bindGenericParameters(decl->getDeclContext());
+    appendDeclType(decl);
+    StringRef privateDiscriminator = getPrivateDiscriminatorIfNecessary(decl);
+    if (!privateDiscriminator.empty()) {
+      appendIdentifier(privateDiscriminator);
+      appendOperator("Ll");
+    }
+    appendOperator("fF");
+    if (callDecl->isStatic())
+      appendOperator("Z");
+    return;
+  }
+
   if (auto storageDecl = dyn_cast<AbstractStorageDecl>(decl))
     return appendAccessorEntity("p", storageDecl, decl->isStatic());
   if (isa<GenericTypeParamDecl>(decl))

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -918,7 +918,9 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
   case DeclKind::Func:
   case DeclKind::Accessor:
   case DeclKind::Constructor:
-  case DeclKind::Destructor: {
+  case DeclKind::Destructor:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call: {
     auto abstractFunction = cast<AbstractFunctionDecl>(decl);
 
     // If we have a generic function and our parent isn't describing our generic

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -150,6 +150,8 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(GenericTypeParam);
   TRIVIAL_KIND(AssociatedType);
   TRIVIAL_KIND(Protocol);
+  // SWIFT_ENABLE_TENSORFLOW
+  TRIVIAL_KIND(Call);
   TRIVIAL_KIND(Subscript);
   TRIVIAL_KIND(Constructor);
   TRIVIAL_KIND(Destructor);
@@ -278,6 +280,8 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(GenericStruct, "generic struct");
   ENTRY(GenericClass, "generic class");
   ENTRY(GenericType, "generic type");
+  // SWIFT_ENABLE_TENSORFLOW
+  ENTRY(Call, "call method");
   ENTRY(Subscript, "subscript");
   ENTRY(Constructor, "initializer");
   ENTRY(Destructor, "deinitializer");
@@ -862,6 +866,8 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
   case DeclKind::Constructor:
   case DeclKind::Destructor:
   case DeclKind::GenericTypeParam:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call:
   case DeclKind::Subscript:
   case DeclKind::EnumElement:
   case DeclKind::Param:
@@ -1900,6 +1906,11 @@ bool ValueDecl::isInstanceMember() const {
   case DeclKind::Param:
     // enum elements and function parameters are not instance members.
     return false;
+
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call:
+    // Call declarations are always instance members.
+    return true;
 
   case DeclKind::Subscript:
     // Subscripts are always instance members.
@@ -5864,6 +5875,42 @@ bool FuncDecl::isBinaryOperator() const {
     !params->get(0)->isVariadic() &&
     !params->get(1)->isVariadic();
 }
+
+// SWIFT_ENABLE_TENSORFLOW
+CallDecl *CallDecl::createImpl(ASTContext &ctx, DeclName name,
+                               SourceLoc declLoc, bool throws,
+                               SourceLoc throwsLoc,
+                               GenericParamList *genericParams,
+                               DeclContext *parent, ClangNode clangNode) {
+  bool hasImplicitSelfDecl = parent->isTypeContext();
+  size_t size = sizeof(CallDecl) + (hasImplicitSelfDecl
+                                        ? sizeof(ParamDecl *)
+                                        : 0);
+  void *buffer =
+      allocateMemoryForDecl<CallDecl>(ctx, size, !clangNode.isNull());
+  auto *D = ::new (buffer)
+      CallDecl(name, declLoc, throws, throwsLoc, hasImplicitSelfDecl,
+               genericParams, parent);
+  if (clangNode)
+    D->setClangNode(clangNode);
+  if (hasImplicitSelfDecl)
+    *D->getImplicitSelfDeclStorage() = nullptr;
+
+   return D;
+}
+
+ CallDecl *CallDecl::create(ASTContext &ctx, DeclName name, SourceLoc declLoc,
+                           bool throws, SourceLoc throwsLoc,
+                           GenericParamList *genericParams,
+                           ParameterList *bodyParams, TypeLoc fnRetType,
+                           DeclContext *parent, ClangNode clangNode) {
+  auto *D = CallDecl::createImpl(
+      ctx, name, declLoc, throws, throwsLoc, genericParams, parent, clangNode);
+  D->setParameters(bodyParams);
+  D->getBodyResultTypeLoc() = fnRetType;
+  return D;
+}
+// SWIFT_ENABLE_TENSORFLOW END
 
 ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
                                  OptionalTypeKind Failability, 

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -336,7 +336,9 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
       // with the same signature.
 
       case DeclKind::Accessor:
-      case DeclKind::Func: {
+      case DeclKind::Func:
+      // SWIFT_ENABLE_TENSORFLOW
+      case DeclKind::Call: {
         auto FD = cast<FuncDecl>(D);
         assert(FD->hasImplicitSelfDecl() && "should not find free functions");
         (void)FD;

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2704,6 +2704,10 @@ NodePointer Demangler::demangleFunctionEntity() {
       Args = TypeAndMaybePrivateName; Kind = Node::Kind::Allocator; break;
     case 'c':
       Args = TypeAndMaybePrivateName; Kind = Node::Kind::Constructor; break;
+    // SWIFT_ENABLE_TENSORFLOW
+    case 'F':
+      Args = TypeAndMaybePrivateName; Kind = Node::Kind::CallDeclaration; break;
+    // SWIFT_ENABLE_TENSORFLOW END
     case 'U': Args = TypeAndIndex; Kind = Node::Kind::ExplicitClosure; break;
     case 'u': Args = TypeAndIndex; Kind = Node::Kind::ImplicitClosure; break;
     case 'A': Args = Index; Kind = Node::Kind::DefaultArgumentInitializer; break;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -319,6 +319,8 @@ private:
     case Node::Kind::AssociatedTypeMetadataAccessor:
     case Node::Kind::AssociatedTypeWitnessTableAccessor:
     case Node::Kind::AutoClosureType:
+    // SWIFT_ENABLE_TENSORFLOW
+    case Node::Kind::CallDeclaration:
     case Node::Kind::ClassMetadataBaseOffset:
     case Node::Kind::CFunctionPointer:
     case Node::Kind::Constructor:
@@ -1041,6 +1043,11 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return printEntity(Node, asPrefixContext, TypePrinting::FunctionStyle,
                        /*hasName*/false, /*ExtraName*/"", /*ExtraIndex*/-1,
                        "subscript");
+    // SWIFT_ENABLE_TENSORFLOW
+  case Node::Kind::CallDeclaration:
+    return printEntity(Node, asPrefixContext, TypePrinting::FunctionStyle,
+                       /*hasName*/false, /*ExtraName*/"", /*ExtraIndex*/-1,
+                       "call");
   case Node::Kind::GenericTypeParamDecl:
     return printEntity(Node, asPrefixContext, TypePrinting::NoType,
                        /*hasName*/true);

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -985,6 +985,13 @@ void Remangler::mangleFunction(Node *node, EntityContext &ctx) {
   mangleNamedAndTypedEntity(node, 'F', "", ctx);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+void Remangler::mangleCallDeclaration(Node *node, EntityContext &ctx) {
+  Out << 'f';
+  mangleEntityContext(node->getChild(0), ctx);
+  Out << 'F';
+}
+
 void Remangler::mangleVariable(Node *node, EntityContext &ctx) {
   mangleNamedAndTypedEntity(node, 'v', "", ctx);
 }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -730,6 +730,11 @@ void Remangler::mangleConstructor(Node *node) {
   mangleAnyConstructor(node, 'c');
 }
 
+void Remangler::mangleCallDeclaration(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fF";
+}
+
 void Remangler::mangleCoroutineContinuationPrototype(Node *node) {
   mangleChildNodes(node);
   Buffer << "TC";

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -307,6 +307,8 @@ void ProvidesEmitter::emitTopLevelDecl(const Decl *const D,
   case DeclKind::GenericTypeParam:
   case DeclKind::AssociatedType:
   case DeclKind::Param:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call:
   case DeclKind::Subscript:
   case DeclKind::Constructor:
   case DeclKind::Destructor:

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -623,6 +623,9 @@ CodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
     return CodeCompletionDeclKind::PrecedenceGroup;
   case DeclKind::EnumElement:
     return CodeCompletionDeclKind::EnumElement;
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call:
+    return CodeCompletionDeclKind::Call;
   case DeclKind::Subscript:
     return CodeCompletionDeclKind::Subscript;
   }
@@ -664,6 +667,10 @@ void CodeCompletionResult::print(raw_ostream &OS) const {
       break;
     case CodeCompletionDeclKind::Destructor:
       Prefix.append("[Destructor]");
+      break;
+    // SWIFT_ENABLE_TENSORFLOW
+    case CodeCompletionDeclKind::Call:
+      Prefix.append("[Call]");
       break;
     case CodeCompletionDeclKind::Subscript:
       Prefix.append("[Subscript]");
@@ -5983,6 +5990,8 @@ void swift::ide::copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
       case CodeCompletionDeclKind::EnumElement:
       case CodeCompletionDeclKind::Constructor:
       case CodeCompletionDeclKind::Destructor:
+      // SWIFT_ENABLE_TENSORFLOW
+      case CodeCompletionDeclKind::Call:
       case CodeCompletionDeclKind::Subscript:
       case CodeCompletionDeclKind::StaticMethod:
       case CodeCompletionDeclKind::InstanceMethod:

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -119,6 +119,8 @@ static void toDisplayString(CodeCompletionResult *Result,
         case CodeCompletionDeclKind::Destructor:
           continue;
 
+        // SWIFT_ENABLE_TENSORFLOW
+        case CodeCompletionDeclKind::Call:
         case CodeCompletionDeclKind::Subscript:
         case CodeCompletionDeclKind::StaticMethod:
         case CodeCompletionDeclKind::InstanceMethod:

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1515,6 +1515,14 @@ namespace {
       getMethodList(constructor).push_back(constructor);
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
+    /// Call methods need to be collected into the appropriate methods list.
+    void visitCallDecl(CallDecl *method) {
+      if (!isBuildingProtocol() && !requiresObjCMethodDescriptor(method))
+        return;
+      getMethodList(method).push_back(method);
+    }
+
     /// Determine whether the given destructor has an Objective-C
     /// definition.
     bool hasObjCDeallocDefinition(DestructorDecl *destructor) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1717,6 +1717,10 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   case DeclKind::Param:
     llvm_unreachable("there are no global function parameters");
 
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call:
+    llvm_unreachable("there are no global call declarations");
+
   case DeclKind::Subscript:
     llvm_unreachable("there are no global subscript operations");
       
@@ -3667,6 +3671,8 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
       continue;
 
     case DeclKind::Var:
+    // SWIFT_ENABLE_TENSORFLOW
+    case DeclKind::Call:
     case DeclKind::Subscript:
     case DeclKind::PatternBinding:
     case DeclKind::Func:

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1418,6 +1418,11 @@ bool irgen::requiresObjCMethodDescriptor(ConstructorDecl *constructor) {
   return constructor->isObjC();
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+bool irgen::requiresObjCMethodDescriptor(CallDecl *method) {
+  return method->isObjC();
+}
+
 bool irgen::requiresObjCPropertyDescriptor(IRGenModule &IGM,
                                            VarDecl *property) {
   // Don't generate a descriptor for a property without any accessors.

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -203,6 +203,10 @@ namespace irgen {
   /// True if the ConstructorDecl requires an ObjC method descriptor.
   bool requiresObjCMethodDescriptor(ConstructorDecl *constructor);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// True if the CallDecl requires an ObjC method descriptor.
+  bool requiresObjCMethodDescriptor(CallDecl *method);
+
   /// True if the VarDecl requires ObjC accessor methods and a property
   /// descriptor.
   bool requiresObjCPropertyDescriptor(IRGenModule &IGM,

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -199,6 +199,11 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
       info.Kind = SymbolKind::InstanceProperty;
       info.SubKind = SymbolSubKind::SwiftSubscript;
       break;
+    // SWIFT_ENABLE_TENSORFLOW
+    case DeclKind::Call:
+      info.Kind = SymbolKind::InstanceMethod;
+      // info.SubKind = SymbolSubKind::SwiftCall;
+      break;
     case DeclKind::Constructor:      info.Kind = SymbolKind::Constructor; break;
     case DeclKind::Destructor:       info.Kind = SymbolKind::Destructor; break;
     case DeclKind::Param:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3105,6 +3105,18 @@ Parser::parseDecl(ParseDeclOptions Flags,
     StaticLoc = SourceLoc(); // we handled static if present.
     MayNeedOverrideCompletion = true;
     break;
+  // SWIFT_ENABLE_TENSORFLOW
+  case tok::kw_call:
+    // Collect all modifiers into a modifier list.
+    DeclParsingContext.setCreateSyntax(SyntaxKind::CallDecl);
+    if (StaticLoc.isValid()) {
+      diagnose(Tok, diag::call_decl_static, StaticSpelling)
+          .fixItRemove(SourceRange(StaticLoc));
+      StaticLoc = SourceLoc();
+    }
+    DeclResult = parseDeclCall(Flags, Attributes);
+    MayNeedOverrideCompletion = true;
+    break;
   case tok::kw_subscript: {
     DeclParsingContext.setCreateSyntax(SyntaxKind::SubscriptDecl);
     if (StaticLoc.isValid()) {
@@ -3184,6 +3196,8 @@ Parser::parseDecl(ParseDeclOptions Flags,
       SmallVector<StringRef, 3> Keywords;
       switch (OrigTok.getKind()) {
       case tok::kw_func:
+      // SWIFT_ENABLE_TENSORFLOW
+      case tok::kw_call:
       case tok::kw_subscript:
       case tok::kw_var:
       case tok::kw_let:
@@ -3559,7 +3573,8 @@ parseIdentifierDeclName(Parser &P, Identifier &Result, SourceLoc &Loc,
                         StringRef DeclKindName, tok ResyncT1, tok ResyncT2,
                         tok ResyncT3, tok ResyncT4,
                         TokenProperty ResyncP1) {
-  if (P.Tok.is(tok::identifier)) {
+  // SWIFT_ENABLE_TENSORFLOW
+  if (P.Tok.is(tok::identifier) || P.Tok.is(tok::kw_call)) {
     Loc = P.consumeIdentifier(&Result);
 
     // We parsed an identifier for the declaration. If we see another
@@ -5741,9 +5756,13 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
   ParameterList *BodyParams;
   SourceLoc throwsLoc;
   bool rethrows;
+  // SWIFT_ENABLE_TENSORFLOW
+  ParameterContextKind paramContext = SimpleName.isOperator() ?
+      ParameterContextKind::Operator : ParameterContextKind::Function;
   ParserStatus SignatureStatus =
-      parseFunctionSignature(SimpleName, FullName, BodyParams, DefaultArgs,
-                             throwsLoc, rethrows, FuncRetTy);
+      // SWIFT_ENABLE_TENSORFLOW
+      parseFunctionSignature(SimpleName, FullName, paramContext, BodyParams,
+                             DefaultArgs, throwsLoc, rethrows, FuncRetTy);
 
   SignatureHasCodeCompletion |= SignatureStatus.hasCodeCompletion();
   if (SignatureStatus.hasCodeCompletion() && !CodeCompletion) {
@@ -5813,6 +5832,122 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
   addToScope(FD);
   return DCC.fixupParserResult(FD);
 }
+
+// SWIFT_ENABLE_TENSORFLOW
+/// \brief Parse a `call` declaration, returning null on error. The caller
+/// handles this case and does recovery as appropriate.
+///
+/// \verbatim
+///   decl-call:
+///     attribute-list? 'mutating'? 'call' 'func'
+///               generic-params? func-signature where-clause?
+///               stmt-brace?
+/// \endverbatim
+///
+/// \note The caller of this method must ensure that the next token is 'call'.
+ParserResult<CallDecl>
+Parser::parseDeclCall(ParseDeclOptions Flags, DeclAttributes &Attributes) {
+  assert(Tok.is(tok::kw_call));
+  SourceLoc callLoc = consumeToken(tok::kw_call);
+  // `call` keyword must be followed by `func`.
+  if (!consumeIf(tok::kw_func))
+    diagnose(Tok, diag::call_decl_expected_func_keyword);
+
+  // Reject `call` declarations outside of types.
+  if (!Flags.contains(PD_HasContainerType))
+    diagnose(Tok, diag::call_decl_wrong_scope);
+
+  // Reject named `call` declarations. e.g. `call func foo()'.
+  if (Tok.is(tok::identifier) &&
+      (peekToken().is(tok::l_paren) || startsWithLess(peekToken()))) {
+    diagnose(Tok, diag::call_decl_cannot_have_name).fixItRemove(Tok.getLoc());
+    consumeToken(tok::identifier);
+  }
+
+  auto simpleName = Context.getIdentifier("$call");
+  DebuggerContextChange DCC(*this, simpleName, DeclKind::Call);
+
+  // Parse the generic parameters, if present.
+  Scope genericsScope(this, ScopeKind::Generics);
+  auto genericParamsResult = maybeParseGenericParams();
+  bool signatureHasCodeCompletion = false;
+  GenericParamList *genericParams = genericParamsResult.getPtrOrNull();
+  if (genericParamsResult.hasCodeCompletion())
+    return makeParserCodeCompletionStatus();
+
+  DefaultArgumentInfo defaultArgs;
+  TypeRepr *funcRetTy = nullptr;
+  DeclName fullName;
+  ParameterList *params;
+  SourceLoc throwsLoc;
+  bool rethrows;
+  ParserStatus signatureStatus =
+      parseFunctionSignature(simpleName, fullName, ParameterContextKind::Call,
+                             params, defaultArgs, throwsLoc, rethrows,
+                             funcRetTy);
+
+  signatureHasCodeCompletion |= signatureStatus.hasCodeCompletion();
+  if (signatureStatus.hasCodeCompletion() && !CodeCompletion) {
+    // Trigger delayed parsing, no need to continue.
+    return signatureStatus;
+  }
+
+  diagnoseWhereClauseInGenericParamList(genericParams);
+
+   // Create the 'call` declaration and add it to the parent scope.
+  auto *CD = CallDecl::create(Context, fullName, callLoc,
+                              /*throws*/ throwsLoc.isValid(), throwsLoc,
+                              /*genericParams*/ nullptr, params, funcRetTy,
+                              CurDeclContext);
+
+   // Parse a 'where' clause if present, adding it to our GenericParamList.
+  if (Tok.is(tok::kw_where)) {
+    ContextChange CC(*this, CD);
+
+    auto whereStatus = parseFreestandingGenericWhereClause(genericParams);
+    signatureHasCodeCompletion |= whereStatus.hasCodeCompletion();
+    if (whereStatus.hasCodeCompletion() && !CodeCompletion) {
+      // Trigger delayed parsing, no need to continue.
+      return whereStatus;
+    }
+  }
+
+  CD->setGenericParams(genericParams);
+
+  // Protocol method arguments may not have default values.
+  if (Flags.contains(PD_InProtocol) && defaultArgs.HasDefaultArgument) {
+    diagnose(callLoc, diag::protocol_method_argument_init);
+    return nullptr;
+  }
+
+  // Add the 'rethrows' attribute.
+  if (rethrows)
+    Attributes.add(new (Context) RethrowsAttr(throwsLoc));
+
+  // Add the attributes here so if we need them while parsing the body
+  // they are available.
+  CD->getAttrs() = Attributes;
+
+  // Pass the function signature to code completion.
+  if (signatureHasCodeCompletion)
+    CodeCompletion->setParsedDecl(CD);
+
+  defaultArgs.setFunctionContext(CD, CD->getParameters());
+  setLocalDiscriminator(CD);
+
+  if (Flags.contains(PD_InProtocol)) {
+    if (Tok.is(tok::l_brace)) {
+      diagnose(Tok, diag::protocol_method_with_body);
+      skipSingle();
+    }
+  } else {
+    parseAbstractFunctionBody(CD);
+  }
+
+  addToScope(CD);
+  return DCC.fixupParserResult(CD);
+}
+// SWIFT_ENABLE_TENSORFLOW END
 
 /// Parse function body into \p AFD.
 void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
@@ -6033,7 +6168,8 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       return Status;
     }
 
-    if (Tok.is(tok::identifier)) {
+    // SWIFT_ENABLE_TENSORFLOW
+    if (Tok.is(tok::identifier) || Tok.is(tok::kw_call)) {
       Status |= parseIdentifierDeclName(*this, Name, NameLoc, "enum 'case'",
                                         tok::l_paren, tok::kw_case, tok::colon,
                                         tok::r_brace);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1537,6 +1537,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       
   case tok::identifier:  // foo
   case tok::kw_self:     // self
+  // SWIFT_ENABLE_TENSORFLOW
+  case tok::kw_call:     // call, treated as a keyword when parsing declarations
 
     // If we are parsing a refutable pattern and are inside a let/var pattern,
     // the identifiers change to be value bindings instead of decl references.
@@ -2127,7 +2129,8 @@ DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
   // Consume the base name.
   DeclBaseName baseName;
   SourceLoc baseNameLoc;
-  if (Tok.isAny(tok::identifier, tok::kw_Self, tok::kw_self)) {
+  // SWIFT_ENABLE_TENSORFLOW
+  if (Tok.isAny(tok::identifier, tok::kw_Self, tok::kw_self, tok::kw_call)) {
     baseName = Context.getIdentifier(Tok.getText());
     baseNameLoc = consumeToken();
   } else if (allowOperators && Tok.isAnyOperator()) {
@@ -2235,7 +2238,8 @@ DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
 ///   expr-identifier:
 ///     unqualified-decl-name generic-args?
 Expr *Parser::parseExprIdentifier() {
-  assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));
+  // SWIFT_ENABLE_TENSORFLOW
+  assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self, tok::kw_call));
   SyntaxParsingContext IDSyntaxContext(SyntaxContext,
                                        SyntaxKind::IdentifierExpr);
   Token IdentTok = Tok;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -826,7 +826,8 @@ bool Parser::parseSpecificIdentifier(StringRef expected, SourceLoc &loc,
 /// its name in Result.  Otherwise, emit an error and return true.
 bool Parser::parseAnyIdentifier(Identifier &Result, SourceLoc &Loc,
                                 const Diagnostic &D) {
-  if (Tok.is(tok::identifier) || Tok.isAnyOperator()) {
+  // SWIFT_ENABLE_TENSORFLOW
+  if (Tok.is(tok::identifier) || Tok.isAnyOperator() || Tok.is(tok::kw_call)) {
     Result = Context.getIdentifier(Tok.getText());
     Loc = Tok.getLoc();
     consumeToken();

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1399,7 +1399,9 @@ void SILGenModule::emitExternalWitnessTable(ProtocolConformance *c) {
 void SILGenModule::emitExternalDefinition(Decl *d) {
   switch (d->getKind()) {
   case DeclKind::Func:
-  case DeclKind::Accessor: {
+  case DeclKind::Accessor:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call: {
     emitFunction(cast<FuncDecl>(d));
     break;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4585,6 +4585,61 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     return simplified;
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  // Handle applications of types with `call` methods.
+  if (auto nominal = desugar2->getAnyNominal()) {
+    auto &ctx = getASTContext();
+    // Get all `call` methods of the nominal type.
+    SmallVector<CallDecl *, 4> callDecls;
+    auto candidates = TC.lookupMember(DC, nominal->getDeclaredTypeInContext(),
+                                      DeclName(ctx.getIdentifier("$call")));
+    for (auto entry : candidates) {
+      auto callDecl = dyn_cast<CallDecl>(entry.getValueDecl());
+      if (!callDecl)
+        continue;
+      callDecls.push_back(callDecl);
+    }
+
+     // Handle `call` methods calls.
+    if (!callDecls.empty()) {
+      // Create a type variable for the `call` method.
+      auto loc = getConstraintLocator(locator);
+      auto tv = createTypeVariable(loc, TVO_CanBindToLValue);
+
+       // Record the `call` method overload set.
+      SmallVector<OverloadChoice, 4> choices;
+      for (auto candidate : callDecls) {
+        TC.validateDecl(candidate);
+        if (candidate->isInvalid()) continue;
+        choices.push_back(
+            OverloadChoice(type2, candidate, FunctionRefKind::SingleApply));
+      }
+      if (choices.empty()) return SolutionKind::Error;
+      addOverloadSet(tv, choices, DC, loc);
+
+       // Create type variables for each parameter type.
+      SmallVector<AnyFunctionType::Param, 4> tvParams;
+      for (unsigned i : range(func1->getNumParams())) {
+        auto param = func1->getParams()[i];
+        auto paramType = param.getPlainType();
+
+         auto *tvParam = createTypeVariable(loc);
+        auto locatorBuilder =
+            locator.withPathElement(LocatorPathElt::getTupleElement(i));
+        addConstraint(ConstraintKind::ArgumentConversion, paramType,
+                      tvParam, locatorBuilder);
+        tvParams.push_back(AnyFunctionType::Param(tvParam));
+      }
+      // Create target function type and an applicable function constraint.
+      AnyFunctionType *funcType =
+          FunctionType::get(tvParams, func1->getResult());
+      addConstraint(ConstraintKind::ApplicableFunction,
+                    funcType, tv, locator);
+
+       return SolutionKind::Solved;
+    }
+  }
+
   // Handle applications of @dynamicCallable types.
   return simplifyDynamicCallableApplicableFnConstraint(type1, origType2,
                                                        subflags, locator);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -54,6 +54,8 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case MemberRefBase:
     case UnresolvedMember:
     case SubscriptMember:
+    // SWIFT_ENABLE_TENSORFLOW
+    case CallMethod:
     case ConstructorMember:
     case LValueConversion:
     case RValueAdjustment:
@@ -192,6 +194,11 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case SequenceIteratorProtocol:
       out << "sequence iterator type";
+      break;
+
+    // SWIFT_ENABLE_TENSORFLOW
+    case CallMethod:
+      out << "call method";
       break;
 
     case SubscriptMember:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -85,6 +85,9 @@ public:
     MemberRefBase,
     /// \brief The lookup for a subscript member.
     SubscriptMember,
+    // SWIFT_ENABLE_TENSORFLOW
+    /// \brief The lookup for a call method.
+    CallMethod,
     /// \brief The lookup for a constructor member.
     ConstructorMember,
     /// \brief An implicit @lvalue-to-inout conversion; only valid for operator
@@ -141,6 +144,8 @@ public:
     case MemberRefBase:
     case UnresolvedMember:
     case SubscriptMember:
+    // SWIFT_ENABLE_TENSORFLOW
+    case CallMethod:
     case ConstructorMember:
     case LValueConversion:
     case RValueAdjustment:
@@ -204,6 +209,8 @@ public:
     case LValueConversion:
     case RValueAdjustment:
     case SubscriptMember:
+    // SWIFT_ENABLE_TENSORFLOW
+    case CallMethod:
     case OpenedGeneric:
     case GenericParameter:
     case GenericArgument:

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -768,6 +768,8 @@ void TypeChecker::checkDeclAttributesEarly(Decl *D) {
     StringRef OnlyKind;
     switch (PossibleDeclKinds) {
     case DeclAttribute::OnAccessor:    OnlyKind = "accessor"; break;
+    // SWIFT_ENABLE_TENSORFLOW
+    case DeclAttribute::OnCall:        OnlyKind = "call"; break;
     case DeclAttribute::OnClass:       OnlyKind = "class"; break;
     case DeclAttribute::OnConstructor: OnlyKind = "init"; break;
     case DeclAttribute::OnDestructor:  OnlyKind = "deinit"; break;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3284,6 +3284,42 @@ public:
     }
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  void visitCallDecl(CallDecl *CD) {
+    TC.validateDecl(CD);
+
+    if (!CD->isInvalid()) {
+      checkGenericParams(CD->getGenericParams(), CD);
+      TC.checkReferencedGenericParams(CD);
+      TC.checkProtocolSelfRequirements(CD);
+    }
+
+    checkAccessControl(TC, CD);
+
+    if (!checkOverrides(CD)) {
+      // If a method has an 'override' keyword but does not
+      // override anything, complain.
+      if (auto *OA = CD->getAttrs().getAttribute<OverrideAttr>()) {
+        if (!CD->getOverriddenDecl()) {
+          TC.diagnose(CD, diag::method_does_not_override)
+            .highlight(OA->getLocation());
+          OA->setInvalid();
+        }
+      }
+    }
+
+    if (requiresDefinition(CD) && !CD->hasBody()) {
+      // Complain if we should have a body.
+      TC.diagnose(CD->getLoc(), diag::func_decl_without_brace);
+    } else {
+      // Record the body.
+      TC.definedFunctions.push_back(CD);
+    }
+
+    if (CD->getAttrs().hasAttribute<DynamicReplacementAttr>())
+      TC.checkDynamicReplacementAttribute(CD);
+  }
+
   void visitModuleDecl(ModuleDecl *) { }
 
   void visitEnumCaseDecl(EnumCaseDecl *ECD) {
@@ -4120,7 +4156,9 @@ void TypeChecker::validateDecl(ValueDecl *D) {
   }
 
   case DeclKind::Func:
-  case DeclKind::Accessor: {
+  case DeclKind::Accessor:
+  // SWIFT_ENABLE_TENSORFLOW
+  case DeclKind::Call: {
     auto *FD = cast<FuncDecl>(D);
     assert(!FD->hasInterfaceType());
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -625,6 +625,12 @@ static bool isPlausibleTypo(DeclRefKind refKind, DeclName typedName,
   if (!candidate->hasName())
     return false;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  // Ignore `call` declarations. Otherwise, "did you mean '$call'" diagnostics
+  // will be produced.
+  if (isa<CallDecl>(candidate))
+    return false;
+
   // An operator / identifier mismatch is never a plausible typo.
   auto fn = dyn_cast<FuncDecl>(candidate);
   if (typedName.isOperator() != (fn && fn->isOperator()))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1964,6 +1964,10 @@ static diag::RequirementKind getRequirementKind(ValueDecl *VD) {
   if (isa<ConstructorDecl>(VD))
     return diag::RequirementKind::Constructor;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  if (isa<CallDecl>(VD))
+    return diag::RequirementKind::Call;
+
   if (isa<FuncDecl>(VD))
     return diag::RequirementKind::Func;
 

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -5,97 +5,32 @@ import StdlibUnittest
 
 var SimpleModelTests = TestSuite("SimpleModel")
 
-struct DenseLayer : Equatable {
-  @differentiable(wrt: self, vjp: vjpW)
-  let w: Float
-  func vjpW() -> (Float, (Float) -> DenseLayer) {
-    return (w, { dw in DenseLayer(w: dw, b: 0) } )
-  }
-
-  @differentiable(wrt: self, vjp: vjpB)
-  let b: Float
-  func vjpB() -> (Float, (Float) -> DenseLayer) {
-    return (b, { db in DenseLayer(w: 0, b: db) } )
-  }
+protocol Layer : Differentiable, VectorNumeric {
+  @differentiable
+  call func(_ input: Float) -> Float
 }
 
-extension DenseLayer : Differentiable, VectorNumeric {
-  typealias TangentVector = DenseLayer
-  typealias CotangentVector = DenseLayer
-  typealias Scalar = Float
-  static var zero: DenseLayer {
-    return DenseLayer(w: 0, b: 0)
-  }
-  static func + (lhs: DenseLayer, rhs: DenseLayer) -> DenseLayer {
-    return DenseLayer(w: lhs.w + rhs.w, b: lhs.b + rhs.b)
-  }
-  static func - (lhs: DenseLayer, rhs: DenseLayer) -> DenseLayer {
-    return DenseLayer(w: lhs.w - rhs.w, b: lhs.b - rhs.b)
-  }
-  static func * (lhs: DenseLayer, rhs: DenseLayer) -> DenseLayer {
-    return DenseLayer(w: lhs.w * rhs.w, b: lhs.b * rhs.b)
-  }
-  static func * (lhs: Float, rhs: DenseLayer) -> DenseLayer {
-    return DenseLayer(w: lhs * rhs.w, b: lhs * rhs.b)
-  }
-}
+struct DenseLayer : Layer {
+  let w, b: Float
 
-extension DenseLayer {
-  func prediction(for input: Float) -> Float {
+  @differentiable
+  call func(_ input: Float) -> Float {
     return input * w + b
   }
 }
 
-struct Model : Equatable {
-  @differentiable(wrt: self, vjp: vjpL1)
-  let l1: DenseLayer
-  func vjpL1() -> (DenseLayer, (DenseLayer) -> Model) {
-    return (l1, { dl1 in Model(l1: dl1, l2: DenseLayer.zero, l3: DenseLayer.zero) } )
-  }
+struct Model : Layer {
+  let l1, l2, l3: DenseLayer
 
-  @differentiable(wrt: self, vjp: vjpL2)
-  let l2: DenseLayer
-  func vjpL2() -> (DenseLayer, (DenseLayer) -> Model) {
-    return (l2, { dl2 in Model(l1: DenseLayer.zero, l2: dl2, l3: DenseLayer.zero) } )
-  }
-
-  @differentiable(wrt: self, vjp: vjpL3)
-  let l3: DenseLayer
-  func vjpL3() -> (DenseLayer, (DenseLayer) -> Model) {
-    return (l3, { dl3 in Model(l1: DenseLayer.zero, l2: DenseLayer.zero, l3: dl3) } )
-  }
-}
-
-extension Model : Differentiable, VectorNumeric {
-  typealias TangentVector = Model
-  typealias CotangentVector = Model
-  typealias Scalar = Float
-  static var zero: Model {
-    return Model(l1: DenseLayer.zero, l2: DenseLayer.zero, l3: DenseLayer.zero)
-  }
-  static func + (lhs: Model, rhs: Model) -> Model {
-    return Model(l1: lhs.l1 + rhs.l1, l2: lhs.l2 + rhs.l2, l3: lhs.l3 + rhs.l3)
-  }
-  static func - (lhs: Model, rhs: Model) -> Model {
-    return Model(l1: lhs.l1 - rhs.l1, l2: lhs.l2 - rhs.l2, l3: lhs.l3 - rhs.l3)
-  }
-  static func * (lhs: Model, rhs: Model) -> Model {
-    return Model(l1: lhs.l1 * rhs.l1, l2: lhs.l2 * rhs.l2, l3: lhs.l3 * rhs.l3)
-  }
-  static func * (lhs: Float, rhs: Model) -> Model {
-    return Model(l1: lhs * rhs.l1, l2: lhs * rhs.l2, l3: lhs * rhs.l3)
+  @differentiable
+  call func(_ input: Float) -> Float {
+    // This model is silly because it has no nonlinearities.
+    // But it is simple and good enough for testing purposes.
+    return l3(l2(l1(input)))
   }
 }
 
 extension Model {
-  func prediction(for input: Float) -> Float {
-    // This "model" is silly because it doesn't have nonlinearities. But it's
-    // simple and good enough for testing purposes.
-    let activation1 = l1.prediction(for: input)
-    let activation2 = l2.prediction(for: activation1)
-    return l3.prediction(for: activation2)
-  }
-
   func loss(of prediction: Float, from label: Float) -> Float {
     return (prediction - label) * (prediction - label)
   }
@@ -107,8 +42,8 @@ SimpleModelTests.test("gradient") {
   let label: Float = 3
   let input: Float = 1
   let gradModel = model.gradient { model -> Float in
-    let pred = model.prediction(for: input)
-    return model.loss(of: pred, from: label)
+    let prediction = model(input)
+    return model.loss(of: prediction, from: label)
   }
   let expectedGrad = Model(l1: DenseLayer(w: -4, b: -4),
                            l2: DenseLayer(w: -4, b: -4),

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -59,7 +59,8 @@ class FooClass {
     self = FooClass()  // expected-error {{cannot assign to value: 'self' is immutable}}
   }
   
-  mutating init(a : Bool) {}     // expected-error {{'mutating' may only be used on 'func' declarations}} {{3-12=}}
+  // SWIFT_ENABLE_TENSORFLOW
+  mutating init(a : Bool) {}     // expected-error {{'mutating' modifier cannot be applied to this declaration}} {{3-12=}}
   
   mutating            // expected-error {{'mutating' isn't valid on methods in classes or class-bound protocols}} {{3-12=}}
   func baz() {}

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -11,6 +11,15 @@
     },
     {
       key.kind: source.lang.swift.keyword,
+      key.name: "call",
+      key.sourcetext: "call",
+      key.description: "call",
+      key.typename: "",
+      key.context: source.codecompletion.context.none,
+      key.num_bytes_to_erase: 0
+    },
+    {
+      key.kind: source.lang.swift.keyword,
       key.name: "class",
       key.sourcetext: "class",
       key.description: "class",

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -22,8 +22,8 @@ public protocol Layer: Differentiable & KeyPathIterable
   where AllDifferentiableVariables : KeyPathIterable {
   associatedtype Input: Differentiable
   associatedtype Output: Differentiable
-  @differentiable(wrt: (self, input))
-  func applied(to input: Input) -> Output
+  @differentiable
+  call func(_ input: Input) -> Output
 }
 
 @_fixed_layout
@@ -40,7 +40,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
   }
 
   @differentiable
-  public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+  public call func(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
     return activation(matmul(input, weight) + bias)
   }
 }
@@ -78,7 +78,7 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
   }
 
   @differentiable
-  public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+  public call func(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
       return activation(input.convolved2D(withFilter: filter,
                                           strides: (1, strides.0, strides.1, 1),
                                           padding: padding) + bias)
@@ -116,9 +116,7 @@ public class RiemannSGD<Model: Layer, Scalar: FloatingPoint>: Optimizer
 ModelADTests.testAllBackends("SimpleLayerAD") {
   let ones = Tensor<Float>(ones: [2, 2])
   let dense = Dense<Float>(inputSize: 2, outputSize: 2, activation: { $0 })
-  let grad = gradient(at: dense) { dense in
-    dense.applied(to: ones).sum()
-  }
+  let grad = gradient(at: dense) { dense in dense(ones).sum() }
   expectEqual([[2, 2], [2, 2]], grad.weight)
   expectEqual([2, 2], grad.bias)
 }
@@ -130,10 +128,9 @@ ModelADTests.testAllBackends("XORTraining") {
       l1 = Dense<Float>(inputSize: 2, outputSize: hiddenSize, activation: relu)
       l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
     }
-    @differentiable(wrt: (self, input))
-    func applied(to input: Tensor<Float>) -> Tensor<Float> {
-      let h1 = l1.applied(to: input)
-      return l2.applied(to: h1)
+    @differentiable
+    call func(_ input: Tensor<Float>) -> Tensor<Float> {
+      return l2(l1(input))
     }
   }
   var classifier = Classifier(hiddenSize: 4)
@@ -142,12 +139,12 @@ ModelADTests.testAllBackends("XORTraining") {
   let y: Tensor<Float> = [0, 1, 1, 0]
   for _ in 0..<1000 {
     let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
-      let ŷ = classifier.applied(to: x)
+      let ŷ = classifier(x)
       return meanSquaredError(predicted: ŷ, expected: y)
     }
     optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
   }
-  print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
+  _ = classifier([[0, 0], [0, 1], [1, 0], [1, 1]])
 }
 
 ModelADTests.testAllBackends("WithRespectToModel") {
@@ -155,18 +152,17 @@ ModelADTests.testAllBackends("WithRespectToModel") {
     var bar: Tensor<Scalar>
     var baz: Tensor<Scalar>
 
-    @differentiable(wrt: (self, input))
-    func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+    @differentiable
+    call func(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
       return bar + input
     }
   }
   let x = Tensor<Float>(0)
   var model = Foo<Float>(bar: x, baz: x)
-  let d = gradient(at: model) { model in
-    model.applied(to: x)
-  }
-  expectEqual(Foo<Float>.AllDifferentiableVariables(bar: Tensor(1.0),
-                                                    baz: Tensor(0.0)), d)
+  let 𝛁model = gradient(at: model) { model in model(x) }
+  expectEqual(
+    Foo<Float>.AllDifferentiableVariables(bar: Tensor(1.0), baz: Tensor(0.0)),
+    𝛁model)
 }
 
 runAllTests()

--- a/test/decl/call/callables.swift
+++ b/test/decl/call/callables.swift
@@ -1,0 +1,136 @@
+// RUN: %target-typecheck-verify-swift
+
+struct SimpleCallable {
+  call func(_ x: Float) -> Float {
+    return x
+  }
+}
+
+// Simple test.
+
+let foo = SimpleCallable()
+_ = foo(1)
+_ = foo(foo(1))
+
+// Test direct `call` member references.
+
+_ = { foo(1) }()
+_ = [1, 2, 3].map { foo($0) }
+let _: (Float) -> Float = { foo($0) }
+
+func callable() -> SimpleCallable {
+  return SimpleCallable()
+}
+extension SimpleCallable {
+  var foo: SimpleCallable {
+    return self
+  }
+  func bar() -> SimpleCallable {
+    return self
+  }
+}
+
+_ = foo.foo(1)
+_ = foo.bar()(1)
+_ = callable()(1)
+
+struct MultipleArgsCallable {
+  call func(x: Int, y: Float) -> [Int] {
+    return [x]
+  }
+}
+
+let bar = MultipleArgsCallable()
+_ = bar(x: 1, y: 1)
+_ = bar(x: bar(x: 1, y: 1)[0], y: 1)
+
+struct Extended {}
+extension Extended {
+  @discardableResult
+  call func() -> Extended {
+    return self
+  }
+}
+var extended = Extended()
+extended()()()
+
+struct OptionalCallable {
+  call func() -> OptionalCallable? {
+    return self
+  }
+}
+var optional = OptionalCallable()
+_ = optional()?()?()
+
+struct VariadicCallable {
+  call func(_ args: Int...) -> [Int] {
+    return args
+  }
+}
+var variadic = VariadicCallable()
+_ = variadic()
+_ = variadic(1, 2, 3)
+
+struct Mutating {
+  var x: Int
+  mutating call func() {
+    x += 1
+  }
+}
+func testMutating(_ x: Mutating, _ y: inout Mutating) {
+  _ = x() // expected-error {{cannot use mutating member on immutable value: 'x' is a 'let' constant}}
+  _ = y()
+}
+
+struct Throwing {
+  call func() throws -> Throwing {
+    return self
+  }
+}
+var throwing = Throwing()
+_ = try throwing()
+
+enum BinaryOperation {
+  case add, subtract, multiply, divide
+}
+extension BinaryOperation {
+  call func(_ lhs: Float, _ rhs: Float) -> Float {
+    switch self {
+    case .add: return lhs + rhs
+    case .subtract: return lhs - rhs
+    case .multiply: return lhs * rhs
+    case .divide: return lhs / rhs
+    }
+  }
+}
+_ = BinaryOperation.add(1, 2)
+
+class BaseClass {
+  call func() -> Self {
+    return self
+  }
+}
+class SubClass : BaseClass {
+  override call func() -> Self {
+    return self
+  }
+}
+
+func testIUO(a: SimpleCallable!, b: MultipleArgsCallable!, c: Extended!,
+             d: OptionalCallable!, e: Throwing!) {
+  _ = a(1)
+  _ = b(x: 1, y: 1)
+  _ = c()
+  _ = d()?()?()
+  _ = try? e()
+}
+
+// Errors.
+
+// TODO: Fix this error. Ideally, it should be "extra argument in call".
+// expected-error @+2 {{cannot call value of non-function type 'SimpleCallable'}}
+// expected-error @+1 {{cannot invoke 'foo' with an argument list of type '(Int, Int)'}}
+_ = foo(1, 1)
+
+_ = bar(1, 1) // expected-error {{missing argument labels 'x:y:' in call}}
+let _: (Float) -> Float = foo // expected-error {{cannot convert value of type 'SimpleCallable' to specified type '(Float) -> Float'}}

--- a/test/decl/call/generic.swift
+++ b/test/decl/call/generic.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P0 {
+  call func(x: Self)
+}
+
+struct ConcreteType {
+  call func<T, U>(_ x: T, _ y: U) -> (T, U) {
+    return (x, y)
+  }
+
+  call func<T, U>(_ fn: @escaping (T) -> U) -> (T) -> U {
+    return fn
+  }
+}
+
+let concrete = ConcreteType()
+_ = concrete(1, 3.0)
+_ = concrete(concrete, { concrete($0, $1) } as ([Int], Float) -> ([Int], Float))
+
+func generic<T, U>(_ x: T, _ y: U) {
+  _ = concrete(x, x)
+  _ = concrete(x, y)
+}
+
+struct GenericType<T : Collection> {
+  let collection: T
+  call func<U>(_ x: U) -> Bool where U == T.Element, U : Equatable {
+    return collection.contains(x)
+  }
+}
+
+// Test conditional conformance.
+extension GenericType where T.Element : Numeric {
+  call func(initialValue: T.Element) -> T.Element {
+    return collection.reduce(initialValue, +)
+  }
+}
+
+let genericString = GenericType<[String]>(collection: ["Hello", "world", "!"])
+_ = genericString("Hello")
+let genericInt = GenericType<Set<Int>>(collection: [1, 2, 3])
+_ = genericInt(initialValue: 1)

--- a/test/decl/call/protocol.swift
+++ b/test/decl/call/protocol.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P0 {
+  // expected-note @+1 {{protocol requires 'call' method with type '() -> Missing'; do you want to add a stub?}}
+  call func() -> Self
+}
+func testProtocol(_ x: P0) {
+  _ = x()
+}
+
+protocol P1 {
+  call func() -> Self
+}
+extension P1 {
+  call func() -> Self {
+    return self
+  }
+}
+protocol P2 {}
+extension P2 {
+  call func(x: Int, y: Int) -> Int {
+    return x + y
+  }
+}
+
+// expected-error @+1 {{type 'Missing' does not conform to protocol 'P0'}}
+struct Missing : P0 {}
+struct S0 : P0 {
+  @discardableResult
+  call func() -> S0 { return self }
+}
+let s0 = S0()
+s0()
+
+struct S1 : P1 {
+  call func() -> S1 { return self }
+}
+
+let s1 = S1()
+_ = s1()()
+
+struct Conforming : P0 & P1 & P2 {}
+let conforming = Conforming()
+_ = conforming()
+_ = conforming(x: 1, y: 2)
+
+protocol P3 {}
+extension P3 {
+  call func() -> Self { return self }
+}
+struct S3 : P3 {}
+
+let s3 = S3()
+_ = s3()()

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -271,6 +271,8 @@ UIdent SwiftLangSupport::getUIDForCodeCompletionDeclKind(
     case CodeCompletionDeclKind::Constructor: return KindRefConstructor;
     case CodeCompletionDeclKind::Destructor: return KindRefDestructor;
     case CodeCompletionDeclKind::Subscript: return KindRefSubscript;
+    // SWIFT_ENABLE_TENSORFLOW
+    case CodeCompletionDeclKind::Call: return KindRefCall;
     case CodeCompletionDeclKind::StaticMethod: return KindRefMethodClass;
     case CodeCompletionDeclKind::InstanceMethod: return KindRefMethodInstance;
     case CodeCompletionDeclKind::PrefixOperatorFunction: return KindRefFunctionPrefixOperator;
@@ -298,6 +300,8 @@ UIdent SwiftLangSupport::getUIDForCodeCompletionDeclKind(
   case CodeCompletionDeclKind::Constructor: return KindDeclConstructor;
   case CodeCompletionDeclKind::Destructor: return KindDeclDestructor;
   case CodeCompletionDeclKind::Subscript: return KindDeclSubscript;
+  // SWIFT_ENABLE_TENSORFLOW
+  case CodeCompletionDeclKind::Call: return KindDeclCall;
   case CodeCompletionDeclKind::StaticMethod: return KindDeclMethodClass;
   case CodeCompletionDeclKind::InstanceMethod: return KindDeclMethodInstance;
   case CodeCompletionDeclKind::PrefixOperatorFunction: return KindDeclFunctionPrefixOperator;
@@ -400,6 +404,9 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclTypeAlias;
     case SyntaxStructureKind::Subscript:
       return KindDeclSubscript;
+    // SWIFT_ENABLE_TENSORFLOW
+    case SyntaxStructureKind::Call:
+      return KindDeclCall;
     case SyntaxStructureKind::AssociatedType:
       return KindDeclAssociatedType;
     case SyntaxStructureKind::GenericTypeParam:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1107,6 +1107,8 @@ private:
       case SyntaxStructureKind::EnumElement: return "enum-elem";
       case SyntaxStructureKind::TypeAlias: return "typealias";
       case SyntaxStructureKind::Subscript: return "subscript";
+      // SWIFT_ENABLE_TENSORFLOW
+      case SyntaxStructureKind::Call: return "call";
       case SyntaxStructureKind::AssociatedType: return "associatedtype";
       case SyntaxStructureKind::GenericTypeParam: return "generic-param";
       case SyntaxStructureKind::Parameter: return "param";

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1869,7 +1869,7 @@ skip-test-playgroundsupport
 
 [preset: tensorflow_osx,installer]
 mixin-preset=
-    tensorflow_osx
+    tensorflow_osx,no_test
     mixin_codesigning
 darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -276,6 +276,9 @@ UID_KINDS = [
     KIND('RefPrecedenceGroup', 'source.lang.swift.ref.precedencegroup'),
     KIND('DeclSubscript', 'source.lang.swift.decl.function.subscript'),
     KIND('RefSubscript', 'source.lang.swift.ref.function.subscript'),
+    # SWIFT_ENABLE_TENSORFLOW
+    KIND('DeclCall', 'source.lang.swift.decl.function.call'),
+    KIND('RefCall', 'source.lang.swift.ref.function.call'),
     KIND('DeclVarGlobal', 'source.lang.swift.decl.var.global'),
     KIND('RefVarGlobal', 'source.lang.swift.ref.var.global'),
     KIND('DeclVarInstance', 'source.lang.swift.decl.var.instance'),

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -380,6 +380,8 @@ DECL_NODES = [
                        'SpacedBinaryOperatorToken',
                        'PrefixOperatorToken',
                        'PostfixOperatorToken',
+                       # SWIFT_ENABLE_TENSORFLOW
+                       'CallToken',
                    ]),
              Child('GenericParameterClause', kind='GenericParameterClause',
                    is_optional=True),
@@ -447,6 +449,23 @@ DECL_NODES = [
                    node_choices=[
                       Child('Accessors', kind='AccessorBlock'),
                       Child('Getter', kind='CodeBlock')]),
+         ]),
+
+    # SWIFT_ENABLE_TENSORFLOW
+    Node('CallDecl', kind='Decl',
+         children=[
+             Child('Attributes', kind='AttributeList',
+                   is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   is_optional=True),
+             Child('CallKeyword', kind='CallToken'),
+             Child('GenericParameterClause', kind='GenericParameterClause',
+                   is_optional=True),
+             Child('Signature', kind='FunctionSignature'),
+             Child('GenericWhereClause', kind='GenericWhereClause',
+                   is_optional=True),
+             # the body is not necessary inside a protocol definition
+             Child('Body', kind='CodeBlock', is_optional=True),
          ]),
 
     # access-level-modifier -> 'private' | 'private' '(' 'set' ')'

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -74,6 +74,8 @@ EXPR_NODES = [
                        'IdentifierToken',
                        'SelfToken',
                        'CapitalSelfToken',
+                       # SWIFT_ENABLE_TENSORFLOW
+                       'CallToken',
                        'DollarIdentifierToken',
                        'SpacedBinaryOperatorToken',
                    ]),

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -241,6 +241,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'DifferentiableAttributeFuncSpecifier': 235,
     'FunctionDeclName': 236,
     'DifferentiatingAttributeArguments': 237,
+    'CallDecl': 238,
 }
 
 

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -335,6 +335,7 @@ SYNTAX_TOKENS = [
                        serialization_code=118,
                        description='TensorFlow operation',
                        protocol='ExpressibleByTensorFlowOp'),
+    DeclKeyword('Call', 'call', serialization_code=119),
 ]
 
 SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}


### PR DESCRIPTION
Introduce callables: values that can be "called" like functions.

```swift
struct Adder {
    var base: Int
    call func(_ x: Int) -> Int {
        return base + x
    }
}
let add3 = Adder(base: 3)
add3(10) // 13
```

This is experimental functionality and highly subject to change:
the design will be updated based on feedback for SE-0253.