### PR TITLE
Add a SILGenCleanup pass and CanonicalizeInstruction utility.

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -171,8 +171,18 @@ inline SILInstruction *getSingleNonDebugUser(SILValue V) {
 /// Precondition: The instruction may only have debug instructions as uses.
 /// If the iterator \p InstIter references any deleted instruction, it is
 /// incremented.
-inline void eraseFromParentWithDebugInsts(SILInstruction *I,
-                                          SILBasicBlock::iterator &InstIter) {
+///
+/// \p callBack will be invoked before each instruction is deleted. \p callBack
+/// is not responsible for deleting the instruction because this utility
+/// unconditionally deletes the \p I and its debug users.
+///
+/// Returns an iterator to the next non-deleted instruction after \p I.
+inline SILBasicBlock::iterator eraseFromParentWithDebugInsts(
+    SILInstruction *I, llvm::function_ref<void(SILInstruction *)> callBack =
+                           [](SILInstruction *) {}) {
+
+  auto nextII = std::next(I->getIterator());
+
   auto results = I->getResults();
 
   bool foundAny;
@@ -183,26 +193,16 @@ inline void eraseFromParentWithDebugInsts(SILInstruction *I,
         foundAny = true;
         auto *User = result->use_begin()->getUser();
         assert(User->isDebugInstruction());
-        if (InstIter == User->getIterator())
-          InstIter++;
-
+        if (nextII == User->getIterator())
+          nextII++;
+        callBack(User);
         User->eraseFromParent();
       }
     }
   } while (foundAny);
 
-  if (InstIter == I->getIterator())
-    ++InstIter;
-
   I->eraseFromParent();
-}
-
-/// Erases the instruction \p I from it's parent block and deletes it, including
-/// all debug instructions which use \p I.
-/// Precondition: The instruction may only have debug instructions as uses.
-inline void eraseFromParentWithDebugInsts(SILInstruction *I) {
-  SILBasicBlock::iterator nullIter;
-  eraseFromParentWithDebugInsts(I, nullIter);
+  return nextII;
 }
 
 /// Return true if the def-use graph rooted at \p V contains any non-debug,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3255,6 +3255,15 @@ class BeginBorrowInst
   BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue)
       : UnaryInstructionBase(DebugLoc, LValue,
                              LValue->getType().getObjectType()) {}
+
+public:
+  /// Return the single use of this BeginBorrowInst, not including any
+  /// EndBorrowInst uses, or return nullptr if the borrow is dead or has
+  /// multiple uses.
+  ///
+  /// Useful for matching common SILGen patterns that emit one borrow per use,
+  /// and simplifying pass logic.
+  Operand *getSingleNonEndingUse() const;
 };
 
 /// Represents a store of a borrowed value into an address. Returns the borrowed

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3252,11 +3252,20 @@ class BeginBorrowInst
                                   SingleValueInstruction> {
   friend class SILBuilder;
 
+  /// Predicate used to filter EndBorrowRange.
+  struct UseToEndBorrow;
+
   BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue)
       : UnaryInstructionBase(DebugLoc, LValue,
                              LValue->getType().getObjectType()) {}
 
 public:
+  using EndBorrowRange =
+      OptionalTransformRange<use_range, UseToEndBorrow, use_iterator>;
+
+  /// Return a range over all EndBorrow instructions for this BeginBorrow.
+  EndBorrowRange getEndBorrows() const;
+
   /// Return the single use of this BeginBorrowInst, not including any
   /// EndBorrowInst uses, or return nullptr if the borrow is dead or has
   /// multiple uses.
@@ -3354,6 +3363,20 @@ public:
     originalValues.emplace_back(value);
   }
 };
