### PR TITLE
[benchmark] Variants for Set Sequence Methods

### DIFF
--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -55,6 +55,41 @@ let setQ: Set<Int> = {
   return set
 }()
 
+// Construction of empty array.
+let arrayE: Array<Int> = []
+let arrayOE: Array<Box<Int>> = []
+
+// Construction kit for arrays with 25% overlap
+let arrayAB = Array(0 ..< size)                              //   0 ..< 400
+let arrayCD = Array(size ..< 2 * size)                       // 400 ..< 800
+let arrayBC = Array(size - quarter ..< 2 * size - quarter)   // 300 ..< 700
+let arrayB = Array(size - quarter ..< size)                  // 300 ..< 400
+
+let arrayOAB = arrayAB.map(Box.init)
+let arrayOCD = arrayCD.map(Box.init)
+let arrayOBC = arrayBC.map(Box.init)
+let arrayOB = arrayB.map(Box.init)
+
+// Construction kit for arrays with 50% overlap
+let arrayXY = Array(0 ..< size)           //   0 ..< 400
+let arrayYZ = Array(half ..< size + half) // 200 ..< 600
+let arrayY = Array(half ..< size)         // 200 ..< 400
+
+let arrayP = Array(0 ..< size)
+
+// Construction of flexible sets.
+var set: Set<Int> = []
+var setBox: Set<Box<Int>> = []
+
+func set(_ size: Int) {
+  set = Set(0 ..< size)
+}
+
+func setBox(_ size: Int) {
+  setBox = Set(Set(0 ..< size).map(Box.init))
+}
+
+
 public let SetTests = [
   // Mnemonic: number after name is percentage of common elements in input sets.
   BenchmarkInfo(
@@ -99,6 +134,47 @@ public let SetTests = [
     setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
+    name: "Set.isSubset.Seq.Empty.Int",
+    runFunction: { n in run_SetIsSubsetSeqInt(setE, arrayAB, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setE, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Int.Empty",
+    runFunction: { n in run_SetIsSubsetSeqInt(setAB, arrayE, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayE]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Int0",
+    runFunction: { n in run_SetIsSubsetSeqInt(setAB, arrayCD, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayCD]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Box0",
+    runFunction: { n in run_SetIsSubsetSeqBox(setOAB, arrayOCD, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOCD]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Int25",
+    runFunction: { n in run_SetIsSubsetSeqInt(setB, arrayAB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setB, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Box25",
+    runFunction: { n in run_SetIsSubsetSeqBox(setOB, arrayOAB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOB, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Int50",
+    runFunction: { n in run_SetIsSubsetSeqInt(setY, arrayXY, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setY, arrayXY]) }),
+  BenchmarkInfo(
+    name: "Set.isSubset.Seq.Int100",
+    runFunction: { n in run_SetIsSubsetSeqInt(setP, arrayP, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
+
+  BenchmarkInfo(
     name: "Set.isStrictSubset.Empty.Int",
     runFunction: { n in run_SetIsStrictSubsetInt(setE, setAB, true, 5000 * n) },
     tags: [.validation, .api, .Set],
@@ -135,9 +211,132 @@ public let SetTests = [
     setUpFunction: { blackHole([setY, setXY]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Int100",
-    runFunction: { n in run_SetIsStrictSubsetInt(setP, setQ, false, 50 * n) },
+    runFunction: { n in run_SetIsStrictSubsetInt(setP, setQ, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
+
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Empty.Int",
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setE, arrayAB, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setE, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Int.Empty",
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setAB, arrayE, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayE]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Int0",
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setAB, arrayCD, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayCD]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Box0",
+    runFunction: { n in run_SetIsStrictSubsetSeqBox(setOAB, arrayOCD, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOCD]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Int25",
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setB, arrayAB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setB, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Box25",
+    runFunction: { n in run_SetIsStrictSubsetSeqBox(setOB, arrayOAB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOB, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Int50",
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setY, arrayXY, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setY, arrayXY]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSubset.Seq.Int100",
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setP, arrayP, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
+
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Empty.Int",
+    runFunction: { n in run_SetIsSupersetSeqInt(setAB, arrayE, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayE]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Int.Empty",
+    runFunction: { n in run_SetIsSupersetSeqInt(setE, arrayAB, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setE, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Int0",
+    runFunction: { n in run_SetIsSupersetSeqInt(setCD, arrayAB, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setCD, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Box0",
+    runFunction: { n in run_SetIsSupersetSeqBox(setOCD, arrayOAB, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOCD, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Int25",
+    runFunction: { n in run_SetIsSupersetSeqInt(setAB, arrayB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayB]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Box25",
+    runFunction: { n in run_SetIsSupersetSeqBox(setOAB, arrayOB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOB]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Int50",
+    runFunction: { n in run_SetIsSupersetSeqInt(setXY, arrayY, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, arrayY]) }),
+  BenchmarkInfo(
+    name: "Set.isSuperset.Seq.Int100",
+    runFunction: { n in run_SetIsSupersetSeqInt(setP, arrayP, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
+
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Empty.Int",
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setAB, arrayE, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayE]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Int.Empty",
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setE, arrayAB, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setE, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Int0",
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setCD, arrayAB, false, 500 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setCD, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Box0",
+    runFunction: { n in run_SetIsStrictSupersetSeqBox(setOCD, arrayOAB, false, 500 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOCD, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Int25",
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setAB, arrayB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Box25",
+    runFunction: { n in run_SetIsStrictSupersetSeqBox(setOAB, arrayOB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOB]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Int50",
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setXY, arrayY, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, arrayY]) }),
+  BenchmarkInfo(
+    name: "Set.isStrictSuperset.Seq.Int100",
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setP, arrayP, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
 
   BenchmarkInfo(
     name: "Set.isDisjoint.Empty.Int",
@@ -189,6 +388,57 @@ public let SetTests = [
     runFunction: { n in run_SetIsDisjointInt(setP, setQ, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
+
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Empty.Int",
+    runFunction: { n in run_SetIsDisjointSeqInt(setE, arrayAB, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setE, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Int.Empty",
+    runFunction: { n in run_SetIsDisjointSeqInt(setAB, arrayE, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayE]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Empty.Box",
+    runFunction: { n in run_SetIsDisjointSeqBox(setOE, arrayOAB, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOE, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Box.Empty",
+    runFunction: { n in run_SetIsDisjointSeqBox(setOAB, arrayOE, true, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOE]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Int0",
+    runFunction: { n in run_SetIsDisjointSeqInt(setAB, arrayCD, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayCD]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Box0",
+    runFunction: { n in run_SetIsDisjointSeqBox(setOAB, arrayOCD, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOCD]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Int25",
+    runFunction: { n in run_SetIsDisjointSeqInt(setB, arrayAB, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setB, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Box25",
+    runFunction: { n in run_SetIsDisjointSeqBox(setOB, arrayOAB, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOB, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Int50",
+    runFunction: { n in run_SetIsDisjointSeqInt(setY, arrayXY, false, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setY, arrayXY]) }),
+  BenchmarkInfo(
+    name: "Set.isDisjoint.Seq.Int100",
+    runFunction: { n in run_SetIsDisjointSeqInt(setP, arrayP, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
 
   BenchmarkInfo(
     name: "SetSymmetricDifferenceInt0",
@@ -251,6 +501,37 @@ public let SetTests = [
     runFunction: { n in run_SetIntersectionInt(setP, setQ, size, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
+
+  BenchmarkInfo(
+    name: "Set.intersection.Seq.Int0",
+    runFunction: { n in run_SetIntersectionSeqInt(setAB, arrayCD, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayCD]) }),
+  BenchmarkInfo(
+    name: "Set.intersection.Seq.Box0",
+    runFunction: { n in run_SetIntersectionSeqBox(setOAB, arrayOCD, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOCD]) }),
+  BenchmarkInfo(
+    name: "Set.intersection.Seq.Int25",
+    runFunction: { n in run_SetIntersectionSeqInt(setAB, arrayBC, countB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayBC]) }),
+  BenchmarkInfo(
+    name: "Set.intersection.Seq.Box25",
+    runFunction: { n in run_SetIntersectionSeqBox(setOAB, arrayOBC, countB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOBC]) }),
+  BenchmarkInfo(
+    name: "Set.intersection.Seq.Int50",
+    runFunction: { n in run_SetIntersectionSeqInt(setXY, arrayYZ, half, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, arrayYZ]) }),
+  BenchmarkInfo(
+    name: "Set.intersection.Seq.Int100",
+    runFunction: { n in run_SetIntersectionSeqInt(setP, arrayP, size, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
 
   BenchmarkInfo(
     name: "SetUnionInt0",
@@ -334,6 +615,98 @@ public let SetTests = [
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
 
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Empty.Int",
+    runFunction: { n in run_SetSubtractingSeqInt(setE, arrayAB, 0, 1000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setE, arrayAB]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Int.Empty",
+    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayE, countAB, 1000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayE]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Empty.Box",
+    runFunction: { n in run_SetSubtractingSeqBox(setOE, arrayOAB, 0, 1000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOE, arrayOAB]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Box.Empty",
+    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOE, countAB, 1000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOE]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Int0",
+    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayCD, countAB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayCD]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Box0",
+    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOCD, countAB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOCD]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Int25",
+    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayBC, countA, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, arrayBC]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Box25",
+    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOBC, countA, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, arrayOBC]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Int50",
+    runFunction: { n in run_SetSubtractingSeqInt(setXY, arrayYZ, half, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, arrayYZ]) }),
+  BenchmarkInfo(
+    name: "Set.subtracting.Seq.Int100",
+    runFunction: { n in run_SetSubtractingSeqInt(setP, arrayP, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, arrayP]) }),
+
+    BenchmarkInfo(
+    name: "Set.filter.Int50.16k",
+    runFunction: { n in run_SetFilterInt50(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(16_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int50.20k",
+    runFunction: { n in run_SetFilterInt50(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(20_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int50.24k",
+    runFunction: { n in run_SetFilterInt50(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(24_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int50.28k",
+    runFunction: { n in run_SetFilterInt50(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(28_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int100.16k",
+    runFunction: { n in run_SetFilterInt100(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(16_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int100.20k",
+    runFunction: { n in run_SetFilterInt100(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(20_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int100.24k",
+    runFunction: { n in run_SetFilterInt100(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(24_000) }),
+  BenchmarkInfo(
+    name: "Set.filter.Int100.28k",
+    runFunction: { n in run_SetFilterInt100(n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { set(28_000) }),
+
   // Legacy benchmarks, kept for continuity with previous releases.
   BenchmarkInfo(
     name: "SetExclusiveOr", // ~"SetSymmetricDifferenceInt0"
@@ -375,6 +748,18 @@ public func run_SetIsSubsetInt(
 }
 
 @inline(never)
+public func run_SetIsSubsetSeqInt(
+  _ a: Set<Int>,
+  _ b: Array<Int>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isSubset = a.isSubset(of: identity(b))
+    CheckResults(isSubset == r)
+  }
+}
+
+@inline(never)
 public func run_SetIsStrictSubsetInt(
   _ a: Set<Int>,
   _ b: Set<Int>,
@@ -383,6 +768,42 @@ public func run_SetIsStrictSubsetInt(
   for _ in 0 ..< n {
     let isStrictSubset = a.isStrictSubset(of: identity(b))
     CheckResults(isStrictSubset == r)
+  }
+}
+
+@inline(never)
+public func run_SetIsStrictSubsetSeqInt(
+  _ a: Set<Int>,
+  _ b: Array<Int>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isStrictSubset = a.isStrictSubset(of: identity(b))
+    CheckResults(isStrictSubset == r)
+  }
+}
+
+@inline(never)
+public func run_SetIsSupersetSeqInt(
+  _ a: Set<Int>,
+  _ b: Array<Int>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isSuperset = a.isSuperset(of: identity(b))
+    CheckResults(isSuperset == r)
+  }
+}
+
+@inline(never)
+public func run_SetIsStrictSupersetSeqInt(
+  _ a: Set<Int>,
+  _ b: Array<Int>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isStrictSuperset = a.isStrictSuperset(of: identity(b))
+    CheckResults(isStrictSuperset == r)
   }
 }
 
@@ -423,9 +844,33 @@ public func run_SetIntersectionInt(
 }
 
 @inline(never)
+public func run_SetIntersectionSeqInt(
+  _ a: Set<Int>,
+  _ b: Array<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.intersection(identity(b))
+    CheckResults(and.count == r)
+  }
+}
+
+@inline(never)
 public func run_SetSubtractingInt(
   _ a: Set<Int>,
   _ b: Set<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.subtracting(identity(b))
+    CheckResults(and.count == r)
+  }
+}
+
+@inline(never)
+public func run_SetSubtractingSeqInt(
+  _ a: Set<Int>,
+  _ b: Array<Int>,
   _ r: Int,
   _ n: Int) {
   for _ in 0 ..< n {
@@ -444,6 +889,34 @@ public func run_SetIsDisjointInt(
         let isDisjoint = a.isDisjoint(with: identity(b))
         CheckResults(isDisjoint == r)
     }
+}
+
+@inline(never)
+public func run_SetIsDisjointSeqInt(
+    _ a: Set<Int>,
+    _ b: Array<Int>,
+    _ r: Bool,
+    _ n: Int) {
+    for _ in 0 ..< n {
+        let isDisjoint = a.isDisjoint(with: identity(b))
+        CheckResults(isDisjoint == r)
+    }
+}
+
+@inline(never)
+public func run_SetFilterInt50(_ n: Int) {
+  for _ in 0 ..< n {
+    let half = set.filter { $0 % 2 == 0 }
+    CheckResults(set.count == half.count * 2)
+  }
+}
+
+@inline(never)
+public func run_SetFilterInt100(_ n: Int) {
+  for _ in 0 ..< n {
+    let copy = set.filter { _ in true }
+    CheckResults(set.count == copy.count)
+  }
 }
 
 class Box<T : Hashable> : Hashable {
@@ -475,6 +948,18 @@ func run_SetIsSubsetBox(
 }
 
 @inline(never)
+func run_SetIsSubsetSeqBox(
+  _ a: Set<Box<Int>>,
+  _ b: Array<Box<Int>>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isSubset = a.isSubset(of: identity(b))
+    CheckResults(isSubset == r)
+  }
+}
+
+@inline(never)
 func run_SetIsStrictSubsetBox(
   _ a: Set<Box<Int>>,
   _ b: Set<Box<Int>>,
@@ -483,6 +968,42 @@ func run_SetIsStrictSubsetBox(
   for _ in 0 ..< n {
     let isStrictSubset = a.isStrictSubset(of: identity(b))
     CheckResults(isStrictSubset == r)
+  }
+}
+
+@inline(never)
+func run_SetIsStrictSubsetSeqBox(
+  _ a: Set<Box<Int>>,
+  _ b: Array<Box<Int>>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isStrictSubset = a.isStrictSubset(of: identity(b))
+    CheckResults(isStrictSubset == r)
+  }
+}
+
+@inline(never)
+func run_SetIsSupersetSeqBox(
+  _ a: Set<Box<Int>>,
+  _ b: Array<Box<Int>>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isSuperset = a.isSuperset(of: identity(b))
+    CheckResults(isSuperset == r)
+  }
+}
+
+@inline(never)
+func run_SetIsStrictSupersetSeqBox(
+  _ a: Set<Box<Int>>,
+  _ b: Array<Box<Int>>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isStrictSuperset = a.isStrictSuperset(of: identity(b))
+    CheckResults(isStrictSuperset == r)
   }
 }
 
@@ -523,6 +1044,18 @@ func run_SetIntersectionBox(
 }
 
 @inline(never)
+func run_SetIntersectionSeqBox(
+  _ a: Set<Box<Int>>,
+  _ b: Array<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.intersection(identity(b))
+    CheckResults(and.count == r)
+  }
+}
+
+@inline(never)
 func run_SetSubtractingBox(
   _ a: Set<Box<Int>>,
   _ b: Set<Box<Int>>,
@@ -535,9 +1068,33 @@ func run_SetSubtractingBox(
 }
 
 @inline(never)
+func run_SetSubtractingSeqBox(
+  _ a: Set<Box<Int>>,
+  _ b: Array<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.subtracting(identity(b))
+    CheckResults(and.count == r)
+  }
+}
+
+@inline(never)
 func run_SetIsDisjointBox(
     _ a: Set<Box<Int>>,
     _ b: Set<Box<Int>>,
+    _ r: Bool,
+    _ n: Int) {
+    for _ in 0 ..< n {
+        let isDisjoint = a.isDisjoint(with: identity(b))
+        CheckResults(isDisjoint == r)
+    }
+}
+
+@inline(never)
+func run_SetIsDisjointSeqBox(
+    _ a: Set<Box<Int>>,
+    _ b: Array<Box<Int>>,
     _ r: Bool,
     _ n: Int) {
     for _ in 0 ..< n {

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -160,14 +160,14 @@ public let SetTests = [
     setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isSubset.Seq.Box25",
-    runFunction: { n in run_SetIsSubsetSeqBox(setOB, arrayOAB, true, 50 * n) },
+    runFunction: { n in run_SetIsSubsetSeqBox(setOB, arrayOBC, true, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOB, arrayOAB]) }),
+    setUpFunction: { blackHole([setOB, arrayOBC]) }),
   BenchmarkInfo(
     name: "Set.isSubset.Seq.Int50",
-    runFunction: { n in run_SetIsSubsetSeqInt(setY, arrayXY, true, 50 * n) },
+    runFunction: { n in run_SetIsSubsetSeqInt(setY, arrayYZ, true, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setY, arrayXY]) }),
+    setUpFunction: { blackHole([setY, arrayYZ]) }),
   BenchmarkInfo(
     name: "Set.isSubset.Seq.Int100",
     runFunction: { n in run_SetIsSubsetSeqInt(setP, arrayP, true, 50 * n) },
@@ -242,14 +242,14 @@ public let SetTests = [
     setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Box25",
-    runFunction: { n in run_SetIsStrictSubsetSeqBox(setOB, arrayOAB, true, 50 * n) },
+    runFunction: { n in run_SetIsStrictSubsetSeqBox(setOB, arrayOBC, true, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOB, arrayOAB]) }),
+    setUpFunction: { blackHole([setOB, arrayOBC]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Int50",
-    runFunction: { n in run_SetIsStrictSubsetSeqInt(setY, arrayXY, true, 50 * n) },
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setY, arrayYZ, true, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setY, arrayXY]) }),
+    setUpFunction: { blackHole([setY, arrayYZ]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Int100",
     runFunction: { n in run_SetIsStrictSubsetSeqInt(setP, arrayP, false, 50 * n) },
@@ -283,14 +283,14 @@ public let SetTests = [
     setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isSuperset.Seq.Box25",
-    runFunction: { n in run_SetIsSupersetSeqBox(setOAB, arrayOB, true, 50 * n) },
+    runFunction: { n in run_SetIsSupersetSeqBox(setOB, arrayOBC, false, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, arrayOB]) }),
+    setUpFunction: { blackHole([setOB, arrayOBC]) }),
   BenchmarkInfo(
     name: "Set.isSuperset.Seq.Int50",
-    runFunction: { n in run_SetIsSupersetSeqInt(setXY, arrayY, true, 50 * n) },
+    runFunction: { n in run_SetIsSupersetSeqInt(setY, arrayYZ, false, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setXY, arrayY]) }),
+    setUpFunction: { blackHole([setY, arrayYZ]) }),
   BenchmarkInfo(
     name: "Set.isSuperset.Seq.Int100",
     runFunction: { n in run_SetIsSupersetSeqInt(setP, arrayP, true, 50 * n) },
@@ -324,14 +324,14 @@ public let SetTests = [
     setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Box25",
-    runFunction: { n in run_SetIsStrictSupersetSeqBox(setOAB, arrayOB, true, 50 * n) },
+    runFunction: { n in run_SetIsStrictSupersetSeqBox(setOB, arrayOBC, false, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, arrayOB]) }),
+    setUpFunction: { blackHole([setOB, arrayOBC]) }),
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Int50",
-    runFunction: { n in run_SetIsStrictSupersetSeqInt(setXY, arrayY, true, 50 * n) },
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setY, arrayYZ, false, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setXY, arrayY]) }),
+    setUpFunction: { blackHole([setY, arrayYZ]) }),
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Int100",
     runFunction: { n in run_SetIsStrictSupersetSeqInt(setP, arrayP, false, 50 * n) },

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -617,52 +617,52 @@ public let SetTests = [
 
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Empty.Int",
-    runFunction: { n in run_SetSubtractingSeqInt(setE, arrayAB, 0, 1000 * n) },
+    runFunction: { n in run_SetSubtractingSeqInt(setE, arrayAB, 0, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setE, arrayAB]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Int.Empty",
-    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayE, countAB, 1000 * n) },
+    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayE, countAB, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, arrayE]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Empty.Box",
-    runFunction: { n in run_SetSubtractingSeqBox(setOE, arrayOAB, 0, 1000 * n) },
+    runFunction: { n in run_SetSubtractingSeqBox(setOE, arrayOAB, 0, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOE, arrayOAB]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Box.Empty",
-    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOE, countAB, 1000 * n) },
+    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOE, countAB, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, arrayOE]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Int0",
-    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayCD, countAB, 10 * n) },
+    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayCD, countAB, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, arrayCD]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Box0",
-    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOCD, countAB, 10 * n) },
+    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOCD, countAB, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, arrayOCD]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Int25",
-    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayBC, countA, 10 * n) },
+    runFunction: { n in run_SetSubtractingSeqInt(setAB, arrayBC, countA, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Box25",
-    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOBC, countA, 10 * n) },
+    runFunction: { n in run_SetSubtractingSeqBox(setOAB, arrayOBC, countA, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, arrayOBC]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Int50",
-    runFunction: { n in run_SetSubtractingSeqInt(setXY, arrayYZ, half, 10 * n) },
+    runFunction: { n in run_SetSubtractingSeqInt(setXY, arrayYZ, half, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setXY, arrayYZ]) }),
   BenchmarkInfo(
     name: "Set.subtracting.Seq.Int100",
-    runFunction: { n in run_SetSubtractingSeqInt(setP, arrayP, 0, 10 * n) },
+    runFunction: { n in run_SetSubtractingSeqInt(setP, arrayP, 0, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, arrayP]) }),
 

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -155,9 +155,9 @@ public let SetTests = [
     setUpFunction: { blackHole([setOAB, arrayOCD]) }),
   BenchmarkInfo(
     name: "Set.isSubset.Seq.Int25",
-    runFunction: { n in run_SetIsSubsetSeqInt(setB, arrayAB, true, 50 * n) },
+    runFunction: { n in run_SetIsSubsetSeqInt(setB, arrayBC, true, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setB, arrayAB]) }),
+    setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isSubset.Seq.Box25",
     runFunction: { n in run_SetIsSubsetSeqBox(setOB, arrayOAB, true, 50 * n) },
@@ -237,9 +237,9 @@ public let SetTests = [
     setUpFunction: { blackHole([setOAB, arrayOCD]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Int25",
-    runFunction: { n in run_SetIsStrictSubsetSeqInt(setB, arrayAB, true, 50 * n) },
+    runFunction: { n in run_SetIsStrictSubsetSeqInt(setB, arrayBC, true, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setB, arrayAB]) }),
+    setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Box25",
     runFunction: { n in run_SetIsStrictSubsetSeqBox(setOB, arrayOAB, true, 50 * n) },
@@ -278,9 +278,9 @@ public let SetTests = [
     setUpFunction: { blackHole([setOCD, arrayOAB]) }),
   BenchmarkInfo(
     name: "Set.isSuperset.Seq.Int25",
-    runFunction: { n in run_SetIsSupersetSeqInt(setAB, arrayB, true, 50 * n) },
+    runFunction: { n in run_SetIsSupersetSeqInt(setB, arrayBC, false, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, arrayB]) }),
+    setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isSuperset.Seq.Box25",
     runFunction: { n in run_SetIsSupersetSeqBox(setOAB, arrayOB, true, 50 * n) },
@@ -319,9 +319,9 @@ public let SetTests = [
     setUpFunction: { blackHole([setOCD, arrayOAB]) }),
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Int25",
-    runFunction: { n in run_SetIsStrictSupersetSeqInt(setAB, arrayB, true, 50 * n) },
+    runFunction: { n in run_SetIsStrictSupersetSeqInt(setB, arrayBC, false, 50 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, arrayB]) }),
+    setUpFunction: { blackHole([setB, arrayBC]) }),
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Box25",
     runFunction: { n in run_SetIsStrictSupersetSeqBox(setOAB, arrayOB, true, 50 * n) },


### PR DESCRIPTION
Added benchmarks for Set.
To support this: https://github.com/apple/swift/pull/24156#pullrequestreview-229848684 
> Some Set operations have generic variants that take a sequence -- e.g., `Set.isSuperset<S: Sequence>(of: S)`. These are currently not covered by benchmarks at all, even though we're planning to [improve them](https://github.com/apple/swift/pull/21300) soon! I'd very much welcome benchmarks that measure those.