### PR TITLE
[5.0][Tests] XFAIL objc_class_resilience Category test on OS X 10.9.

### DIFF
--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -36,7 +36,10 @@ func takesMyProtocol(_ p: MyProtocol) -> Int {
   return p.myMethod()
 }
 
-ResilientClassTestSuite.test("Category") {
+ResilientClassTestSuite.test("Category")
+  .xfail(.osxMinor(10, 9, reason:
+         "Category attachment with ARCLite on 10.9 doesn't work currently"))
+  .code {
   expectEqual(42, takesMyProtocol(ResilientFieldWithCategory()))
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24245 to 5.0.

rdar://problem/49794438