### PR TITLE
[5.1][ASTPrinter] Print opaque type using ArchetypeType::getExistentialType()

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3412,20 +3412,18 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     bool isSimple = T->hasSimpleTypeRepr();
     if (isSimple && T->is<OpaqueTypeArchetypeType>()) {
       auto opaqueTy = T->castTo<OpaqueTypeArchetypeType>();
-      auto opaqueDecl = opaqueTy->getDecl();
-      if (!opaqueDecl->hasName()) {
-        switch (Options.OpaqueReturnTypePrinting) {
-        case PrintOptions::OpaqueReturnTypePrintingMode::StableReference:
-        case PrintOptions::OpaqueReturnTypePrintingMode::Description:
-          isSimple = true;
-          break;
-        case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
-          isSimple = false;
-          break;
-        case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword: {
-          isSimple = opaqueTy->getConformsTo().size() < 2;
-        }
-        }
+      switch (Options.OpaqueReturnTypePrinting) {
+      case PrintOptions::OpaqueReturnTypePrintingMode::StableReference:
+      case PrintOptions::OpaqueReturnTypePrintingMode::Description:
+        isSimple = true;
+        break;
+      case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
+        isSimple = false;
+        break;
+      case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword: {
+        isSimple = opaqueTy->getExistentialType()->hasSimpleTypeRepr();
+        break;
+      }
       }
     }
 
@@ -4207,14 +4205,7 @@ public:
       Printer << "some ";
       LLVM_FALLTHROUGH;
     case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword: {
-      SmallVector<Type, 2> types;
-      for (auto proto : T->getConformsTo())
-        types.push_back(proto->TypeDecl::getDeclaredInterfaceType());
-
-      // Create and visit temporary ProtocolCompositionType.
-      auto composition =
-          ProtocolCompositionType::get(T->getASTContext(), types, false);
-      visit(composition);
+      visit(T->getExistentialType());
       return;
     }
     case PrintOptions::OpaqueReturnTypePrintingMode::StableReference: {

--- a/test/IDE/print_opaque_result_type.swift
+++ b/test/IDE/print_opaque_result_type.swift
@@ -1,0 +1,12 @@
+// RUN: %swift-ide-test -print-swift-file-interface -source-filename %s
+
+public class Base {}
+// CHECK: public class Base {
+public protocol Proto {}
+// CHECK: public protocol Proto {
+}
+public func foo() -> some Base & Proto {
+// CHECK: public func foo() -> some Base & Proto
+  class Derived: Base, Proto {}
+  return Derived()
+}


### PR DESCRIPTION
(Cherry-pick of #24315 to `swift-5.1-branch`)
rdar://problem/50113513
