### PR TITLE
Clarified variant casing

### DIFF
--- a/benchmark/Naming.md
+++ b/benchmark/Naming.md
@@ -89,7 +89,7 @@ relative comparison across the different axis of variation.
 
 </details><p><!-- spacer --></p></li>
 <li>
-<strong>Groups and types are <code>UpperCase</code>, methods are
+<strong>Groups, variants and types are <code>UpperCase</code>, methods are
 <code>lowerCase</code>.</strong>
 <details>
 


### PR DESCRIPTION
Adjusted section about name casing to explicitly call out that benchmark variants should also be `UpperCase`. Only methods should be `lowerCase`.
