### PR TITLE
Fix callable type-checking for inout parameters.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4627,7 +4627,8 @@ ConstraintSystem::simplifyApplicableFnConstraint(
             locator.withPathElement(LocatorPathElt::getTupleElement(i));
         addConstraint(ConstraintKind::ArgumentConversion, paramType,
                       tvParam, locatorBuilder);
-        tvParams.push_back(AnyFunctionType::Param(tvParam));
+        tvParams.push_back(AnyFunctionType::Param(
+            tvParam, Identifier(), param.getParameterFlags()));
       }
       // Create target function type and an applicable function constraint.
       AnyFunctionType *funcType =

--- a/test/Sema/call_method_simple.swift
+++ b/test/Sema/call_method_simple.swift
@@ -6,11 +6,18 @@ struct SimpleCallable {
   }
 }
 
-// Simple test.
+// Simple tests.
 
 let foo = SimpleCallable()
 _ = foo(1)
 _ = foo(foo(1))
+
+// TODO: Improve this error to match the error using a direct `call` member reference.
+// expected-error @+2 {{cannot call value of non-function type 'SimpleCallable'}}
+// expected-error @+1 {{cannot invoke 'foo' with an argument list of type '(Int, Int)'}}
+_ = foo(1, 1)
+// expected-error @+1 {{cannot convert value of type 'SimpleCallable' to specified type '(Float) -> Float'}}
+let _: (Float) -> Float = foo
 
 // Test direct `call` member references.
 
@@ -50,6 +57,7 @@ _ = bar(x: 1, y: 1)
 _ = bar.call(x: 1, y: 1)
 _ = bar(x: bar.call(x: 1, y: 1)[0], y: 1)
 _ = bar.call(x: bar(x: 1, y: 1)[0], y: 1)
+_ = bar(1, 1) // expected-error {{missing argument labels 'x:y:' in call}}
 
 struct Extended {}
 extension Extended {
@@ -69,12 +77,12 @@ struct OptionalCallable {
 var optional = OptionalCallable()
 _ = optional()?.call()?()
 
-struct VariadicCallable {
+struct Variadic {
   func call(_ args: Int...) -> [Int] {
     return args
   }
 }
-var variadic = VariadicCallable()
+var variadic = Variadic()
 _ = variadic()
 _ = variadic(1, 2, 3)
 
@@ -91,13 +99,47 @@ func testMutating(_ x: Mutating, _ y: inout Mutating) {
   _ = y.call()
 }
 
+struct Inout {
+  func call(_ x: inout Int) {
+    x += 5
+  }
+}
+func testInout(_ x: Inout, _ arg: inout Int) {
+  x(&arg)
+  x.call(&arg)
+  // TODO: Improve this error to match the error using a direct `call` member reference.
+  // expected-error @+2 {{cannot invoke 'x' with an argument list of type '(Int)'}}
+  // expected-error @+1 {{cannot call value of non-function type 'Inout'}}
+  x(arg)
+  // expected-error @+1 {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
+  x.call(arg)
+}
+
+struct Autoclosure {
+  func call(_ condition: @autoclosure () -> Bool,
+            _ message: @autoclosure () -> String) {
+    if condition() {
+      print(message())
+    }
+  }
+}
+func testAutoclosure(_ x: Autoclosure) {
+  x(true, "Failure")
+  x({ true }(), { "Failure" }())
+}
+
 struct Throwing {
   func call() throws -> Throwing {
     return self
   }
+  func call(_ f: () throws -> ()) rethrows {
+    try f()
+  }
 }
+struct DummyError : Error {}
 var throwing = Throwing()
 _ = try throwing()
+_ = try throwing { throw DummyError() }
 
 enum BinaryOperation {
   case add, subtract, multiply, divide
@@ -126,20 +168,17 @@ class SubClass : BaseClass {
 }
 
 func testIUO(a: SimpleCallable!, b: MultipleArgsCallable!, c: Extended!,
-             d: OptionalCallable!, e: Throwing!) {
+             d: OptionalCallable!, e: Variadic!, f: inout Mutating!,
+             g: Inout!, inoutInt: inout Int, h: Throwing!) {
   _ = a(1)
   _ = b(x: 1, y: 1)
   _ = c()
   _ = d()?.call()?()
-  _ = try? e()
+  _ = e()
+  _ = e(1, 2, 3)
+  // FIXME(TF-444): `mutating func call` and IUO doesn't work.
+  // _ = f()
+  _ = g(&inoutInt)
+  _ = try? h()
+  _ = try? h { throw DummyError() }
 }
-
-// Errors.
-
-// TODO: Fix this error. Ideally, it should be "extra argument in call".
-// expected-error @+2 {{cannot call value of non-function type 'SimpleCallable'}}
-// expected-error @+1 {{cannot invoke 'foo' with an argument list of type '(Int, Int)'}}
-_ = foo(1, 1)
-
-_ = bar(1, 1) // expected-error {{missing argument labels 'x:y:' in call}}
-let _: (Float) -> Float = foo // expected-error {{cannot convert value of type 'SimpleCallable' to specified type '(Float) -> Float'}}


### PR DESCRIPTION
Support inout parameters by propagating parameter flags.
Add and reorganize tests. Expose [TF-444](https://bugs.swift.org/browse/TF-444).