### PR TITLE
[ConstraintSystem] Diagnose missing explicit calls in assignment

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1589,6 +1589,17 @@ bool MissingCallFailure::diagnoseAsError() {
     }
   }
 
+  if (auto *AE = dyn_cast<AssignExpr>(baseExpr)) {
+    auto *srcExpr = AE->getSrc();
+    if (auto *fnType = getType(srcExpr)->getAs<FunctionType>()) {
+      emitDiagnostic(srcExpr->getLoc(), diag::missing_nullary_call,
+                     fnType->getResult())
+          .highlight(srcExpr->getSourceRange())
+          .fixItInsertAfter(srcExpr->getEndLoc(), "()");
+      return true;
+    }
+  }
+
   emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function_value)
       .fixItInsertAfter(insertLoc, "()");
   return true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1978,10 +1978,9 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
 /// Attempt to repair typing failures and record fixes if needed.
 /// \return true if at least some of the failures has been repaired
 /// successfully, which allows type matcher to continue.
-static bool
-repairFailures(ConstraintSystem &cs, Type lhs, Type rhs,
-               SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
-               ConstraintLocatorBuilder locator) {
+bool ConstraintSystem::repairFailures(
+    Type lhs, Type rhs, SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
+    ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
   auto *anchor = locator.getLocatorParts(path);
 
@@ -2005,14 +2004,14 @@ repairFailures(ConstraintSystem &cs, Type lhs, Type rhs,
   case ConstraintLocator::ApplyArgToParam: {
     if (lhs->getOptionalObjectType() && !rhs->getOptionalObjectType()) {
       conversionsOrFixes.push_back(
-          ForceOptional::create(cs, lhs, lhs->getOptionalObjectType(),
-                                cs.getConstraintLocator(locator)));
+          ForceOptional::create(*this, lhs, lhs->getOptionalObjectType(),
+                                getConstraintLocator(locator)));
     }
     break;
   }
 
   case ConstraintLocator::FunctionArgument: {
-    auto *argLoc = cs.getConstraintLocator(
+    auto *argLoc = getConstraintLocator(
         locator.withPathElement(LocatorPathElt::getSynthesizedArgument(0)));
 
     // Let's drop the last element which points to a single argument
@@ -2023,7 +2022,7 @@ repairFailures(ConstraintSystem &cs, Type lhs, Type rhs,
           path.back().getKind() == ConstraintLocator::ContextualType))
       return false;
 
-    auto arg = llvm::find_if(cs.getTypeVariables(),
+    auto arg = llvm::find_if(getTypeVariables(),
                              [&argLoc](const TypeVariableType *typeVar) {
                                return typeVar->getImpl().getLocator() == argLoc;
                              });
@@ -2040,27 +2039,27 @@ repairFailures(ConstraintSystem &cs, Type lhs, Type rhs,
     //
     // But if `T.Element` didn't get resolved to `Void` we'd like
     // to diagnose this as a missing argument which can't be ignored.
-    if (arg != cs.getTypeVariables().end()) {
+    if (arg != getTypeVariables().end()) {
       auto fnType = FunctionType::get({FunctionType::Param(lhs)},
-                                      cs.getASTContext().TheEmptyTupleType);
+                                      getASTContext().TheEmptyTupleType);
       conversionsOrFixes.push_back(AddMissingArguments::create(
-          cs, fnType, {FunctionType::Param(*arg)},
-          cs.getConstraintLocator(anchor, path,
-                                  /*summaryFlags=*/0)));
+          *this, fnType, {FunctionType::Param(*arg)},
+          getConstraintLocator(anchor, path,
+                               /*summaryFlags=*/0)));
     }
     break;
   }
 
   case ConstraintLocator::TypeParameterRequirement:
   case ConstraintLocator::ConditionalRequirement: {
-    if (auto *fix = fixRequirementFailure(cs, lhs, rhs, anchor, path))
+    if (auto *fix = fixRequirementFailure(*this, lhs, rhs, anchor, path))
       conversionsOrFixes.push_back(fix);
     break;
   }
 
   case ConstraintLocator::ClosureResult: {
-    auto *fix = ContextualMismatch::create(cs, lhs, rhs,
-                                           cs.getConstraintLocator(locator));
+    auto *fix = ContextualMismatch::create(*this, lhs, rhs,
+                                           getConstraintLocator(locator));
     conversionsOrFixes.push_back(fix);
     break;
   }
@@ -2070,14 +2069,14 @@ repairFailures(ConstraintSystem &cs, Type lhs, Type rhs,
     // between them are mutability and/or root, value type mismatch.
     if (isKnownKeyPathType(lhs) && isKnownKeyPathType(rhs)) {
       auto *fix = KeyPathContextualMismatch::create(
-          cs, lhs, rhs, cs.getConstraintLocator(locator));
+          *this, lhs, rhs, getConstraintLocator(locator));
       conversionsOrFixes.push_back(fix);
     }
 
     if (lhs->is<FunctionType>() && !rhs->is<AnyFunctionType>() &&
         isa<ClosureExpr>(anchor)) {
-      auto *fix = ContextualMismatch::create(cs, lhs, rhs,
-                                             cs.getConstraintLocator(locator));
+      auto *fix = ContextualMismatch::create(*this, lhs, rhs,
+                                             getConstraintLocator(locator));
       conversionsOrFixes.push_back(fix);
     }
     break;
@@ -2899,7 +2898,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
   // Attempt to repair any failures identifiable at this point.
   if (attemptFixes) {
-    if (repairFailures(*this, type1, type2, conversionsOrFixes, locator)) {
+    if (repairFailures(type1, type2, conversionsOrFixes, locator)) {
       if (conversionsOrFixes.empty())
         return getTypeMatchSuccess();
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1985,16 +1985,37 @@ bool ConstraintSystem::repairFailures(
   auto *anchor = locator.getLocatorParts(path);
 
   if (path.empty()) {
+    if (!anchor)
+      return false;
+
     // If method reference forms a value type of the key path,
     // there is going to be a constraint to match result of the
     // member lookup to the generic parameter `V` of *KeyPath<R, V>
     // type associated with key path expression, which we need to
     // fix-up here.
-    if (anchor && isa<KeyPathExpr>(anchor)) {
+    if (isa<KeyPathExpr>(anchor)) {
       auto *fnType = lhs->getAs<FunctionType>();
       if (fnType && fnType->getResult()->isEqual(rhs))
         return true;
     }
+
+    if (isa<AssignExpr>(anchor)) {
+      if (auto *fnType = lhs->getAs<FunctionType>()) {
+        // If left-hand side is a function type but right-hand
+        // side isn't, let's check it would be possible to fix
+        // this by forming an explicit call.
+        if (!rhs->is<FunctionType>() && !rhs->isVoid() &&
+            fnType->getNumParams() == 0 &&
+            matchTypes(fnType->getResult(), rhs, ConstraintKind::Conversion,
+                       TypeMatchFlags::TMF_ApplyingFix, locator)
+                .isSuccess()) {
+          conversionsOrFixes.push_back(
+              InsertExplicitCall::create(*this, getConstraintLocator(locator)));
+          return true;
+        }
+      }
+    }
+
     return false;
   }
 
@@ -6447,6 +6468,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     return result;
   }
 
+  case FixKind::InsertCall:
   case FixKind::SkipSameTypeRequirement:
   case FixKind::SkipSuperclassRequirement:
   case FixKind::ContextualMismatch:
@@ -6455,7 +6477,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   }
 
   case FixKind::UseSubscriptOperator:
-  case FixKind::InsertCall:
   case FixKind::ExplicitlyEscaping:
   case FixKind::CoerceToCheckedCast:
   case FixKind::RelabelArguments:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2624,6 +2624,13 @@ public:
     TypeMatchResult(SolutionKind result) : Kind(result) {}
   };
 
+  /// Attempt to repair typing failures and record fixes if needed.
+  /// \return true if at least some of the failures has been repaired
+  /// successfully, which allows type matcher to continue.
+  bool repairFailures(Type lhs, Type rhs,
+                      SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
+                      ConstraintLocatorBuilder locator);
+
   /// Subroutine of \c matchTypes(), which matches up two tuple types.
   ///
   /// \returns the result of performing the tuple-to-tuple conversion.

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -14,8 +14,8 @@ func f4() -> B { }
 func f5(_ a: A) { }
 func f6(_ a: A, _: Int) { }
 
-func createB() -> B { }  // expected-note {{found this candidate}}
-func createB(_ i: Int) -> B { } // expected-note {{found this candidate}}
+func createB() -> B { }
+func createB(_ i: Int) -> B { }
 
 func f7(_ a: A, _: @escaping () -> Int) -> B { }
 func f7(_ a: A, _: Int) -> Int { }
@@ -37,7 +37,7 @@ func forgotCall() {
   f6(f4, f2) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
 
   // With overloading: only one succeeds.
-  a = createB // expected-error{{ambiguous reference to member 'createB()'}}
+  a = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
 
   // With overloading, pick the fewest number of fixes.
   var b = f7(f4, f1) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}


### PR DESCRIPTION
If the source of the assignment is a function type which has
a result that could be converted to expected destination type,
let's diagnose that as missing call if such function doesn't
have any parameters.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
