### PR TITLE
Add PrettyStackTraceSwiftVersion, and use it in the swiftc executable

### DIFF
--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -44,6 +44,12 @@ public:
   void print(llvm::raw_ostream &OS) const override;
 };
 
+/// A PrettyStackTraceEntry to print the version of the compiler.
+class PrettyStackTraceSwiftVersion : public llvm::PrettyStackTraceEntry {
+public:
+  void print(llvm::raw_ostream &OS) const override;
+};
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PRETTYSTACKTRACE_H

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/QuotedString.h"
+#include "swift/Basic/Version.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -32,4 +33,8 @@ void PrettyStackTraceFileContents::print(llvm::raw_ostream &out) const {
   if (!Buffer.getBuffer().endswith("\n"))
     out << '\n';
   out << "---\n";
+}
+
+void PrettyStackTraceSwiftVersion::print(llvm::raw_ostream &out) const {
+  out << version::getSwiftFullVersion() << '\n';
 }

--- a/test/Frontend/crash.swift
+++ b/test/Frontend/crash.swift
@@ -4,6 +4,7 @@
 // Check that we see the contents of the input file list in the crash log.
 // CHECK-LABEL: Stack dump
 // CHECK-NEXT: Program arguments: {{.*swift(c?)(.EXE)?}} -frontend
+// CHECK-NEXT: Swift version
 // CHECK-NEXT: Contents of {{.*}}.filelist.txt:
 // CHECK-NEXT: ---
 // CHECK-NEXT: test{{[\\/]}}Frontend{{[\\/]}}crash.swift{{$}}

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/Program.h"
 #include "swift/Basic/TaskQueue.h"
 #include "swift/Basic/SourceManager.h"
@@ -223,6 +224,8 @@ int main(int argc_, const char **argv_) {
   const char **ThrowawayExpandedArgv = ExpandedArgs.data();
   PROGRAM_START(ThrowawayExpandedArgc, ThrowawayExpandedArgv);
   ArrayRef<const char *> argv(ExpandedArgs);
+
+  PrettyStackTraceSwiftVersion versionStackTrace;
 
   // Check if this invocation should execute a subcommand.
   StringRef ExecName = llvm::sys::path::stem(argv[0]);


### PR DESCRIPTION
As pointed out on a recent JIRA, crash traces don't mention what version of Swift you were running. Usually that can be gleaned from the path, but not always.