+
+struct BeginBorrowInst::UseToEndBorrow {
+  Optional<EndBorrowInst *> operator()(Operand *use) const {
+    if (auto borrow = dyn_cast<EndBorrowInst>(use->getUser())) {
+      return borrow;
+    } else {
+      return None;
+    }
+  }
+};
+
+inline auto BeginBorrowInst::getEndBorrows() const -> EndBorrowRange {
+  return EndBorrowRange(getUses(), UseToEndBorrow());
+}
 
 /// Different kinds of access.
 enum class SILAccessKind : uint8_t {

--- a/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
+++ b/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
@@ -38,7 +38,7 @@ SILValue simplifyInstruction(SILInstruction *I);
 ///
 /// If it is nonnull, eraseNotify will be called before each instruction is
 /// deleted.
-void replaceAllSimplifiedUsesAndErase(
+SILBasicBlock::iterator replaceAllSimplifiedUsesAndErase(
     SILInstruction *I, SILValue result,
     std::function<void(SILInstruction *)> eraseNotify = nullptr);
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -267,6 +267,8 @@ PASS(SideEffectsDumper, "side-effects-dump",
      "Print Side-Effect Information for all Functions")
 PASS(IRGenPrepare, "irgen-prepare",
      "Cleanup SIL in preparation for IRGen")
+PASS(SILGenCleanup, "silgen-cleanup",
+     "Cleanup SIL in preparation for diagnostics")
 PASS(SILCombine, "sil-combine",
      "Combine SIL Instructions via Peephole Optimization")
 PASS(SILDebugInfoGenerator, "sil-debuginfo-gen",

--- a/include/swift/SILOptimizer/Utils/CanonicalizeInstruction.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeInstruction.h
@@ -1,0 +1,87 @@
+//===-- CanonicalizeInstruction.h - canonical SIL peepholes -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// SSA-peephole transformations that yield a more canonical SIL representation.
+///
+/// Unlike simplifyInstruction, these transformations may effect any
+/// instruction, not only single-values, and may arbitrarily generate new SIL
+/// instructions.
+///
+/// Unlike SILCombine, these peepholes must work on 'raw' SIL form and should be
+/// limited to those necessary to aid in diagnostics and other mandatory
+/// pipelin/e passes. Optimization may only be done to the extent that it
+/// neither interferes with diagnostics nor increases compile time.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEINSTRUCTION_H
+#define SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEINSTRUCTION_H
+
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
+#include "llvm/Support/Debug.h"
+
+namespace swift {
+
+/// Abstract base class. Implements all canonicalization transforms. Extended by
+/// passes to be notified of each SIL modification.
+struct CanonicalizeInstruction {
+  // May be overriden by passes.
+  static constexpr const char *defaultDebugType = "sil-canonicalize";
+  const char *debugType = defaultDebugType;
+
+  CanonicalizeInstruction(const char *passDebugType) {
+#ifndef NDEBUG
+    if (llvm::DebugFlag && !llvm::isCurrentDebugType(debugType))
+      debugType = passDebugType;
+#endif
+  }
+
+  virtual ~CanonicalizeInstruction();
+
+  /// Rewrite this instruction, based on its operands and uses, into a more
+  /// canonical representation.
+  ///
+  /// Return an iterator to the next instruction or to the end of the block.
+  /// The returned iterator will follow any newly added or to-be-deleted
+  /// instructions, regardless of whether the pass immediately deletes the
+  /// instructions or simply records them for later deletion.
+  ///
+  /// To (re)visit new instructions, override notifyNewInstruction().
+  ///
+  /// To determine if any transformation at all occurred, override
+  /// notifyNewInstruction(), killInstruction(), and notifyNewUsers().
+  ///
+  /// Warning: If the \p inst argument is killed and the client immediately
+  /// erases \p inst, then it may be an invalid pointer upon return.
+  SILBasicBlock::iterator canonicalize(SILInstruction *inst);
+
+  /// Record a newly generated instruction.
+  virtual void notifyNewInstruction(SILInstruction *inst) = 0;
+
+  /// Kill an instruction that no longer has uses, or whose side effect is now
+  /// represented by a different instruction. The client can defer erasing the
+  /// instruction but must eventually erase all killed instructions to restore
+  /// valid SIL.
+  ///
+  /// This callback should not mutate any other instructions. It may only delete
+  /// the given argument. It will be called separately for each end-of-scope and
+  /// debug use before being called on the instruction they use.
+  virtual void killInstruction(SILInstruction *inst) = 0;
+
+  /// Record a SIL value that has acquired new users.
+  virtual void notifyHasNewUsers(SILValue value) = 0;
+};
+
+} // end namespace swift
+
+#endif // SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEINSTRUCTION_H

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -64,20 +64,6 @@ recursivelyDeleteTriviallyDeadInstructions(
   ArrayRef<SILInstruction*> I, bool Force = false,
   llvm::function_ref<void(SILInstruction *)> C = [](SILInstruction *){});
 
-/// For each of the given instructions, if they are dead delete them
-/// along with their dead operands.
-///
-/// \param I The ArrayRef of instructions to be deleted.
-/// \param InstIter is updated to the next valid instruction if it points to any
-/// deleted instruction, including debug values.
-/// \param Force If Force is set, don't check if the top level instructions
-///        are considered dead - delete them regardless.
-/// \param C a callback called whenever an instruction is deleted.
-void recursivelyDeleteTriviallyDeadInstructions(
-    ArrayRef<SILInstruction *> I, SILBasicBlock::iterator &InstIter,
-    bool Force = false,
-    llvm::function_ref<void(SILInstruction *)> C = [](SILInstruction *) {});
-
 /// If the given instruction is dead, delete it along with its dead
 /// operands.
 ///
@@ -85,10 +71,7 @@ void recursivelyDeleteTriviallyDeadInstructions(
 /// \param Force If Force is set, don't check if the top level instruction is
 ///        considered dead - delete it regardless.
 /// \param C a callback called whenever an instruction is deleted.
-///
-/// Returns a valid instruction iterator to the next nondeleted instruction
-/// after `I`.
-SILBasicBlock::iterator recursivelyDeleteTriviallyDeadInstructions(
+void recursivelyDeleteTriviallyDeadInstructions(
     SILInstruction *I, bool Force = false,
     llvm::function_ref<void(SILInstruction *)> C = [](SILInstruction *) {});
 

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -279,6 +279,20 @@ void SILInstruction::replaceAllUsesPairwiseWith(
   }
 }
 
+Operand *BeginBorrowInst::getSingleNonEndingUse() const {
+  Operand *singleUse = nullptr;
+  for (auto *use : getUses()) {
+    if (isa<EndBorrowInst>(use->getUser()))
+      continue;
+
+    if (singleUse)
+      return nullptr;
+
+    singleUse = use;
+  }
+  return singleUse;
+}
+
 namespace {
 class InstructionDestroyer
     : public SILInstructionVisitor<InstructionDestroyer> {

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -2,12 +2,21 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
+//===----------------------------------------------------------------------===//
+///
+/// An SSA-peephole analysis. Given a single-value instruction, find an existing
+/// equivalent but less costly or more canonical SIL value.
+///
+/// This analysis must handle 'raw' SIL form. It should be possible to perform
+/// the substitution discovered by the analysis without interfering with
+/// subsequent diagnostic passes.
+///
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-simplify"
@@ -665,12 +674,17 @@ SILValue swift::simplifyInstruction(SILInstruction *I) {
 /// Replace an instruction with a simplified result, including any debug uses,
 /// and erase the instruction. If the instruction initiates a scope, do not
 /// replace the end of its scope; it will be deleted along with its parent.
-void swift::replaceAllSimplifiedUsesAndErase(
+///
+/// This is a simple transform based on the above analysis.
+///
+/// Return an iterator to the next (nondeleted) instruction.
+SILBasicBlock::iterator swift::replaceAllSimplifiedUsesAndErase(
     SILInstruction *I, SILValue result,
-    std::function<void(SILInstruction *)> eraseNotify) {
+    std::function<void(SILInstruction *)> eraseHandler) {
 
   auto *SVI = cast<SingleValueInstruction>(I);
   assert(SVI != result && "Cannot RAUW a value with itself");
+  SILBasicBlock::iterator nextii = std::next(I->getIterator());
 
   // Only SingleValueInstructions are currently simplified.
   while (!SVI->use_empty()) {
@@ -678,16 +692,22 @@ void swift::replaceAllSimplifiedUsesAndErase(
     SILInstruction *user = use->getUser();
     // Erase the end of scope marker.
     if (isEndOfScopeMarker(user)) {
-      if (eraseNotify)
-        eraseNotify(user);
-      user->eraseFromParent();
+      if (&*nextii == user)
+        ++nextii;
+      if (eraseHandler)
+        eraseHandler(user);
+      else
+        user->eraseFromParent();
       continue;
     }
     use->set(result);
   }
-  I->eraseFromParent();
-  if (eraseNotify)
-    eraseNotify(I);
+  if (eraseHandler)
+    eraseHandler(I);
+  else
+    I->eraseFromParent();
+
+  return nextii;
 }
 
 /// Simplify invocations of builtin operations that may overflow.

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -2,6 +2,7 @@ silopt_register_sources(
   AccessEnforcementSelection.cpp
   AccessMarkerElimination.cpp
   AddressLowering.cpp
+  ClosureLifetimeFixup.cpp
   ConstantPropagation.cpp
   DefiniteInitialization.cpp
   DIMemoryUseCollector.cpp
@@ -15,8 +16,8 @@ silopt_register_sources(
   MandatoryInlining.cpp
   PredictableMemOpt.cpp
   PMOMemoryUseCollector.cpp
-  SemanticARCOpts.cpp
-  ClosureLifetimeFixup.cpp
   RawSILInstLowering.cpp
+  SemanticARCOpts.cpp
+  SILGenCleanup.cpp
   YieldOnceCheck.cpp
 )

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -861,8 +861,7 @@ void LifetimeChecker::handleLoadForTypeOfSelfUse(const DIMemoryUse &Use) {
           valueMetatype->getLoc(), metatypeArgument,
           valueMetatype->getType());
     }
-    replaceAllSimplifiedUsesAndErase(valueMetatype, metatypeArgument,
-                                     [](SILInstruction*) { });
+    replaceAllSimplifiedUsesAndErase(valueMetatype, metatypeArgument);
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
+++ b/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
@@ -1,0 +1,108 @@
+//===--- SILGenCleanup.cpp ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Perform peephole-style "cleanup" to aid SIL diagnostic passes.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "silgen-cleanup"
+
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CanonicalizeInstruction.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+
+using namespace swift;
+
+// Define a CanonicalizeInstruction subclass for use in SILGenCleanup.
+struct SILGenCanonicalize final : CanonicalizeInstruction {
+  bool changed = false;
+  llvm::SmallPtrSet<SILInstruction *, 16> deadOperands;
+
+  SILGenCanonicalize() : CanonicalizeInstruction(DEBUG_TYPE) {}
+
+  void notifyNewInstruction(SILInstruction *) override { changed = true; }
+
+  // Just delete the given 'inst' and record its operands. The callback isn't
+  // allowed to mutate any other instructions.
+  void killInstruction(SILInstruction *inst) override {
+    deadOperands.erase(inst);
+    for (auto &operand : inst->getAllOperands()) {
+      if (auto *operInst = operand.get()->getDefiningInstruction())
+        deadOperands.insert(operInst);
+    }
+    inst->eraseFromParent();
+    changed = true;
+  }
+
+  void notifyHasNewUsers(SILValue) override { changed = true; }
+
+  SILBasicBlock::iterator deleteDeadOperands(SILBasicBlock::iterator nextII) {
+    // Delete trivially dead instructions in non-determistic order.
+    while (!deadOperands.empty()) {
+      SILInstruction *deadOperInst = *deadOperands.begin();
+      // Make sure at least the first instruction is removed from the set.
+      deadOperands.erase(deadOperInst);
+      recursivelyDeleteTriviallyDeadInstructions(
+        deadOperInst, false,
+        [&](SILInstruction *deadInst) {
+          LLVM_DEBUG(llvm::dbgs() << "Trivially dead: " << *deadInst);
+          if (nextII == deadInst->getIterator())
+            ++nextII;
+          deadOperands.erase(deadInst);
+        });
+    }
+    return nextII;
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// SILGenCleanup: Top-Level Module Transform
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// SILGenCleanup must run on all functions that will be seen by any analysis
+// used by diagnostics before transforming the function that requires the
+// analysis. e.g. Closures need to be cleaned up before the closure's parent can
+// be diagnosed.
+//
+// TODO: This pass can be converted to a function transform if the mandatory
+// pipeline runs in bottom-up closure order.
+struct SILGenCleanup : SILModuleTransform {
+  void run() override;
+};
+
+void SILGenCleanup::run() {
+  auto &module = *getModule();
+  for (auto &function : module) {
+    SILGenCanonicalize sgCanonicalize;
+
+    // Iterate over all blocks even if they aren't reachable. No phi-less
+    // dataflow cycles should have been created yet, and these transformations
+    // are simple enough they shouldn't be affected by cycles.
+    for (auto &bb : function) {
+      for (auto ii = bb.begin(), ie = bb.end(); ii != ie;) {
+        ii = sgCanonicalize.canonicalize(&*ii);
+        ii = sgCanonicalize.deleteDeadOperands(ii);
+      }
+    }
+    if (sgCanonicalize.changed) {
+      auto invalidKind = SILAnalysis::InvalidationKind::Instructions;
+      invalidateAnalysis(&function, invalidKind);
+    }
+  }
+}
+
+} // end anonymous namespace
+
+SILTransform *swift::createSILGenCleanup() { return new SILGenCleanup(); }

--- a/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
+++ b/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
@@ -85,6 +85,9 @@ struct SILGenCleanup : SILModuleTransform {
 void SILGenCleanup::run() {
   auto &module = *getModule();
   for (auto &function : module) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "\nRunning SILGenCleanup on " << function.getName() << "\n");
+
     SILGenCanonicalize sgCanonicalize;
 
     // Iterate over all blocks even if they aren't reachable. No phi-less

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -81,6 +81,7 @@ static void addDefiniteInitialization(SILPassPipelinePlan &P) {
 
 static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("Guaranteed Passes");
+  P.addSILGenCleanup();
   P.addDiagnoseInvalidEscapingCaptures();
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -798,11 +798,7 @@ bool CSE::processNode(DominanceInfoNode *Node) {
     if (SILValue V = simplifyInstruction(Inst)) {
       LLVM_DEBUG(llvm::dbgs() << "SILCSE SIMPLIFY: " << *Inst << "  to: " << *V
                               << '\n');
-      replaceAllSimplifiedUsesAndErase(Inst, V,
-                                       [&nextI](SILInstruction *deleteI) {
-                                         if (nextI == deleteI->getIterator())
-                                           ++nextI;
-                                       });
+      nextI = replaceAllSimplifiedUsesAndErase(Inst, V);
       Changed = true;
       ++NumSimplify;
       continue;

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 silopt_register_sources(
   CFG.cpp
+  CanonicalizeInstruction.cpp
   CastOptimizer.cpp
   CheckedCastBrJumpThreading.cpp
   ConstantFolding.cpp

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -110,9 +110,15 @@ simplifyAndReplace(SILInstruction *inst, CanonicalizeInstruction &pass) {
 //                        Canonicalize Memory Operations
 //===----------------------------------------------------------------------===//
 
-// Replace all uses of an original struct or tuple extract instruction, with the
+// Replace all uses of an original struct or tuple extract instruction with the
 // given load instruction. The caller ensures that the load only loads the
 // extracted field.
+//
+// \p extract has the form:
+// (struct_extract (load %base), #field)
+//
+// \p loadInst has the form:
+// (load (struct_element_addr %base, #field)
 static void replaceUsesOfExtract(SingleValueInstruction *extract,
                                  LoadInst *loadInst,
                                  CanonicalizeInstruction &pass) {

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -1,0 +1,78 @@
+//===--- CanonicalizeInstruction.cpp - canonical SIL peepholes ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// SSA-peephole transformations that yield a more canonical SIL representation.
+///
+/// A superset of simplifyInstruction.
+///
+//===----------------------------------------------------------------------===//
+
+// CanonicalizeInstruction defines a default DEBUG_TYPE: "sil-canonicalize"
+
+#include "swift/SILOptimizer/Utils/CanonicalizeInstruction.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+// STATISTIC uses the default DEBUG_TYPE.
+#define DEBUG_TYPE CanonicalizeInstruction::defaultDebugType
+STATISTIC(NumSimplified, "Number of instructions simplified");
+
+// Tracing within the implementation can also be activiated by the pass.
+#undef DEBUG_TYPE
+#define DEBUG_TYPE pass.debugType
+
+// Vtable anchor.
+CanonicalizeInstruction::~CanonicalizeInstruction() {}
+
+// If simplification is successful, return a valid iterator to the next
+// intruction that wasn't erased.
+static Optional<SILBasicBlock::iterator>
+simplifyAndReplace(SILInstruction *inst, CanonicalizeInstruction &pass) {
+  // FIXME: temporarily bypass simplification untill all simplifications
+  // preserve ownership SIL.
+  if (inst->getFunction()->hasOwnership())
+    return None;
+
+  SILValue result = simplifyInstruction(inst);
+  if (!result)
+    return None;
+
+  ++NumSimplified;
+
+  LLVM_DEBUG(llvm::dbgs() << "Simplify Old = " << *inst
+                          << "    New = " << *result << '\n');
+
+  // Erase the simplified instruction and any instructions that end its
+  // scope. Nothing needs to be added to the worklist except for Result,
+  // because the instruction and all non-replaced users will be deleted.
+  auto nextII = replaceAllSimplifiedUsesAndErase(
+      inst, result,
+      [&pass](SILInstruction *deleted) { pass.killInstruction(deleted); });
+
+  // Push the new instruction and any users onto the worklist.
+  pass.newUsers(result);
+  return nextII;
+}
+
+SILBasicBlock::iterator
+CanonicalizeInstruction::canonicalize(SILInstruction *inst) {
+  if (auto nextII = simplifyAndReplace(inst, *this))
+    return nextII.getValue();
+
+  // Skip ahead.
+  return std::next(inst->getIterator());
+}

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -20,6 +20,8 @@
 
 #include "swift/SILOptimizer/Utils/CanonicalizeInstruction.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/Projection.h"
+#include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
 #include "llvm/ADT/Statistic.h"
@@ -37,6 +39,35 @@ STATISTIC(NumSimplified, "Number of instructions simplified");
 
 // Vtable anchor.
 CanonicalizeInstruction::~CanonicalizeInstruction() {}
+
+// Helper to delete an instruction, or mark it for deletion.
+//
+// Return an iterator to the next non-deleted instruction. The incoming iterator
+// may already have advanced beyond 'inst'.
+static SILBasicBlock::iterator killInstruction(SILInstruction *inst,
+                                               SILBasicBlock::iterator nextII,
+                                               CanonicalizeInstruction &pass) {
+  if (nextII == inst->getIterator())
+    ++nextII;
+  pass.killInstruction(inst);
+  return nextII;
+}
+
+// Helper to delete, or mark for deletion, an instruction with potential debug
+// uses.
+static SILBasicBlock::iterator
+killInstAndDebugUses(SingleValueInstruction *inst,
+                     SILBasicBlock::iterator nextII,
+                     CanonicalizeInstruction &pass) {
+  for (Operand *du : getDebugUses(inst))
+    nextII = killInstruction(du->getUser(), nextII, pass);
+
+  return killInstruction(inst, nextII, pass);
+}
+
+//===----------------------------------------------------------------------===//
+//                          Instruction Simplification
+//===----------------------------------------------------------------------===//
 
 // If simplification is successful, return a valid iterator to the next
 // intruction that wasn't erased.
@@ -64,14 +95,124 @@ simplifyAndReplace(SILInstruction *inst, CanonicalizeInstruction &pass) {
       [&pass](SILInstruction *deleted) { pass.killInstruction(deleted); });
 
   // Push the new instruction and any users onto the worklist.
-  pass.newUsers(result);
+  pass.notifyHasNewUsers(result);
   return nextII;
 }
+
+//===----------------------------------------------------------------------===//
+//                        Canonicalize Memory Operations
+//===----------------------------------------------------------------------===//
+
+// Given a load with multiple struct_extracts/tuple_extracts and no other uses,
+// canonicalize the load into several (struct_element_addr (load)) pairs.
+//
+// (struct_extract (load %base))
+//   ->
+// (load (struct_element_addr %base, #field)
+//
+// TODO: Consider handling LoadBorrowInst.
+static SILBasicBlock::iterator
+splitAggregateLoad(LoadInst *loadInst, CanonicalizeInstruction &pass) {
+  // Keep track of the next iterator after any newly added or to-be-deleted
+  // instructions. This must be valid regardless of whether the pass immediately
+  // deletes the instructions or simply records them for later deletion.
+  auto nextII = std::next(loadInst->getIterator());
+
+  switch (loadInst->getOwnershipQualifier()) {
+  case LoadOwnershipQualifier::Unqualified:
+  case LoadOwnershipQualifier::Trivial:
+    break;
+  case LoadOwnershipQualifier::Take:
+  case LoadOwnershipQualifier::Copy:
+    // Skip ahead if the ownership qualifier isn't handled.
+    //
+    // FIXME: To handle Copy/Take, the code below needs to properly peek through
+    // and destroy borrow scopes.
+    return nextII;
+  }
+  struct ProjInstPair {
+    Projection proj;
+    SingleValueInstruction *svi;
+
+    // When sorting, just look at the projection and ignore the instruction.
+    // Including the instruction address in the sort key would be
+    // nondeterministic.
+    bool operator<(const ProjInstPair &rhs) const { return proj < rhs.proj; }
+  };
+
+  // Add load projections to a projection list.
+  llvm::SmallVector<ProjInstPair, 8> projections;
+  for (auto *use : getNonDebugUses(loadInst)) {
+    auto *user = use->getUser();
+
+    // If we have any non SEI, TEI instruction, don't do anything here.
+    if (!isa<StructExtractInst>(user) && !isa<TupleExtractInst>(user))
+      return nextII;
+
+    auto extract = cast<SingleValueInstruction>(user);
+    projections.push_back({Projection(extract), extract});
+  }
+  // Sort the list so projections with the same value decl and tuples with the
+  // same indices will be processed together. This makes it easy to reuse the
+  // load from the first such projection for all subsequent projections on the
+  // same value decl or index.
+  std::sort(projections.begin(), projections.end());
+
+  // Create a new address projection instruction and load instruction for each
+  // unique projection.
+  Projection *lastProj = nullptr;
+  LoadInst *lastNewLoad = nullptr;
+  for (auto &pair : projections) {
+    auto &proj = pair.proj;
+    auto *svi = pair.svi;
+
+    // If this projection is the same as the last projection we processed, just
+    // replace all uses of the projection with the load we created previously.
+    if (lastProj && proj == *lastProj) {
+      LLVM_DEBUG(llvm::dbgs() << "Replacing " << *svi
+                 << "    with " << *lastNewLoad<< "\n");
+      svi->replaceAllUsesWith(lastNewLoad);
+      nextII = killInstruction(svi, nextII, pass);
+      continue;
+    }
+
+    // This is a unique projection. Create the new address projection and load.
+    lastProj = &proj;
+    // Insert new instructions before the original load.
+    SILBuilderWithScope B(loadInst);
+    auto *projInst = proj.createAddressProjection(B, loadInst->getLoc(),
+                                                  loadInst->getOperand())
+                         .get();
+    pass.notifyNewInstruction(projInst);
+
+    lastNewLoad = B.createLoad(loadInst->getLoc(), projInst,
+                               loadInst->getOwnershipQualifier());
+    pass.notifyNewInstruction(lastNewLoad);
+
+    LLVM_DEBUG(llvm::dbgs() << "Replacing " << *svi
+               << "    with " << *lastNewLoad << "\n");
+    svi->replaceAllUsesWith(lastNewLoad);
+    nextII = killInstruction(svi, nextII, pass);
+  }
+  // Avoid removing dead loads from raw SIL. That may weaken definite-init.
+  if (loadInst->getModule().getStage() == SILStage::Raw)
+    return nextII;
+
+  // Erase the old load.
+  return killInstAndIncidentalUses(loadInst, nextII, pass);
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top-Level Entry Point
+//===----------------------------------------------------------------------===//
 
 SILBasicBlock::iterator
 CanonicalizeInstruction::canonicalize(SILInstruction *inst) {
   if (auto nextII = simplifyAndReplace(inst, *this))
     return nextII.getValue();
+
+  if (auto *loadInst = dyn_cast<LoadInst>(inst))
+    return splitAggregateLoad(loadInst, *this);
 
   // Skip ahead.
   return std::next(inst->getIterator());

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -518,11 +518,13 @@ void SILInlineCloner::fixUp(SILFunction *calleeFunction) {
   assert(!Apply.getInstruction()->hasUsesOfAnyResult());
 
   auto deleteCallback = [this](SILInstruction *deletedI) {
+    if (NextIter == deletedI->getIterator())
+      ++NextIter;
     if (DeletionCallback)
       DeletionCallback(deletedI);
   };
-  NextIter = recursivelyDeleteTriviallyDeadInstructions(Apply.getInstruction(),
-                                                        true, deleteCallback);
+  recursivelyDeleteTriviallyDeadInstructions(Apply.getInstruction(), true,
+                                             deleteCallback);
 }
 
 SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -4,14 +4,14 @@ import Builtin
 import Swift
 
 class A {
-  @_hasStorage var property: Int { get set }
+  @_hasStorage var property: Int64 { get set }
   @_hasStorage var exProperty: Any { get set }
   deinit
   init()
 }
 
 // CHECK-DAG: [[C:%T14access_markers1AC]] = type
-// CHECK-DAG: [[INT:%TSi]] = type <{ [[SIZE:i(32|64)]] }>
+// CHECK-DAG: [[INT:%Ts5Int64V]] = type <{ i64 }>
 
 sil_vtable A {}
 
@@ -27,24 +27,32 @@ bb0(%0 : $A):
   // CHECK-NEXT: [[T0:%.*]] = bitcast [[BUFFER]]* [[SCRATCH1]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 {{.*}}, i8* [[T0]])
   // CHECK-NEXT: [[T1:%.*]] = bitcast [[INT]]* [[PROPERTY]] to i8*
-  // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH1]], [[SIZE]] 33, i8* null)
-  %3 = begin_access [modify] [dynamic] %2 : $*Int
+  // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH1]], [[SIZE:i(32|64)]] 33, i8* null)
+  %3 = begin_access [modify] [dynamic] %2 : $*Int64
+
+  // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* [[PROPERTY]], i32 0, i32 0
+  // CHECK-NEXT: load i64, i64*
+  %4 = load %3 : $*Int64
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH1]])
   // CHECK-NEXT: [[T0:%.*]] = bitcast [[BUFFER]]* [[SCRATCH1]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 {{.*}}, i8* [[T0]])
-  end_access %3 : $*Int
+  end_access %3 : $*Int64
 
   // CHECK-NEXT: [[T0:%.*]] = bitcast [[BUFFER]]* [[SCRATCH2]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 {{.*}}, i8* [[T0]])
   // CHECK-NEXT: [[T1:%.*]] = bitcast [[INT]]* [[PROPERTY]] to i8*
   // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH2]], [[SIZE]] 32, i8* null)
-  %5 = begin_access [read] [dynamic] %2 : $*Int
+  %6 = begin_access [read] [dynamic] %2 : $*Int64
+
+  // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* [[PROPERTY]], i32 0, i32 0
+  // CHECK-NEXT: load i64, i64*
+  %7 = load %6 : $*Int64
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH2]])
   // CHECK-NEXT: [[T0:%.*]] = bitcast [[BUFFER]]* [[SCRATCH2]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 {{.*}}, i8* [[T0]])
-  end_access %5 : $*Int
+  end_access %6 : $*Int64
 
   %20 = tuple ()
   return %20 : $()
@@ -61,14 +69,14 @@ bb0(%0 : $A):
 
   // CHECK-NEXT: [[T1:%.*]] = bitcast [[INT]]* [[PROPERTY]] to i8*
   // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH]], [[SIZE]] 33, i8* null)
-  begin_unpaired_access [modify] [dynamic] %2 : $*Int, %1 : $*Builtin.UnsafeValueBuffer
+  begin_unpaired_access [modify] [dynamic] %2 : $*Int64, %1 : $*Builtin.UnsafeValueBuffer
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH]])
   end_unpaired_access [dynamic] %1 : $*Builtin.UnsafeValueBuffer
 
   // CHECK-NEXT: [[T1:%.*]] = bitcast [[INT]]* [[PROPERTY]] to i8*
   // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH]], [[SIZE]] 32, i8* null)
-  begin_unpaired_access [read] [dynamic] %2 : $*Int, %1 : $*Builtin.UnsafeValueBuffer
+  begin_unpaired_access [read] [dynamic] %2 : $*Int64, %1 : $*Builtin.UnsafeValueBuffer
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH]])
   end_unpaired_access [dynamic] %1 : $*Builtin.UnsafeValueBuffer
@@ -88,7 +96,7 @@ bb0(%0 : $A, %1 : $*Builtin.UnsafeValueBuffer):
   // CHECK-NEXT: [[T1:%.*]] = bitcast [[INT]]* [[PROPERTY]] to i8*
   // CHECK-NEXT: [[PC:%.*]] = call i8* @llvm.returnaddress(i32 0)
   // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH:%1]], [[SIZE]] 33, i8* [[PC]])
-  begin_unpaired_access [modify] [dynamic] %2 : $*Int, %1 : $*Builtin.UnsafeValueBuffer
+  begin_unpaired_access [modify] [dynamic] %2 : $*Int64, %1 : $*Builtin.UnsafeValueBuffer
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH]])
   end_unpaired_access [dynamic] %1 : $*Builtin.UnsafeValueBuffer
@@ -96,7 +104,7 @@ bb0(%0 : $A, %1 : $*Builtin.UnsafeValueBuffer):
   // CHECK-NEXT: [[T1:%.*]] = bitcast [[INT]]* [[PROPERTY]] to i8*
   // CHECK-NEXT: [[PC:%.*]] = call i8* @llvm.returnaddress(i32 0)
   // CHECK-NEXT: call void @swift_beginAccess(i8* [[T1]], [[BUFFER]]* [[SCRATCH]], [[SIZE]] 32, i8* [[PC]])
-  begin_unpaired_access [read] [dynamic] %2 : $*Int, %1 : $*Builtin.UnsafeValueBuffer
+  begin_unpaired_access [read] [dynamic] %2 : $*Int64, %1 : $*Builtin.UnsafeValueBuffer
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH]])
   end_unpaired_access [dynamic] %1 : $*Builtin.UnsafeValueBuffer
