### PR TITLE
[5.1] Code-completion, indexing, cursor-info, etc. for KeyPath dynamic member lookup

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -41,8 +41,10 @@ enum class SemaReferenceKind : uint8_t {
 struct ReferenceMetaData {
   SemaReferenceKind Kind;
   llvm::Optional<AccessKind> AccKind;
-  ReferenceMetaData(SemaReferenceKind Kind, llvm::Optional<AccessKind> AccKind) :
-    Kind(Kind), AccKind(AccKind) {}
+  bool isImplicit = false;
+  ReferenceMetaData(SemaReferenceKind Kind, llvm::Optional<AccessKind> AccKind,
+                    bool isImplicit = false)
+      : Kind(Kind), AccKind(AccKind), isImplicit(isImplicit) {}
 };
 
 /// An abstract class used to traverse an AST.

--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -113,11 +113,11 @@ public:
   ///
   /// \param D the referenced decl.
   /// \param Range the source range of the source reference.
-  /// \param AccKind whether this is a read, write or read/write access.
+  /// \param Data whether this is a read, write or read/write access, etc.
   /// \param IsOpenBracket this is \c true when the method is called on an
   /// open bracket.
   virtual bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
-                                       Optional<AccessKind> AccKind,
+                                       ReferenceMetaData Data,
                                        bool IsOpenBracket);
 
   /// This method is called for each keyword argument in a call expression.

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -231,7 +231,7 @@ private:
   bool tryResolve(ModuleEntity Mod, SourceLoc Loc);
   bool tryResolve(Stmt *St);
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
-                               Optional<AccessKind> AccKind,
+                               ReferenceMetaData Data,
                                bool IsOpenBracket) override;
 };
 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -202,6 +202,18 @@ namespace swift {
   /// the decl context.
   bool resolveProtocolNames(DeclContext *DC, ArrayRef<const char *> names,
                             llvm::MapVector<ProtocolDecl*, StringRef> &result);
+
+  /// Return true if the specified type or a super-class/super-protocol has the
+  /// @dynamicMemberLookup attribute on it.
+  bool hasDynamicMemberLookupAttribute(Type type);
+
+  /// Returns the root type of the keypath type in a keypath dynamic member
+  /// lookup subscript, or \c None if it cannot be determined.
+  ///
+  /// \param subscript The potential keypath dynamic member lookup subscript.
+  /// \param DC The DeclContext from which the subscript is being referenced.
+  Optional<Type> getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
+                                                   const DeclContext *DC);
 }
 
 #endif

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -70,8 +70,7 @@ private:
   bool passReference(ModuleEntity Mod, std::pair<Identifier, SourceLoc> IdLoc);
 
   bool passSubscriptReference(ValueDecl *D, SourceLoc Loc,
-                              Optional<AccessKind> AccKind,
-                              bool IsOpenBracket);
+                              ReferenceMetaData Data, bool IsOpenBracket);
 
   bool passCallArgNames(Expr *Fn, TupleExpr *TupleE);
 
@@ -265,6 +264,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       !isa<MakeTemporarilyEscapableExpr>(E) &&
       !isa<CollectionUpcastConversionExpr>(E) &&
       !isa<OpaqueValueExpr>(E) &&
+      !isa<SubscriptExpr>(E) &&
       !isa<KeyPathExpr>(E) &&
       E->isImplicit())
     return { true, E };
@@ -327,8 +327,11 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     if (SE->hasDecl())
       SubscrD = SE->getDecl().getDecl();
 
+    ReferenceMetaData data(SemaReferenceKind::SubscriptRef, OpAccess,
+                           SE->isImplicit());
+
     if (SubscrD) {
-      if (!passSubscriptReference(SubscrD, E->getLoc(), OpAccess, true))
+      if (!passSubscriptReference(SubscrD, E->getLoc(), data, true))
         return { false, nullptr };
     }
 
@@ -336,7 +339,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       return { false, nullptr };
 
     if (SubscrD) {
-      if (!passSubscriptReference(SubscrD, E->getEndLoc(), OpAccess, false))
+      if (!passSubscriptReference(SubscrD, E->getEndLoc(), data, false))
         return { false, nullptr };
     }
 
