### PR TITLE
TensorShape.swift file updated to improve TensorShape printing

### DIFF
--- a/stdlib/public/TensorFlow/TensorShape.swift
+++ b/stdlib/public/TensorFlow/TensorShape.swift
@@ -161,8 +161,7 @@ extension TensorShape : Codable {
 }
 
 extension TensorShape : CustomStringConvertible {
-  @inlinable
   public var description: String {
-    return "TensorShape(\(dimensions))"
-    }
+    return dimensions.description
+  }
 }

--- a/stdlib/public/TensorFlow/TensorShape.swift
+++ b/stdlib/public/TensorFlow/TensorShape.swift
@@ -159,3 +159,10 @@ extension TensorShape : Codable {
     self.init(dimensions)
   }
 }
+
+extension TensorShape : CustomStringConvertible {
+  @inlinable
+  public var description: String {
+    return "TensorShape(\(dimensions))"
+    }
+}

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -623,6 +623,11 @@ TensorTests.testAllBackends("SimpleCond") {
   expectEqual(0, selectValue(true).scalar)
 }
 
+TensorTests.testAllBackends("TensorShapeDescription") {
+  expectEqual("[2, 2]", Tensor<Int32>(ones: [2, 2]).shape.description)
+  expectEqual("[]", Tensor(1).shape.description)
+}
+
 @inline(never)
 func testXORInference() {
   func xor(_ x: Float, _ y: Float) -> Float {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Added description property to `TensorShape` by conforming to `CustomStringConvertible` so that we can obtain the desired `TensorShape` printing. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [TF-447](https://bugs.swift.org/browse/TF-447).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
