### PR TITLE
[SourceKit] SourceKit support for opaque result types

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -118,6 +118,10 @@ public:
   /// Callers should use callPrintDeclPost().
   virtual void printDeclPost(const Decl *D, Optional<BracketOptions> Bracket) {}
 
+  /// Called before printing the result type of the declaration. Printer can
+  /// replace \p TL to customize the input.
+  virtual void printDeclResultTypePre(ValueDecl *VD, TypeLoc &TL) {}
+
   /// Called before printing a type.
   virtual void printTypePre(const TypeLoc &TL) {}
   /// Called after printing a type.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -574,6 +574,7 @@ struct PrintOptions {
     PO.ExplodeEnumCaseDecls = true;
     PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;
     PO.PrintParameterSpecifiers = true;
+    PO.SkipImplicit = true;
     return PO;
   }
 };

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -135,6 +135,9 @@ struct PrintOptions {
   /// Whether to print *any* accessors on properties.
   bool PrintPropertyAccessors = true;
 
+  /// Whether to print *any* accessors on subscript.
+  bool PrintSubscriptAccessors = true;
+
   /// Whether to print the accessors of a property abstractly,
   /// i.e. always as:
   /// ```

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -260,9 +260,20 @@ struct PrintOptions {
   /// Whether to skip keywords with a prefix of underscore such as __consuming.
   bool SkipUnderscoredKeywords = false;
 
-  /// Whether to print declarations with opaque return types with a stable,
-  /// parsable internal syntax.
-  bool PrintStableReferencesToOpaqueReturnTypes = false;
+  /// How to print opaque return types.
+  enum class OpaqueReturnTypePrintingMode {
+    /// 'some P1 & P2'.
+    WithOpaqueKeyword,
+    /// 'P1 & P2'.
+    WithoutOpaqueKeyword,
+    /// Stable parsable internal syntax.
+    StableReference,
+    /// Description suitable for debugging.
+    Description
+  };
+
+  OpaqueReturnTypePrintingMode OpaqueReturnTypePrinting =
+      OpaqueReturnTypePrintingMode::WithOpaqueKeyword;
 
   /// Whether to print decl attributes that are only used internally,
   /// such as _silgen_name, transparent, etc.
@@ -521,7 +532,8 @@ struct PrintOptions {
     result.PrintInSILBody = true;
     result.PreferTypeRepr = false;
     result.PrintIfConfig = false;
-    result.PrintStableReferencesToOpaqueReturnTypes = true;
+    result.OpaqueReturnTypePrinting =
+        OpaqueReturnTypePrintingMode::StableReference;
     return result;
   }
 

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -489,6 +489,7 @@ enum class CompletionKind {
   SuperExprDot,
   KeyPathExprObjC,
   KeyPathExprSwift,
+  TypeDeclResultBeginning,
   TypeSimpleBeginning,
   TypeIdentifierWithDot,
   TypeIdentifierWithoutDot,

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -155,6 +155,9 @@ public:
   /// #keyPath argument have been parsed yet.
   virtual void completeExprKeyPath(KeyPathExpr *KPE, SourceLoc DotLoc) {};
 
+  /// Complete the beginning of the type of result of func/var/let/subscript.
+  virtual void completeTypeDeclResultBeginning() {};
+
   /// Complete the beginning of type-simple -- no tokens provided
   /// by user.
   virtual void completeTypeSimpleBeginning() {};

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1028,6 +1028,8 @@ public:
   ParserResult<PrecedenceGroupDecl>
   parseDeclPrecedenceGroup(ParseDeclOptions flags, DeclAttributes &attributes);
 
+  ParserResult<TypeRepr> parseDeclResultType(Diag<> MessageID);
+
   //===--------------------------------------------------------------------===//
   // Type Parsing
   

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1714,6 +1714,8 @@ void PrintAST::printMutatingModifiersIfNeeded(const AccessorDecl *accessor) {
 void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
   if (isa<VarDecl>(ASD) && !Options.PrintPropertyAccessors)
     return;
+  if (isa<SubscriptDecl>(ASD) && !Options.PrintSubscriptAccessors)
+    return;
 
   auto impl = ASD->getImplInfo();
 
@@ -2534,6 +2536,7 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
     if (!tyLoc.getTypeRepr())
       tyLoc = TypeLoc::withoutLoc(decl->getInterfaceType());
 
+    Printer.printDeclResultTypePre(decl, tyLoc);
     if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
       printTypeLocForImplicitlyUnwrappedOptional(tyLoc);
     else
@@ -2804,6 +2807,8 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
           ResultTyLoc = TypeLoc::withoutLoc(ResultTy);
       }
       Printer << " -> ";
+
+      Printer.printDeclResultTypePre(decl, ResultTyLoc);
       Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
       if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
         printTypeLocForImplicitlyUnwrappedOptional(ResultTyLoc);
@@ -2931,8 +2936,9 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   });
   Printer << " -> ";
 
-  Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
   TypeLoc elementTy = decl->getElementTypeLoc();
+  Printer.printDeclResultTypePre(decl, elementTy);
+  Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
   if (!elementTy.getTypeRepr())
     elementTy = TypeLoc::withoutLoc(decl->getElementInterfaceType());
   if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -107,7 +107,8 @@ PrintOptions PrintOptions::printParseableInterfaceFile() {
   result.FunctionDefinitions = true;
   result.CollapseSingleGetterProperty = false;
   result.VarInitializers = true;
-  result.PrintStableReferencesToOpaqueReturnTypes = true;
+  result.OpaqueReturnTypePrinting =
+      OpaqueReturnTypePrintingMode::StableReference;
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;
@@ -3402,7 +3403,27 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       return;
     }
 
-    if (T->hasSimpleTypeRepr()) {
+    bool isSimple = T->hasSimpleTypeRepr();
+    if (isSimple && T->is<OpaqueTypeArchetypeType>()) {
+      auto opaqueTy = T->castTo<OpaqueTypeArchetypeType>();
+      auto opaqueDecl = opaqueTy->getDecl();
+      if (!opaqueDecl->hasName()) {
+        switch (Options.OpaqueReturnTypePrinting) {
+        case PrintOptions::OpaqueReturnTypePrintingMode::StableReference:
+        case PrintOptions::OpaqueReturnTypePrintingMode::Description:
+          isSimple = true;
+          break;
+        case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
+          isSimple = false;
+          break;
+        case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword: {
+          isSimple = opaqueTy->getConformsTo().size() < 2;
+        }
+        }
+      }
+    }
+
+    if (isSimple) {
       visit(T);
     } else {
       Printer << "(";
@@ -4165,7 +4186,7 @@ public:
   }
   
   void visitNestedArchetypeType(NestedArchetypeType *T) {
-    visit(T->getParent());
+    printWithParensIfNotSimple(T->getParent());
     Printer << ".";
     printArchetypeCommon(T);
   }
@@ -4175,16 +4196,28 @@ public:
   }
   
   void visitOpaqueTypeArchetypeType(OpaqueTypeArchetypeType *T) {
-    // Print the type by referencing the opaque decl's synthetic name, if we
-    // were asked to.
-    OpaqueTypeDecl *decl = T->getDecl();
-    
-    if (Options.PrintStableReferencesToOpaqueReturnTypes) {
+    switch (Options.OpaqueReturnTypePrinting) {
+    case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
+      Printer << "some ";
+      LLVM_FALLTHROUGH;
+    case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword: {
+      SmallVector<Type, 2> types;
+      for (auto proto : T->getConformsTo())
+        types.push_back(proto->TypeDecl::getDeclaredInterfaceType());
+
+      // Create and visit temporary ProtocolCompositionType.
+      auto composition =
+          ProtocolCompositionType::get(T->getASTContext(), types, false);
+      visit(composition);
+      return;
+    }
+    case PrintOptions::OpaqueReturnTypePrintingMode::StableReference: {
       // Print the source of the opaque return type as a mangled name.
       // We'll use type reconstruction while parsing the attribute to
       // turn this back into a reference to the naming decl for the opaque
       // type.
       Printer << "@_opaqueReturnTypeOf(";
+      OpaqueTypeDecl *decl = T->getDecl();
       
       Printer.printEscapedStringLiteral(
                                    decl->getOpaqueReturnTypeIdentifier().str());
@@ -4195,7 +4228,9 @@ public:
       
       Printer << u8") \U0001F9B8";
       printGenericArgs(T->getSubstitutions().getReplacementTypes());
-    } else {
+      return;
+    }
+    case PrintOptions::OpaqueReturnTypePrintingMode::Description: {
       // TODO(opaque): present opaque types with user-facing syntax. we should
       // probably print this as `some P` and record the fact that we printed that
       // so that diagnostics can add followup notes.
@@ -4209,6 +4244,8 @@ public:
                    [&] { Printer << ", "; });
         Printer << '>';
       }
+      return;
+    }
     }
   }
 

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -373,6 +373,8 @@ public:
     PrintOptions PO;
     PO.SkipAttributes = true;
     PO.PrintOptionalAsImplicitlyUnwrapped = IsIUO;
