### PR TITLE
[cmake] Fix typo in SWIFT_INCLUDE_DIRS SwiftConfig definition

### DIFF
--- a/cmake/modules/SwiftConfig.cmake.in
+++ b/cmake/modules/SwiftConfig.cmake.in
@@ -5,7 +5,7 @@
 set(SWIFT_VERSION @SWIFT_VERSION@)
 set(SWIFT_MAIN_SRC_DIR @SWIFT_SOURCE_DIR@)
 
-set(SWIFT_INCLUDE_DIRS "@SWIFT_INCLUDE_DIR@")
+set(SWIFT_INCLUDE_DIRS "@SWIFT_INCLUDE_DIRS@")
 set(SWIFT_LIBRARY_DIRS "@SWIFT_CONFIG_LIBRARY_DIRS@")
 
 # These variables are duplicated, but they must match the LLVM variables of the


### PR DESCRIPTION
Correct the SwiftConfig definition of `SWIFT_INCLUDE_DIRS` to reference `SWIFT_INCLUDE_DIRS` (plural), not `SWIFT_INCLUDE_DIR` (singular). This will help the out of tree use case, for cmake builds that depend on libraries from Swift.

Note that the SwiftConfig definition of `SWIFT_INCLUDE_DIR` (singular) correctly references the plural `SWIFT_INCLUDE_DIRS`, as the comment indicates it should.

The plural `SWIFT_INCLUDE_DIRS` is defined in [cmake/modules/CMakeLists.txt](https://github.com/apple/swift/blob/1ed77dcf1bac97201bb69c57f316085933889760/cmake/modules/CMakeLists.txt#L13) and includes both `SWIFT_INCLUDE_DIR` and `SWIFT_MAIN_INCLUDE_DIR`.

The singular `SWIFT_INCLUDE_DIR` is defined in the root [CMakeLists.txt](https://github.com/apple/swift/blob/1ed77dcf1bac97201bb69c57f316085933889760/CMakeLists.txt#L504) 

