### PR TITLE
Disable hanging GPU test.

### DIFF
--- a/test/TensorFlowRuntime/string_description.swift
+++ b/test/TensorFlowRuntime/string_description.swift
@@ -15,6 +15,7 @@ import Foundation
 
 var StringDescriptionTests = TestSuite("StringDescriptionTests")
 
+#if !CUDA
 StringDescriptionTests.test("Empty") {
   let empty = Tensor<Float>([] as [Float])
   expectEqual("[]", empty.description)
@@ -253,5 +254,6 @@ StringDescriptionTests.test("FullDescription") {
   expectEqual("[[[1.0, 1.0], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]]",
               vector.fullDescription)
 }
+#endif // !CUDA
 
 runAllTests()


### PR DESCRIPTION
Disable `test/TensorFlowRuntime/string_description.swift` to unblock GPU CI.
Filed [TF-441](https://bugs.swift.org/projects/TF/issues/TF-441) to track investigating the hang more closely.