### PR TITLE
[5.1] [Frontend] Default the prebuilt cache to <resourcedir>/<platform>/prebuilt-modules

### DIFF
--- a/test/ParseableInterface/default-prebuilt-module-location.swift
+++ b/test/ParseableInterface/default-prebuilt-module-location.swift
@@ -1,0 +1,25 @@
+// 1. Create folders for a) our Swift module, b) the module cache, and c) a
+//    fake resource dir with a default prebuilt module cache inside.
+// RUN: %empty-directory(%t/PrebuiltModule.swiftmodule)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/ResourceDir/%target-sdk-name/prebuilt-modules/PrebuiltModule.swiftmodule)
+
+// 2. Define some public API
+// RUN: echo 'public struct InPrebuiltModule {}' > %t/PrebuiltModule.swift
+
+// 3. Compile this into a module and put it into the default prebuilt cache
+//    location relative to the fake resource dir. Also drop an interface into
+//    the build dir.
+// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/PrebuiltModule.swiftmodule/%target-cpu.swiftmodule -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-cpu.swiftinterface
+
+// 4. Import this prebuilt module, but DON'T pass in -prebuilt-module-cache-path, it should use the implicit one.
+// RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t
+
+// 5. Make sure we installed a forwarding module in the module cache.
+// RUN: %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
+
+import PrebuiltModule
+
+func x<T>(_ x: T) {}
+
+x(InPrebuiltModule.self)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1008,6 +1008,9 @@ else:
 config.substitutions.append(('%module-target-triple',
                              target_specific_module_triple))
 
+# Add 'target-sdk-name' as the name for platform-specific directories
+config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
+
 # Different OS's require different prefixes for the environment variables to be
 # propagated to the calling contexts.
 # In order to make tests OS-agnostic, names of environment variables should be


### PR DESCRIPTION
By default, prebuilt modules will live in
<resource-dir>/<platform>/prebuilt-modules, so make this explicit if it wasn't
passed in explicitly.

rdar://49631050

(Cherry-pick of #24295 to 5.1)