### PR TITLE
[5.1] [ModuleInterface] Escape `Type` and `Protocol` when they're type members

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -44,6 +44,8 @@ enum class PrintNameContext {
   Normal,
   /// Keyword context, where no keywords are escaped.
   Keyword,
+  /// Type member context, e.g. properties or enum cases.
+  TypeMember,
   /// Generic parameter context, where 'Self' is not escaped.
   GenericParameter,
   /// Class method return type, where 'Self' is not escaped.

--- a/test/ParseableInterface/escape-Type-and-Protocol.swift
+++ b/test/ParseableInterface/escape-Type-and-Protocol.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s | %FileCheck %s
+
+// CHECK: public let Type: Swift.Int
+public let Type = 0
+
+// CHECK: public struct A {
+public struct A {
+  // CHECK-NEXT: public struct `Type` {
+  // CHECK-NEXT: }
+  public struct `Type` {}
+// CHECK-NEXT: }
+}
+
+// CHECK: public class B {
+public class B {
+  // CHECK-NEXT: public class `Type` {
+  // CHECK: }
+  public class `Type` {}
+
+  // CHECK-NEXT: @_hasInitialValue public var `Type`: Swift.Int
+  public var `Type` = 0
+// CHECK: }
+}
+
+// CHECK: public struct C {
+public struct C {
+  // CHECK: public enum `Type` {
+  public enum `Type` {
+    // CHECK: }
+  }
+// CHECK-NEXT: }
+}
+
+// CHECK: public struct D {
+public struct D {
+  // CHECK: public typealias `Type` = Int
+  public typealias `Type` = Int
+// CHECK-NEXT: }
+}
+
+// CHECK: public protocol BestProtocol {
+public protocol BestProtocol {
+  // CHECK-NEXT: associatedtype `Type`
+  associatedtype `Type`
+// CHECK-NEXT: }
+}
+
+// CHECK: public enum CoolEnum {
+public enum CoolEnum {
+  // CHECK-NEXT: case `Type`
+  case `Type`
+  // CHECK-NEXT: case `Protocol`
+  case `Protocol`
+  // CHECK-NEXT: case `init`
+  case `init`
+  // CHECK-NEXT: case `self`
+  case `self`
+
+  // We allow Type and Protocol as method names, but we should still print them
+  // escaped in case we tighten this restriction.
+  // CHECK-NEXT: public func `Type`()
+  public func Type() {}
+  // CHECK-NEXT: public func `Protocol`()
+  public func Protocol() {}
+// CHECK: }
+}
+
+// CHECK: public enum UncoolEnum {
+public enum UncoolEnum {
+  // CHECK-NEXT: case `Type`, `Protocol`
+  case `Type`, `Protocol`
+// CHECK: }
+}


### PR DESCRIPTION
Previously, we wouldn't escape `Type` and `Protocol` at all in the
ASTPrinter, which lead to unfortunate build failures while compiling an
interface.

Instead, make sure we escape them whenever we print a name that's a type
member. Except for methods, which are erroneously allowed to be called
`Type` and `Protocol`.

rdar://49858651