+    PO.OpaqueReturnTypePrinting =
+        PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword;
     std::string TypeName = Ty->getString(PO);
     addChunkWithText(CodeCompletionString::Chunk::ChunkKind::CallParameterType,
                      TypeName);
@@ -385,6 +387,8 @@ public:
       PrintOptions PO;
       PO.PrintFunctionRepresentationAttrs = false;
       PO.SkipAttributes = true;
+      PO.OpaqueReturnTypePrinting =
+          PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword;
       addChunkWithText(
           CodeCompletionString::Chunk::ChunkKind::CallParameterClosureType,
           AFT->getString(PO));

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6380,7 +6380,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
     }
 
     // type
-    ElementTy = parseType(diag::expected_type_subscript);
+    ElementTy = parseDeclResultType(diag::expected_type_subscript);
     Status |= ElementTy;
     SignatureHasCodeCompletion |= ElementTy.hasCodeCompletion();
     if (SignatureHasCodeCompletion && !CodeCompletion) {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -814,7 +814,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
     }
 
     ParserResult<TypeRepr> ResultType =
-      parseType(diag::expected_type_function_result);
+        parseDeclResultType(diag::expected_type_function_result);
     if (ResultType.hasCodeCompletion())
       return ResultType;
     retType = ResultType.getPtrOrNull();
@@ -857,7 +857,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
     if (result.isNull())  // Recover by creating AnyPattern.
       result = makeParserErrorResult(new (Context) AnyPattern(colonLoc));
     
-    ParserResult<TypeRepr> Ty = parseType();
+    ParserResult<TypeRepr> Ty = parseDeclResultType(diag::expected_type);
     if (Ty.hasCodeCompletion())
       return makeParserCodeCompletionResult<Pattern>();
     if (!Ty.isNull()) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -675,6 +675,7 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
 ParserResult<TypeRepr>
 Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
                                      bool HandleCodeCompletion) {
+  SyntaxParsingContext SomeTypeContext(SyntaxContext, SyntaxKind::SomeType);
   // Check for the opaque modifier.
   // This is only semantically allowed in certain contexts, but we parse it
   // generally for diagnostics and recovery.
@@ -683,6 +684,9 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
       && Tok.is(tok::identifier)
       && Tok.getRawText() == "some") {
     opaqueLoc = consumeToken();
+  } else {
+    // This isn't a some type.
+    SomeTypeContext.setTransparent();
   }
   
   auto applyOpaque = [&](TypeRepr *type) -> TypeRepr* {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -506,6 +506,16 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
                                                specifierLoc));
 }
 
+ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
+  if (Tok.is(tok::code_complete)) {
+    if (CodeCompletion)
+      CodeCompletion->completeTypeDeclResultBeginning();
+    consumeToken(tok::code_complete);
+    return makeParserCodeCompletionStatus();
+  }
+  return parseType(MessageID);
+}
+
 ParserStatus Parser::parseGenericArguments(SmallVectorImpl<TypeRepr *> &Args,
                                            SourceLoc &LAngleLoc,
                                            SourceLoc &RAngleLoc) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -683,6 +683,8 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
   if (Context.LangOpts.EnableOpaqueResultTypes
       && Tok.is(tok::identifier)
       && Tok.getRawText() == "some") {
+    // Treat some as a keyword.
+    TokReceiver->registerTokenKindChange(Tok.getLoc(), tok::contextual_keyword);
     opaqueLoc = consumeToken();
   } else {
     // This isn't a some type.

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -417,3 +417,9 @@ let closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] i
 protocol FakeClassRestrictedProtocol : `class` {}
 // CHECK: <kw>protocol</kw> FakeClassRestrictedProtocol : <type>`class`</type> {}
 // FIXME: rdar://42801404: OLD and NEW should be the same '<type>`class`</type>'.
