### PR TITLE
[5.1][RemoteMirror] Mark swift_reflection_classIsSwiftMask as a weak import.

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -37,7 +37,7 @@
 extern "C" {
 #endif
 
-SWIFT_REMOTE_MIRROR_LINKAGE
+SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__weak_import__))
 extern unsigned long long swift_reflection_classIsSwiftMask;
 
 /// Get the metadata version supported by the Remote Mirror library.

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -37,7 +37,10 @@
 extern "C" {
 #endif
 
-SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__weak_import__))
+SWIFT_REMOTE_MIRROR_LINKAGE
+#if !defined(_WIN32)
+__attribute__((__weak_import__))
+#endif
 extern unsigned long long swift_reflection_classIsSwiftMask;
 
 /// Get the metadata version supported by the Remote Mirror library.

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -14,7 +14,7 @@
 
 #define SWIFT_CLASS_IS_SWIFT_MASK swift_reflection_classIsSwiftMask
 extern "C" {
-SWIFT_REMOTE_MIRROR_LINKAGE
+SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__weak_import__))
 unsigned long long swift_reflection_classIsSwiftMask = 2;
 }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -11,10 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SwiftRemoteMirror/Platform.h"
+#include "swift/SwiftRemoteMirror/SwiftRemoteMirror.h"
 
 #define SWIFT_CLASS_IS_SWIFT_MASK swift_reflection_classIsSwiftMask
 extern "C" {
-SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__weak_import__))
+SWIFT_REMOTE_MIRROR_LINKAGE
 unsigned long long swift_reflection_classIsSwiftMask = 2;
 }
 
@@ -22,7 +23,6 @@ unsigned long long swift_reflection_classIsSwiftMask = 2;
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Remote/CMemoryReader.h"
 #include "swift/Runtime/Unreachable.h"
-#include "swift/SwiftRemoteMirror/SwiftRemoteMirror.h"
 
 using namespace swift;
 using namespace swift::reflection;

--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -576,7 +576,10 @@ int main(int argc, char *argv[]) {
 
   const char *BinaryFilename = argv[1];
   
-  swift_reflection_classIsSwiftMask = computeClassIsSwiftMask();
+  // swift_reflection_classIsSwiftMask is weak linked so we can work
+  // with older Remote Mirror dylibs.
+  if (&swift_reflection_classIsSwiftMask != NULL)
+    swift_reflection_classIsSwiftMask = computeClassIsSwiftMask();
 
   uint16_t Version = swift_reflection_getSupportedMetadataVersion();
   printf("Metadata version: %u\n", Version);


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24216 to 5.1.

Also have swift-reflection-test check if the symbol exists. This allows swift-reflection-test to work with older Remote Mirror dylibs that don't have it.

rdar://problem/50030805