### PR TITLE
[AutoDiff] Fix `AdjointEmitter::visitStructExtract`.

### DIFF
--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -54,4 +54,26 @@ struct SupervisedTrainer<Model : Layer> {
   }
 }
 
+// Tests TF-440.
+struct TF_440_Input<Input: Differentiable, State: Differentiable>: Differentiable {
+    var input: Input
+    var state: State
+}
+struct TF_440<T : Differentiable> {
+    @differentiable
+    func applied(to input: TF_440_Input<Float, Float>) -> Float {
+        return input.state
+    }
+
+    @differentiable
+    func applied(to input: TF_440_Input<T, Float>) -> Float {
+        return input.state
+    }
+
+    @differentiable
+    func applied(to input: TF_440_Input<T, Float>) -> T {
+        return input.input
+    }
+}
+
 // TODO: add more tests.


### PR DESCRIPTION
Use struct type member substitution map to remap field types, instead of
using unbound generic field types.

Resolves [TF-440](https://bugs.swift.org/browse/TF-440).