@@ -578,14 +581,14 @@ bool SemaAnnotator::passModulePathElements(
 }
 
 bool SemaAnnotator::passSubscriptReference(ValueDecl *D, SourceLoc Loc,
-                                           Optional<AccessKind> AccKind,
+                                           ReferenceMetaData Data,
                                            bool IsOpenBracket) {
   CharSourceRange Range = Loc.isValid()
                         ? CharSourceRange(Loc, 1)
                         : CharSourceRange();
 
-  bool Continue = SEWalker.visitSubscriptReference(D, Range, AccKind,
-                                                   IsOpenBracket);
+  bool Continue =
+      SEWalker.visitSubscriptReference(D, Range, Data, IsOpenBracket);
   if (!Continue)
     Cancelled = true;
   return Continue;
@@ -728,13 +731,14 @@ bool SourceEntityWalker::visitDeclReference(ValueDecl *D, CharSourceRange Range,
 
 bool SourceEntityWalker::visitSubscriptReference(ValueDecl *D,
                                                  CharSourceRange Range,
-                                                 Optional<AccessKind> AccKind,
+                                                 ReferenceMetaData Data,
                                                  bool IsOpenBracket) {
   // Most of the clients treat subscript reference the same way as a
   // regular reference when called on the open bracket and
   // ignore the closing one.
-  return IsOpenBracket ? visitDeclReference(D, Range, nullptr, nullptr, Type(),
-    ReferenceMetaData(SemaReferenceKind::SubscriptRef, AccKind)) : true;
+  return IsOpenBracket
+             ? visitDeclReference(D, Range, nullptr, nullptr, Type(), Data)
+             : true;
 }
 
 bool SourceEntityWalker::visitCallArgName(Identifier Name,

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -265,6 +265,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       !isa<MakeTemporarilyEscapableExpr>(E) &&
       !isa<CollectionUpcastConversionExpr>(E) &&
       !isa<OpaqueValueExpr>(E) &&
+      !isa<KeyPathExpr>(E) &&
       E->isImplicit())
     return { true, E };
 

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -118,12 +118,12 @@ bool CursorInfoResolver::tryResolve(Stmt *St) {
   return false;
 }
 
-bool CursorInfoResolver::visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
-                                                 Optional<AccessKind> AccKind,
+bool CursorInfoResolver::visitSubscriptReference(ValueDecl *D,
+                                                 CharSourceRange Range,
+                                                 ReferenceMetaData Data,
                                                  bool IsOpenBracket) {
   // We should treat both open and close brackets equally
-  return visitDeclReference(D, Range, nullptr, nullptr, Type(),
-                    ReferenceMetaData(SemaReferenceKind::SubscriptRef, AccKind));
+  return visitDeclReference(D, Range, nullptr, nullptr, Type(), Data);
 }
 
 ResolvedCursorInfo CursorInfoResolver::resolve(SourceLoc Loc) {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -190,6 +190,8 @@ bool CursorInfoResolver::visitDeclReference(ValueDecl *D,
                                             ReferenceMetaData Data) {
   if (isDone())
     return false;
+  if (Data.isImplicit)
+    return true;
   return !tryResolve(D, CtorTyRef, ExtTyRef, Range.getStart(), /*IsRef=*/true, T);
 }
 
@@ -1423,7 +1425,7 @@ public:
     if (Data.Kind != SemaReferenceKind::DeclRef)
       return;
 
-    if (!isContainedInSelection(CharSourceRange(Start, 0)))
+    if (Data.isImplicit || !isContainedInSelection(CharSourceRange(Start, 0)))
       return;
 
     // If the VD is declared outside of current file, exclude such decl.

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -394,6 +394,10 @@ private:
       return true;
 
     IndexSymbol Info;
+
+    if (Data.isImplicit)
+      Info.roles |= (unsigned)SymbolRole::Implicit;
+
     if (CtorTyRef)
       if (!reportRef(CtorTyRef, Loc, Info, Data.AccKind))
         return false;

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -484,6 +484,9 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
                           Type T, ReferenceMetaData Data) override {
+    if (Data.isImplicit)
+      return true;
+
     for (auto *Item: getRelatedDiffItems(CtorTyRef ? CtorTyRef: D)) {
       std::string RepText;
       if (isSimpleReplacement(Item, isDotMember(Range), RepText)) {
@@ -501,7 +504,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                             TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
                             Type T, ReferenceMetaData Data) override {
-      if (D == Target) {
+      if (D == Target && !Data.isImplicit) {
         Result = Range;
         return false;
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Compiler.h"
 
@@ -3556,6 +3557,12 @@ static bool hasDynamicMemberLookupAttribute(Type type,
   return result;
 }
 
+// for IDETypeChecking
+bool swift::hasDynamicMemberLookupAttribute(Type type) {
+  llvm::DenseMap<CanType, bool> DynamicMemberLookupCache;
+  return ::hasDynamicMemberLookupAttribute(type, DynamicMemberLookupCache);
+}
+
 static bool isKeyPathDynamicMemberLookup(ConstraintLocator *locator) {
   auto path = locator ? locator->getPath() : None;
   return !path.empty() && path.back().isKeyPathDynamicMember();
@@ -3930,8 +3937,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // as representing "dynamic lookup" unless it's a direct call
     // to such subscript (in that case label is expected to match).
     if (auto *subscript = dyn_cast<SubscriptDecl>(cand)) {
-      if (hasDynamicMemberLookupAttribute(instanceTy,
-                                          DynamicMemberLookupCache) &&
+      if (::hasDynamicMemberLookupAttribute(instanceTy,
+                                            DynamicMemberLookupCache) &&
           isValidKeyPathDynamicMemberLookup(subscript, TC)) {
         auto info =
             getArgumentLabels(*this, ConstraintLocatorBuilder(memberLocator));
@@ -4023,7 +4030,8 @@ retry_after_fail:
       constraintKind == ConstraintKind::ValueMember &&
       memberName.isSimpleName() && !memberName.isSpecial()) {
     auto name = memberName.getBaseIdentifier();
-    if (hasDynamicMemberLookupAttribute(instanceTy, DynamicMemberLookupCache)) {
+    if (::hasDynamicMemberLookupAttribute(instanceTy,
+                                          DynamicMemberLookupCache)) {
       auto &ctx = getASTContext();
 
       // Recursively look up `subscript(dynamicMember:)` methods in this type.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -628,9 +628,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
     LookupState LS, DeclVisibilityKind reason, LazyResolver *typeResolver,
     GenericSignatureBuilder *GSB, VisitedSet &visited) {
 
-  if (!hasDynamicMemberLookupAttribute(baseType))
-    return;
-
+  assert(hasDynamicMemberLookupAttribute(baseType));
   auto &ctx = dc->getASTContext();
 
   // Lookup the `subscript(dynamicMember:)` methods in this type.
@@ -652,9 +650,12 @@ static void lookupVisibleDynamicMemberLookupDecls(
 
     auto subs =
         baseType->getMemberSubstitutionMap(dc->getParentModule(), subscript);
-    if (auto memberType = rootType->subst(subs))
-      lookupVisibleMemberDeclsImpl(memberType, consumer, dc, LS, reason,
-                                   typeResolver, GSB, visited);
+    auto memberType = rootType->subst(subs);
+    if (!memberType || !memberType->mayHaveMembers())
+      continue;
+
+    lookupVisibleMemberDeclsImpl(memberType, consumer, dc, LS, reason,
+                                 typeResolver, GSB, visited);
   }
 }
 
@@ -888,13 +889,15 @@ static void lookupVisibleMemberDecls(
   lookupVisibleMemberDeclsImpl(BaseTy, overrideConsumer, CurrDC, LS, Reason,
                                TypeResolver, GSB, Visited);
 
-  llvm::DenseSet<DeclBaseName> knownMembers;
-  for (auto &kv : overrideConsumer.FoundDecls) {
-    knownMembers.insert(kv.first);
+  if (hasDynamicMemberLookupAttribute(BaseTy)) {
+    llvm::DenseSet<DeclBaseName> knownMembers;
+    for (auto &kv : overrideConsumer.FoundDecls) {
+      knownMembers.insert(kv.first);
+    }
+    ShadowedKeyPathMembers dynamicConsumer(overrideConsumer, knownMembers);
+    lookupVisibleDynamicMemberLookupDecls(BaseTy, dynamicConsumer, CurrDC, LS,
+                                          Reason, TypeResolver, GSB, Visited);
   }
-  ShadowedKeyPathMembers dynamicConsumer(overrideConsumer, knownMembers);
-  lookupVisibleDynamicMemberLookupDecls(BaseTy, dynamicConsumer, CurrDC, LS,
-                                        Reason, TypeResolver, GSB, Visited);
 
   // Report the declarations we found to the real consumer.
   for (const auto &DeclAndReason : overrideConsumer.DeclsToReport)

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -623,6 +623,41 @@ static void lookupVisibleMemberDeclsImpl(
   } while (1);
 }
 
+static void lookupVisibleDynamicMemberLookupDecls(
+    Type baseType, VisibleDeclConsumer &consumer, const DeclContext *dc,
+    LookupState LS, DeclVisibilityKind reason, LazyResolver *typeResolver,
+    GenericSignatureBuilder *GSB, VisitedSet &visited) {
+
+  if (!hasDynamicMemberLookupAttribute(baseType))
+    return;
+
+  auto &ctx = dc->getASTContext();
+
+  // Lookup the `subscript(dynamicMember:)` methods in this type.
+  auto subscriptName =
+      DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember);
+
+  SmallVector<ValueDecl *, 2> subscripts;
+  dc->lookupQualified(baseType, subscriptName, NL_QualifiedDefault,
+                      typeResolver, subscripts);
+
+  for (ValueDecl *VD : subscripts) {
+    auto *subscript = dyn_cast<SubscriptDecl>(VD);
+    if (!subscript)
+      continue;
+
+    auto rootType = getRootTypeOfKeypathDynamicMember(subscript, dc);
+    if (!rootType)
+      continue;
+
+    auto subs =
+        baseType->getMemberSubstitutionMap(dc->getParentModule(), subscript);
+    if (auto memberType = rootType->subst(subs))
+      lookupVisibleMemberDeclsImpl(memberType, consumer, dc, LS, reason,
+                                   typeResolver, GSB, visited);
+  }
+}
+
 namespace {
 
 struct FoundDeclTy {
@@ -824,6 +859,18 @@ public:
     DeclsToReport.insert(FoundDeclTy(VD, Reason));
   }
 };
+
+struct ShadowedKeyPathMembers : public VisibleDeclConsumer {
+  VisibleDeclConsumer &consumer;
+  llvm::DenseSet<DeclBaseName> &seen;
+  ShadowedKeyPathMembers(VisibleDeclConsumer &consumer, llvm::DenseSet<DeclBaseName> &knownMembers) : consumer(consumer), seen(knownMembers) {}
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind reason) override {
+    // Dynamic lookup members are only visible if they are not shadowed by
+    // non-dynamic members.
+    if (seen.count(VD->getBaseName()) == 0)
+      consumer.foundDecl(VD, reason);
+  }
+};  
 } // end anonymous namespace
 
 /// Enumerate all members in \c BaseTy (including members of extensions,
@@ -840,6 +887,14 @@ static void lookupVisibleMemberDecls(
   VisitedSet Visited;
   lookupVisibleMemberDeclsImpl(BaseTy, overrideConsumer, CurrDC, LS, Reason,
                                TypeResolver, GSB, Visited);
+
+  llvm::DenseSet<DeclBaseName> knownMembers;
+  for (auto &kv : overrideConsumer.FoundDecls) {
+    knownMembers.insert(kv.first);
+  }
+  ShadowedKeyPathMembers dynamicConsumer(overrideConsumer, knownMembers);
+  lookupVisibleDynamicMemberLookupDecls(BaseTy, dynamicConsumer, CurrDC, LS,
+                                        Reason, TypeResolver, GSB, Visited);
 
   // Report the declarations we found to the real consumer.
   for (const auto &DeclAndReason : overrideConsumer.DeclsToReport)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -14,18 +14,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "TypeChecker.h"
 #include "MiscDiagnostics.h"
 #include "TypeCheckType.h"
-#include "swift/AST/GenericSignatureBuilder.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
@@ -1029,6 +1030,25 @@ bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
            NTD == TC.Context.getReferenceWritableKeyPathDecl();
   }
   return false;
+}
+
+Optional<Type>
+swift::getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
+                                         const DeclContext *DC) {
+  auto &TC = TypeChecker::createForContext(DC->getASTContext());
+
+  if (!isValidKeyPathDynamicMemberLookup(subscript, TC))
+    return None;
+
+  const auto *param = subscript->getIndices()->get(0);
+  auto keyPathType = param->getType()->getAs<BoundGenericType>();
+  if (!keyPathType)
+    return None;
+
+  assert(!keyPathType->getGenericArgs().empty() &&
+         "invalid keypath dynamic member");
+  auto rootType = keyPathType->getGenericArgs()[0];
+  return rootType;
 }
 
 /// The @dynamicMemberLookup attribute is only allowed on types that have at

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -339,3 +339,30 @@ test_arg_tuple2(p1:0,0)
 test_arg_tuple3(0,p2:0)
 // CHECK: <Func@[[@LINE-7]]:6>test_arg_tuple4</Func>(<Func@[[@LINE-7]]:6#p1>p1</Func>:0,<Func@[[@LINE-7]]:6#p2>p2</Func>:0)
 test_arg_tuple4(p1:0,p2:0)
+
+
+@dynamicMemberLookup
+struct Lens<T> {
+  var obj: T
+  init(_ obj: T) {
+    self.obj = obj
+  }
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+}
+struct Point {
+  var x: Int
+  var y: Int
+}
+struct Rectangle {
+  var topLeft: Point
+  var bottomRight: Point
+}
+func testDynamicMemberLookup(r: Lens<Rectangle>) {
+  _ = r.topLeft
+  // CHECK: _ = <Param@[[@LINE-2]]:30>r</Param>.<Var@[[@LINE-5]]:7>topLeft</Var>
+  _ = r.bottomRight.y
+  // CHECK: _ = <Param@[[@LINE-4]]:30>r</Param>.<Var@[[@LINE-6]]:7>bottomRight</Var>.<Var@[[@LINE-10]]:7>y</Var>
+}

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -12,6 +12,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testProtocolConform1 | %FileCheck %s -check-prefix=testProtocolConform1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OnSelf1 | %FileCheck %s -check-prefix=OnSelf1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testSelfExtension1 | %FileCheck %s -check-prefix=testSelfExtension1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid1 | %FileCheck %s -check-prefix=testInvalid1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid2 | %FileCheck %s -check-prefix=testInvalid2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid3 | %FileCheck %s -check-prefix=testInvalid3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid4 | %FileCheck %s -check-prefix=testInvalid4
 
 struct Point {
   var x: Int
@@ -219,3 +223,48 @@ extension Lens where T: HalfRect {
 // testSelfExtension1-NOT: bottomRight
 // testSelfExtension1: Decl[InstanceVar]/CurrNominal:      topLeft[#Point#];
 // testSelfExtension1-NOT: bottomRight
+
+struct Invalid1 {
+  subscript<U>(dynamicMember member: KeyPath<Rectangle, U>) -> U {
+    return Point(x: 0, y: 1)[keyPath: member]
+  }
+}
+func testInvalid1(r: Invalid1) {
+  r.#^testInvalid1^#
+}
+// testInvalid1-NOT: topLeft
+
+@dynamicMemberLookup
+struct Invalid2 {
+  subscript<U>(dynamicMember: KeyPath<Rectangle, U>) -> U {
+    return Point(x: 0, y: 1)[keyPath: dynamicMember]
+  }
+}
+func testInvalid2(r: Invalid2) {
+  r.#^testInvalid2^#
+}
+// testInvalid2-NOT: topLeft
+
+@dynamicMemberLookup
+struct Invalid3 {
+  subscript<U>(dynamicMember member: Rectangle) -> U {
+    return Point(x: 0, y: 1)[keyPath: member]
+  }
+}
+func testInvalid3(r: Invalid3) {
+  r.#^testInvalid3^#
+}
+// testInvalid3-NOT: topLeft
+
+struct NotKeyPath<T, U> {}
+
+@dynamicMemberLookup
+struct Invalid4 {
+  subscript<U>(dynamicMember member: NotKeyPath<Rectangle, U>) -> U {
+    return Point(x: 0, y: 1)[keyPath: member]
+  }
+}
+func testInvalid4(r: Invalid4) {
+  r.#^testInvalid4^#
+}
+// testInvalid4-NOT: topLeft

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -1,0 +1,221 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testMembersPostfix1 | %FileCheck %s -check-prefix=testMembersPostfix1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testMembersDot1 | %FileCheck %s -check-prefix=testMembersDot1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testMembersDot2 | %FileCheck %s -check-prefix=testMembersDot2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testMultipleSubscript1 | %FileCheck %s -check-prefix=testMultipleSubscript1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInherit1 | %FileCheck %s -check-prefix=testInherit1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInherit2 | %FileCheck %s -check-prefix=testInherit2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testShadow1 | %FileCheck %s -check-prefix=testShadow1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testGeneric1 | %FileCheck %s -check-prefix=testGeneric1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testGenericUnderconstrained1 | %FileCheck %s -check-prefix=testGenericUnderconstrained1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testExistential1 | %FileCheck %s -check-prefix=testGenericUnderconstrained1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testExistential2 | %FileCheck %s -check-prefix=testExistential2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testProtocolConform1 | %FileCheck %s -check-prefix=testProtocolConform1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OnSelf1 | %FileCheck %s -check-prefix=OnSelf1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testSelfExtension1 | %FileCheck %s -check-prefix=testSelfExtension1
+
+struct Point {
+  var x: Int
+  var y: Int
+}
+
+struct Rectangle {
+  var topLeft: Point
+  var bottomRight: Point
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+  var obj: T
+  init(_ obj: T) { self.obj = obj }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+}
+
+func testMembersPostfix1(r: Lens<Rectangle>) {
+  r#^testMembersPostfix1^#
+}
+
+// testMembersPostfix1: Begin completions
+// testMembersPostfix1-DAG: Decl[Subscript]/CurrNominal:        [{#dynamicMember: WritableKeyPath<Rectangle, U>#}][#Lens<U>#];
+
+// FIXME: the type should be Lens<Point>
+// testMembersPostfix1-DAG: Decl[InstanceVar]/CurrNominal:      .topLeft[#Point#];
+// testMembersPostfix1-DAG: Decl[InstanceVar]/CurrNominal:      .bottomRight[#Point#];
+// testMembersPostfix1: End completions
+
+func testMembersDot1(r: Lens<Rectangle>) {
+  r.#^testMembersDot1^#
+}
+// testMembersDot1: Begin completions
+// FIXME: the type should be Lens<Point>
+// testMembersDot1-DAG: Decl[InstanceVar]/CurrNominal:      topLeft[#Point#];
+// testMembersDot1-DAG: Decl[InstanceVar]/CurrNominal:      bottomRight[#Point#];
+// testMembersDot1: End completions
+
+func testMembersDot2(r: Lens<Rectangle>) {
+  r.topLeft.#^testMembersDot2^#
+}
+
+// testMembersDot2: Begin completions
+// FIXME: the type should be Lens<Int>
+// testMembersDot2-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testMembersDot2-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testMembersDot2: End completions
+
+@dynamicMemberLookup
+struct MultipleSubscript {
+  subscript<U>(dynamicMember member: KeyPath<Point, U>) -> U {
+    return Point(x: 1, y: 2)[keyPath: member]
+  }
+
+  subscript<U>(dynamicMember member: KeyPath<Rectangle, U>) -> U {
+    return Rectangle(topLeft: Point(x: 0, y: 0), bottomRight: Point(x: 1, y: 1))[keyPath: member]
+  }
+}
+
+func testMultipleSubscript1(r: MultipleSubscript) {
+  r.#^testMultipleSubscript1^#
+}
+
+// testMultipleSubscript1: Begin completions
+// testMultipleSubscript1-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testMultipleSubscript1-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testMultipleSubscript1-DAG: Decl[InstanceVar]/CurrNominal:      topLeft[#Point#];
+// testMultipleSubscript1-DAG: Decl[InstanceVar]/CurrNominal:      bottomRight[#Point#];
+// testMultipleSubscript1: End completions
+
+@dynamicMemberLookup
+class Base<T> {
+  var t: T
+  init(_ t: T) { self.t = t }
+  subscript<U>(dynamicMember member: KeyPath<T, U>) -> U {
+    return t[keyPath: member]
+  }
+}
+
+class Inherit1<T>: Base<T> {}
+
+func testInherit1(r: Inherit1<Point>) {
+  r.#^testInherit1^#
+}
+// testInherit1: Begin completions
+// testInherit1-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testInherit1-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testInherit1: End completions
+
+class Inherit2<T, U>: Base<T> {
+  var u: U
+  init(_ t: T, _ u: U) { super.init(t); self.u = u }
+  subscript<V>(dynamicMember member: KeyPath<U, V>) -> V {
+    return u[keyPath: member]
+  }
+}
+
+func testInherit2(r: Inherit2<Point, Rectangle>) {
+  r.#^testInherit2^#
+}
+// testInherit2: Begin completions
+// testInherit2-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testInherit2-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testInherit2-DAG: Decl[InstanceVar]/CurrNominal:      topLeft[#Point#];
+// testInherit2-DAG: Decl[InstanceVar]/CurrNominal:      bottomRight[#Point#];
+// testInherit2: End completions
+
+class Shadow1<T>: Base<T> {
+  var x: String = ""
+}
+
+func testShadow1(r: Shadow1<Point>) {
+  r.#^testShadow1^#
+}
+// testShadow1-NOT: x[#Int#];
+// testShadow1: Decl[InstanceVar]/CurrNominal:      x[#String#];
+// testShadow1-NOT: x[#Int#];
+// testShadow1: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+
+@dynamicMemberLookup
+protocol P {
+  associatedtype T
+  subscript<U>(dynamicMember member: KeyPath<T, U>) -> U
+}
+
+func testGeneric1<G: P>(r: G) where G.T == Point {
+  r.#^testGeneric1^#
+}
+// testGeneric1: Begin completions
+// testGeneric1-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testGeneric1-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testGeneric1: End completions
+
+
+func testGenericUnderconstrained1<G: P>(r: G) {
+  r.#^testGenericUnderconstrained1^#
+}
+// testGenericUnderconstrained1-NOT: CurrNominal
+// testGenericUnderconstrained1: Keyword[self]/CurrNominal:          self[#{{[GP]}}#];
+// testGenericUnderconstrained1-NOT: CurrNominal
+
+func testExistential1(r: P) {
+  r.#^testExistential1^#
+}
+
+@dynamicMemberLookup
+protocol E {
+  subscript<U>(dynamicMember member: KeyPath<Point, U>) -> U
+}
+
+func testExistential2(r: E) {
+  r.#^testExistential2^#
+}
+// testExistential2: Begin completions
+// testExistential2-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testExistential2-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testExistential2: End completions
+
+struct WithP<T>: P {
+  var t: T
+  init(t: T) { self.t = t }
+  subscript<U>(dynamicMember member: KeyPath<T, U>) -> U {
+    return t[keyPath: member]
+  }
+}
+
+func testProtocolConform1(r: WithP<Point>) {
+  r.#^testProtocolConform1^#
+}
+// testProtocolConform1: Begin completions
+// testProtocolConform1-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testProtocolConform1-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testProtocolConform1: End completions
+
+@dynamicMemberLookup
+struct OnSelf {
+  subscript<U>(dynamicMember member: KeyPath<Point, U>) -> U {
+    return Point(x: 0, y: 1)[keyPath: member]
+  }
+
+  func test() {
+    self.#^OnSelf1^#
+  }
+}
+// OnSelf1: Begin completions
+// OnSelf1-DAG: Decl[InstanceMethod]/CurrNominal:   test()[#Void#];
+// OnSelf1-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// OnSelf1-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// OnSelf1: End completions
+
+protocol HalfRect {
+  var topLeft: Point
+}
+
+extension Lens where T: HalfRect {
+  func testSelfExtension1() {
+    self.#^testSelfExtension1^#
+  }
+}
+// testSelfExtension1-NOT: bottomRight
+// testSelfExtension1: Decl[InstanceVar]/CurrNominal:      topLeft[#Point#];
+// testSelfExtension1-NOT: bottomRight

--- a/test/Index/index_keypath_member_lookup.swift
+++ b/test/Index/index_keypath_member_lookup.swift
@@ -48,7 +48,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[TL_LINE:[0-9]+]]:7 | param/Swift | r
 
 // => implicit dynamicMember subscript (topLeft)
-// CHECK: [[TL_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[TL_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
 // CHECK: [[TL_LINE]]:9 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => property topLeft
@@ -59,7 +59,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[BR_LINE:[0-9]+]]:7 | param/Swift | r
 
 // => implicit dynamicMember subscript (bottomRight)
-// CHECK: [[BR_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
 // CHECK: [[BR_LINE]]:9 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => property bottomRight
@@ -67,7 +67,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[BR_LINE]]:9 | instance-method/acc-get/Swift | getter:bottomRight | [[BR_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => implicit dynamicMember subscript (y)
-// CHECK: [[BR_LINE]]:21 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:21 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
 // CHECK: [[BR_LINE]]:21 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => property y
@@ -78,7 +78,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[A_LINE:[0-9]+]]:7 | param/Swift | a
 
 // => implicit dynamicMember subscript
-// CHECK: [[A_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[A_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
 // CHECK: [[A_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => subscript [Int]
@@ -92,7 +92,7 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 // CHECK: [[WTL_LINE:[0-9]+]]:3 | param/Swift | r
 
 // => implicit dynamicMember subscript (topLeft)
-// CHECK: [[WTL_LINE]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,RelCont | rel: 1
+// CHECK: [[WTL_LINE]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,Impl,RelCont | rel: 1
 // CHECK: [[WTL_LINE]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property topLeft
@@ -103,7 +103,7 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 // CHECK: [[WBR_LINE:[0-9]+]]:3 | param/Swift | r
 
 // => implicit dynamicMember subscript (bottomRight)
-// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Writ,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Writ,Impl,RelCont | rel: 1
 // CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 // CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
@@ -113,7 +113,7 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 // CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-set/Swift | setter:bottomRight | [[BR_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => implicit dynamicMember subscript (y)
-// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,Impl,RelCont | rel: 1
 // CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property y
@@ -122,4 +122,18 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 
   // FIXME: crashes typechecker rdar://problem/49533404
   // a[0] = Lens(1)
+}
+
+func testExplicit(r: Lens<Rectangle>, a: Lens<[Int]>) {
+  _ = r[dynamicMember: \.topLeft]
+// CHECK: [[ETL_LINE:[0-9]+]]:7 | param/Swift | r
+// Not implicit.
+// CHECK: [[ETL_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[ETL_LINE]]:26 | instance-property/Swift | topLeft | [[TL_USR]] | Ref,Read,RelCont | rel: 1
+
+  _ = a[dynamicMember: \.[0]]
+// CHECK: [[EA_LINE:[0-9]+]]:7 | param/Swift | a
+// Not implicit.
+// CHECK: [[EA_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[EA_LINE]]:26 | instance-property/subscript/Swift | subscript(_:) | s:SayxSicip | Ref,Read,RelCont | rel: 1
 }

--- a/test/Index/index_keypath_member_lookup.swift
+++ b/test/Index/index_keypath_member_lookup.swift
@@ -1,0 +1,125 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+struct Point {
+// CHECK: [[@LINE-1]]:8 | struct/Swift | Point | {{.*}} | Def | rel: 0
+  var x: Int
+// CHECK: [[@LINE-1]]:7 | instance-property/Swift | x | [[PX_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:x | [[PX_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+// CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:x | [[PX_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+  var y: Int
+// CHECK: [[@LINE-1]]:7 | instance-property/Swift | y | [[PY_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:y | [[PY_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+// CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:y | [[PY_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+}
+
+struct Rectangle {
+// CHECK: [[@LINE-1]]:8 | struct/Swift | Rectangle | {{.*}} | Def | rel: 0
+  var topLeft: Point
+// CHECK: [[@LINE-1]]:7 | instance-property/Swift | topLeft | [[TL_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:topLeft | [[TL_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+// CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:topLeft | [[TL_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+  var bottomRight: Point
+// CHECK: [[@LINE-1]]:7 | instance-property/Swift | bottomRight | [[BR_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:bottomRight | [[BR_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+// CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:bottomRight | [[BR_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+// CHECK: [[@LINE-1]]:8 | struct/Swift | Lens | {{.*}} | Def | rel: 0
+  var obj: T
+
+  init(_ obj: T) {
+    self.obj = obj
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+// CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR:s:.*]] | Def,RelChild | rel: 1
+    get { return Lens<U>(obj[keyPath: member]) }
+// CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR:s:.*]] | Def,RelChild,RelAcc | rel: 1
+    set { obj[keyPath: member] = newValue.obj }
+// CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR:s:.*]] | Def,RelChild,RelAcc | rel: 1
+  }
+}
+
+
+func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
+  _ = r.topLeft
+// CHECK: [[TL_LINE:[0-9]+]]:7 | param/Swift | r
+
+// => implicit dynamicMember subscript (topLeft)
+// CHECK: [[TL_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[TL_LINE]]:9 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+
+// => property topLeft
+// CHECK: [[TL_LINE]]:9 | instance-property/Swift | topLeft | [[TL_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[TL_LINE]]:9 | instance-method/acc-get/Swift | getter:topLeft | [[TL_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+  _ = r.bottomRight.y
+// CHECK: [[BR_LINE:[0-9]+]]:7 | param/Swift | r
+
+// => implicit dynamicMember subscript (bottomRight)
+// CHECK: [[BR_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:9 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+
+// => property bottomRight
+// CHECK: [[BR_LINE]]:9 | instance-property/Swift | bottomRight | [[BR_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:9 | instance-method/acc-get/Swift | getter:bottomRight | [[BR_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+// => implicit dynamicMember subscript (y)
+// CHECK: [[BR_LINE]]:21 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:21 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+
+// => property y
+// CHECK: [[BR_LINE]]:21 | instance-property/Swift | y | [[PY_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:21 | instance-method/acc-get/Swift | getter:y | [[PY_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+  _ = a[0]
+// CHECK: [[A_LINE:[0-9]+]]:7 | param/Swift | a
+
+// => implicit dynamicMember subscript
+// CHECK: [[A_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
+// CHECK: [[A_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+
+// => subscript [Int]
+// CHECK: [[A_LINE]]:8 | instance-property/subscript/Swift | subscript(_:) | s:SayxSicip | Ref,Read,RelCont | rel: 1
+// CHECK: [[A_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(_:) | s:SayxSicig | Ref,Call,Impl,RelCall,RelCont | rel: 1
+}
+
+
+func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) {
+  r.topLeft = p
+// CHECK: [[WTL_LINE:[0-9]+]]:3 | param/Swift | r
+
+// => implicit dynamicMember subscript (topLeft)
+// CHECK: [[WTL_LINE]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,RelCont | rel: 1
+// CHECK: [[WTL_LINE]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+// => property topLeft
+// CHECK: [[WTL_LINE]]:5 | instance-property/Swift | topLeft | [[TL_USR]] | Ref,Writ,RelCont | rel: 1
+// CHECK: [[WTL_LINE]]:5 | instance-method/acc-set/Swift | setter:topLeft | [[TL_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+  r.bottomRight.y = Lens(3)
+// CHECK: [[WBR_LINE:[0-9]+]]:3 | param/Swift | r
+
+// => implicit dynamicMember subscript (bottomRight)
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Writ,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+// => property bottomRight
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-property/Swift | bottomRight | [[BR_USR]] | Ref,Read,Writ,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-get/Swift | getter:bottomRight | [[BR_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-set/Swift | setter:bottomRight | [[BR_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+// => implicit dynamicMember subscript (y)
+// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+// => property y
+// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-property/Swift | y | [[PY_USR]] | Ref,Writ,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-method/acc-set/Swift | setter:y | [[PY_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+
+  // FIXME: crashes typechecker rdar://problem/49533404
+  // a[0] = Lens(1)
+}

--- a/test/Index/index_keypath_member_lookup.swift
+++ b/test/Index/index_keypath_member_lookup.swift
@@ -48,8 +48,8 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[TL_LINE:[0-9]+]]:7 | param/Swift | r
 
 // => implicit dynamicMember subscript (topLeft)
-// CHECK: [[TL_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[TL_LINE]]:9 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[TL_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
+// CHECK: [[TL_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => property topLeft
 // CHECK: [[TL_LINE]]:9 | instance-property/Swift | topLeft | [[TL_USR]] | Ref,Read,RelCont | rel: 1
@@ -59,16 +59,16 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[BR_LINE:[0-9]+]]:7 | param/Swift | r
 
 // => implicit dynamicMember subscript (bottomRight)
-// CHECK: [[BR_LINE]]:9 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[BR_LINE]]:9 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[BR_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => property bottomRight
 // CHECK: [[BR_LINE]]:9 | instance-property/Swift | bottomRight | [[BR_USR]] | Ref,Read,RelCont | rel: 1
 // CHECK: [[BR_LINE]]:9 | instance-method/acc-get/Swift | getter:bottomRight | [[BR_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => implicit dynamicMember subscript (y)
-// CHECK: [[BR_LINE]]:21 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[BR_LINE]]:21 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[BR_LINE]]:20 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
+// CHECK: [[BR_LINE]]:20 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
 
 // => property y
 // CHECK: [[BR_LINE]]:21 | instance-property/Swift | y | [[PY_USR]] | Ref,Read,RelCont | rel: 1
@@ -92,8 +92,8 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 // CHECK: [[WTL_LINE:[0-9]+]]:3 | param/Swift | r
 
 // => implicit dynamicMember subscript (topLeft)
-// CHECK: [[WTL_LINE]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,Impl,RelCont | rel: 1
-// CHECK: [[WTL_LINE]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+// CHECK: [[WTL_LINE]]:4 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,Impl,RelCont | rel: 1
+// CHECK: [[WTL_LINE]]:4 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property topLeft
 // CHECK: [[WTL_LINE]]:5 | instance-property/Swift | topLeft | [[TL_USR]] | Ref,Writ,RelCont | rel: 1
@@ -103,9 +103,9 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 // CHECK: [[WBR_LINE:[0-9]+]]:3 | param/Swift | r
 
 // => implicit dynamicMember subscript (bottomRight)
-// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Writ,Impl,RelCont | rel: 1
-// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
-// CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:4 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Writ,Impl,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:4 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:4 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property bottomRight
 // CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-property/Swift | bottomRight | [[BR_USR]] | Ref,Read,Writ,RelCont | rel: 1
@@ -113,8 +113,8 @@ func testWrite1(r: inout Lens<Rectangle>, p: Lens<Point>, a: inout Lens<[Int]>) 
 // CHECK: [[WBR_LINE:[0-9]+]]:5 | instance-method/acc-set/Swift | setter:bottomRight | [[BR_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => implicit dynamicMember subscript (y)
-// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,Impl,RelCont | rel: 1
-// CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:16 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Writ,Impl,RelCont | rel: 1
+// CHECK: [[WBR_LINE:[0-9]+]]:16 | instance-method/acc-set/Swift | setter:subscript(dynamicMember:) | [[SUB_SET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property y
 // CHECK: [[WBR_LINE:[0-9]+]]:17 | instance-property/Swift | y | [[PY_USR]] | Ref,Writ,RelCont | rel: 1

--- a/test/SourceKit/CursorInfo/cursor_info_keypath_member_lookup.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_keypath_member_lookup.swift
@@ -1,0 +1,63 @@
+struct Point {
+  var x: Int
+  var y: Int
+}
+
+struct Rectangle {
+  var topLeft: Point
+  var bottomRight: Point
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+  var obj: T
+  init(_ obj: T) {
+    self.obj = obj
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+}
+
+func test(r: Lens<Rectangle>) {
+  _ = r.topLeft
+  _ = r.bottomRight.y
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=18:3 -cursor-action %s -- %s | %FileCheck -check-prefix=SUBSCRIPT %s
+// SUBSCRIPT: source.lang.swift.decl.function.subscript (18:3-18:12)
+// SUBSCRIPT: subscript(dynamicMember:)
+// SUBSCRIPT: <T, U> (dynamicMember: WritableKeyPath<T, U>) -> Lens<U>
+// SUBSCRIPT: <decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>&lt;<decl.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1UL_qd__mfp"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>dynamicMember</decl.var.parameter.argument_label> <decl.var.parameter.name>member</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr="s:s15WritableKeyPathC">WritableKeyPath</ref.class>&lt;<ref.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1Txmfp">T</ref.generic_type_param>, <ref.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1UL_qd__mfp">U</ref.generic_type_param>&gt;</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr="s:33cursor_info_keypath_member_lookup4LensV">Lens</ref.struct>&lt;<ref.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1UL_qd__mfp">U</ref.generic_type_param>&gt;</decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.function.subscript>
+// SUBSCRIPT: ACTIONS BEGIN
+// FIXME: should not allow rename since that would break the contract.
+// SUBSCRIPT: source.refactoring.kind.rename.global
+// SUBSCRIPT: ACTIONS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=25:9 -cursor-action %s -- %s | %FileCheck -check-prefix=TOP_LEFT %s
+// TOP_LEFT: source.lang.swift.ref.var.instance
+// TOP_LEFT: topLeft
+// TOP_LEFT: Point
+// TOP_LEFT: <decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>topLeft</decl.name>: <decl.var.type><ref.struct usr="{{s:.*}}">Point</ref.struct></decl.var.type></decl.var.instance>
+// TOP_LEVEL: ACTIONS BEGIN
+// TOP_LEVEL: source.refactoring.kind.rename.global
+// TOP_LEVEL: ACTIONS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=26:9 -cursor-action %s -- %s | %FileCheck -check-prefix=BOTTOM_RIGHT %s
+// BOTTOM_RIGHT: source.lang.swift.ref.var.instance
+// BOTTOM_RIGHT: bottomRight
+// BOTTOM_RIGHT: Point
+// BOTTOM_RIGHT: ACTIONS BEGIN
+// BOTTOM_RIGHT: source.refactoring.kind.rename.global
+// BOTTOM_RIGHT: ACTIONS END
+
+/// RUN: %sourcekitd-test -req=cursor -pos=26:21 -cursor-action %s -- %s | %FileCheck -check-prefix=YREF %s
+// YREF: source.lang.swift.ref.var.instance
+// YREF: y
+// YREF: Int
+// YREF: <decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.type></decl.var.instance>
+// YREF: ACTIONS BEGIN
+// YREF: source.refactoring.kind.rename.global
+// YREF: ACTIONS END

--- a/test/SourceKit/CursorInfo/cursor_info_keypath_member_lookup.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_keypath_member_lookup.swift
@@ -30,7 +30,6 @@ func test(r: Lens<Rectangle>) {
 // SUBSCRIPT: source.lang.swift.decl.function.subscript (18:3-18:12)
 // SUBSCRIPT: subscript(dynamicMember:)
 // SUBSCRIPT: <T, U> (dynamicMember: WritableKeyPath<T, U>) -> Lens<U>
-// SUBSCRIPT: <decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>&lt;<decl.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1UL_qd__mfp"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>dynamicMember</decl.var.parameter.argument_label> <decl.var.parameter.name>member</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr="s:s15WritableKeyPathC">WritableKeyPath</ref.class>&lt;<ref.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1Txmfp">T</ref.generic_type_param>, <ref.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1UL_qd__mfp">U</ref.generic_type_param>&gt;</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr="s:33cursor_info_keypath_member_lookup4LensV">Lens</ref.struct>&lt;<ref.generic_type_param usr="s:33cursor_info_keypath_member_lookup4LensV1UL_qd__mfp">U</ref.generic_type_param>&gt;</decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.function.subscript>
 // SUBSCRIPT: ACTIONS BEGIN
 // FIXME: should not allow rename since that would break the contract.
 // SUBSCRIPT: source.refactoring.kind.rename.global

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1032,6 +1032,8 @@ public:
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type Ty,
                           ReferenceMetaData Data) override {
+    if (Data.isImplicit)
+      return true;
     unsigned StartOffset = getOffset(Range.getStart());
     References.emplace_back(D, StartOffset, Range.getByteLength(), Ty);
     return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1038,11 +1038,10 @@ public:
   }
 
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
-                               Optional<AccessKind> AccKind,
+                               ReferenceMetaData Data,
                                bool IsOpenBracket) override {
     // Treat both open and close brackets equally
-    return visitDeclReference(D, Range, nullptr, nullptr, Type(),
-                      ReferenceMetaData(SemaReferenceKind::SubscriptRef, AccKind));
+    return visitDeclReference(D, Range, nullptr, nullptr, Type(), Data);
   }
 
   bool isLocal(Decl *D) const {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -905,8 +905,11 @@ public:
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
-      if (isa<VarDecl>(D) && D->hasName() &&
-          D->getFullName() == D->getASTContext().Id_self)
+    if (Data.isImplicit)
+      return true;
+
+    if (isa<VarDecl>(D) && D->hasName() &&
+        D->getFullName() == D->getASTContext().Id_self)
       return true;
 
     // Do not annotate references to unavailable decls.

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -920,11 +920,10 @@ public:
   }
 
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
-                               Optional<AccessKind> AccKind,
+                               ReferenceMetaData Data,
                                bool IsOpenBracket) override {
     // We should treat both open and close brackets equally
-    return visitDeclReference(D, Range, nullptr, nullptr, Type(),
-                      ReferenceMetaData(SemaReferenceKind::SubscriptRef, AccKind));
+    return visitDeclReference(D, Range, nullptr, nullptr, Type(), Data);
   }
 
   void annotate(const Decl *D, bool IsRef, CharSourceRange Range) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1439,10 +1439,9 @@ private:
   }
 
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
-                               Optional<AccessKind> AccKind,
+                               ReferenceMetaData Data,
                                bool IsOpenBracket) override {
-    return visitDeclReference(D, Range, nullptr, nullptr, Type(),
-                      ReferenceMetaData(SemaReferenceKind::SubscriptRef, AccKind));
+    return visitDeclReference(D, Range, nullptr, nullptr, Type(), Data);
   }
 
   bool visitCallArgName(Identifier Name, CharSourceRange Range,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1434,7 +1434,8 @@ private:
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type Ty,
                           ReferenceMetaData Data) override {
-    annotateSourceEntity({ Range, D, CtorTyRef, /*IsRef=*/true });
+    if (!Data.isImplicit)
+      annotateSourceEntity({ Range, D, CtorTyRef, /*IsRef=*/true });
     return true;
   }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24072
Reviewed by: @rintaro @nathawes 

---

Add support for code-completion looking up keypath dynamic members, and cursor-info/indexing walking the underlying decls.

rdar://49028783
rdar://49028895
rdar://49029126