### PR TITLE
Disable failing Tensor subscript assignment tests in GPU mode.

### DIFF
--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -130,6 +130,8 @@ TensorTests.testAllBackends("ElementIndexing") {
   expectEqual([43], array0D.scalars)
 }
 
+#if !CUDA
+// TODO(https://bugs.swift.org/browse/TF-469): This test fails in GPU mode.
 TensorTests.testAllBackends("ElementIndexingAssignment") {
   // NOTE: cannot test multiple `Tensor.shape` or `Tensor.scalars` directly
   // until send and receive are implemented (without writing a bunch of mini
@@ -157,6 +159,7 @@ TensorTests.testAllBackends("ElementIndexingAssignment") {
   expectEqual(Array(stride(from: 35.0, to: 40, by: 1)), array1D.scalars)
   expectEqual([23], array0D.scalars)
 }
+#endif // !CUDA
 
 TensorTests.testAllBackends("NestedElementIndexing") {
   // NOTE: This test could use a clearer name, along with other "indexing"
@@ -205,6 +208,9 @@ TensorTests.testAllBackends("SliceIndexing") {
   expectEqual(Array(stride(from: 3.0, to: 5, by: 1)), array1D.scalars)
 }
 
+
+#if !CUDA
+// TODO(https://bugs.swift.org/browse/TF-469): This test fails in GPU mode.
 TensorTests.testAllBackends("SliceIndexingAssignment") {
   // NOTE: cannot test `Tensor.shape` or `Tensor.scalars` directly until send
   // and receive are implemented (without writing a bunch of mini tests).
@@ -232,7 +238,10 @@ TensorTests.testAllBackends("SliceIndexingAssignment") {
   expectEqual(Array(stride(from: 20.0, to: 30, by: 1)), array2D.scalars)
   expectEqual(Array(stride(from: 3.0, to: 5, by: 1)), array1D.scalars)
 }
+#endif // !CUDA
 
+#if !CUDA
+// TODO(https://bugs.swift.org/browse/TF-469): This test fails in GPU mode.
 TensorTests.testAllBackends("EllipsisIndexing") {
   // NOTE: cannot test `Tensor.shape` or `Tensor.scalars` directly until send
   // and receive are implemented (without writing a bunch of mini tests).
@@ -260,6 +269,7 @@ TensorTests.testAllBackends("EllipsisIndexing") {
   expectEqual(Array(stride(from: 20.0, to: 30, by: 1)), array2D.scalars)
   expectEqual(Array(stride(from: 3.0, to: 5, by: 1)), array1D.scalars)
 }
+#endif // !CUDA
 
 TensorTests.testAllBackends("NewAxisIndexing") {
   // NOTE: cannot test `Tensor.shape` or `Tensor.scalars` directly until send
@@ -347,6 +357,8 @@ TensorTests.testAllBackends("StridedSliceIndexing") {
   expectEqual(Array(stride(from: 1.0, to: 5, by: 2)), array1D.scalars)
 }
 
+#if !CUDA
+// TODO(https://bugs.swift.org/browse/TF-469): This test fails in GPU mode.
 TensorTests.testAllBackends("StridedSliceIndexingAssignment") {
   // NOTE: cannot test `Tensor.shape` or `Tensor.scalars` directly until send
   // and receive are implemented (without writing a bunch of mini tests).
@@ -378,6 +390,7 @@ TensorTests.testAllBackends("StridedSliceIndexingAssignment") {
   expectEqual(Array(stride(from: 20.0, to: 30, by: 1)), array2D.scalars)
   expectEqual(Array(stride(from: 3.0, to: 5, by: 1)), array1D.scalars)
 }
+#endif // !CUDA
 
 TensorTests.test("WholeTensorSlicing") {
   let t: Tensor<Int32> = [[[1, 1, 1], [2, 2, 2]],


### PR DESCRIPTION
This is related to https://bugs.swift.org/browse/TF-469