### PR TITLE
Create opaque type constraint for single expr return. [49581931] [5.1]

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1119,7 +1119,8 @@ ConstraintSystem::solveImpl(Expr *&expr,
   if (convertType) {
     auto constraintKind = ConstraintKind::Conversion;
     
-    if (getContextualTypePurpose() == CTP_ReturnStmt
+    if ((getContextualTypePurpose() == CTP_ReturnStmt ||
+         getContextualTypePurpose() == CTP_ReturnSingleExpr)
         && Options.contains(ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
       constraintKind = ConstraintKind::OpaqueUnderlyingType;
     

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -174,7 +174,8 @@ func recursion(x: Int) -> some P {
   return recursion(x: x - 1)
 }
 
-func noReturnStmts() -> some P { fatalError() } // expected-error{{no return statements}}
+// FIXME: We need to emit a better diagnostic than the failure to convert Never to opaque.
+func noReturnStmts() -> some P { fatalError() } // expected-error{{cannot convert return expression of type 'Never' to return type 'some P'}} expected-error{{no return statements}}
 
 func mismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> some P { // expected-error{{do not have matching underlying types}}
   if x {


### PR DESCRIPTION
Previously, an OpaqueUnderlyingType constraint was created only if the contextual type purpose was CTP_ReturnStmt. Now that there is a distinct CTP for implicit, single-expression returns, an OpaqueUnderlyingType constraint needs to be created if that is the CTP.