### PR TITLE
Centralize the definition of isMemberwiseInitialized()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5142,7 +5142,11 @@ public:
 
   /// Returns true if the name is the self identifier and is implicit.
   bool isSelfParameter() const;
-  
+
+  /// Determine whether this property will be part of the implicit memberwise
+  /// initializer.
+  bool isMemberwiseInitialized() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { 
     return D->getKind() == DeclKind::Var || D->getKind() == DeclKind::Param; 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5145,7 +5145,13 @@ public:
 
   /// Determine whether this property will be part of the implicit memberwise
   /// initializer.
-  bool isMemberwiseInitialized() const;
+  ///
+  /// \param preferDeclaredProperties When encountering a `lazy` property
+  /// or a property that has an attached property delegate, prefer the
+  /// actual declared property (which may or may not be considered "stored"
+  /// as the moment) to the backing storage property. Otherwise, the stored
+  /// backing property will be treated as the member-initialized property.
+  bool isMemberwiseInitialized(bool preferDeclaredProperties) const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -239,10 +239,6 @@ namespace swift {
   /// \param DC The DeclContext from which the subscript is being referenced.
   Optional<Type> getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
                                                    const DeclContext *DC);
-
-  /// Determine whether the given property is part of the memberwise initializer
-  /// for a struct.
-  bool isMemberwiseInitialized(VarDecl *var);
 }
 
 #endif

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5254,6 +5254,30 @@ bool VarDecl::isSelfParameter() const {
   return false;
 }
 
