### PR TITLE
Update WindowsBuild.md

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -105,8 +105,8 @@ Warning: Creating the above links usually requires administrator privileges. The
   either build everything `Debug` or some variant of `Release` (e.g. `Release`,
   `RelWithDebInfo`).
 ```cmd
-mkdir "S:\b\llvm"
-pushd "S:\b\llvm"
+md "S:\b\llvm"
+cd "S:\b\llvm"
 cmake -G Ninja^
  -DCMAKE_BUILD_TYPE=Release^
  -DCMAKE_C_COMPILER=cl^
@@ -117,8 +117,7 @@ cmake -G Ninja^
  -DLLVM_ENABLE_PROJECTS=clang^
  -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86"^
  S:/llvm
-popd
-cmake --build "S:\b\llvm"
+ninja
 ```
 
 - Update your path to include the LLVM tools.
@@ -130,15 +129,14 @@ path S:\b\llvm\bin;%PATH%
 - This must be done from within a developer command prompt. CMark is a fairly
   small project and should only take a few minutes to build.
 ```cmd
-mkdir "S:\b\cmark"
-pushd "S:\b\cmark"
+md "S:\b\cmark"
+cd "S:\b\cmark"
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DCMAKE_C_COMPILER=cl^
   -DCMAKE_CXX_COMPILER=cl^
   S:\cmark
-popd
-cmake --build "S:\b\cmark"
+ninja
 ```
 
 ## 8. Build Swift
@@ -146,8 +144,8 @@ cmake --build "S:\b\cmark"
 - Note that Visual Studio vends a 32-bit python 2.7 installation in `C:\Python27` and a 64-bit python in `C:\Python27amd64`.  You may use either one based on your installation.
 
 ```cmd
-mkdir "S:\b\swift"
-pushd "S:\b\swift"
+md "S:\b\swift"
+cd "S:\b\swift"
 cmake -G Ninja^
  -DCMAKE_BUILD_TYPE=RelWithDebInfo^
  -DCMAKE_C_COMPILER=cl^
@@ -167,8 +165,7 @@ cmake -G Ninja^
  -DCMAKE_INSTALL_PREFIX="C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr"^
  -DPYTHON_EXECUTABLE=C:\Python27\python.exe^
  S:\swift
-popd
-cmake --build "S:\b\swift"
+ninja
 ```
 
 - To create a Visual Studio project, you'll need to change the generator and,
@@ -186,8 +183,8 @@ cmake -G "Visual Studio 2017" -A x64 -T "host=x64"^ ...
 - This must be done from within a developer command prompt and could take hours
   depending on your system.
 ```cmd
-mkdir "S:\b\lldb"
-pushd "S:\b\lldb"
+md "S:\b\lldb"
+cd "S:\b\lldb"
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DLLDB_ALLOW_STATIC_BINDINGS=YES^
@@ -199,8 +196,7 @@ cmake -G Ninja^
   -DLLVM_ENABLE_ASSERTIONS=ON^
   -DPYTHON_HOME="%ProgramFiles(x86)%\Microsoft Visual Studio\Shared\Python37_64"^
   S:\lldb
-popd
-cmake --build S:\b\lldb
+ninja
 ```
 
 ## 10. Running tests on Windows
@@ -215,8 +211,8 @@ ninja -C S:\b\swift check-swift
 ## 11. Build swift-corelibs-libdispatch
 
 ```cmd
-mkdir "S:\b\libdispatch"
-pushd "S:\b\libdispatch"
+md "S:\b\libdispatch"
+cd "S:\b\libdispatch"
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DCMAKE_C_COMPILER=clang-cl^
@@ -225,8 +221,7 @@ cmake -G Ninja^
   -DENABLE_SWIFT=ON^
   -DENABLE_TESTING=OFF^
   S:\swift-corelibs-libdispatch
-popd
-cmake --build S:\b\libdispatch
+ninja
 ```
 
 - Add libdispatch to your path:
@@ -237,27 +232,25 @@ path S:\b\libdispatch;S:\b\libdispatch\src;%PATH%
 ## 12. Build curl
 
 ```cmd
-pushd "S:\curl"
+cd "S:\curl"
 .\buildconf.bat
 cd winbuild
 nmake /f Makefile.vc mode=static VC=15 MACHINE=x64
-popd
 ```
 
 ## 13. Build libxml2
 
 ```cmd
-pushd "S:\libxml2\win32"
+cd "S:\libxml2\win32"
 cscript //E:jscript configure.js iconv=no
 nmake /f Makefile.msvc
-popd
 ```
 
 ## 14. Build swift-corelibs-foundation
 
 ```cmd
-mkdir "S:\b\foundation"
-pushd "S:\b\foundation
+md "S:\b\foundation"
+cd "S:\b\foundation
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DCMAKE_C_COMPILER=clang-cl^
@@ -271,8 +264,7 @@ cmake -G Ninja^
   -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=S:\swift-corelibs-libdispatch^
   -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=S:\b\libdispatch^
    S:\swift-corelibs-foundation
- popd
- cmake --build S:\b\foundation
+ninja
 ```
 
 - Add Foundation to your path:
@@ -283,8 +275,8 @@ path S:\b\foundation;%PATH%
 ## 15. Build swift-corelibs-xctest
 
 ```cmd
-mkdir "S:\b\xctest"
-pushd "S:\b\xctest"
+md "S:\b\xctest"
+cd "S:\b\xctest"
 cmake -G Ninja^
   -DBUILD_SHARED_LIBS=YES^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
@@ -295,8 +287,7 @@ cmake -G Ninja^
   -DLIT_COMMAND=S:\llvm\utils\lit\lit.py^
   -DPYTHON_EXECUTABLE=C:\Python27\python.exe^
   S:\swift-corelibs-xctest
-popd
-cmake --build S:\b\xctest
+ninja
 ```
 
 - Add XCTest to your path:
@@ -313,8 +304,7 @@ ninja -C S:\b\xctest check-xctest
 ## 17. Rebuild Foundation
 
 ```cmd
-mkdir "S:\b\foundation"
-pushd "S:\b\foundation
+cd "S:\b\foundation
 cmake -G Ninja^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
   -DCMAKE_C_COMPILER=clang-cl^
@@ -329,8 +319,7 @@ cmake -G Ninja^
   -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=S:\b\libdispatch^
   -DFOUNDATION_PATH_TO_XCTEST_BUILD=S:\b\xctest^
    S:\swift-corelibs-foundation
- popd
- cmake --build S:\b\foundation
+ninja
 ```
 
 ## 18. Test Foundation


### PR DESCRIPTION
Clean up the Windows build steps to use `md` and `cd`, remove the unnecessary `pushd`, `popd`, directly invoke `ninja` rather than invoking it through `cmake`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
