### PR TITLE
[5.1] Cherry-pick module interface fixes to 5.1

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2613,7 +2613,10 @@ public:
     if (auto *overridden = ctor->getOverriddenDecl()) {
       if (!attributeChainContains<RequiredAttr>(DAttrs) ||
           !overridden->isRequired()) {
-        AddAttribute(new (ctx) OverrideAttr(SourceLoc()));
+        // FIXME: why is a convenience init considered overridden when the
+        // overriding init can't be marked overriding in source?
+        if (!overridden->isConvenienceInit())
+          AddAttribute(new (ctx) OverrideAttr(SourceLoc()));
       }
     }
 

--- a/test/ParseableInterface/convenience-init.swift
+++ b/test/ParseableInterface/convenience-init.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+
+// Generate the parseable interface of the current file via the merge-modules step
+// RUN: %target-build-swift -emit-module -o %t/Test.swiftmodule -emit-parseable-module-interface-path %t/TestMerge.swiftinterface -module-name Test %s
+
+// Generate the parseable interface of the current file via a single frontend invocation
+// RUN: %target-swift-frontend -typecheck  -enable-objc-interop -emit-parseable-module-interface-path %t/TestSingle.swiftinterface -module-name Test %s
+
+// Make sure both don't add override for inits shadowing convenience initializers
+// RUN: %FileCheck --check-prefixes=CHECK,SINGLE %s < %t/TestSingle.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,MERGE %s < %t/TestMerge.swiftinterface
+
+// Check we can consume the interface without issue
+// RUN: %target-swift-frontend -swift-version 5 -build-module-from-parseable-interface -o %t/Test.swiftmodule %t/TestSingle.swiftinterface
+// RUN: %target-swift-frontend -swift-version 5 -build-module-from-parseable-interface -o %t/Test.swiftmodule %t/TestMerge.swiftinterface
+
+public class Base {
+  let x: Int
+  public init(x: Int) {
+    self.x = x
+  }
+  convenience public init() {
+    self.init(x: 1)
+  }
+}
+
+public class Derived: Base {
+  // MERGE: {{^}}  public init(z: Swift.Int)
+  // SINGLE: {{^}}  public init(z: Int)
+  public init(z: Int) {
+    super.init(x: z)
+  }
+  // MERGE: {{^}}  public convenience init()
+  // SINGLE: {{^}}  convenience public init()
+  convenience public init() {
+    self.init(z: 1)
+  }
+}
+
+public class Derived2: Base {
+  // CHECK: {{^}}  public init()
+  public init() {
+    super.init(x: 1)
+  }
+
+  // MERGE: {{^}}  override public convenience init(x: Swift.Int)
+  // SINGLE: {{^}}  override convenience public init(x: Int)
+  override convenience public init(x: Int) {
+    self.init()
+  }
+}

--- a/test/ParseableInterface/iboutlet-private-set.swift
+++ b/test/ParseableInterface/iboutlet-private-set.swift
@@ -1,0 +1,18 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path %t/Foo.swiftinterface %s
+// RUN: %FileCheck %s -input-file %t/Foo.swiftinterface
+// RUN: %target-swift-frontend -build-module-from-parseable-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
+
+// Test the interface we generate for @IBOutlet private(set) properties is
+// consumable.
+
+@objc public class MyType {}
+
+open class Bar {
+	// CHECK: @objc @IBOutlet weak public var foo: MyType! {
+	// CHECK-NEXT: get
+	// CHECK-NEXT: }
+	@IBOutlet public private(set) weak var foo: MyType!
+}


### PR DESCRIPTION
Cherry-pick of module interface fixes to 5.1 from:
https://github.com/apple/swift/pull/24225
https://github.com/apple/swift/pull/24212

Resolves rdar://problem/49856177
Resolves rdar://problem/49856927