### PR TITLE
Remove all refs to libtensorflow_framework because of duplicate symbols.

### DIFF
--- a/cmake/modules/FindTensorFlow.cmake
+++ b/cmake/modules/FindTensorFlow.cmake
@@ -17,10 +17,7 @@ endif()
 find_library(TF_LIBRARY
   NAMES tensorflow
   HINTS ${SWIFT_TENSORFLOW_TARGET_LIB_DIR} /usr/lib /usr/local/lib)
-find_library(TF_FRAMEWORK_LIBRARY
-  NAMES tensorflow_framework
-  HINTS ${SWIFT_TENSORFLOW_TARGET_LIB_DIR} /usr/lib /usr/local/lib)
-set(TF_LIBRARIES ${TF_LIBRARY} ${TF_FRAMEWORK_LIBRARY})
+set(TF_LIBRARIES ${TF_LIBRARY})
 
 find_package_handle_standard_args(TensorFlow DEFAULT_MSG TF_INCLUDE_DIR TF_LIBRARIES)
 mark_as_advanced(${TF_INCLUDE_DIR} ${TF_LIBRARIES})

--- a/stdlib/public/CTensorFlow/ctensorflow_init.cpp
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.cpp
@@ -3,7 +3,6 @@
 #include "tensorflow/c/c_api.h"
 #include "tensorflow/c/c_api_experimental.h"
 #include "tensorflow/c/eager/c_api.h"
-#include "tensorflow/core/platform/init_main.h"
 
 #include <assert.h>
 #include <signal.h>
@@ -42,7 +41,7 @@ void InitTensorFlowRuntime(unsigned char enable_debug_logging,
   int my_argc = my_argv.size();
   char** tmpArgv = my_argv.data();
   // Initialize GPU devices.
-  tensorflow::port::InitMain(/*usage=*/nullptr, &my_argc, &tmpArgv);
+  TF_InitMain(/*usage=*/nullptr, &my_argc, &tmpArgv);
 }
 
 static bool setValue(TF_DataType tfDtype, int64_t val, void *ptr) {

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2011,7 +2011,7 @@ function set_lldb_xcodebuild_options() {
         lldb_xcodebuild_options=(
             "${lldb_xcodebuild_options[@]}"
             ENABLE_TENSORFLOW=1
-            EXTRA_OTHER_LDFLAGS="-L\$(LLDB_PATH_TO_SWIFT_BUILD)/lib/swift/\$(PLATFORM_NAME) ${RPATHS} -ltensorflow -ltensorflow_framework"
+            EXTRA_OTHER_LDFLAGS="-L\$(LLDB_PATH_TO_SWIFT_BUILD)/lib/swift/\$(PLATFORM_NAME) ${RPATHS} -ltensorflow"
         )
     fi
 }
@@ -2993,7 +2993,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Configure TensorFlow and build using bazel.
                 echo yes "" | "${source_dir}/configure"
                 with_pushd "${source_dir}" \
-                    call bazel build -c opt "${TENSORFLOW_BAZEL_OPTIONS[@]}" //tensorflow:libtensorflow.so //tensorflow:libtensorflow_framework.so
+                    call bazel build -c opt "${TENSORFLOW_BAZEL_OPTIONS[@]}" --define framework_shared_object=false //tensorflow:libtensorflow.so //tensorflow:libtensorflow_framework.so
 
                 # Set TensorFlow include/lib directories.
                 TENSORFLOW_HOST_INCLUDE_DIR="${source_dir}"


### PR DESCRIPTION
This was causing XLA to not get triggered because it was linking into a different address space.

The missed refs are related to testing and building of the module itself. All refs that result in it being linked into anything important (the resulting TensorFlow .so file) have been removed.