### PR TITLE
[stdlib] fix return type of getNumRuntimeFunctionCounters

### DIFF
--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -108,7 +108,7 @@ struct _RuntimeFunctionCounters {
   public static let runtimeFunctionCountersOffsets =
     _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
   public static let numRuntimeFunctionCounters =
-    _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+    Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
   public static let runtimeFunctionNameToIndex: [String: Int] =
     getRuntimeFunctionNameToIndex()
 
@@ -121,7 +121,7 @@ struct _RuntimeFunctionCounters {
   public static func getRuntimeFunctionNames() -> [String] {
     let names = _RuntimeFunctionCounters._getRuntimeFunctionNames()
     let numRuntimeFunctionCounters =
-      _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+      Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
     var functionNames: [String] = []
     functionNames.reserveCapacity(numRuntimeFunctionCounters)
     for index in 0..<numRuntimeFunctionCounters {
@@ -140,7 +140,7 @@ struct _RuntimeFunctionCounters {
   /// Get the number of different runtime functions whose calls are being
   /// tracked.
   @_silgen_name("_swift_getNumRuntimeFunctionCounters")
-  public static func getNumRuntimeFunctionCounters() -> Int
+  public static func getNumRuntimeFunctionCounters() -> UInt64
 
   /// Dump all per-object runtime function counters.
   @_silgen_name("_swift_dumpObjectsRuntimeFunctionPointers")
@@ -166,7 +166,7 @@ struct _RuntimeFunctionCounters {
   internal static func getRuntimeFunctionNameToIndex() -> [String: Int] {
     let runtimeFunctionNames = _RuntimeFunctionCounters.getRuntimeFunctionNames()
     let numRuntimeFunctionCounters =
-      _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+      Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
     var runtimeFunctionNameToIndex: [String: Int] = [:]
     runtimeFunctionNameToIndex.reserveCapacity(numRuntimeFunctionCounters)
 

--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -100,7 +100,7 @@ func testCollectReferencesInsideObject() {
 func testRuntimeCounters() {
   print("TEST: APIs from _RuntimeFunctionCounters")
   let numRuntimeFunctionPointer =
-    _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+    Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
 
   print("Number of runtime function pointers: \(numRuntimeFunctionPointer)")
 


### PR DESCRIPTION
The return type of these functions are uint64_t in Stubs.cpp but UInt in the Swift code; this changes the Swift code to match the C++ return type.

Found when compiling the stdlib for WebAssembly, which requires that all return types match: UInt maps to i32 while uint64_t maps to i64, so functions calling these functions fail the validation.