### PR TITLE
XFAIL the vImage test, as it's falling over for arm64.

### DIFF
--- a/test/stdlib/Accelerate_vImage.swift
+++ b/test/stdlib/Accelerate_vImage.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50244151
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 


### PR DESCRIPTION
quick fix for <rdar://problem/50244151>
