### PR TITLE
[TF] Revert to `Tensor<Int32>` as the `index_type` for `Raw.fill`.

### DIFF
--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -358,7 +358,7 @@ public extension Tensor {
   @differentiable(vjp: _vjpInit(repeating:shape:)
                   where Scalar : TensorFlowFloatingPoint)
   init(repeating repeatedValue: Scalar, shape: TensorShape) {
-    self = Raw.fill(dims: Tensor<Int64>(shape.dimensions.map(Int64.init)),
+    self = Raw.fill(dims: Tensor<Int32>(shape.dimensions.map(Int32.init)),
                     value: Tensor(repeatedValue))
   }
 }


### PR DESCRIPTION
`Tensor<Int64>` is not a supported `index_type` on GPU.

Example failure: https://ci-external.swift.org/view/Pull%20Request/job/swift-PR-TensorFlow-Linux-gpu/1265/console