### PR TITLE
[WIP] Fix mangling of generic params to protocol extension contexts

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1168,11 +1168,17 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
   auto decl = dc->getInnermostDeclarationDeclContext();
   if (!decl) return 0;
 
-  // For an extension declaration, use the nominal type declaration instead.
+  // For a non-protocol extension declaration, use the nominal type declaration
+  // instead.
+  //
   // This is important when extending a nested type, because the generic
   // parameters will line up with the (semantic) nesting of the nominal type.
-  if (auto ext = dyn_cast<ExtensionDecl>(decl))
-    decl = ext->getSelfNominalTypeDecl();
+  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
+    auto extendedDecl = ext->getSelfNominalTypeDecl();
+    if (!isa<ProtocolDecl>(extendedDecl)) {
+      decl = extendedDecl;
+    }
+  }
 
   // Handle the generic arguments of the parent.
   unsigned currentGenericParamIdx =


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
