### PR TITLE
[ModuleInterface] Escape `Type` and `Protocol` when they're type members

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -44,6 +44,8 @@ enum class PrintNameContext {
   Normal,
   /// Keyword context, where no keywords are escaped.
   Keyword,
+  /// Type member context, e.g. properties or enum cases.
+  TypeMember,
   /// Generic parameter context, where 'Self' is not escaped.
   GenericParameter,
   /// Class method return type, where 'Self' is not escaped.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -379,16 +379,26 @@ ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
 
 /// Determine whether to escape the given keyword in the given context.
 static bool escapeKeywordInContext(StringRef keyword, PrintNameContext context){
+
+  bool isKeyword = llvm::StringSwitch<bool>(keyword)
+#define KEYWORD(KW) \
+      .Case(#KW, true)
+#include "swift/Syntax/TokenKinds.def"
+      .Default(false);
+
   switch (context) {
   case PrintNameContext::Normal:
   case PrintNameContext::Attribute:
-    return true;
+    return isKeyword;
   case PrintNameContext::Keyword:
     return false;
 
   case PrintNameContext::ClassDynamicSelf:
   case PrintNameContext::GenericParameter:
-    return keyword != "Self";
+    return isKeyword && keyword != "Self";
+
+  case PrintNameContext::TypeMember:
+    return isKeyword || !canBeMemberName(keyword);
 
   case PrintNameContext::FunctionParameterExternal:
   case PrintNameContext::FunctionParameterLocal:
@@ -407,19 +417,13 @@ void ASTPrinter::printName(Identifier Name, PrintNameContext Context) {
     printNamePost(Context);
     return;
   }
-  bool IsKeyword = llvm::StringSwitch<bool>(Name.str())
-#define KEYWORD(KW) \
-      .Case(#KW, true)
-#include "swift/Syntax/TokenKinds.def"
-      .Default(false);
 
-  if (IsKeyword)
-    IsKeyword = escapeKeywordInContext(Name.str(), Context);
+  bool shouldEscapeKeyword = escapeKeywordInContext(Name.str(), Context);
 
-  if (IsKeyword)
+  if (shouldEscapeKeyword)
     *this << "`";
   *this << Name.str();
-  if (IsKeyword)
+  if (shouldEscapeKeyword)
     *this << "`";
 
   printNamePost(Context);
@@ -1029,6 +1033,14 @@ static bool mustPrintPropertyName(VarDecl *decl, PrintOptions opts) {
   return false;
 }
 
+/// Gets the print name context of a given decl, choosing between TypeMember
+/// and Normal, depending if this decl lives in a nominal type decl.
+static PrintNameContext getTypeMemberPrintNameContext(const Decl *d) {
+  return d->getDeclContext()->isTypeContext() ?
+      PrintNameContext::TypeMember :
+      PrintNameContext::Normal;
+}
+
 void PrintAST::printPattern(const Pattern *pattern) {
   switch (pattern->getKind()) {
   case PatternKind::Any:
@@ -1042,7 +1054,8 @@ void PrintAST::printPattern(const Pattern *pattern) {
       // FIXME: This always returns true now, because of the FIXMEs listed in
       //        mustPrintPropertyName.
       if (mustPrintPropertyName(decl, Options))
-        Printer.printName(named->getBoundName());
+        Printer.printName(named->getBoundName(),
+                          getTypeMemberPrintNameContext(decl));
       else
         Printer << "_";
     });
@@ -2255,7 +2268,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
   printContextIfNeeded(decl);
   recordDeclLoc(decl,
     [&]{
-      Printer.printName(decl->getName());
+      Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
     }, [&]{ // Signature
       printGenericDeclGenericParams(decl);
     });
@@ -2298,7 +2311,7 @@ void PrintAST::visitAssociatedTypeDecl(AssociatedTypeDecl *decl) {
     Printer << tok::kw_associatedtype << " ";
   recordDeclLoc(decl,
     [&]{
-      Printer.printName(decl->getName());
+      Printer.printName(decl->getName(), PrintNameContext::TypeMember);
     });
 
   auto proto = decl->getProtocol();
@@ -2339,7 +2352,7 @@ void PrintAST::visitEnumDecl(EnumDecl *decl) {
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
-        Printer.printName(decl->getName());
+        Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
       }, [&]{ // Signature
         printGenericDeclGenericParams(decl);
       });
@@ -2367,7 +2380,7 @@ void PrintAST::visitStructDecl(StructDecl *decl) {
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
-        Printer.printName(decl->getName());
+        Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
       }, [&]{ // Signature
         printGenericDeclGenericParams(decl);
       });
@@ -2395,7 +2408,7 @@ void PrintAST::visitClassDecl(ClassDecl *decl) {
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
-        Printer.printName(decl->getName());
+        Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
       }, [&]{ // Signature
         printGenericDeclGenericParams(decl);
       });
@@ -2528,7 +2541,7 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
   printContextIfNeeded(decl);
   recordDeclLoc(decl,
     [&]{
-      Printer.printName(decl->getName());
+      Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
     });
   if (decl->hasInterfaceType()) {
     Printer << ": ";
@@ -2785,7 +2798,8 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         if (!decl->hasName()) {
           Printer << "<anonymous>";
         } else {
-          Printer.printName(decl->getName());
+          Printer.printName(decl->getName(),
+                            getTypeMemberPrintNameContext(decl));
           if (decl->isOperator())
             Printer << " ";
         }
@@ -2831,7 +2845,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
 void PrintAST::printEnumElement(EnumElementDecl *elt) {
   recordDeclLoc(elt,
     [&]{
-      Printer.printName(elt->getName());
+      Printer.printName(elt->getName(), getTypeMemberPrintNameContext(elt));
     });
 
   if (auto *PL = elt->getParameterList()) {

--- a/test/ParseableInterface/escape-Type-and-Protocol.swift
+++ b/test/ParseableInterface/escape-Type-and-Protocol.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s | %FileCheck %s
+
+// CHECK: public let Type: Swift.Int
+public let Type = 0
+
+// CHECK: public struct A {
+public struct A {
+  // CHECK-NEXT: public struct `Type` {
+  // CHECK-NEXT: }
+  public struct `Type` {}
+// CHECK-NEXT: }
+}
+
+// CHECK: public class B {
+public class B {
+  // CHECK-NEXT: public class `Type` {
+  // CHECK: }
+  public class `Type` {}
+
+  // CHECK-NEXT: @_hasInitialValue public var `Type`: Swift.Int
+  public var `Type` = 0
+// CHECK: }
+}
+
+// CHECK: public struct C {
+public struct C {
+  // CHECK: public enum `Type` {
+  public enum `Type` {
+    // CHECK: }
+  }
+// CHECK-NEXT: }
+}
+
+// CHECK: public struct D {
+public struct D {
+  // CHECK: public typealias `Type` = Int
+  public typealias `Type` = Int
+// CHECK-NEXT: }
+}
+
+// CHECK: public protocol BestProtocol {
+public protocol BestProtocol {
+  // CHECK-NEXT: associatedtype `Type`
+  associatedtype `Type`
+// CHECK-NEXT: }
+}
+
+// CHECK: public enum CoolEnum {
+public enum CoolEnum {
+  // CHECK-NEXT: case `Type`
+  case `Type`
+  // CHECK-NEXT: case `Protocol`
+  case `Protocol`
+  // CHECK-NEXT: case `init`
+  case `init`
+  // CHECK-NEXT: case `self`
+  case `self`
+
+  // We allow Type and Protocol as method names, but we should still print them
+  // escaped in case we tighten this restriction.
+  // CHECK-NEXT: public func `Type`()
+  public func Type() {}
+  // CHECK-NEXT: public func `Protocol`()
+  public func Protocol() {}
+// CHECK: }
+}
+
+// CHECK: public enum UncoolEnum {
+public enum UncoolEnum {
+  // CHECK-NEXT: case `Type`, `Protocol`
+  case `Type`, `Protocol`
+// CHECK: }
+}


### PR DESCRIPTION
Previously, we wouldn't escape `Type` and `Protocol` at all in the
ASTPrinter, which lead to unfortunate build failures while compiling an
interface.

Instead, make sure we escape them whenever we print a name that's a type
member. Except for methods, which are erroneously allowed to be called
`Type` and `Protocol`.

rdar://49858651