### PR TITLE
[5.1-04-24-2019] Single case enum fixes

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -630,6 +630,18 @@ namespace {
       IGF.Builder.CreateCall(
                     IGF.IGM.getInitEnumMetadataSingleCaseFn(),
                     {metadata, flags, payloadLayout});
+
+      // Pre swift-5.1 runtimes were missing the initialization of the
+      // the extraInhabitantCount field. Do it here instead.
+      auto payloadRef = IGF.Builder.CreateBitOrPointerCast(
+          payloadLayout, IGF.IGM.TypeLayoutTy->getPointerTo());
+      auto payloadExtraInhabitantCount =
+          IGF.Builder.CreateLoad(IGF.Builder.CreateStructGEP(
+              Address(payloadRef, Alignment(1)), 3,
+              Size(IGF.IGM.DataLayout.getTypeAllocSize(IGF.IGM.SizeTy) * 2 +
+                   IGF.IGM.DataLayout.getTypeAllocSize(IGF.IGM.Int32Ty))));
+      emitStoreOfExtraInhabitantCount(IGF, payloadExtraInhabitantCount,
+                                      metadata);
     }
 
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {

--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -215,6 +215,10 @@ namespace irgen {
   /// Emit a load of the 'extraInhabitantCount' value witness.
   llvm::Value *emitLoadOfExtraInhabitantCount(IRGenFunction &IGF, SILType T);
 
+  /// Emit a stored to the 'extraInhabitantCount' value witness.
+  void emitStoreOfExtraInhabitantCount(IRGenFunction &IGF, llvm::Value *val,
+                                       llvm::Value *metadata);
+
   /// Returns the IsInline flag and the loaded flags value.
   std::pair<llvm::Value *, llvm::Value *>
   emitLoadOfIsInline(IRGenFunction &IGF, llvm::Value *metadata);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -228,6 +228,13 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     SizeTy  // extra inhabitant flags (optional)
   });
 
+  TypeLayoutTy = createStructType(*this, "swift.type_layout", {
+    SizeTy, // size
+    SizeTy, // stride
+    Int32Ty, // flags
+    Int32Ty // extra inhabitant count
+  });
+
   // A protocol descriptor describes a protocol. It is not type metadata in
   // and of itself, but is referenced in the structure of existential type
   // metadata records.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -580,6 +580,7 @@ public:
   };
   llvm::StructType *OffsetPairTy;      /// { iSize, iSize }
   llvm::StructType *FullTypeLayoutTy;  /// %swift.full_type_layout = { ... }
+  llvm::StructType *TypeLayoutTy;  /// %swift.type_layout = { ... }
   llvm::PointerType *TupleTypeMetadataPtrTy; /// %swift.tuple_type*
   llvm::StructType *FullHeapMetadataStructTy; /// %swift.full_heapmetadata = type { ... }
   llvm::PointerType *FullHeapMetadataPtrTy;/// %swift.full_heapmetadata*

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -54,6 +54,7 @@ swift::swift_initEnumMetadataSingleCase(EnumMetadata *self,
   layout.size = payloadLayout->size;
   layout.stride = payloadLayout->stride;
   layout.flags = payloadLayout->flags.withEnumWitnesses(true);
+  layout.extraInhabitantCount = payloadLayout->getNumExtraInhabitants();
 
   vwtable->publishLayout(layout);
 }

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2683,6 +2683,15 @@ entry(%x : $*MyOptional):
 // CHECK:   [[T_VWT:%.*]] = load i8**, i8*** [[T_VWT_ADDR]]
 // CHECK:   [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VWT]], i32 8
 // CHECK:   call void @swift_initEnumMetadataSingleCase(%swift.type* [[METADATA]], [[WORD]] 0, i8** [[T_LAYOUT]])
+// CHECK:   [[PAYLOAD_TYPELAYOUT:%.*]] = bitcast i8** [[T_LAYOUT]] to %swift.type_layout*
+// CHECK:   [[PAYLOAD_EXTRAINHABITANTCNT:%.*]] = getelementptr inbounds %swift.type_layout, %swift.type_layout* [[PAYLOAD_TYPELAYOUT]], i32 0, i32 3
+// CHECK:   [[CNT:%.*]] = load i32, i32* [[PAYLOAD_EXTRAINHABITANTCNT]]
+// CHECK:   [[METADATA2:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
+// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[METADATA2]], [[WORD]] -1
+// CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
+// CHECK:   [[VWT2:%.*]] = bitcast i8** [[VWT]] to %swift.vwtable*
+// CHECK:   [[XIC_ADDR:%.*]] = getelementptr inbounds %swift.vwtable, %swift.vwtable* [[VWT2]], i32 0, i32 11
+// CHECK:   store i32 [[CNT]], i32* [[XIC_ADDR]]
 // CHECK:   ret %swift.metadata_response
 
 // -- Fill function for dynamic single-payload. Call into the runtime to

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -462,4 +462,33 @@ ResilientEnumTestSuite.test("ResilientPrivateEnumMember") {
   _ = Container()
 }
 
+struct Nested {
+  var str: String
+  var r: ResilientInt
+}
+
+enum SingleCase {
+  case only(nested: Nested)
+}
+
+struct Status {
+  let fst: SingleCase
+  let snd: Bool
+}
+
+func getOptional<T>(_ t: T) -> T? {
+  return t
+}
+
+func test<T>(_ t: T) {
+  let o = getOptional(t)
+  if let c = o {
+    print("success")
+  }
+}
+
+ResilientEnumTestSuite.test("ResilientEnumSingleCase") {
+  // This used to crash.
+  test(Status(fst: .only(nested: Nested(str: "foobar", r: ResilientInt(i: 1))), snd: false))
+}
 runAllTests()


### PR DESCRIPTION
* Initialize the extraInhabitantCount field of single case enums
* IRGen: Initialize single case enum extrainhabitant value witness in generated code

rdar://49786768