### PR TITLE
[stdlib] Use String’s underlying UTF-8 view for Float parsing

### DIFF
--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -126,7 +126,7 @@ extension ${Self} : LosslessStringConvertible {
   ///   is `nil`.
   @inlinable // FIXME(sil-serialize-all)
   public init?<S: StringProtocol>(_ text: S) {
-    let u16 = text.utf16
+    let u8 = text.utf8
 
     let (result, n) : (${Self}, Int) = text.withCString { chars in
       var result: ${Self} = 0
@@ -136,8 +136,12 @@ extension ${Self} : LosslessStringConvertible {
       return (result, endPtr == nil ? 0 : endPtr! - chars)
     }
 
-    if n == 0 || n != u16.count
-    || u16.contains(where: { $0 > 127 || _isspace_clocale($0) }) {
+    if n == 0 || n != u8.count
+    || u8.contains(where: { codeUnit in
+        // Check if the code unit is either non-ASCII or if isspace(codeUnit)
+        // would return nonzero when the current locale is the C locale.
+        codeUnit > 127 || "\t\n\u{b}\u{c}\r ".utf8.contains(codeUnit) 
+      }) {
       return nil
     }
     self = result


### PR DESCRIPTION
Swift `String`s are natively UTF8 as of Swift 5. Use the underlying UTF8 view for parsing floats to avoid a performance overhead from generating the UTF16 view.

This only requires type (i.e. no logic) changes since non-ASCII characters (values above 127) cannot be parsed.

cc @milseman and @airspeedswift.

Resolves [SR-10095](https://bugs.swift.org/browse/SR-10095).