### PR TITLE
[os_log][stdlib-private] Refactor new os log APIs based on string interpolation for enabling optimizations.

### DIFF
--- a/stdlib/private/OSLog/OSLog.swift
+++ b/stdlib/private/OSLog/OSLog.swift
@@ -18,6 +18,7 @@
 
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 public struct Logger {
+  @usableFromInline
   internal let logObject: OSLog
 
   /// Create a custom OS log object.
@@ -30,8 +31,16 @@ public struct Logger {
     logObject = OSLog.default
   }
 
+  // Functions defined below are marked @_optimize(none) to prevent inlining
+  // of string internals (such as String._StringGuts) which will interfere with
+  // constant evaluation and folding. Note that these functions will be inlined,
+  // constant evaluated/folded and optimized in the context of a caller.
+
   /// Log a string interpolation at a given level. The level is `default` if
   /// it is not specified.
+  @inlinable
+  @_semantics("oslog.log")
+  @_optimize(none)
   public func log(level: OSLogType = .default, _ message: OSLogMessage) {
     osLog(logObject, level, message)
   }
@@ -44,28 +53,46 @@ public struct Logger {
 /// extract the format string, serialize the arguments to a byte buffer,
 /// and pass them to the OS logging system.
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+@usableFromInline
+@_transparent
+@_optimize(none)
 internal func osLog(
   _ logObject: OSLog,
   _ logLevel: OSLogType,
   _ message: OSLogMessage
 ) {
-  guard logObject.isEnabled(type: logLevel) else { return }
-
+  // Compute static constants first so that they can be folded by
+  // OSLogOptimization pass.
+  let formatString = message.interpolation.formatString
+  let preamble = message.interpolation.preamble
+  let argumentCount = message.interpolation.argumentCount
   let bufferSize = message.bufferSize
-  let bufferMemory = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
-  var builder = OSLogByteBufferBuilder(bufferMemory)
 
-  message.serializeArguments(into: &builder)
+  // Code that will execute at runtime.
+  let arguments = message.interpolation.arguments
+  formatString.withCString { cFormatString in
 
-  message.formatString.withCString { cFormatString in
+    guard logObject.isEnabled(type: logLevel) else { return }
+
+    // Ideally, we could stack allocate the buffer as it is local to this
+    // function and also its size is a compile-time constant.
+    let bufferMemory =
+      UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    var builder = OSLogByteBufferBuilder(bufferMemory)
+
+    builder.serialize(preamble)
+    builder.serialize(argumentCount)
+    arguments.serialize(into: &builder)
+
     ___os_log_impl(UnsafeMutableRawPointer(mutating: #dsohandle),
                    logObject,
                    logLevel,
                    cFormatString,
                    bufferMemory,
                    UInt32(bufferSize))
+
+    bufferMemory.deallocate()
   }
-  bufferMemory.deallocate()
 }
 
 /// A test helper that constructs a byte buffer and a format string from an
@@ -76,18 +103,31 @@ internal func osLog(
 ///   - message: An instance of `OSLogMessage` created from string interpolation
 ///   - assertion: A closure that takes a format string and a pointer to a
 ///     byte buffer and asserts a condition.
+@inlinable
+@_semantics("oslog.log.test_helper")
+@_optimize(none)
 public // @testable
 func _checkFormatStringAndBuffer(
   _ message: OSLogMessage,
   with assertion: (String, UnsafeBufferPointer<UInt8>) -> Void
 ) {
+  // Compute static constants first so that they can be folded by
+  // OSLogOptimization pass.
+  let formatString = message.interpolation.formatString
+  let preamble = message.interpolation.preamble
+  let argumentCount = message.interpolation.argumentCount
   let bufferSize = message.bufferSize
+
+  // Code that will execute at runtime.
   let bufferMemory = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
   var builder = OSLogByteBufferBuilder(bufferMemory)
-  message.serializeArguments(into: &builder)
+
+  builder.serialize(preamble)
+  builder.serialize(argumentCount)
+  message.interpolation.arguments.serialize(into: &builder)
 
   assertion(
-    message.formatString,
+    formatString,
     UnsafeBufferPointer(start: UnsafePointer(bufferMemory), count: bufferSize))
 
   bufferMemory.deallocate()

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -43,13 +43,12 @@ public enum Privacy {
 /// Maximum number of arguments i.e., interpolated expressions that can
 /// be used in the string interpolations passed to the log APIs.
 /// This limit is imposed by the ABI of os_log.
-public var maxOSLogArgumentCount: Int {
-  return 48
-}
+@_transparent
+public var maxOSLogArgumentCount: Int { return 48 }
 
-internal var bitsPerByte: Int {
-  return 8
-}
+@usableFromInline
+@_transparent
+internal var bitsPerByte: Int { return 8 }
 
 /// Represents a string interpolation passed to the log APIs.
 ///
@@ -61,9 +60,11 @@ internal var bitsPerByte: Int {
 /// when you pass a string interpolation to the log APIs.
 /// Extend this type with more `appendInterpolation` overloads to enable
 /// interpolating additional types.
+@_fixed_layout
 public struct OSLogInterpolation : StringInterpolationProtocol {
   /// A format string constructed from the given string interpolation to be
   /// passed to the os_log ABI.
+  @usableFromInline
   internal var formatString: String
 
   /// A representation of a sequence of arguments that must be serialized
@@ -86,52 +87,104 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
   ///                 |     2nd argument bytes    |
   ///                 ----------------------------
   ///                         ...
+  @usableFromInline
   internal var arguments: OSLogArguments
 
   /// The possible values for the argument flag, as defined by the os_log ABI,
   /// which occupies four least significant bits of the first byte of the
   /// argument header. The first two bits are used to indicate privacy and
   /// the other two are reserved.
-  internal enum ArgumentFlag: UInt8 {
-    case privateFlag = 0x1
-    case publicFlag = 0x2
+  @usableFromInline
+  @_frozen
+  internal enum ArgumentFlag {
+    case privateFlag
+    case publicFlag
+
+    @inlinable
+    internal var rawValue: UInt8 {
+      switch self {
+      case .privateFlag:
+        return 0x1
+      case .publicFlag:
+        return 0x2
+      }
+    }
   }
 
   /// The possible values for the argument type, as defined by the os_log ABI,
   /// which occupies four most significant bits of the first byte of the
   /// argument header.
-  internal enum ArgumentType: UInt8 {
-    case scalar = 0
+  @usableFromInline
+  @_frozen
+  internal enum ArgumentType {
+    case scalar
     // TODO: more types will be added here.
+
+    @inlinable
+    internal var rawValue: UInt8 {
+      switch self {
+      case .scalar:
+        return 0
+      }
+    }
   }
 
   /// The first summary byte in the byte buffer passed to the os_log ABI that
   /// summarizes the privacy and nature of the arguments.
+  @usableFromInline
   internal var preamble: UInt8
 
   /// Bit mask for setting bits in the peamble. The bits denoted by the bit
   /// mask indicate whether there is an argument that is private, and whether
   /// there is an argument that is non-scalar: String, NSObject or Pointer.
-  internal enum PreambleBitMask: UInt8 {
-    case privateBitMask = 0x1
-    case nonScalarBitMask = 0x2
+  @usableFromInline
+  @_frozen
+  internal enum PreambleBitMask {
+    case privateBitMask
+    case nonScalarBitMask
+
+    @inlinable
+    internal var rawValue: UInt8 {
+      switch self {
+      case .privateBitMask:
+        return 0x1
+      case .nonScalarBitMask:
+        return 0x2
+      }
+    }
   }
 
   /// The second summary byte that denotes the number of arguments, which is
   /// also the number of interpolated expressions. This will be determined
   /// on the fly in order to support concatenation and interpolation of
   /// instances of `OSLogMessage`.
+  @usableFromInline
   internal var argumentCount: UInt8
 
+  /// Sum total of all the bytes (including header bytes) needed for
+  /// serializing the arguments.
+  @usableFromInline
+  internal var totalBytesForSerializingArguments: Int
+
+  // Some methods defined below are marked @_optimize(none) to prevent inlining
+  // of string internals (such as String._StringGuts) which will interfere with
+  // constant evaluation and folding. Note that these methods will be inlined,
+  // constant evaluated/folded and optimized in the context of a caller.
+
+  @_transparent
+  @_optimize(none)
   public init(literalCapacity: Int, interpolationCount: Int) {
-    // TODO: format string must be fully constructed at compile time.
-    // The parameters `literalCapacity` and `interpolationCount` are ignored.
+    // Since the format string is fully constructed at compile time,
+    // the parameters `literalCapacity` and `interpolationCount` are ignored.
     formatString = ""
     arguments = OSLogArguments()
     preamble = 0
     argumentCount = 0
+    totalBytesForSerializingArguments = 0
   }
 
+  @_transparent
+  @_optimize(none)
   public mutating func appendLiteral(_ literal: String) {
     formatString += literal.percentEscapedString
   }
@@ -148,6 +201,8 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
   ///    enum `IntFormat`.
   ///  - privacy: a privacy qualifier which is either private or public.
   ///    The default is public.
+  @_transparent
+  @_optimize(none)
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Int,
     format: IntFormat = .decimal,
@@ -157,16 +212,17 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
 
     addIntHeadersAndFormatSpecifier(
       format,
-      isPrivate: privacy == .private,
+      isPrivate: isPrivate(privacy),
       bitWidth: Int.bitWidth,
       isSigned: true)
     arguments.append(number)
+    argumentCount += 1
   }
 
-  /// Construct/update format string and headers from the qualifiers (of the
-  /// interpolated expression) passed as parameters.
-  ///
-  /// All arguments to this function must be known at compile time.
+  /// Construct/update format string and headers from the parameters of the
+  /// interpolation.
+  @_transparent
+  @_optimize(none)
   public mutating func addIntHeadersAndFormatSpecifier(
     _ format: IntFormat,
     isPrivate: Bool,
@@ -179,39 +235,75 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
       bitWidth: bitWidth,
       isSigned: isSigned)
 
-    addArgumentHeaders(
-      flag: isPrivate ? .privateFlag : .publicFlag,
-      type: .scalar,
-      size: UInt8(bitWidth / bitsPerByte))
+    // Append argument header.
+    let argumentHeader =
+      getArgumentHeader(isPrivate: isPrivate, bitWidth: bitWidth, type: .scalar)
+    arguments.append(argumentHeader)
 
-    updateSummaryBytes(isPrivate: isPrivate)
+    // Append number of bytes needed to serialize the argument.
+    let argumentByteCount = OSLogSerializationInfo.sizeForEncoding(Int.self)
+    arguments.append(UInt8(argumentByteCount))
+
+    // Increment total byte size by the number of bytes needed for this
+    // argument, which is the sum of the byte size of the argument and
+    // two bytes needed for the headers.
+    totalBytesForSerializingArguments += argumentByteCount + 2
+
+    preamble = getUpdatedPreamble(isPrivate: isPrivate)
   }
 
-  /// Set the private bit of the preamble if the `isPrivate` parameter is true
-  /// and increment the argument count. Note that the private bit in the
-  /// preamable is set if any of the arguments is private.
-  internal mutating func updateSummaryBytes(isPrivate: Bool) {
-    if (isPrivate) {
-      preamble |= PreambleBitMask.privateBitMask.rawValue
+  /// Return true if and only if the parameter is .private.
+  @inlinable
+  @_semantics("oslog.interpolation.isPrivate")
+  @_effects(readonly)
+  @_optimize(none)
+  internal func isPrivate(_ privacy: Privacy) -> Bool {
+    // Do not use equality comparisons on enums as it is not supported by
+    // the constant evaluator.
+    if case .private = privacy {
+      return true
     }
-    argumentCount += 1
+    return false
   }
 
-  /// Append the given argument headers and size.
-  internal mutating func addArgumentHeaders(
-    flag: ArgumentFlag,
-    type: ArgumentType,
-    size: UInt8
-  ) {
-    // Flag and type take up one byte where the least significant four bits
-    // is flag and most significant four bits is the type.
-    let flagAndType: UInt8 = (type.rawValue << 4) | flag.rawValue
-    arguments.append(flagAndType)
-    arguments.append(size)
+  /// compute a byte-sized argument header consisting of flag and type.
+  /// Flag and type take up the least and most significant four bits
+  /// of the header byte, respectively.
+  /// This function should be constant evaluable.
+  @inlinable
+  @_semantics("oslog.interpolation.getArgumentHeader")
+  @_effects(readonly)
+  @_optimize(none)
+  internal func getArgumentHeader(
+    isPrivate: Bool,
+    bitWidth: Int,
+    type: ArgumentType
+  ) -> UInt8 {
+    let flag: ArgumentFlag = isPrivate ? .privateFlag : .publicFlag
+    let flagAndType: UInt8 = (type.rawValue &<< 4) | flag.rawValue
+    return flagAndType
+  }
+
+  /// Compute the new preamble based whether the current argument is private
+  /// or not. This function must be constant evaluable.
+  @inlinable
+  @_semantics("oslog.interpolation.getUpdatedPreamble")
+  @_effects(readonly)
+  @_optimize(none)
+  internal func getUpdatedPreamble(isPrivate: Bool) -> UInt8 {
+    if isPrivate {
+      return preamble | PreambleBitMask.privateBitMask.rawValue
+    }
+    return preamble
   }
 
   /// Construct an os_log format specifier from the given parameters.
-  /// All arguments to this function must be known at compile time.
+  /// This function must be constant evaluable and all its arguments
+  /// must be known at compile time.
+  @inlinable
+  @_semantics("oslog.interpolation.getFormatSpecifier")
+  @_effects(readonly)
+  @_optimize(none)
   internal func getIntegerFormatSpecifier(
     _ format: IntFormat,
     isPrivate: Bool,
@@ -243,6 +335,9 @@ extension String {
   /// Replace all percents "%" in the string by "%%" so that the string can be
   /// interpreted as a C format string.
   public var percentEscapedString: String {
+    @_semantics("string.escapePercent.get")
+    @_effects(readonly)
+    @_optimize(none)
     get {
       return self
         .split(separator: "%", omittingEmptySubsequences: false)
@@ -251,45 +346,37 @@ extension String {
   }
 }
 
+@_fixed_layout
 public struct OSLogMessage :
   ExpressibleByStringInterpolation, ExpressibleByStringLiteral
 {
   public let interpolation: OSLogInterpolation
 
   /// Initializer for accepting string interpolations.
+  @_transparent
+  @_optimize(none)
   public init(stringInterpolation: OSLogInterpolation) {
-    interpolation = stringInterpolation
+    self.interpolation = stringInterpolation
   }
 
   /// Initializer for accepting string literals.
+  @_transparent
+  @_optimize(none)
   public init(stringLiteral value: String) {
     // Note that the actual value of `literalCapacity` is not important as it
-    // is ignored by `OSLogInterpolation.init`. However, it must be a literal.
+    // is ignored by `OSLogInterpolation.init`.
     var s = OSLogInterpolation(literalCapacity: 1, interpolationCount: 0)
     s.appendLiteral(value)
     self.init(stringInterpolation: s)
   }
 
-  /// Format string constructed from the string interpolation.
-  public var formatString: String {
-    get { return interpolation.formatString }
-  }
-
-  /// The byte size of the buffer that will passed to the C os_log ABI.
-  /// It will contain the elements of interpolation.arguments and the two
+  /// The byte size of the buffer that will be passed to the C os_log ABI.
+  /// It will contain the elements of `interpolation.arguments` and the two
   /// summary bytes: preamble and argument count.
+  @_transparent
+  @_optimize(none)
   public var bufferSize: Int {
-    get { return interpolation.arguments.byteCount + 2 }
-  }
-
-  /// Serialize the summary bytes and arguments into the given byte-buffer
-  /// builder. The summary bytes are serailized first followed by the arguments.
-  internal func serializeArguments(
-    into bufferBuilder: inout OSLogByteBufferBuilder
-  ) {
-    bufferBuilder.serialize(interpolation.preamble)
-    bufferBuilder.serialize(interpolation.argumentCount)
-    interpolation.arguments.serialize(into: &bufferBuilder)
+    return interpolation.totalBytesForSerializingArguments + 2
   }
 }
 
@@ -298,70 +385,83 @@ public struct OSLogMessage :
 /// are captured within closures and stored in an array. The closures accept an
 /// instance of `OSLogByteBufferBuilder`, and when invoked, serialize the
 /// argument using the passed `OSLogByteBufferBuilder` instance.
+@usableFromInline
 internal struct OSLogArguments {
   /// An array of closures that captures arguments of possibly different types.
   internal var argumentClosures: [(inout OSLogByteBufferBuilder) -> ()]
-  /// Sum total of the byte size of the arguments that are tracked.
-  internal var byteCount: Int
 
+  @usableFromInline
   internal init() {
     argumentClosures = []
-    byteCount = 0
   }
 
   /// Append a byte-sized header, constructed by
   /// `OSLogMessage.appendInterpolation`, to the tracked array of closures.
+  @usableFromInline
   internal mutating func append(_ header: UInt8) {
     argumentClosures.append({ $0.serialize(header) })
-    byteCount += OSLogByteBufferBuilder.sizeForEncoding(UInt8.self)
   }
 
   /// Append an (autoclosured) interpolated expression of type Int, passed to
   /// `OSLogMessage.appendInterpolation`, to the tracked array of closures.
+  @usableFromInline
   internal mutating func append(_ value: @escaping () -> Int) {
     argumentClosures.append({ $0.serialize(value()) })
-    byteCount += OSLogByteBufferBuilder.sizeForEncoding(Int.self)
   }
 
+  @usableFromInline
   internal func serialize(into bufferBuilder: inout OSLogByteBufferBuilder) {
     argumentClosures.forEach { $0(&bufferBuilder) }
+  }
+}
+
+/// A struct that provides information regarding the serialization of types
+/// to a byte buffer as specified by the C os_log ABIs.
+@usableFromInline
+internal struct OSLogSerializationInfo {
+  /// Return the number of bytes needed for serializing an UInt8 value.
+  @usableFromInline
+  @_transparent
+  internal static func sizeForEncoding(_ type: UInt8.Type) -> Int {
+    return 1
+  }
+
+  /// Return the number of bytes needed for serializing an Int value.
+  @usableFromInline
+  @_transparent
+  internal static func sizeForEncoding(_ type: Int.Type) -> Int {
+    return Int.bitWidth / bitsPerByte
   }
 }
 
 /// A struct that manages serialization of instances of specific types to a
 /// byte buffer. The byte buffer is provided as an argument to the initializer
 /// so that its lifetime can be managed by the caller.
+@usableFromInline
 internal struct OSLogByteBufferBuilder {
   internal var position: UnsafeMutablePointer<UInt8>
 
   /// Initializer that accepts a pointer to a preexisting buffer.
   /// - Parameter bufferStart: the starting pointer to a byte buffer
   ///   that must contain the serialized bytes.
+  @usableFromInline
   internal init(_ bufferStart: UnsafeMutablePointer<UInt8>) {
     position = bufferStart
   }
 
   /// Serialize a UInt8 value at the buffer location pointed to by `position`.
+  @usableFromInline
   internal mutating func serialize(_ value: UInt8) {
     position[0] = value
     position += 1
   }
 
   /// Serialize an Int at the buffer location pointed to by `position`.
+  @usableFromInline
   internal mutating func serialize(_ value: Int) {
-    let byteCount = OSLogByteBufferBuilder.sizeForEncoding(Int.self)
+    let byteCount = OSLogSerializationInfo.sizeForEncoding(Int.self)
     let dest = UnsafeMutableRawBufferPointer(start: position, count: byteCount)
     withUnsafeBytes(of: value) { dest.copyMemory(from: $0) }
     position += byteCount
-  }
-
-  /// Return the number of bytes needed for serializing an UInt8 value.
-  internal static func sizeForEncoding(_ type: UInt8.Type) -> Int {
-    return 1
-  }
-
-  /// Return the number of bytes needed for serializing an Int value.
-  internal static func sizeForEncoding(_ type: Int.Type) -> Int {
-    return Int.bitWidth / bitsPerByte
   }
 }


### PR DESCRIPTION
Refactor and add inlining and @_semantics attributes to the new os log APIs  so that it can be optimized by the new OSLogOptimization compiler pass. The implementation now clearly marks out code that will be evaluated at compile time from the code that will be executed at runtime.