### PR TITLE
SIL: Correctly handle @_alwaysEmitIntoClient properties and subscripts [5.1]

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -301,6 +301,11 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   // serialized bodies, but no public symbol in the generated binary.
   if (d->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
     limit = Limit::AlwaysEmitIntoClient;
+  if (auto accessor = dyn_cast<AccessorDecl>(d)) {
+    auto *storage = accessor->getStorage();
+    if (storage->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
+      limit = Limit::AlwaysEmitIntoClient;
+  }
 
   // ivar initializers and destroyers are completely contained within the class
   // from which they come, and never get seen externally.

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -11,3 +11,21 @@
 @_alwaysEmitIntoClient func implicitlyUsableFromInline() {
   alwaysEmitIntoClientOtherFunction()
 }
+
+public struct S {
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1SV8propertySivg : $@convention(method) (S) -> Int
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1SV8propertySivs : $@convention(method) (Int, @inout S) -> ()
+  // CHECK-LABEL: sil non_abi [transparent] [serialized] [ossa] @$s33always_emit_into_client_attribute1SV8propertySivM : $@yield_once @convention(method) (@inout S) -> @yields @inout Int
+  @_alwaysEmitIntoClient public var property: Int {
+    get { return 0 }
+    set { }
+  }
+
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1SVyS2icig : $@convention(method) (Int, S) -> Int
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1SVyS2icis : $@convention(method) (Int, Int, @inout S) -> ()
+  // CHECK-LABEL: sil non_abi [transparent] [serialized] [ossa] @$s33always_emit_into_client_attribute1SVyS2iciM : $@yield_once @convention(method) (Int, @inout S) -> @yields @inout Int
+  @_alwaysEmitIntoClient public subscript(x: Int) -> Int {
+    get { return 0 }
+    set { }
+  }
+}


### PR DESCRIPTION
Fixes <rdar://problem/50058883>.
