### PR TITLE
[TF] Update README to specify user to download Bazel v0.22.0 and java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ You will also need [CMake](https://cmake.org), [Ninja](https://ninja-build.org),
 ```shell
 brew install cmake ninja
 brew cask install caskroom/versions/java8 # required for Bazel
-brew install bazel # required for TensorFlow support
 ```
 
-Instructions for installing CMake, Ninja, and Bazel directly can be found [below](#build-dependencies).
+Additionally, [Bazel](https://www.bazel.build) v0.22.0 is required to build with TensorFlow support. Instructions to download Bazel directly can be found [below](###bazel). You can find instructions for installing CMake, and Ninja directly [below](#build-dependencies) as well.
 
 #### Linux
 
@@ -50,7 +49,7 @@ For Ubuntu, you'll need the following development dependencies:
 
     sudo apt-get install git cmake ninja-build clang python uuid-dev libicu-dev icu-devtools libbsd-dev libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config libblocksruntime-dev libcurl4-openssl-dev systemtap-sdt-dev tzdata rsync
 
-Additionally, [Bazel](https://www.bazel.build) is required to build with TensorFlow support. Ubuntu installation instructions are [here](https://docs.bazel.build/versions/master/install-ubuntu.html).
+Additionally, [Bazel](https://www.bazel.build) v0.22.0 is required to build with TensorFlow support. Ubuntu installation instructions can be found [below](###bazel).
 
 **Note:** LLDB currently requires at least `swig-1.3.40` but will successfully build
 with version 2 shipped with Ubuntu.
@@ -341,3 +340,4 @@ next to the other projects and it will be bootstrapped automatically:
 The Bazel website has detailed installation instructions for
 [macOS](https://docs.bazel.build/versions/master/install-os-x.html) and
 [Ubuntu](https://docs.bazel.build/versions/master/install-ubuntu.html).
+When picking the version to download in step 2, select v0.22.0 which can be found in the release notes [here](https://github.com/bazelbuild/bazel/releases/tag/0.22.0).


### PR DESCRIPTION
PR stems from the conversation found with @rxwei in the mailing list [here](https://groups.google.com/a/tensorflow.org/forum/#!topic/swift/OrOtoxZTkds). Three things to note:

1. I only have a macOS system so I cannot verify this on Linux. However, instructions are simple enough that this shouldn't be a problem.
2. I'm still unsure what to do with `java8`. After running:
```bash
brew update 
brew tap caskroom/versions 
brew search java
``` 
`java8` does not show up likely due to [this PR](https://github.com/Homebrew/brew/pull/6035) (or something buggy on my computer...more on this in point 3.). I can add manual installation instructions instead of `brew cask install caskroom/versions/java8` depending on what everyone thinks (I manually installed it).

3. Unsure if these changes are related or if this is some other problem, but I'm having issues building swift using the `utils/build-script --enable-tensorflow --release-debuginfo` command as I get the following error:

```
clang: error: no such file or directory: 'Projects/swift-workspace/build/Ninja-RelWithDebInfoAssert/llvm-macosx-x86_64/lib/Transforms/Hello/LLVMHello.exports'
```
However, I can't build swift from master either (instead it can't find the file `Ninja-RelWithDebInfoAssert/llvm-macosx-x86_64/tools/clang/tools/driver/Info.plist`) so this is likely some bug on my end unrelated to Bazel, `java8`, or the `tensorflow` branch. So I'll try to debug it myself. If I continue to have issues I will ping for help in the mailing list.