### PR TITLE
[Swift+WASM] [IRGen] Disable COMDAT for reflection metadata

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1095,6 +1095,14 @@ public:
     if (Triple.isOSBinFormatELF())
       return;
 
+    // WebAssembly: disable COMDATs.
+    // LLVM's Wasm COMDAT code assumes each COMDAT will be in its own section.
+    // This works for C++ on Clang, since each COMDAT is emitted into its own
+    // .rodata.<symbol name> section,
+    // but not for Swift metadata, which are all placed in the same section.
+    if (Triple.isOSBinFormatWasm())
+      return;
+
     if (IRL.Linkage == llvm::GlobalValue::LinkOnceODRLinkage ||
         IRL.Linkage == llvm::GlobalValue::WeakODRLinkage)
       if (Triple.supportsCOMDAT())


### PR DESCRIPTION
LLVM's Wasm COMDAT code assumes each COMDAT will be in its own section. This works for C++ on Clang, since each COMDAT is emitted into its own .rodata.<symbol name> section, but not for Swift metadata, which are all placed in the same section.

Disable COMDAT support when emitting reflection metadata.

This matches the behaviour on ELF (where COMDATs are disabled) and MachO (which doesn't support COMDAT)

This shouldn't affect existing platforms.

----

@ddunbar @MaxDesiatov This avoids an LLVM assert when building stdlib for WebAssembly: should be helpful for [SR-9307](https://bugs.swift.org/browse/SR-9307).

@compnerd: You added the COMDAT support originally for Windows/COFF, right? Should the check for COMDAT support use a whitelist instead of a blacklist, since ELF, MachO, and now WASM all disabled it?