### PR TITLE
[api-digester] Force lazy attribute calculations as workaround

### DIFF
--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1158,6 +1158,16 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Decl *D):
       IsImplicit(D->isImplicit()),
       IsDeprecated(D->getAttrs().getDeprecated(D->getASTContext())),
       IsABIPlaceholder(isABIPlaceholderRecursive(D)) {
+
+  // Force some attributes that are lazily computed.
+  // FIXME: we should use these AST predicates directly instead of looking at
+  // the attributes rdar://50217247.
+  if (auto *VD = dyn_cast<ValueDecl>(D)) {
+    (void) VD->isObjC();
+    (void) VD->isFinal();
+    (void) VD->isDynamic();
+  }
+
   // Capture all attributes.
   auto AllAttrs = D->getAttrs();
   std::transform(AllAttrs.begin(), AllAttrs.end(), std::back_inserter(DeclAttrs),


### PR DESCRIPTION
We were relying on attributes being propagated by the type-checker, for
example from a property to its accessors, but the goal is for these to
be caculated lazily by the request evaluator, so we should be checking
the AST predicates instead.  As a workaround, force calculating them to
cause the attributes to be added for now to fix a CI failure.

Patch by @slavapestov

rdar://50184238