### PR TITLE
Sema: don't consider opaque types distinct for overloading purposes.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -232,11 +232,14 @@ struct OverloadSignature {
   /// Whether this signature is of a member defined in an extension of a generic
   /// type.
   unsigned InExtensionOfGenericType : 1;
+  
+  /// Whether this declaration has an opaque return type.
+  unsigned HasOpaqueReturnType : 1;
 
   OverloadSignature()
       : UnaryOperator(UnaryOperatorKind::None), IsInstanceMember(false),
         IsVariable(false), IsFunction(false), InProtocolExtension(false),
-        InExtensionOfGenericType(false) {}
+        InExtensionOfGenericType(false), HasOpaqueReturnType(false) {}
 };
 
 /// Determine whether two overload signatures conflict.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4687,6 +4687,14 @@ public:
   
   /// Get the generic environment this archetype lives in.
   GenericEnvironment *getGenericEnvironment() const;
+  
+  /// Get the protocol/class existential type that most closely represents the
+  /// set of constraints on this archetype.
+  ///
+  /// Right now, this only considers constraints on the archetype itself, not
+  /// any of its associated types, since those are the only kind of existential
+  /// type we can represent.
+  Type getExistentialType() const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2378,6 +2378,24 @@ ArchetypeType *ArchetypeType::getRoot() const {
   return const_cast<ArchetypeType*>(parent);
 }
 
+Type ArchetypeType::getExistentialType() const {
+  // Opened types hold this directly.
+  if (auto opened = dyn_cast<OpenedArchetypeType>(this))
+    return opened->getOpenedExistentialType();
+  
+  // Otherwise, compute it from scratch.
+  SmallVector<Type, 4> constraintTypes;
+  
+  if (auto super = getSuperclass()) {
+    constraintTypes.push_back(super);
+  }
+  for (auto proto : getConformsTo()) {
+    constraintTypes.push_back(proto->getDeclaredType());
+  }
+  return ProtocolCompositionType::get(
+     const_cast<ArchetypeType*>(this)->getASTContext(), constraintTypes, false);
+}
+
 PrimaryArchetypeType::PrimaryArchetypeType(const ASTContext &Ctx,
                                      GenericEnvironment *GenericEnv,
                                      Type InterfaceType,

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -287,4 +287,29 @@ var DoesNotConformComputedProp: some P {
 }
 */
 
+func redeclaration() -> some P { return 0 } // expected-note{{previously declared}}
+func redeclaration() -> some P { return 0 } // expected-error{{redeclaration}}
+func redeclaration() -> some Q { return 0 }
+func redeclaration() -> P { return 0 }
 
+var redeclaredProp: some P { return 0 } // expected-note 3{{previously declared}}
+var redeclaredProp: some P { return 0 } // expected-error{{redeclaration}}
+var redeclaredProp: some Q { return 0 } // expected-error{{redeclaration}}
+var redeclaredProp: P { return 0 } // expected-error{{redeclaration}}
+
+struct RedeclarationTest {
+  func redeclaration() -> some P { return 0 } // expected-note{{previously declared}}
+  func redeclaration() -> some P { return 0 } // expected-error{{redeclaration}}
+  func redeclaration() -> some Q { return 0 }
+  func redeclaration() -> P { return 0 }
+
+  var redeclaredProp: some P { return 0 } // expected-note 3{{previously declared}}
+  var redeclaredProp: some P { return 0 } // expected-error{{redeclaration}}
+  var redeclaredProp: some Q { return 0 } // expected-error{{redeclaration}}
+  var redeclaredProp: P { return 0 } // expected-error{{redeclaration}}
+
+  subscript(redeclared _: Int) -> some P { return 0 } // expected-note{{previously declared}}
+  subscript(redeclared _: Int) -> some P { return 0 } // expected-error{{redeclaration}}
+  subscript(redeclared _: Int) -> some Q { return 0 }
+  subscript(redeclared _: Int) -> P { return 0 }
+}


### PR DESCRIPTION
This is necessary because:

```
func foo() -> some P
func foo() -> some P
```

theoretically defines two distinct return types, but there'd be no way to disambiguate them. Disallow overloading only by opaque return type.