### PR TITLE
[android] Do not try to turn EOF into an UInt8

### DIFF
--- a/validation-test/StdlibUnittest/Stdin.swift
+++ b/validation-test/StdlibUnittest/Stdin.swift
@@ -18,13 +18,13 @@ func simple_getline() -> [UInt8]? {
   var result = [UInt8]()
   while true {
     let c = getchar()
-    result.append(UInt8(c))
     if c == EOF {
       if result.count == 0 {
         return nil
       }
       return result
     }
+    result.append(UInt8(c))
     if c == CInt(UnicodeScalar("\n").value) {
       return result
     }


### PR DESCRIPTION
Android is one of those platforms that define the symbol EOF as a
negative number. Trying to turn it into an UInt8 will only crash the
test. Move the transformation after we have checked for EOF first. In my
opinion, in other platforms, having the EOF attached to the getline
result was also invalid, and that's probably why the two test that use
EOF were sending an extra newline.

Even with this, the tests do not pass on Android because it deadlocks
waiting for input/output from the child process, which never happens. I
haven't find why this happens, but only happens if the last test of the
suite closes stdin. I will try to fix that in another PR.
