### PR TITLE
[TF] Remove `unbroadcast(to:)` and improve derivative performance.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1665,30 +1665,6 @@ public extension Tensor {
   func broadcast<OtherScalar>(like other: Tensor<OtherScalar>) -> Tensor {
     return broadcast(toShape: other.shapeTensor)
   }
-}
-
-public extension Tensor where Scalar : Numeric {
-  @inlinable
-  func unbroadcast(toShape otherShape: Tensor<Int32>) -> Tensor {
-    let rankDiff = (rankTensor - otherShape.scalarCountTensor).rankLifted()
-    let ones: Tensor<Int32> = Raw.fill(dims: rankDiff, value: Tensor<Int32>(1))
-    let paddedShape = ones ++ otherShape
-    let nonEqualIndices = paddedShape .!= shapeTensor
-    let broadcastIndices = Raw.where_(nonEqualIndices).flattened()
-    let unbroadcasted: Tensor = Raw.sum(
-      self, reductionIndices: Tensor<Int32>(broadcastIndices), keepDims: false)
-    return Raw.reshape(unbroadcasted, shape: otherShape)
-  }
-
-  @inlinable @inline(__always)
-  func unbroadcast<OtherScalar>(like other: Tensor<OtherScalar>) -> Tensor {
-    return unbroadcast(toShape: other.shapeTensor)
-  }
-
-  @inlinable @inline(__always)
-  func unbroadcast(to shape: TensorShape) -> Tensor {
-    return unbroadcast(toShape: Tensor<Int32>(shape.dimensions.map(Int32.init)))
-  }
 
   @inlinable @inline(__always)
   static func .= (lhs: inout Tensor, rhs: Tensor) {

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -219,6 +219,7 @@ TensorADTests.testAllBackends("Differentiate global") {
 }
 
 TensorADTests.testAllBackends("Side effects") {
+/* This is failing reshape for some reason
   let foo: @differentiable (Tensor<Float>) -> Tensor<Float> = { x in
     var a = x
     a = a + x
@@ -226,6 +227,7 @@ TensorADTests.testAllBackends("Side effects") {
     return a + x
   }
   expectEqual(Tensor([8, 8]), pullback(at: Tensor(4), in: foo)([1, 1]))
+*/
 
   func bar(x: Tensor<Float>) -> Tensor<Float> {
     var a = x

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -25,6 +25,18 @@ TensorADTests.testAllBackends("TestSimpleGrad") {
   expectEqual([[20], [40]], gradient(at: [[10], [20]], in: square))
 }
 
+// TODO: This is also failing!
+TensorADTests.testAllBackends("TestBroadcastingGrad") {
+  func foo(_ x: Tensor<Float>, _ y: Tensor<Float>) -> Tensor<Float> {
+    return x * y + x
+  }
+  let x = Tensor<Float>(ones: [1, 2, 1, 4])
+  let y = Tensor<Float>(ones: [4, 1, 3, 1])
+  let (dx, dy) = gradient(at: x, y, in: foo)
+  expectEqual(x.shape, dx.shape)
+  expectEqual(y.shape, dx.shape)
+}
+
 TensorADTests.testAllBackends("TestGenericGrad") {
   func square<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     return x * x
@@ -219,7 +231,7 @@ TensorADTests.testAllBackends("Differentiate global") {
 }
 
 TensorADTests.testAllBackends("Side effects") {
-/* This is failing reshape for some reason
+///* This is failing reshape for some reason
   let foo: @differentiable (Tensor<Float>) -> Tensor<Float> = { x in
     var a = x
     a = a + x
@@ -227,7 +239,7 @@ TensorADTests.testAllBackends("Side effects") {
     return a + x
   }
   expectEqual(Tensor([8, 8]), pullback(at: Tensor(4), in: foo)([1, 1]))
-*/
+//*/
 
   func bar(x: Tensor<Float>) -> Tensor<Float> {
     var a = x


### PR DESCRIPTION
In the pullback for operators that broadcast, use `Raw.broadcastGradientArgs(s0:s1:)` to compute reduction indices instead of using the inefficient `unbroadcast(to:)`.

`unbroadcast(to:)` was introduced only for defining derivatives for broadcasting operators and has no practical use, so now we remove it.

Operators affected:
- `Tensor.+(_:_:)`
- `Tensor.-(_:_:)`
- `Tensor.*(_:_:)`
- `Tensor./(_:_:)`
- `min(_:_:)`
- `max(_:_:)`
- `pow(_:_:)`

**TODO before merging:**
Currently there's a failure on `+` (see the test being commented out). Figure out what's wrong and fix it.