### PR TITLE
Fix `KeyPathIterable` conformance for `Array.DifferentiableView`.

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1875,7 +1875,7 @@ extension Array where Element : Differentiable {
   /// The view of an array as the differentiable product manifold of `Element`
   /// multiplied with itself `count` times.
   @_fixed_layout
-  public struct DifferentiableView : Differentiable & KeyPathIterable {
+  public struct DifferentiableView : Differentiable {
     private var _base: [Element]
 
     /// The viewed array.

--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -104,6 +104,13 @@ extension Array : KeyPathIterable {
   }
 }
 
+extension Array.DifferentiableView : KeyPathIterable {
+  public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
+  public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
+    return [\Array.DifferentiableView.base]
+  }
+}
+
 extension Dictionary : KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Dictionary>]
   public var allKeyPaths: [PartialKeyPath<Dictionary>] {


### PR DESCRIPTION
Previously, `Array.DifferentiableView` made use of `KeyPathIterable` derived conformances.
`allKeyPaths` used the private property `[\Array.DifferentiableView._base]`.

Now, `allKeyPaths` uses the public property `[\Array.DifferentiableView.base]`.

Gather all stdlib `KeyPathIterable` conformances in KeyPathIterable.swift to
avoid such errors in the future.