### PR TITLE
[AutoDiff] Add requirements to `@differentiable` attribute on getters.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -776,9 +776,15 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     // call to the getter.
     if (member->getEffectiveAccess() > AccessLevel::Internal &&
         !member->getAttrs().hasAttribute<DifferentiableAttr>()) {
+      ArrayRef<Requirement> requirements;
+      // If the parent declaration context is an extension, the nominal type may
+      // conditionally conform to `Differentiable`. Use the conditional
+      // conformance requirements in getter `@differentiable` attributes.
+      if (auto *extDecl = dyn_cast<ExtensionDecl>(parentDC->getAsDecl()))
+        requirements = extDecl->getGenericRequirements();
       auto *diffableAttr = DifferentiableAttr::create(
           C, /*implicit*/ true, SourceLoc(), SourceLoc(), {}, None,
-          None, nullptr);
+          None, requirements);
       member->getAttrs().add(diffableAttr);
       // If getter does not exist, trigger synthesis and compute type.
       if (!member->getGetter())

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -85,3 +85,14 @@ struct GenericCotanMember<T : Differentiable> : Differentiable, AdditiveArithmet
 // CHECK-AST:           internal typealias TangentVector = GenericCotanMember<T>.CotangentVector
 // CHECK-AST:           internal typealias CotangentVector = GenericCotanMember<T>
 // CHECK-AST:           internal typealias AllDifferentiableVariables = GenericCotanMember<T>.CotangentVector
+
+public struct ConditionallyDifferentiable<T> {
+  public let x: T
+}
+extension ConditionallyDifferentiable : Differentiable where T : Differentiable {}
+
+// CHECK-AST-LABEL: @_fieldwiseDifferentiable public struct ConditionallyDifferentiable<T> {
+// CHECK-AST:         @differentiable(where T : Differentiable)
+// CHECK-AST:         public let x: T
+// CHECK-AST:         internal init(x: T)
+// CHECK-AST:       }


### PR DESCRIPTION
If a nominal type conditionally conforms to `Differentiable`, use the
conditional conformance requirements in getter `@differentiable` attributes.

Resolves [TF-435](https://bugs.swift.org/browse/TF-435).