### PR TITLE
SwiftRemoteMirror: do not mark as weak import on Windows

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -37,7 +37,10 @@
 extern "C" {
 #endif
 
-SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__weak_import__))
+SWIFT_REMOTE_MIRROR_LINKAGE
+#if !defined(_WIN32)
+__attribute__((__weak_import__))
+#endif
 extern unsigned long long swift_reflection_classIsSwiftMask;
 
 /// Get the metadata version supported by the Remote Mirror library.


### PR DESCRIPTION
Weak import semantics are not available on PE/COFF.  Ensure that we do not mark
the type as having weak import semantics.  Otherwise, the dllimport'ed symbol is
marked as `dso_local` which is invalid.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
