### PR TITLE
Revert accidental change to `tensorflow_osx,installer` preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1869,7 +1869,7 @@ skip-test-playgroundsupport
 
 [preset: tensorflow_osx,installer]
 mixin-preset=
-    tensorflow_osx,no_test
+    tensorflow_osx
     mixin_codesigning
 darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 


### PR DESCRIPTION
`tensorflow_osx,no_test` was accidentally committed as a mixin preset.