### PR TITLE
[5.1] lit.cfg: Respect the DYLD_LIBRARY_PATH restrictions when not using %target-run

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1178,48 +1178,6 @@ if sftp_server_path:
 config.substitutions.append(('%sftp-server',
                              sftp_server_path or 'no-sftp-server'))
 
-
-if not getattr(config, 'target_run_simple_swift', None):
-    config.target_run_simple_swift_parameterized =                               \
-        (SubstituteCaptures('%%empty-directory(%%t) && '
-                            '%s %s %%s \\1 -o %%t/a.out -module-name main -Xfrontend -verify-sil-ownership && '
-                            '%s %%t/a.out &&'
-                            '%s %%t/a.out' % (config.target_build_swift,
-                                              mcp_opt, config.target_codesign,
-                                              config.target_run)))
-    config.target_run_simple_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main -Xfrontend -verify-sil-ownership && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_stdlib_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control -Xfrontend -verify-sil-ownership && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_swiftgyb = (
-        '%%empty-directory(%%t) && '
-        '%%gyb %%s -o %%t/main.swift && '
-        '%%line-directive %%t/main.swift -- '
-        '%s %s %%t/main.swift -o %%t/a.out -module-name main -Xfrontend -verify-sil-ownership && '
-        '%s %%t/a.out &&'
-        '%%line-directive %%t/main.swift -- '
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_stdlib_swiftgyb = (
-        '%%empty-directory(%%t) && '
-        '%%gyb %%s -o %%t/main.swift && '
-        '%%line-directive %%t/main.swift -- '
-        '%s %s %%t/main.swift -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control -Xfrontend -verify-sil-ownership && '
-        '%s %%t/a.out &&'
-        '%%line-directive %%t/main.swift -- '
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-
 subst_target_jit_run = ""
 if 'swift_interpreter' in config.available_features:
     subst_target_jit_run = (
@@ -1309,6 +1267,47 @@ if not kIsWindows:
 			"LD_LIBRARY_PATH='{0}' " # Linux option
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
 			.format(all_stdlib_path)) + config.target_run
+			
+if not getattr(config, 'target_run_simple_swift', None):
+    config.target_run_simple_swift_parameterized =                               \
+        (SubstituteCaptures('%%empty-directory(%%t) && '
+                            '%s %s %%s \\1 -o %%t/a.out -module-name main  && '
+                            '%s %%t/a.out &&'
+                            '%s %%t/a.out' % (config.target_build_swift,
+                                              mcp_opt, config.target_codesign,
+                                              config.target_run)))
+    config.target_run_simple_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_stdlib_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -o %%t/a.out -module-name main '
+        '-Xfrontend -disable-access-control  && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_simple_swiftgyb = (
+        '%%empty-directory(%%t) && '
+        '%%gyb %%s -o %%t/main.swift && '
+        '%%line-directive %%t/main.swift -- '
+        '%s %s %%t/main.swift -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out &&'
+        '%%line-directive %%t/main.swift -- '
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_stdlib_swiftgyb = (
+        '%%empty-directory(%%t) && '
+        '%%gyb %%s -o %%t/main.swift && '
+        '%%line-directive %%t/main.swift -- '
+        '%s %s %%t/main.swift -o %%t/a.out -module-name main '
+        '-Xfrontend -disable-access-control  && '
+        '%s %%t/a.out &&'
+        '%%line-directive %%t/main.swift -- '
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
 
 #
 # When changing substitutions, update docs/Testing.rst.


### PR DESCRIPTION
Some test cases use something like
```
config.target_run_simple_swift = (
        '%%empty-directory(%%t) && '
        '%s %s %%s -o %%t/a.out -module-name main  && '
        '%s %%t/a.out &&'
        '%s %%t/a.out’
```
That does not respect the %target-run DYLD_LIBRARY_PATH for choosing the just built libraries and/or OS libraries.
This PR respects said library path in such situations

rdar://problem/49835064