+bool VarDecl::isMemberwiseInitialized() const {
+  if (!getDeclContext()->isTypeContext())
+    return false;
+
+  // Implicit, computed, and static properties are not initialized.
+  // The exception is lazy properties, which due to batch mode we may or
+  // may not have yet finalized, so they may currently be "stored" or
+  // "computed" in the current AST state.
+  if (isImplicit() || isStatic())
+    return false;
+
+  if (!hasStorage() && !getAttrs().hasAttribute<LazyAttr>() &&
+      !getAttachedPropertyDelegate())
+    return false;
+
+  // Initialized 'let' properties have storage, but don't get an argument
+  // to the memberwise initializer since they already have an initial
+  // value that cannot be overridden.
+  if (isLet() && isParentInitialized())
+    return false;
+
+  return true;
+}
+
 void VarDecl::setSpecifier(Specifier specifier) {
   Bits.VarDecl.Specifier = static_cast<unsigned>(specifier);
   setSupportsMutationIfStillStored(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5254,19 +5254,50 @@ bool VarDecl::isSelfParameter() const {
   return false;
 }
 
-bool VarDecl::isMemberwiseInitialized() const {
-  if (!getDeclContext()->isTypeContext())
+/// Whether the given variable is the backing storage property for
+/// a declared property that is either `lazy` or has an attached
+/// property delegate.
+static bool isBackingStorageForDeclaredProperty(const VarDecl *var) {
+  if (var->getOriginalDelegatedProperty())
+    return true;
+
+  auto name = var->getName();
+  if (name.empty())
     return false;
 
-  // Implicit, computed, and static properties are not initialized.
-  // The exception is lazy properties, which due to batch mode we may or
-  // may not have yet finalized, so they may currently be "stored" or
-  // "computed" in the current AST state.
-  if (isImplicit() || isStatic())
+  return name.str().startswith("$__lazy_storage_$_");
+}
+
+/// Whether the given variable
+static bool isDeclaredPropertyWithBackingStorage(const VarDecl *var) {
+  if (var->getAttrs().hasAttribute<LazyAttr>())
+    return true;
+
+  if (var->getAttachedPropertyDelegate())
+    return true;
+
+  return false;
+}
+
+bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
+  // Only non-static properties in type context can be part of a memberwise
+  // initializer.
+  if (!getDeclContext()->isTypeContext() || isStatic())
     return false;
 
-  if (!hasStorage() && !getAttrs().hasAttribute<LazyAttr>() &&
-      !getAttachedPropertyDelegate())
+  // If this is a stored property, and not a backing property in a case where
+  // we only want to see the declared properties, it can be memberwise
+  // initialized.
+  if (hasStorage() && preferDeclaredProperties &&
+      isBackingStorageForDeclaredProperty(this))
+    return false;
+
+  // If this is a computed property, it's not memberwise initialized unless
+  // the caller has asked for the declared properties and it is either a
+  // `lazy` property or a property with an attached delegate.
+  if (!hasStorage() &&
+      !(preferDeclaredProperties &&
+        isDeclaredPropertyWithBackingStorage(this)))
     return false;
 
   // Initialized 'let' properties have storage, but don't get an argument

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -360,11 +360,12 @@ private:
       return;
 
     unsigned CurLabel = 0;
-    for (auto Prop : TypeContext->getStoredProperties()) {
-      if (auto Original = Prop->getOriginalDelegatedProperty())
-        Prop = Original;
+    for (auto Member : TypeContext->getMembers()) {
+      auto Prop = dyn_cast<VarDecl>(Member);
+      if (!Prop)
+        continue;
 
-      if (!Prop->isMemberwiseInitialized())
+      if (!Prop->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
         continue;
 
       if (CurLabel == LabelLocs.size())

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -364,7 +364,7 @@ private:
       if (auto Original = Prop->getOriginalDelegatedProperty())
         Prop = Original;
 
-      if (!isMemberwiseInitialized(Prop))
+      if (!Prop->isMemberwiseInitialized())
         continue;
 
       if (CurLabel == LabelLocs.size())

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -217,14 +217,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
     auto fieldTy = selfTy.getFieldType(field, SGF.SGM.M);
     SILValue v;
 
-    // An initialized 'let' property has a single value specified by the
-    // initializer - it doesn't come from an argument.
-    if (!field->isStatic() && field->isLet() && field->getParentInitializer()) {
-      // Cleanup after this initialization.
-      FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
-      v = SGF.emitRValue(field->getParentInitializer())
-             .forwardAsSingleStorageValue(SGF, fieldTy, Loc);
-    } else {
+    // If it's memberwise initialized, do so now.
+    if (field->isMemberwiseInitialized()) {
       FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
       assert(elti != eltEnd && "number of args does not match number of fields");
       (void)eltEnd;
@@ -237,6 +231,14 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
         v = std::move(*elti).forwardAsSingleStorageValue(SGF, fieldTy, Loc);
       }
       ++elti;
+    } else {
+      // Otherwise, use its initializer.
+      assert(field->isParentInitialized());
+
+      // Cleanup after this initialization.
+      FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
+      v = SGF.emitRValue(field->getParentInitializer())
+             .forwardAsSingleStorageValue(SGF, fieldTy, Loc);
     }
 
     eltValues.push_back(v);

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -218,7 +218,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
     SILValue v;
 
     // If it's memberwise initialized, do so now.
-    if (field->isMemberwiseInitialized()) {
+    if (field->isMemberwiseInitialized(/*preferDeclaredProperties=*/false)) {
       FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
       assert(elti != eltEnd && "number of args does not match number of fields");
       (void)eltEnd;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2077,7 +2077,7 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       if (!var)
         continue;
 
-      if (!var->isMemberwiseInitialized())
+      if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
         continue;
 
       accessLevel = std::min(accessLevel, var->getFormalAccess());

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -69,8 +69,6 @@ enum class ImplicitConstructorKind {
   Memberwise
 };
 
-bool isMemberwiseInitialized(VarDecl *var);
-
 /// Create an implicit struct or class constructor.
 ///
 /// \param decl The struct or class for which a constructor will be created.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5230,7 +5230,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   if (isa<StructDecl>(decl)) {
     for (auto member : decl->getMembers()) {
       if (auto var = dyn_cast<VarDecl>(member)) {
-        if (!isMemberwiseInitialized(var))
+        if (!var->isMemberwiseInitialized())
           continue;
 
         validateDecl(var);
@@ -5303,7 +5303,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
         if (backingStorageVars.count(var) > 0)
           continue;
 
-        if (isMemberwiseInitialized(var)) {
+        if (var->isMemberwiseInitialized()) {
           // Initialized 'let' properties have storage, but don't get an argument
           // to the memberwise initializer since they already have an initial
           // value that cannot be overridden.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5230,7 +5230,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   if (isa<StructDecl>(decl)) {
     for (auto member : decl->getMembers()) {
       if (auto var = dyn_cast<VarDecl>(member)) {
-        if (!var->isMemberwiseInitialized())
+        if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
           continue;
 
         validateDecl(var);
@@ -5303,7 +5303,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
         if (backingStorageVars.count(var) > 0)
           continue;
 
-        if (var->isMemberwiseInitialized()) {
+        if (var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true)) {
           // Initialized 'let' properties have storage, but don't get an argument
           // to the memberwise initializer since they already have an initial
           // value that cannot be overridden.


### PR DESCRIPTION
This utility was defined in Sema, used in Sema and Index, declared in
two headers, and semi- copy-pasted into SILGen. Pull it into
`VarDecl::isMemberwiseInitialized()` and use it consistently.
