### PR TITLE
[5.1] [ParseableInterfaces] Stop replacing inaccessible properties with '_'

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -985,6 +985,33 @@ void PrintAST::printTypedPattern(const TypedPattern *TP) {
   printTypeLoc(TP->getTypeLoc());
 }
 
+/// Determines if we are required to print the name of a property declaration,
+/// or if we can elide it by printing a '_' instead.
+static bool mustPrintPropertyName(VarDecl *decl, PrintOptions opts) {
+  // If we're not allowed to omit the name, we must print it.
+  if (!opts.OmitNameOfInaccessibleProperties) return true;
+
+  // If it contributes to the parent's storage, we must print it because clients
+  // need to be able to directly access the storage.
+  // FIXME: We might be able to avoid printing names for some of these
+  //        if we serialized references to them using field indices.
+  if (contributesToParentTypeStorage(decl)) return true;
+
+  // If it's public or @usableFromInline, we must print the name because it's a
+  // visible entry-point.
+  if (isPublicOrUsableFromInline(decl)) return true;
+
+  // If it has an initial value, we must print the name because it's used in
+  // the mangled name of the initializer expression generator function.
+  // FIXME: We _could_ figure out a way to generate an entry point
+  //        for the initializer expression without revealing the name. We just
+  //        don't have a mangling for it.
+  if (decl->hasInitialValue()) return true;
+
+  // If none of those are true, we can elide the name of the variable.
+  return false;
+}
+
 void PrintAST::printPattern(const Pattern *pattern) {
   switch (pattern->getKind()) {
   case PatternKind::Any:
@@ -995,16 +1022,13 @@ void PrintAST::printPattern(const Pattern *pattern) {
     auto named = cast<NamedPattern>(pattern);
     auto decl = named->getDecl();
     recordDeclLoc(decl, [&]{
-      if (Options.OmitNameOfInaccessibleProperties &&
-          contributesToParentTypeStorage(decl) &&
-          !isPublicOrUsableFromInline(decl) &&
-          // FIXME: We need to figure out a way to generate an entry point
-          //        for the initializer expression without revealing the name.
-          !decl->hasInitialValue())
-        Printer << "_";
-      else
+      // FIXME: This always returns true now, because of the FIXMEs listed in
+      //        mustPrintPropertyName.
+      if (mustPrintPropertyName(decl, Options))
         Printer.printName(named->getBoundName());
-      });
+      else
+        Printer << "_";
+    });
     break;
   }
 

--- a/test/ParseableInterface/private-stored-members.swift
+++ b/test/ParseableInterface/private-stored-members.swift
@@ -21,12 +21,12 @@ public struct MyStruct {
 // COMMON-NEXT: let publicLet: [[BOOL:(Swift\.)?Bool]]{{$}}
   public let publicLet: Bool
 
-// CHECK-NEXT: internal var _: [[INT64]]{{$}}
-// RESILIENT-NOT: internal var _: [[INT64]]{{$}}
+// CHECK-NEXT: internal var internalVar: [[INT64]]{{$}}
+// RESILIENT-NOT: internal var internalVar: [[INT64]]{{$}}
   var internalVar: Int64
 
-// CHECK-NEXT: internal let _: [[BOOL]]{{$}}
-// RESILIENT-NOT: internal let _: [[BOOL]]{{$}}
+// CHECK-NEXT: internal let internalLet: [[BOOL]]{{$}}
+// RESILIENT-NOT: internal let internalLet: [[BOOL]]{{$}}
   let internalLet: Bool
 
 // COMMON-NEXT: @usableFromInline
@@ -37,12 +37,12 @@ public struct MyStruct {
 // COMMON-NEXT: internal let ufiLet: [[BOOL]]{{$}}
   @usableFromInline let ufiLet: Bool
 
-// CHECK-NEXT: private var _: [[INT64]]{{$}}
-// RESILIENT-NOT: private var _: [[INT64]]{{$}}
+// CHECK-NEXT: private var privateVar: [[INT64]]{{$}}
+// RESILIENT-NOT: private var privateVar: [[INT64]]{{$}}
   private var privateVar: Int64
 
-// CHECK-NEXT: private let _: [[BOOL]]{{$}}
-// RESILIENT-NOT: private let _: [[BOOL]]{{$}}
+// CHECK-NEXT: private let privateLet: [[BOOL]]{{$}}
+// RESILIENT-NOT: private let privateLet: [[BOOL]]{{$}}
   private let privateLet: Bool
 
 // CHECK-NOT: private var

--- a/test/ParseableInterface/stored-properties.swift
+++ b/test/ParseableInterface/stored-properties.swift
@@ -49,7 +49,8 @@ public struct HasStoredProperties {
   // COMMON-NEXT: }
   public private(set) var storedPrivateSet: Int
 
-  // CHECK: private var _: [[BOOL]]
+  // CHECK: private var privateVar: [[BOOL]]
+  // RESILIENT-NOT: private var privateVar: [[BOOL]]
   private var privateVar: Bool
 
   // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: [[INT]] {


### PR DESCRIPTION
Turns out this isn't correct, since SROA can explode these structs into
scalars in inlinable code.

Put the logic in place to effectively disable it, and document the steps
we need to take to make it work in the future.