### PR TITLE
[5.1 04-24-2019] Correct availability for opaque type execution test.

### DIFF
--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -1,29 +1,41 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 protocol P {
   associatedtype AT
   func foo() -> AT
 }
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 struct Adapter<T: P>: P {
   var inner: T
+
+  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
   func foo() -> some P {
     return inner
   }
 }
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 extension P {
+  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
   func foo() -> some P {
     return Adapter(inner: self)
   }
 }
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 func getPAT<T: P>(_: T.Type) -> Any.Type {
   return T.AT.self
 }
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 extension Int: P { }
 
-// CHECK: Adapter<Int>
-print(getPAT(Int.self))
+// CHECK: {{Adapter<Int>|too old}}
+if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+  print(getPAT(Int.self))
+} else {
+  print("i'm getting too old for this sh")
+}


### PR DESCRIPTION
Opaque types require the next Swift runtime. rdar://problem/50148564