### PR TITLE
[stdlib] Add a version number for the stdlib itself; use it in unit tests

### DIFF
--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -26,6 +26,7 @@ add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   RaceTest.swift
   Statistics.swift
   StdlibCoreExtras.swift
+  StdlibVersion.swift
   StringConvertible.swift
   TestHelpers.swift
   TypeIndexed.swift

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1899,6 +1899,8 @@ public enum TestRunPredicate : CustomStringConvertible {
   case objCRuntime(/*reason:*/ String)
   case nativeRuntime(/*reason:*/ String)
 
+  case stdlibOlderThan(StdlibVersion, reason: String)
+
   public var description: String {
     switch self {
     case .custom(_, let reason):
@@ -1995,6 +1997,9 @@ public enum TestRunPredicate : CustomStringConvertible {
       return "Objective-C runtime, reason: \(reason))"
     case .nativeRuntime(let reason):
       return "Native runtime (no ObjC), reason: \(reason))"
+
+    case .stdlibOlderThan(let version, reason: let reason):
+      return "stdlibOlderThan(\(version), reason: \(reason))"
     }
   }
 
@@ -2295,6 +2300,9 @@ public enum TestRunPredicate : CustomStringConvertible {
 #else
       return true
 #endif
+
+    case .stdlibOlderThan(let version, reason: _):
+      return StdlibVersion.currentlyRunning < version
     }
   }
 }

--- a/stdlib/private/StdlibUnittest/StdlibVersion.swift
+++ b/stdlib/private/StdlibUnittest/StdlibVersion.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_fixed_layout
+public struct StdlibVersion: RawRepresentable {
+  public let rawValue: Double
+
+  @inlinable
+  public init(rawValue: Double) {
+    self.rawValue = rawValue
+  }
+}
+
+extension StdlibVersion {
+  public static func custom(_ version: Double) -> StdlibVersion {
+    return StdlibVersion(rawValue: version)
+  }
+
+  public static var currentlyRunning: StdlibVersion {
+    return StdlibVersion(rawValue: _stdlibDynamicVersion)
+  }
+
+  // Shipped in macOS 10.14.2, iOS 12.2, watchOS 5.2, tvOS 13.2
+  public static var swift5_0: StdlibVersion {
+    return StdlibVersion(rawValue: 1000.0)
+  }
+
+}
+
+extension StdlibVersion: CustomStringConvertible {
+  public var description: String {
+    return "\(rawValue)"
+  }
+}
+
+extension StdlibVersion: Equatable {}
+extension StdlibVersion: Hashable {}
+
+extension StdlibVersion: Comparable {
+  public static func < (left: StdlibVersion, right: StdlibVersion) -> Bool {
+    return left.rawValue < right.rawValue
+  }
+}