+
+// CHECK: <kw>func</kw> foo() -> <kw>some</kw> <type>P</type> {}
+func foo() -> some P {}
+
+// CHECK: <kw>func</kw> foo() -> <kw>some</kw> <type>P</type> & <type>Q</type> {}
+func foo() -> some P & Q {}

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FUNC | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_VAR | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_ASSOCIATEDTYPE | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_METHOD_REQUIREMENT | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_VAR_REQUIREMENT | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SUBSCRIPT_REQUIREMENT | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_METHOD_EXTENSION | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_VAR_EXTENSION | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SUBSCRIPT_EXTENSION | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_METHOD | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_VAR | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_SUBSCRIPT | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_TYPEALIAS_RHS | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
+
+protocol MyProtocol {}
+struct MyStruct {}
+enum MyEnum {}
+class MyClass {}
+
+// BEGINNING_WITH_SOME: Begin completions
+// BEGINNING_WITH_SOME-DAG: Keyword/None:                       some[#some#]; name=some
+// BEGINNING_WITH_SOME-DAG: Keyword/None:                       Any[#Any#]; name=Any
+// BEGINNING_WITH_SOME-DAG: Decl[Enum]/CurrModule:              MyEnum[#MyEnum#]; name=MyEnum
+// BEGINNING_WITH_SOME-DAG: Decl[Class]/CurrModule:             MyClass[#MyClass#]; name=MyClass
+// BEGINNING_WITH_SOME-DAG: Decl[Protocol]/CurrModule:          MyProtocol[#MyProtocol#]; name=MyProtocol
+// BEGINNING_WITH_SOME-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// BEGINNING_WITH_SOME: End completions
+
+// BEGINNING_WITHOUT_SOME: Begin completions
+// BEGINNING_WITHOUT_SOME-NOT: Keyword/None: some
+// BEGINNING_WITHOUT_SOME-DAG: Keyword/None:                       Any[#Any#]; name=Any
+// BEGINNING_WITHOUT_SOME-DAG: Decl[Enum]/CurrModule:              MyEnum[#MyEnum#]; name=MyEnum
+// BEGINNING_WITHOUT_SOME-DAG: Decl[Class]/CurrModule:             MyClass[#MyClass#]; name=MyClass
+// BEGINNING_WITHOUT_SOME-DAG: Decl[Protocol]/CurrModule:          MyProtocol[#MyProtocol#]; name=MyProtocol
+// BEGINNING_WITHOUT_SOME-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// BEGINNING_WITHOUT_SOME-NOT: Keyword/None: some
+// BEGINNING_WITHOUT_SOME: End completions
+
+func gloabalFunc() -> #^GLOBAL_FUNC^#
+var globalVar: #^GLOBAL_VAR^#
+
+protocol SomeProto {
+  associatedtype Assoc: MyProtocol
+
+  associatedtype protoAssocTy: #^PROTOCOL_ASSOCIATEDTYPE^#
+  func protoMethodReq() -> #^PROTOCOL_METHOD_REQUIREMENT^#
+  var protoVarReq: #^PROTOCOL_VAR_REQUIREMENT^#
+  subscript(req: Int) -> #^PROTOCOL_SUBSCRIPT_REQUIREMENT^#
+}
+
+extension SomeProto {
+  func protoMethodExt() -> #^PROTOCOL_METHOD_EXTENSION^#
+  var protoVarExt: #^PROTOCOL_VAR_EXTENSION^#
+  subscript(ext: Int) -> #^PROTOCOL_SUBSCRIPT_EXTENSION^#
+}
+
+struct SomeStruct {
+  typealias TyAlias = #^STRUCT_TYPEALIAS_RHS^#
+  func structMethodExt() -> #^STRUCT_METHOD^#
+  var structVarExt: #^STRUCT_VAR^#
+  subscript(struct: Int) -> #^STRUCT_SUBSCRIPT^#
+}

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -15,10 +15,21 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_SUBSCRIPT | %FileCheck %s -check-prefix=BEGINNING_WITH_SOME
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_TYPEALIAS_RHS | %FileCheck %s -check-prefix=BEGINNING_WITHOUT_SOME
 
-protocol MyProtocol {}
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_TestClass | %FileCheck %s -check-prefix=OVERRIDE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_TestStruct | %FileCheck %s -check-prefix=OVERRIDE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_HasTypealias | %FileCheck %s -check-prefix=OVERRIDE_HasTypealias
+
+protocol MyProtocol {
+  associatedtype Mistery
+}
 struct MyStruct {}
 enum MyEnum {}
 class MyClass {}
+struct ConcreteMyProtocol : MyProtocol {
+  typealias Mistery = MyStruct
+}
+
+// MARK: 'some' keyword.
 
 // BEGINNING_WITH_SOME: Begin completions
 // BEGINNING_WITH_SOME-DAG: Keyword/None:                       some[#some#]; name=some
