### PR TITLE
[ModuleInterface] Fix indentation for private(set) vars

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1726,6 +1726,10 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
 
   auto impl = ASD->getImplInfo();
 
+  // AbstractAccessors is suppressed by FunctionDefinitions.
+  bool PrintAbstract =
+    Options.AbstractAccessors && !Options.FunctionDefinitions;
+
   // Don't print accessors for trivially stored properties...
   if (impl.isSimpleStored()) {
     // ...unless we're printing for SIL, which expects a { get set? } on
@@ -1736,22 +1740,23 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
     // ...or you're private/internal(set), at which point we'll print
     //    @_hasStorage var x: T { get }
     else if (ASD->isSettable(nullptr) && hasLessAccessibleSetter(ASD)) {
-      Printer << " {";
-      {
-        IndentRAII indentMore(*this);
+      if (PrintAbstract) {
+        Printer << " { get }";
+      } else {
+        Printer << " {";
+        {
+          IndentRAII indentMore(*this);
+          indent();
+          Printer.printNewline();
+          Printer << "get";
+        }
         indent();
         Printer.printNewline();
-        Printer << "get";
-        Printer.printNewline();
+        Printer << "}";
       }
-      Printer << "}";
     }
     return;
   }
-
-  // AbstractAccessors is suppressed by FunctionDefinitions.
-  bool PrintAbstract =
-    Options.AbstractAccessors && !Options.FunctionDefinitions;
 
   // We sometimes want to print the accessors abstractly
   // instead of listing out how they're actually implemented.

--- a/test/ModuleInterface/stored-properties.swift
+++ b/test/ModuleInterface/stored-properties.swift
@@ -35,18 +35,18 @@ public struct HasStoredProperties {
   public var simpleStoredMutable: Int
 
   // CHECK: @_hasStorage public var storedWithObservers: Swift.Bool {
-  // RESILIENT: {{^}}  public var storedWithObservers: Swift.Bool {
-  // COMMON-NEXT: get
-  // COMMON-NEXT: set
-  // COMMON-NEXT: }
+  // RESILIENT:   {{^}}  public var storedWithObservers: Swift.Bool {
+  // COMMON-NEXT: {{^}}    get
+  // COMMON-NEXT: {{^}}    set
+  // COMMON-NEXT: {{^}}  }
   public var storedWithObservers: Bool {
     willSet {}
   }
 
   // CHECK: @_hasStorage public var storedPrivateSet: Swift.Int {
-  // RESILIENT: {{^}}  public var storedPrivateSet: Swift.Int {
-  // COMMON-NEXT: get
-  // COMMON-NEXT: }
+  // RESILIENT:   {{^}}  public var storedPrivateSet: Swift.Int {
+  // COMMON-NEXT: {{^}}    get
+  // COMMON-NEXT: {{^}}  }
   public private(set) var storedPrivateSet: Int
 
   // CHECK: private var privateVar: Swift.Bool
@@ -54,10 +54,10 @@ public struct HasStoredProperties {
   private var privateVar: Bool
 
   // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: Swift.Int {
-  // RESILIENT: {{^}}  public var storedWithObserversInitialValue: Swift.Int {
-  // COMMON-NEXT: get
-  // COMMON-NEXT: set
-  // COMMON-NEXT: }
+  // RESILIENT:   {{^}}  public var storedWithObserversInitialValue: Swift.Int {
+  // COMMON-NEXT: {{^}}    get
+  // COMMON-NEXT: {{^}}    set
+  // COMMON-NEXT: {{^}}  }
   public var storedWithObserversInitialValue: Int = 0 {
     didSet {}
   }
@@ -101,10 +101,10 @@ public struct HasStoredPropertiesFixedLayout {
   // COMMON: public var simpleStoredMutable: StoredProperties.BagOfVariables
   public var simpleStoredMutable: BagOfVariables
 
-  // COMMON: @_hasStorage public var storedWithObservers: StoredProperties.BagOfVariables {
-  // COMMON-NEXT: get
-  // COMMON-NEXT: set
-  // COMMON-NEXT: }
+  // COMMON:      {{^}} @_hasStorage public var storedWithObservers: StoredProperties.BagOfVariables {
+  // COMMON-NEXT: {{^}}    get
+  // COMMON-NEXT: {{^}}    set
+  // COMMON-NEXT: {{^}} }
   public var storedWithObservers: BagOfVariables {
     didSet {}
   }


### PR DESCRIPTION
Previously, we would print

```swift
public private(set) var x: Int
```

as

```swift
@_hasStorage public var x: Swift.Int {
  get
  }
```

which is a) incorrectly indented, and b) shouldn't have newlines when AbstractAccessors is enabled.

Fixes [SR-9816](https://bugs.swift.org/browse/SR-9816)