### PR TITLE
MetadataLookup: Use extension's generic context for non-nominal extensions.

### DIFF
--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+protocol P {
+  associatedtype AT
+  func foo() -> AT
+}
+
+extension P {
+  func foo() -> some P {
+    return self
+  }
+}
+
+func getPAT<T: P>(_: T.Type) -> Any.Type {
+  return T.AT.self
+}
+
+extension Int: P { }
+
+// CHECK: Int
+print(getPAT(Int.self))


### PR DESCRIPTION
In protocol extensions, and in the future parameterized extensions, have their own generic arguments
independent of an originating nominal type's formal generic parameters. Instead of crashing, handle
this gracefully. rdar://problem/50038754