### PR TITLE
[ownership] Run a bridged cast folding test a 2nd time with ownership…

### DIFF
--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -1,5 +1,5 @@
-
 // RUN: %target-swift-frontend -O -emit-sil -enforce-exclusivity=unchecked %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -O -emit-sil -enforce-exclusivity=unchecked %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
… stripping after -Onone.

No actual FileCheck patterns needed to be changed.
