### PR TITLE
[tf.data]: Expose parallel map to improve input pipeline performance.

### DIFF
--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -114,6 +114,20 @@ public extension Dataset {
   }
 
   @inlinable @inline(__always)
+  func map<ResultElement : TensorGroup>(parallelCallCount: Int,
+    _ transform: (Element) -> ResultElement) -> Dataset<ResultElement> {
+    return Dataset<ResultElement>(
+      _handle: #tfop("ParallelMapDataset", _handle, [Tensor<Int32>(0)],
+        [Tensor<Int64>(Int64(parallelCallCount))],
+        f$func: _tffunc(transform),
+        Targuments$dtype: [Int32.tensorFlowDataType],
+        output_types$dtype: ResultElement._typeList,
+        output_shapes: ResultElement._unknownShapeList
+      )
+    )
+  }
+
+  @inlinable @inline(__always)
   func filter(
     _ isIncluded: (Element) -> Tensor<Bool>
   ) -> Dataset {

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -118,7 +118,7 @@ public extension Dataset {
     _ transform: (Element) -> ResultElement) -> Dataset<ResultElement> {
     return Dataset<ResultElement>(
       _handle: #tfop("ParallelMapDataset", _handle, [Tensor<Int32>(0)],
-        [Tensor<Int64>(Int64(parallelCallCount))],
+        [Tensor<Int32>(Int32(parallelCallCount))],
         f$func: _tffunc(transform),
         Targuments$dtype: [Int32.tensorFlowDataType],
         output_types$dtype: ResultElement._typeList,

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -65,6 +65,17 @@ DatasetAPITests.testAllBackends("SingleValueHOFs") {
   expectEqual([0, 2, 4], evens.flatMap { $0.scalars })
 }
 
+DatasetAPITests.testAllBackends("ParallelMap") {
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+  let dataset = Dataset(elements: scalars)
+  let addedOne: Dataset = dataset.map(parallelCallCount: 5) { $0 + 1 }
+  expectEqual([1, 2, 3, 4, 5], addedOne.flatMap { $0.scalars })
+  // Use '.==' in the following closure to avoid any conversions to
+  // host data types, which is not handled correctly in tracing.
+  let evens: Dataset = dataset.filter { Tensor($0 % 2) .== Tensor(0) }
+  expectEqual([0, 2, 4], evens.flatMap { $0.scalars })
+}
+
 DatasetAPITests.testAllBackends("MapToDifferentType") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let dataset = Dataset(elements: scalars)


### PR DESCRIPTION
Expose tf.data's parallel map implementation to Swift for TensorFlow users to unblock high performance input pipelines.