### PR TITLE
 Prevent less-visible properties with delegates from affecting memberwise initializer

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5316,6 +5316,18 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   if (isLet() && isParentInitialized())
     return false;
 
+  // Properties with attached delegates that have an access level < internal
+  // but do have an initializer don't participate in the memberwise
+  // initializer, because they would arbitrarily lower the access of the
+  // memberwise initializer.
+  auto origVar = this;
+  if (auto origDelegate = getOriginalDelegatedProperty())
+    origVar = origDelegate;
+  if (origVar->getFormalAccess() < AccessLevel::Internal &&
+      origVar->getAttachedPropertyDelegate() &&
+      origVar->isParentInitialized())
+    return false;
+
   return true;
 }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1584,6 +1584,9 @@ PropertyDelegateBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   if (parentPBD->isInitialized(patternNumber) &&
       !parentPBD->isInitializerChecked(patternNumber)) {
     auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
+    if (!var->hasType())
+      tc.validateDecl(var);
+
     tc.typeCheckPatternBinding(parentPBD, patternNumber);
   }
 

--- a/test/SILGen/property_delegates.swift
+++ b/test/SILGen/property_delegates.swift
@@ -103,15 +103,9 @@ func forceHasMemberwiseInit() {
 
 // CHECK: return
 
-// CHECK-LABEL: sil private [ossa] @$s18property_delegates9HasNestedV1yACyxGSayxG_tc33_
-// CHECK: [[STACK_SLOT:%.*]] = alloc_stack $HasNested<T>.PrivateDelegate<Array<T>>
-// CHECK: [[METATYPE:%.*]] = metatype $@thin HasNested<T>.PrivateDelegate<Array<T>>.Type
-// CHECK: [[ARRAY_STACK_SLOT:%.*]] = alloc_stack $Array<T>
-// CHECK: store %0 to [init] [[ARRAY_STACK_SLOT]] : $*Array<T>
-// CHECK: [[INIT:%.*]] = function_ref @$s18property_delegates9HasNestedV15PrivateDelegate{{.*}}initialValue
-// CHECK: [[DELEGATE_INSTANCE:%.*]] = apply [[INIT]]<T, [T]>([[STACK_SLOT]], [[ARRAY_STACK_SLOT]], [[METATYPE]])
-// CHECK: [[DELEGATE_VALUE:%.*]] = load [take] [[STACK_SLOT]] : $*HasNested<T>.PrivateDelegate<Array<T>>
-// CHECK: struct $HasNested<T> ([[DELEGATE_VALUE]] : $HasNested<T>.PrivateDelegate<Array<T>>)
+// CHECK-LABEL: sil hidden [transparent] [ossa] @$s18property_delegates9HasNestedV2$y33_4EEAE04FCFB319F460A84BF3BE29C303LLAC15PrivateDelegateAELLVyx_SayxGGvpfi : $@convention(thin) <T> () -> @owned Array<T> {
+// CHECK: bb0:
+// CHECK: function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 struct HasNested<T> {
   @_propertyDelegate
   private struct PrivateDelegate<U> {
@@ -125,7 +119,7 @@ struct HasNested<T> {
   private var y: [T] = []
 
   static func blah(y: [T]) -> HasNested<T> {
-    return HasNested<T>(y: y)
+    return HasNested<T>()
   }
 }
 

--- a/test/decl/var/property_delegates.swift
+++ b/test/decl/var/property_delegates.swift
@@ -610,6 +610,24 @@ func testDefaultInitializers() {
   _ = NoDefaultInitializerStruct() // expected-error{{missing argument for parameter 'x' in call}}
 }
 
+struct DefaultedPrivateMemberwiseLets {
+  @Wrapper(value: true)
+  private var x: Bool
+
+  @WrapperWithInitialValue
+  var y: Int = 17
+
+  @WrapperWithInitialValue(initialValue: 17)
+  private var z: Int
+}
+
+func testDefaultedPrivateMemberwiseLets() {
+  _ = DefaultedPrivateMemberwiseLets()
+  _ = DefaultedPrivateMemberwiseLets(y: 42)
+  _ = DefaultedPrivateMemberwiseLets(x: Wrapper(value: false)) // expected-error{{incorrect argument label in call (have 'x:', expected 'y:')}}
+}
+
+
 // ---------------------------------------------------------------------------
 // Storage references
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
When a property with an attached delegate has less-than-internal visibility
and is initialized, don’t put it into the memberwise initializer because
doing so lowers the access level of the memberwise initializer, making it
fairly useless.

Longer term, it probably makes sense to have several memberwise initializers
at different access levels, so adding an initialized `private var` make
the memberwise initializer useless throughout the rest of the module.

Addresses rdar://problem/50266245.