### PR TITLE
Revert "[lldb] Switch PR testing and build to use CMake by default."

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -528,7 +528,7 @@ assertions
 test
 validation-test
 
-llvm-targets-to-build=X86;ARM;AArch64;PowerPC
+llvm-targets-to-build=X86;AArch64;PowerPC
 
 # Set the vendor to apple
 compiler-vendor=apple

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -74,7 +74,7 @@ KNOWN_SETTINGS=(
     swift-stdlib-enable-assertions "1"           "enable assertions in Swift"
     swift-stdlib-use-nonatomic-rc "0"            "build the Swift stdlib and overlays with nonatomic reference count operations enabled"
     lldb-build-type             "Debug"          "the CMake build variant for LLDB"
-    lldb-build-with-xcode       "0"              "Use xcodebuild to build LLDB, instead of CMake"
+    lldb-build-with-xcode       "1"              "Use xcodebuild to build LLDB, instead of CMake"
     llbuild-build-type          "Debug"          "the CMake build variant for llbuild"
     foundation-build-type       "Debug"          "the build variant for Foundation"
     libdispatch-build-type      "Debug"          "the build variant for libdispatch"

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -629,11 +629,11 @@ def create_argument_parser():
            help='build the Debug variant of LLDB')
 
     option('--lldb-build-with-xcode', store('lldb_build_with_xcode'),
-           const='1',
+           const='0',
            help='build LLDB using xcodebuild, if possible')
 
     option('--lldb-build-with-cmake', store('lldb_build_with_xcode'),
-           const='0',
+           const='1',
            help='build LLDB using CMake')
 
     option('--debug-cmark', store('cmark_build_variant'),

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -77,7 +77,7 @@ def _apply_default_arguments(args):
         args.lldb_build_variant = args.build_variant
 
     if args.lldb_build_with_xcode is None:
-        args.lldb_build_with_xcode = '0'
+        args.lldb_build_with_xcode = '1'
 
     if args.foundation_build_variant is None:
         args.foundation_build_variant = args.build_variant
@@ -629,11 +629,11 @@ def create_argument_parser():
            help='build the Debug variant of LLDB')
 
     option('--lldb-build-with-xcode', store('lldb_build_with_xcode'),
-           const='0',
+           const='1',
            help='build LLDB using xcodebuild, if possible')
 
     option('--lldb-build-with-cmake', store('lldb_build_with_xcode'),
-           const='1',
+           const='0',
            help='build LLDB using CMake')
 
     option('--debug-cmark', store('cmark_build_variant'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -152,7 +152,7 @@ EXPECTED_DEFAULTS = {
     'llbuild_assertions': True,
     'lldb_assertions': True,
     'lldb_build_variant': 'Debug',
-    'lldb_build_with_xcode': '0',
+    'lldb_build_with_xcode': '1',
     'llvm_assertions': True,
     'llvm_build_variant': 'Debug',
     'llvm_max_parallel_lto_link_jobs':


### PR DESCRIPTION
Some tests are timing out, we also run too many tests. Unblock PR as we fix.