### PR TITLE
XFAIL all the Accelerate tests for 5.1 branch.

### DIFF
--- a/test/stdlib/Accelerate.swift
+++ b/test/stdlib/Accelerate.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_Quadrature.swift
+++ b/test/stdlib/Accelerate_Quadrature.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPBiquad.swift
+++ b/test/stdlib/Accelerate_vDSPBiquad.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPClippingLimitThreshold.swift
+++ b/test/stdlib/Accelerate_vDSPClippingLimitThreshold.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPComplexOperations.swift
+++ b/test/stdlib/Accelerate_vDSPComplexOperations.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPConversion.swift
+++ b/test/stdlib/Accelerate_vDSPConversion.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPConvolution.swift
+++ b/test/stdlib/Accelerate_vDSPConvolution.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPElementwiseArithmetic.swift
+++ b/test/stdlib/Accelerate_vDSPElementwiseArithmetic.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPFillClearGenerate.swift
+++ b/test/stdlib/Accelerate_vDSPFillClearGenerate.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPFourierTransform.swift
+++ b/test/stdlib/Accelerate_vDSPFourierTransform.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPGeometry.swift
+++ b/test/stdlib/Accelerate_vDSPGeometry.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPIntegration.swift
+++ b/test/stdlib/Accelerate_vDSPIntegration.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPReduction.swift
+++ b/test/stdlib/Accelerate_vDSPReduction.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPSingleVectorOps.swift
+++ b/test/stdlib/Accelerate_vDSPSingleVectorOps.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vForce.swift
+++ b/test/stdlib/Accelerate_vForce.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 


### PR DESCRIPTION
They assume bitwise reproducible results for vDSP calls, but don't align the buffers they are working with enough to guarantee that will occur.

These tests should be updated to use the new approximate comparison stuff once it becomes available, or otherwise revised.

fixes: <rdar://problem/50301438>