### PR TITLE
[stdlib] Fix return type of swift_{uint64,int64,float*}ToString

### DIFF
--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -161,7 +161,7 @@ internal func _float${bits}ToStringImpl(
   _ buffer: UnsafeMutablePointer<UTF8.CodeUnit>,
   _ bufferLength: UInt, _ value: Float${bits},
   _ debug: Bool
-) -> UInt
+) -> UInt64
 
 internal func _float${bits}ToString(
   _ value: Float${bits}, debug: Bool
@@ -185,7 +185,7 @@ internal func _int64ToStringImpl(
   _ buffer: UnsafeMutablePointer<UTF8.CodeUnit>,
   _ bufferLength: UInt, _ value: Int64,
   _ radix: Int64, _ uppercase: Bool
-) -> UInt
+) -> UInt64
 
 internal func _int64ToString(
   _ value: Int64, radix: Int64 = 10, uppercase: Bool = false
@@ -213,7 +213,7 @@ internal func _int64ToString(
 internal func _uint64ToStringImpl(
   _ buffer: UnsafeMutablePointer<UTF8.CodeUnit>,
   _ bufferLength: UInt, _ value: UInt64, _ radix: Int64, _ uppercase: Bool
-) -> UInt
+) -> UInt64
 
 public // @testable
 func _uint64ToString(


### PR DESCRIPTION
The return type of these functions are uint64_t in Stubs.cpp but UInt in the Swift code; this changes the Swift code to match the C++ return type.

Found when compiling the stdlib for WebAssembly, which requires that all return types match: UInt maps to i32 while uint64_t maps to i64, so functions calling these functions fail the validation.