### PR TITLE
test: repair the Windows test suite

### DIFF
--- a/test/Serialization/group_info_diags.swift
+++ b/test/Serialization/group_info_diags.swift
@@ -5,7 +5,7 @@
 // RUN: %FileCheck %s -check-prefix=CORRUPTED < %t/result.txt
 
 // RUN: %target-swift-frontend -emit-module %s -module-name HasArray -o %t -module-cache-path %t/mcp -group-info-path %S/Inputs/group_info.json -emit-module-doc &> %t/result.txt
-// RUN: strings %t/HasArray.swiftdoc > %t/doc_strings.txt
+// RUN: %llvm-strings %t/HasArray.swiftdoc > %t/doc_strings.txt
 // RUN: %FileCheck %s -check-prefix=INCLUDED < %t/doc_strings.txt
 // RUN: %FileCheck %s -check-prefix=EXCLUDED < %t/doc_strings.txt
 


### PR DESCRIPTION
`strings` is not available, use `%llvm-strings` which uses the LLVM
`strings` implementation instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
