### PR TITLE
Temporarily disable a new vImage test that's failing for some platforms.

### DIFF
--- a/test/stdlib/Accelerate_vImage.swift
+++ b/test/stdlib/Accelerate_vImage.swift
@@ -73,7 +73,8 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         expectEqual(coreVideoToCoreGraphics.sourceBuffers(colorSpace: colorSpace),
                     coreGraphicsToCoreVideo.destinationBuffers(colorSpace: colorSpace))
     }
-    
+  
+    /* Disabled due to <rdar://problem/50209312>
     Accelerate_vImageTests.test("vImage/BufferOrder") {
         let sourceFormat = vImage_CGImageFormat(bitsPerComponent: 8,
                                                 bitsPerPixel: 32,
@@ -96,6 +97,7 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         expectEqual(sBuffers, [.coreGraphics])
         expectEqual(dBuffers, [.coreGraphics])
     }
+    */
     
     Accelerate_vImageTests.test("vImage/AnyToAnyError") {
         var error = kvImageNoError


### PR DESCRIPTION
It appears to only effect the i386-simulator target, so we can simply disable this and let the Accelerate team sort it out.

<rdar://problem/50209312>