### PR TITLE
Disable @convention(tensorflow) and @TensorFlowGraph attributes + GPE passes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2791,6 +2791,8 @@ ERROR(compiler_evaluable_ref_non_compiler_evaluable,none,
 // @TensorFlowGraph attribute
 ERROR(tf_graph_attr_top_level_only,none,
       "@TensorFlowGraph can only be applied to top-level functions", ())
+ERROR(tf_graph_deprecated_please_remove,none,
+      "@TensorFlowGraph has no effect and is deprecated. Please remove.", ())
 ERROR(tf_graph_attr_function_tensorflow_value_only,none,
       "@TensorFlowGraph can only be applied to functions whose parameters and "
       "return values are TensorFlow values or aggregates of TensorFlow "

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2625,12 +2625,8 @@ enum class FunctionTypeRepresentation : uint8_t {
   /// convention.
   CFunctionPointer,
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// A function that will be promoted to a TensorFlow Graph.
-  TensorFlow,
-
   /// The value of the greatest AST function representation.
-  Last = TensorFlow,
+  Last = CFunctionPointer,
 };
 
 /// The representation form of a SIL function.
@@ -2656,12 +2652,8 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   /// convention.
   CFunctionPointer = uint8_t(FunctionTypeRepresentation::CFunctionPointer),
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// A TensorFlow function pointer.
-  TensorFlow = uint8_t(FunctionTypeRepresentation::TensorFlow),
-
   /// The value of the greatest AST function representation.
-  LastAST = TensorFlow,
+  LastAST = CFunctionPointer,
 
   /// The value of the least SIL-only function representation.
   FirstSIL = 8,
@@ -2677,6 +2669,10 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   
   /// A closure invocation function that has not been bound to a context.
   Closure,
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// A TensorFlow function pointer.
+  TensorFlow,
 };
 
 /// Can this calling convention result in a function being called indirectly

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1745,9 +1745,6 @@ void ASTMangler::appendFunctionType(AnyFunctionType *fn, bool isAutoClosure) {
   case AnyFunctionType::Representation::Thin:
     return appendOperator("Xf");
   case AnyFunctionType::Representation::Swift:
-  // SWIFT_ENABLE_TENSORFLOW
-  case AnyFunctionType::Representation::TensorFlow:
-
     if (isAutoClosure) {
       if (fn->isNoEscape())
         return appendOperator("XK");

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1890,8 +1890,6 @@ getForeignRepresentable(Type type, ForeignLanguage language,
     // Check the representation of the function type.
     bool isBlock = false;
     switch (functionType->getRepresentation()) {
-    // SWIFT_ENABLE_TENSORFLOW
-    case AnyFunctionType::Representation::TensorFlow:
     case AnyFunctionType::Representation::Thin:
       return failure();
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1034,8 +1034,6 @@ namespace {
         metadataConvention = FunctionMetadataConvention::Swift;
         isEscaping = !type->isNoEscape();
         break;
-      // SWIFT_ENABLE_TENSORFLOW
-      case FunctionTypeRepresentation::TensorFlow:
       case FunctionTypeRepresentation::Thin:
         metadataConvention = FunctionMetadataConvention::Thin;
         break;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1143,8 +1143,6 @@ private:
           break;
         case FunctionTypeRepresentation::Thin:
         case FunctionTypeRepresentation::CFunctionPointer:
-        // SWIFT_ENABLE_TENSORFLOW
-        case FunctionTypeRepresentation::TensorFlow:
           break;
         }
       } else if (isObjCReferenceCountableObjectType(copyTy)) {
@@ -1889,8 +1887,6 @@ private:
   void visitFunctionType(FunctionType *FT, 
                          Optional<OptionalTypeKind> optionalKind) {
     switch (FT->getRepresentation()) {
-    // SWIFT_ENABLE_TENSORFLOW
-    case AnyFunctionType::Representation::TensorFlow:
     case AnyFunctionType::Representation::Thin:
       llvm_unreachable("can't represent thin functions in ObjC");
     // Native Swift function types bridge to block types.

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2289,13 +2289,6 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
     case SILDeclRef::Kind::Func:
       if (c.getDecl()->getDeclContext()->isTypeContext())
         return SILFunctionTypeRepresentation::Method;
-      // SWIFT_ENABLE_TENSORFLOW
-      if (auto *FD = dyn_cast<FuncDecl>(c.getDecl())) {
-        auto *fnTy = FD->getInterfaceType()->castTo<AnyFunctionType>();
-        if (fnTy->getExtInfo().getRepresentation() ==
-              AnyFunctionType::Representation::TensorFlow)
-          return SILFunctionTypeRepresentation::TensorFlow;
-      }
       return SILFunctionTypeRepresentation::Thin;
 
     case SILDeclRef::Kind::Destroyer:

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -237,8 +237,6 @@ namespace {
         // is @differentiable?
         return asImpl().handleReference(type);
 
-      // SWIFT_ENABLE_TENSORFLOW
-      case AnyFunctionType::Representation::TensorFlow:
       case AnyFunctionType::Representation::CFunctionPointer:
       case AnyFunctionType::Representation::Thin:
         return asImpl().handleTrivial(type);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -68,8 +68,6 @@ getIndirectApplyAbstractionPattern(SILGenFunction &SGF,
   switch (fnType->getRepresentation()) {
   case FunctionTypeRepresentation::Swift:
   case FunctionTypeRepresentation::Thin:
-  // SWIFT_ENABLE_TENSORFLOW
-  case FunctionTypeRepresentation::TensorFlow:
     return pattern;
 
   case FunctionTypeRepresentation::CFunctionPointer:

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -116,9 +116,6 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addEmitDFDiagnostics();
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();
-
-  // SWIFT_ENABLE_TENSORFLOW
-  P.addTFDeabstractionMandatory();
 }
 
 SILPassPipelinePlan
@@ -394,7 +391,6 @@ static void addMidModulePassesStackPromotePassPipeline(SILPassPipelinePlan &P) {
 
 static void addMidLevelPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("MidLevel");
-  P.addTFDeabstractionOpt();
   addSSAPasses(P, OptimizationLevelKind::MidLevel);
 
   // Specialize partially applied functions with dead arguments as a preparation
@@ -627,9 +623,6 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
   // Has only an effect if the -gsil option is specified.
   P.addSILDebugInfoGenerator();
 
-  // SWIFT_ENABLE_TENSORFLOW
-  P.addTFPartitionMandatory();
-
   return P;
 }
 
@@ -641,7 +634,6 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
 SILPassPipelinePlan SILPassPipelinePlan::getTFPartitionPassPipeline() {
   SILPassPipelinePlan P;
   P.startPipeline("TensorFlow Partitioning");
-  P.addTFPartitionOpt();
   return P;
 }
 /// SWIFT_ENABLE_TENSORFLOW End

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3350,41 +3350,8 @@ void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
 
 // SWIFT_ENABLE_TENSORFLOW
 void AttributeChecker::visitTensorFlowGraphAttr(TensorFlowGraphAttr *attr) {
-  FuncDecl *FD = cast<FuncDecl>(D);
-  // The function must be top-level.
-  if (FD->getImplicitSelfDecl()) {
-    diagnoseAndRemoveAttr(attr, diag::tf_graph_attr_top_level_only);
-    return;
-  }
-  // Generic functions are not supported.
-  if (FD->isGeneric()) {
-    diagnoseAndRemoveAttr(attr, diag::tf_graph_attr_no_generic_functions);
-    return;
-  }
-  // Only functions taking and returning TensorFlow values are permitted.
-  auto allParamsAreTFValues = llvm::all_of(FD->getParameters()->getArray(),
-      [&](ParamDecl *decl) {
-        return tf::isTensorFlowValueOrAggregate(decl->getInterfaceType());
-      });
-  if (!allParamsAreTFValues ||
-      !tf::isTensorFlowValueOrAggregate(FD->getResultInterfaceType())) {
-    diagnoseAndRemoveAttr(attr,
-                          diag::tf_graph_attr_function_tensorflow_value_only);
-    return;
-  }
-  // Only functions with no captures are permitted.
-  TC.computeCaptures(FD);
-  if (!FD->getCaptureInfo().isTrivial()) {
-    diagnoseAndRemoveAttr(attr,
-                          diag::tf_graph_attr_no_functions_with_captures);
-    return;
-  }
-  // Assign @convention(tensorflow).
-  AnyFunctionType *fnTy = FD->getInterfaceType()->castTo<AnyFunctionType>();
-  auto *newFnTy = fnTy->withExtInfo(
-    fnTy->getExtInfo().withRepresentation(
-      AnyFunctionType::Representation::TensorFlow));
-  FD->setInterfaceType(newFnTy);
+  diagnoseAndRemoveAttr(attr, diag::tf_graph_deprecated_please_remove);
+  return;
 }
 
 // SWIFT_ENABLE_TENSORFLOW

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2021,8 +2021,6 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
               .Case("block", SILFunctionType::Representation::Block)
               .Case("thin", SILFunctionType::Representation::Thin)
               .Case("c", SILFunctionType::Representation::CFunctionPointer)
-              // SWIFT_ENABLE_TENSORFLOW
-              .Case("tensorflow", SILFunctionType::Representation::TensorFlow)
               .Case("method", SILFunctionType::Representation::Method)
               .Case("objc_method", SILFunctionType::Representation::ObjCMethod)
               .Case("witness_method",
@@ -2063,8 +2061,6 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           .Case("block", FunctionType::Representation::Block)
           .Case("thin", FunctionType::Representation::Thin)
           .Case("c", FunctionType::Representation::CFunctionPointer)
-          // SWIFT_ENABLE_TENSORFLOW
-          .Case("tensorflow", FunctionType::Representation::TensorFlow)
           .Default(None);
       if (!parsedRep) {
         diagnose(attrs.getLoc(TAK_convention),
@@ -2405,8 +2401,6 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
     }
     break;
 
-  // SWIFT_ENABLE_TENSORFLOW
-  case AnyFunctionType::Representation::TensorFlow:
   case AnyFunctionType::Representation::Thin:
   case AnyFunctionType::Representation::Swift:
     break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4113,8 +4113,6 @@ getActualFunctionTypeRepresentation(uint8_t rep) {
   CASE(Block)
   CASE(Thin)
   CASE(CFunctionPointer)
-  // SWIFT_ENABLE_TENSORFLOW
-  CASE(TensorFlow)
 #undef CASE
   default:
     return None;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3592,8 +3592,6 @@ static uint8_t getRawStableFunctionTypeRepresentation(
   SIMPLE_CASE(FunctionTypeRepresentation, Block)
   SIMPLE_CASE(FunctionTypeRepresentation, Thin)
   SIMPLE_CASE(FunctionTypeRepresentation, CFunctionPointer)
-  // SWIFT_ENABLE_TENSORFLOW
-  SIMPLE_CASE(FunctionTypeRepresentation, TensorFlow)
   }
   llvm_unreachable("bad calling convention");
 }

--- a/test/TensorFlow/accelerator_only_functions.swift
+++ b/test/TensorFlow/accelerator_only_functions.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/attr_tensorflow_graph_sema.swift
+++ b/test/TensorFlow/attr_tensorflow_graph_sema.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/attr_tensorflow_graph_silgen.swift
+++ b/test/TensorFlow/attr_tensorflow_graph_silgen.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module -Xllvm -tf-dynamic-compilation=false | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // This file contains various regression tests that crashed the compiler.
 

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -1,11 +1,10 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 import TensorFlow
 
 // Creates a dataset, which produces one float scalar value in each get next
 // call.
-// TODO: declare with @convention tensorflow
 // Enforce no sends/recvs, and all logic is lowered to TF graph.
-@TensorFlowGraph
 public func createMockDataSet() -> VariantHandle {
   let values = Tensor<Float>([1.0, 2.0, 3.0])
   // REGISTER_OP("TensorSliceDataset")

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 import TensorFlow
 
 // FIXME: This should not build with -O.

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/diagnostics-silgen.swift
+++ b/test/TensorFlow/diagnostics-silgen.swift
@@ -1,6 +1,7 @@
 // This test file captures the diagnostics related to TensorFlow that are
 // generated during the SILGen phase.
 // RUN: %target-swift-frontend -O -emit-sil -verify %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -Xllvm -tf-warn-send-recv -O -emit-sil -verify %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/diagnostics_scalar_transfers.swift
+++ b/test/TensorFlow/diagnostics_scalar_transfers.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-warn-send-recv -Xllvm -tf-warn-scalar-transfer=true -O -emit-sil -verify %s
+// REQUIRES: deprecated_gpe_mode
 
 // Tests that we diagnose scalar transfers when tf-warn-scalar-transfer=true. There are parallel
 // tests in diagnostics.swift ensuring that we do not diagnost the transfers when

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// REQUIRES: deprecated_gpe_mode
 
 // This file contains tests that used to be in ./diagnostics.swift that produced
 // expected errors in the deabstraction pass, which prevented partitioning from

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-graph -O -emit-sil %s -verify | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-module-level-graph=false %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
+
 import TensorFlow
 
 @_optimize(none)

--- a/test/TensorFlow/playground_1.swift
+++ b/test/TensorFlow/playground_1.swift
@@ -8,6 +8,7 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -debugger-support -dump-ast -playground %t/main.swift %S/PlaygroundsRuntime.swift
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -debugger-support -Xllvm -tf-dump-intermediates -O -emit-sil -playground %t/main.swift %S/PlaygroundsRuntime.swift
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -debugger-support -Xllvm -tf-dump-intermediates -O -emit-sil -playground %t/main.swift %S/PlaygroundsRuntime.swift -verify | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/retain_release.swift
+++ b/test/TensorFlow/retain_release.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -o -
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/sema_errors.swift
+++ b/test/TensorFlow/sema_errors.swift
@@ -22,22 +22,18 @@ public func testExpressibleByLiteral() {
 
 
 func testTensorFlowFunctionTypes() {
+  // expected-error@+2 {{convention 'tensorflow' not supported}}
+  // expected-error@+1 {{convention 'tensorflow' not supported}}
   var tf_fn, tf_fn2 : @convention(tensorflow) () -> ()
-  var fn : () -> ()
-  var cfn : @convention(c) () -> ()
 
   tf_fn = tf_fn2
-
-  tf_fn = fn // expected-error {{TensorFlow functions cannot be converted to other function types}}
-  fn = tf_fn // expected-error {{TensorFlow functions cannot be converted to other function types}}
-
-  tf_fn = cfn // expected-error {{TensorFlow functions cannot be converted to other function types}}
-  cfn = tf_fn // expected-error {{TensorFlow functions cannot be converted to other function types}}
+  tf_fn2 = tf_fn
 }
 
 
 // These are testcases that show the next steps in "@convention(tensorflow)" support.
 
+// expected-error@+1 {{convention 'tensorflow' not supported}}
 func takesTFFunc(fn : @convention(tensorflow) (Tensor<Float>) -> Tensor<Float>) {
 }
 
@@ -52,10 +48,11 @@ func testTFFunc() {
   // check if the closures that are tensorflow functions do not have captures.
   takesTFFunc { $0 + one }
   // FIXME: Should eventually be supported.
+  //expect-error@+1 {{convention 'tensorflow' not supported}}
   @convention(tensorflow) // expected-error {{attribute can only be applied to types, not declarations}}
   func inner1(a : Tensor<Float>) -> Tensor<Float> {
     return a+1
   }
-  takesTFFunc(fn: inner1)  // expected-error {{TensorFlow functions cannot be converted to other function types}}
+  takesTFFunc(fn: inner1)
 }
 

--- a/test/TensorFlow/sese_loop_canonicalization.swift
+++ b/test/TensorFlow/sese_loop_canonicalization.swift
@@ -2,6 +2,7 @@
 // preserves the loop nesting.  Note that we use `@_optimize(none)` to preserve the
 // structure of control flow for tests.
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
+++ b/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank0.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank3.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -emit-sil -Xllvm -tf-dump-graph -O %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.

--- a/test/TensorFlow/tf_graph_func_decls.swift
+++ b/test/TensorFlow/tf_graph_func_decls.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s -verify -verify-ignore-unknown
+// REQUIRES: deprecated_gpe_mode
 // FIXME: Remove -verify-ignore-unknown when we fix the source location.
 
 import TensorFlow

--- a/test/TensorFlow/tfop_packing.swift
+++ b/test/TensorFlow/tfop_packing.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/ExternalStructs.swift -enable-resilience -emit-module -emit-module-path %t/ExternalStructs.swiftmodule
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -O -emit-sil -enable-resilience -I %t -verify %s | %FileCheck %s
 
 import TensorFlow
 import ExternalStructs

--- a/test/TensorFlow/top_level_code_1.swift
+++ b/test/TensorFlow/top_level_code_1.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in-graph:

--- a/test/TensorFlow/top_level_code_2.swift
+++ b/test/TensorFlow/top_level_code_2.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in-graph:

--- a/test/TensorFlow/with_device.swift
+++ b/test/TensorFlow/with_device.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-use-device-stack -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -emit-sil -O -verify %s | %FileCheck %s
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 

--- a/test/TensorFlowRuntime/accelerator_only.swift
+++ b/test/TensorFlowRuntime/accelerator_only.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -emit-sil -O %s -verify | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
+// REQUIRES: deprecated_gpe_mode
 
 import TensorFlow
 #if TPU

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //
@@ -11,8 +10,6 @@
 // tensors to TF->host sends, so that in this case we can send directly from TF
 // CPU to host, even if the primary device is TPU.
 
-// UN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-target-tpu -O -emit-sil %s >/dev/null
-//
 // Dataset tests.
 
 import TensorFlow
@@ -26,81 +23,7 @@ import StdlibUnittest
 
 var DatasetTests = TestSuite("Dataset")
 
-// Creates a dataset, which produces one float scalar value in each get next
-// call.
-@TensorFlowGraph
-public func createMockDataSet() -> VariantHandle {
-  // A dataset graph function must run on TF CPU.
-  TensorFlow.enableCPU()
-  let values = Tensor<Float>([1.0, 2.0, 3.0])
-  // REGISTER_OP("TensorSliceDataset")
-  //   .Input("components: Toutput_types")
-  //   .Output("handle: variant")
-  //   .Attr("Toutput_types: list(type) >= 1")
-  //   .Attr("output_shapes: list(shape) >= 1")
-  let dataset : VariantHandle = #tfop("TensorSliceDataset",
-                                      [values],
-                                      Toutput_types$dtype: [Float.tensorFlowDataType],
-                                      output_shapes: [nil as TensorShape?])
-  return dataset
-}
-
-func getNextScalarFloatTensor(_ iterator: ResourceHandle) -> Tensor<Float> {
-  // REGISTER_OP("IteratorGetNext")
-  //   .Input("iterator: resource")
-  //   .Output("components: output_types")
-  //   .Attr("output_types: list(type) >= 1")
-  //   .Attr("output_shapes: list(shape) >= 1")
-  let ret: TensorHandle<Float> = #tfop("IteratorGetNext",
-                                       iterator,
-                                       output_types$dtype: [Float.tensorFlowDataType],
-                                       output_shapes: [nil as TensorShape?])
-  return Tensor(handle: ret)
-}
-
-public func model() {
-  // REGISTER_OP("OneShotIterator")
-  //   .Output("handle: resource")
-  //   .Attr("dataset_factory: func")
-  //   .Attr("output_types: list(type) >= 1")
-  //   .Attr("output_shapes: list(shape) >= 1")
-  //   .Attr("container: string = ''")
-  //   .Attr("shared_name: string = ''")
-  let iterator: ResourceHandle = #tfop(
-    "OneShotIterator",
-    dataset_factory : createMockDataSet,
-    output_types$dtype: [Float.tensorFlowDataType],
-    output_shapes: [nil as TensorShape?]
-  )
-
-  let one = getNextScalarFloatTensor(iterator)
-  _hostOp(one)
-  expectNearlyEqualWithScalarTensor(1.0, one)
-
-  let two = getNextScalarFloatTensor(iterator)
-  _hostOp(two)
-  expectNearlyEqualWithScalarTensor(2.0, two)
-
-  let three = getNextScalarFloatTensor(iterator)
-  _hostOp(three)
-  expectNearlyEqualWithScalarTensor(3.0, three)
-
-  // Running the commented-out code below will cause the process to exit, with
-  // TF error message "End of sequence" printed on STDERR. The code is commented
-  // out because running it will unfortunately cause the test to fail.
-
-  // let _: TensorHandle<Float> = #tfop("IteratorGetNext",
-  //                                    iterator,
-  //                                    output_types$dtype: [Float.tensorFlowDataType],
-  //                                    output_shapes: [nil as TensorShape?])
-}
-
 #if !CUDA
-DatasetTests.testAllBackends("Basic") {
-  // OneShotIterator is not supported on GPU.
-  model()
-}
-
 DatasetTests.testAllBackends("MultiValue") {
   enableCPU()
   let elements1: Tensor<Int32> = [0, 1, 2]

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -1,5 +1,4 @@
 // This test has various test cases to check that SESE regions are computed correctly.
-// RUN: %target-swift-frontend -Xllvm -tf-dynamic-compilation=false -Xllvm -tf-dump-intermediates -emit-sil -O %s -verify | %FileCheck %s
 // RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/string_description.swift
+++ b/test/TensorFlowRuntime/string_description.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,13 +1,8 @@
 // FIXME: TFPartition fails in `GraphFunctionDeviceInfo::finalizeUsedDevices()`
-// because used device set includes RUNTIME device.
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
 
 // RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
-//
-// Compiler-only testing for TPU graph lowering (e.g. shape requirements by XLA).
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-target-tpu -O -emit-sil %s >/dev/null
 //
 // Tensor API tests.
 

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,8 +1,5 @@
 // RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
 
-// SR-9737: hanging tests in GPE GPU mode
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
-
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //


### PR DESCRIPTION
These are not getting used in the library anywhere and are just unused compiler features.

Because @convention(tensorflow) is the only consumer of GPE, the GPE passes are also removed from the pass manager.

Methodology for this change:
- First disabled the FunctionTypeRepresentation, and removed all references.
- Changed the type checker to emit errors for @TensorFlowGraph.
- Removed convention handling for "tensorflow".

Methodology for tests:
- Anything with: "-Xllvm -tf-dynamic-compilation=false" and a version that didn't have it, I just deleted the run line that tries to invoke GPE.
- Added: "// REQUIRES: deprecated_gpe_mode" for any tests that had only GPE features. I can extend this PR later to just remove those files.
- There is this dataset_1 test that is mostly just duplicate of dataset_api using tfop. I just deleted this code. Technically those ops are not all exposed in the dataset API. (_tffunc needs to be extended to handle variant tensors to make this work).