@@ -149,20 +157,20 @@ bb0(%0 : $A):
 // CHECK-LABEL: define {{.*}}void @testNontracking(
 sil @testNontracking : $(@guaranteed A) -> () {
 bb0(%0 : $A):
-  %1 = alloc_stack $Int
+  %1 = alloc_stack $Int64
   // CHECK:      [[PROPERTY:%.*]] = getelementptr inbounds [[C]], [[C]]* %0, i32 0, i32 1
   %2 = ref_element_addr %0 : $A, #A.property
   // CHECK: call void @swift_beginAccess(i8* %{{.*}}, [[BUFFER]]* %{{.*}}, [[SIZE]] 0, i8* null)
-  %3 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Int
-  copy_addr %3 to [initialization] %1 : $*Int
+  %3 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Int64
+  copy_addr %3 to [initialization] %1 : $*Int64
   // CHECK-NOT: end_access
-  end_access %3 : $*Int
+  end_access %3 : $*Int64
   %9 = alloc_stack $Builtin.UnsafeValueBuffer
   // CHECK: call void @swift_beginAccess(i8* %{{.*}}, [[BUFFER]]* %{{.*}}, [[SIZE]] 0, i8* null)
-  begin_unpaired_access [read] [dynamic] [no_nested_conflict] %2 : $*Int, %9 : $*Builtin.UnsafeValueBuffer
-  copy_addr %2 to %1 : $*Int
+  begin_unpaired_access [read] [dynamic] [no_nested_conflict] %2 : $*Int64, %9 : $*Builtin.UnsafeValueBuffer
+  copy_addr %2 to %1 : $*Int64
   dealloc_stack %9 : $*Builtin.UnsafeValueBuffer
-  dealloc_stack %1 : $*Int
+  dealloc_stack %1 : $*Int64
   %20 = tuple ()
   return %20 : $()
 }

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1,7 +1,7 @@
 // #if directives don't work with SIL keywords, therefore please put ObjC tests
 // in `enum_objc.sil`.
