### PR TITLE
Ensure only strings are passed to subprocess

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -83,6 +83,8 @@ def call(command, stderr=None, env=None, dry_run=None, echo=True):
         _env = dict(os.environ)
         _env.update(env)
     try:
+        # Ensure all items in the command array are strings, not unicode not byte
+        command = [c.encode('ascii') for c in command]
         subprocess.check_call(command, env=_env, stderr=stderr)
     except subprocess.CalledProcessError as e:
         diagnostics.fatal(


### PR DESCRIPTION
Added one line on 87.

This should go through the command array that is being passed and ensure all items are ascii encoded before calling check_call.
Should completely stop any unicode or byte code strings from leaking through.

I don't believe there is a bug request, but a user on the forum was attempting to build:
https://forums.swift.org/t/a-compiler-that-builds-a-very-unorthodox-idea/23453/4
The error looks like a unicode string was being passed to subprocess, best practice would be to ensure that everything getting sent to subprocess is in the correct encoding.
