### PR TITLE
[5.1][RemoteMirror] Add a missing NULL check when reading metadata in readMetadataAndValueErrorExistential.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -362,6 +362,9 @@ public:
     bool isBridged = false;
 
     auto Meta = readMetadata(*MetadataAddress);
+    if (!Meta)
+      return None;
+
     if (auto ClassMeta = dyn_cast<TargetClassMetadata<Runtime>>(Meta)) {
       if (ClassMeta->isPureObjC()) {
         // If we can determine the Objective-C class name, this is probably an


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24130 for 5.1.

rdar://problem/49246601