### PR TITLE
[Accelerate] [vImage] Fix `arrayFromBuffer` in tests.

### DIFF
--- a/test/stdlib/Accelerate_vImage.swift
+++ b/test/stdlib/Accelerate_vImage.swift
@@ -64,6 +64,7 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
                                              destination: &destinationCGBuffer)
         
         let destinationPixels: [UInt8] = arrayFromBuffer(buffer: destinationCGBuffer,
+                                                         channelCount: 4,
                                                          count: pixels.count)
         
         expectEqual(destinationPixels, pixels)
@@ -187,8 +188,10 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         // Compare results
         
         let destinationPixels: [UInt8] = arrayFromBuffer(buffer: destinationBuffer,
+                                                         channelCount: 4,
                                                          count: pixels.count)
         let legacyDestinationPixels: [UInt8] = arrayFromBuffer(buffer: legacyDestinationBuffer,
+                                                               channelCount: 4,
                                                                count: pixels.count)
         
         expectTrue(legacyDestinationPixels.elementsEqual(destinationPixels))
@@ -300,8 +303,10 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
                          pixelSize: 4)
         
         let sourcePixels: [UInt8] = arrayFromBuffer(buffer: source,
+                                                    channelCount: 4,
                                                     count: pixels.count)
         let destinationPixels: [UInt8] = arrayFromBuffer(buffer: destination,
+                                                         channelCount: 4,
                                                          count: pixels.count)
         
         expectTrue(sourcePixels.elementsEqual(destinationPixels))
@@ -325,6 +330,7 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
                                         format:  format)
         
         let bufferPixels: [UInt8] = arrayFromBuffer(buffer: buffer,
+                                                    channelCount: 4,
                                                     count: pixels.count)
         
         expectTrue(bufferPixels.elementsEqual(pixels))
@@ -386,9 +392,11 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         }()
         
         let bufferPixels: [UInt8] = arrayFromBuffer(buffer: buffer,
+                                                    channelCount: 4,
                                                     count: pixels.count)
         
         let legacyBufferPixels: [UInt8] = arrayFromBuffer(buffer: legacyBuffer,
+                                                          channelCount: 4,
                                                           count: pixels.count)
         
         expectTrue(bufferPixels.elementsEqual(legacyBufferPixels))
@@ -550,7 +558,7 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         expectTrue(vImageCGImageFormat_IsEqual(&format, &legacyFormat))
         expectTrue(format.componentCount == 4)
     }
-    
+
     //===----------------------------------------------------------------------===//
     //
     //  MARK: Helper Functions
@@ -569,10 +577,33 @@ if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
         return pixelBuffer
     }
     
-    func arrayFromBuffer<T>(buffer: vImage_Buffer, count: Int) -> Array<T> {
-        let ptr = buffer.data.bindMemory(to: T.self, capacity: count)
-        let buf = UnsafeBufferPointer(start: ptr, count: count)
-        return Array(buf)
+    func arrayFromBuffer<T>(buffer: vImage_Buffer,
+                            channelCount: Int,
+                            count: Int) -> Array<T> {
+        
+        if (buffer.rowBytes == Int(buffer.width) * MemoryLayout<T>.stride * channelCount) {
+            let ptr = buffer.data.bindMemory(to: T.self,
+                                             capacity: count)
+            
+            let buf = UnsafeBufferPointer(start: ptr, count: count)
+            return Array(buf)
+        } else {
+            var returnArray = [T]()
+            
+            let perRowCount = Int(buffer.width) * MemoryLayout<T>.stride * channelCount
+            var ptr = buffer.data.bindMemory(to: T.self,
+                                             capacity: perRowCount)
+            
+            for _ in 0 ..< buffer.height {
+                let buf = UnsafeBufferPointer(start: ptr, count: perRowCount)
+                
+                returnArray.append(contentsOf: Array(buf))
+                
+                ptr = ptr.advanced(by: buffer.rowBytes)
+            }
+            
+            return returnArray
+        }
     }
     
     func imageToPixels(image: CGImage) -> [UInt8] {


### PR DESCRIPTION
A buffer's `data` may contain padding (containing undefined data) when the `rowBytes` isn't equal to the number of channels * width * size of the element. I've updated `arrayFromBuffer` to return an array that excludes any `rowByte` padding in that case. 

cc: @stephentyrone 