### PR TITLE
[DO NOT MERGE] Refactoring Generics (GenericParamList)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1270,12 +1270,42 @@ public:
   void print(raw_ostream &OS) const;
   void print(ASTPrinter &Printer) const;
 };
+    
+/// GenericParamDecl - This class represents all the different types of generic
+/// parameters.
+class GenericParamDecl {
+public:
+  enum class ParamKind {
+    TypeParameter = 0
+  };
+    
+private:
+  ParamKind Kind;
+
+  GenericTypeParamDecl *GTPD;
+
+public:
+  GenericParamDecl(GenericTypeParamDecl *GTPD)
+    : Kind(ParamKind::TypeParameter), GTPD(GTPD)
+    { }
+    
+  ParamKind getKind() const { return Kind; }
+
+  GenericTypeParamDecl *getGenericTypeParamDecl() const {
+    assert(getKind() == ParamKind::TypeParameter
+           && "Not a GenericTypeParamDecl");
+
+    return GTPD;
+  }
+    
+  void setDepth(unsigned int depth) const;
+};
   
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
 class GenericParamList final :
-    private llvm::TrailingObjects<GenericParamList, GenericTypeParamDecl *> {
+    private llvm::TrailingObjects<GenericParamList, GenericParamDecl> {
   friend TrailingObjects;
 
   SourceRange Brackets;
@@ -1289,7 +1319,7 @@ class GenericParamList final :
   unsigned FirstTrailingWhereArg;
 
   GenericParamList(SourceLoc LAngleLoc,
-                   ArrayRef<GenericTypeParamDecl *> Params,
+                   ArrayRef<GenericParamDecl> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
@@ -1309,7 +1339,7 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericTypeParamDecl *> Params,
+                                  ArrayRef<GenericParamDecl> Params,
                                   SourceLoc RAngleLoc);
 
   /// create - Create a new generic parameter list and "where" clause within
@@ -1326,21 +1356,21 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(const ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericTypeParamDecl *> Params,
+                                  ArrayRef<GenericParamDecl> Params,
                                   SourceLoc WhereLoc,
                                   ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
-  MutableArrayRef<GenericTypeParamDecl *> getParams() {
-    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
+  MutableArrayRef<GenericParamDecl> getParams() {
+    return {getTrailingObjects<GenericParamDecl>(), NumParams};
   }
 
-  ArrayRef<GenericTypeParamDecl *> getParams() const {
-    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
+  ArrayRef<GenericParamDecl> getParams() const {
+    return {getTrailingObjects<GenericParamDecl>(), NumParams};
   }
 
-  using iterator = GenericTypeParamDecl **;
-  using const_iterator = const GenericTypeParamDecl * const *;
+  using iterator = GenericParamDecl *;
+  using const_iterator = const GenericParamDecl * const;
 
   unsigned size() const { return NumParams; }
   iterator begin() { return getParams().begin(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1271,56 +1271,11 @@ public:
   void print(ASTPrinter &Printer) const;
 };
   
-class GenericParam final {
-public:
-  enum class ParamKind {
-    TypeParam,
-  };
-    
-private:
-  ParamKind Kind;
-    
-  GenericTypeParamDecl *GTPD;
-    
-public:
-  GenericParam(GenericTypeParamDecl *GTPD)
-    : Kind(ParamKind::TypeParam), GTPD(GTPD)
-    {}
-    
-  ParamKind getKind() const { return Kind; }
-    
-  bool is(ParamKind Kind) const { return this->Kind == Kind; }
-    
-  GenericTypeParamDecl *getTypeParam() const {
-    assert(is(ParamKind::TypeParam) && "not a TypeParam");
-      
-    return GTPD;
-  }
-
-  SourceLoc getEndLoc() const;
-
-  ArrayRef<TypeLoc> getInherited() const;
-    
-  Identifier getName() const;
-
-  void setDeclContext(DeclContext *DC) const;
-    
-  void setDepth(unsigned depth) const;
-
-  bool operator ==(GenericTypeParamDecl *GTPD) const {
-    return is(ParamKind::TypeParam) && this->GTPD == GTPD;
-  }
-    
-  bool operator !=(GenericTypeParamDecl *GTPD) const {
-    return !(*this == GTPD);
-  }
-};
-    
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
 class GenericParamList final :
-    private llvm::TrailingObjects<GenericParamList, GenericParam> {
+    private llvm::TrailingObjects<GenericParamList, GenericTypeParamDecl *> {
   friend TrailingObjects;
 
   SourceRange Brackets;
@@ -1334,7 +1289,7 @@ class GenericParamList final :
   unsigned FirstTrailingWhereArg;
 
   GenericParamList(SourceLoc LAngleLoc,
-                   ArrayRef<GenericParam> Params,
+                   ArrayRef<GenericTypeParamDecl *> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
@@ -1354,7 +1309,7 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericParam> Params,
+                                  ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc RAngleLoc);
 
   /// create - Create a new generic parameter list and "where" clause within
@@ -1371,21 +1326,21 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(const ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericParam> Params,
+                                  ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc WhereLoc,
                                   ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
-  MutableArrayRef<GenericParam> getParams() {
-    return {getTrailingObjects<GenericParam>(), NumParams};
+  MutableArrayRef<GenericTypeParamDecl *> getParams() {
+    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
   }
 
-  ArrayRef<GenericParam> getParams() const {
-    return {getTrailingObjects<GenericParam>(), NumParams};
+  ArrayRef<GenericTypeParamDecl *> getParams() const {
+    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
   }
 
-  using iterator = GenericParam *;
-  using const_iterator = GenericParam const * const;
+  using iterator = GenericTypeParamDecl **;
+  using const_iterator = const GenericTypeParamDecl * const *;
 
   unsigned size() const { return NumParams; }
   iterator begin() { return getParams().begin(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1271,11 +1271,69 @@ public:
   void print(ASTPrinter &Printer) const;
 };
   
+class GenericParam final {
+public:
+  enum class ParamKind {
+    TypeParam,
+  };
+
+private:
+  ParamKind Kind;
+    
+  GenericTypeParamDecl *GTPD;
+    
+public:
+  GenericParam(GenericTypeParamDecl *GTPD)
+    : Kind(ParamKind::TypeParam), GTPD(GTPD)
+    {}
+    
+  ParamKind getKind() const { return Kind; }
+
+  bool is(ParamKind Kind) const { return this->Kind == Kind; }
+    
+  GenericTypeParamDecl *getTypeParam() const {
+    assert(is(ParamKind::TypeParam) && "not a TypeParam");
+    return GTPD;
+  }
+    
+  ArrayRef<ProtocolDecl *> getConformingProtocols() const;
+
+  Type getDeclaredInterfaceType() const;
+
+  DeclContext *getDeclContext() const;
+
+  unsigned int getDepth() const;
+
+  SourceLoc getEndLoc() const;
+    
+  unsigned int getIndex() const;
+    
+  ArrayRef<TypeLoc> getInherited() const;
+
+  Identifier getName() const;
+
+  Type getSuperclass() const;
+
+  void setDeclContext(DeclContext *DC) const;
+
+  void setDepth(unsigned depth) const;
+    
+  void setInherited(MutableArrayRef<TypeLoc> i) const;
+
+  bool operator ==(GenericTypeParamDecl *GTPD) const {
+    return is(ParamKind::TypeParam) && this->GTPD == GTPD;
+  }
+    
+  bool operator !=(GenericTypeParamDecl *GTPD) const {
+    return !(*this == GTPD);
+  }
+};
+    
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
 class GenericParamList final :
-    private llvm::TrailingObjects<GenericParamList, GenericTypeParamDecl *> {
+    private llvm::TrailingObjects<GenericParamList, GenericParam> {
   friend TrailingObjects;
 
   SourceRange Brackets;
@@ -1289,7 +1347,7 @@ class GenericParamList final :
   unsigned FirstTrailingWhereArg;
 
   GenericParamList(SourceLoc LAngleLoc,
-                   ArrayRef<GenericTypeParamDecl *> Params,
+                   ArrayRef<GenericParam> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
@@ -1309,7 +1367,7 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericTypeParamDecl *> Params,
+                                  ArrayRef<GenericParam> Params,
                                   SourceLoc RAngleLoc);
 
   /// create - Create a new generic parameter list and "where" clause within
@@ -1326,21 +1384,21 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(const ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericTypeParamDecl *> Params,
+                                  ArrayRef<GenericParam> Params,
                                   SourceLoc WhereLoc,
                                   ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
-  MutableArrayRef<GenericTypeParamDecl *> getParams() {
-    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
+  MutableArrayRef<GenericParam> getParams() {
+    return {getTrailingObjects<GenericParam>(), NumParams};
   }
 
-  ArrayRef<GenericTypeParamDecl *> getParams() const {
-    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
+  ArrayRef<GenericParam> getParams() const {
+    return {getTrailingObjects<GenericParam>(), NumParams};
   }
 
-  using iterator = GenericTypeParamDecl **;
-  using const_iterator = const GenericTypeParamDecl * const *;
+  using iterator = GenericParam *;
+  using const_iterator = GenericParam const * const;
 
   unsigned size() const { return NumParams; }
   iterator begin() { return getParams().begin(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1270,52 +1270,12 @@ public:
   void print(raw_ostream &OS) const;
   void print(ASTPrinter &Printer) const;
 };
-
-class GenericParam {
-public:
-  enum class ParamKind {
-    TypeParam
-  };
-    
-private:
-  ParamKind Kind;
-
-  GenericTypeParamDecl *TypeParam;
-
-public:  
-  GenericParam(GenericTypeParamDecl *GTPD)
-    : Kind(ParamKind::TypeParam), TypeParam(GTPD)
-    {}
-    
-  ParamKind getKind() const { return Kind; }
-    
-  GenericTypeParamDecl *getTypeParam() const {
-    assert(getKind() == ParamKind::TypeParam
-           && "GenericParam::getTypeParam(): not a TypeParam");
-    
-    return TypeParam;
-  }
-
-  void setDepth(unsigned depth) const;
-    
-  Identifier getName() const;
   
-  ArrayRef<TypeLoc> getInherited() const;
-
-  void setDeclContext(DeclContext *DC) const;
-
-  void setInherited(MutableArrayRef<TypeLoc> i) const;
-
-  bool operator ==(GenericTypeParamDecl const * const GTPD) const {
-    return getKind() == ParamKind::TypeParam && getTypeParam() == GTPD;
-  }
-};
-    
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
 class GenericParamList final :
-    private llvm::TrailingObjects<GenericParamList, GenericParam> {
+    private llvm::TrailingObjects<GenericParamList, GenericTypeParamDecl *> {
   friend TrailingObjects;
 
   SourceRange Brackets;
@@ -1329,7 +1289,7 @@ class GenericParamList final :
   unsigned FirstTrailingWhereArg;
 
   GenericParamList(SourceLoc LAngleLoc,
-                   ArrayRef<GenericParam> Params,
+                   ArrayRef<GenericTypeParamDecl *> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
@@ -1349,7 +1309,7 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericParam> Params,
+                                  ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc RAngleLoc);
 
   /// create - Create a new generic parameter list and "where" clause within
@@ -1366,21 +1326,21 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(const ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericParam> Params,
+                                  ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc WhereLoc,
                                   ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
-  MutableArrayRef<GenericParam> getParams() {
-    return {getTrailingObjects<GenericParam>(), NumParams};
+  MutableArrayRef<GenericTypeParamDecl *> getParams() {
+    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
   }
 
-  ArrayRef<GenericParam> getParams() const {
-    return {getTrailingObjects<GenericParam>(), NumParams};
+  ArrayRef<GenericTypeParamDecl *> getParams() const {
+    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
   }
 
-  using iterator = GenericParam *;
-  using const_iterator = const GenericParam * const;
+  using iterator = GenericTypeParamDecl **;
+  using const_iterator = const GenericTypeParamDecl * const *;
 
   unsigned size() const { return NumParams; }
   iterator begin() { return getParams().begin(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1271,11 +1271,56 @@ public:
   void print(ASTPrinter &Printer) const;
 };
   
+class GenericParam final {
+public:
+  enum class ParamKind {
+    TypeParam,
+  };
+    
+private:
+  ParamKind Kind;
+    
+  GenericTypeParamDecl *GTPD;
+    
+public:
+  GenericParam(GenericTypeParamDecl *GTPD)
+    : Kind(ParamKind::TypeParam), GTPD(GTPD)
+    {}
+    
+  ParamKind getKind() const { return Kind; }
+    
+  bool is(ParamKind Kind) const { return this->Kind == Kind; }
+    
+  GenericTypeParamDecl *getTypeParam() const {
+    assert(is(ParamKind::TypeParam) && "not a TypeParam");
+      
+    return GTPD;
+  }
+
+  SourceLoc getEndLoc() const;
+
+  ArrayRef<TypeLoc> getInherited() const;
+    
+  Identifier getName() const;
+
+  void setDeclContext(DeclContext *DC) const;
+    
+  void setDepth(unsigned depth) const;
+
+  bool operator ==(GenericTypeParamDecl *GTPD) const {
+    return is(ParamKind::TypeParam) && this->GTPD == GTPD;
+  }
+    
+  bool operator !=(GenericTypeParamDecl *GTPD) const {
+    return !(*this == GTPD);
+  }
+};
+    
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
 class GenericParamList final :
-    private llvm::TrailingObjects<GenericParamList, GenericTypeParamDecl *> {
+    private llvm::TrailingObjects<GenericParamList, GenericParam> {
   friend TrailingObjects;
 
   SourceRange Brackets;
@@ -1289,7 +1334,7 @@ class GenericParamList final :
   unsigned FirstTrailingWhereArg;
 
   GenericParamList(SourceLoc LAngleLoc,
-                   ArrayRef<GenericTypeParamDecl *> Params,
+                   ArrayRef<GenericParam> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
@@ -1309,7 +1354,7 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericTypeParamDecl *> Params,
+                                  ArrayRef<GenericParam> Params,
                                   SourceLoc RAngleLoc);
 
   /// create - Create a new generic parameter list and "where" clause within
@@ -1326,21 +1371,21 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(const ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericTypeParamDecl *> Params,
+                                  ArrayRef<GenericParam> Params,
                                   SourceLoc WhereLoc,
                                   ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
-  MutableArrayRef<GenericTypeParamDecl *> getParams() {
-    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
+  MutableArrayRef<GenericParam> getParams() {
+    return {getTrailingObjects<GenericParam>(), NumParams};
   }
 
-  ArrayRef<GenericTypeParamDecl *> getParams() const {
-    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
+  ArrayRef<GenericParam> getParams() const {
+    return {getTrailingObjects<GenericParam>(), NumParams};
   }
 
-  using iterator = GenericTypeParamDecl **;
-  using const_iterator = const GenericTypeParamDecl * const *;
+  using iterator = GenericParam *;
+  using const_iterator = GenericParam const * const;
 
   unsigned size() const { return NumParams; }
   iterator begin() { return getParams().begin(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1270,42 +1270,12 @@ public:
   void print(raw_ostream &OS) const;
   void print(ASTPrinter &Printer) const;
 };
-    
-/// GenericParamDecl - This class represents all the different types of generic
-/// parameters.
-class GenericParamDecl {
-public:
-  enum class ParamKind {
-    TypeParameter = 0
-  };
-    
-private:
-  ParamKind Kind;
-
-  GenericTypeParamDecl *GTPD;
-
-public:
-  GenericParamDecl(GenericTypeParamDecl *GTPD)
-    : Kind(ParamKind::TypeParameter), GTPD(GTPD)
-    { }
-    
-  ParamKind getKind() const { return Kind; }
-
-  GenericTypeParamDecl *getGenericTypeParamDecl() const {
-    assert(getKind() == ParamKind::TypeParameter
-           && "Not a GenericTypeParamDecl");
-
-    return GTPD;
-  }
-    
-  void setDepth(unsigned int depth) const;
-};
   
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
 class GenericParamList final :
-    private llvm::TrailingObjects<GenericParamList, GenericParamDecl> {
+    private llvm::TrailingObjects<GenericParamList, GenericTypeParamDecl *> {
   friend TrailingObjects;
 
   SourceRange Brackets;
@@ -1319,7 +1289,7 @@ class GenericParamList final :
   unsigned FirstTrailingWhereArg;
 
   GenericParamList(SourceLoc LAngleLoc,
-                   ArrayRef<GenericParamDecl> Params,
+                   ArrayRef<GenericTypeParamDecl *> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
@@ -1339,7 +1309,7 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericParamDecl> Params,
+                                  ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc RAngleLoc);
 
   /// create - Create a new generic parameter list and "where" clause within
@@ -1356,21 +1326,21 @@ public:
   /// \param RAngleLoc The location of the closing angle bracket ('>')
   static GenericParamList *create(const ASTContext &Context,
                                   SourceLoc LAngleLoc,
-                                  ArrayRef<GenericParamDecl> Params,
+                                  ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc WhereLoc,
                                   ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
-  MutableArrayRef<GenericParamDecl> getParams() {
-    return {getTrailingObjects<GenericParamDecl>(), NumParams};
+  MutableArrayRef<GenericTypeParamDecl *> getParams() {
+    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
   }
 
-  ArrayRef<GenericParamDecl> getParams() const {
-    return {getTrailingObjects<GenericParamDecl>(), NumParams};
+  ArrayRef<GenericTypeParamDecl *> getParams() const {
+    return {getTrailingObjects<GenericTypeParamDecl *>(), NumParams};
   }
 
-  using iterator = GenericParamDecl *;
-  using const_iterator = const GenericParamDecl * const;
+  using iterator = GenericTypeParamDecl **;
+  using const_iterator = const GenericTypeParamDecl * const *;
 
   unsigned size() const { return NumParams; }
   iterator begin() { return getParams().begin(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1271,6 +1271,11 @@ public:
   void print(ASTPrinter &Printer) const;
 };
   
+/// GenericParam - This type is a common interface to all the different types of
+/// generic parameters that exist.
+///
+/// Some of the methods of this class may need to be deleted and / or refactored
+/// once they are no longer shared between all the `ParamKind`s.
 class GenericParam final {
 public:
   enum class ParamKind {
@@ -1278,11 +1283,17 @@ public:
   };
 
 private:
+  /// The type of this generic parameter.
   ParamKind Kind;
-    
-  GenericTypeParamDecl *GTPD;
+
+  union {
+    /// If this `GenericParam` is a `TypeParam`, this pointer contains a
+    /// reference to a `GenericTypeParamDecl`.
+    GenericTypeParamDecl *GTPD;
+  };
     
 public:
+  /// Create a new `GenericParam` wrapping a `GenericTypeParamDecl`.
   GenericParam(GenericTypeParamDecl *GTPD)
     : Kind(ParamKind::TypeParam), GTPD(GTPD)
     {}

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -560,13 +560,13 @@ public:
   TypeArrayView<GenericTypeParamType> getGenericParams() const;
 
   /// Add a new generic parameter for which there may be requirements.
-  void addGenericParameter(GenericParam param);
+  void addGenericParameter(GenericTypeParamDecl *GenericParam);
 
   /// Add the requirements placed on the given abstract type parameter
   /// to the given potential archetype.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool addGenericParameterRequirements(GenericParam param);
+  bool addGenericParameterRequirements(GenericTypeParamDecl *GenericParam);
 
   /// Add a new generic parameter for which there may be requirements.
   void addGenericParameter(GenericTypeParamType *GenericParam);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -560,13 +560,13 @@ public:
   TypeArrayView<GenericTypeParamType> getGenericParams() const;
 
   /// Add a new generic parameter for which there may be requirements.
-  void addGenericParameter(GenericTypeParamDecl *GenericParam);
+  void addGenericParameter(GenericParam param);
 
   /// Add the requirements placed on the given abstract type parameter
   /// to the given potential archetype.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool addGenericParameterRequirements(GenericTypeParamDecl *GenericParam);
+  bool addGenericParameterRequirements(GenericParam param);
 
   /// Add a new generic parameter for which there may be requirements.
   void addGenericParameter(GenericTypeParamType *GenericParam);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1455,7 +1455,7 @@ public:
   ParserResult<GenericParamList> parseGenericParameters();
   ParserResult<GenericParamList> parseGenericParameters(SourceLoc LAngleLoc);
   ParserStatus parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
-                        SmallVectorImpl<GenericParam> &GenericParams);
+                        SmallVectorImpl<GenericTypeParamDecl *> &GenericParams);
   ParserResult<GenericParamList> maybeParseGenericParams();
   void
   diagnoseWhereClauseInGenericParamList(const GenericParamList *GenericParams);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1455,7 +1455,7 @@ public:
   ParserResult<GenericParamList> parseGenericParameters();
   ParserResult<GenericParamList> parseGenericParameters(SourceLoc LAngleLoc);
   ParserStatus parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
-                        SmallVectorImpl<GenericTypeParamDecl *> &GenericParams);
+                        SmallVectorImpl<GenericParam> &GenericParams);
   ParserResult<GenericParamList> maybeParseGenericParams();
   void
   diagnoseWhereClauseInGenericParamList(const GenericParamList *GenericParams);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -164,11 +164,11 @@ void RequirementRepr::print(ASTPrinter &out) const {
 void GenericParamList::print(llvm::raw_ostream &OS) {
   OS << '<';
   interleave(*this,
-             [&](const GenericTypeParamDecl *P) {
-               OS << P->getName();
-               if (!P->getInherited().empty()) {
+             [&](const GenericParam P) {
+               OS << P.getName();
+               if (!P.getInherited().empty()) {
                  OS << " : ";
-                 P->getInherited()[0].getType().print(OS);
+                 P.getInherited()[0].getType().print(OS);
                }
              },
              [&] { OS << ", "; });

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -164,11 +164,11 @@ void RequirementRepr::print(ASTPrinter &out) const {
 void GenericParamList::print(llvm::raw_ostream &OS) {
   OS << '<';
   interleave(*this,
-             [&](const GenericParam P) {
-               OS << P.getName();
-               if (!P.getInherited().empty()) {
+             [&](const GenericTypeParamDecl *P) {
+               OS << P->getName();
+               if (!P->getInherited().empty()) {
                  OS << " : ";
-                 P.getInherited()[0].getType().print(OS);
+                 P->getInherited()[0].getType().print(OS);
                }
              },
              [&] { OS << ", "; });

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -164,11 +164,19 @@ void RequirementRepr::print(ASTPrinter &out) const {
 void GenericParamList::print(llvm::raw_ostream &OS) {
   OS << '<';
   interleave(*this,
-             [&](const GenericTypeParamDecl *P) {
-               OS << P->getName();
-               if (!P->getInherited().empty()) {
-                 OS << " : ";
-                 P->getInherited()[0].getType().print(OS);
+             [&](const GenericParamDecl *GPD) {
+               switch (GPD->getKind()) {
+               case GenericParamDecl::ParamKind::TypeParameter: {
+                 auto P = GPD->getGenericTypeParamDecl();
+                 OS << P->getName();
+                 if (!P->getInherited().empty()) {
+                   OS << " : ";
+                   P->getInherited()[0].getType().print(OS);
+                 }
+                 break;
+               }
+               default:
+                 llvm_unreachable("Unhandled GenericParamDecl::getKind()");
                }
              },
              [&] { OS << ", "; });

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -164,19 +164,11 @@ void RequirementRepr::print(ASTPrinter &out) const {
 void GenericParamList::print(llvm::raw_ostream &OS) {
   OS << '<';
   interleave(*this,
-             [&](const GenericParamDecl *GPD) {
-               switch (GPD->getKind()) {
-               case GenericParamDecl::ParamKind::TypeParameter: {
-                 auto P = GPD->getGenericTypeParamDecl();
-                 OS << P->getName();
-                 if (!P->getInherited().empty()) {
-                   OS << " : ";
-                   P->getInherited()[0].getType().print(OS);
-                 }
-                 break;
-               }
-               default:
-                 llvm_unreachable("Unhandled GenericParamDecl::getKind()");
+             [&](const GenericTypeParamDecl *P) {
+               OS << P->getName();
+               if (!P->getInherited().empty()) {
+                 OS << " : ";
+                 P->getInherited()[0].getType().print(OS);
                }
              },
              [&] { OS << ", "; });

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1403,7 +1403,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
     // Explicitly-written generic parameters are in scope following their
     // definition.
     return SourceRange(genericParams.params->getParams()[genericParams.index]
-                       .getEndLoc(),
+                         ->getEndLoc(),
                        genericParams.decl->getEndLoc());
 
   case ASTScopeKind::AbstractFunctionDecl: {
@@ -1765,13 +1765,8 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     for (auto genericParams = extension->getGenericParams();
          genericParams;
          genericParams = genericParams->getOuterParameters()) {
-      for (auto param : genericParams->getParams()) {
-        switch (param.getKind()) {
-        case GenericParamDecl::ParamKind::TypeParameter:
-          result.push_back(param.getGenericTypeParamDecl());
-          break;
-        }
-      }
+      for (auto param : genericParams->getParams())
+        result.push_back(param);
     }
     break;
   }

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1403,7 +1403,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
     // Explicitly-written generic parameters are in scope following their
     // definition.
     return SourceRange(genericParams.params->getParams()[genericParams.index]
-                         ->getEndLoc(),
+                         .getEndLoc(),
                        genericParams.decl->getEndLoc());
 
   case ASTScopeKind::AbstractFunctionDecl: {
@@ -1765,15 +1765,28 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     for (auto genericParams = extension->getGenericParams();
          genericParams;
          genericParams = genericParams->getOuterParameters()) {
-      for (auto param : genericParams->getParams())
-        result.push_back(param);
+      for (auto param : genericParams->getParams()) {
+        switch (param.getKind()) {
+          case GenericParam::ParamKind::TypeParam:
+            result.push_back(param.getTypeParam());
+            break;
+        }
+      }
     }
     break;
   }
 
-  case ASTScopeKind::GenericParams:
-    result.push_back(genericParams.params->getParams()[genericParams.index]);
+  case ASTScopeKind::GenericParams: {
+    auto param = genericParams.params->getParams()[genericParams.index];
+      
+    switch (param.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        result.push_back(param.getTypeParam());
+        break;
+    }
+    
     break;
+  }
 
   case ASTScopeKind::AbstractFunctionParams:
     result.push_back(

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1403,7 +1403,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
     // Explicitly-written generic parameters are in scope following their
     // definition.
     return SourceRange(genericParams.params->getParams()[genericParams.index]
-                         ->getEndLoc(),
+                       .getEndLoc(),
                        genericParams.decl->getEndLoc());
 
   case ASTScopeKind::AbstractFunctionDecl: {
@@ -1765,8 +1765,13 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     for (auto genericParams = extension->getGenericParams();
          genericParams;
          genericParams = genericParams->getOuterParameters()) {
-      for (auto param : genericParams->getParams())
-        result.push_back(param);
+      for (auto param : genericParams->getParams()) {
+        switch (param.getKind()) {
+        case GenericParamDecl::ParamKind::TypeParameter:
+          result.push_back(param.getGenericTypeParamDecl());
+          break;
+        }
+      }
     }
     break;
   }

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1400,12 +1400,17 @@ SourceRange ASTScope::getSourceRangeImpl() const {
                          protoDecl->getEndLoc());
     }
 
-    // Explicitly-written generic parameters are in scope following their
-    // definition.
-    return SourceRange(genericParams.params->getParams()[genericParams.index]
-                         ->getEndLoc(),
-                       genericParams.decl->getEndLoc());
-
+    auto GP = genericParams.params->getParams()[genericParams.index];
+      
+    switch (GP.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        // Explicitly-written generic parameters are in scope following their
+        // definition.
+        return SourceRange(GP.getTypeParam()->getEndLoc(),
+                           genericParams.decl->getEndLoc());
+    }
+    llvm_unreachable("Unhandled GenericParam::getKind()");
+  
   case ASTScopeKind::AbstractFunctionDecl: {
     // For an accessor, all of the parameters are implicit, so start them at
     // the start location of the accessor.

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1403,7 +1403,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
     // Explicitly-written generic parameters are in scope following their
     // definition.
     return SourceRange(genericParams.params->getParams()[genericParams.index]
-                         .getEndLoc(),
+                         ->getEndLoc(),
                        genericParams.decl->getEndLoc());
 
   case ASTScopeKind::AbstractFunctionDecl: {
@@ -1765,27 +1765,16 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     for (auto genericParams = extension->getGenericParams();
          genericParams;
          genericParams = genericParams->getOuterParameters()) {
-      for (auto param : genericParams->getParams()) {
-        switch (param.getKind()) {
-          case GenericParam::ParamKind::TypeParam:
-            result.push_back(param.getTypeParam());
-            break;
-        }
-      }
+      for (auto param : genericParams->getParams())
+        result.push_back(param);
     }
     break;
   }
 
-  case ASTScopeKind::GenericParams: {
-    auto param = genericParams.params->getParams()[genericParams.index];
-    switch (param.getKind()) {
-      case GenericParam::ParamKind::TypeParam:
-        result.push_back(param.getTypeParam());
-        break;
-    }
+  case ASTScopeKind::GenericParams:
+    result.push_back(genericParams.params->getParams()[genericParams.index]);
     break;
-  }
-      
+
   case ASTScopeKind::AbstractFunctionParams:
     result.push_back(
       getParameter(abstractFunctionParams.decl,

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1400,17 +1400,12 @@ SourceRange ASTScope::getSourceRangeImpl() const {
                          protoDecl->getEndLoc());
     }
 
-    auto GP = genericParams.params->getParams()[genericParams.index];
-      
-    switch (GP.getKind()) {
-      case GenericParam::ParamKind::TypeParam:
-        // Explicitly-written generic parameters are in scope following their
-        // definition.
-        return SourceRange(GP.getTypeParam()->getEndLoc(),
-                           genericParams.decl->getEndLoc());
-    }
-    llvm_unreachable("Unhandled GenericParam::getKind()");
-  
+    // Explicitly-written generic parameters are in scope following their
+    // definition.
+    return SourceRange(genericParams.params->getParams()[genericParams.index]
+                         ->getEndLoc(),
+                       genericParams.decl->getEndLoc());
+
   case ASTScopeKind::AbstractFunctionDecl: {
     // For an accessor, all of the parameters are implicit, so start them at
     // the start location of the accessor.

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1403,7 +1403,7 @@ SourceRange ASTScope::getSourceRangeImpl() const {
     // Explicitly-written generic parameters are in scope following their
     // definition.
     return SourceRange(genericParams.params->getParams()[genericParams.index]
-                         ->getEndLoc(),
+                         .getEndLoc(),
                        genericParams.decl->getEndLoc());
 
   case ASTScopeKind::AbstractFunctionDecl: {
@@ -1765,16 +1765,27 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     for (auto genericParams = extension->getGenericParams();
          genericParams;
          genericParams = genericParams->getOuterParameters()) {
-      for (auto param : genericParams->getParams())
-        result.push_back(param);
+      for (auto param : genericParams->getParams()) {
+        switch (param.getKind()) {
+          case GenericParam::ParamKind::TypeParam:
+            result.push_back(param.getTypeParam());
+            break;
+        }
+      }
     }
     break;
   }
 
-  case ASTScopeKind::GenericParams:
-    result.push_back(genericParams.params->getParams()[genericParams.index]);
+  case ASTScopeKind::GenericParams: {
+    auto param = genericParams.params->getParams()[genericParams.index];
+    switch (param.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        result.push_back(param.getTypeParam());
+        break;
+    }
     break;
-
+  }
+      
   case ASTScopeKind::AbstractFunctionParams:
     result.push_back(
       getParameter(abstractFunctionParams.decl,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2794,16 +2794,8 @@ public:
       }
       assert(paramList && "this is guaranteed by the parameter list's depth");
 
-      bool hasError = paramList->size() <= GTPD->getIndex();
-
-      if (!hasError) {
-        auto param = paramList->getParams()[GTPD->getIndex()];
-
-        hasError = param.getKind() != GenericParam::ParamKind::TypeParam ||
-                   param.getTypeParam() != GTPD;
-      }
-        
-      if (hasError) {
+      if (paramList->size() <= GTPD->getIndex() ||
+          paramList->getParams()[GTPD->getIndex()] != GTPD) {
         if (llvm::is_contained(paramList->getParams(), GTPD))
           Out << "GenericTypeParamDecl has incorrect index\n";
         else

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2794,8 +2794,16 @@ public:
       }
       assert(paramList && "this is guaranteed by the parameter list's depth");
 
-      if (paramList->size() <= GTPD->getIndex() ||
-          paramList->getParams()[GTPD->getIndex()] != GTPD) {
+      bool hasError = paramList->size() <= GTPD->getIndex();
+
+      if (!hasError) {
+        auto param = paramList->getParams()[GTPD->getIndex()];
+
+        hasError = param.getKind() != GenericParam::ParamKind::TypeParam ||
+                   param.getTypeParam() != GTPD;
+      }
+        
+      if (hasError) {
         if (llvm::is_contained(paramList->getParams(), GTPD))
           Out << "GenericTypeParamDecl has incorrect index\n";
         else

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,8 +376,14 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      if (doIt(P))
-        return true;
+      switch (P.getKind()) {
+        case GenericParam::ParamKind::TypeParam: {
+          if (doIt(P.getTypeParam()))
+            return true;
+            
+          break;
+        }
+      }
     }
 
     // Visit param conformance

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,16 +376,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      switch (P.getKind()) {
-        case GenericParam::ParamKind::TypeParam: {
-          if (doIt(P.getTypeParam()))
-            return true;
-            
-          break;
-        }
-      }
+      if (doIt(P))
+        return true;
     }
-      
+
     // Visit param conformance
     for (auto Req : GPL->getNonTrailingRequirements()) {
       if (doIt(Req))

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,14 +376,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      switch (P.getKind()) {
-        case GenericParam::ParamKind::TypeParam: {
-          if (doIt(P.getTypeParam()))
-            return true;
-          continue;
-        }
-      }
-      llvm_unreachable("Unhandled GenericParam::getKind()");
+      if (doIt(P))
+        return true;
     }
 
     // Visit param conformance

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,10 +376,16 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      if (doIt(P))
-        return true;
+      switch (P.getKind()) {
+        case GenericParam::ParamKind::TypeParam: {
+          if (doIt(P.getTypeParam()))
+            return true;
+            
+          break;
+        }
+      }
     }
-
+      
     // Visit param conformance
     for (auto Req : GPL->getNonTrailingRequirements()) {
       if (doIt(Req))

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,13 +376,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      switch (P->getKind()) {
-      case GenericParamDecl::ParamKind::TypeParameter:
-        if (doIt(P->getGenericTypeParamDecl())) return true;
-        break;
-      default:
-        llvm_unreachable("Unhandled GenericParamDecl::getKind()");
-      }
+      if (doIt(P))
+        return true;
     }
 
     // Visit param conformance

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,8 +376,14 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      if (doIt(P))
-        return true;
+      switch (P.getKind()) {
+        case GenericParam::ParamKind::TypeParam: {
+          if (doIt(P.getTypeParam()))
+            return true;
+          continue;
+        }
+      }
+      llvm_unreachable("Unhandled GenericParam::getKind()");
     }
 
     // Visit param conformance

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -376,8 +376,13 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitGenericParamList(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
-      if (doIt(P))
-        return true;
+      switch (P->getKind()) {
+      case GenericParamDecl::ParamKind::TypeParameter:
+        if (doIt(P->getGenericTypeParamDecl())) return true;
+        break;
+      default:
+        llvm_unreachable("Unhandled GenericParamDecl::getKind()");
+      }
     }
 
     // Visit param conformance

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -424,7 +424,7 @@ static const char * const GenericParamNames[] = {
   "Z"
 };
 
-static GenericTypeParamDecl*
+static GenericParamDecl
 createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   ModuleDecl *M = ctx.TheBuiltinModule;
   Identifier ident = ctx.getIdentifier(name);
@@ -432,13 +432,13 @@ createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   auto genericParam =
     new (ctx) GenericTypeParamDecl(&M->getMainFile(FileUnitKind::Builtin),
                                    ident, SourceLoc(), 0, index);
-  return genericParam;
+  return GenericParamDecl(genericParam);
 }
 
 /// Create a generic parameter list with multiple generic parameters.
 static GenericParamList *getGenericParams(ASTContext &ctx,
                                           unsigned numParameters,
-                       SmallVectorImpl<GenericTypeParamDecl*> &genericParams) {
+                       SmallVectorImpl<GenericParamDecl> &genericParams) {
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
 
@@ -457,7 +457,7 @@ namespace {
 
   private:
     GenericParamList *TheGenericParamList;
-    SmallVector<GenericTypeParamDecl*, 2> GenericTypeParams;
+    SmallVector<GenericParamDecl, 2> GenericParams;
     GenericEnvironment *GenericEnv = nullptr;
     SmallVector<AnyFunctionType::Param, 4> InterfaceParams;
     Type InterfaceResult;
@@ -466,10 +466,10 @@ namespace {
     BuiltinGenericSignatureBuilder(ASTContext &ctx, unsigned numGenericParams = 1)
         : Context(ctx) {
       TheGenericParamList = getGenericParams(ctx, numGenericParams,
-                                             GenericTypeParams);
+                                             GenericParams);
 
       GenericSignatureBuilder Builder(ctx);
-      for (auto gp : GenericTypeParams) {
+      for (auto gp : GenericParams) {
         Builder.addGenericParameter(gp);
       }
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -442,10 +442,17 @@ static GenericParamList *getGenericParams(ASTContext &ctx,
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
 
-  for (unsigned i = 0; i != numParameters; ++i)
-    genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i));
+  // TODO: [GENERICS] Temporary hack, to be removed during generics refactoring
+  SmallVector<GenericParam, 2> genericParamsForParamList;
+    
+  for (unsigned i = 0; i != numParameters; ++i) {
+    auto GTPD = createGenericParam(ctx, GenericParamNames[i], i);
+    genericParams.push_back(GTPD);
+    genericParamsForParamList.push_back(GTPD);
+  }
 
-  auto paramList = GenericParamList::create(ctx, SourceLoc(), genericParams,
+  auto paramList = GenericParamList::create(ctx, SourceLoc(),
+                                            genericParamsForParamList,
                                             SourceLoc());
   return paramList;
 }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -442,10 +442,17 @@ static GenericParamList *getGenericParams(ASTContext &ctx,
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
 
-  for (unsigned i = 0; i != numParameters; ++i)
-    genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i));
+  // TODO: [GENERICS] Temporary hack while refactoring generics
+  SmallVector<GenericParam, 2> genericParamsForParamList;
 
-  auto paramList = GenericParamList::create(ctx, SourceLoc(), genericParams,
+  for (unsigned i = 0; i != numParameters; ++i) {
+    auto *GTPD = createGenericParam(ctx, GenericParamNames[i], i);
+    genericParams.push_back(GTPD);
+    genericParamsForParamList.push_back(GTPD);
+  }
+
+  auto paramList = GenericParamList::create(ctx, SourceLoc(),
+                                            genericParamsForParamList,
                                             SourceLoc());
   return paramList;
 }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -442,17 +442,10 @@ static GenericParamList *getGenericParams(ASTContext &ctx,
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
 
-  // TODO: [GENERICS] Temporary hack, to be removed during generics refactoring
-  SmallVector<GenericParam, 2> genericParamsForParamList;
-    
-  for (unsigned i = 0; i != numParameters; ++i) {
-    auto GTPD = createGenericParam(ctx, GenericParamNames[i], i);
-    genericParams.push_back(GTPD);
-    genericParamsForParamList.push_back(GTPD);
-  }
+  for (unsigned i = 0; i != numParameters; ++i)
+    genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i));
 
-  auto paramList = GenericParamList::create(ctx, SourceLoc(),
-                                            genericParamsForParamList,
+  auto paramList = GenericParamList::create(ctx, SourceLoc(), genericParams,
                                             SourceLoc());
   return paramList;
 }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -441,11 +441,18 @@ static GenericParamList *getGenericParams(ASTContext &ctx,
                        SmallVectorImpl<GenericTypeParamDecl*> &genericParams) {
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
+    
+  // TODO: [GENERICS] This is a temporary hack until generics refactoring is finished
+  SmallVector<GenericParam, 2> genericParamsForParamList;
+    
+  for (unsigned i = 0; i != numParameters; ++i) {
+    auto GTPD = createGenericParam(ctx, GenericParamNames[i], i);
+    genericParams.push_back(GTPD);
+    genericParamsForParamList.push_back(GenericParam(GTPD));
+  }
 
-  for (unsigned i = 0; i != numParameters; ++i)
-    genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i));
-
-  auto paramList = GenericParamList::create(ctx, SourceLoc(), genericParams,
+  auto paramList = GenericParamList::create(ctx, SourceLoc(),
+                                            genericParamsForParamList,
                                             SourceLoc());
   return paramList;
 }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -424,7 +424,7 @@ static const char * const GenericParamNames[] = {
   "Z"
 };
 
-static GenericParamDecl
+static GenericTypeParamDecl*
 createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   ModuleDecl *M = ctx.TheBuiltinModule;
   Identifier ident = ctx.getIdentifier(name);
@@ -432,13 +432,13 @@ createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   auto genericParam =
     new (ctx) GenericTypeParamDecl(&M->getMainFile(FileUnitKind::Builtin),
                                    ident, SourceLoc(), 0, index);
-  return GenericParamDecl(genericParam);
+  return genericParam;
 }
 
 /// Create a generic parameter list with multiple generic parameters.
 static GenericParamList *getGenericParams(ASTContext &ctx,
                                           unsigned numParameters,
-                       SmallVectorImpl<GenericParamDecl> &genericParams) {
+                       SmallVectorImpl<GenericTypeParamDecl*> &genericParams) {
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
 
@@ -457,7 +457,7 @@ namespace {
 
   private:
     GenericParamList *TheGenericParamList;
-    SmallVector<GenericParamDecl, 2> GenericParams;
+    SmallVector<GenericTypeParamDecl*, 2> GenericTypeParams;
     GenericEnvironment *GenericEnv = nullptr;
     SmallVector<AnyFunctionType::Param, 4> InterfaceParams;
     Type InterfaceResult;
@@ -466,10 +466,10 @@ namespace {
     BuiltinGenericSignatureBuilder(ASTContext &ctx, unsigned numGenericParams = 1)
         : Context(ctx) {
       TheGenericParamList = getGenericParams(ctx, numGenericParams,
-                                             GenericParams);
+                                             GenericTypeParams);
 
       GenericSignatureBuilder Builder(ctx);
-      for (auto gp : GenericParams) {
+      for (auto gp : GenericTypeParams) {
         Builder.addGenericParameter(gp);
       }
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -441,18 +441,11 @@ static GenericParamList *getGenericParams(ASTContext &ctx,
                        SmallVectorImpl<GenericTypeParamDecl*> &genericParams) {
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
   assert(genericParams.empty());
-    
-  // TODO: [GENERICS] This is a temporary hack until generics refactoring is finished
-  SmallVector<GenericParam, 2> genericParamsForParamList;
-    
-  for (unsigned i = 0; i != numParameters; ++i) {
-    auto GTPD = createGenericParam(ctx, GenericParamNames[i], i);
-    genericParams.push_back(GTPD);
-    genericParamsForParamList.push_back(GenericParam(GTPD));
-  }
 
-  auto paramList = GenericParamList::create(ctx, SourceLoc(),
-                                            genericParamsForParamList,
+  for (unsigned i = 0; i != numParameters; ++i)
+    genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i));
+
+  auto paramList = GenericParamList::create(ctx, SourceLoc(), genericParams,
                                             SourceLoc());
   return paramList;
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -597,8 +597,48 @@ bool Decl::isWeakImported(ModuleDecl *fromModule,
   return false;
 }
 
+SourceLoc GenericParam::getEndLoc() const {
+  switch (Kind) {
+    case ParamKind::TypeParam:
+      return GTPD->getEndLoc();
+  }
+  llvm_unreachable("Unhandled GenericParam::getKind()");
+}
+
+ArrayRef<TypeLoc> GenericParam::getInherited() const {
+  switch (Kind) {
+    case ParamKind::TypeParam:
+      return GTPD->getInherited();
+  }
+  llvm_unreachable("Unhandled GenericParam::getKind()");
+}
+
+Identifier GenericParam::getName() const {
+    switch (Kind) {
+        case ParamKind::TypeParam:
+        return GTPD->getName();
+    }
+    llvm_unreachable("Unhandled GenericParam::getKind()");
+}
+
+void GenericParam::setDeclContext(DeclContext *DC) const {
+  switch (Kind) {
+    case ParamKind::TypeParam:
+      GTPD->setDeclContext(DC);
+      break;
+  }
+}
+
+void GenericParam::setDepth(unsigned depth) const {
+  switch (Kind) {
+    case ParamKind::TypeParam:
+      GTPD->setDepth(depth);
+      break;
+  }
+}
+
 GenericParamList::GenericParamList(SourceLoc LAngleLoc,
-                                   ArrayRef<GenericTypeParamDecl *> Params,
+                                   ArrayRef<GenericParam> Params,
                                    SourceLoc WhereLoc,
                                    MutableArrayRef<RequirementRepr> Requirements,
                                    SourceLoc RAngleLoc)
@@ -608,15 +648,15 @@ GenericParamList::GenericParamList(SourceLoc LAngleLoc,
     FirstTrailingWhereArg(Requirements.size())
 {
   std::uninitialized_copy(Params.begin(), Params.end(),
-                          getTrailingObjects<GenericTypeParamDecl *>());
+                          getTrailingObjects<GenericParam>());
 }
 
 GenericParamList *
 GenericParamList::create(ASTContext &Context,
                          SourceLoc LAngleLoc,
-                         ArrayRef<GenericTypeParamDecl *> Params,
+                         ArrayRef<GenericParam> Params,
                          SourceLoc RAngleLoc) {
-  unsigned Size = totalSizeToAlloc<GenericTypeParamDecl *>(Params.size());
+  unsigned Size = totalSizeToAlloc<GenericParam>(Params.size());
   void *Mem = Context.Allocate(Size, alignof(GenericParamList));
   return new (Mem) GenericParamList(LAngleLoc, Params, SourceLoc(),
                                     MutableArrayRef<RequirementRepr>(),
@@ -626,11 +666,11 @@ GenericParamList::create(ASTContext &Context,
 GenericParamList *
 GenericParamList::create(const ASTContext &Context,
                          SourceLoc LAngleLoc,
-                         ArrayRef<GenericTypeParamDecl *> Params,
+                         ArrayRef<GenericParam> Params,
                          SourceLoc WhereLoc,
                          ArrayRef<RequirementRepr> Requirements,
                          SourceLoc RAngleLoc) {
-  unsigned Size = totalSizeToAlloc<GenericTypeParamDecl *>(Params.size());
+  unsigned Size = totalSizeToAlloc<GenericParam>(Params.size());
   void *Mem = Context.Allocate(Size, alignof(GenericParamList));
   return new (Mem) GenericParamList(LAngleLoc, Params,
                                     WhereLoc,
@@ -641,18 +681,26 @@ GenericParamList::create(const ASTContext &Context,
 GenericParamList *
 GenericParamList::clone(DeclContext *dc) const {
   auto &ctx = dc->getASTContext();
-  SmallVector<GenericTypeParamDecl *, 2> params;
+  SmallVector<GenericParam, 2> params;
+    
   for (auto param : getParams()) {
-    auto *newParam = new (ctx) GenericTypeParamDecl(
-      dc, param->getName(), param->getNameLoc(),
-      GenericTypeParamDecl::InvalidDepth,
-      param->getIndex());
-    params.push_back(newParam);
-
-    SmallVector<TypeLoc, 2> inherited;
-    for (auto loc : param->getInherited())
-      inherited.push_back(loc.clone(ctx));
-    newParam->setInherited(ctx.AllocateCopy(inherited));
+    switch (param.getKind()) {
+      case GenericParam::ParamKind::TypeParam: {
+        auto GTPD = param.getTypeParam();
+        auto *newParam = new (ctx) GenericTypeParamDecl(
+          dc, GTPD->getName(), GTPD->getNameLoc(),
+          GenericTypeParamDecl::InvalidDepth,
+          GTPD->getIndex());
+        params.push_back(newParam);
+          
+        SmallVector<TypeLoc, 2> inherited;
+        for (auto loc : GTPD->getInherited())
+          inherited.push_back(loc.clone(ctx));
+        newParam->setInherited(ctx.AllocateCopy(inherited));
+          
+        break;
+      }
+    }
   }
 
   SmallVector<RequirementRepr, 2> requirements;
@@ -721,7 +769,7 @@ void GenericParamList::addTrailingWhereClause(
 
 void GenericParamList::setDepth(unsigned depth) {
   for (auto param : *this)
-    param->setDepth(depth);
+    param.setDepth(depth);
 }
 
 TrailingWhereClause::TrailingWhereClause(
@@ -764,7 +812,7 @@ void GenericContext::setGenericParams(GenericParamList *params) {
 
   if (GenericParams) {
     for (auto param : *GenericParams)
-      param->setDeclContext(this);
+      param.setDeclContext(this);
   }
 }
 
@@ -1094,17 +1142,22 @@ static GenericParamList *cloneGenericParams(ASTContext &ctx,
                                             ExtensionDecl *ext,
                                             GenericParamList *fromParams) {
   // Clone generic parameters.
-  SmallVector<GenericTypeParamDecl *, 2> toGenericParams;
-  for (auto fromGP : *fromParams) {
-    // Create the new generic parameter.
-    auto toGP = new (ctx) GenericTypeParamDecl(ext, fromGP->getName(),
-                                               SourceLoc(),
-                                               fromGP->getDepth(),
-                                               fromGP->getIndex());
-    toGP->setImplicit(true);
-
-    // Record new generic parameter.
-    toGenericParams.push_back(toGP);
+  SmallVector<GenericParam, 2> toGenericParams;
+  for (auto param : *fromParams) {
+    switch (param.getKind()) {
+      case GenericParam::ParamKind::TypeParam: {
+        auto fromGP = param.getTypeParam();
+        auto toGP = new (ctx) GenericTypeParamDecl(ext, fromGP->getName(),
+                                                   SourceLoc(),
+                                                   fromGP->getDepth(),
+                                                   fromGP->getIndex());
+          
+        toGP->setImplicit(true);
+        toGenericParams.push_back(toGP);
+          
+        break;
+      }
+    }
   }
 
   return GenericParamList::create(ctx, SourceLoc(), toGenericParams,
@@ -1156,8 +1209,14 @@ void ExtensionDecl::createGenericParamsIfMissing(NominalTypeDecl *nominal) {
   if (auto *proto = dyn_cast<ProtocolDecl>(nominal)) {
     auto protoType = proto->getDeclaredType();
     TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
-    genericParams->getParams().front()->setInherited(
-      ctx.AllocateCopy(selfInherited));
+    
+    auto param = genericParams->getParams().front();
+
+    switch (param.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        param.getTypeParam()->setInherited(ctx.AllocateCopy(selfInherited));
+        break;
+    }
   }
 
   // Set the depth of every generic parameter.
@@ -3157,8 +3216,13 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
       // the generic parameter list directly instead of looking
       // at the signature.
       SmallVector<Type, 4> args;
-      for (auto param : decl->getGenericParams()->getParams())
-        args.push_back(param->getDeclaredInterfaceType());
+      for (auto param : decl->getGenericParams()->getParams()) {
+        switch (param.getKind()) {
+          case GenericParam::ParamKind::TypeParam:
+            args.push_back(param.getTypeParam()->getDeclaredInterfaceType());
+            break;
+        }
+      }
 
       return BoundGenericType::get(decl, Ty, args);
     }
@@ -4416,10 +4480,10 @@ void ProtocolDecl::createGenericParamsIfMissing() {
   TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
   selfDecl->setInherited(ctx.AllocateCopy(selfInherited));
   selfDecl->setImplicit();
-
+    
   // The generic parameter list itself.
-  auto result = GenericParamList::create(ctx, SourceLoc(), selfDecl,
-                                         SourceLoc());
+  auto result = GenericParamList::create(ctx, SourceLoc(),
+                                         GenericParam(selfDecl), SourceLoc());
   setGenericParams(result);
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -597,8 +597,18 @@ bool Decl::isWeakImported(ModuleDecl *fromModule,
   return false;
 }
 
+void GenericParamDecl::setDepth(unsigned int depth) const {
+  switch (getKind()) {
+  case ParamKind::TypeParameter: {
+    getGenericTypeParamDecl()->setDepth(depth);
+    return;
+  }
+  }
+  llvm_unreachable("Unhandled GenericParamDecl::getKind()")
+}
+
 GenericParamList::GenericParamList(SourceLoc LAngleLoc,
-                                   ArrayRef<GenericTypeParamDecl *> Params,
+                                   ArrayRef<GenericParamDecl> Params,
                                    SourceLoc WhereLoc,
                                    MutableArrayRef<RequirementRepr> Requirements,
                                    SourceLoc RAngleLoc)
@@ -608,15 +618,15 @@ GenericParamList::GenericParamList(SourceLoc LAngleLoc,
     FirstTrailingWhereArg(Requirements.size())
 {
   std::uninitialized_copy(Params.begin(), Params.end(),
-                          getTrailingObjects<GenericTypeParamDecl *>());
+                          getTrailingObjects<GenericParamDecl>());
 }
 
 GenericParamList *
 GenericParamList::create(ASTContext &Context,
                          SourceLoc LAngleLoc,
-                         ArrayRef<GenericTypeParamDecl *> Params,
+                         ArrayRef<GenericParamDecl> Params,
                          SourceLoc RAngleLoc) {
-  unsigned Size = totalSizeToAlloc<GenericTypeParamDecl *>(Params.size());
+  unsigned Size = totalSizeToAlloc<GenericParamDecl>(Params.size());
   void *Mem = Context.Allocate(Size, alignof(GenericParamList));
   return new (Mem) GenericParamList(LAngleLoc, Params, SourceLoc(),
                                     MutableArrayRef<RequirementRepr>(),
@@ -626,11 +636,11 @@ GenericParamList::create(ASTContext &Context,
 GenericParamList *
 GenericParamList::create(const ASTContext &Context,
                          SourceLoc LAngleLoc,
-                         ArrayRef<GenericTypeParamDecl *> Params,
+                         ArrayRef<GenericParamDecl> Params,
                          SourceLoc WhereLoc,
                          ArrayRef<RequirementRepr> Requirements,
                          SourceLoc RAngleLoc) {
-  unsigned Size = totalSizeToAlloc<GenericTypeParamDecl *>(Params.size());
+  unsigned Size = totalSizeToAlloc<GenericParamDecl>(Params.size());
   void *Mem = Context.Allocate(Size, alignof(GenericParamList));
   return new (Mem) GenericParamList(LAngleLoc, Params,
                                     WhereLoc,
@@ -641,18 +651,26 @@ GenericParamList::create(const ASTContext &Context,
 GenericParamList *
 GenericParamList::clone(DeclContext *dc) const {
   auto &ctx = dc->getASTContext();
-  SmallVector<GenericTypeParamDecl *, 2> params;
-  for (auto param : getParams()) {
-    auto *newParam = new (ctx) GenericTypeParamDecl(
-      dc, param->getName(), param->getNameLoc(),
-      GenericTypeParamDecl::InvalidDepth,
-      param->getIndex());
-    params.push_back(newParam);
-
-    SmallVector<TypeLoc, 2> inherited;
-    for (auto loc : param->getInherited())
-      inherited.push_back(loc.clone(ctx));
-    newParam->setInherited(ctx.AllocateCopy(inherited));
+  SmallVector<GenericParamDecl, 2> params;
+  for (auto GPD : getParams()) {
+    switch (GPD.getKind()) {
+    case GenericParamDecl::ParamKind::TypeParameter: {
+      auto GTPD = GPD.getGenericTypeParamDecl();
+        
+      auto *newParam = new (ctx) GenericTypeParamDecl(
+        dc, GTPD->getName(), GTPD->getNameLoc(),
+        GenericTypeParamDecl::InvalidDepth,
+        GTPD->getIndex());
+      params.push_back(newParam);
+        
+      SmallVector<TypeLoc, 2> inherited;
+      for (auto loc : GTPD->getInherited())
+        inherited.push_back(loc.clone(ctx));
+      newParam->setInherited(ctx.AllocateCopy(inherited));
+        
+      break;
+    }
+    }
   }
 
   SmallVector<RequirementRepr, 2> requirements;
@@ -721,7 +739,7 @@ void GenericParamList::addTrailingWhereClause(
 
 void GenericParamList::setDepth(unsigned depth) {
   for (auto param : *this)
-    param->setDepth(depth);
+    param.setDepth(depth);
 }
 
 TrailingWhereClause::TrailingWhereClause(
@@ -763,8 +781,14 @@ void GenericContext::setGenericParams(GenericParamList *params) {
   GenericParams = params;
 
   if (GenericParams) {
-    for (auto param : *GenericParams)
-      param->setDeclContext(this);
+    for (auto param : *GenericParams) {
+      switch (param.getKind()) {
+      case GenericParamDecl::ParamKind::TypeParameter: {
+        param.getGenericTypeParamDecl()->setDeclContext(this);
+        break;
+      }
+      }
+    }
   }
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -98,7 +98,8 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (genericParams == nullptr)
     return nullptr;
 
-  return genericParams->getParams().front()
+  // Self must always be the first generic parameter
+  return genericParams->getParams().front().getTypeParam()
       ->getDeclaredInterfaceType()
       ->castTo<GenericTypeParamType>();
 }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -98,7 +98,12 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (genericParams == nullptr)
     return nullptr;
 
-  return genericParams->getParams().front()
+  auto SelfParam = genericParams->getParams().front();
+
+  assert(SelfParam.is(GenericParam::ParamKind::TypeParam)
+         && "Self was not declared as a GenericTypeParamDecl");
+    
+  return SelfParam.getTypeParam()
       ->getDeclaredInterfaceType()
       ->castTo<GenericTypeParamType>();
 }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -98,9 +98,15 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (genericParams == nullptr)
     return nullptr;
 
-  return genericParams->getParams().front()
-      ->getDeclaredInterfaceType()
-      ->castTo<GenericTypeParamType>();
+  auto GPD = genericParams->getParams().front();
+    
+  switch (GPD.getKind()) {
+  case GenericParamDecl::ParamKind::TypeParameter:
+    return GPD.getGenericTypeParamDecl()
+              ->getDeclaredInterfaceType()
+              ->castTo<GenericTypeParamType>();
+  }
+  llvm_unreachable("Unhandled GenericParamDecl::getKind()");
 }
 
 Type DeclContext::getDeclaredTypeInContext() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -99,7 +99,7 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
     return nullptr;
 
   return genericParams->getParams().front()
-      ->getDeclaredInterfaceType()
+      .getDeclaredInterfaceType()
       ->castTo<GenericTypeParamType>();
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -98,15 +98,9 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (genericParams == nullptr)
     return nullptr;
 
-  auto GPD = genericParams->getParams().front();
-    
-  switch (GPD.getKind()) {
-  case GenericParamDecl::ParamKind::TypeParameter:
-    return GPD.getGenericTypeParamDecl()
-              ->getDeclaredInterfaceType()
-              ->castTo<GenericTypeParamType>();
-  }
-  llvm_unreachable("Unhandled GenericParamDecl::getKind()");
+  return genericParams->getParams().front()
+      ->getDeclaredInterfaceType()
+      ->castTo<GenericTypeParamType>();
 }
 
 Type DeclContext::getDeclaredTypeInContext() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -98,12 +98,7 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (genericParams == nullptr)
     return nullptr;
 
-  auto SelfParam = genericParams->getParams().front();
-
-  assert(SelfParam.is(GenericParam::ParamKind::TypeParam)
-         && "Self was not declared as a GenericTypeParamDecl");
-    
-  return SelfParam.getTypeParam()
+  return genericParams->getParams().front()
       ->getDeclaredInterfaceType()
       ->castTo<GenericTypeParamType>();
 }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -98,8 +98,7 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (genericParams == nullptr)
     return nullptr;
 
-  // Self must always be the first generic parameter
-  return genericParams->getParams().front().getTypeParam()
+  return genericParams->getParams().front()
       ->getDeclaredInterfaceType()
       ->castTo<GenericTypeParamType>();
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7466,8 +7466,13 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
 
   // Add all of the generic parameters.
   proto->createGenericParamsIfMissing();
-  for (auto gp : *proto->getGenericParams())
-    builder.addGenericParameter(gp);
+    for (auto gp : *proto->getGenericParams()) {
+      switch (gp.getKind()) {
+      case GenericParamDecl::ParamKind::TypeParameter:
+        builder.addGenericParameter(gp.getGenericTypeParamDecl());
+        break;      
+      }
+    }
 
   // Add the conformance of 'self' to the protocol.
   auto selfType =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7466,8 +7466,14 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
 
   // Add all of the generic parameters.
   proto->createGenericParamsIfMissing();
-  for (auto gp : *proto->getGenericParams())
-    builder.addGenericParameter(gp);
+  for (auto gp : *proto->getGenericParams()) {
+    switch (gp.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        builder.addGenericParameter(gp.getTypeParam());
+        continue;
+    }
+    llvm_unreachable("Unhandled GenericParam::getKind()");
+  }
 
   // Add the conformance of 'self' to the protocol.
   auto selfType =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7466,8 +7466,14 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
 
   // Add all of the generic parameters.
   proto->createGenericParamsIfMissing();
-  for (auto gp : *proto->getGenericParams())
-    builder.addGenericParameter(gp);
+  for (auto gp : *proto->getGenericParams()) {
+    // TODO: [GENERICS] Make GenericSignatureBuilder accept GenericParam
+    switch (gp.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        builder.addGenericParameter(gp.getTypeParam());
+        break;
+    }
+  }
 
   // Add the conformance of 'self' to the protocol.
   auto selfType =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7466,13 +7466,8 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
 
   // Add all of the generic parameters.
   proto->createGenericParamsIfMissing();
-    for (auto gp : *proto->getGenericParams()) {
-      switch (gp.getKind()) {
-      case GenericParamDecl::ParamKind::TypeParameter:
-        builder.addGenericParameter(gp.getGenericTypeParamDecl());
-        break;      
-      }
-    }
+  for (auto gp : *proto->getGenericParams())
+    builder.addGenericParameter(gp);
 
   // Add the conformance of 'self' to the protocol.
   auto selfType =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4013,19 +4013,14 @@ GenericSignatureBuilder::getGenericParams() const {
   return TypeArrayView<GenericTypeParamType>(Impl->GenericParams);
 }
 
-void GenericSignatureBuilder::addGenericParameter(GenericParam param) {
-  switch (param.getKind()) {
-    case GenericParam::ParamKind::TypeParam:
-      addGenericParameter(param.getTypeParam()
-                            ->getDeclaredInterfaceType()
-                            ->castTo<GenericTypeParamType>());
-      break;
-  }
+void GenericSignatureBuilder::addGenericParameter(GenericTypeParamDecl *GenericParam) {
+  addGenericParameter(
+     GenericParam->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
 }
 
 bool GenericSignatureBuilder::addGenericParameterRequirements(
-                                                          GenericParam param) {
-  GenericParamKey Key(param);
+                                           GenericTypeParamDecl *GenericParam) {
+  GenericParamKey Key(GenericParam);
   auto PA = Impl->PotentialArchetypes[Key.findIndexIn(getGenericParams())];
   
   // Add the requirements from the declaration.
@@ -7471,14 +7466,9 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
 
   // Add all of the generic parameters.
   proto->createGenericParamsIfMissing();
-  for (auto gp : *proto->getGenericParams()) {
-    switch (gp.getKind()) {
-      case GenericParam::ParamKind::TypeParam:
-        builder.addGenericParameter(gp.getTypeParam());
-        break;
-    }
-  }
-  
+  for (auto gp : *proto->getGenericParams())
+    builder.addGenericParameter(gp);
+
   // Add the conformance of 'self' to the protocol.
   auto selfType =
     proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7466,14 +7466,8 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
 
   // Add all of the generic parameters.
   proto->createGenericParamsIfMissing();
-  for (auto gp : *proto->getGenericParams()) {
-    switch (gp.getKind()) {
-      case GenericParam::ParamKind::TypeParam:
-        builder.addGenericParameter(gp.getTypeParam());
-        continue;
-    }
-    llvm_unreachable("Unhandled GenericParam::getKind()");
-  }
+  for (auto gp : *proto->getGenericParams())
+    builder.addGenericParameter(gp);
 
   // Add the conformance of 'self' to the protocol.
   auto selfType =

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,13 +2246,8 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params) {
-    switch (P.getKind()) {
-      case GenericParam::ParamKind::TypeParam:
-        checkValueDecl(P.getTypeParam(), DeclVisibilityKind::GenericParameter);
-        break;
-    }
-  }
+  for (auto P : *Params)
+    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,8 +2246,14 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params)
-    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
+    for (auto P : *Params) {
+      switch (P.getKind()) {
+        case GenericParam::ParamKind::TypeParam:
+          checkValueDecl(P.getTypeParam(), DeclVisibilityKind::GenericParameter);
+          continue;
+      }
+      llvm_unreachable("Unhandled GenericParam::getKind()");
+    }
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,14 +2246,8 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params) {
-    switch (P.getKind()) {
-    case GenericParamDecl::ParamKind::TypeParameter:
-      checkValueDecl(P.getGenericTypeParamDecl(),
-                     DeclVisibilityKind::GenericParameter);
-      break;
-    }
-  }
+  for (auto P : *Params)
+    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,8 +2246,14 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params)
-    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
+  for (auto P : *Params) {
+    switch (P.getKind()) {
+    case GenericParamDecl::ParamKind::TypeParameter:
+      checkValueDecl(P.getGenericTypeParamDecl(),
+                     DeclVisibilityKind::GenericParameter);
+      break;
+    }
+  }
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,14 +2246,8 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-    for (auto P : *Params) {
-      switch (P.getKind()) {
-        case GenericParam::ParamKind::TypeParam:
-          checkValueDecl(P.getTypeParam(), DeclVisibilityKind::GenericParameter);
-          continue;
-      }
-      llvm_unreachable("Unhandled GenericParam::getKind()");
-    }
+  for (auto P : *Params)
+    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,8 +2246,13 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params)
-    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
+  for (auto P : *Params) {
+    switch (P.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        checkValueDecl(P.getTypeParam(), DeclVisibilityKind::GenericParameter);
+        break;
+    }
+  }    
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2246,8 +2246,13 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params)
-    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
+  for (auto P : *Params) {
+    switch (P.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        checkValueDecl(P.getTypeParam(), DeclVisibilityKind::GenericParameter);
+        break;
+    }
+  }
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4396,7 +4396,7 @@ namespace {
       result->computeType();
 
       // FIXME: Kind of awkward that we have to do this here
-      result->getGenericParams()->getParams()[0].setDepth(0);
+      result->getGenericParams()->getParams()[0]->setDepth(0);
 
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
@@ -6719,7 +6719,7 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
     return nullptr;
   }
   assert(typeParamList->size() > 0);
-  SmallVector<GenericParam, 4> genericParams;
+  SmallVector<GenericTypeParamDecl *, 4> genericParams;
   for (auto *objcGenericParam : *typeParamList) {
     auto genericParamDecl = Impl.createDeclWithClangNode<GenericTypeParamDecl>(
         objcGenericParam, AccessLevel::Public, dc,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4396,7 +4396,7 @@ namespace {
       result->computeType();
 
       // FIXME: Kind of awkward that we have to do this here
-      result->getGenericParams()->getParams()[0]->setDepth(0);
+      result->getGenericParams()->getParams()[0].setDepth(0);
 
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
@@ -6719,7 +6719,7 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
     return nullptr;
   }
   assert(typeParamList->size() > 0);
-  SmallVector<GenericTypeParamDecl *, 4> genericParams;
+  SmallVector<GenericParam, 4> genericParams;
   for (auto *objcGenericParam : *typeParamList) {
     auto genericParamDecl = Impl.createDeclWithClangNode<GenericTypeParamDecl>(
         objcGenericParam, AccessLevel::Public, dc,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -940,16 +940,16 @@ namespace {
                 return nullptr;
               }
               importedTypeArg = subresult.AbstractType;
-            } else if (typeParam->getSuperclass() &&
-                       typeParam->getConformingProtocols().empty()) {
-              importedTypeArg = typeParam->getSuperclass();
+            } else if (typeParam.getSuperclass() &&
+                       typeParam.getConformingProtocols().empty()) {
+              importedTypeArg = typeParam.getSuperclass();
             } else {
               SmallVector<Type, 4> memberTypes;
 
-              if (auto superclassType = typeParam->getSuperclass())
+              if (auto superclassType = typeParam.getSuperclass())
                 memberTypes.push_back(superclassType);
 
-              for (auto protocolDecl : typeParam->getConformingProtocols())
+              for (auto protocolDecl : typeParam.getConformingProtocols())
                 memberTypes.push_back(protocolDecl->getDeclaredType());
 
               bool hasExplicitAnyObject = false;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -931,34 +931,46 @@ namespace {
           auto typeArgs = type->getObjectType()->getTypeArgs();
           assert(typeArgs.empty() || typeArgs.size() == typeParamCount);
           llvm::SmallVector<Type, 2> importedTypeArgs;
+            
           for (unsigned i = 0; i < typeParamCount; i++) {
             Type importedTypeArg;
             auto typeParam = imported->getGenericParams()->getParams()[i];
+              
             if (!typeArgs.empty()) {
               auto subresult = Visit(typeArgs[i]);
               if (!subresult) {
                 return nullptr;
               }
               importedTypeArg = subresult.AbstractType;
-            } else if (typeParam->getSuperclass() &&
-                       typeParam->getConformingProtocols().empty()) {
-              importedTypeArg = typeParam->getSuperclass();
             } else {
-              SmallVector<Type, 4> memberTypes;
-
-              if (auto superclassType = typeParam->getSuperclass())
-                memberTypes.push_back(superclassType);
-
-              for (auto protocolDecl : typeParam->getConformingProtocols())
-                memberTypes.push_back(protocolDecl->getDeclaredType());
-
-              bool hasExplicitAnyObject = false;
-              if (memberTypes.empty())
-                hasExplicitAnyObject = true;
-
-              importedTypeArg = ProtocolCompositionType::get(
-                  Impl.SwiftContext, memberTypes,
-                  hasExplicitAnyObject);
+              switch (typeParam.getKind()) {
+              case GenericParam::ParamKind::TypeParam: {
+                auto GTPD = typeParam.getTypeParam();
+                  
+                if (GTPD->getSuperclass() &&
+                    GTPD->getConformingProtocols().empty()) {
+                  importedTypeArg = GTPD->getSuperclass();
+                } else {
+                  SmallVector<Type, 4> memberTypes;
+                    
+                  if (auto superclassType = GTPD->getSuperclass())
+                    memberTypes.push_back(superclassType);
+                    
+                  for (auto protocolDecl : GTPD->getConformingProtocols())
+                    memberTypes.push_back(protocolDecl->getDeclaredType());
+                    
+                  bool hasExplicitAnyObject = false;
+                  if (memberTypes.empty())
+                    hasExplicitAnyObject = true;
+                    
+                  importedTypeArg = ProtocolCompositionType::get(
+                      Impl.SwiftContext, memberTypes,
+                      hasExplicitAnyObject);
+                }
+                      
+                break;
+              }
+              }
             }
             importedTypeArgs.push_back(importedTypeArg);
           }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5299,8 +5299,12 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (auto GT = ParsedTypeLoc.getType()->getAnyGeneric()) {
       if (auto Params = GT->getGenericParams()) {
         for (auto GP : Params->getParams()) {
-          Lookup.addGenericTypeParamRef(GP,
+          switch (GP.getKind()) {
+            case GenericParam::ParamKind::TypeParam:
+              Lookup.addGenericTypeParamRef(GP.getTypeParam(),
                                         DeclVisibilityKind::GenericParameter);
+              break;
+          }
         }
       }
     }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -46,7 +46,7 @@ ParserResult<GenericParamList> Parser::parseGenericParameters() {
 
 ParserStatus
 Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
-                        SmallVectorImpl<GenericParam> &GenericParams) {
+                        SmallVectorImpl<GenericTypeParamDecl *> &GenericParams) {
   ParserStatus Result;
   SyntaxParsingContext GPSContext(SyntaxContext, SyntaxKind::GenericParameterList);
   bool HasNextParam;
@@ -129,7 +129,7 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
 ParserResult<GenericParamList>
 Parser::parseGenericParameters(SourceLoc LAngleLoc) {
   // Parse the generic parameter list.
-  SmallVector<GenericParam, 4> GenericParams;
+  SmallVector<GenericTypeParamDecl *, 4> GenericParams;
   auto Result = parseGenericParametersBeforeWhere(LAngleLoc, GenericParams);
 
   // Return early if there was code completion token.
@@ -206,7 +206,7 @@ Parser::diagnoseWhereClauseInGenericParamList(const GenericParamList *
   // as written all the way to the right angle bracket (">")
   auto LastGenericParam = GenericParams->getParams().back();
   auto EndOfLastGenericParam =
-      Lexer::getLocForEndOfToken(SourceMgr, LastGenericParam.getEndLoc());
+      Lexer::getLocForEndOfToken(SourceMgr, LastGenericParam->getEndLoc());
 
   CharSourceRange RemoveWhereRange { SourceMgr,
     EndOfLastGenericParam,
@@ -380,15 +380,9 @@ parseFreestandingGenericWhereClause(GenericParamList *&genericParams,
   // find them.
   Scope S(this, ScopeKind::Generics);
   
-  if (genericParams) {
-    for (auto pd : genericParams->getParams()) {
-      switch (pd.getKind()) {
-        case GenericParam::ParamKind::TypeParam:
-          addToScope(pd.getTypeParam());
-          break;
-      }
-    }
-  }
+  if (genericParams)
+    for (auto pd : genericParams->getParams())
+      addToScope(pd);
   
   SmallVector<RequirementRepr, 4> Requirements;
   SourceLoc WhereLoc;

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -46,7 +46,7 @@ ParserResult<GenericParamList> Parser::parseGenericParameters() {
 
 ParserStatus
 Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
-                        SmallVectorImpl<GenericTypeParamDecl *> &GenericParams) {
+                        SmallVectorImpl<GenericParam> &GenericParams) {
   ParserStatus Result;
   SyntaxParsingContext GPSContext(SyntaxContext, SyntaxKind::GenericParameterList);
   bool HasNextParam;
@@ -129,7 +129,7 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
 ParserResult<GenericParamList>
 Parser::parseGenericParameters(SourceLoc LAngleLoc) {
   // Parse the generic parameter list.
-  SmallVector<GenericTypeParamDecl *, 4> GenericParams;
+  SmallVector<GenericParam, 4> GenericParams;
   auto Result = parseGenericParametersBeforeWhere(LAngleLoc, GenericParams);
 
   // Return early if there was code completion token.
@@ -206,7 +206,7 @@ Parser::diagnoseWhereClauseInGenericParamList(const GenericParamList *
   // as written all the way to the right angle bracket (">")
   auto LastGenericParam = GenericParams->getParams().back();
   auto EndOfLastGenericParam =
-      Lexer::getLocForEndOfToken(SourceMgr, LastGenericParam->getEndLoc());
+      Lexer::getLocForEndOfToken(SourceMgr, LastGenericParam.getEndLoc());
 
   CharSourceRange RemoveWhereRange { SourceMgr,
     EndOfLastGenericParam,
@@ -380,9 +380,15 @@ parseFreestandingGenericWhereClause(GenericParamList *&genericParams,
   // find them.
   Scope S(this, ScopeKind::Generics);
   
-  if (genericParams)
-    for (auto pd : genericParams->getParams())
-      addToScope(pd);
+  if (genericParams) {
+    for (auto pd : genericParams->getParams()) {
+      switch (pd.getKind()) {
+        case GenericParam::ParamKind::TypeParam:
+          addToScope(pd.getTypeParam());
+          break;
+      }
+    }
+  }
   
   SmallVector<RequirementRepr, 4> Requirements;
   SourceLoc WhereLoc;

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -293,8 +293,8 @@ static bool isDeclMoreConstrainedThan(ValueDecl *decl1, ValueDecl *decl2) {
         auto p1 = params1[i];
         auto p2 = params2[i];
           
-        int np1 = static_cast<int>(p1->getConformingProtocols().size());
-        int np2 = static_cast<int>(p2->getConformingProtocols().size());
+        int np1 = static_cast<int>(p1.getConformingProtocols().size());
+        int np2 = static_cast<int>(p2.getConformingProtocols().size());
         int aDelta = np1 - np2;
           
         if (aDelta)

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -350,11 +350,11 @@ void AccessControlCheckerBase::checkGenericParamAccess(
   auto *DC = owner->getDeclContext();
 
   for (auto param : *params) {
-    if (param->getInherited().empty())
+    if (param.getInherited().empty())
       continue;
-    assert(param->getInherited().size() == 1);
-    checkTypeAccessImpl(param->getInherited().front().getType(),
-                        param->getInherited().front().getTypeRepr(),
+    assert(param.getInherited().size() == 1);
+    checkTypeAccessImpl(param.getInherited().front().getType(),
+                        param.getInherited().front().getTypeRepr(),
                         accessScope, DC, /*mayBeInferred*/false, callback);
   }
   callbackACEK = ACEK::Requirement;
@@ -1532,10 +1532,10 @@ class ImplementationOnlyImportChecker
       return;
 
     for (auto param : *params) {
-      if (param->getInherited().empty())
+      if (param.getInherited().empty())
         continue;
-      assert(param->getInherited().size() == 1);
-      checkType(param->getInherited().front(), owner,
+      assert(param.getInherited().size() == 1);
+      checkType(param.getInherited().front(), owner,
                 getDiagnoseCallback(owner), getDiagnoseCallback(owner));
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -752,10 +752,15 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   if (AllMemberRefs) {
     Expr *BaseExpr;
     if (auto PD = dyn_cast<ProtocolDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(Loc,
-                                         PD->getGenericParams()->getParams().front(),
-                                         /*DC*/nullptr,
-                                         /*isImplicit=*/true);
+      auto GP = PD->getGenericParams()->getParams().front();
+
+      switch (GP.getKind()) {
+        case GenericParam::ParamKind::TypeParam:
+          BaseExpr = TypeExpr::createForDecl(Loc, GP.getTypeParam(),
+                                             /*DC*/nullptr,
+                                             /*isImplicit=*/true);
+          break;
+      }
     } else if (auto NTD = dyn_cast<NominalTypeDecl>(Base)) {
       BaseExpr = TypeExpr::createForDecl(Loc, NTD, BaseDC, /*isImplicit=*/true);
     } else {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -478,8 +478,13 @@ static void checkGenericParams(GenericParamList *genericParams,
     return;
 
   for (auto gp : *genericParams) {
-    tc.checkDeclAttributesEarly(gp);
-    checkInheritanceClause(gp);
+    switch (gp.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        auto *GTPD = gp.getTypeParam();
+        tc.checkDeclAttributesEarly(GTPD);
+        checkInheritanceClause(GTPD);
+        break;
+    }
   }
 
   // Force visitation of each of the requirements here.
@@ -4524,7 +4529,7 @@ static Type formExtensionInterfaceType(
     for (auto gp : *genericParams) {
       SWIFT_DEFER { ++gpIndex; };
 
-      auto gpType = gp->getDeclaredInterfaceType();
+      auto gpType = gp.getDeclaredInterfaceType();
       genericArgs.push_back(gpType);
 
       if (currentBoundType) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -672,7 +672,7 @@ GenericParamList *ModuleFile::maybeReadGenericParams(DeclContext *DC) {
     return nullptr;
   lastRecordOffset.reset();
 
-  SmallVector<GenericTypeParamDecl *, 8> params;
+  SmallVector<GenericParam, 8> params;
 
   ArrayRef<uint64_t> paramIDs;
   GenericParamListLayout::readRecord(scratch, paramIDs);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1399,8 +1399,13 @@ void Serializer::writeGenericParams(const GenericParamList *genericParams) {
     return;
 
   SmallVector<DeclID, 4> paramIDs;
-  for (auto next : genericParams->getParams())
-    paramIDs.push_back(addDeclRef(next));
+  for (auto next : genericParams->getParams()) {
+    switch (next.getKind()) {
+      case GenericParam::ParamKind::TypeParam:
+        paramIDs.push_back(addDeclRef(next.getTypeParam()));
+        break;
+    }
+  }
 
   unsigned abbrCode = DeclTypeAbbrCodes[GenericParamListLayout::Code];
   GenericParamListLayout::emitRecord(Out, ScratchRecord, abbrCode, paramIDs);


### PR DESCRIPTION
As stated in [this](https://forums.swift.org/t/starting-to-implement-variadic-generics/21159/5) thread on the Swift Forums, before introducing Variadic Generics we might want to refactor a little bit how generics are handled in the compiler, one piece at a time.

This PR is about two things:
1) it introduces a new type, `GenericParam`, which is a wrapper class+enum for any kind of generic parameter declaration (for now, only `GenericTypeParamDecl`)
2) it (mainly) edits `GenericParamList` to use `GenericParam` instead of `GenericTypeParamDecl`s. Code that depends on it has been changed as well.

~~The new type `GenericParam` has no code comments attached to it, might want to write them before merging this PR.~~