### PR TITLE
Sema: Fix order dependency in @objc inference from witnessed protocol requirement [5.1 4/24]

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -897,7 +897,6 @@ public:
 ///
 /// \returns the result of performing the match.
 RequirementMatch matchWitness(
-             TypeChecker &tc,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness,
              llvm::function_ref<
                      std::tuple<Optional<RequirementMatch>, Type, Type>(void)>

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -756,7 +756,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
   // Match the witness. If we don't succeed, throw away the inference
   // information.
   // FIXME: A renamed match might be useful to retain for the failure case.
-  if (matchWitness(tc, dc, req, witness, setup, matchTypes, finalize)
+  if (matchWitness(dc, req, witness, setup, matchTypes, finalize)
           .Kind != MatchKind::ExactMatch) {
     inferred.Inferred.clear();
   }

--- a/test/decl/protocol/conforms/objc_from_witness_corner_case.swift
+++ b/test/decl/protocol/conforms/objc_from_witness_corner_case.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -print-ast %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// This bug required an elaborate setup where isObjC() was checked prior
+// to validateDecl() getting called on a declaration. In this case, we
+// did not infer @objc from witnessed protocol requirements as required.
+//
+// https://bugs.swift.org/browse/SR-10257
+
+@objc public protocol P {
+  @objc optional func f()
+}
+
+public class Other {
+  // This triggers a walk over all nominals in the file, collecting
+  // @objc members into the dynamic dispatch lookup table.
+  let a = (Base() as AnyObject).g()
+}
+
+@objc public class Base : P {
+  @objc public func g() -> Int { return 0 }
+}
+
+public class D : Base {
+  // This method witnesses P.f() and so it should be @objc.
+  //
+  // CHECK-LABEL: @objc public func f()
+  public func f() {}
+}
+


### PR DESCRIPTION
If we haven't validated the declaration yet, the 'witnesses @objc
requirement' check would immediately fail. Move the validateDecl()
call to matchWitness() to fix this.

Fixes <rdar://problem/49482328>, <https://bugs.swift.org/browse/SR-10257>.