### PR TITLE
Add availability information to the new Math function protocols

### DIFF
--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -515,7 +515,7 @@ public func %=(lhs: inout CGFloat, rhs: CGFloat) {
 
 %from SwiftMathFunctions import *
 
-extension CGFloat: Real {
+extension CGFloat: ElementaryFunctions {
 % for func in ElementaryFunctions + RealFunctions:
 
   @_alwaysEmitIntoClient
@@ -558,8 +558,6 @@ extension CGFloat: Real {
     return CGFloat(NativeType.logGamma(x.native))
   }
 
-  // We get this for free from an extension defined on Real, but we need it
-  // on the concrete type as well for back-deployment to older stdlib versions.
   @_alwaysEmitIntoClient
   public static func signGamma(_ x: CGFloat) -> FloatingPointSign {
     if x >= 0 { return .plus }

--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -553,12 +553,22 @@ extension CGFloat: Real {
     return CGFloat(NativeType.atan2(y: y.native, x: x.native))
   }
 
-#if !os(Windows)
   @_alwaysEmitIntoClient
   public static func logGamma(_ x: CGFloat) -> CGFloat {
     return CGFloat(NativeType.logGamma(x.native))
   }
-#endif
+
+  // We get this for free from an extension defined on Real, but we need it
+  // on the concrete type as well for back-deployment to older stdlib versions.
+  @_alwaysEmitIntoClient
+  public static func signGamma(_ x: CGFloat) -> FloatingPointSign {
+    if x >= 0 { return .plus }
+    let trunc = x.rounded(.towardZero)
+    if x == trunc { return .plus }
+    let halfTrunc = trunc/2
+    if halfTrunc == halfTrunc.rounded(.towardZero) { return .minus }
+    return .plus
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -178,6 +178,19 @@ extension ${Self}: Real {
   public static func logGamma(_ x: ${Self}) -> ${Self} {
     return _swift_stdlib_lgamma${type.cFuncSuffix}(x)
   }
+
+  // We get this for free from the extension above, but we also need it here
+  // to facilitate back-deployment to standard library versions from before it
+  // was introduced.
+  @_alwaysEmitIntoClient
+  public static func signGamma(_ x: ${Self}) -> FloatingPointSign {
+    if x >= 0 { return .plus }
+    let trunc = x.rounded(.towardZero)
+    if x == trunc { return .plus }
+    let halfTrunc = trunc/2
+    if halfTrunc == halfTrunc.rounded(.towardZero) { return .minus }
+    return .plus
+  }
 #endif
 }
 % if type.bits == 80:

--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -34,6 +34,7 @@ import SwiftShims
 /// ElementaryFunctions and FloatingPoint.
 ///
 /// [elfn]: http://en.wikipedia.org/wiki/Elementary_function
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public protocol ElementaryFunctions {
 
 %for func in ElementaryFunctions:
@@ -59,14 +60,8 @@ public protocol ElementaryFunctions {
   static func root(_ x: Self, _ n: Int) -> Self
 }
 
-/// A type that models the real numbers.
-///
-/// Conformance to this protocol means that all the FloatingPoint operations
-/// are available, as well as the ElementaryFunctions, plus the following
-/// additional math functions: atan2, erf, erc, hypot, tgamma.
-///
-/// logGamma and signGamma are also available on non-Windows platforms.
-public protocol Real: ElementaryFunctions, FloatingPoint {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public protocol RealFunctions: ElementaryFunctions {
 %for func in RealFunctions:
 
   ${func.comment}
@@ -93,6 +88,17 @@ public protocol Real: ElementaryFunctions, FloatingPoint {
 #endif
 }
 
+/// A type that models the real numbers.
+///
+/// Conformance to this protocol means that all the FloatingPoint operations
+/// are available, as well as the ElementaryFunctions, plus the following
+/// additional math functions: atan2, erf, erc, hypot, tgamma.
+///
+/// logGamma and signGamma are also available on non-Windows platforms.
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public protocol Real: RealFunctions, FloatingPoint { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension Real {
 #if !os(Windows)
   //  lgamma is not available on Windows; no lgamma means signGamma
@@ -177,4 +183,89 @@ extension ${Self}: Real {
 % if type.bits == 80:
 #endif
 % end
+%end
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension SIMD where Scalar: ElementaryFunctions {
+% for func in ElementaryFunctions:
+
+  @_alwaysEmitIntoClient
+  public static func ${func.decl("Self")} {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.${func.swiftName}(${func.params(suffix="[i]")})
+    }
+    return r
+  }
+% end
+
+  @_alwaysEmitIntoClient
+  public static func pow(_ x: Self, _ y: Self) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.pow(x[i], y[i])
+    }
+    return r
+  }
+
+  @_alwaysEmitIntoClient
+  public static func pow(_ x: Self, _ n: Int) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.pow(x[i], n)
+    }
+    return r
+  }
+
+  @_alwaysEmitIntoClient
+  public static func root(_ x: Self, _ n: Int) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.root(x[i], n)
+    }
+    return r
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension SIMD where Scalar: RealFunctions {
+% for func in RealFunctions:
+
+  @_alwaysEmitIntoClient
+  public static func ${func.decl("Self")} {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.${func.swiftName}(${func.params(suffix="[i]")})
+    }
+    return r
+  }
+% end
+
+  @_alwaysEmitIntoClient
+  public static func atan2(y: Self, x: Self) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.atan2(y: y[i], x: x[i])
+    }
+    return r
+  }
+
+  #if !os(Windows)
+  @_alwaysEmitIntoClient
+  public static func logGamma(_ x: Self) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.logGamma(x[i])
+    }
+    return r
+  }
+  #endif
+}
+
+%for n in [2,3,4,8,16,32,64]:
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension SIMD${n}: ElementaryFunctions where Scalar: ElementaryFunctions { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension SIMD${n}: RealFunctions where Scalar: RealFunctions { }
 %end

--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -60,82 +60,12 @@ public protocol ElementaryFunctions {
   static func root(_ x: Self, _ n: Int) -> Self
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-public protocol RealFunctions: ElementaryFunctions {
-%for func in RealFunctions:
-
-  ${func.comment}
-  static func ${func.decl("Self")}
-%end
-
-  /// `atan(y/x)` with quadrant fixup.
-  ///
-  /// There is an infinite family of angles whose tangent is `y/x`. `atan2`
-  /// selects the representative that is the angle between the vector `(x, y)`
-  /// and the real axis in the range [-π, π].
-  static func atan2(y: Self, x: Self) -> Self
-
-#if !os(Windows)
-  //  lgamma is not available on Windows.
-  //  TODO: provide an implementation of lgamma with the stdlib to support
-  //  Windows so we can vend a uniform interface.
-
-  /// `log(gamma(x))` computed without undue overflow.
-  ///
-  /// `log(abs(gamma(x)))` is returned. To get the sign of `gamma(x)` cheaply,
-  /// use `signGamma(x)`.
-  static func logGamma(_ x: Self) -> Self
-#endif
-}
-
-/// A type that models the real numbers.
-///
-/// Conformance to this protocol means that all the FloatingPoint operations
-/// are available, as well as the ElementaryFunctions, plus the following
-/// additional math functions: atan2, erf, erc, hypot, tgamma.
-///
-/// logGamma and signGamma are also available on non-Windows platforms.
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-public protocol Real: RealFunctions, FloatingPoint { }
-
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-extension Real {
-#if !os(Windows)
-  //  lgamma is not available on Windows; no lgamma means signGamma
-  //  is basically useless, so don't bother exposing it.
-
-  /// The sign of `gamma(x)`.
-  ///
-  /// This function is typically used in conjunction with `logGamma(x)`, which
-  /// computes `log(abs(gamma(x)))`, to recover the sign information that is
-  /// lost to the absolute value.
-  ///
-  /// `gamma(x)` has a simple pole at each non-positive integer and an
-  /// essential singularity at infinity; we arbitrarily choose to return
-  /// `.plus` for the sign in those cases. For all other values, `signGamma(x)`
-  /// is `.plus` if `x >= 0` or `trunc(x)` is odd, and `.minus` otherwise.
-  @_alwaysEmitIntoClient
-  public static func signGamma(_ x: Self) -> FloatingPointSign {
-    if x >= 0 { return .plus }
-    let trunc = x.rounded(.towardZero)
-    // Treat poles as gamma(x) == +inf. This is arbitrary, but we need to
-    // pick one sign or the other.
-    if x == trunc { return .plus }
-    // Result is .minus if trunc is even, .plus otherwise. To figure out if
-    // trunc is even or odd, check if trunc/2 is an integer.
-    let halfTrunc = trunc/2
-    if halfTrunc == halfTrunc.rounded(.towardZero) { return .minus }
-    return .plus
-  }
-#endif
-}
-
 %for type in all_floating_point_types():
 % if type.bits == 80:
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
 % end
 % Self = type.stdlib_name
-extension ${Self}: Real {
+extension ${Self}: ElementaryFunctions {
 % for func in ElementaryFunctions + RealFunctions:
 
   @_alwaysEmitIntoClient
@@ -179,9 +109,6 @@ extension ${Self}: Real {
     return _swift_stdlib_lgamma${type.cFuncSuffix}(x)
   }
 
-  // We get this for free from the extension above, but we also need it here
-  // to facilitate back-deployment to standard library versions from before it
-  // was introduced.
   @_alwaysEmitIntoClient
   public static func signGamma(_ x: ${Self}) -> FloatingPointSign {
     if x >= 0 { return .plus }
@@ -240,45 +167,7 @@ extension SIMD where Scalar: ElementaryFunctions {
   }
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-extension SIMD where Scalar: RealFunctions {
-% for func in RealFunctions:
-
-  @_alwaysEmitIntoClient
-  public static func ${func.decl("Self")} {
-    var r = Self()
-    for i in r.indices {
-      r[i] = Scalar.${func.swiftName}(${func.params(suffix="[i]")})
-    }
-    return r
-  }
-% end
-
-  @_alwaysEmitIntoClient
-  public static func atan2(y: Self, x: Self) -> Self {
-    var r = Self()
-    for i in r.indices {
-      r[i] = Scalar.atan2(y: y[i], x: x[i])
-    }
-    return r
-  }
-
-  #if !os(Windows)
-  @_alwaysEmitIntoClient
-  public static func logGamma(_ x: Self) -> Self {
-    var r = Self()
-    for i in r.indices {
-      r[i] = Scalar.logGamma(x[i])
-    }
-    return r
-  }
-  #endif
-}
-
 %for n in [2,3,4,8,16,32,64]:
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension SIMD${n}: ElementaryFunctions where Scalar: ElementaryFunctions { }
-
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-extension SIMD${n}: RealFunctions where Scalar: RealFunctions { }
 %end

--- a/test/stdlib/MathFunctions.swift.gyb
+++ b/test/stdlib/MathFunctions.swift.gyb
@@ -79,22 +79,6 @@ internal extension ElementaryFunctions where Self: BinaryFloatingPoint {
   }
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-internal extension Real where Self: BinaryFloatingPoint {
-  static func realFunctionTests() {
-    expectEqualWithTolerance(0.54041950027058415544357836460859991, Self.atan2(y: 0.375, x: 0.625))
-    expectEqualWithTolerance(0.72886898685566255885926910969319788, Self.hypot(0.375, 0.625))
-    expectEqualWithTolerance(0.4041169094348222983238250859191217675, Self.erf(0.375))
-    expectEqualWithTolerance(0.5958830905651777016761749140808782324, Self.erfc(0.375))
-    expectEqualWithTolerance(2.3704361844166009086464735041766525098, Self.gamma(0.375))
-#if !os(Windows)
-    expectEqualWithTolerance( -0.11775527074107877445136203331798850, Self.logGamma(1.375), ulps: 16)
-    expectEqual(.plus,  Self.signGamma(1.375))
-    expectEqual(.minus, Self.signGamma(-2.375))
-#endif
-  }
-}
-
 %for T in ['Float', 'Double', 'CGFloat', 'Float80']:
 % if T == 'Float80':
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
@@ -106,7 +90,6 @@ internal extension Real where Self: BinaryFloatingPoint {
 MathTests.test("${T}") {
   if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
     ${T}.elementaryFunctionTests()
-    ${T}.realFunctionTests()
   }
 }
 

--- a/test/stdlib/MathFunctions.swift.gyb
+++ b/test/stdlib/MathFunctions.swift.gyb
@@ -45,6 +45,7 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
 
 %from SwiftMathFunctions import *
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 internal extension ElementaryFunctions where Self: BinaryFloatingPoint {
   static func elementaryFunctionTests() {
     /* Default tolerance is 3 ulps unless specified otherwise. It's OK to relax
@@ -78,6 +79,7 @@ internal extension ElementaryFunctions where Self: BinaryFloatingPoint {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 internal extension Real where Self: BinaryFloatingPoint {
   static func realFunctionTests() {
     expectEqualWithTolerance(0.54041950027058415544357836460859991, Self.atan2(y: 0.375, x: 0.625))
@@ -102,8 +104,10 @@ internal extension Real where Self: BinaryFloatingPoint {
 % end
 
 MathTests.test("${T}") {
-  ${T}.elementaryFunctionTests()
-  ${T}.realFunctionTests()
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    ${T}.elementaryFunctionTests()
+    ${T}.realFunctionTests()
+  }
 }
 
 % if T in ['CGFloat', 'Float80']:

--- a/utils/SwiftMathFunctions.py
+++ b/utils/SwiftMathFunctions.py
@@ -18,7 +18,7 @@ class SwiftMathFunction(object):
         return self.swiftName + "(" + self.params("_ ", ": " + type) + \
             ") -> " + type
 
-    def free_decl(self, constraint="T: ElementaryFunctions"):
+    def freeDecl(self, constraint):
         return self.swiftName + "<T>(" + self.params("_ ", ": T") + \
             ") -> T where " + constraint
 


### PR DESCRIPTION
The protocols ElementaryFunctions, RealFunctions, and Real are new in Swift 5.1 and accordingly need to have availability attached to them for platforms that are ABI-stable. The actual implementation hooks (static functions) are unconditionally defined on scalar types and marked @_alwaysEmitIntoClient, so they are available even when targeting older library versions, but the protocols themselves, and anything defined in terms of them (the global functions and the SIMD extensions) is only available when targeting library versions that have the new protocols.

This change also restores the statics on SIMD types, when targeting supported standard library versions.

<rdar://problem/50060408>