### PR TITLE
[5.1] Cherry-pick: [stdlib] Include POSIXError as part of Glibc

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_
 add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Glibc.swift.gyb
     ${swift_platform_sources}
+    POSIXError.swift
 
     SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"


### PR DESCRIPTION
Integrates https://github.com/apple/swift/pull/24028 into the Swift 5.1 branch

See https://github.com/apple/swift-corelibs-foundation/pull/2113#issuecomment-484268044