### PR TITLE
[5.1] Undo "Disable TSan in coroutine functions" (0ca3f79).

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1222,10 +1222,7 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
     auto declContext = f->getDeclContext();
-    if (f->getLoweredFunctionType()->isCoroutine()) {
-      // Disable TSan in coroutines; the instrumentation currently interferes
-      // with coroutine structural invariants.
-    } else if (declContext && isa<DestructorDecl>(declContext)) {
+    if (declContext && isa<DestructorDecl>(declContext)) {
       // Do not report races in deinit and anything called from it
       // because TSan does not observe synchronization between retain
       // count dropping to '0' and the object deinitialization.

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -1,6 +1,6 @@
 // This test verifies that we add the function attributes used by TSan.
 
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
+// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
 
 // TSan is currently only supported on 64 bit mac and simulators.
 // (We do not test the simulators here.)
@@ -22,5 +22,5 @@ public var x: Int {
 // TSAN-SAME: }
 
 // TSAN: attributes [[COROUTINE_ATTRS]] =
-// TSAN-NOT: sanitize_address
+// TSAN-SAME: sanitize_thread
 // TSAN-SAME: }


### PR DESCRIPTION
Cherry-pick of <https://github.com/apple/swift/pull/23952> to 5.1.