### PR TITLE
[sil] Teach the verifier that open_existential_addr immutable is safe…

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2885,11 +2885,20 @@ public:
       case SILArgumentConvention::Indirect_In_Guaranteed:
         return false;
 
+      case SILArgumentConvention::Indirect_InoutAliasable:
+        // DISCUSSION: We do not consider inout_aliasable to be "truly mutating"
+        // since today it is just used as a way to mark a captured argument and
+        // not that something truly has mutating semantics. The reason why this
+        // is safe is that the typechecker guarantees that if our value was
+        // immutable, then the use in the closure must be immutable as well.
+        //
+        // TODO: Remove this in favor of using Inout and In_Guaranteed.
+        return false;
+
       case SILArgumentConvention::Indirect_Out:
       case SILArgumentConvention::Indirect_In:
       case SILArgumentConvention::Indirect_In_Constant:
       case SILArgumentConvention::Indirect_Inout:
-      case SILArgumentConvention::Indirect_InoutAliasable:
         return true;
 
       case SILArgumentConvention::Direct_Unowned:

--- a/test/SIL/verifier_nofail.sil
+++ b/test/SIL/verifier_nofail.sil
@@ -1,0 +1,25 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s
+
+// This file contains a collection of tests that ensure that the verifier does
+// not fail on specific segments of code. The idea is to ensure that changing
+// the verifier does not cause these to start asserting. When one adds a new
+// check to the verifier, add a test case to make sure normal cases do not
+// crash.
+
+sil_stage canonical
+
+import Builtin
+
+protocol P {
+}
+
+sil @generic_user : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout_aliasable τ_0_0) -> ()
+
+sil @open_existential_immutable_access_to_inout_aliasable : $@convention(thin) (@in_guaranteed P) -> () {
+bb0(%0 : $*P):
+  %1 = open_existential_addr immutable_access %0 : $*P to $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") P
+  %2 = function_ref @generic_user : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout_aliasable τ_0_0) -> ()
+  apply %2<@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") P>(%1) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout_aliasable τ_0_0) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
… to pass as Indirect_InoutAliasable.

We do not consider inout_aliasable to be "truly mutating" since today it is just
used as a way to mark a captured argument and not that something truly has
mutating semantics. The reason why this is safe is that the typechecker
guarantees that if our value was immutable, then the use in the closure must be
immutable as well.

In a future SIL, we want to remove Inout_Aliasable in favor of just using
inout/in_guaranteed using the capture info from the type checker.

rdar://50212579
