### PR TITLE
[5.1] [code-completion] Add type context for single-expression function bodies

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -805,7 +805,21 @@ class CodeCompletionContext {
 public:
   CodeCompletionCache &Cache;
   CompletionKind CodeCompletionKind = CompletionKind::None;
-  bool HasExpectedTypeRelation = false;
+
+  enum class TypeContextKind {
+    /// There is no known contextual type. All types are equally good.
+    None,
+
+    /// There is a contextual type from a single-expression closure/function
+    /// body. The context is a hint, and enables unresolved member completion,
+    /// but should not hide any results.
+    SingleExpressionBody,
+
+    /// There are known contextual types.
+    Required,
+  };
+
+  TypeContextKind typeContextKind = TypeContextKind::None;
 
   /// Whether there may be members that can use implicit member syntax,
   /// e.g. `x = .foo`.

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -180,7 +180,7 @@ public:
       SmallVectorImpl<StringRef> &Keywords, SourceLoc introducerLoc) {};
 
   /// Complete at the beginning of accessor in a accessor block.
-  virtual void completeAccessorBeginning() {};
+  virtual void completeAccessorBeginning(CodeCompletionExpr *E) {};
 
   /// Complete the keyword in attribute, for instance, @available.
   virtual void completeDeclAttrKeyword(Decl *D, bool Sil, bool Param) {};

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -929,6 +929,18 @@ calculateMaxTypeRelationForDecl(
     bool IsImplicitlyCurriedInstanceMethod = false) {
   auto Result = CodeCompletionResult::ExpectedTypeRelation::Unrelated;
   for (auto Type : typeContext.possibleTypes) {
+    // Do not use Void type context for a single-expression body, since the
+    // implicit return does not constrain the expression.
+    //
+    //     { ... -> ()  in x } // x can be anything
+    //
+    // This behaves differently from explicit return, and from non-Void:
+    //
+    //     { ... -> Int in x }        // x must be Int
+    //     { ... -> ()  in return x } // x must be Void
+    if (typeContext.isSingleExpressionBody && Type->isVoid())
+      continue;
+
     Result = std::max(Result, calculateTypeRelationForDecl(
                                   D, Type, IsImplicitlyCurriedInstanceMethod));
 
@@ -1650,7 +1662,15 @@ public:
         expectedTypeContext.possibleTypes.push_back(T);
   }
 
-  bool hasExpectedTypes() const { return !expectedTypeContext.empty(); }
+  CodeCompletionContext::TypeContextKind typeContextKind() const {
+    if (expectedTypeContext.empty()) {
+      return CodeCompletionContext::TypeContextKind::None;
+    } else if (expectedTypeContext.isSingleExpressionBody) {
+      return CodeCompletionContext::TypeContextKind::SingleExpressionBody;
+    } else {
+      return CodeCompletionContext::TypeContextKind::Required;
+    }
+  }
 
   bool needDot() const {
     return NeedLeadingDot;
@@ -3548,9 +3568,7 @@ public:
       builder.addSimpleNamedParameter("values");
       builder.addRightParen();
       for (auto T : expectedTypeContext.possibleTypes) {
-        if (!T)
-          continue;
-        if (T->is<TupleType>()) {
+        if (T && T->is<TupleType>() && !T->isVoid()) {
           addTypeAnnotation(builder, T);
           builder.setExpectedTypeRelation(CodeCompletionResult::Identical);
           break;
@@ -5394,7 +5412,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.RequestedCachedResults.clear();
   }
 
-  CompletionContext.HasExpectedTypeRelation = Lookup.hasExpectedTypes();
+  CompletionContext.typeContextKind = Lookup.typeContextKind();
 
   deliverCompletionResults();
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4430,20 +4430,30 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
 
       if (Tok.is(tok::code_complete)) {
         if (CodeCompletion) {
+          CodeCompletionExpr *CCE = nullptr;
           if (IsFirstAccessor && !parsingLimitedSyntax) {
             // If CC token is the first token after '{', it might be implicit
             // getter. Set up dummy accessor as the decl context to populate
             // 'self' decl.
+
+            // FIXME: if there is already code inside the body, we should fall
+            // through to parseImplicitGetter and handle the completion there so
+            // that we can differentiate a single-expression body from the first
+            // expression in a multi-statement body.
             auto getter = createAccessorFunc(
                 accessors.LBLoc, /*ValueNamePattern*/ nullptr, GenericParams,
                 Indices, ElementTy, StaticLoc, Flags, AccessorKind::Get,
                 storage, this, /*AccessorKeywordLoc*/ SourceLoc());
+            CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
+            getter->setBody(BraceStmt::create(Context, Tok.getLoc(),
+                                              ASTNode(CCE), Tok.getLoc(),
+                                              /*implicit*/ true));
             accessors.add(getter);
             CodeCompletion->setParsedDecl(getter);
           } else {
             CodeCompletion->setParsedDecl(storage);
           }
-          CodeCompletion->completeAccessorBeginning();
+          CodeCompletion->completeAccessorBeginning(CCE);
         }
         consumeToken(tok::code_complete);
         accessorHasCodeCompletion = true;

--- a/test/IDE/complete_accessor.swift
+++ b/test/IDE/complete_accessor.swift
@@ -135,7 +135,7 @@
 // NO_OBSERVER-NOT: willSet
 // NO_OBSERVER-NOT: didSet
 
-// WITH_GLOBAL: Decl[GlobalVar]/CurrModule:         globalValue[#String#];
+// WITH_GLOBAL: Decl[GlobalVar]/CurrModule{{(/TypeRelation\[Identical\])?}}: globalValue[#String#];
 // NO_GLOBAL-NOT: globalValue;
 
 // WITH_SELF: Decl[LocalVar]/Local:               self[#{{.+}}#]; name=self

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -299,7 +299,7 @@ _ = {
 }()
 // TOP_LEVEL_CLOSURE_1: Begin completions
 // TOP_LEVEL_CLOSURE_1-DAG: Decl[Struct]/CurrModule: FooStruct[#FooStruct#]{{; name=.+$}}
-// TOP_LEVEL_CLOSURE_1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: fooFunc1()[#Void#]{{; name=.+$}}
+// TOP_LEVEL_CLOSURE_1-DAG: Decl[FreeFunction]/CurrModule: fooFunc1()[#Void#]{{; name=.+$}}
 // TOP_LEVEL_CLOSURE_1-DAG: Decl[GlobalVar]/Local: fooObject[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_CLOSURE_1: End completions
 

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -67,7 +67,7 @@ while true {
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_PARAM_AND_ASSOC_TYPE | %FileCheck %s -check-prefix=GENERIC_PARAM_AND_ASSOC_TYPE
 struct CustomGenericCollection<Key> : ExpressibleByDictionaryLiteral {
   // GENERIC_PARAM_AND_ASSOC_TYPE: Begin completions
-  // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[InstanceVar]/CurrNominal:      count[#Int#]; name=count
+  // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:      count[#Int#]; name=count
   // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[GenericTypeParam]/Local:       Key[#Key#]; name=Key
   // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[TypeAlias]/CurrNominal:        Value[#CustomGenericCollection<Key>.Value#]; name=Value
   // GENERIC_PARAM_AND_ASSOC_TYPE: End completions

--- a/test/IDE/complete_in_accessors.swift
+++ b/test/IDE/complete_in_accessors.swift
@@ -132,7 +132,7 @@ func returnsInt() -> Int {}
 
 // WITH_GLOBAL_DECLS: Begin completions
 // WITH_GLOBAL_DECLS-DAG: Decl[Struct]/CurrModule:       FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_GLOBAL_DECLS-DAG: Decl[FreeFunction]/CurrModule: returnsInt()[#Int#]{{; name=.+$}}
+// WITH_GLOBAL_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Identical\])?}}: returnsInt()[#Int#]{{; name=.+$}}
 // WITH_GLOBAL_DECLS: End completions
 
 // WITH_GLOBAL_DECLS1: Begin completions
@@ -142,7 +142,7 @@ func returnsInt() -> Int {}
 
 // WITH_MEMBER_DECLS: Begin completions
 // WITH_MEMBER_DECLS-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_MEMBER_DECLS-DAG: Decl[FreeFunction]/CurrModule:    returnsInt()[#Int#]{{; name=.+$}}
+// WITH_MEMBER_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Identical\])?}}:    returnsInt()[#Int#]{{; name=.+$}}
 // WITH_MEMBER_DECLS-DAG: Decl[LocalVar]/Local:             self[#MemberAccessors#]{{; name=.+$}}
 // WITH_MEMBER_DECLS-DAG: Decl[InstanceVar]/CurrNominal:    instanceVar[#Double#]{{; name=.+$}}
 // WITH_MEMBER_DECLS-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc({#(a): Int#})[#Float#]{{; name=.+$}}
@@ -159,8 +159,8 @@ func returnsInt() -> Int {}
 
 // WITH_LOCAL_DECLS: Begin completions
 // WITH_LOCAL_DECLS-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_LOCAL_DECLS-DAG: Decl[FreeFunction]/CurrModule:    returnsInt()[#Int#]{{; name=.+$}}
-// WITH_LOCAL_DECLS-DAG: Decl[LocalVar]/Local:             functionParam[#Int#]{{; name=.+$}}
+// WITH_LOCAL_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Identical\])?}}:    returnsInt()[#Int#]{{; name=.+$}}
+// WITH_LOCAL_DECLS-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Identical\])?}}:             functionParam[#Int#]{{; name=.+$}}
 // WITH_LOCAL_DECLS-DAG: Decl[FreeFunction]/Local:         localFunc({#(a): Int#})[#Float#]{{; name=.+$}}
 // WITH_LOCAL_DECLS: End completions
 
@@ -456,7 +456,7 @@ func accessorsInFunction(_ functionParam: Int) {
 
 // ACCESSORS_IN_MEMBER_FUNC_2: Begin completions
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local:            self[#AccessorsInMemberFunction#]
-// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local:            functionParam[#Int#]
+// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Identical\])?}}:            functionParam[#Int#]
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceVar]/OutNominal:    instanceVar[#Double#]
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceMethod]/OutNominal: instanceFunc({#(a): Int#})[#Float#]
 // ACCESSORS_IN_MEMBER_FUNC_2: End completions

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -2,12 +2,39 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureRetVoid | %FileCheck %s -check-prefix=TestSingleExprClosureRetVoid
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureRetUnresolved | %FileCheck %s -check-prefix=TestSingleExprClosureRetUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosure | %FileCheck %s -check-prefix=TestSingleExprClosure
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureVoid | %FileCheck %s -check-prefix=TestSingleExprClosureRetVoid
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureVoid | %FileCheck %s -check-prefix=TestSingleExprClosureVoid
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureUnresolved | %FileCheck %s -check-prefix=TestSingleExprClosureRetUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureCall | %FileCheck %s -check-prefix=TestSingleExprClosure
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprClosureGlobal | %FileCheck %s -check-prefix=TestSingleExprClosureGlobal
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprClosureGlobal | %FileCheck %s -check-prefix=TestNonSingleExprClosureGlobal
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprClosureUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprClosureUnresolved
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprFuncRet | %FileCheck %s -check-prefix=TestSingleExprFuncRet
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprFunc | %FileCheck %s -check-prefix=TestSingleExprFunc
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprFuncUnresolved | %FileCheck %s -check-prefix=TestSingleExprFuncUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprFuncUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprFuncUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprLocalFuncUnresolved | %FileCheck %s -check-prefix=TestSingleExprFuncUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprFuncGlobal | %FileCheck %s -check-prefix=TestSingleExprFuncGlobal
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprFuncGlobal | %FileCheck %s -check-prefix=TestNonSingleExprFuncGlobal
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorRet | %FileCheck %s -check-prefix=TestSingleExprAccessorRet
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessor | %FileCheck %s -check-prefix=TestSingleExprAccessor
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprAccessorUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprAccessorUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprLocalAccessorUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorUnresolved
+// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGlobal | %FileCheck %s -check-prefix=TestSingleExprAccessorGlobal
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprAccessorGlobal | %FileCheck %s -check-prefix=TestNonSingleExprAccessorGlobal
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGetUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorSetUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorSetUnresolved
+// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGetGlobal | %FileCheck %s -check-prefix=TestSingleExprAccessorGlobal
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptRet | %FileCheck %s -check-prefix=TestSingleExprSubscriptRet
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscript | %FileCheck %s -check-prefix=TestSingleExprSubscript
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptUnresolved | %FileCheck %s -check-prefix=TestSingleExprSubscriptUnresolved
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprSubscriptUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprSubscriptUnresolved
+// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptGlobal | %FileCheck %s -check-prefix=TestSingleExprSubscriptGlobal
+
+// MARK: Single-expression closures
 
 struct TestSingleExprClosureRet {
   func void() -> Void {}
@@ -92,6 +119,12 @@ struct TestSingleExprClosureVoid {
       self.#^TestSingleExprClosureVoid^#
     }()
   }
+// TestSingleExprClosureVoid: Begin completions
+// TestSingleExprClosureVoid-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestSingleExprClosureVoid-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// Note: this differs from explicit return by having no type context.
+// TestSingleExprClosureVoid-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprClosureVoid: End completions
 }
 
 struct TestSingleExprClosureUnresolved {
@@ -170,4 +203,346 @@ struct TestNonSingleExprClosureUnresolved {
   }
 // TestNonSingleExprClosureUnresolved-NOT: myEnum
 // TestNonSingleExprClosureUnresolved-NOT: notMine
+}
+
+// MARK: Single-expression functions
+
+struct TestSingleExprFuncRet {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() -> Int {
+    return self.#^TestSingleExprFuncRet^#
+  }
+
+// TestSingleExprFuncRet: Begin completions
+// TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: void()[#Void#];
+// TestSingleExprFuncRet: End completions
+}
+
+struct TestSingleExprFunc {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() -> Int {
+    self.#^TestSingleExprFunc^#
+  }
+
+// TestSingleExprFunc: Begin completions
+// TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprFunc: End completions
+}
+
+struct TestSingleExprFuncUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  func test() -> MyEnum {
+    .#^TestSingleExprFuncUnresolved^#
+  }
+
+// TestSingleExprFuncUnresolved: Begin completions
+// TestSingleExprFuncUnresolved-NOT: notMine
+// TestSingleExprFuncUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#TestSingleExpr{{(Local)?}}FuncUnresolved.MyEnum#];
+// TestSingleExprFuncUnresolved-NOT: notMine
+// TestSingleExprFuncUnresolved: End completions
+}
+
+struct TestNonSingleExprFuncUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  func test() -> MyEnum {
+    .#^TestNonSingleExprFuncUnresolved^#
+    return .myEnum
+  }
+
+// TestNonSingleExprFuncUnresolved-NOT: myEnum
+// TestNonSingleExprFuncUnresolved-NOT: notMine
+}
+
+struct TestSingleExprLocalFuncUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  func test() {
+    func local() -> MyEnum {
+      .#^TestSingleExprLocalFuncUnresolved^#
+    }
+  }
+}
+
+struct TestSingleExprFuncGlobal {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() -> Int {
+    #^TestSingleExprFuncGlobal^#
+  }
+// TestSingleExprFuncGlobal: Begin completions
+// TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprFuncGlobal: End completions
+}
+
+struct TestNonSingleExprFuncGlobal {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() -> Int {
+    #^TestNonSingleExprFuncGlobal^#
+    return 42
+  }
+// TestNonSingleExprFuncGlobal: Begin completions
+// TestNonSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestNonSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestNonSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestNonSingleExprFuncGlobal: End completions
+}
+
+// MARK: Single-expression accessors
+
+struct TestSingleExprAccessorRet {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  var test: Int {
+    return self.#^TestSingleExprAccessorRet^#
+  }
+
+// TestSingleExprAccessorRet: Begin completions
+// TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: void()[#Void#];
+// TestSingleExprAccessorRet: End completions
+}
+
+struct TestSingleExprAccessor {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  var test: Int {
+    self.#^TestSingleExprAccessor^#
+  }
+
+// TestSingleExprAccessor: Begin completions
+// TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprAccessor: End completions
+}
+
+struct TestSingleExprAccessorUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  var test: MyEnum {
+    .#^TestSingleExprAccessorUnresolved^#
+  }
+
+// TestSingleExprAccessorUnresolved: Begin completions
+// TestSingleExprAccessorUnresolved-NOT: notMine
+// TestSingleExprAccessorUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#TestSingleExpr{{(Local)?}}Accessor{{(Get)?}}Unresolved.MyEnum#];
+// TestSingleExprAccessorUnresolved-NOT: notMine
+// TestSingleExprAccessorUnresolved: End completions
+}
+
+struct TestNonSingleExprAccessorUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  var test: MyEnum {
+    .#^TestNonSingleExprAccessorUnresolved^#
+    return .myEnum
+  }
+
+// TestNonSingleExprAccessorUnresolved-NOT: myEnum
+// TestNonSingleExprAccessorUnresolved-NOT: notMine
+}
+
+struct TestSingleExprLocalAccessorUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  func test() {
+    var test: MyEnum {
+      .#^TestSingleExprLocalAccessorUnresolved^#
+    }
+  }
+}
+
+struct TestSingleExprAccessorGlobal {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  var test: Int {
+    #^TestSingleExprAccessorGlobal^#
+  }
+// TestSingleExprAccessorGlobal: Begin completions
+// TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprAccessorGlobal: End completions
+}
+
+struct TestNonSingleExprAccessorGlobal {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  var test: Int {
+    #^TestNonSingleExprAccessorGlobal^#
+    return 42
+  }
+// TestNonSingleExprAccessorGlobal: Begin completions
+// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestNonSingleExprAccessorGlobal: End completions
+}
+
+struct TestSingleExprAccessorGetUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  var test: MyEnum {
+    get {
+      .#^TestSingleExprAccessorGetUnresolved^#
+    }
+  }
+}
+
+struct TestSingleExprAccessorGetGlobal {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  var test: MyEnum {
+    get {
+      #^TestSingleExprAccessorGetGlobal^#
+    }
+  }
+}
+
+struct TestSingleExprAccessorSetUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  var test: MyEnum {
+    set {
+      .#^TestSingleExprAccessorSetUnresolved^#
+    }
+  }
+// TestSingleExprAccessorSetUnresolved-NOT: myEnum
+// TestSingleExprAccessorSetUnresolved-NOT: notMine
+}
+
+// MARK: Single-expression subscripts
+
+struct TestSingleExprSubscriptRet {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  subscript(_: Int) -> Int {
+    return self.#^TestSingleExprSubscriptRet^#
+  }
+
+// TestSingleExprSubscriptRet: Begin completions
+// TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: void()[#Void#];
+// TestSingleExprSubscriptRet: End completions
+}
+
+struct TestSingleExprSubscript {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  subscript(_: Int) -> Int {
+    self.#^TestSingleExprSubscript^#
+  }
+
+// TestSingleExprSubscript: Begin completions
+// TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprSubscript: End completions
+}
+
+struct TestSingleExprSubscriptUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  subscript(_: Int) -> MyEnum {
+    .#^TestSingleExprSubscriptUnresolved^#
+  }
+
+// TestSingleExprSubscriptUnresolved: Begin completions
+// TestSingleExprSubscriptUnresolved-NOT: notMine
+// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#TestSingleExpr{{(Local)?}}Subscript{{(Get)?}}Unresolved.MyEnum#];
+// TestSingleExprSubscriptUnresolved-NOT: notMine
+// TestSingleExprSubscriptUnresolved: End completions
+}
+
+struct TestNonSingleExprSubscriptUnresolved {
+  enum MyEnum { case myEnum }
+  enum NotMine { case notMine }
+  func mine() -> MyEnum { return .myEnum }
+  func notMine() -> NotMine { return .notMine }
+
+  subscript(_: Int) -> MyEnum {
+    .#^TestNonSingleExprSubscriptUnresolved^#
+    return .myEnum
+  }
+
+// TestNonSingleExprSubscriptUnresolved-NOT: myEnum
+// TestNonSingleExprSubscriptUnresolved-NOT: notMine
+}
+
+struct TestSingleExprSubscriptGlobal {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  subscript(input: Int) -> Int {
+    #^TestSingleExprSubscriptGlobal^#
+  }
+
+// TestSingleExprSubscriptGlobal: Begin completions
+// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+// TestSingleExprSubscriptGlobal: End completions
 }

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -34,6 +34,18 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprSubscriptUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprSubscriptUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptGlobal | %FileCheck %s -check-prefix=TestSingleExprSubscriptGlobal
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingeExprInitInvalid | %FileCheck %s -check-prefix=TestSingeExprInitInvalid
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingeExprInitNone | %FileCheck %s -check-prefix=TestSingeExprInitNone
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingeExprInitNilRet | %FileCheck %s -check-prefix=TestSingeExprInitNilRet
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingeExprInitNil | %FileCheck %s -check-prefix=TestSingeExprInitNil
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingeExprInitNil1 | %FileCheck %s -check-prefix=TestNonSingeExprInitNil
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingeExprInitNil2 | %FileCheck %s -check-prefix=TestNonSingeExprInitNil
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingeExprDeinitInvalid | %FileCheck %s -check-prefix=TestSingeExprDeinitInvalid
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testAccessorUnresolvedTopLevel | %FileCheck %s -check-prefix=TopLevelEnum
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testAccessorUnresolvedTopLevelGet | %FileCheck %s -check-prefix=TopLevelEnum
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testClosureUnresolvedTopLevelInit | %FileCheck %s -check-prefix=TopLevelEnum
+
 // MARK: Single-expression closures
 
 struct TestSingleExprClosureRet {
@@ -548,3 +560,88 @@ struct TestSingleExprSubscriptGlobal {
 // TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprSubscriptGlobal: End completions
 }
+
+// MARK: Single-expression initializers
+
+enum TestSingeExprInitInvalid {
+  case foo
+  init() {
+    .#^TestSingeExprInitInvalid^#
+  }
+// TestSingeExprInitInvalid-NOT: foo
+}
+
+enum TestSingeExprInitNone {
+  case foo
+  init?() {
+    .#^TestSingeExprInitNone^#
+  }
+// TestSingeExprInitNone-NOT: foo
+// Note: only `nil` is allowed here, not `.none`.
+// TestSingeExprInitNone-NOT: none
+}
+
+enum TestSingeExprInitNilRet {
+  case foo
+  init?() {
+    return #^TestSingeExprInitNilRet^#
+  }
+// TestSingeExprInitNilRet: Literal[Nil]/None/TypeRelation[Identical]: nil[#TestSingeExprInitNil{{(Ret)?}}?#];
+}
+
+enum TestSingeExprInitNil {
+  case foo
+  init?() {
+    #^TestSingeExprInitNil^#
+  }
+// FIXME: For consistency, this should be same as TestSingeExprInitNilRet.
+// TestSingeExprInitNil: Literal[Nil]/None: nil;
+}
+
+enum TestNonSingeExprInitNil1 {
+  case foo
+  init?() {
+    #^TestNonSingeExprInitNil1^#
+    return nil
+  }
+// No type relation.
+// TestNonSingeExprInitNil: Literal[Nil]/None: nil;
+}
+
+enum TestNonSingeExprInitNil2 {
+  case foo
+  init?() {
+    #^TestNonSingeExprInitNil2^#
+    self = .foo
+  }
+}
+
+enum TestSingeExprDeinitInvalid {
+  case foo
+  deinit {
+    .#^TestSingeExprDeinitInvalid^#
+  }
+// TestSingeExprDeinitInvalid-NOT: foo
+}
+
+// MARK: Top-level code
+
+enum TopLevelEnum {
+  case foo
+}
+
+// TopLevelEnum: Decl[EnumElement]/ExprSpecific:     foo[#TopLevelEnum#];
+
+var testAccessorUnresolvedTopLevel: TopLevelEnum {
+  .#^testAccessorUnresolvedTopLevel^#
+}
+
+var testAccessorUnresolvedTopLevelGet: TopLevelEnum {
+  get {
+    .#^testAccessorUnresolvedTopLevelGet^#
+  }
+}
+
+var testClosureUnresolvedTopLevelInit: TopLevelEnum = {
+  .#^testClosureUnresolvedTopLevelInit^#
+}()

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -22,17 +22,17 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprAccessorUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprAccessorUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprLocalAccessorUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorUnresolved
-// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGlobal | %FileCheck %s -check-prefix=TestSingleExprAccessorGlobal
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGlobal | %FileCheck %s -check-prefix=TestSingleExprAccessorGlobal
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprAccessorGlobal | %FileCheck %s -check-prefix=TestNonSingleExprAccessorGlobal
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGetUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorSetUnresolved | %FileCheck %s -check-prefix=TestSingleExprAccessorSetUnresolved
-// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGetGlobal | %FileCheck %s -check-prefix=TestSingleExprAccessorGlobal
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprAccessorGetGlobal | %FileCheck %s -check-prefix=TestSingleExprAccessorGlobal
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptRet | %FileCheck %s -check-prefix=TestSingleExprSubscriptRet
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscript | %FileCheck %s -check-prefix=TestSingleExprSubscript
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptUnresolved | %FileCheck %s -check-prefix=TestSingleExprSubscriptUnresolved
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestNonSingleExprSubscriptUnresolved | %FileCheck %s -check-prefix=TestNonSingleExprSubscriptUnresolved
-// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptGlobal | %FileCheck %s -check-prefix=TestSingleExprSubscriptGlobal
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TestSingleExprSubscriptGlobal | %FileCheck %s -check-prefix=TestSingleExprSubscriptGlobal
 
 // MARK: Single-expression closures
 
@@ -418,9 +418,11 @@ struct TestNonSingleExprAccessorGlobal {
     #^TestNonSingleExprAccessorGlobal^#
     return 42
   }
+
 // TestNonSingleExprAccessorGlobal: Begin completions
 // TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
-// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// FIXME: should should not have type context.
+// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
 // TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestNonSingleExprAccessorGlobal: End completions
 }
