### PR TITLE
[Swift+WASM] [IRGen] disable debugger tuning and atomics on WebAssembly

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -156,6 +156,14 @@ swift::getIRTargetOptions(IRGenOptions &Opts, ASTContext &Ctx) {
 
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
   clang::TargetOptions &ClangOpts = Clang->getTargetInfo().getTargetOpts();
+
+  // WebAssembly doesn't support atomics or DWARF5 yet.
+  // (LLVM debugger tuning generates a DWARF5 accel table even when DWARF5 is disabled)
+  if (Clang->getTargetInfo().getTriple().isOSBinFormatWasm()) {
+    TargetOpts.DebuggerTuning = llvm::DebuggerKind::Default;
+    TargetOpts.ThreadModel = llvm::ThreadModel::Single;
+  }
+
   return std::make_tuple(TargetOpts, ClangOpts.CPU, ClangOpts.Features, ClangOpts.Triple);
 }
 


### PR DESCRIPTION
LLVM doesn't support generating DWARF5 debugging data for WebAssembly, and support for atomics is currently very limited.

Set LLVM target options to avoid generating DWARF5 debug data and lower atomics to regular load/stores when building for WebAssembly.

This shouldn't affect existing platforms.

@ddunbar @MaxDesiatov This should be helpful for [SR-9307](https://bugs.swift.org/browse/SR-9307).
