### PR TITLE
[5.1] [Typechecker] Allow bridging of Unmanaged to Objective-C for throwing functions

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -413,12 +413,20 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
   return false;
 }
 
-/// Determines whether the given type is bridged to an Objective-C class type.
-static bool isBridgedToObjectiveCClass(DeclContext *dc, Type type) {
+/// Determines whether the given type is a valid Objective-C class type that
+/// can be returned as a result of a throwing function.
+static bool isValidObjectiveCErrorResultType(DeclContext *dc, Type type) {
   switch (type->getForeignRepresentableIn(ForeignLanguage::ObjectiveC, dc)
             .first) {
   case ForeignRepresentableKind::Trivial:
   case ForeignRepresentableKind::None:
+    // Special case: If the type is Unmanaged<T>, then return true, because
+    // Unmanaged<T> can be represented in Objective-C (if T can be).
+    if (auto BGT = type->getAs<BoundGenericType>()) {
+      if (BGT->getDecl() == dc->getASTContext().getUnmanagedDecl()) {
+        return true;
+      }
+    }
     return false;
 
   case ForeignRepresentableKind::Object:
@@ -604,12 +612,12 @@ bool swift::isRepresentableInObjC(
 
       errorResultType = boolDecl->getDeclaredType()->getCanonicalType();
     } else if (!resultType->getOptionalObjectType() &&
-               isBridgedToObjectiveCClass(dc, resultType)) {
+               isValidObjectiveCErrorResultType(dc, resultType)) {
       // Functions that return a (non-optional) type bridged to Objective-C
       // can be throwing; they indicate failure with a nil result.
       kind = ForeignErrorConvention::NilResult;
     } else if ((optOptionalType = resultType->getOptionalObjectType()) &&
-               isBridgedToObjectiveCClass(dc, optOptionalType)) {
+               isValidObjectiveCErrorResultType(dc, optOptionalType)) {
       // Cannot return an optional bridged type, because 'nil' is reserved
       // to indicate failure. Call this out in a separate diagnostic.
       if (Diagnose) {

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol SR_9035_P {
+  func returnUnmanagedCFArray() throws -> Unmanaged<CFArray>
+}
+
+// CHECK-LABEL: define hidden swiftcc %TSo10CFArrayRefa* @"$s25unmanaged_objc_throw_func9SR_9035_CC22returnUnmanagedCFArrays0G0VySo0H3RefaGyKF"
+@objc class SR_9035_C: NSObject, SR_9035_P {
+  func returnUnmanagedCFArray() throws -> Unmanaged<CFArray> {
+    // CHECK: %[[T0:.+]] = call swiftcc { %swift.bridge*, i8* } @"$ss27_allocateUninitializedArrayySayxG_BptBwlF"(i{{32|64}} 1, %swift.type* @"$sSiN")
+    // CHECK-NEXT: %[[T1:.+]] = extractvalue { %swift.bridge*, i8* } %[[T0]], 0
+    // CHECK-NEXT: %[[T2:.+]] = extractvalue { %swift.bridge*, i8* } %[[T0]], 1
+    // CHECK-NEXT: %[[T3:.+]] = bitcast i8* %[[T2]] to %TSi*
+    // CHECK-NEXT: %._value = getelementptr inbounds %TSi, %TSi* %[[T3]], i32 0, i32 0
+    // CHECK-NEXT: store i{{32|64}} 1, i{{32|64}}* %._value, align {{[0-9]+}}
+    // CHECK-NEXT: %[[T4:.+]] = call swiftcc %TSo7NSArrayC* @"$sSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF"(%swift.bridge* %[[T1]], %swift.type* @"$sSiN")
+    // CHECK-NEXT: %[[T5:.+]] = bitcast %TSo7NSArrayC* %[[T4]] to %TSo10CFArrayRefa*
+    // CHECK-NEXT: call void asm sideeffect "", "r"(%TSo10CFArrayRefa* %[[T5]])
+    // CHECK-NEXT: call void @swift_bridgeObjectRelease(%swift.bridge* %[[T1]]) #{{[0-9]+}}
+    // CHECK-NEXT: %[[T6:.+]] = bitcast %TSo10CFArrayRefa* %[[T5]] to i8*
+    // CHECK-NEXT: call void @llvm.objc.release(i8* %[[T6]])
+    // CHECK-NEXT: ret %TSo10CFArrayRefa* %[[T5]]
+    let arr = [1] as CFArray
+    return Unmanaged.passUnretained(arr) 
+  } 
+}
+
+// CHECK: %[[T0:.+]] = call swiftcc %TSo10CFArrayRefa* @"$s25unmanaged_objc_throw_func9SR_9035_CC22returnUnmanagedCFArrays0G0VySo0H3RefaGyKF"
+// CHECK-NEXT: %[[T2:.+]] = load %swift.error*, %swift.error** %swifterror, align {{[0-9]+}}
+// CHECK-NEXT: %[[T3:.+]] = icmp ne %swift.error* %[[T2]], null
+// CHECK-NEXT: br i1 %[[T3]], label %[[L1:.+]], label %[[L2:.+]]
+
+// CHECK: ; <label>:[[L2]]:                                     ; preds = %entry
+// CHECK-NEXT: %[[T4:.+]] = phi %TSo10CFArrayRefa* [ %[[T0]], %entry ]
+// CHECK-NEXT: %[[T5:.+]] = ptrtoint %TSo10CFArrayRefa* %[[T4]] to i{{32|64}}
+// CHECK-NEXT: br label %[[L3:.+]]
+
+// CHECK: ; <label>:[[L1]]:                                     ; preds = %entry
+// CHECK-NEXT: %[[T6:.+]] = phi %swift.error* [ %[[T2]], %entry ]
+// CHECK-NEXT: store %swift.error* null, %swift.error** %swifterror, align {{[0-9]+}}
+// CHECK-NEXT: %[[T7:.+]] = icmp eq i{{32|64}} %{{.+}}, 0
+// CHECK-NEXT: br i1 %[[T7]], label %[[L4:.+]], label %[[L5:.+]]
+
+// CHECK: ; <label>:[[L5]]:                                     ; preds = %[[L1]]
+// CHECK-NEXT: %[[T8:.+]] = inttoptr i{{32|64}} %{{.+}} to i8*
+// CHECK-NEXT: br label %[[L6:.+]]
+
+// CHECK: ; <label>:[[L6]]:                                     ; preds = %[[L5]]
+// CHECK-NEXT: %[[T9:.+]] = phi i8* [ %[[T8]], %[[L5]] ]
+// CHECK-NEXT: %[[T10:.+]] = call swiftcc %TSo7NSErrorC* @"$s10Foundation22_convertErrorToNSErrorySo0E0Cs0C0_pF"(%swift.error* %[[T6]]) #{{[0-9]+}}
+// CHECK: call swiftcc void @"$sSA7pointeexvs"(%swift.opaque* noalias nocapture %{{.+}}, i8* %[[T9]], %swift.type* %{{.+}}) #{{[0-9]+}}
+// CHECK-NEXT: %[[T11:.+]] = bitcast %TSo7NSErrorCSg* %{{.+}} to i8*
+// CHECK: call void @swift_errorRelease(%swift.error* %[[T6]]) #{{[0-9]+}}
+// CHECK-NEXT: br label %[[L7:.+]]
+
+// CHECK: ; <label>:[[L4]]:                                     ; preds = %[[L1]]
+// CHECK-NEXT: call void @swift_errorRelease(%swift.error* %[[T6]]) #{{[0-9]+}}
+// CHECK-NEXT: br label %[[L7]]
+
+// CHECK: ; <label>:[[L7]]:                                     ; preds = %[[L6]], %[[L4]]
+// CHECK-NEXT: br label %[[L3]]
+
+// CHECK: ; <label>:[[L3]]:                                     ; preds = %[[L2]], %[[L7]]
+// CHECK-NEXT: %[[T12:.+]] = phi i{{32|64}} [ 0, %[[L7]] ], [ %[[T5]], %[[L2]] ]
+// CHECK-NEXT: %[[T13:.+]] = bitcast %T25unmanaged_objc_throw_func9SR_9035_CC* %{{.+}} to i8*
+// CHECK-NEXT: call void @llvm.objc.release(i8* %[[T13]])
+// CHECK-NEXT: %[[T14:.+]] = inttoptr i{{32|64}} %[[T12]] to %struct.__CFArray**
+// CHECK-NEXT: ret %struct.__CFArray** %[[T14]]

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -16,10 +16,11 @@ import Foundation
     // CHECK-NEXT: %[[T3:.+]] = bitcast i8* %[[T2]] to %TSi*
     // CHECK-NEXT: %._value = getelementptr inbounds %TSi, %TSi* %[[T3]], i32 0, i32 0
     // CHECK-NEXT: store i{{32|64}} 1, i{{32|64}}* %._value, align {{[0-9]+}}
-    // CHECK-NEXT: %[[T4:.+]] = call swiftcc %TSo7NSArrayC* @"$sSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF"(%swift.bridge* %[[T1]], %swift.type* @"$sSiN")
+    // CHECK-NEXT: %[[LITERAL:.+]] = call swiftcc %swift.bridge* @"$sSa12arrayLiteralSayxGxd_tcfCSi_Tg5"(%swift.bridge* %[[T1]])
+    // CHECK-NEXT: %[[T4:.+]] = call swiftcc %TSo7NSArrayC* @"$sSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF"(%swift.bridge* %[[LITERAL]], %swift.type* @"$sSiN")
     // CHECK-NEXT: %[[T5:.+]] = bitcast %TSo7NSArrayC* %[[T4]] to %TSo10CFArrayRefa*
     // CHECK-NEXT: call void asm sideeffect "", "r"(%TSo10CFArrayRefa* %[[T5]])
-    // CHECK-NEXT: call void @swift_bridgeObjectRelease(%swift.bridge* %[[T1]]) #{{[0-9]+}}
+    // CHECK-NEXT: call void @swift_bridgeObjectRelease(%swift.bridge* %[[LITERAL]]) #{{[0-9]+}}
     // CHECK-NEXT: %[[T6:.+]] = bitcast %TSo10CFArrayRefa* %[[T5]] to i8*
     // CHECK-NEXT: call void @llvm.objc.release(i8* %[[T6]])
     // CHECK-NEXT: ret %TSo10CFArrayRefa* %[[T5]]

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2347,3 +2347,12 @@ extension MyObjCClass {
   private func notExposedToObjC() {}
 }
 
+// SR-9035
+
+class SR_9035_C {}
+
+@objc protocol SR_9035_P {
+  func throwingMethod1() throws -> Unmanaged<CFArray> // Ok
+  func throwingMethod2() throws -> Unmanaged<SR_9035_C> // expected-error {{method cannot be a member of an @objc protocol because its result type cannot be represented in Objective-C}}
+  // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+}


### PR DESCRIPTION
Cherry-pick of #24135

---

Previously, we would emit an error diagnostic if a throwing `@objc` function returned `Unmanaged<T>`. This is now allowed when `T` is representable in Objective-C.

For example:

```swift
class Foo {}

@objc protocol Bar {
  func throwingMethod1() throws -> Unmanaged<CFArray> // ok
  func throwingMethod2() throws -> Unmanaged<Foo> // error
}
```
  

Resolves [SR-9035](https://bugs.swift.org/browse/SR-9035).