### PR TITLE
[5.1] [String] [Foundation] perf: UTF8 String -> Data

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSStringAPI.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringAPI.swift
@@ -800,9 +800,14 @@ extension StringProtocol where Index == String.Index {
     using encoding: String.Encoding,
     allowLossyConversion: Bool = false
   ) -> Data? {
-    return _ns.data(
-      using: encoding.rawValue,
-      allowLossyConversion: allowLossyConversion)
+    switch encoding {
+    case .utf8:
+      return Data(self.utf8)
+    default:
+      return _ns.data(
+        using: encoding.rawValue,
+        allowLossyConversion: allowLossyConversion)
+    }
   }
 
   // @property NSString* decomposedStringWithCanonicalMapping;


### PR DESCRIPTION
Cherry-pick of #24215 to `swift-5.1-branch`.

Currently, `str.data(using:allowLossyConversion)` always bridges via
`NSString`.

As `String` is now natively UTF8 we can fastpath this conversion in the
case where the user requests UTF8 encoding.

A benchmark for this was previously added in #22648.