### PR TITLE
Proposes a more "swifty" DispatchQueue.global

### DIFF
--- a/stdlib/public/Darwin/Dispatch/Queue.swift
+++ b/stdlib/public/Darwin/Dispatch/Queue.swift
@@ -129,9 +129,13 @@ extension DispatchQueue {
 
 	@available(macOS 10.10, iOS 8.0, *)
 	public class func global(qos: DispatchQoS.QoSClass = .default) -> DispatchQueue {
+		return __dispatch_get_global_queue(Int(DispatchQoS.QoSClass.default.rawValue.rawValue), 0)
+	}
+	
+	public class var global: DispatchQueue {
 		return __dispatch_get_global_queue(Int(qos.rawValue.rawValue), 0)
 	}
-
+	
 	public class func getSpecific<T>(key: DispatchSpecificKey<T>) -> T? {
 		let k = Unmanaged.passUnretained(key).toOpaque()
 		if let p = __dispatch_get_specific(k) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR is all about a nonbreaking change in the `DispatchQueue` API, and more specifically about `DispatchQueue.global`

I found that writing `DispatchQueue.global()` is a bit weird, especially since you can write `DispatchQueue.main`, so I propose to add a method that removes the unnecessary parentheses while keeping the benefits of `DispatchQueue.global(qos: .default)`

Now, instead of writing DispatchQueue.global() every time, you can just type DispatchQueue.global, which fits much more in the spirit of swift

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->