### PR TITLE
 IRGen: Disable eager initialization of NSCoding adopters on newer targets [5.1]

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -383,6 +383,15 @@ namespace swift {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 
+    // The following deployment targets ship an Objective-C runtime supporting
+    // the class metadata update callback mechanism:
+    //
+    // - macOS 10.14.4
+    // - iOS 12.2
+    // - tvOS 12.2
+    // - watchOS 5.2
+    bool doesTargetSupportObjCMetadataUpdateCallback() const;
+
     /// Returns true if the given platform condition argument represents
     /// a supported target operating system.
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -392,6 +392,15 @@ namespace swift {
     // - watchOS 5.2
     bool doesTargetSupportObjCMetadataUpdateCallback() const;
 
+    // The following deployment targets ship an Objective-C runtime supporting
+    // the objc_getClass() hook:
+    //
+    // - macOS 10.14.4
+    // - iOS 12.2
+    // - tvOS 12.2
+    // - watchOS 5.2
+    bool doesTargetSupportObjCGetClassHook() const;
+
     /// Returns true if the given platform condition argument represents
     /// a supported target operating system.
     ///

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -288,3 +288,7 @@ bool LangOptions::doesTargetSupportObjCMetadataUpdateCallback() const {
   // tests that -enable-objc-interop.
   return false;
 }
+
+bool LangOptions::doesTargetSupportObjCGetClassHook() const {
+  return doesTargetSupportObjCMetadataUpdateCallback();
+}

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -275,3 +275,16 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
 
   return { false, false };
 }
+
+bool LangOptions::doesTargetSupportObjCMetadataUpdateCallback() const {
+  if (Target.isMacOSX())
+    return !Target.isMacOSXVersionLT(10, 14, 4);
+  if (Target.isiOS()) // also returns true on tvOS
+    return !Target.isOSVersionLT(12, 2);
+  if (Target.isWatchOS())
+    return !Target.isOSVersionLT(5, 2);
+
+  // If we're running on a non-Apple platform, we still want to allow running
+  // tests that -enable-objc-interop.
+  return false;
+}

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2327,7 +2327,7 @@ IRGenModule::getClassMetadataStrategy(const ClassDecl *theClass) {
 
     // If the Objective-C runtime is new enough, we can just use the update
     // pattern unconditionally.
-    if (Types.doesPlatformSupportObjCMetadataUpdateCallback())
+    if (Context.LangOpts.doesTargetSupportObjCMetadataUpdateCallback())
       return ClassMetadataStrategy::Update;
 
     // Otherwise, check if we have legacy type info for backward deployment.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1439,8 +1439,8 @@ void IRGenerator::emitEagerClassInitialization() {
   RegisterFn->setCallingConv(IGM->DefaultCC);
 
   for (ClassDecl *CD : ClassesForEagerInitialization) {
-    Type Ty = CD->getDeclaredType();
-    llvm::Value *MetaData = RegisterIGF.emitTypeMetadataRef(getAsCanType(Ty));
+    auto Ty = CD->getDeclaredType()->getCanonicalType();
+    llvm::Value *MetaData = RegisterIGF.emitTypeMetadataRef(Ty);
     assert(CD->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>());
 
     // Get the metadata to make sure that the class is registered. We need to 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1147,37 +1147,19 @@ static bool doesPlatformUseLegacyLayouts(StringRef platformName,
   return false;
 }
 
-// The following Apple platforms ship an Objective-C runtime supporting
-// the class metadata update hook:
-//
-// - macOS 10.14.4
-// - iOS 12.2
-// - tvOS 12.2
-// - watchOS 5.2
-static bool doesPlatformSupportObjCMetadataUpdateCallback(
-    const llvm::Triple &triple) {
-  if (triple.isMacOSX())
-    return !triple.isMacOSXVersionLT(10, 14, 4);
-  if (triple.isiOS()) // also returns true on tvOS
-    return !triple.isOSVersionLT(12, 2);
-  if (triple.isWatchOS())
-    return !triple.isOSVersionLT(5, 2);
-
-  return false;
-}
-
 TypeConverter::TypeConverter(IRGenModule &IGM)
   : IGM(IGM),
     FirstType(invalidTypeInfo()) {
-  const auto &Triple = IGM.Context.LangOpts.Target;
-
-  SupportsObjCMetadataUpdateCallback =
-    ::doesPlatformSupportObjCMetadataUpdateCallback(Triple);
+  // Whether the Objective-C runtime is guaranteed to invoke the class
+  // metadata update callback when realizing a Swift class referenced from
+  // Objective-C.
+  bool supportsObjCMetadataUpdateCallback =
+    IGM.Context.LangOpts.doesTargetSupportObjCMetadataUpdateCallback();
 
   // If our deployment target allows us to rely on the metadata update
   // callback being called, we don't have to emit a legacy layout for a
   // class with resiliently-sized fields.
-  if (SupportsObjCMetadataUpdateCallback)
+  if (supportsObjCMetadataUpdateCallback)
     return;
 
   // We have a bunch of -parse-stdlib tests that pass a -target in the test
@@ -1191,6 +1173,8 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
 
   StringRef path = IGM.IRGen.Opts.ReadLegacyTypeInfoPath;
   if (path.empty()) {
+    const auto &Triple = IGM.Context.LangOpts.Target;
+
     // If the flag was not explicitly specified, look for a file in a
     // platform-specific location, if this platform is known to require
     // one.

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -114,7 +114,6 @@ private:
   const LoadableTypeInfo *SwiftRetainablePointerBoxTI = nullptr,
                          *UnknownObjectRetainablePointerBoxTI = nullptr;
 
-  bool SupportsObjCMetadataUpdateCallback = false;
   llvm::StringMap<YAMLTypeInfoNode> LegacyTypeInfos;
   llvm::DenseMap<NominalTypeDecl *, std::string> DeclMangledNames;
 
@@ -158,10 +157,6 @@ public:
 
   Mode getLoweringMode() const {
     return LoweringMode;
-  }
-
-  bool doesPlatformSupportObjCMetadataUpdateCallback() const {
-    return SupportsObjCMetadataUpdateCallback;
   }
 
   const TypeInfo *getTypeEntry(CanType type);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -814,15 +814,8 @@ void IRGenerator::addClassForEagerInitialization(ClassDecl *ClassDecl) {
   if (!ClassDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 
-  // Exclude some classes where those attributes make no sense but could be set
-  // for some reason. Just to be on the safe side.
-  Type ClassTy = ClassDecl->getDeclaredType();
-  if (ClassTy->is<UnboundGenericType>())
-    return;
-  if (ClassTy->hasArchetype())
-    return;
-  if (ClassDecl->hasClangNode())
-    return;
+  assert(!ClassDecl->isGenericContext());
+  assert(!ClassDecl->hasClangNode());
 
   ClassesForEagerInitialization.push_back(ClassDecl);
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4925,6 +4925,12 @@ static void inferStaticInitializeObjCMetadata(TypeChecker &tc,
   if (classDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 
+  // If the class does not have a custom @objc name and the deployment target
+  // supports the objc_getClass() hook, the workaround is unnecessary.
+  if (tc.Context.LangOpts.doesTargetSupportObjCGetClassHook() &&
+      !hasExplicitObjCName(classDecl))
+    return;
+
   // If we know that the Objective-C metadata will be statically registered,
   // there's nothing to do.
   if (!classDecl->checkAncestry(AncestryFlags::Generic)) {

--- a/test/IRGen/eager-class-initialization.swift
+++ b/test/IRGen/eager-class-initialization.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -target x86_64-apple-macosx10.14.4 -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK
+// REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
+
+import Foundation
+
+class BaseWithCoding : NSObject, NSCoding {
+  required init(coder: NSCoder) { fatalError() }
+
+  func encode(coder: NSCoder) { fatalError() }
+}
+
+class Generic<T> : BaseWithCoding {}
+
+class GenericAncestry : Generic<Int> {}
+
+@objc(custom_name)
+class GenericAncestryWithCustomName : Generic<Double> {}
+
+// CHECK-LABEL: define {{.*}} @_swift_eager_class_initialization
+// CHECK-NEXT:  entry:
+// CHECK-OLD-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s4main15GenericAncestryCMa"([[INT]] 0)
+// CHECK-OLD-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK-OLD-NEXT: call void asm sideeffect "", "r"(%swift.type* [[METADATA]])
+// CHECK-NEXT:     [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s4main29GenericAncestryWithCustomNameCMa"([[INT]] 0)
+// CHECK-NEXT:     [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK-NEXT:     call void asm sideeffect "", "r"(%swift.type* [[METADATA]])
+// CHECK-NEXT:     ret

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -1,18 +1,20 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name=test -DENCODE -o %t/encode
-// RUN: %target-build-swift %s -module-name=test -o %t/decode
-// RUN: %target-build-swift %s -module-name=test -Xfrontend -disable-llvm-optzns -emit-ir | %FileCheck -check-prefix=CHECK-IR %s
 // RUN: %target-run %t/encode %t/test.arc
 // RUN: plutil -p %t/test.arc | %FileCheck -check-prefix=CHECK-ARCHIVE %s
-// RUN: %target-run %t/decode %t/test.arc | %FileCheck %s
+
+// RUN: %target-build-swift %s -module-name=test -o %t/decode
+// RUN: %target-run %t/decode %t/test.arc --stdlib-unittest-in-process
+
+// RUN: %target-build-swift %s -module-name=test -o %t/decode -target x86_64-apple-macosx10.14.4
+// RUN: %target-run %t/decode %t/test.arc NEW --stdlib-unittest-in-process
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: CPU=i386 || CPU=x86_64
-// UNSUPPORTED: OS=tvos
-// UNSUPPORTED: OS=watchos
+// REQUIRES: OS=macosx
 
 import Foundation
+import StdlibUnittest
 
 struct ABC {
   // CHECK-ARCHIVE-DAG: "$classname" => "nested_class_coding"
@@ -133,59 +135,37 @@ class TopLevel : NSObject, NSCoding {
   }
 }
 
-func main() {
-
-  let args = CommandLine.arguments
-
 #if ENCODE
-  let c = TopLevel(27)
-  c.nested = ABC.NestedClass(28)
-  c.priv = PrivateClass(29)
-  c.intc = IntClass(ii: 42)
-  c.doublec = DoubleClass(dd: 3.14)
+let c = TopLevel(27)
+c.nested = ABC.NestedClass(28)
+c.priv = PrivateClass(29)
+c.intc = IntClass(ii: 42)
+c.doublec = DoubleClass(dd: 3.14)
 
-  NSKeyedArchiver.archiveRootObject(c, toFile: args[1])
+NSKeyedArchiver.archiveRootObject(c, toFile: CommandLine.arguments[1])
 #else
-  if let u = NSKeyedUnarchiver.unarchiveObject(withFile: args[1]) {
-    if let x = u as? TopLevel {
-      // CHECK: top-level: 27
-      print("top-level: \(x.tli)")
-      if let n = x.nested {
-        // CHECK: nested: 28
-        print("nested: \(n.i)")
-      }
-      if let p = x.priv {
-        // CHECK: private: 29
-        print("private: \(p.pi)")
-      }
-      if let g = x.intc {
-        // CHECK: int: 42
-        print("int: \(g.gi!)")
-      }
-      if let d = x.doublec {
-        // CHECK: double: 3.14
-        print("double: \(d.gi!)")
-      }
-    } else {
-      print(u)
-    }
-  } else {
-    print("nil")
+var DecodeTestSuite = TestSuite("Decode")
+
+DecodeTestSuite.test("Decode") {
+  func doIt() {
+    let u = NSKeyedUnarchiver.unarchiveObject(withFile: CommandLine.arguments[1])!
+    let x = u as! TopLevel
+    expectEqual(27, x.tli)
+    expectEqual(28, x.nested!.i)
+    expectEqual(29, x.priv!.pi)
+    expectEqual(42, x.intc!.gi!)
+    expectEqual(3.14, x.doublec!.gi!)
   }
-#endif
+
+  if CommandLine.arguments[2] == "NEW" {
+    if #available(macOS 10.14.4, *) {
+      doIt()
+    }
+    return
+  }
+
+  doIt()
 }
 
-main()
-
-// Check that we eagerly create metadata of generic classes, but not for nested classes.
-
-// CHECK-IR-LABEL: define {{.*}} @_swift_eager_class_initialization
-// CHECK-IR-NEXT:  entry:
-// CHECK-IR-NEXT:    call {{.*}}IntClassCMa
-// CHECK-IR-NEXT:    extractvalue
-// CHECK-IR-NEXT:    call void asm
-// CHECK-IR-NEXT:    call {{.*}}DoubleClassCMa
-// CHECK-IR-NEXT:    extractvalue
-// CHECK-IR-NEXT:    call void asm
-// CHECK-IR-NEXT:    ret
-
+runAllTests()
+#endif


### PR DESCRIPTION
Fixes <rdar://problem/49660515>.