### PR TITLE
[utils/gyb_syntax_support] Add `collection_element_name` for when specifying a `Child`

### DIFF
--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -48,10 +48,12 @@ public:
   ${node.name}Builder &use${child.name}(${child.type_name} ${child.name});
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
-%         child_elt = child_node.collection_element_name
+%         child_elt = child.collection_element_name
 %         child_elt_type = child_node.collection_element_type
-%         child_elt_name = child.name + 'Member'
-  ${node.name}Builder &add${child_elt_name}(${child_elt_type} ${child_elt});
+%         if not child_elt:
+%           raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
+%         end
+  ${node.name}Builder &add${child_elt}(${child_elt_type} ${child_elt});
 %       end
 %     end
 

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -88,15 +88,18 @@ public:
 
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
-%         child_elt = child_node.collection_element_name
+%         child_elt = child.collection_element_name
 %         child_elt_type = child_node.collection_element_type
+%         if not child_elt:
+%           raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
+%         end
   /// Adds the provided `${child_elt}` to the node's `${child.name}`
   /// collection.
   /// - param element: The new `${child_elt}` to add to the node's
   ///                  `${child.name}` collection.
   /// - returns: A copy of the receiver with the provided `${child_elt}`
   ///            appended to its `${child.name}` collection.
-  ${node.name} add${child.name}Member(${child_elt_type} ${child_elt});
+  ${node.name} add${child_elt}(${child_elt_type} ${child_elt});
 %       end
 
   /// Returns a copy of the receiver with its `${child.name}` replaced.

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -36,11 +36,13 @@ ${node.name}Builder::use${child.name}(${child.type_name} ${child.name}) {
 }
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
-%         child_elt = child_node.collection_element_name
+%         child_elt = child.collection_element_name
 %         child_elt_type = child_node.collection_element_type
-%         child_elt_name = child.name + 'Member'
+%         if not child_elt:
+%           raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
+%         end
 ${node.name}Builder &
