### PR TITLE
[5.1 EARLY]  Rename -enable-resilience to -enable-library-evolution and make it a driver flag

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -225,9 +225,9 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-sil-verify-all")
   endif()
 
-  # The standard library and overlays are always built with resilience.
+  # The standard library and overlays are always built resiliently.
   if(SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-Xfrontend" "-enable-resilience")
+    list(APPEND swift_flags "-enable-library-evolution")
   endif()
 
   if(SWIFT_STDLIB_USE_NONATOMIC_RC)

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3958,7 +3958,7 @@ unless the enum can be exhaustively switched in the current function, i.e. when
 the compiler can be sure that it knows all possible present and future values
 of the enum in question. This is generally true for enums defined in Swift, but
 there are two exceptions: *non-frozen enums* declared in libraries compiled
-with the ``-enable-resilience`` flag, which may grow new cases in the future in
+with the ``-enable-library-evolution`` flag, which may grow new cases in the future in
 an ABI-compatible way; and enums marked with the ``objc`` attribute, for which
 other bit patterns are permitted for compatibility with C. All enums imported
 from C are treated as "non-exhaustive" for the same reason, regardless of the

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1305,7 +1305,7 @@ ERROR(indirect_case_without_payload,none,
 ERROR(indirect_case_in_indirect_enum,none,
       "enum case in 'indirect' enum cannot also be 'indirect'", ())
 WARNING(enum_frozen_nonresilient,none,
-        "%0 has no effect without -enable-resilience", (DeclAttribute))
+        "%0 has no effect without -enable-library-evolution", (DeclAttribute))
 WARNING(enum_frozen_nonpublic,none,
         "%0 has no effect on non-public enums", (DeclAttribute))
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -117,7 +117,7 @@ enum class ResilienceStrategy : unsigned {
   /// Public nominal types: resilient
   /// Non-inlinable function bodies: resilient
   ///
-  /// This is the behavior with -enable-resilience.
+  /// This is the behavior with -enable-library-evolution.
   Resilient
 };
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -214,7 +214,7 @@ public:
   /// Enables the "fully resilient" resilience strategy.
   ///
   /// \see ResilienceStrategy::Resilient
-  bool EnableResilience = false;
+  bool EnableLibraryEvolution = false;
 
   /// Indicates that the frontend should emit "verbose" SIL
   /// (if asked to emit SIL).

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -174,10 +174,6 @@ def disable_objc_attr_requires_foundation_module :
   HelpText<"Disable requiring uses of @objc to require importing the "
            "Foundation module">;
 
-def enable_resilience : Flag<["-"], "enable-resilience">,
-   HelpText<"Compile the module to export resilient interfaces for all "
-            "public declarations by default">;
-
 def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
    HelpText<"Enable resilient layout for classes containing resilient value types">;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -174,6 +174,9 @@ def disable_objc_attr_requires_foundation_module :
   HelpText<"Disable requiring uses of @objc to require importing the "
            "Foundation module">;
 
+def enable_resilience : Flag<["-"], "enable-resilience">,
+   HelpText<"Deprecated, use -enable-library-evolution instead">;
+
 def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
    HelpText<"Enable resilient layout for classes containing resilient value types">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -305,6 +305,10 @@ def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the Clang module cache path">;
 
+def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
+  HelpText<"Build the module to allow binary-compatible library evolution">;
+
 def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Name of the module to build">;

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -25,14 +25,14 @@ class SourceLoader : public ModuleLoader {
 private:
   ASTContext &Ctx;
   bool SkipBodies;
-  bool EnableResilience;
+  bool EnableLibraryEvolution;
 
   explicit SourceLoader(ASTContext &ctx,
                         bool skipBodies,
                         bool enableResilience,
                         DependencyTracker *tracker)
     : ModuleLoader(tracker), Ctx(ctx),
-      SkipBodies(skipBodies), EnableResilience(enableResilience) {}
+      SkipBodies(skipBodies), EnableLibraryEvolution(enableResilience) {}
 
 public:
   static std::unique_ptr<SourceLoader>

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -185,6 +185,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_enable_private_imports);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -71,7 +71,7 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);
-  Opts.EnableResilience |= Args.hasArg(OPT_enable_resilience);
+  Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_library_evolution);
   Opts.EnableImplicitDynamic |= Args.hasArg(OPT_enable_implicit_dynamic);
 
   Opts.TrackSystemDeps |= Args.hasArg(OPT_track_system_dependencies);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -72,6 +72,10 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_library_evolution);
