### PR TITLE
[benchmark] BucketSort: tag .existential

### DIFF
--- a/benchmark/single-source/BucketSort.swift
+++ b/benchmark/single-source/BucketSort.swift
@@ -31,7 +31,7 @@ import Foundation
 public let BucketSort = BenchmarkInfo(
   name: "BucketSort",
   runFunction: run_BucketSort,
-  tags: [.validation, .algorithm],
+  tags: [.existential, .algorithm],
   setUpFunction: { blackHole(buckets) }
 )
 


### PR DESCRIPTION
Tag the `BucketSort` benchmark as `.existential`.

Sorry, this change got somehow lost in my local edits… 