### PR TITLE
[5.1 04-24] [ModuleInterface] Rename 'parseable interface' to 'module interface' in diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -84,8 +84,8 @@ ERROR(error_unknown_target,none,
 
 ERROR(error_framework_bridging_header,none,
       "using bridging headers with framework targets is unsupported", ())
-ERROR(error_bridging_header_parseable_interface,none,
-      "using bridging headers with parseable module interfaces is unsupported",
+ERROR(error_bridging_header_module_interface,none,
+      "using bridging headers with module interfaces is unsupported",
       ())
 
 ERROR(error_i_mode,none,

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -119,7 +119,7 @@ ERROR(error_mode_cannot_emit_module,none,
 ERROR(error_mode_cannot_emit_module_doc,none,
       "this mode does not support emitting module documentation files", ())
 ERROR(error_mode_cannot_emit_interface,none,
-      "this mode does not support emitting parseable interface files", ())
+      "this mode does not support emitting module interface files", ())
 
 WARNING(emit_reference_dependencies_without_primary_file,none,
   "ignoring -emit-reference-dependencies (requires -primary-file)", ())
@@ -258,18 +258,18 @@ ERROR(error_invalid_debug_prefix_map, none,
 ERROR(invalid_vfs_overlay_file,none,
       "invalid virtual overlay file '%0'", (StringRef))
 
-WARNING(parseable_interface_scoped_import_unsupported,none,
-        "scoped imports are not yet supported in parseable module interfaces",
+WARNING(module_interface_scoped_import_unsupported,none,
+        "scoped imports are not yet supported in module interfaces",
         ())
-ERROR(error_extracting_version_from_parseable_interface,none,
-      "error extracting version from parseable module interface", ())
-ERROR(unsupported_version_of_parseable_interface,none,
-      "unsupported version of parseable module interface '%0': '%1'",
+ERROR(error_extracting_version_from_module_interface,none,
+      "error extracting version from module interface", ())
+ERROR(unsupported_version_of_module_interface,none,
+      "unsupported version of module interface '%0': '%1'",
       (StringRef, llvm::VersionTuple))
-ERROR(error_extracting_flags_from_parseable_interface,none,
-      "error extracting flags from parseable module interface", ())
-ERROR(missing_dependency_of_parseable_module_interface,none,
-      "missing dependency '%0' of parseable module interface '%1': %2",
+ERROR(error_extracting_flags_from_module_interface,none,
+      "error extracting flags from module interface", ())
+ERROR(missing_dependency_of_module_interface,none,
+      "missing dependency '%0' of module interface '%1': %2",
       (StringRef, StringRef, StringRef))
 ERROR(error_extracting_dependencies_from_cached_module,none,
       "error extracting dependencies from cached module '%0'",

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -129,7 +129,7 @@ static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
 
   if (args.hasArgNoClaim(options::OPT_emit_module_interface,
                          options::OPT_emit_module_interface_path)) {
-    diags.diagnose({}, diag::error_bridging_header_parseable_interface);
+    diags.diagnose({}, diag::error_bridging_header_module_interface);
   }
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -296,11 +296,13 @@ bool CompilerInstance::setUpModuleLoaders() {
   auto MLM = ModuleLoadingMode::PreferSerialized;
   if (auto forceModuleLoadingMode =
       llvm::sys::Process::GetEnv("SWIFT_FORCE_MODULE_LOADING")) {
-    if (*forceModuleLoadingMode == "prefer-parseable")
+    if (*forceModuleLoadingMode == "prefer-interface" ||
+        *forceModuleLoadingMode == "prefer-parseable")
       MLM = ModuleLoadingMode::PreferParseable;
     else if (*forceModuleLoadingMode == "prefer-serialized")
       MLM = ModuleLoadingMode::PreferSerialized;
-    else if (*forceModuleLoadingMode == "only-parseable")
+    else if (*forceModuleLoadingMode == "only-interface" ||
+             *forceModuleLoadingMode == "only-parseable")
       MLM = ModuleLoadingMode::OnlyParseable;
     else if (*forceModuleLoadingMode == "only-serialized")
       MLM = ModuleLoadingMode::OnlySerialized;

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -227,7 +227,7 @@ static std::unique_ptr<llvm::MemoryBuffer> getBufferOfDependency(
                                     /*RequiresNullTerminator=*/false);
   if (!depBuf) {
     diags.diagnose(diagnosticLoc,
-                   diag::missing_dependency_of_parseable_module_interface,
+                   diag::missing_dependency_of_module_interface,
                    depPath, interfacePath, depBuf.getError().message());
     return nullptr;
   }
@@ -240,7 +240,7 @@ static Optional<llvm::vfs::Status> getStatusOfDependency(
   auto status = fs.status(depPath);
   if (!status) {
     diags.diagnose(diagnosticLoc,
-                   diag::missing_dependency_of_parseable_module_interface,
+                   diag::missing_dependency_of_module_interface,
                    depPath, interfacePath, status.getError().message());
     return None;
   }
@@ -367,12 +367,12 @@ class swift::ParseableInterfaceBuilder {
     SmallVector<StringRef, 1> VersMatches, FlagMatches;
     if (!VersRe.match(SB, &VersMatches)) {
       diags.diagnose(diagnosticLoc,
-                     diag::error_extracting_version_from_parseable_interface);
+                     diag::error_extracting_version_from_module_interface);
       return true;
     }
     if (!FlagRe.match(SB, &FlagMatches)) {
       diags.diagnose(diagnosticLoc,
-                     diag::error_extracting_flags_from_parseable_interface);
+                     diag::error_extracting_flags_from_module_interface);
       return true;
     }
     assert(VersMatches.size() == 2);
@@ -519,7 +519,7 @@ public:
       // compatible field variant.
       if (Vers.asMajorVersion() != InterfaceFormatVersion.asMajorVersion()) {
         diags.diagnose(diagnosticLoc,
-                       diag::unsupported_version_of_parseable_interface,
+                       diag::unsupported_version_of_module_interface,
                        interfacePath, Vers);
         SubError = true;
         return;
@@ -872,7 +872,7 @@ class ParseableInterfaceModuleLoaderImpl {
       // The rest of the function should be covered by this.
       break;
     case ModuleLoadingMode::OnlySerialized:
-      llvm_unreachable("parseable module loader should not have been created");
+      llvm_unreachable("module interface loader should not have been created");
     }
 
     // First, check the cached module path. Whatever's in this cache represents

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -50,7 +50,7 @@ static void diagnoseScopedImports(DiagnosticEngine &diags,
     if (importPair.first.empty())
       continue;
     diags.diagnose(importPair.first.front().second,
-                   diag::parseable_interface_scoped_import_unsupported);
+                   diag::module_interface_scoped_import_unsupported);
   }
 }
 

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -27,7 +27,7 @@
 
 // RUN: not %swiftc_driver -import-objc-header fake.h -emit-parseable-module-interface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s
 // RUN: not %swiftc_driver -import-objc-header fake.h -emit-parseable-module-interface-path fake.swiftinterface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s
-// BRIDGING_HEADER_SWIFTINTERFACE: error: using bridging headers with parseable module interfaces is unsupported
+// BRIDGING_HEADER_SWIFTINTERFACE: error: using bridging headers with module interfaces is unsupported
 
 // RUN: %swift_driver -### | %FileCheck -check-prefix=DEFAULT_REPL %s
 // DEFAULT_REPL: -repl

--- a/test/Frontend/supplementary-output-support.swift
+++ b/test/Frontend/supplementary-output-support.swift
@@ -25,6 +25,6 @@
 // RESOLVE_IMPORTS_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
 
 // RUN: not %target-swift-frontend -parse -emit-parseable-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_INTERFACE %s
-// PARSE_NO_INTERFACE: error: this mode does not support emitting parseable interface files{{$}}
+// PARSE_NO_INTERFACE: error: this mode does not support emitting module interface files{{$}}
 // RUN: not %target-swift-frontend -emit-silgen -emit-parseable-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=SILGEN_NO_INTERFACE %s
-// SILGEN_NO_INTERFACE: error: this mode does not support emitting parseable interface files{{$}}
+// SILGEN_NO_INTERFACE: error: this mode does not support emitting module interface files{{$}}

--- a/test/ParseableInterface/ModuleCache/module-cache-bad-version.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-bad-version.swift
@@ -20,7 +20,7 @@
 // RUN: test ! -f %t/TestModule.swiftmodule
 // RUN: test ! -f %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERR <%t/err.txt
-// CHECK-ERR: {{error: unsupported version of parseable module interface '.*/LeafModule.swiftinterface': '9999.999'}}
+// CHECK-ERR: {{error: unsupported version of module interface '.*[/\\]LeafModule.swiftinterface': '9999.999'}}
 // CHECK-ERR: error: no such module 'LeafModule
 
 import LeafModule

--- a/test/ParseableInterface/imports.swift
+++ b/test/ParseableInterface/imports.swift
@@ -5,7 +5,7 @@
 
 @_exported import empty
 import B.B2
-import func C.c // expected-warning {{scoped imports are not yet supported in parseable module interfaces}}
+import func C.c // expected-warning {{scoped imports are not yet supported in module interfaces}}
 import D
 @_implementationOnly import Secret_BAD
 


### PR DESCRIPTION
I missed a couple of commits when cherry-picking #23969 to 5.1 in #24053.

Reviewed originally by @jrose-apple and @nathawes 