### PR TITLE
[AutoDiff] Fix double release in indirect pullback results.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4151,9 +4151,8 @@ public:
       else {
         auto origArg = ai->getArgument(origNumIndRes + selfParamIndex);
         if (cotanWrtSelf->getType().isAddress()) {
-          addToAdjointBuffer(origArg, ValueWithCleanup(
-              cotanWrtSelf,
-              makeCleanup(cotanWrtSelf, emitCleanup, {seed.getCleanup()})));
+          addToAdjointBuffer(origArg, cotanWrtSelf);
+          emitCleanup(builder, loc, cotanWrtSelf);
         } else {
           if (origArg->getType().isAddress()) {
             auto adjBuf = getAdjointBuffer(origArg);

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4195,8 +4195,8 @@ public:
         continue;
       }
       if (cotan->getType().isAddress()) {
-        addToAdjointBuffer(origArg, ValueWithCleanup(
-            cotan, makeCleanup(cotan, emitCleanup, {seed.getCleanup()})));
+        addToAdjointBuffer(origArg, cotan);
+        emitCleanup(builder, loc, cotan);
       } else {
         if (origArg->getType().isAddress()) {
           auto adjBuf = getAdjointBuffer(origArg);
@@ -4219,10 +4219,8 @@ public:
       }
     }
     // Deallocate pullback indirect results.
-    for (auto *alloc : reversed(pullbackIndirectResults)) {
-      emitCleanup(builder, loc, alloc);
+    for (auto *alloc : reversed(pullbackIndirectResults))
       builder.createDeallocStack(loc, alloc);
-    }
   }
 
   /// Handle `struct` instruction.


### PR DESCRIPTION
Previously two `destroy_addr`s may be emitted on the same result from a pullback when the result is indirect. This caused segfaults in [TF-437](https://bugs.swift.org/browse/TF-437).

Since we are looping over all pullback results in `AdjointEmitter::visitApplyInst`, we should release the unused ones and indirect ones as we go over and process them. There should not be a call to `emitRelease` before we deallocate all indirect adjoint buffers.

Resolves [TF-437](https://bugs.swift.org/browse/TF-437).