@@ -43,8 +54,6 @@ func gloabalFunc() -> #^GLOBAL_FUNC^#
 var globalVar: #^GLOBAL_VAR^#
 
 protocol SomeProto {
-  associatedtype Assoc: MyProtocol
-
   associatedtype protoAssocTy: #^PROTOCOL_ASSOCIATEDTYPE^#
   func protoMethodReq() -> #^PROTOCOL_METHOD_REQUIREMENT^#
   var protoVarReq: #^PROTOCOL_VAR_REQUIREMENT^#
@@ -62,4 +71,68 @@ struct SomeStruct {
   func structMethodExt() -> #^STRUCT_METHOD^#
   var structVarExt: #^STRUCT_VAR^#
   subscript(struct: Int) -> #^STRUCT_SUBSCRIPT^#
+}
+
+// MARK: Conformance.
+
+protocol HasAssocPlain {
+  associatedtype AssocPlain
+  func returnAssocPlain() -> AssocPlain
+}
+protocol HasAssocWithConformanceConstraint {
+  associatedtype AssocWithConformanceConstraint: MyProtocol
+  func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> AssocWithConformanceConstraint
+}
+protocol HasAssocWithSuperClassConstraint {
+  associatedtype AssocWithSuperClassConstraint: MyClass
+  var valAssocWithSuperClassConstraint: AssocWithSuperClassConstraint { get }
+}
+protocol HasAssocWithCompositionConstraint {
+  associatedtype AssocWithCompositionConstraint: MyClass & MyProtocol
+  subscript<T>(idx: T) -> AssocWithCompositionConstraint where T: Comparable { get }
+}
+protocol HasAssocWithDefault {
+  associatedtype AssocWithDefault = MyEnum
+  func returnAssocWithDefault() -> AssocWithDefault
+}
+protocol HasAssocWithConstraintAndDefault {
+  associatedtype AssocWithConstraintAndDefault: MyProtocol = ConcreteMyProtocol
+  func returnAssocWithConstraintAndDefault() -> AssocWithConstraintAndDefault
+}
+
+class TestClass :
+    HasAssocPlain,
+    HasAssocWithConformanceConstraint,
+    HasAssocWithSuperClassConstraint,
+    HasAssocWithCompositionConstraint,
+    HasAssocWithDefault,
+    HasAssocWithConstraintAndDefault {
+  #^OVERRIDE_TestClass^#
+// OVERRIDE: found code completion token OVERRIDE_[[BASETYPE:[A-Za-z0-9]+]] at
+// OVERRIDE: Begin completions
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocPlain() -> [[BASETYPE]].AssocPlain {|};
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> some MyProtocol {|};
+// OVERRIDE-DAG: Decl[InstanceVar]/Super:            var valAssocWithSuperClassConstraint: some MyClass;
+// OVERRIDE-DAG: Decl[Subscript]/Super:              subscript<T>(idx: T) -> some MyClass & MyProtocol where T : Comparable {|};
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithDefault() -> MyEnum {|};
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConstraintAndDefault() -> ConcreteMyProtocol {|};
+// OVERRIDE: End completions
+}
+
+struct TestStruct :
+    HasAssocPlain,
+    HasAssocWithConformanceConstraint,
+    HasAssocWithSuperClassConstraint,
+    HasAssocWithCompositionConstraint,
+    HasAssocWithDefault,
+    HasAssocWithConstraintAndDefault {
+  #^OVERRIDE_TestStruct^#
+}
+
+class HasTypealias : HasAssocWithConformanceConstraint {
+  typealias AssocWithConformanceConstraint = ConcreteMyProtocol
+  #^OVERRIDE_HasTypealias^#
+// OVERRIDE_HasTypealias: Begin completions
+// OVERRIDE_HasTypealias-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> ConcreteMyProtocol {|};
+// OVERRIDE_HasTypealias: End completions
 }

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -169,6 +169,7 @@ protocol ProtocolA {
 // WITH_PA-DAG: Decl[Constructor]/Super:    required init(fromProtocolA: Int) {|}{{; name=.+$}}
 // WITH_PA-DAG: Decl[InstanceMethod]/Super: func protoAFunc() {|}{{; name=.+$}}
 // WITH_PA-DAG: Decl[InstanceMethod]/Super: func protoAFuncOptional() {|}{{; name=.+$}}
+// WITH_PA-DAG: Decl[Subscript]/Super:      subscript(a: TagPA) -> Int {|}{{; name=.+$}}
 // WITH_PA-DAG: Decl[InstanceVar]/Super:    var protoAVarRW: Int{{; name=.+$}}
 // WITH_PA-DAG: Decl[InstanceVar]/Super:    var protoAVarRO: Int{{; name=.+$}}
 // WITH_PA: End completions
@@ -195,6 +196,7 @@ protocol ProtocolB : ProtocolA {
 // WITH_PB-DAG: Decl[Constructor]/Super:    required init(fromProtocolA: Int) {|}{{; name=.+$}}
 // WITH_PB-DAG: Decl[InstanceMethod]/Super: func protoAFunc() {|}{{; name=.+$}}
 // WITH_PB-DAG: Decl[InstanceMethod]/Super: func protoBFunc() {|}{{; name=.+$}}
+// WITH_PB-DAG: Decl[Subscript]/Super:      subscript(a: TagPB) -> Int {|}{{; name=.+$}}
 // WITH_PB-DAG: Decl[InstanceVar]/Super:    var protoBVarRW: Int{{; name=.+$}}
 // WITH_PB-DAG: Decl[InstanceVar]/Super:    var protoBVarRO: Int{{; name=.+$}}
 // WITH_PB: End completions
@@ -213,6 +215,7 @@ protocol ProtocolE {
 // WITH_PE: Begin completions
 // WITH_PE-DAG: Decl[Constructor]/Super:    required init(fromProtocolE: Int) {|}{{; name=.+$}}
 // WITH_PE-DAG: Decl[InstanceMethod]/Super: func protoEFunc() {|}{{; name=.+$}}
+// WITH_PE-DAG: Decl[Subscript]/Super:      subscript(a: TagPE) -> Int {|}{{; name=.+$}}
 // WITH_PE-DAG: Decl[InstanceVar]/Super:    var protoEVarRW: Int{{; name=.+$}}
 // WITH_PE-DAG: Decl[InstanceVar]/Super:    var protoEVarRO: Int{{; name=.+$}}
 // WITH_PE: End completions
@@ -283,6 +286,7 @@ class BaseE : ProtocolE {
 // WITH_BE: Begin completions
 // WITH_BE-DAG: Decl[Constructor]/Super:    required init(fromProtocolE: Int) {|}{{; name=.+$}}
 // WITH_BE-DAG: Decl[InstanceMethod]/Super: override func protoEFunc() {|}{{; name=.+$}}
+// WITH_BE-DAG: Decl[Subscript]/Super:      override subscript(a: TagPE) -> Int {|}{{; name=.+$}}
 // WITH_BE-DAG: Decl[Constructor]/Super:    override init(fromBaseE: Int) {|}{{; name=.+$}}
 // WITH_BE-DAG: Decl[InstanceMethod]/Super: override func baseEFunc() {|}{{; name=.+$}}
 // WITH_BE-DAG: Decl[InstanceVar]/Super:    override var protoEVarRW: Int{{; name=.+$}}
@@ -304,6 +308,7 @@ class ProtocolEImpl /* : ProtocolE but does not implement the protocol */ {
 // WITH_PEI: Begin completions
 // WITH_PEI-DAG: Decl[Constructor]/Super:    override init(fromProtocolE: Int) {|}{{; name=.+$}}
 // WITH_PEI-DAG: Decl[InstanceMethod]/Super: override func protoEFunc() {|}{{; name=.+$}}
+// WITH_PEI-DAG: Decl[Subscript]/Super:      override subscript(a: TagPE) -> Int {|}{{; name=.+$}}
 // WITH_PEI-DAG: Decl[InstanceVar]/Super:    override var protoEVarRW: Int{{; name=.+$}}
 // WITH_PEI-DAG: Decl[InstanceVar]/Super:    override var protoEVarRO: Int{{; name=.+$}}
 // WITH_PEI: End completions
@@ -315,7 +320,7 @@ class TestClass_PA : ProtocolA {
 
   #^CLASS_PA^#
 }
-// CLASS_PA: Begin completions, 5 items
+// CLASS_PA: Begin completions, 6 items
 
 class TestClass_PA_Ext {
   func ERROR1() {}
@@ -329,12 +334,12 @@ extension TestClass_PA_Ext : ProtocolA {
 class TestClass_PB : ProtocolB {
   #^CLASS_PB^#
 }
-// CLASS_PB: Begin completions, 9 items
+// CLASS_PB: Begin completions, 11 items
 
 class TestClass_PA_PB : ProtocolA, ProtocolB {
   #^CLASS_PA_PB^#
 }
-// CLASS_PA_PB: Begin completions, 9 items
+// CLASS_PA_PB: Begin completions, 11 items
 
 class TestClass_BA : BaseA {
   #^CLASS_BA^#
@@ -344,7 +349,7 @@ class TestClass_BA : BaseA {
 class TestClass_BA_PA : BaseA, ProtocolA {
   #^CLASS_BA_PA^#
 }
-// CLASS_BA_PA: Begin completions, 11 items
+// CLASS_BA_PA: Begin completions, 12 items
 
 class TestClass_BA_PA_Ext : BaseA {
   #^CLASS_BA_PA_EXT1^#
@@ -357,7 +362,7 @@ extension TestClass_BA_PA_Ext : ProtocolA {
 class TestClass_BA_PB : BaseA, ProtocolB {
   #^CLASS_BA_PB^#
 }
-// CLASS_BA_PB: Begin completions, 15 items
+// CLASS_BA_PB: Begin completions, 17 items
 
 class TestClass_BB : BaseB {
   #^CLASS_BB^#
@@ -367,17 +372,17 @@ class TestClass_BB : BaseB {
 class TestClass_BE : BaseE {
   #^CLASS_BE^#
 }
-// CLASS_BE: Begin completions, 8 items
+// CLASS_BE: Begin completions, 9 items
 
 class TestClass_BE_PA : BaseE, ProtocolA {
   #^CLASS_BE_PA^#
 }
-// CLASS_BE_PA: Begin completions, 13 items
+// CLASS_BE_PA: Begin completions, 15 items
 
 class TestClass_BE_PA_PE : BaseE, ProtocolA, ProtocolE {
   #^CLASS_BE_PA_PE^#
 }
-// CLASS_BE_PA_PE: Begin completions, 13 items
+// CLASS_BE_PA_PE: Begin completions, 15 items
 
 class TestClass_BE_PA_PE_Ext : BaseE {
   #^CLASS_BE_PA_PE_EXT1^#
@@ -389,7 +394,7 @@ extension TestClass_BE_PA_PE_Ext : ProtocolA, ProtocolE {
 class TestClass_PEI_PE : ProtocolEImpl, ProtocolE {
   #^CLASS_PEI_PE^#
 }
-// CLASS_PEI_PE: Begin completions, 4 items
+// CLASS_PEI_PE: Begin completions, 5 items
 
 protocol TestProtocol_PA : ProtocolA {
   #^PROTOCOL_PA^#
@@ -405,6 +410,7 @@ extension TestProtocol_PA {
 // PROTOCOL_PA_EXT-DAG: Decl[Constructor]/Super:            init(fromProtocolA: Int) {|}; name=init(fromProtocolA: Int)
 // PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc()
 // PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional()
+// PROTOCOL_PA_EXT-DAG: Decl[Subscript]/Super:              subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
 // PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRW: Int; name=protoAVarRW: Int
 // PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRO: Int; name=protoAVarRO: Int
 // PROTOCOL_PA_EXT: End completions
@@ -433,10 +439,11 @@ class OmitKW1 : ProtocolA {
   override#^OMIT_KEYWORD1^#
 }
 
-//OMIT_KEYWORD1:         Begin completions
+// OMIT_KEYWORD1:        Begin completions
 // OMIT_KEYWORD1-NOT:    Decl[Constructor]
-//OMIT_KEYWORD1-DAG:     Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc(){{$}}
-//OMIT_KEYWORD1-DAG:     Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional(){{$}}
+// OMIT_KEYWORD1-DAG:    Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc(){{$}}
+// OMIT_KEYWORD1-DAG:    Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional(){{$}}
+// OMIT_KEYWORD1-DAG:    Decl[Subscript]/Super:              subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
 // OMIT_KEYWORD1-DAG:    Decl[InstanceVar]/Super:            var protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD1-NOT:    Decl[Constructor]
 // OMIT_KEYWORD1: End completions
@@ -448,10 +455,12 @@ class OmitKW2 : ProtocolA {
 // OMIT_KEYWORD2:        Begin completions
 // OMIT_KEYWORD2-NOT:    Decl[InstanceVar]/Super:            var protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD2-NOT:    Decl[Constructor]
+// OMIT_KEYWORD2-NOT:    Decl[Subscript]
 // OMIT_KEYWORD2-DAG:    Decl[InstanceMethod]/Super:         protoAFunc() {|}; name=protoAFunc(){{$}}
 // OMIT_KEYWORD2-DAG:    Decl[InstanceMethod]/Super:         protoAFuncOptional() {|}; name=protoAFuncOptional(){{$}}
 // OMIT_KEYWORD2-NOT:    Decl[InstanceVar]/Super:            var protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD2-NOT:    Decl[Constructor]
+// OMIT_KEYWORD2-NOT:    Decl[Subscript]
 // OMIT_KEYWORD2: End completions
 
 class OmitKW3 : ProtocolA {
@@ -462,10 +471,12 @@ class OmitKW3 : ProtocolA {
 // FIXME: missing 'override'
 // OMIT_KEYWORD3-NOT:    Decl[InstanceVar]/Super:            var protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD3-NOT:    Decl[Constructor]
+// OMIT_KEYWORD2-NOT:    Decl[Subscript]
 // OMIT_KEYWORD3-DAG:    Decl[InstanceMethod]/Super:         protoAFunc() {|}; name=protoAFunc(){{$}}
 // OMIT_KEYWORD3-DAG:    Decl[InstanceMethod]/Super:         protoAFuncOptional() {|}; name=protoAFuncOptional(){{$}}
 // OMIT_KEYWORD3-NOT:    Decl[InstanceVar]/Super:            var protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD3-NOT:    Decl[Constructor]
+// OMIT_KEYWORD2-NOT:    Decl[Subscript]
 // OMIT_KEYWORD3: End completions
 
 class OmitKW4: ProtocolA {
@@ -480,6 +491,7 @@ class OmitKW4_let: ProtocolA {
 // OMIT_KEYWORD4:        Decl[InstanceVar]/Super: protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD4-NOT:    Decl[InstanceMethod]
 // OMIT_KEYWORD4-NOT:    Decl[Constructor]
+// OMIT_KEYWORD4-NOT:    Decl[Subscript]
 
 class OmitKW5: ProtocolA {
   override

--- a/test/IDE/complete_override_access_control_class.swift
+++ b/test/IDE/complete_override_access_control_class.swift
@@ -91,16 +91,18 @@ public class TestPublicAD : ProtocolAPrivate, ProtocolD {
   #^TEST_PUBLIC_AD^#
 }
 
-// TEST_PRIVATE_AD: Begin completions, 5 items
+// TEST_PRIVATE_AD: Begin completions, 6 items
 // TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func baseAFunc(x: TagPA) {|}; name=baseAFunc(x: TagPA)
+// TEST_PRIVATE_AD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
 // TEST_PRIVATE_AD-DAG: Decl[InstanceVar]/Super:            override var baseAVarRW: TagPA; name=baseAVarRW: TagPA
 // TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
 // TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
 // TEST_PRIVATE_AD-DAG: Decl[Constructor]/Super:            override init(fromBase: TagPA) {|}; name=init(fromBase: TagPA)
 // TEST_PRIVATE_AD: End completions
 
-// TEST_INTERNAL_AD: Begin completions, 5 items
+// TEST_INTERNAL_AD: Begin completions, 6 items
 // TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func baseAFunc(x: TagPA) {|}; name=baseAFunc(x: TagPA)
+// TEST_INTERNAL_AD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
 // TEST_INTERNAL_AD-DAG: Decl[InstanceVar]/Super:            override var baseAVarRW: TagPA; name=baseAVarRW: TagPA
 // TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
 // TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
@@ -126,24 +128,27 @@ public class TestPublicBD : BaseBInternal, ProtocolD {
   #^TEST_PUBLIC_BD^#
 }
 
-// TEST_PRIVATE_BD: Begin completions, 5 items
+// TEST_PRIVATE_BD: Begin completions, 6 items
 // TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x: TagPB)
+// TEST_PRIVATE_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(a: TagPB) -> Int
 // TEST_PRIVATE_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW: TagPB
 // TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
 // TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
 // TEST_PRIVATE_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB: TagPB)
 // TEST_PRIVATE_BD: End completions
 
-// TEST_INTERNAL_BD: Begin completions, 5 items
+// TEST_INTERNAL_BD: Begin completions, 6 items
 // TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x: TagPB)
+// TEST_INTERNAL_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(a: TagPB) -> Int
 // TEST_INTERNAL_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW: TagPB
 // TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
 // TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
 // TEST_INTERNAL_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB: TagPB)
 // TEST_INTERNAL_BD: End completions
 
-// TEST_PUBLIC_BD: Begin completions, 5 items
+// TEST_PUBLIC_BD: Begin completions, 6 items
 // TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x: TagPB)
+// TEST_PUBLIC_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(a: TagPB) -> Int
 // TEST_PUBLIC_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW: TagPB
 // TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         public override func colliding() {|}; name=colliding()
 // TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         public override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
@@ -164,24 +169,27 @@ public class TestPublicCD : BaseCPublic, ProtocolD {
   #^TEST_PUBLIC_CD^#
 }
 
-// TEST_PRIVATE_CD: Begin completions, 5 items
+// TEST_PRIVATE_CD: Begin completions, 6 items
 // TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x: TagPC)
+// TEST_PRIVATE_CD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPC) -> Int {|}; name=subscript(a: TagPC) -> Int
 // TEST_PRIVATE_CD-DAG: Decl[InstanceVar]/Super:            override var baseCVarRW: TagPC; name=baseCVarRW: TagPC
 // TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
 // TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
 // TEST_PRIVATE_CD-DAG: Decl[Constructor]/Super:            override init(fromBaseC: TagPC) {|}; name=init(fromBaseC: TagPC)
 // TEST_PRIVATE_CD: End completions
 
-// TEST_INTERNAL_CD: Begin completions, 5 items
+// TEST_INTERNAL_CD: Begin completions, 6 items
 // TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x: TagPC)
+// TEST_INTERNAL_CD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPC) -> Int {|}; name=subscript(a: TagPC) -> Int
 // TEST_INTERNAL_CD-DAG: Decl[InstanceVar]/Super:            override var baseCVarRW: TagPC; name=baseCVarRW: TagPC
 // TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
 // TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
 // TEST_INTERNAL_CD-DAG: Decl[Constructor]/Super:            override init(fromBaseC: TagPC) {|}; name=init(fromBaseC: TagPC)
 // TEST_INTERNAL_CD: End completions
 
-// TEST_PUBLIC_CD: Begin completions, 5 items
+// TEST_PUBLIC_CD: Begin completions, 6 items
 // TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x: TagPC)
+// TEST_PUBLIC_CD-DAG: Decl[Subscript]/Super:              public override subscript(a: TagPC) -> Int {|}; name=subscript(a: TagPC) -> Int
 // TEST_PUBLIC_CD-DAG: Decl[InstanceVar]/Super:            public override var baseCVarRW: TagPC; name=baseCVarRW: TagPC
 // TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func colliding() {|}; name=colliding()
 // TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)

--- a/test/IDE/complete_override_access_control_protocol.swift
+++ b/test/IDE/complete_override_access_control_protocol.swift
@@ -100,16 +100,19 @@ public class TestPublicABC : ProtocolAPrivate, ProtocolBInternal, ProtocolCPubli
   #^TEST_PUBLIC_ABC^#
 }
 
-// TEST_PRIVATE_ABC: Begin completions, 15 items
+// TEST_PRIVATE_ABC: Begin completions, 18 items
 // TEST_PRIVATE_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolA: TagPA) {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceMethod]/Super: func protoAFunc(x: TagPA) {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceMethod]/Super: func protoAFuncOptional(x: TagPA) {|}{{; name=.+$}}
+// TEST_PRIVATE_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPA) -> Int {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolB: TagPB) {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceMethod]/Super: func protoBFunc(x: TagPB) {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceMethod]/Super: func protoBFuncOptional(x: TagPB) {|}{{; name=.+$}}
+// TEST_PRIVATE_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPB) -> Int {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolC: TagPC) {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceMethod]/Super: func protoCFunc(x: TagPC) {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceMethod]/Super: func protoCFuncOptional(x: TagPC) {|}{{; name=.+$}}
+// TEST_PRIVATE_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPC) -> Int {|}{{; name=.+$}}
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceVar]/Super:    var protoAVarRW: TagPA
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceVar]/Super:    var protoAVarRO: TagPA
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceVar]/Super:    var protoBVarRW: TagPB
@@ -118,16 +121,19 @@ public class TestPublicABC : ProtocolAPrivate, ProtocolBInternal, ProtocolCPubli
 // TEST_PRIVATE_ABC-DAG: Decl[InstanceVar]/Super:    var protoCVarRO: TagPC
 // TEST_PRIVATE_ABC: End completions
 
-// TEST_INTERNAL_ABC: Begin completions, 15 items
+// TEST_INTERNAL_ABC: Begin completions, 18 items
 // TEST_INTERNAL_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolA: TagPA) {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceMethod]/Super: func protoAFunc(x: TagPA) {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceMethod]/Super: func protoAFuncOptional(x: TagPA) {|}{{; name=.+$}}
+// TEST_INTERNAL_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPA) -> Int {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolB: TagPB) {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceMethod]/Super: func protoBFunc(x: TagPB) {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceMethod]/Super: func protoBFuncOptional(x: TagPB) {|}{{; name=.+$}}
+// TEST_INTERNAL_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPB) -> Int {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolC: TagPC) {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceMethod]/Super: func protoCFunc(x: TagPC) {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceMethod]/Super: func protoCFuncOptional(x: TagPC) {|}{{; name=.+$}}
+// TEST_INTERNAL_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPC) -> Int {|}{{; name=.+$}}
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceVar]/Super:    var protoAVarRW: TagPA
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceVar]/Super:    var protoAVarRO: TagPA
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceVar]/Super:    var protoBVarRW: TagPB
@@ -136,16 +142,19 @@ public class TestPublicABC : ProtocolAPrivate, ProtocolBInternal, ProtocolCPubli
 // TEST_INTERNAL_ABC-DAG: Decl[InstanceVar]/Super:    var protoCVarRO: TagPC
 // TEST_INTERNAL_ABC: End completions
 
-// TEST_PUBLIC_ABC: Begin completions, 15 items
+// TEST_PUBLIC_ABC: Begin completions, 18 items
 // TEST_PUBLIC_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolA: TagPA) {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceMethod]/Super: func protoAFunc(x: TagPA) {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceMethod]/Super: func protoAFuncOptional(x: TagPA) {|}{{; name=.+$}}
+// TEST_PUBLIC_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPA) -> Int {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[Constructor]/Super:    required init(fromProtocolB: TagPB) {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceMethod]/Super: func protoBFunc(x: TagPB) {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceMethod]/Super: func protoBFuncOptional(x: TagPB) {|}{{; name=.+$}}
+// TEST_PUBLIC_ABC-DAG: Decl[Subscript]/Super:      subscript(a: TagPB) -> Int {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[Constructor]/Super:    public required init(fromProtocolC: TagPC) {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceMethod]/Super: public func protoCFunc(x: TagPC) {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceMethod]/Super: public func protoCFuncOptional(x: TagPC) {|}{{; name=.+$}}
+// TEST_PUBLIC_ABC-DAG: Decl[Subscript]/Super:      public subscript(a: TagPC) -> Int {|}{{; name=.+$}}
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceVar]/Super:    var protoAVarRW: TagPA
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceVar]/Super:    var protoAVarRO: TagPA
 // TEST_PUBLIC_ABC-DAG: Decl[InstanceVar]/Super:    var protoBVarRW: TagPB

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -124,3 +124,11 @@ struct AssocViaExtension {
 extension AssocViaExtension: WithAssocType {} // CHECK: [[@LINE]]:11 | struct/Swift | T | [[AssocViaExtensionT_USR]] | Impl,RelOver,RelCont | rel: 2
   // CHECK-NEXT: RelOver | type-alias/associated-type/Swift | T | [[WithAssocT_USR]]
   // CHECK-NEXT: RelCont | extension/ext-struct/Swift | AssocViaExtension
+
+func returnOpaqueResultType() -> some BaseConfFromBase & P1 & WithAssocType {} // CHECK: [[@LINE]]:6 | function/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF | Def | rel: 0
+// CHECK: [[@LINE-1]]:39 | class/Swift | BaseConfFromBase | s:14swift_ide_test012BaseConfFromD0C | Ref,RelCont | rel: 1
+// CHECK-NEXT:   RelCont | function/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF
+// CHECK: [[@LINE-3]]:58 | protocol/Swift | P1 | s:14swift_ide_test2P1P | Ref,RelCont | rel: 1
+// CHECK-NEXT:   RelCont | function/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF
+// CHECK: [[@LINE-5]]:63 | protocol/Swift | WithAssocType | s:14swift_ide_test13WithAssocTypeP | Ref,RelCont | rel: 1
+// CHECK-NEXT:   RelCont | function/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -562,4 +562,8 @@ func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSigna
 
 #assert(<BooleanLiteralExpr>true</BooleanLiteralExpr>)</PoundAssertStmt><PoundAssertStmt>
 #assert(<BooleanLiteralExpr>false</BooleanLiteralExpr>)</PoundAssertStmt><PoundAssertStmt>
-#assert(<BooleanLiteralExpr>true</BooleanLiteralExpr>, "hello world")</PoundAssertStmt>
+#assert(<BooleanLiteralExpr>true</BooleanLiteralExpr>, "hello world")</PoundAssertStmt><FunctionDecl><DeclModifier>
+
+public </DeclModifier>func anyFoo<FunctionSignature><ParameterClause>() </ParameterClause><ReturnClause>-> <SomeType>some <SimpleTypeIdentifier>Foo </SimpleTypeIdentifier></SomeType></ReturnClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><FunctionDecl><DeclModifier>
+public </DeclModifier>func qoo<FunctionSignature><ParameterClause>() </ParameterClause><ReturnClause>-> <SomeType>some <CompositionType><CompositionTypeElement><SimpleTypeIdentifier>O </SimpleTypeIdentifier>& </CompositionTypeElement><CompositionTypeElement><SimpleTypeIdentifier>O2 </SimpleTypeIdentifier></CompositionTypeElement></CompositionType></SomeType></ReturnClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><FunctionDecl>
+func zlop<FunctionSignature><ParameterClause>() </ParameterClause><ReturnClause>-> <SomeType>some <CompositionType><CompositionTypeElement><SimpleTypeIdentifier>C </SimpleTypeIdentifier>& </CompositionTypeElement><CompositionTypeElement><SimpleTypeIdentifier>AnyObject </SimpleTypeIdentifier>& </CompositionTypeElement><CompositionTypeElement><SimpleTypeIdentifier>P </SimpleTypeIdentifier></CompositionTypeElement></CompositionType></SomeType></ReturnClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -563,3 +563,7 @@ func foo() {}
 #assert(true)
 #assert(false)
 #assert(true, "hello world")
+
+public func anyFoo() -> some Foo {}
+public func qoo() -> some O & O2 {}
+func zlop() -> some C & AnyObject & P {}

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -191,6 +191,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
         addCompletion(custom);
       }
       break;
+    case CompletionKind::TypeDeclResultBeginning:
     case CompletionKind::TypeSimpleBeginning:
       if (custom.Contexts.contains(CustomCompletionInfo::Type)) {
         changed = true;
@@ -537,6 +538,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
   if (filterText.empty()) {
     bool hideLowPriority =
         options.hideLowPriority &&
+        completionKind != CompletionKind::TypeDeclResultBeginning &&
         completionKind != CompletionKind::TypeSimpleBeginning &&
         completionKind != CompletionKind::PostfixExpr;
     for (Completion *completion : completions) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -117,6 +117,7 @@ public:
   UID_FOR(Constructor)
   UID_FOR(Destructor)
   UID_FOR(Subscript)
+  UID_FOR(OpaqueType)
 #undef UID_FOR
 };
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -322,6 +322,8 @@ UID_KINDS = [
     KIND('DeclExtensionProtocol', 'source.lang.swift.decl.extension.protocol'),
     KIND('DeclAssociatedType', 'source.lang.swift.decl.associatedtype'),
     KIND('RefAssociatedType', 'source.lang.swift.ref.associatedtype'),
+    KIND('DeclOpaqueType', 'source.lang.swift.decl.opaquetype'),
+    KIND('RefOpaqueType', 'source.lang.swift.ref.opaquetype'),
     KIND('DeclTypeAlias', 'source.lang.swift.decl.typealias'),
     KIND('RefTypeAlias', 'source.lang.swift.ref.typealias'),
     KIND('DeclGenericTypeParam', 'source.lang.swift.decl.generic_type_param'),

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -232,6 +232,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'NamedAttributeStringArgument': 227,
     'DeclName': 228,
     'PoundAssertStmt': 229,
+    'SomeType': 230,
 }
 
 

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -81,6 +81,7 @@ TYPE_NODES = [
     Node('SomeType', kind='Type',
          children=[
              Child('SomeSpecifier', kind='IdentifierToken',
+                   classification='Keyword',
                    text_choices=['some']),
              Child('BaseType', kind='Type'),
          ]),

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -77,6 +77,14 @@ TYPE_NODES = [
              Child('QuestionMark', kind='PostfixQuestionMarkToken'),
          ]),
 
+    # some type -> some 'type'
+    Node('SomeType', kind='Type',
+         children=[
+             Child('SomeSpecifier', kind='IdentifierToken',
+                   text_choices=['some']),
+             Child('BaseType', kind='Type'),
+         ]),
+
     # implicitly-unwrapped-optional-type -> type '!'
     Node('ImplicitlyUnwrappedOptionalType', kind='Type',
          children=[


### PR DESCRIPTION
Initial implementation for SourceKit support for "opaque result types"

* libSyntax: Grammer and parser change
* Syntax highlighting, Cursor Info, Indexing
* Code completion for `some` keyword
* Conformance completion using opaque result types

rdar://problem/49997412