### PR TITLE
[test] bridged_casts_folding: Explicitly override optimization level to -Onone

### DIFF
--- a/test/Interpreter/bridged_casts_folding.swift
+++ b/test/Interpreter/bridged_casts_folding.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-Onone) | %FileCheck %s
 // RUN: %target-run-simple-swift(-O) | %FileCheck -check-prefix=CHECK-OPT %s
 
 // NOTE: We use FileCheck for the crashing test cases to make sure we crash for


### PR DESCRIPTION
Otherwise the unoptimized tests fail when the tests are run with optimizations enabled.

rdar://problem/50040132