### PR TITLE
[silgen] Fix SILGenBuilder::emitDestructureValueOperation to create a…

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -819,10 +819,21 @@ void SILGenBuilder::emitDestructureValueOperation(
     SILLocation loc, ManagedValue value,
     llvm::function_ref<void(unsigned, ManagedValue)> func) {
   CleanupCloner cloner(*this, value);
-  emitDestructureValueOperation(loc, value.forward(SGF),
-                                [&](unsigned index, SILValue subValue) {
-                                  return func(index, cloner.clone(subValue));
-                                });
+
+  // NOTE: We can not directly use SILBuilder::emitDestructureValueOperation()
+  // here since we need to create all of our cleanups before invoking \p
+  // func. This is necessary since our func may want to emit conditional code
+  // with an early exit, emitting unused cleanups from the current scope via the
+  // function emitBranchAndCleanups(). If we have not yet created those
+  // cleanups, we will introduce a leak along that path.
+  SmallVector<ManagedValue, 8> destructuredValues;
+  emitDestructureValueOperation(
+      loc, value.forward(SGF), [&](unsigned index, SILValue subValue) {
+        destructuredValues.push_back(cloner.clone(subValue));
+      });
+  for (auto p : llvm::enumerate(destructuredValues)) {
+    func(p.index(), p.value());
+  }
 }
 
 ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -1583,3 +1583,40 @@ enum Storage {
   }
 }
 
+// Make sure that we do not leak tuple elements if we fail to match the first
+// tuple element.
+enum rdar49990484Enum1 {
+  case case1(Klass)
+  case case2(Klass, Int)
+}
+
+enum rdar49990484Enum2 {
+  case case1(Klass)
+  case case2(rdar49990484Enum1, Klass)
+}
+
+struct rdar49990484Struct {
+  var value: rdar49990484Enum2
+
+  func doSomethingIfLet() {
+    if case let .case2(.case2(k, _), _) = value {
+      return
+    }
+  }
+
+  func doSomethingSwitch() {
+    switch value {
+    case let .case2(.case2(k, _), _):
+      return
+    default:
+      return
+    }
+    return
+  }
+
+  func doSomethingGuardLet() {
+    guard case let .case2(.case2(k, _), _) = value else {
+      return
+    }
+  }
+}


### PR DESCRIPTION
…ll sub-ManagedValues before invoking the user defined function.

This is necessary since our func may want to emit conditional code with an early
exit, emitting unused cleanups from the current scope via the function
emitBranchAndCleanups(). If we have not yet created those cleanups, we will
introduce a leak along that path.

rdar://49990484
