### PR TITLE
[Property delegates] Allow 'let' with attached property delegates.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4347,9 +4347,6 @@ NOTE(previous_property_delegate_here,none,
 
 ERROR(property_delegate_local,none,
       "property delegates are not yet supported on local properties", ())
-ERROR(property_delegate_let, none,
-      "property delegate can only be applied to a 'var'",
-      ())
 
 ERROR(property_with_delegate_conflict_attribute,none,
       "property %0 with a delegate cannot also be "

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -219,7 +219,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
 
     // An initialized 'let' property has a single value specified by the
     // initializer - it doesn't come from an argument.
-    if (!field->isStatic() && field->isLet() && field->getParentInitializer()) {
+    if (!field->isStatic() && field->isLet() && field->isParentInitialized()) {
       // Cleanup after this initialization.
       FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
       v = SGF.emitRValue(field->getParentInitializer())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1475,7 +1475,7 @@ static VarDecl *synthesizePropertyDelegateStorageDelegateProperty(
   // Form the property.
   auto dc = var->getDeclContext();
   VarDecl *property = new (ctx) VarDecl(/*IsStatic=*/var->isStatic(),
-                                        VarDecl::Specifier::Var,
+                                        var->getSpecifier(),
                                         /*IsCaptureList=*/false,
                                         var->getLoc(),
                                         name, dc);
@@ -1555,7 +1555,7 @@ PropertyDelegateBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
 
   // Create the backing storage property and note it in the cache.
   VarDecl *backingVar = new (ctx) VarDecl(/*IsStatic=*/var->isStatic(),
-                                          VarDecl::Specifier::Var,
+                                          var->getSpecifier(),
                                           /*IsCaptureList=*/false,
                                           var->getLoc(),
                                           name, dc);

--- a/lib/Sema/TypeCheckPropertyDelegate.cpp
+++ b/lib/Sema/TypeCheckPropertyDelegate.cpp
@@ -225,12 +225,6 @@ AttachedPropertyDelegateRequest::evaluate(Evaluator &evaluator,
       return nullptr;
     }
 
-    // A property delegate cannot be attached to a 'let'.
-    if (var->isLet()) {
-      ctx.Diags.diagnose(attr->getLocation(), diag::property_delegate_let);
-      return nullptr;
-    }
-
     // Check for conflicting attributes.
     if (var->getAttrs().hasAttribute<LazyAttr>() ||
         var->getAttrs().hasAttribute<NSCopyingAttr>() ||

--- a/test/decl/var/property_delegates.swift
+++ b/test/decl/var/property_delegates.swift
@@ -426,7 +426,7 @@ struct UseMutatingnessDelegates {
   @DelegateWithMutatingGetter
   var y = 17
 
-  @DelegateWithNonMutatingSetter // expected-error{{property delegate can only be applied to a 'var'}}
+  @DelegateWithNonMutatingSetter
   let z = 3.14159 // expected-note 2{{change 'let' to 'var' to make it mutable}}
 
   @ClassDelegate
@@ -574,6 +574,24 @@ func testDefaultedMemberwiseInits() {
   _ = DefaultedMemberwiseInits(x: Wrapper(value: false))
   _ = DefaultedMemberwiseInits(z: WrapperWithInitialValue(initialValue: 42))
 }
+
+struct DefaultedPrivateMemberwiseLets {
+  @Wrapper(value: true)
+  private let x: Bool
+
+  @WrapperWithInitialValue
+  var y: Int = 17
+
+  @WrapperWithInitialValue(initialValue: 17)
+  private let z: Int
+}
+
+func testDefaultedPrivateMemberwiseLets() {
+  _ = DefaultedPrivateMemberwiseLets()
+  _ = DefaultedPrivateMemberwiseLets(y: 42)
+  _ = DefaultedPrivateMemberwiseLets(x: Wrapper(value: false)) // expected-error{{incorrect argument label in call (have 'x:', expected 'y:')}}
+}
+
 
 // ---------------------------------------------------------------------------
 // Default initializers


### PR DESCRIPTION
Remove the restriction on the use of property delegates with a
"let". The end result is a computed property (for the original) with a
'let' as the backing storage, allowing the backing storage to be
initialized but not mutated directly.
