### PR TITLE
Replacing ! with not.py because it hides lit errors and breaks on Win32.

### DIFF
--- a/test/PlaygroundTransform/implicit_return_never.swift
+++ b/test/PlaygroundTransform/implicit_return_never.swift
@@ -2,10 +2,10 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -o %t/main %t/main.swift
 // RUN: %target-codesign %t/main
-// RUN: ! %target-run %t/main --crash 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
+// RUN: %{python} %S/Inputs/not.py "%target-run %t/main --crash" 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
 // REQUIRES: executable_test
 
-// NOTE: "!" is used above instead of "not --crash" because simctl's exit
+// NOTE: not.py is used above instead of "not --crash" because simctl's exit
 // status doesn't reflect whether its child process crashed or not. So "not
 // --crash %target-run ..." always fails when testing for the iOS Simulator.
 // The more precise solution would be to use a version of 'not' cross-compiled
@@ -13,6 +13,7 @@
 
 func f() -> Int {
     fatalError()
+// CRASH-CHECK: {{[fF]}}atal error: file {{.*}}/main.swift, line [[@LINE-1]]
 }
 
 f()


### PR DESCRIPTION
use not.py not !

! both breaks on Win32 and hides that this test didn't have a single check line even though it pipes into FileCheck.