### PR TITLE
References to _swift_FORCE_LOAD* symbols should be weak

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1085,6 +1085,7 @@ struct IRLinkage {
   static const IRLinkage Internal;
 
   static const IRLinkage ExternalImport;
+  static const IRLinkage ExternalWeakImport;
   static const IRLinkage ExternalExport;
 };
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -985,7 +985,7 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
     encodeForceLoadSymbolName(buf, linkLib.getName());
     auto ForceImportThunk =
         Module.getOrInsertFunction(buf, llvm::FunctionType::get(VoidTy, false));
-    ApplyIRLinkage(IRLinkage::ExternalImport)
+    ApplyIRLinkage(IRLinkage::ExternalWeakImport)
         .to(cast<llvm::GlobalValue>(ForceImportThunk));
 
     buf += "_$";

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -57,6 +57,12 @@ const IRLinkage IRLinkage::ExternalImport = {
   llvm::GlobalValue::DLLImportStorageClass,
 };
 
+const IRLinkage IRLinkage::ExternalWeakImport = {
+  llvm::GlobalValue::ExternalWeakLinkage,
+  llvm::GlobalValue::DefaultVisibility,
+  llvm::GlobalValue::DLLImportStorageClass,
+};
+
 const IRLinkage IRLinkage::ExternalExport = {
   llvm::GlobalValue::ExternalLinkage,
   llvm::GlobalValue::DefaultVisibility,

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -46,5 +46,5 @@ import someModule
 // FORCE-LOAD-CLIENT: @llvm.used = appending global [{{[0-9]+}} x i8*] [
 // FORCE-LOAD-CLIENT: i8* bitcast (void ()** @"_swift_FORCE_LOAD_$_module_$_autolinking" to i8*)
 // FORCE-LOAD-CLIENT: ], section "llvm.metadata"
-// FORCE-LOAD-CLIENT: declare {{(dllimport )?}}void @"_swift_FORCE_LOAD_$_module"()
+// FORCE-LOAD-CLIENT: declare extern_weak {{(dllimport )?}}void @"_swift_FORCE_LOAD_$_module"()
 


### PR DESCRIPTION
When Swift always copied the overlay dylibs into app bundles, it was OK
for these symbol references to be non-weak, but with the overlays now
part of the OS on Apple platforms, we need to handle backward deployment
scenarios where a new overlay does not exist on an old OS version.
A weak reference will serve to pull in the overlay dylib if it exists,
without causing a fatal error if it does not. rdar://problem/50110036