### PR TITLE
[benchmark] Use Int.random instead of arc4random_uniform.

### DIFF
--- a/benchmark/single-source/BucketSort.swift
+++ b/benchmark/single-source/BucketSort.swift
@@ -111,7 +111,7 @@ let NUMBUCKETS: Int = 10
 let items: [Int] = {
   var array: [Int]? = [Int]()
   for _ in 0..<NUMITEMS {
-    array!.append( Int(arc4random_uniform( UInt32( MAXBUCKETSIZE ) ) ) )
+    array!.append(Int.random(in: 0..<MAXBUCKETSIZE))
   }
   return array!
 }()


### PR DESCRIPTION
This should be more portable, and easier to understand to Swift
programmers that the BSD function.

The usage of the BSD function was breaking the Android CI (https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/448/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/2247/). The CI machines have libbsd-devel, but I don’t understand why `arc4random_uniform` is not being found. I decided for this faster workaround, which makes the code more “swifty”, while I figure out what's happening in the CI machines.