### PR TITLE
Factor out the pre-registered MemoryBuffer functionality

### DIFF
--- a/include/swift/ASTSectionImporter/ASTSectionImporter.h
+++ b/include/swift/ASTSectionImporter/ASTSectionImporter.h
@@ -21,18 +21,16 @@
 #include <string>
 
 namespace swift {
-  class SerializedModuleLoader;
+  class MemoryBufferSerializedModuleLoader;
 
-  /// Provided a memory buffer with an entire Mach-O __apple_ast
-  /// section, this function makes memory buffer copies of all swift
-  /// modules found in it and registers them using
-  /// registerMemoryBuffer() so they can be found by loadModule(). The
-  /// access path of all modules found in the section is appended to
-  /// the vector foundModules.
+  /// Provided a memory buffer with an entire Mach-O __swift_ast section, this
+  /// function makes memory buffer copies of all swift modules found in it and
+  /// registers them using registerMemoryBuffer() so they can be found by
+  /// loadModule(). The access path of all modules found in the section is
+  /// appended to the vector foundModules.
   /// \return true if successful.
-  bool parseASTSection(SerializedModuleLoader* SML, StringRef Data,
+  bool parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
+                       StringRef Data,
                        SmallVectorImpl<std::string> &foundModules);
-
-
 }
 #endif

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -104,6 +104,10 @@ namespace swift {
     /// Enable features useful for running in the debugger.
     bool DebuggerSupport = false;
 
+    /// Enable the MemoryBufferSerializedModuleImporter.
+    /// Only used by lldb-moduleimport-test.
+    bool EnableMemoryBufferImporter = false;
+
     /// Enable the DWARFImporter. Only used by lldb-moduleimport-test.
     bool EnableDWARFImporter = false;
     

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -52,6 +52,7 @@
 namespace swift {
 
 class SerializedModuleLoader;
+class MemoryBufferSerializedModuleLoader;
 class SILModule;
 
 /// The abstract configuration of the compiler, including:
@@ -372,6 +373,7 @@ class CompilerInstance {
 
   ModuleDecl *MainModule = nullptr;
   SerializedModuleLoader *SML = nullptr;
+  MemoryBufferSerializedModuleLoader *MemoryBufferLoader = nullptr;
 
   /// Contains buffer IDs for input source code files.
   std::vector<unsigned> InputSourceCodeBufferIDs;
@@ -465,7 +467,10 @@ public:
 
   ModuleDecl *getMainModule();
 
-  SerializedModuleLoader *getSerializedModuleLoader() const { return SML; }
+  MemoryBufferSerializedModuleLoader *
+  getMemoryBufferSerializedModuleLoader() const {
+    return MemoryBufferLoader;
+  }
 
   ArrayRef<unsigned> getInputBufferIDs() const {
     return InputSourceCodeBufferIDs;

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -24,7 +24,8 @@
 
 using namespace swift;
 
-bool swift::parseASTSection(SerializedModuleLoader *SML, StringRef buf,
+bool swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
+                            StringRef buf,
                             SmallVectorImpl<std::string> &foundModules) {
   if (!serialization::isSerializedAST(buf))
     return false;
@@ -44,7 +45,7 @@ bool swift::parseASTSection(SerializedModuleLoader *SML, StringRef buf,
           llvm::MemoryBuffer::getMemBuffer(moduleData, info.name, false));
 
         // Register the memory buffer.
-        SML->registerMemoryBuffer(info.name, std::move(bitstream));
+        Loader.registerMemoryBuffer(info.name, std::move(bitstream));
         foundModules.push_back(info.name);
       }
     } else {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -312,6 +312,13 @@ bool CompilerInstance::setUpModuleLoaders() {
     }
   }
 
+  if (Invocation.getLangOptions().EnableMemoryBufferImporter) {
+    auto MemoryBufferLoader = MemoryBufferSerializedModuleLoader::create(
+        *Context, getDependencyTracker());
+    this->MemoryBufferLoader = MemoryBufferLoader.get();
+    Context->addModuleLoader(std::move(MemoryBufferLoader));
+  }
+
   std::unique_ptr<SerializedModuleLoader> SML =
     SerializedModuleLoader::create(*Context, getDependencyTracker(), MLM);
   this->SML = SML.get();
@@ -1064,6 +1071,7 @@ void CompilerInstance::freeASTContext() {
   Context.reset();
   MainModule = nullptr;
   SML = nullptr;
+  MemoryBufferLoader = nullptr;
   PrimaryBufferIDs.clear();
   PrimarySourceFiles.clear();
 }

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -279,6 +279,7 @@ int main(int argc, char **argv) {
 
   Invocation.setModuleName("lldbtest");
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
+  Invocation.getLangOptions().EnableMemoryBufferImporter = true;
   Invocation.getLangOptions().EnableDWARFImporter = EnableDWARFImporter;
 
   if (!ResourceDir.empty()) {
@@ -289,7 +290,7 @@ int main(int argc, char **argv) {
     return 1;
 
   for (auto &Module : Modules)
-    if (!parseASTSection(CI.getSerializedModuleLoader(),
+    if (!parseASTSection(*CI.getMemoryBufferSerializedModuleLoader(),
                          StringRef(Module.first, Module.second), modules))
       return 1;
 


### PR DESCRIPTION
form SerializedModuleLoader into its own ModuleLoader class. (NFC-ish)

This gives better control over the order in which the various module
load mechanisms are applied.

(cherry picked from commit bc1e9003f6d6cb436bd93463da3bf591ec0eb159)


