### PR TITLE
Fix syntax support for `call func`.

### DIFF
--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -591,4 +591,9 @@ func negateDerivative<FunctionSignature><ParameterClause>(<FunctionParameter>_ x
 func bazDerivative<FunctionSignature><ParameterClause>(<FunctionParameter>_ x: <SimpleTypeIdentifier>Float</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>y: <SimpleTypeIdentifier>Float</SimpleTypeIdentifier></FunctionParameter>)</ParameterClause><ReturnClause>
     -> <TupleType>(<TupleTypeElement>value: <SimpleTypeIdentifier>Float</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement>pullback: <FunctionType>(<TupleTypeElement><SimpleTypeIdentifier>Float</SimpleTypeIdentifier></TupleTypeElement>) -> <TupleType>(<TupleTypeElement><SimpleTypeIdentifier>Float</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement><SimpleTypeIdentifier>Float</SimpleTypeIdentifier></TupleTypeElement>)</TupleType></FunctionType></TupleTypeElement>) </TupleType></ReturnClause></FunctionSignature><CodeBlock>{<ReturnStmt>
   return <TupleExpr>(<TupleElement><IdentifierExpr>x</IdentifierExpr>, </TupleElement><TupleElement><ClosureExpr>{ <ClosureSignature><ClosureParam>v </ClosureParam>in </ClosureSignature><IdentifierExpr>v </IdentifierExpr>}</ClosureExpr></TupleElement>)</TupleExpr></ReturnStmt>
-}</CodeBlock></FunctionDecl>
+}</CodeBlock></FunctionDecl><ProtocolDecl>
+
+protocol Layer <TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Differentiable </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{<MemberDeclListItem><CallDecl><Attribute>
+  @differentiable</Attribute>
+  call func<FunctionSignature><ParameterClause>(<FunctionParameter>_ input: <SimpleTypeIdentifier>Float</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Float</SimpleTypeIdentifier></ReturnClause></FunctionSignature></CallDecl></MemberDeclListItem>
+}</MemberDeclBlock></ProtocolDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -592,3 +592,8 @@ func bazDerivative(_ x: Float, y: Float)
     -> (value: Float, pullback: (Float) -> (Float, Float)) {
   return (x, { v in v })
 }
+
+protocol Layer : Differentiable {
+  @differentiable
+  call func(_ input: Float) -> Float
+}

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -459,6 +459,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList',
                    is_optional=True),
              Child('CallKeyword', kind='CallToken'),
+             Child('FuncKeyword', kind='FuncToken'),
              Child('GenericParameterClause', kind='GenericParameterClause',
                    is_optional=True),
              Child('Signature', kind='FunctionSignature'),


### PR DESCRIPTION
Unblocks usage of `call func(_ input: Input) -> Output` in [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis).