### PR TITLE
[test] Re-enable SmallString tests with updated platform checks

### DIFF
--- a/test/stdlib/SmallString.swift
+++ b/test/stdlib/SmallString.swift
@@ -9,7 +9,9 @@
 //
 
 import StdlibUnittest
+#if _runtime(_ObjC)
 import Foundation
+#endif
 var SmallStringTests = TestSuite("SmallStringTests")
 
 extension String: Error {}


### PR DESCRIPTION
- Tagged NSString checks are only expected to work on recent macOS/iOS versions
- SmallStrings are a thing on Linux, too, although they don't bridge as tagged pointers.

rdar://problem/49083892