### PR TITLE
[vImage] Don't Infer Pixel Size in Buffer Copy

### DIFF
--- a/stdlib/public/Darwin/Accelerate/vImage_Buffer.swift
+++ b/stdlib/public/Darwin/Accelerate/vImage_Buffer.swift
@@ -205,8 +205,10 @@ extension vImage_Buffer {
     /// Copies this buffer to `destinationBuffer`.
     ///
     /// - Parameter destinationBuffer: The destination vImage buffer.
+    /// - Parameter pixelSize: The number of bytes for one pixel.
     /// - Parameter options: The options to use when performing this operation.
     public func copy(destinationBuffer: inout vImage_Buffer,
+                     pixelSize: Int,
                      flags options: vImage.Options = .noFlags) throws {
         
         if Int(width) == 0 {
@@ -218,7 +220,7 @@ extension vImage_Buffer {
         _ = withUnsafePointer(to: self) {
             error =  vImageCopyBuffer($0,
                                       &destinationBuffer,
-                                      rowBytes / Int(width),
+                                      pixelSize,
                                       options.flags)
         }
         

--- a/test/stdlib/Accelerate_vImage.swift
+++ b/test/stdlib/Accelerate_vImage.swift
@@ -269,7 +269,8 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         var destination = try! vImage_Buffer(width: 20, height: 20, bitsPerPixel: 32)
         
         expectCrashLater()
-        try! source.copy(destinationBuffer: &destination)
+        try! source.copy(destinationBuffer: &destination,
+                         pixelSize: 4)
     }
 
     Accelerate_vImageTests.test("vImage/CopyBadHeight") {
@@ -277,7 +278,8 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         var destination = try! vImage_Buffer(width: 20, height: 20, bitsPerPixel: 32)
         
         expectCrashLater()
-        try! source.copy(destinationBuffer: &destination)
+        try! source.copy(destinationBuffer: &destination,
+                         pixelSize: 4)
     }
     
     Accelerate_vImageTests.test("vImage/Copy") {
@@ -294,7 +296,8 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         var destination = try! vImage_Buffer(width: widthi, height: heighti,
                                              bitsPerPixel: 32)
         
-        try! source.copy(destinationBuffer: &destination)
+        try! source.copy(destinationBuffer: &destination,
+                         pixelSize: 4)
         
         let sourcePixels: [UInt8] = arrayFromBuffer(buffer: source,
                                                     count: pixels.count)
@@ -306,7 +309,7 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         source.free()
         destination.free()
     }
-    
+
     Accelerate_vImageTests.test("vImage/InitializeWithFormat") {
         let pixels: [UInt8] = (0 ..< width * height * 4).map { _ in
             return UInt8.random(in: 0 ..< 255)

--- a/test/stdlib/Accelerate_vImage.swift
+++ b/test/stdlib/Accelerate_vImage.swift
@@ -11,10 +11,10 @@ import Accelerate
 var Accelerate_vImageTests = TestSuite("Accelerate_vImage")
 
 if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
-    let width = UInt(48)
-    let height = UInt(12)
-    let widthi = 48
-    let heighti = 12
+    let width = UInt(64)
+    let height = UInt(32)
+    let widthi = 64
+    let heighti = 32
     
     //===----------------------------------------------------------------------===//
     //


### PR DESCRIPTION
A buffer's `rowBytes` doesn't have a direct relationship with its `width`, so `rowBytes / Int(width)` isn't a good way to calculate pixel size. To resolve this, I've added `pixelSize` as a parameter to `vImage_Buffer.copy`.

Attention: @stephentyrone 
