### PR TITLE
[SR-10574] Update ICU from 61.1 to 61.2

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -68,7 +68,7 @@
                 "swift-integration-tests": "master",
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
-                "icu": "release-61-1",
+                "icu": "release-61-2",
                 "clang-tools-extra": "stable",
                 "libcxx": "stable",
                 "indexstore-db": "master",


### PR DESCRIPTION
ICU 61.2 is a maintenance release adding support for the new Japanese
Reiwa Era (令和).

https://github.com/unicode-org/icu/releases/tag/release-61-2

Resolves [SR-10574](https://bugs.swift.org/browse/SR-10574).