### PR TITLE
[5.1 04-24-2019] [placeholder-expansion] Expand trailing closure in statements correctly

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -53,7 +53,9 @@ func f() {
 func f1() {
   bar(<#T##d: () -> ()##() -> ()#>)
 }
-// CHECK-NOT: bar { () -> () in
+// CHECK:      bar {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
 
 func f1() {
   bar(<#T##d: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
@@ -91,3 +93,95 @@ if true {
 
 foo(.foo(<#T##block: () -> Void##() -> Void#>))
 // CHECK: foo(.foo({
+
+func returnTrailing() -> Int {
+  return withtrail(<#T##() -> ()#>)
+// CHECK: return withtrail {
+// CHECK-NEXT: <#code#>
+}
+
+var yieldTrailing: Int {
+  _read {
+    yield withtrail(<#T##() -> ()#>)
+  // CHECK: yield withtrail {
+  // CHECK-NEXT: <#code#>
+  }
+}
+
+func caseTrailing() -> Int {
+  switch true {
+    case true: withtrail(<#T##() -> ()#>)
+// CHECK: case true: withtrail {
+// CHECK-NEXT: <#code#>
+    default: withtrail(<#T##() -> ()#>)
+// CHECK: default: withtrail {
+// CHECK-NEXT: <#code#>
+  }
+}
+
+func throwTrailing() -> Int {
+   throw withtrail(<#T##() -> ()#>)
+// CHECK: throw withtrail {
+// CHECK-NEXT: <#code#>
+}
+
+func singleExprTrailing1() -> Int {
+  withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+}
+var singleExprTrailing2: Int {
+  withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+}
+var singleExprTrailing3: Int {
+  get {
+    withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+  }
+}
+
+closureTrailingMulti {
+  bah()
+  withtrail(<#T##() -> ()#>)
+// CHECK: bah()
+// CHECK-NEXT: withtrail {
+// CHECK-NEXT: <#code#>
+}
+
+closureIf {
+  if withtrail(<#T##() -> ()#>) {}
+// CHECK: if withtrail({
+// CHECK-NEXT: <#code#>
+}
+
+closureNonTrail {
+  nonTrail(<#T##() -> ()#>, 1)
+// CHECK: nonTrail({
+// CHECK-NEXT: <#code#>
+}
+
+singleExprClosureTrailing {
+  withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+}
+
+singleExprClosureTrailingParens({
+  withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+})
+
+singleExprClosureMultiArg(1) {
+  withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+}
+singleExprClosureMultiArg(1) {
+  withtrail(<#T##() -> ()#>)
+// CHECK: withtrail {
+// CHECK-NEXT: <#code#>
+}


### PR DESCRIPTION
Cherry-pick #24317 to swift-5.1-branch-04-24-2019

Reviewed by: @rintaro

---

In addition to brace statements (previously handled), several other
statements allow a trailing closure (return, yield, throw). Also fix the
handling of statements nested within expressions for closures - both
single-expression bodies and brace statements.

This also fixes a particular regression caused by single-expression
function bodies where we would fail to expand to a trailing closure when
a function body only contained a single expression.

rdar://50227500

Conflicts:
	test/SourceKit/CodeExpand/code-expand.swift