### PR TITLE
[android] Make ADB push use sync if available.

### DIFF
--- a/utils/android/adb_push_built_products/main.py
+++ b/utils/android/adb_push_built_products/main.py
@@ -53,9 +53,9 @@ def argument_parser():
     return parser
 
 
-def _push(source, destination):
-    print('Pushing "{}" to device path "{}".'.format(source, destination))
-    print(adb.commands.push(source, destination))
+def _push(sources, destination):
+    print('Pushing "{}" to device path "{}".'.format(sources, destination))
+    print(adb.commands.push(sources, destination))
 
 
 def main():
@@ -70,8 +70,10 @@ def main():
 
     for path in args.paths:
         if os.path.isdir(path):
-            for basename in glob.glob(os.path.join(path, '*.so')):
-                _push(os.path.join(path, basename), args.destination)
+            full_paths = [
+                os.path.join(path, basename)
+                for basename in glob.glob(os.path.join(path, '*.so'))]
+            _push(full_paths, args.destination)
         else:
             _push(path, args.destination)
 


### PR DESCRIPTION
In recent adb versions, the push command supports a new option --sync
which performs checksumming of the files to transmit against the files
already in the device. This increases the effective transmission speed
of the inital step in the test for Android.

It should not affect the speed of each tests, since they are pushed to
different folders, and also they are removed when they are successful.
However, the test executables are small compared to the size of the
libraries from the stadard library and dependencies.

This should exclusively affect Android and only to people testing the
executable tests (not CI).