--- a/stdlib/private/StdlibUnittest/StdlibVersion.swift
+++ b/stdlib/private/StdlibUnittest/StdlibVersion.swift
@@ -10,19 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_fixed_layout
 public struct StdlibVersion: RawRepresentable {
-  public let rawValue: Double
+  public let rawValue: (Int, Int)
 
-  @inlinable
-  public init(rawValue: Double) {
+  public init(rawValue: (Int, Int)) {
     self.rawValue = rawValue
   }
 }
 
 extension StdlibVersion {
-  public static func custom(_ version: Double) -> StdlibVersion {
-    return StdlibVersion(rawValue: version)
+  public static func custom(_ version1: Int, _ version2: Int) -> StdlibVersion {
+    return StdlibVersion(rawValue: (version1, version2))
   }
 
   public static var currentlyRunning: StdlibVersion {
@@ -31,9 +29,8 @@ extension StdlibVersion {
 
   // Shipped in macOS 10.14.2, iOS 12.2, watchOS 5.2, tvOS 13.2
   public static var swift5_0: StdlibVersion {
-    return StdlibVersion(rawValue: 1000.0)
+    return StdlibVersion(rawValue: (1000, 0))
   }
-
 }
 
 extension StdlibVersion: CustomStringConvertible {
@@ -42,8 +39,18 @@ extension StdlibVersion: CustomStringConvertible {
   }
 }
 
-extension StdlibVersion: Equatable {}
-extension StdlibVersion: Hashable {}
+extension StdlibVersion: Equatable {
+  public static func == (left: StdlibVersion, right: StdlibVersion) -> Bool {
+    return left.rawValue == right.rawValue
+  }
+}
+
+extension StdlibVersion: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(rawValue.0)
+    hasher.combine(rawValue.1)
+  }
+}
 
 extension StdlibVersion: Comparable {
   public static func < (left: StdlibVersion, right: StdlibVersion) -> Bool {

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -45,3 +45,39 @@ public func _stdlib_isOSVersionAtLeast(
   return false._value
 #endif
 }
+
+
+/// Returns the version number for the Swift Standard Library that the code
+/// calling this was originally compiled with.
+///
+/// The version number is an arbitrary `Double` value that is monotonically
+/// increasing between toolchain releases. It does not correlate with toolchain
+/// or OS version numbers, and it is not a semantic version number.
+@_alwaysEmitIntoClient @_transparent
+public var _stdlibStaticVersion: Double {
+  return 1001.0
+}
+
+/// Returns the version number for the Swift Standard Library that is currently
+/// loaded.
+///
+/// The version number is an arbitrary `Double` value that is monotonically
+/// increasing between toolchain releases. It does not correlate with toolchain
+/// or OS version numbers, and it is not a semantic version number.
+@_alwaysEmitIntoClient // Introduced in 5.1
+public var _stdlibDynamicVersion: Double {
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    return _stdlibOpaqueVersion
+  }
+  else {
+    // When linked with the 5.0 stdlib, we return this default value.
+    return 1000.0
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@usableFromInline
+internal var _stdlibOpaqueVersion: Double {
+  return _stdlibStaticVersion
+}
+

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -50,34 +50,46 @@ public func _stdlib_isOSVersionAtLeast(
 /// Returns the version number for the Swift Standard Library that the code
 /// calling this was originally compiled with.
 ///
-/// The version number is an arbitrary `Double` value that is monotonically
-/// increasing between toolchain releases. It does not correlate with toolchain
-/// or OS version numbers, and it is not a semantic version number.
-@_alwaysEmitIntoClient @_transparent
-public var _stdlibStaticVersion: Double {
-  return 1001.0
+/// The version number is an arbitrary pair of integers, with lexicographical
+/// ordering. Version numbers of (logically) successive stdlib releases form a
+/// monotonically increasing sequence; i.e., versions should not decrease, but
+/// they are allowed to stay the same.
+///
+/// The two integer components are not intended to correspond to major or minor
+/// versions in a semantic versioning scheme. Neither do they correlate with
+/// toolchain or OS version numbers.
+@_alwaysEmitIntoClient
+public var _stdlibStaticVersion: (Int, Int) {
+  // On the master branch, increment the first number.
+  // On release branches, increment the second number.
+  return (1001, 0)
 }
 
 /// Returns the version number for the Swift Standard Library that is currently
 /// loaded.
 ///
-/// The version number is an arbitrary `Double` value that is monotonically
-/// increasing between toolchain releases. It does not correlate with toolchain
-/// or OS version numbers, and it is not a semantic version number.
+/// The version number is an arbitrary pair of integers, with lexicographical
+/// ordering. Version numbers of (logically) successive stdlib releases form a
+/// monotonically increasing sequence; i.e., versions should not decrease, but
+/// they are allowed to stay the same.
+///
+/// The two integer components are not intended to correspond to major or minor
+/// versions in a semantic versioning scheme. Neither do they correlate with
+/// toolchain or OS version numbers.
 @_alwaysEmitIntoClient // Introduced in 5.1
-public var _stdlibDynamicVersion: Double {
+public var _stdlibDynamicVersion: (Int, Int) {
   if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
     return _stdlibOpaqueVersion
   }
   else {
     // When linked with the 5.0 stdlib, we return this default value.
-    return 1000.0
+    return (1000, 0)
   }
 }
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @usableFromInline
-internal var _stdlibOpaqueVersion: Double {
+internal var _stdlibOpaqueVersion: (Int, Int) {
   return _stdlibStaticVersion
 }
 

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -46,6 +46,12 @@ public func _stdlib_isOSVersionAtLeast(
 #endif
 }
 
+@inlinable
+internal var _stdlibCurrentVersion: (Int, Int) {
+  // On the master branch, increment the first number.
+  // On release branches, increment the second number.
+  return (1001, 0)
+}
 
 /// Returns the version number for the Swift Standard Library that the code
 /// calling this was originally compiled with.
@@ -58,11 +64,11 @@ public func _stdlib_isOSVersionAtLeast(
 /// The two integer components are not intended to correspond to major or minor
 /// versions in a semantic versioning scheme. Neither do they correlate with
 /// toolchain or OS version numbers.
-@_alwaysEmitIntoClient
 public var _stdlibStaticVersion: (Int, Int) {
-  // On the master branch, increment the first number.
-  // On release branches, increment the second number.
-  return (1001, 0)
+  @_alwaysEmitIntoClient
+  get {
+    return _stdlibCurrentVersion
+  }
 }
 
 /// Returns the version number for the Swift Standard Library that is currently
@@ -90,6 +96,6 @@ public var _stdlibDynamicVersion: (Int, Int) {
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @usableFromInline
 internal var _stdlibOpaqueVersion: (Int, Int) {
-  return _stdlibStaticVersion
+  return _stdlibCurrentVersion
 }
 

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -46,13 +46,6 @@ public func _stdlib_isOSVersionAtLeast(
 #endif
 }
 
-@inlinable
-internal var _stdlibCurrentVersion: (Int, Int) {
-  // On the master branch, increment the first number.
-  // On release branches, increment the second number.
-  return (1001, 0)
-}
-
 /// Returns the version number for the Swift Standard Library that the code
 /// calling this was originally compiled with.
 ///
@@ -67,7 +60,9 @@ internal var _stdlibCurrentVersion: (Int, Int) {
 public var _stdlibStaticVersion: (Int, Int) {
   @_alwaysEmitIntoClient
   get {
-    return _stdlibCurrentVersion
+    // On the master branch, increment the first number.
+    // On release branches, increment the second number.
+    return (1001, 0)
   }
 }
 
@@ -96,6 +91,6 @@ public var _stdlibDynamicVersion: (Int, Int) {
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @usableFromInline
 internal var _stdlibOpaqueVersion: (Int, Int) {
-  return _stdlibCurrentVersion
+  return _stdlibStaticVersion
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3005,7 +3005,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/22527"))
   .code {
   do {
@@ -3303,7 +3303,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/22527"))
   .code {
   let d1 = getBridgedNonverbatimEquatableDictionary([:])

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3003,7 +3003,11 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
   }
 }
 
-DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
+DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/22527"))
+  .code {
   do {
     var d = getBridgedNonverbatimDictionary([:])
     assert(isNativeDictionary(d))
@@ -3297,7 +3301,11 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
   assert(identity2 == d2._rawIdentifier())
 }
 
-DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
+DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/22527"))
+  .code {
   let d1 = getBridgedNonverbatimEquatableDictionary([:])
   let identity1 = d1._rawIdentifier()
   assert(isNativeDictionary(d1))

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1920,7 +1920,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/22527"))
   .code {
   do {
@@ -2179,7 +2179,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/22527"))
   .code {
   let s1 = getBridgedNonverbatimSet([])
@@ -4627,7 +4627,7 @@ SetTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -4651,7 +4651,7 @@ SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -4784,7 +4784,7 @@ SetTestSuite.test("ForcedVerbatimDowncast.Trap.Int")
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -4808,7 +4808,7 @@ SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -4833,7 +4833,7 @@ SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
 #if _runtime(_ObjC)
 SetTestSuite.test("Upcast.StringEqualityMismatch")
   .skip(
-    .stdlibOlderThan(.custom(1001.0),
+    .stdlibOlderThan(.custom(1001, 0),
       reason: "https://github.com/apple/swift/pull/23683"))
   .code {
   // Upcasting from NSString to String keys changes their concept of equality,

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1918,7 +1918,11 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
   }
 }
 
-SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
+SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/22527"))
+  .code {
   do {
     var s = getBridgedVerbatimSet([])
     expectTrue(isCocoaSet(s))
@@ -2173,7 +2177,11 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
   expectNotEqual(s1, s2)
 }
 
-SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
+SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/22527"))
+  .code {
   let s1 = getBridgedNonverbatimSet([])
   let identity1 = s1._rawIdentifier()
   expectTrue(isNativeSet(s1))
@@ -4618,6 +4626,9 @@ SetTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
 
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -4639,6 +4650,9 @@ SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
 
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -4769,6 +4783,9 @@ SetTestSuite.test("ForcedVerbatimDowncast.Trap.Int")
 
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -4790,6 +4807,9 @@ SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
 
 #if _runtime(_ObjC)
 SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/23174"))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -4811,7 +4831,11 @@ SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
 #endif
 
 #if _runtime(_ObjC)
-SetTestSuite.test("Upcast.StringEqualityMismatch") {
+SetTestSuite.test("Upcast.StringEqualityMismatch")
+  .skip(
+    .stdlibOlderThan(.custom(1001.0),
+      reason: "https://github.com/apple/swift/pull/23683"))
+  .code {
   // Upcasting from NSString to String keys changes their concept of equality,
   // resulting in two equal keys, one of which should be discarded by the
   // downcast. (Along with its associated value.)


### PR DESCRIPTION
The usual OS-based availability checks aren't always appropriate -- the stdlib we're actually using may not correspond to the version that shipped with the OS we're running on. This makes it tricky to decide whether a particular fix is supposed to be present in the current stdlib, which is a problem for unit tests that are supposed to test these changes.

Add an (arbitrary) version number for the stdlib itself, and use it to skip certain tests that are checking for behavioral changes introduced in 5.1.

rdar://problem/50150948