-// RUN: %target-swift-frontend %s -gnone -emit-ir -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend %s -gnone -emit-ir -disable-diagnostic-passes -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend %s -gnone -emit-ir -disable-diagnostic-passes -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize -DWORD=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/SILOptimizer/opaque_values_mandatory.sil
+++ b/test/SILOptimizer/opaque_values_mandatory.sil
@@ -45,11 +45,8 @@ bb0(%0 : $*T, %1 : $T):
 // CHECK: bb0(%0 : $Builtin.Int64):
 // CHECK:   %1 = function_ref @f040_multiResult : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
 // CHECK:   %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
-// CHECK:   %3 = tuple_extract %2 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64), 0
-// CHECK:   %4 = tuple_extract %2 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64), 1
-// CHECK:   %5 = tuple_extract %2 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64), 2
-// CHECK:   %6 = tuple (%3 : $Builtin.Int64, %4 : $Builtin.Int64, %5 : $Builtin.Int64)
-// CHECK:   return %6 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
+// Note: the tuple construction is simplified away.
+// CHECK:   return %2 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
 // CHECK-LABEL: } // end sil function 'f030_callMultiResult'
 sil @f030_callMultiResult : $@convention(thin) (Int) -> (Int, Int, Int) {
 bb0(%0 : $Int):

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -62,3 +62,56 @@ bb0(%0 : $*(Builtin.Int8, Builtin.Int8)):
   %6 = tuple (%1 : $(Builtin.Int8, Builtin.Int8), %5 : $Builtin.Int8)
   return %6 : $((Builtin.Int8, Builtin.Int8), Builtin.Int8)
 }