-${node.name}Builder::add${child_elt_name}(${child_elt_type} ${child_elt}) {
+${node.name}Builder::add${child_elt}(${child_elt_type} ${child_elt}) {
   auto &raw = Layout[cursorIndex(${node.name}::Cursor::${child.name})];
   if (!raw)
     raw = RawSyntax::make(SyntaxKind::${child_node.syntax_kind},

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -69,10 +69,12 @@ ${child.type_name} ${node.name}::get${child.name}() {
 
 %     child_node = NODE_MAP.get(child.syntax_kind)
 %     if child_node and child_node.is_syntax_collection():
-%       child_elt = child_node.collection_element_name
+%       child_elt = child.collection_element_name
 %       child_elt_type = child_node.collection_element_type
-%       child_elt_name = child.name + 'Member'
-${node.name} ${node.name}::add${child_elt_name}(${child_elt_type} ${child_elt}) {
+%       if not child_elt:
+%         raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
+%       end
+${node.name} ${node.name}::add${child_elt}(${child_elt_type} ${child_elt}) {
   RC<RawSyntax> raw = getRaw()->getChild(Cursor::${child.name});
   if (raw)
     raw = raw->append(${child_elt}.getRaw());

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -88,7 +88,7 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
     auto GenericParams = GenericParameterClauseSyntaxBuilder()
       .useLeftAngleBracket(LeftAngle)
       .useRightAngleBracket(RightAngle)
-      .addGenericParameterListMember(ElementParam)
+      .addGenericParameter(ElementParam)
       .build();
     auto Assignment = SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
     auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
@@ -97,7 +97,7 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
     auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
       .useLeftAngleBracket(LeftAngle)
       .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-      .addArgumentsMember(ElementArg)
+      .addArgument(ElementArg)
       .build();
 
     auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
@@ -126,7 +126,7 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
   auto GenericParams = GenericParameterClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
     .useRightAngleBracket(RightAngle)
-    .addGenericParameterListMember(ElementParam)
+    .addGenericParameter(ElementParam)
     .build();
   auto Equal = SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
 
@@ -135,7 +135,7 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
   auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
     .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgumentsMember(ElementArg)
+    .addArgument(ElementArg)
     .build();
 
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
@@ -170,7 +170,7 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   auto GenericParams = GenericParameterClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
     .useRightAngleBracket(RightAngle)
-    .addGenericParameterListMember(ElementParam)
+    .addGenericParameter(ElementParam)
     .build();
   auto Equal =
     SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
@@ -181,7 +181,7 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
     .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgumentsMember(ElementArg)
+    .addArgument(ElementArg)
     .build();
 
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
@@ -519,8 +519,8 @@ GenericParameterClauseSyntax getCannedGenericParams() {
   auto T = SyntaxFactory::makeGenericParameter(TType, Comma);
   auto U = SyntaxFactory::makeGenericParameter(UType, None);
 
-  GB.addGenericParameterListMember(T);
-  GB.addGenericParameterListMember(U);
+  GB.addGenericParameter(T);
+  GB.addGenericParameter(U);
   GB.useLeftAngleBracket(LAngle);
   GB.useRightAngleBracket(RAngle);
 

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -68,7 +68,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
     ArgBuilder
       .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
       .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-      .addArgumentsMember(GenericArg);
+      .addArgument(GenericArg);
 
     auto GenericArgs = ArgBuilder.build();
 
@@ -98,7 +98,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
   ArgBuilder
     .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
     .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgumentsMember(GenericArg);
+    .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
@@ -135,7 +135,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
   ArgBuilder
     .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
     .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgumentsMember(GenericArg);
+    .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
@@ -528,7 +528,7 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    CallBuilder.addArgumentListMember(OneArg);
+    CallBuilder.addArgument(OneArg);
     CallBuilder.build().print(OS);
     ASSERT_EQ(OS.str().str(), "foo(1, )");
   }
@@ -536,7 +536,7 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    CallBuilder.addArgumentListMember(OneArg.withTrailingComma(NoComma));
+    CallBuilder.addArgument(OneArg.withTrailingComma(NoComma));
     CallBuilder.build().print(OS);
     ASSERT_EQ(OS.str().str(), "foo(1, 1)");
   }

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -202,9 +202,9 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     auto StringId = SyntaxFactory::makeIdentifier("String", {}, {});
     auto StringType = SyntaxFactory::makeSimpleTypeIdentifier(StringId, None);
     auto String = SyntaxFactory::makeTupleTypeElement(StringType, Comma);
-    Builder.addElementsMember(IntWithComma);
-    Builder.addElementsMember(String);
-    Builder.addElementsMember(Int);
+    Builder.addElement(IntWithComma);
+    Builder.addElement(String);
+    Builder.addElement(Int);
     Builder.useRightParen(SyntaxFactory::makeRightParenToken({}, {}));
 
     auto TupleType = Builder.build();
@@ -229,8 +229,8 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     auto yTypeElt = SyntaxFactory::makeTupleTypeElement(yLabel, Colon,
                                                         Int)
       .withInOut(inout);
-    Builder.addElementsMember(xTypeElt);
-    Builder.addElementsMember(yTypeElt);
+    Builder.addElement(xTypeElt);
+    Builder.addElement(yTypeElt);
     Builder.useRightParen(SyntaxFactory::makeRightParenToken({}, {}));
 
     auto TupleType = Builder.build();
@@ -562,8 +562,8 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
 
     SyntaxFactory::makeBlankFunctionType()
       .withLeftParen(LeftParen)
-      .addArgumentsMember(xArg)
-      .addArgumentsMember(yArg)
+      .addArgument(xArg)
+      .addArgument(yArg)
       .withRightParen(RightParen)
       .withThrowsOrRethrowsKeyword(Throws)
       .withArrow(Arrow)
@@ -580,8 +580,8 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
     SyntaxFactory::makeBlankFunctionType()
       .withLeftParen(LeftParen)
       .withRightParen(RightParen)
-      .addArgumentsMember(IntArg.withTrailingComma(Comma))
-      .addArgumentsMember(IntArg)
+      .addArgument(IntArg.withTrailingComma(Comma))
+      .addArgument(IntArg)
       .withThrowsOrRethrowsKeyword(Rethrows)
       .withArrow(Arrow)
       .withReturnType(Int)
@@ -628,8 +628,8 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
-      .addArgumentsMember(xArg)
-      .addArgumentsMember(yArg)
+      .addArgument(xArg)
+      .addArgument(yArg)
       .useThrowsOrRethrowsKeyword(Throws)
       .useArrow(Arrow)
       .useReturnType(Int);
@@ -646,8 +646,8 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
                                                       Int, None, None, None);
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
-      .addArgumentsMember(IntArg.withTrailingComma(Comma))
-      .addArgumentsMember(IntArg)
+      .addArgument(IntArg.withTrailingComma(Comma))
+      .addArgument(IntArg)
       .useThrowsOrRethrowsKeyword(Rethrows)
       .useArrow(Arrow)
       .useReturnType(Int);

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -56,7 +56,8 @@ ATTRIBUTE_NODES = [
                    '''),
              # TokenList to gather remaining tokens of invalid attributes
              # FIXME: Remove this recovery option entirely
-             Child('TokenList', kind='TokenList', is_optional=True),
+             Child('TokenList', kind='TokenList',
+                   collection_element_name='Token', is_optional=True),
          ]),
 
     # attribute-list -> attribute attribute-list?
@@ -72,7 +73,7 @@ ATTRIBUTE_NODES = [
          description='''
          A collection of arguments for the `@_specialize` attribute
          ''',
-         element='Syntax',
+         element='Syntax', element_name='SpecializeAttribute',
          element_choices=[
              'LabeledSpecializeEntry',
              'GenericWhereClause',

--- a/utils/gyb_syntax_support/Child.py
+++ b/utils/gyb_syntax_support/Child.py
@@ -11,6 +11,7 @@ class Child(object):
     """
     def __init__(self, name, kind, description=None, is_optional=False,
                  token_choices=None, text_choices=None, node_choices=None,
+                 collection_element_name=None,
                  classification=None, force_classification=False):
         """
         If a classification is passed, it specifies the color identifiers in 
@@ -25,6 +26,7 @@ class Child(object):
         self.description = description
         self.swift_syntax_kind = lowercase_first_word(self.syntax_kind)
         self.type_name = kind_to_type(self.syntax_kind)
+        self.collection_element_name = collection_element_name
         self.classification = classification_by_name(classification)
         self.force_classification = force_classification
 

--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -46,7 +46,8 @@ COMMON_NODES = [
          traits=['Braced', 'WithStatements'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
-             Child('Statements', kind='CodeBlockItemList'),
+             Child('Statements', kind='CodeBlockItemList',
+                   collection_element_name='Statement'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 ]

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -18,8 +18,9 @@ DECL_NODES = [
     Node('TypealiasDecl', kind='Decl', traits=['IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('TypealiasKeyword', kind='TypealiasToken'),
              Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause',
@@ -38,8 +39,9 @@ DECL_NODES = [
     Node('AssociatedtypeDecl', kind='Decl', traits=['IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('AssociatedtypeKeyword', kind='AssociatedtypeToken'),
              Child('Identifier', kind='IdentifierToken'),
              Child('InheritanceClause', kind='TypeInheritanceClause',
@@ -57,7 +59,8 @@ DECL_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('ParameterList', kind='FunctionParameterList'),
+             Child('ParameterList', kind='FunctionParameterList',
+                   collection_element_name='Parameter'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
@@ -110,7 +113,8 @@ DECL_NODES = [
     #   else-clause? '#endif'
     Node('IfConfigDecl', kind='Decl',
          children=[
-             Child('Clauses', kind='IfConfigClauseList'),
+             Child('Clauses', kind='IfConfigClauseList',
+                   collection_element_name='Clause'),
              Child('PoundEndif', kind='PoundEndifToken', 
                    classification='BuildConfigId'),
          ]),
@@ -184,7 +188,8 @@ DECL_NODES = [
     Node('TypeInheritanceClause', kind='Syntax',
          children=[
              Child('Colon', kind='ColonToken'),
-             Child('InheritedTypeCollection', kind='InheritedTypeList'),
+             Child('InheritedTypeCollection', kind='InheritedTypeList',
+                   collection_element_name='InheritedType'),
          ]),
 
     # class-declaration -> attributes? access-level-modifier?
@@ -198,8 +203,9 @@ DECL_NODES = [
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('ClassKeyword', kind='ClassToken'),
              Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause',
@@ -222,8 +228,9 @@ DECL_NODES = [
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('StructKeyword', kind='StructToken'),
              Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause',
@@ -239,8 +246,9 @@ DECL_NODES = [
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('ProtocolKeyword', kind='ProtocolToken'),
              Child('Identifier', kind='IdentifierToken'),
              Child('InheritanceClause', kind='TypeInheritanceClause',
@@ -259,8 +267,9 @@ DECL_NODES = [
     Node('ExtensionDecl', kind='Decl', traits=['DeclGroup'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('ExtensionKeyword', kind='ExtensionToken'),
              Child('ExtendedType', kind='Type'),
              Child('InheritanceClause', kind='TypeInheritanceClause',
@@ -273,7 +282,8 @@ DECL_NODES = [
     Node('MemberDeclBlock', kind='Syntax', traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
-             Child('Members', kind='MemberDeclList'),
+             Child('Members', kind='MemberDeclList',
+                   collection_element_name='Member'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 
@@ -298,7 +308,8 @@ DECL_NODES = [
     Node('SourceFile', kind='Syntax',
          traits=['WithStatements'],
          children=[
-             Child('Statements', kind='CodeBlockItemList'),
+             Child('Statements', kind='CodeBlockItemList',
+                   collection_element_name='Statement'),
              Child('EOFToken', kind='EOFToken')
          ]),
 
@@ -316,7 +327,7 @@ DECL_NODES = [
          traits=['WithTrailingComma'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('FirstName', kind='Token',
                    token_choices=[
                        'IdentifierToken',
@@ -369,9 +380,9 @@ DECL_NODES = [
     Node('FunctionDecl', kind='Decl', traits=['IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList',
-                   is_optional=True),
+                   collection_element_name='Modifier', is_optional=True),
              Child('FuncKeyword', kind='FuncToken'),
              Child('Identifier', kind='Token',
                    token_choices=[
@@ -393,9 +404,9 @@ DECL_NODES = [
     Node('InitializerDecl', kind='Decl',
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList',
-                   is_optional=True),
+                   collection_element_name='Modifier', is_optional=True),
              Child('InitKeyword', kind='InitToken'),
              Child('OptionalMark', kind='Token',
                    token_choices=[
@@ -422,9 +433,9 @@ DECL_NODES = [
     Node('DeinitializerDecl', kind='Decl',
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList',
-                   is_optional=True),
+                   collection_element_name='Modifier', is_optional=True),
              Child('DeinitKeyword', kind='DeinitToken'),
              Child('Body', kind='CodeBlock'),
          ]),
@@ -432,9 +443,9 @@ DECL_NODES = [
     Node('SubscriptDecl', kind='Decl',
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList',
-                   is_optional=True),
+                   collection_element_name='Modifier', is_optional=True),
              Child('SubscriptKeyword', kind='SubscriptToken'),
              Child('GenericParameterClause', kind='GenericParameterClause',
                    is_optional=True),
@@ -475,9 +486,10 @@ DECL_NODES = [
 
     Node('ImportDecl', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True),
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList',
-                   is_optional=True),
+                   collection_element_name='Modifier', is_optional=True),
              Child('ImportTok', kind='ImportToken'),
              Child('ImportKind', kind='Token', is_optional=True,
                    token_choices=[
@@ -485,7 +497,8 @@ DECL_NODES = [
                       'EnumToken', 'ProtocolToken', 'VarToken', 'LetToken',
                       'FuncToken',
                    ]),
-             Child('Path', kind='AccessPath'),
+             Child('Path', kind='AccessPath',
+                   collection_element_name='PathComponent'),
          ]),
 
     # (value)
@@ -499,7 +512,8 @@ DECL_NODES = [
 
     Node('AccessorDecl', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True),
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True),
              Child('Modifier', kind='DeclModifier', is_optional=True),
              Child('AccessorKind', kind='Token',
                    text_choices=[
@@ -519,7 +533,8 @@ DECL_NODES = [
     Node('AccessorBlock', kind="Syntax", traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
-             Child('Accessors', kind='AccessorList'),
+             Child('Accessors', kind='AccessorList',
+                   collection_element_name='Accessor'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 
@@ -542,13 +557,16 @@ DECL_NODES = [
 
     Node('VariableDecl', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True),
-             Child('Modifiers', kind='ModifierList', is_optional=True),
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True),
              Child('LetOrVarKeyword', kind='Token',
                    token_choices=[
                        'LetToken', 'VarToken',
                    ]),
-             Child('Bindings', kind='PatternBindingList'),
+             Child('Bindings', kind='PatternBindingList',
+                   collection_element_name='Binding'),
          ]),
 
     Node('EnumCaseElement', kind='Syntax',
@@ -584,28 +602,33 @@ DECL_NODES = [
          enum.
          ''',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True,
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the case declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList', is_optional=True,
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True,
                    description='''
                    The declaration modifiers applied to the case declaration.
                    '''),
              Child('CaseKeyword', kind='CaseToken',
                    description='The `case` keyword for this case.'),
              Child('Elements', kind='EnumCaseElementList',
+                   collection_element_name='Element',
                    description='The elements this case declares.')
          ]),
 
     Node('EnumDecl', kind='Decl', traits=['IdentifiedDecl'],
          description='A Swift `enum` declaration.',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True,
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the enum declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList', is_optional=True,
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True,
                    description='''
                    The declaration modifiers applied to the enum declaration.
                    '''),
@@ -644,11 +667,13 @@ DECL_NODES = [
     Node('OperatorDecl', kind='Decl', traits=['IdentifiedDecl'],
          description='A Swift `operator` declaration.',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True,
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the 'operator' declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList', is_optional=True,
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True,
                    classification='Attribute',
                    description='''
                    The declaration modifiers applied to the 'operator'
@@ -680,6 +705,7 @@ DECL_NODES = [
          children=[
              Child('Colon', kind='ColonToken'),
              Child('PrecedenceGroupAndDesignatedTypes', kind='IdentifierList',
+                   collection_element_name='PrecedenceGroupAndDesignatedType',
                    description='''
                    The precedence group and designated types for this operator
                    '''),
@@ -691,11 +717,13 @@ DECL_NODES = [
     Node('PrecedenceGroupDecl', kind='Decl', traits=['IdentifiedDecl'],
          description='A Swift `precedencegroup` declaration.',
          children=[
-             Child('Attributes', kind='AttributeList', is_optional=True,
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the 'precedencegroup' declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList', is_optional=True,
+             Child('Modifiers', kind='ModifierList',
+                   collection_element_name='Modifier', is_optional=True,
                    description='''
                    The declaration modifiers applied to the 'precedencegroup'
                    declaration.
@@ -707,6 +735,7 @@ DECL_NODES = [
                    '''),
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('GroupAttributes', kind='PrecedenceGroupAttributeList',
+                   collection_element_name='GroupAttribute',
                    description='''
                    The characteristics of this precedence group.
                    '''),
@@ -717,7 +746,7 @@ DECL_NODES = [
     #     (precedence-group-relation | precedence-group-assignment |
     #      precedence-group-associativity )*
     Node('PrecedenceGroupAttributeList', kind='SyntaxCollection',
-         element='Syntax',
+         element='Syntax', element_name='PrecedenceGroupAttribute',
          element_choices=[
              'PrecedenceGroupRelation',
              'PrecedenceGroupAssignment',
@@ -742,6 +771,7 @@ DECL_NODES = [
                    '''),
              Child('Colon', kind='ColonToken'),
              Child('OtherNames', kind='PrecedenceGroupNameList',
+                   collection_element_name='OtherName',
                    description='''
                    The name of other precedence group to which this precedence
                    group relates.

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -62,7 +62,8 @@ EXPR_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Arguments', kind='DeclNameArgumentList'),
+             Child('Arguments', kind='DeclNameArgumentList',
+                   collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
@@ -108,7 +109,8 @@ EXPR_NODES = [
     # A flat list of expressions before sequence folding, e.g. 1 + 2 + 3.
     Node('SequenceExpr', kind='Expr',
          children=[
-             Child('Elements', kind='ExprList'),
+             Child('Elements', kind='ExprList',
+                   collection_element_name='Element'),
          ]),
 
     Node('ExprList', kind='SyntaxCollection',
@@ -186,7 +188,8 @@ EXPR_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('ElementList', kind='TupleElementList'),
+             Child('ElementList', kind='TupleElementList',
+                   collection_element_name='Element'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
@@ -194,7 +197,8 @@ EXPR_NODES = [
     Node('ArrayExpr', kind='Expr',
          children=[
              Child('LeftSquare', kind='LeftSquareBracketToken'),
-             Child('Elements', kind='ArrayElementList'),
+             Child('Elements', kind='ArrayElementList',
+                   collection_element_name='Element'),
              Child('RightSquare', kind='RightSquareBracketToken'),
          ]),
 
@@ -333,7 +337,9 @@ EXPR_NODES = [
     Node('ClosureCaptureItem', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child("Specifier", kind='TokenList', is_optional=True),
+             # FIXME: Add a 'CaptureSpecifier' node kind for `Specifier`.
+             Child("Specifier", kind='TokenList',
+                   collection_element_name='SpecifierToken', is_optional=True),
              Child("Name", kind='IdentifierToken', is_optional=True),
              Child('AssignToken', kind='EqualToken', is_optional=True),
              Child("Expression", kind='Expr'),
@@ -346,7 +352,8 @@ EXPR_NODES = [
     Node('ClosureCaptureSignature', kind='Syntax',
          children=[
              Child('LeftSquare', kind='LeftSquareBracketToken'),
-             Child('Items', kind='ClosureCaptureItemList', is_optional=True),
+             Child('Items', kind='ClosureCaptureItemList',
+                   collection_element_name='Item', is_optional=True),
              Child('RightSquare', kind='RightSquareBracketToken'),
          ]),
 
@@ -383,7 +390,8 @@ EXPR_NODES = [
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Signature', kind='ClosureSignature', is_optional=True),
-             Child('Statements', kind='CodeBlockItemList'),
+             Child('Statements', kind='CodeBlockItemList',
+                   collection_element_name='Statement'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 
@@ -400,7 +408,8 @@ EXPR_NODES = [
              Child('CalledExpression', kind='Expr'),
              Child('LeftParen', kind='LeftParenToken',
                    is_optional=True),
-             Child('ArgumentList', kind='FunctionCallArgumentList'),
+             Child('ArgumentList', kind='FunctionCallArgumentList',
+                   collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken',
                    is_optional=True),
              Child('TrailingClosure', kind='ClosureExpr',
@@ -412,7 +421,8 @@ EXPR_NODES = [
          children=[
              Child('CalledExpression', kind='Expr'),
              Child('LeftBracket', kind='LeftSquareBracketToken'),
-             Child('ArgumentList', kind='FunctionCallArgumentList'),
+             Child('ArgumentList', kind='FunctionCallArgumentList',
+                   collection_element_name='Argument'),
              Child('RightBracket', kind='RightSquareBracketToken'),
              Child('TrailingClosure', kind='ClosureExpr',
                    is_optional=True),
@@ -472,7 +482,8 @@ EXPR_NODES = [
                        'StringQuoteToken',
                        'MultilineStringQuoteToken',
                    ]),
-             Child('Segments', kind='StringInterpolationSegments'),
+             Child('Segments', kind='StringInterpolationSegments',
+                   collection_element_name='Segment'),
              Child('CloseQuote', kind='Token',
                    token_choices=[
                        'StringQuoteToken',
@@ -515,7 +526,8 @@ EXPR_NODES = [
          children=[
              Child('KeyPath', kind='PoundKeyPathToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Name', kind='ObjcName'),
+             Child('Name', kind='ObjcName',
+                   collection_element_name='NamePiece'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
@@ -550,7 +562,8 @@ EXPR_NODES = [
                        'PoundImageLiteralToken',
                    ]),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Arguments', kind='FunctionCallArgumentList'),
+             Child('Arguments', kind='FunctionCallArgumentList',
+                   collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 ]

--- a/utils/gyb_syntax_support/GenericNodes.py
+++ b/utils/gyb_syntax_support/GenericNodes.py
@@ -6,7 +6,8 @@ GENERIC_NODES = [
     Node('GenericWhereClause', kind='Syntax',
          children=[
              Child('WhereKeyword', kind='WhereToken'),
-             Child('RequirementList', kind='GenericRequirementList'),
+             Child('RequirementList', kind='GenericRequirementList',
+                   collection_element_name='Requirement'),
          ]),
 
     Node('GenericRequirementList', kind='SyntaxCollection',
@@ -38,7 +39,7 @@ GENERIC_NODES = [
          traits=['WithTrailingComma'],
          children=[
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('Name', kind='IdentifierToken'),
              Child('Colon', kind='ColonToken',
                    is_optional=True),
@@ -52,7 +53,8 @@ GENERIC_NODES = [
     Node('GenericParameterClause', kind='Syntax',
          children=[
              Child('LeftAngleBracket', kind='LeftAngleToken'),
-             Child('GenericParameterList', kind='GenericParameterList'),
+             Child('GenericParameterList', kind='GenericParameterList',
+                   collection_element_name='GenericParameter'),
              Child('RightAngleBracket', kind='RightAngleToken'),
          ]),
 

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -38,6 +38,9 @@ class Node(object):
 
         self.omit_when_empty = omit_when_empty
         self.collection_element = element or ""
+        # For SyntaxCollections make sure that the element_name is set.
+        assert(not self.is_syntax_collection() or element_name or
+               (element and element != 'Syntax'))
         # If there's a preferred name for the collection element that differs
         # from its supertype, use that.
         self.collection_element_name = element_name or self.collection_element

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -54,7 +54,8 @@ PATTERN_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Elements', kind='TuplePatternElementList'),
+             Child('Elements', kind='TuplePatternElementList',
+                   collection_element_name='Element'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -19,7 +19,8 @@ STMT_NODES = [
              Child('LabelColon', kind='ColonToken',
                    is_optional=True),
              Child('WhileKeyword', kind='WhileToken'),
-             Child('Conditions', kind='ConditionElementList'),
+             Child('Conditions', kind='ConditionElementList',
+                   collection_element_name='Condition'),
              Child('Body', kind='CodeBlock'),
          ]),
 
@@ -39,7 +40,7 @@ STMT_NODES = [
 
     # switch-case-list -> switch-case switch-case-list?
     Node('SwitchCaseList', kind='SyntaxCollection',
-         element='Syntax',
+         element='Syntax', element_name='SwitchCase',
          element_choices=['SwitchCase', 'IfConfigDecl']),
 
     # repeat-while-stmt -> label? ':'? 'repeat' code-block 'while' expr ';'?
@@ -61,7 +62,8 @@ STMT_NODES = [
          traits=['WithCodeBlock'],
          children=[
              Child('GuardKeyword', kind='GuardToken'),
-             Child('Conditions', kind='ConditionElementList'),
+             Child('Conditions', kind='ConditionElementList',
+                   collection_element_name='Condition'),
              Child('ElseKeyword', kind='ElseToken'),
              Child('Body', kind='CodeBlock'),
          ]),
@@ -106,7 +108,8 @@ STMT_NODES = [
              Child('SwitchKeyword', kind='SwitchToken'),
              Child('Expression', kind='Expr'),
              Child('LeftBrace', kind='LeftBraceToken'),
-             Child('Cases', kind='SwitchCaseList'),
+             Child('Cases', kind='SwitchCaseList',
+                   collection_element_name='Case'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 
@@ -125,7 +128,7 @@ STMT_NODES = [
              Child('DoKeyword', kind='DoToken'),
              Child('Body', kind='CodeBlock'),
              Child('CatchClauses', kind='CatchClauseList',
-                   is_optional=True),
+                   collection_element_name='CatchClause', is_optional=True),
          ]),
 
     # return-stmt -> 'return' expr? ';'?
@@ -150,7 +153,8 @@ STMT_NODES = [
     Node('YieldList', kind='Syntax',
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('ElementList', kind='ExprList'),
+             Child('ElementList', kind='ExprList',
+                   collection_element_name='Element'),
              Child('TrailingComma', kind='CommaToken', is_optional=True),
              Child('RightParen', kind='RightParenToken'),
          ]),
@@ -198,7 +202,8 @@ STMT_NODES = [
          children=[
              Child('PoundAvailableKeyword', kind='PoundAvailableToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('AvailabilitySpec', kind='AvailabilitySpecList'),
+             Child('AvailabilitySpec', kind='AvailabilitySpecList',
+                   collection_element_name='AvailabilityArgument'),
              Child('RightParen', kind='RightParenToken'),
          ]),
     Node('MatchingPatternCondition', kind='Syntax',
@@ -250,7 +255,8 @@ STMT_NODES = [
              Child('LabelColon', kind='ColonToken',
                    is_optional=True),
              Child('IfKeyword', kind='IfToken'),
-             Child('Conditions', kind='ConditionElementList'),
+             Child('Conditions', kind='ConditionElementList',
+                   collection_element_name='Condition'),
              Child('Body', kind='CodeBlock'),
              Child('ElseKeyword', kind='ElseToken',
                    is_optional=True),
@@ -287,7 +293,8 @@ STMT_NODES = [
                        Child('Default', kind='SwitchDefaultLabel'),
                        Child('Case', kind='SwitchCaseLabel'),
                    ]),
-             Child('Statements', kind='CodeBlockItemList'),
+             Child('Statements', kind='CodeBlockItemList',
+                   collection_element_name='Statement'),
          ]),
 
     # switch-default-label -> 'default' ':'
@@ -312,7 +319,8 @@ STMT_NODES = [
     Node('SwitchCaseLabel', kind='Syntax',
          children=[
              Child('CaseKeyword', kind='CaseToken'),
-             Child('CaseItems', kind='CaseItemList'),
+             Child('CaseItems', kind='CaseItemList',
+                   collection_element_name='CaseItem'),
              Child('Colon', kind='ColonToken'),
          ]),
 

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -110,7 +110,8 @@ TYPE_NODES = [
     # composition-type -> composition-type-element-list
     Node('CompositionType', kind='Type',
          children=[
-             Child('Elements', kind='CompositionTypeElementList'),
+             Child('Elements', kind='CompositionTypeElementList',
+                   collection_element_name='Element'),
          ]),
 
     # tuple-type-element -> identifier? ':'? type-annotation ','?
@@ -151,7 +152,8 @@ TYPE_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Elements', kind='TupleTypeElementList'),
+             Child('Elements', kind='TupleTypeElementList',
+                   collection_element_name='Element'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
@@ -162,7 +164,8 @@ TYPE_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Arguments', kind='TupleTypeElementList'),
+             Child('Arguments', kind='TupleTypeElementList',
+                   collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken'),
              Child('ThrowsOrRethrowsKeyword', kind='Token',
                    is_optional=True,
@@ -183,7 +186,7 @@ TYPE_NODES = [
                    text_choices=['inout', '__shared', '__owned'],
                    is_optional=True),
              Child('Attributes', kind='AttributeList',
-                   is_optional=True),
+                   collection_element_name='Attribute', is_optional=True),
              Child('BaseType', kind='Type'),
          ]),
 
@@ -206,7 +209,8 @@ TYPE_NODES = [
     Node('GenericArgumentClause', kind='Syntax',
          children=[
              Child('LeftAngleBracket', kind='LeftAngleToken'),
-             Child('Arguments', kind='GenericArgumentList'),
+             Child('Arguments', kind='GenericArgumentList',
+                   collection_element_name='Argument'),
              Child('RightAngleBracket', kind='RightAngleToken'),
          ]),
 ]


### PR DESCRIPTION
This is useful to provide `add<ELEMENT_NAME>` APIs for SwiftSyntax that are better named
and without having name conflicts.