+
+  // FIXME: Remove this flag
+  Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_resilience);
+
   Opts.EnableImplicitDynamic |= Args.hasArg(OPT_enable_implicit_dynamic);
 
   Opts.TrackSystemDeps |= Args.hasArg(OPT_track_system_dependencies);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -286,10 +286,11 @@ bool CompilerInstance::setUpModuleLoaders() {
   if (hasSourceImport()) {
     bool immediate = FrontendOptions::isActionImmediate(
         Invocation.getFrontendOptions().RequestedAction);
-    bool enableResilience = Invocation.getFrontendOptions().EnableResilience;
+    bool enableLibraryEvolution =
+      Invocation.getFrontendOptions().EnableLibraryEvolution;
     Context->addModuleLoader(SourceLoader::create(*Context,
                                                   !immediate,
-                                                  enableResilience,
+                                                  enableLibraryEvolution,
                                                   getDependencyTracker()));
   }
   auto MLM = ModuleLoadingMode::PreferSerialized;
@@ -528,7 +529,7 @@ ModuleDecl *CompilerInstance::getMainModule() {
     if (Invocation.getFrontendOptions().EnableImplicitDynamic)
       MainModule->setImplicitDynamicEnabled();
 
-    if (Invocation.getFrontendOptions().EnableResilience)
+    if (Invocation.getFrontendOptions().EnableLibraryEvolution)
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
   }
   return MainModule;

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -125,7 +125,7 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
     bufferID = Ctx.SourceMgr.addNewSourceBuffer(std::move(inputFile));
 
   auto *importMod = ModuleDecl::create(moduleID.first, Ctx);
-  if (EnableResilience)
+  if (EnableLibraryEvolution)
     importMod->setResilienceStrategy(ResilienceStrategy::Resilient);
   Ctx.LoadedModules[moduleID.first] = importMod;
 

--- a/test/Serialization/attr-invalid.swift
+++ b/test/Serialization/attr-invalid.swift
@@ -8,7 +8,7 @@
 // CHECK-RESILIENT: Frozen_DECL_ATTR
 // CHECK-NON-RESILIENT-NOT: Frozen_DECL_ATTR
 
-@_frozen // expected-warning {{@_frozen has no effect without -enable-resilience}}
+@_frozen // expected-warning {{@_frozen has no effect without -enable-library-evolution}}
 public enum SomeEnum {
   case x
 }

--- a/test/Serialization/resilience.swift
+++ b/test/Serialization/resilience.swift
@@ -1,20 +1,22 @@
 // RUN: %empty-directory(%t)
 
-// This test checks that we serialize the -enable-resilience and -sil-serialize-all
-// flags correctly.
+// This test checks that we serialize the -enable-library-evolution
+// flag.
 
 // RUN: %target-swift-frontend -emit-module -o %t %s
 // RUN: llvm-bcanalyzer -dump %t/resilience.swiftmodule > %t/resilience.dump.txt
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=DEFAULT %s < %t/resilience.dump.txt
 
+// RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %s
+// RUN: llvm-bcanalyzer -dump %t/resilience.swiftmodule > %t/resilience2.dump.txt
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=RESILIENCE %s < %t/resilience2.dump.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/resilience2.dump.txt
+
+// FIXME: The alternate -enable-resilience flag is going away soon.
+
 // RUN: %target-swift-frontend -emit-module -o %t -enable-resilience %s
 // RUN: llvm-bcanalyzer -dump %t/resilience.swiftmodule > %t/resilience2.dump.txt
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=RESILIENCE %s < %t/resilience2.dump.txt
-
-// RUN: %target-swift-frontend -emit-module -o %t %s
-// RUN: llvm-bcanalyzer -dump %t/resilience.swiftmodule > %t/resilience3.dump.txt
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAGILE %s < %t/resilience3.dump.txt
-
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/resilience2.dump.txt
 
 // CHECK: <MODULE_BLOCK {{.*}}>

--- a/test/decl/enum/frozen-nonresilient.swift
+++ b/test/decl/enum/frozen-nonresilient.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-@_frozen public enum Exhaustive {} // expected-warning {{@_frozen has no effect without -enable-resilience}} {{1-10=}}
+@_frozen public enum Exhaustive {} // expected-warning {{@_frozen has no effect without -enable-library-evolution}} {{1-10=}}
 
-@_frozen enum NotPublic {} // expected-warning {{@_frozen has no effect without -enable-resilience}} {{1-10=}}
+@_frozen enum NotPublic {} // expected-warning {{@_frozen has no effect without -enable-library-evolution}} {{1-10=}}

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -305,7 +305,7 @@ int main(int argc, char **argv) {
     Invocation.setTargetTriple(Target);
   if (!ResourceDir.empty())
     Invocation.setRuntimeResourcePath(ResourceDir);
-  Invocation.getFrontendOptions().EnableResilience = EnableResilience;
+  Invocation.getFrontendOptions().EnableLibraryEvolution = EnableResilience;
   // Set the module cache path. If not passed in we use the default swift module
   // cache.
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;


### PR DESCRIPTION
Cherry-picks @slavapestov's #23280 and #23336 in cut-down form for the old 5.1 branch, for Apple-internal purposes.

rdar://problem/49985713