### PR TITLE
[5.1] [Index] Handle memberwise initializers with defaulted arguments.

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -214,6 +214,10 @@ namespace swift {
   /// \param DC The DeclContext from which the subscript is being referenced.
   Optional<Type> getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
                                                    const DeclContext *DC);
+
+  /// Determine whether the given property is part of the memberwise initializer
+  /// for a struct.
+  bool isMemberwiseInitialized(VarDecl *var);
 }
 
 #endif

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -334,6 +334,7 @@ private:
     // get label locations
     auto *MemberwiseInit = DeclRef->getDecl();
     std::vector<SourceLoc> LabelLocs;
+    ArrayRef<Identifier> Labels;
     auto NameLoc = DeclRef->getNameLoc();
     if (NameLoc.isCompound()) {
       size_t LabelIndex = 0;
@@ -341,12 +342,16 @@ private:
       while ((ArgLoc = NameLoc.getArgumentLabelLoc(LabelIndex++)).isValid()) {
         LabelLocs.push_back(ArgLoc);
       }
+      Labels = MemberwiseInit->getFullName().getArgumentNames();
     } else if (auto *CallParent = dyn_cast_or_null<CallExpr>(getParentExpr())) {
       LabelLocs = CallParent->getArgumentLabelLocs();
+      Labels = CallParent->getArgumentLabels();
     }
 
     if (LabelLocs.empty())
       return;
+
+    assert(Labels.size() == LabelLocs.size());
 
     // match labels to properties
     auto *TypeContext =
@@ -354,14 +359,22 @@ private:
     if (!TypeContext || !shouldIndex(TypeContext, false))
       return;
 
-    auto LabelIt = LabelLocs.begin();
+    unsigned CurLabel = 0;
     for (auto Prop : TypeContext->getStoredProperties()) {
-      if (Prop->getParentInitializer() && Prop->isLet())
+      if (auto Original = Prop->getOriginalDelegatedProperty())
+        Prop = Original;
+
+      if (!isMemberwiseInitialized(Prop))
         continue;
 
-      assert(LabelIt != LabelLocs.end());
+      if (CurLabel == LabelLocs.size())
+        break;
+
+      if (Labels[CurLabel] != Prop->getName())
+        continue;
+
       IndexSymbol Info;
-      if (initIndexSymbol(Prop, *LabelIt++, /*IsRef=*/true, Info))
+      if (initIndexSymbol(Prop, LabelLocs[CurLabel++], /*IsRef=*/true, Info))
         continue;
       if (startEntity(Prop, Info, /*IsRef=*/true))
         finishCurrentEntity();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -361,9 +361,6 @@ private:
 
     unsigned CurLabel = 0;
     for (auto Prop : TypeContext->getStoredProperties()) {
-      if (auto Original = Prop->getOriginalDelegatedProperty())
-        Prop = Original;
-
       if (!isMemberwiseInitialized(Prop))
         continue;
 

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -503,3 +503,15 @@ _ = \StructWithKeypath.[0]
 // CHECK: [[@LINE-1]]:24 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test17StructWithKeypathVyS2icip | Ref,Read | rel: 0
 // CHECK: [[@LINE-2]]:24 | instance-method/acc-get/Swift | getter:subscript(_:) | s:14swift_ide_test17StructWithKeypathVyS2icig | Ref,Call,Impl | rel: 0
 
+
+struct BStruct {
+  var x = 17
+  var y = true
+  var z = "hello"
+}
+
+func useDefaultInits() {
+  _ = BStruct(y: false)
+  // CHECK: [[@LINE-1]]:15 | instance-property/Swift | y | s:14swift_ide_test7BStructV1ySbvp | Ref,RelCont
+  // CHECK: [[@LINE-2]]:7 | constructor/Swift | init(x:y:z:) | s:14swift_ide_test7BStructV1x1y1zACSi_SbSStcfc | Ref,Call,RelCall,RelCont | rel: 1
+}


### PR DESCRIPTION
Cherry-pick 99d4e80 to swift-5.1-branch

Patch by: @DougGregor
Reviewed by: @benlangmuir

---

Fix indexing crash when calling a memberwise initializer that has synthesized default values, which became legal after SE-0242.

rdar://problem/50303017