### PR TITLE
 SILGen: Allocating entry points for @objc dynamic inits should use alloc_ref_dynamic [5.1 4/24]

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -485,7 +485,9 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   // Allocate the 'self' value.
   bool useObjCAllocation = usesObjCAllocator(selfClassDecl);
 
-  if (ctor->hasClangNode() || ctor->isConvenienceInit()) {
+  if (ctor->hasClangNode() ||
+      ctor->isObjCDynamic() ||
+      ctor->isConvenienceInit()) {
     assert(ctor->hasClangNode() || ctor->isObjC());
     // For an allocator thunk synthesized for an @objc convenience initializer
     // or imported Objective-C init method, allocate using the metatype.

--- a/test/Interpreter/objc_metatypes.swift
+++ b/test/Interpreter/objc_metatypes.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+protocol Horse {
+  init()
+}
+
+class Pony : NSObject, Horse {
+  override required init() {}
+}
+
+class ChincoteaguePony : Pony {}
+
+var ObjCMetatypesTest = TestSuite("ObjCMetatypes")
+
+ObjCMetatypesTest.test("ClassInit") {
+  let metatype: Pony.Type = ChincoteaguePony.self
+  let instance = metatype.init()
+  expectEqual(type(of: instance), ChincoteaguePony.self)
+}
+
+ObjCMetatypesTest.test("ProtocolInit") {
+  let metatype: Horse.Type = ChincoteaguePony.self
+  let instance = metatype.init()
+  expectEqual(type(of: instance), ChincoteaguePony.self)
+}
+
+runAllTests()

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -117,13 +117,11 @@ class ObjCInit {
   @objc dynamic required init() { }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s12dynamic_self12testObjCInit{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@thick ObjCInit.Type) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s12dynamic_self12testObjCInit4metayAA0dE0Cm_tF : $@convention(thin) (@thick ObjCInit.Type) -> ()
 func testObjCInit(meta: ObjCInit.Type) {
 // CHECK: bb0([[THICK_META:%[0-9]+]] : $@thick ObjCInit.Type):
-// CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[THICK_META]] : $@thick ObjCInit.Type to $@objc_metatype ObjCInit.Type
-// CHECK:   [[OBJ:%[0-9]+]] = alloc_ref_dynamic [objc] [[OBJC_META]] : $@objc_metatype ObjCInit.Type, $ObjCInit
-// CHECK:   [[INIT:%[0-9]+]] = objc_method [[OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit, $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
-// CHECK:   [[RESULT_OBJ:%[0-9]+]] = apply [[INIT]]([[OBJ]]) : $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
+// CHECK:   [[INIT:%[0-9]+]] = function_ref @$s12dynamic_self8ObjCInitCACycfC : $@convention(method) (@thick ObjCInit.Type) -> @owned ObjCInit
+// CHECK:   [[RESULT_OBJ:%[0-9]+]] = apply [[INIT]]([[THICK_META]]) : $@convention(method) (@thick ObjCInit.Type) -> @owned ObjCInit
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
   _ = meta.init()

--- a/test/SILGen/objc_dynamic_init.swift
+++ b/test/SILGen/objc_dynamic_init.swift
@@ -17,6 +17,16 @@ class Gadget: NSObject, Hoozit {
     }
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s17objc_dynamic_init6GadgetCACycfC : $@convention(method) (@thick Gadget.Type) -> @owned Gadget
+// CHECK: [[OBJC_METATYPE:%.*]] = thick_to_objc_metatype %0 : $@thick Gadget.Type to $@objc_metatype Gadget.Type
+// CHECK: [[SELF:%.*]] = alloc_ref_dynamic [objc] %1 : $@objc_metatype Gadget.Type, $Gadget
+// CHECK: [[INIT:%.*]] = function_ref @$s17objc_dynamic_init6GadgetCACycfcTD : $@convention(method) (@owned Gadget) -> @owned Gadget
+// CHECK: [[NEW_SELF:%.*]] = apply [[INIT]]([[SELF]]) : $@convention(method) (@owned Gadget) -> @owned Gadget
+// CHECK: return [[NEW_SELF]]
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s17objc_dynamic_init6GadgetCAA6HoozitA2aDPxycfCTW : $@convention(witness_method: Hoozit) (@thick Gadget.Type) -> @out Gadget {
+// CHECK:         function_ref @$s17objc_dynamic_init6GadgetCACycfC
+
 class Gizmo: Gadget, Wotsit {
     required init() {
         super.init()
@@ -35,8 +45,7 @@ final class Bobamathing: Thingamabob {
     }
 }
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s{{.*}}GadgetC{{.*}}CTW
-// CHECK:         function_ref @{{.*}}Gadget{{.*}}fC :
+
 
 // CHECK-LABEL: sil_vtable Gadget {
 // CHECK-NOT:     #Gadget.init!allocator.1

--- a/test/SILGen/objc_dynamic_init.swift
+++ b/test/SILGen/objc_dynamic_init.swift
@@ -45,7 +45,16 @@ final class Bobamathing: Thingamabob {
     }
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s17objc_dynamic_init8callInityyF : $@convention(thin) () -> ()
+// CHECK: [[METATYPE:%.*]] = metatype $@thick Gadget.Type
+// CHECK: [[CTOR:%.*]] = function_ref @$s17objc_dynamic_init6GadgetCACycfC
+// CHECK: [[INSTANCE:%.*]] = apply [[CTOR]]([[METATYPE]])
+// CHECK: destroy_value [[INSTANCE]]
 
+func callInit() {
+    let metatype = Gadget.self
+    _ = metatype.init()
+}
 
 // CHECK-LABEL: sil_vtable Gadget {
 // CHECK-NOT:     #Gadget.init!allocator.1


### PR DESCRIPTION
Fixes <rdar://problem/49560721>, <https://bugs.swift.org/browse/SR-10285>.