### PR TITLE
[5.1] Module interfaces: preserve -autolink-force-load

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -321,7 +321,7 @@ def module_link_name : Separate<["-"], "module-link-name">,
 def module_link_name_EQ : Joined<["-"], "module-link-name=">,
   Flags<[FrontendOption]>, Alias<module_link_name>;
 def autolink_force_load : Flag<["-"], "autolink-force-load">,
-  Flags<[FrontendOption, HelpHidden]>,
+  Flags<[FrontendOption, ModuleInterfaceOption, HelpHidden]>,
   HelpText<"Force ld to link against this module even if no symbols are used">;
 
 def emit_module : Flag<["-"], "emit-module">,

--- a/test/ParseableInterface/option-preservation.swift
+++ b/test/ParseableInterface/option-preservation.swift
@@ -1,20 +1,22 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked
+// RUN: %target-swift-frontend -enable-library-evolution -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE: swift-module-flags:
 // CHECK-SWIFTINTERFACE-SAME: -enable-library-evolution
 // CHECK-SWIFTINTERFACE-SAME: -Onone
 // CHECK-SWIFTINTERFACE-SAME: -enforce-exclusivity=unchecked
+// CHECK-SWIFTINTERFACE-SAME: -autolink-force-load
 
 // Make sure flags show up when filelists are enabled
 
-// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation -Ounchecked -enforce-exclusivity=unchecked 2>&1
+// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation -Ounchecked -enforce-exclusivity=unchecked -autolink-force-load 2>&1
 // RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
 
 // CHECK-FILELIST-INTERFACE: swift-module-flags:
 // CHECK-FILELIST-INTERFACE-SAME: -target
+// CHECK-FILELIST-INTERFACE-SAME: -autolink-force-load
 // CHECK-FILELIST-INTERFACE-SAME: -module-link-name fooCore
 // CHECK-FILELIST-INTERFACE-SAME: -enforce-exclusivity=unchecked
 // CHECK-FILELIST-INTERFACE-SAME: -Ounchecked


### PR DESCRIPTION
Cherry-pick of #24262 to the 5.1 branch. Reviewed by @nathawes.

rdar://problem/50191735