### PR TITLE
[CSDiagnostics] Removes lazy when applying computed property fix-it

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1474,6 +1474,10 @@ void ContextualFailure::tryComputedPropertyFixIts(Expr *expr) const {
         if (VD->isLet()) {
           diag.fixItReplace(PBD->getStartLoc(), getTokenText(tok::kw_var));
         }
+
+        if (auto lazyAttr = VD->getAttrs().getAttribute<LazyAttr>()) {
+          diag.fixItRemove(lazyAttr->getRange());
+        }
       }
     }
   }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1306,3 +1306,8 @@ class SR_9267_C {
 class SR_9267_C2 {
   let SR_9267_prop_3: Int = { return 0 } // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_3' a computed property}}{{3-6=var}}{{27-29=}}
 }
+
+class LazyPropInClass {
+  lazy var foo: Int = { return 0 } // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}}
+  // expected-note@-1 {{Remove '=' to make 'foo' a computed property}}{{21-23=}}{{3-8=}}
+}


### PR DESCRIPTION
Follow up to #23500. 

When applying the fix-it, I forgot to check for the possibility of the variable being `lazy`. This means we would end up emitting another diagnostic complaining about the fact that computed properties cannot be lazy.

This PR fixes the mistake, by removing `lazy` if present.