+
+// Handle a combination of trivial and nontrivial elements.
+
+struct X1 {
+  @_hasStorage @_hasInitialValue let a: Int { get }
+  @_hasStorage @_hasInitialValue var obj1: AnyObject { get set }
+  @_hasStorage @_hasInitialValue var obj2: AnyObject { get set }
+  init(a: Int, obj1: AnyObject, obj2: AnyObject)
+}
+
+// CHECK-LABEL: sil private [ossa] @testLoadNontrivial : $@convention(thin) (@inout_aliasable X1) -> (Int, @owned AnyObject, @owned AnyObject) {
+// CHECK-LABEL: bb0(%0 : $*X1):
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*X1
+// CHECK: [[AA:%.*]] = struct_element_addr [[ACCESS]] : $*X1, #X1.a
+// CHECK: load [trivial] [[AA]] : $*Int
+// CHECK: [[OA1:%.*]] = struct_element_addr [[ACCESS]] : $*X1, #X1.obj1
+// CHECK: [[OV1:%.*]] = load [copy] [[OA1]] : $*AnyObject
+// CHECK: [[OA2:%.*]] = struct_element_addr [[ACCESS]] : $*X1, #X1.obj2
+// CHECK: [[OV2:%.*]] = load [copy] [[OA2]] : $*AnyObject
+// CHECK: end_access [[ACCESS]] : $*X1
+// CHECK: [[B1:%.*]] = begin_borrow [[OV1]] : $AnyObject
+// CHECK: copy_value [[B1]] : $AnyObject
+// CHECK: end_borrow [[B1]] : $AnyObject
+// CHECK: [[B2:%.*]] = begin_borrow [[OV2]] : $AnyObject
+// CHECK: copy_value [[B2]] : $AnyObject
+// CHECK: end_borrow [[B2]] : $AnyObject
+// CHECK: return
+// CHECK-LABEL: } // end sil function 'testLoadNontrivial'
+sil private [ossa] @testLoadNontrivial : $@convention(thin) (@inout_aliasable X1) -> (Int, @owned AnyObject, @owned AnyObject) {
+bb0(%0 : $*X1):
+  %access = begin_access [read] [unknown] %0 : $*X1
+  %load = load [copy] %access : $*X1
+  end_access %access : $*X1
+
+  %borrowa = begin_borrow %load : $X1
+  %a = struct_extract %borrowa : $X1, #X1.a
+  end_borrow %borrowa : $X1
+
+  %borrow1 = begin_borrow %load : $X1
+  %o1 = struct_extract %borrow1 : $X1, #X1.obj1
+  %copy1 = copy_value %o1 : $AnyObject
+  end_borrow %borrow1 : $X1
+
+  %borrow2 = begin_borrow %load : $X1
+  %o2 = struct_extract %borrow2 : $X1, #X1.obj2
+  %copy2 = copy_value %o2 : $AnyObject
+  end_borrow %borrow2 : $X1
+
+  destroy_value %load : $X1
+
+  %result = tuple (%a : $Int, %copy1 : $AnyObject, %copy2 : $AnyObject)
+  return %result : $(Int, AnyObject, AnyObject)
+}

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -1,0 +1,64 @@
+// RUN: %target-sil-opt -silgen-cleanup %s | %FileCheck %s
+
+import Builtin
+
+sil_stage raw
+
+import Swift
+import SwiftShims
+
+// CHECK-LABEL: sil [ossa] @struct_extract_load_to_load_struct_element_addr
+// CHECK: bb0([[IN:%[0-9]+]] : $*UInt8):
+// CHECK-NEXT:  [[IN_GEP:%[0-9]+]] = struct_element_addr [[IN]] : $*UInt8, #UInt8._value
+// CHECK-NEXT:  [[IN_LOADED:%[0-9]+]] = load [trivial] [[IN_GEP]] : $*Builtin.Int8
+// CHECK-NEXT:  return [[IN_LOADED]] : $Builtin.Int8
+sil [ossa] @struct_extract_load_to_load_struct_element_addr : $@convention(thin) (@inout UInt8) -> (Builtin.Int8) {
+bb0(%0 : $*UInt8):
+  %1 = load [trivial] %0 : $*UInt8
+  %5 = struct_extract %1 : $UInt8, #UInt8._value
+  return %5 : $Builtin.Int8
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_extract_load_to_load_tuple_element_addr
+// CHECK: bb0([[IN:%[0-9]+]] : $*(Builtin.Int8, Builtin.Int8)):
+// CHECK-NEXT:  [[IN_GEP:%[0-9]+]] = tuple_element_addr [[IN]] : $*(Builtin.Int8, Builtin.Int8), 0
+// CHECK-NEXT:  [[IN_LOADED:%[0-9]+]] = load [trivial] [[IN_GEP]] : $*Builtin.Int8
+// CHECK-NEXT:  return [[IN_LOADED]] : $Builtin.Int8
+sil [ossa] @tuple_extract_load_to_load_tuple_element_addr : $@convention(thin) (@inout (Builtin.Int8, Builtin.Int8)) -> (Builtin.Int8) {
+bb0(%0 : $*(Builtin.Int8, Builtin.Int8)):
+  %1 = load [trivial] %0 : $*(Builtin.Int8, Builtin.Int8)
+  %5 = tuple_extract %1 : $(Builtin.Int8, Builtin.Int8), 0
+  return %5 : $Builtin.Int8
+}
+
+// Do not perform the optimization of the input load has multiple uses.
+//
+// CHECK-LABEL: sil [ossa] @multiple_use_struct_extract_load_to_load_struct_element_addr
+// CHECK: bb0([[IN:%[0-9]+]] : $*UInt8):
+// CHECK-NEXT: load
+// CHECK-NEXT: struct_extract
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+sil [ossa] @multiple_use_struct_extract_load_to_load_struct_element_addr : $@convention(thin) (@inout UInt8) -> (UInt8, Builtin.Int8) {
+bb0(%0 : $*UInt8):
+  %1 = load [trivial] %0 : $*UInt8
+  %5 = struct_extract %1 : $UInt8, #UInt8._value
+  %6 = tuple (%1 : $UInt8, %5 : $Builtin.Int8)
+  return %6 : $(UInt8, Builtin.Int8)
+}
+
+// Do not perform the optimization of the input load has multiple uses.
+//
+// CHECK-LABEL: sil [ossa] @multiple_use_tuple_extract_load_to_load_tuple_element_addr
+// CHECK: bb0
+// CHECK-NEXT: load
+// CHECK-NEXT: tuple_extract
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+sil [ossa] @multiple_use_tuple_extract_load_to_load_tuple_element_addr : $@convention(thin) (@inout (Builtin.Int8, Builtin.Int8)) -> ((Builtin.Int8, Builtin.Int8), Builtin.Int8) {
+bb0(%0 : $*(Builtin.Int8, Builtin.Int8)):
+  %1 = load [trivial] %0 : $*(Builtin.Int8, Builtin.Int8)
+  %5 = tuple_extract %1 : $(Builtin.Int8, Builtin.Int8), 0
+  %6 = tuple (%1 : $(Builtin.Int8, Builtin.Int8), %5 : $Builtin.Int8)
+  return %6 : $((Builtin.Int8, Builtin.Int8), Builtin.Int8)
+}


### PR DESCRIPTION
Canonicalize instruction will be a superset of
simplifyInstruction (once all the transforms are fixed for ownership
SIL). Additionally, it will also include simple SSA-based
canonicalization that requires new instruction creation. It may not
perform any optimization that interferes with diagnostics or increases
compile time.

The SILGenCleanup pass runs before diagnostics to perform any
canonicalization required by diagnostics.

Canonicalization replaces simplifyInstruction in SILCombine so we can
easily factor some existing SILCombine transforms into canonicalization.
