### PR TITLE
[AutoDiff] Fix a memory leak in pullback reabstraction thunks.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2293,7 +2293,6 @@ static SILFunction *getOrCreateReabstractionThunk(SILOptFunctionBuilder &fb,
       auto indRes = *fromIndResultsIter++;
       auto *load = builder.createLoad(loc, indRes,
           getBufferLOQ(indRes->getType().getASTType(), *thunk));
-      builder.createRetainValue(loc, load, builder.getDefaultAtomicity());
       results.push_back(load);
       continue;
     }


### PR DESCRIPTION
In pullback reabstraction thunks, values returned from function applications should not be retained before being immediately returned.

Resolves [TF-340](https://bugs.swift.org/browse/TF-340).