### PR TITLE
AST: inline the definition for `AnyValue::Holder<Type>::equals`

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -550,7 +550,11 @@ public:
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>
-bool AnyValue::Holder<Type>::equals(const HolderBase &other) const;
+inline bool AnyValue::Holder<Type>::equals(const HolderBase &other) const {
+  assert(typeID == other.typeID && "Caller should match type IDs");
+  return value.getPointer() ==
+      static_cast<const Holder<Type> &>(other).value.getPointer();
+}
 
 void simple_display(llvm::raw_ostream &out, const Type &type);
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -646,14 +646,6 @@ void swift::simple_display(
   out << " }";
 }
 
-
-template<>
-bool swift::AnyValue::Holder<Type>::equals(const HolderBase &other) const {
-  assert(typeID == other.typeID && "Caller should match type IDs");
-  return value.getPointer() ==
-  static_cast<const Holder<Type> &>(other).value.getPointer();
-}
-
 void swift::simple_display(llvm::raw_ostream &out, const Type &type) {
   if (type)
     type.print(out);


### PR DESCRIPTION
Unfortunately, MSVC will not preserve the template specialization in
swiftAST.  However, the function is pretty tiny, so simply inline it
into the header.  This allows the template specialization to be
instantiated and inlined at the use site.  The overall size impact
should be negligible and this repairs the Windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
