### PR TITLE
[android] Remove parts of the build process which are not Android.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -824,7 +824,22 @@ android-icu-i18n=%(arm_dir)s/libicui18nswift.so
 android-icu-i18n-include=%(arm_dir)s/icu/source/i18n
 android-icu-data=%(arm_dir)s/libicudataswift.so
 
+# Disable many build host products. They are unrelated to Android. Foundation,
+# libdispatch and XCTest are also disabled because build-script-impl doesn't
+# build them for cross-compiled Android.
 skip-test-linux
+skip-build-lldb
+skip-build-llbuild
+skip-build-swiftpm
+skip-build-libdispatch
+skip-build-foundation
+skip-build-xctest
+skip-build-playgroundsupport
+skip-build-benchmarks
+indexstore-db=0
+sourcekit-lsp=0
+toolchain-benchmarks=0
+test-installable-package=
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,aarch64]
 mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build


### PR DESCRIPTION
At the moment, the only piece build for Android with the build-script
is the standard library for Swift. This changes the Android CI presets
to skip the later parts of the build-script which only build for the
host machine, saving time and random errors.

