### PR TITLE
[ASTPrinter] Print opaque type using ArchetypeType::getExistentialType()

### DIFF
--- a/test/IDE/print_opaque_result_type.swift
+++ b/test/IDE/print_opaque_result_type.swift
@@ -1,0 +1,12 @@
+// RUN: %swift-ide-test -print-swift-file-interface -source-filename %s
+
+public class Base {}
+// CHECK: public class Base {
+public protocol Proto {}
+// CHECK: public protocol Proto {
+}
+public func foo() -> some Base & Proto {
+// CHECK: public func foo() -> some Base & Proto
+  class Derived: Base, Proto {}
+  return Derived()
+}


### PR DESCRIPTION
Previously, it did't take super class constraint into account.

rdar://problem/50113513

