### PR TITLE
Move color-diagnostics to Options.td

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -18,9 +18,6 @@ let Flags = [FrontendOption, NoDriverOption] in {
 
 def triple : Separate<["-"], "triple">, Alias<target>;
 
-def color_diagnostics : Flag<["-"], "color-diagnostics">,
-  HelpText<"Print diagnostics in color">;
-
 def primary_file : Separate<["-"], "primary-file">,
   HelpText<"Produce output for this file, not the whole module">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -300,6 +300,9 @@ def serialize_diagnostics_path : Separate<["-"], "serialize-diagnostics-path">,
 def serialize_diagnostics_path_EQ: Joined<["-"], "serialize-diagnostics-path=">,
   Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   Alias<serialize_diagnostics_path>;
+def color_diagnostics : Flag<["-"], "color-diagnostics">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Print diagnostics in color">;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,

--- a/test/Driver/color-diagnostics.swift
+++ b/test/Driver/color-diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swiftc_driver -Xfrontend -color-diagnostics -emit-executable -o %t %s 2>&1 | %FileCheck %s
+// RUN: not %target-swiftc_driver -color-diagnostics -emit-executable -o %t %s 2>&1 | %FileCheck %s
 
 // CHECK: [0m1 = 2{{$}}
 1 = 2


### PR DESCRIPTION
This allows us to mark this flag as DoesNotAffectIncrementalBuild, so
that switching between a tty and non-tty doesn't cause full rebuilds
with swiftpm.

Resolves [SR-7982](https://bugs.swift.org/browse/SR-7982).