### PR TITLE
[5.1][ConstraintSystem] Detect and fix use of method references in key path

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4579,20 +4579,13 @@ namespace {
                                   ConstraintLocator *locator) {
       if (overload.choice.isDecl()) {
         auto property = overload.choice.getDecl();
-
         // Key paths can only refer to properties currently.
-        if (!isa<VarDecl>(property)) {
-          cs.TC.diagnose(componentLoc, diag::expr_keypath_not_property,
-                         property->getDescriptiveKind(),
-                         property->getFullName());
-        } else {
-          // Key paths don't work with mutating-get properties.
-          auto varDecl = cast<VarDecl>(property);
-          assert(!varDecl->isGetterMutating());
-          // Key paths don't currently support static members.
-          // There is a fix which diagnoses such situation already.
-          assert(!varDecl->isStatic());
-        }
+        auto varDecl = cast<VarDecl>(property);
+        // Key paths don't work with mutating-get properties.
+        assert(!varDecl->isGetterMutating());
+        // Key paths don't currently support static members.
+        // There is a fix which diagnoses such situation already.
+        assert(!varDecl->isStatic());
 
         cs.TC.requestMemberLayout(property);
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2482,3 +2482,9 @@ bool InvalidMemberWithMutatingGetterInKeyPath::diagnoseAsError() {
   emitDiagnostic(getLoc(), diag::expr_keypath_mutating_getter, getName());
   return true;
 }
+
+bool InvalidMethodRefInKeyPath::diagnoseAsError() {
+  emitDiagnostic(getLoc(), diag::expr_keypath_not_property, getKind(),
+                 getName());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1512,6 +1512,13 @@ bool MissingCallFailure::diagnoseAsError() {
   if (auto *FVE = dyn_cast<ForceValueExpr>(baseExpr))
     baseExpr = FVE->getSubExpr();
 
+  // Calls are not yet supported by key path, but it
+  // is useful to record this fix to diagnose chaining
+  // where one of the key path components is a method
+  // reference.
+  if (isa<KeyPathExpr>(baseExpr))
+    return false;
+
   if (auto *DRE = dyn_cast<DeclRefExpr>(baseExpr)) {
     emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function,
                    DRE->getDecl()->getBaseName().getIdentifier())

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1042,6 +1042,8 @@ public:
     assert(locator->isForKeyPathComponent());
   }
 
+  DescriptiveDeclKind getKind() const { return Member->getDescriptiveKind(); }
+
   DeclName getName() const { return Member->getFullName(); }
 
   bool diagnoseAsError() override = 0;
@@ -1094,6 +1096,29 @@ public:
                                            ValueDecl *member,
                                            ConstraintLocator *locator)
       : InvalidMemberRefInKeyPath(root, cs, member, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
+/// Diagnose an attempt to reference a method as a key path component
+/// e.g.
+///
+/// ```swift
+/// struct S {
+///   func foo() -> Int { return 42 }
+///   static func bar() -> Int { return 0 }
+/// }
+///
+/// _ = \S.foo
+/// _ = \S.Type.bar
+/// ```
+class InvalidMethodRefInKeyPath final : public InvalidMemberRefInKeyPath {
+public:
+  InvalidMethodRefInKeyPath(Expr *root, ConstraintSystem &cs, ValueDecl *method,
+                            ConstraintLocator *locator)
+      : InvalidMemberRefInKeyPath(root, cs, method, locator) {
+    assert(isa<FuncDecl>(method));
+  }
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -438,7 +438,9 @@ bool AllowInvalidRefInKeyPath::diagnose(Expr *root, bool asNote) const {
   }
 
   case RefKind::Method: {
-    return false;
+    InvalidMethodRefInKeyPath failure(root, getConstraintSystem(), Member,
+                                      getLocator());
+    return failure.diagnose(asNote);
   }
   }
 }

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -791,6 +791,9 @@ class AllowInvalidRefInKeyPath final : public ConstraintFix {
     // Allow a reference to a declaration with mutating getter as
     // a key path component.
     MutatingGetter,
+    // Allow a reference to a method (instance or static) as
+    // a key path component.
+    Method,
   } Kind;
 
   ValueDecl *Member;
@@ -808,22 +811,16 @@ public:
     case RefKind::MutatingGetter:
       return "allow reference to a member with mutating getter as a key "
              "path component";
+    case RefKind::Method:
+      return "allow reference to a method as a key path component";
     }
   }
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static AllowInvalidRefInKeyPath *forStaticMember(ConstraintSystem &cs,
-                                                   ValueDecl *member,
-                                                   ConstraintLocator *locator) {
-    return create(cs, RefKind::StaticMember, member, locator);
-  }
-
+  /// Determine whether give reference requires a fix and produce one.
   static AllowInvalidRefInKeyPath *
-  forMutatingGetter(ConstraintSystem &cs, ValueDecl *member,
-                    ConstraintLocator *locator) {
-    return create(cs, RefKind::MutatingGetter, member, locator);
-  }
+  forRef(ConstraintSystem &cs, ValueDecl *member, ConstraintLocator *locator);
 
 private:
   static AllowInvalidRefInKeyPath *create(ConstraintSystem &cs, RefKind kind,

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -776,6 +776,31 @@ func test_keypath_with_mutating_getter() {
   }
 }
 
+func test_keypath_with_method_refs() {
+  struct S {
+    func foo() -> Int { return 42 }
+    static func bar() -> Int { return 0 }
+  }
+
+  let _: KeyPath<S, Int> = \.foo // expected-error {{key path cannot refer to instance method 'foo()'}}
+  let _: KeyPath<S, Int> = \.bar // expected-error {{key path cannot refer to static member 'bar()'}}
+  let _ = \S.Type.bar // expected-error {{key path cannot refer to static method 'bar()'}}
+
+  struct A {
+    func foo() -> B { return B() }
+    static func faz() -> B { return B() }
+  }
+
+  struct B {
+    var bar: Int = 42
+  }
+
+  let _: KeyPath<A, Int> = \.foo.bar // expected-error {{key path cannot refer to instance method 'foo()'}}
+  let _: KeyPath<A, Int> = \.faz.bar // expected-error {{key path cannot refer to static member 'faz()'}}
+  let _ = \A.foo.bar // expected-error {{key path cannot refer to instance method 'foo()'}}
+  let _ = \A.Type.faz.bar // expected-error {{key path cannot refer to static method 'faz()'}}
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
Referencing (instance or static) methods in the key path is not
currently allowed, solver should be responsible for early detection
and diagnosis of both standalone e.g. `\.foo` and chained
e.g. `\.foo.bar` (where foo is a method) references in key path
components.

```swift
struct S {
  func foo() -> Int { return 42 }
}

let _: KeyPath<S, Int> = \.foo
```

Resolves: rdar://problem/49413561
(cherry picked from commit d6a3a31ae9b323c00f50836279ba9fee0c27ff16)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