@@ -443,7 +445,7 @@ struct TestSingleExprAccessorGetGlobal {
   func str() -> String { return "" }
   func int() -> Int { return 0 }
 
-  var test: MyEnum {
+  var test: Int {
     get {
       #^TestSingleExprAccessorGetGlobal^#
     }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -103,7 +103,7 @@ std::vector<Completion *> SourceKit::CodeCompletion::extendCompletions(
     if (result->getSemanticContext() == SemanticContextKind::OtherModule) {
       builder.setModuleImportDepth(depth.lookup(result->getModuleName()));
 
-      if (info.completionContext->HasExpectedTypeRelation &&
+      if (info.completionContext->typeContextKind == TypeContextKind::Required &&
           result->getKind() == Completion::Declaration) {
         // FIXME: because other-module results are cached, they will not be
         // given a type-relation of invalid.  As a hack, we look at the text of
@@ -212,13 +212,13 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
 class CodeCompletionOrganizer::Impl {
   std::unique_ptr<Group> rootGroup;
   CompletionKind completionKind;
-  bool completionHasExpectedTypes;
+  TypeContextKind typeContextKind;
 
   void groupStemsRecursive(Group *group, bool recurseIntoNewGroups,
                            StringRef(getStem)(StringRef));
 
 public:
-  Impl(CompletionKind kind, bool hasExpectedTypes);
+  Impl(CompletionKind kind, TypeContextKind typeContextKind);
 
   void addCompletionsWithFilter(ArrayRef<Completion *> completions,
                                 StringRef filterText, Options options,
@@ -275,8 +275,8 @@ public:
 
 CodeCompletionOrganizer::CodeCompletionOrganizer(const Options &options,
                                                  CompletionKind kind,
-                                                 bool hasExpectedTypes)
-    : impl(*new Impl(kind, hasExpectedTypes)), options(options) {}
+                                                 TypeContextKind typeContextKind)
+    : impl(*new Impl(kind, typeContextKind)), options(options) {}
 CodeCompletionOrganizer::~CodeCompletionOrganizer() { delete &impl; }
 
 void CodeCompletionOrganizer::preSortCompletions(
@@ -412,8 +412,8 @@ static std::unique_ptr<Result> make_result(Completion *result) {
 // CodeCompletionOrganizer::Impl implementation
 //===----------------------------------------------------------------------===//
 
-CodeCompletionOrganizer::Impl::Impl(CompletionKind kind, bool hasExpectedTypes)
-    : completionKind(kind), completionHasExpectedTypes(hasExpectedTypes) {
+CodeCompletionOrganizer::Impl::Impl(CompletionKind kind, TypeContextKind typeContextKind)
+    : completionKind(kind), typeContextKind(typeContextKind) {
   assert(!rootGroup && "initialized twice");
   rootGroup = make_group("");
 }
@@ -572,7 +572,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
         if (completion->getExpectedTypeRelation() >= Completion::Convertible ||
             (completion->getKind() == Completion::Literal &&
              completionKind != CompletionKind::StmtOrExpr &&
-             !completionHasExpectedTypes))
+             typeContextKind < TypeContextKind::Required))
           break;
 
         if (completion->getKind() == Completion::Keyword &&
@@ -602,7 +602,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
     // Hide literals other than the ones that are also keywords if they don't
     // match the expected types.
     if (completion->getKind() == Completion::Literal &&
-        completionHasExpectedTypes &&
+        typeContextKind == TypeContextKind::Required &&
         completion->getExpectedTypeRelation() < Completion::Convertible &&
         completion->getLiteralKind() !=
             CodeCompletionLiteralKind::BooleanLiteral &&
@@ -718,7 +718,7 @@ enum class ResultBucket {
 };
 } // end anonymous namespace
 
-static ResultBucket getResultBucket(Item &item, bool hasExpectedTypes,
+static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
                                     bool skipMetaGroups = false) {
   if (item.isExactMatch && !skipMetaGroups)
     return ResultBucket::ExactMatch;
@@ -745,7 +745,7 @@ static ResultBucket getResultBucket(Item &item, bool hasExpectedTypes,
   case Completion::Literal:
     if (matchesType) {
       return ResultBucket::LiteralTypeMatch;
-    } else if (!hasExpectedTypes) {
+    } else if (!hasRequiredTypes) {
       return ResultBucket::Literal;
     } else {
       // When we have type context, we still show literals that are keywords,
@@ -910,19 +910,19 @@ static bool isTopNonLiteralResult(Item &item, ResultBucket literalBucket) {
 }
 
 static void sortTopN(const Options &options, Group *group,
-                     bool hasExpectedTypes) {
+                     bool hasRequiredTypes) {
 
   auto &contents = group->contents;
   if (contents.empty() || options.showTopNonLiteralResults == 0)
     return;
 
-  auto best = getResultBucket(*contents[0], hasExpectedTypes);
+  auto best = getResultBucket(*contents[0], hasRequiredTypes);
   if (best == ResultBucket::LiteralTypeMatch || best == ResultBucket::Literal) {
 
     unsigned beginNewIndex = 0;
     unsigned endNewIndex = 0;
     for (unsigned i = 1; i < contents.size(); ++i) {
-      auto bucket = getResultBucket(*contents[i], hasExpectedTypes);
+      auto bucket = getResultBucket(*contents[i], hasRequiredTypes);
       if (bucket < best) {
         // This algorithm assumes we don't have both literal and
         // literal-type-match at the start of the list.
@@ -967,13 +967,13 @@ static void sortTopN(const Options &options, Group *group,
 }
 
 static void sortRecursive(const Options &options, Group *group,
-                          bool hasExpectedTypes) {
+                          bool hasRequiredTypes) {
   // Sort all of the subgroups first, and fill in the bucket for each result.
   auto &contents = group->contents;
   double best = -1.0;
   for (auto &item : contents) {
     if (auto *g = dyn_cast<Group>(item.get())) {
-      sortRecursive(options, g, hasExpectedTypes);
+      sortRecursive(options, g, hasRequiredTypes);
     } else {
       Result *r = cast<Result>(item.get());
       item->finalScore = combinedScore(options, item->matchScore, r->value);
@@ -999,8 +999,8 @@ static void sortRecursive(const Options &options, Group *group,
     Item &a = *a_;
     Item &b = *b_;
 
-    auto bucketA = getResultBucket(a, hasExpectedTypes);
-    auto bucketB = getResultBucket(b, hasExpectedTypes);
+    auto bucketA = getResultBucket(a, hasRequiredTypes);
+    auto bucketB = getResultBucket(b, hasRequiredTypes);
     if (bucketA < bucketB)
       return false;
     else if (bucketB < bucketA)
@@ -1011,8 +1011,8 @@ static void sortRecursive(const Options &options, Group *group,
     if (bucketA == ResultBucket::ExactMatch ||
         bucketA == ResultBucket::ExpressionSpecific ||
         bucketA == ResultBucket::NotRecommended) {
-      bucketA = getResultBucket(a, hasExpectedTypes, /*skipMetaGroups*/ true);
-      bucketB = getResultBucket(b, hasExpectedTypes, /*skipMetaGroups*/ true);
+      bucketA = getResultBucket(a, hasRequiredTypes, /*skipMetaGroups*/ true);
+      bucketB = getResultBucket(b, hasRequiredTypes, /*skipMetaGroups*/ true);
       if (bucketA < bucketB)
         return false;
       else if (bucketB < bucketA)
@@ -1047,9 +1047,10 @@ static void sortRecursive(const Options &options, Group *group,
 }
 
 void CodeCompletionOrganizer::Impl::sort(Options options) {
-  sortRecursive(options, rootGroup.get(), completionHasExpectedTypes);
+  bool hasRequiredTypes = typeContextKind == TypeContextKind::Required;
+  sortRecursive(options, rootGroup.get(), hasRequiredTypes);
   if (options.showTopNonLiteralResults != 0)
-    sortTopN(options, rootGroup.get(), completionHasExpectedTypes);
+    sortTopN(options, rootGroup.get(), hasRequiredTypes);
 }
 
 void CodeCompletionOrganizer::Impl::groupStemsRecursive(

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -22,6 +22,9 @@ class CompilerInvocation;
 }
 
 namespace SourceKit {
+
+  using TypeContextKind = swift::ide::CodeCompletionContext::TypeContextKind;
+
 namespace CodeCompletion {
 
 struct Options {
@@ -75,7 +78,7 @@ class CodeCompletionOrganizer {
   const Options &options;
 public:
   CodeCompletionOrganizer(const Options &options, CompletionKind kind,
-                          bool hasExpectedTypes);
+                          TypeContextKind typeContextKind);
   ~CodeCompletionOrganizer();
 
   static void

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -74,6 +74,8 @@ namespace SourceKit {
   class Context;
   class NotificationCenter;
 
+  using TypeContextKind = swift::ide::CodeCompletionContext::TypeContextKind;
+
 class SwiftEditorDocument :
     public ThreadSafeRefCountedBase<SwiftEditorDocument> {
 
@@ -162,7 +164,7 @@ class SessionCache : public ThreadSafeRefCountedBase<SessionCache> {
   CompletionSink sink;
   std::vector<Completion *> sortedCompletions;
   CompletionKind completionKind;
-  bool completionHasExpectedTypes;
+  TypeContextKind typeContextKind;
   bool completionMayUseImplicitMemberExpr;
   FilterRules filterRules;
   llvm::sys::Mutex mtx;
@@ -171,11 +173,10 @@ public:
   SessionCache(CompletionSink &&sink,
                std::unique_ptr<llvm::MemoryBuffer> &&buffer,
                std::vector<std::string> &&args, CompletionKind completionKind,
-               bool hasExpectedTypes, bool mayUseImplicitMemberExpr,
+               TypeContextKind typeContextKind, bool mayUseImplicitMemberExpr,
                FilterRules filterRules)
       : buffer(std::move(buffer)), args(std::move(args)), sink(std::move(sink)),
-        completionKind(completionKind),
-        completionHasExpectedTypes(hasExpectedTypes),
+        completionKind(completionKind), typeContextKind(typeContextKind),
         completionMayUseImplicitMemberExpr(mayUseImplicitMemberExpr),
         filterRules(std::move(filterRules)) {}
   void setSortedCompletions(std::vector<Completion *> &&completions);
@@ -184,7 +185,7 @@ public:
   ArrayRef<std::string> getCompilerArgs();
   const FilterRules &getFilterRules();
   CompletionKind getCompletionKind();
-  bool getCompletionHasExpectedTypes();
+  TypeContextKind getCompletionTypeContextKind();
   bool getCompletionMayUseImplicitMemberExpr();
 };
 typedef RefPtr<SessionCache> SessionCacheRef;


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/23587 to swift-5.1

Reviewed by @rintaro 

---

Extend the support for single-expression closures to handle single-expression functions of all kinds. This allows, e.g.

func foo() -> MyEnum { .<here> }
to complete members of MyEnum.

rdar://problem/48938531