### PR TITLE
[ParseableInterfaces] Disable `inherited-defaults-execution.swift` test

### DIFF
--- a/test/ParseableInterface/inherited-defaults-execution.swift
+++ b/test/ParseableInterface/inherited-defaults-execution.swift
@@ -1,6 +1,8 @@
 // REQUIRES: executable_test
 // RUN: %empty-directory(%t)
 
+// REQUIRES: rdar_50050902
+
 // 1) Build the 'Inherited' library and its interface from this file
 //
 // RUN: %target-build-swift-dylib(%t/%target-library-name(Inherited)) -emit-module-path %t/Inherited.swiftmodule -emit-parseable-module-interface-path %t/Inherited.swiftinterface -module-name Inherited %s


### PR DESCRIPTION
Currently fails on extended testing

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
