### PR TITLE
Fix swift KVO when keyPath having a optional value

### DIFF
--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -191,3 +191,30 @@ print("keyPath == \\Sortable1.name:", descriptor.keyPath == \Sortable1.name)
 
 // CHECK-51-LABEL: creating NSSortDescriptor
 // CHECK-51-NEXT: keyPath == \Sortable1.name: true
+
+//===----------------------------------------------------------------------===//
+// Test keyPath with optional value has correct oldValue/newValue behavior
+//===----------------------------------------------------------------------===//
+
+class TestClassForOptionalKeyPath : NSObject {
+    
+    // Should not use NSObject? as object type
+    @objc dynamic var optionalObject: String?
+    
+}
+
+let testObjectForOptionalKeyPath = TestClassForOptionalKeyPath()
+
+print("observe keyPath with optional value")
+
+let optionalKeyPathObserver = testObjectForOptionalKeyPath.observe(\.optionalObject, options: [.initial, .old, .new]) { (_, change) in
+    Swift.print("oldValue = \(change.oldValue as String??), newValue = \(change.newValue as String??)")
+}
+
+testObjectForOptionalKeyPath.optionalObject = nil
+testObjectForOptionalKeyPath.optionalObject = "foo"
+
+// CHECK-LABEL: observe keyPath with optional value
+// CHECK-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
+// CHECK-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
+// CHECK-NEXT: oldValue = Optional(nil), newValue = Optional(Optional("foo"))


### PR DESCRIPTION
Fix a long standing issue https://bugs.swift.org/browse/SR-6066.
When keyPath has an optional value, we provide an overloaded method on `_KeyValueCodingAndObserving` to handle the special case.

Resolves [SR-6066](https://bugs.swift.org/browse/SR-6066).
