### PR TITLE
[5.1] [IRGen] Emit lazy opaque type descriptors.

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -245,6 +245,7 @@ private:
   struct LazyOpaqueInfo {
     bool IsLazy = false;
     bool IsDescriptorUsed = false;
+    bool IsDescriptorEmitted = false;
   };
   /// The set of opaque types enqueued for lazy emission.
   llvm::DenseMap<OpaqueTypeDecl*, LazyOpaqueInfo> LazyOpaqueTypes;

--- a/test/IRGen/lazy_opaque_result_type.swift
+++ b/test/IRGen/lazy_opaque_result_type.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
+// RUN: %FileCheck %s < %t.ll
+
+protocol P { }
+
+protocol Q {
+  associatedtype AT: P
+  func getAT() -> AT
+}
+
+private struct X: Q {
+  private struct Inner: P { }
+
+  // CHECK: @"$s4test1X33_58D62B15E5EAC1447430E52C74EAD489LLV5getATQryFQOMQ" = internal constant
+  func getAT() -> some P {
+    return Inner()
+  }
+}
+
+func testMe<T: Q>(_ t: T) {
+  _ = t.getAT()
+}
+
+func doIt() {
+  testMe(X())
+}


### PR DESCRIPTION
These were recorded but never emitted. Fixes rdar://problem/50258536.
