### PR TITLE
[Build System: CMake] Install the apinotes in the 'compiler' install component.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,15 @@ option(SWIFT_INCLUDE_DOCS
     "Create targets for building docs."
     TRUE)
 
+set(_swift_include_apinotes_default FALSE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(_swift_include_apinotes_default TRUE)
+endif()
+
+option(SWIFT_INCLUDE_APINOTES
+  "Create targets for installing the remaining apinotes in the built toolchain."
+  ${_swift_include_apinotes_default})
+
 #
 # Miscellaneous User-configurable options.
 #
@@ -1042,12 +1051,8 @@ endif()
 # https://bugs.swift.org/browse/SR-5975
 add_subdirectory(stdlib)
 
-if(SWIFT_BUILD_SDK_OVERLAY)
-  list_intersect("${SWIFT_APPLE_PLATFORMS}" "${SWIFT_SDKS}"
-                 building_darwin_sdks)
-  if(building_darwin_sdks)
-    add_subdirectory(apinotes)
-  endif()
+if(SWIFT_INCLUDE_APINOTES)
+  add_subdirectory(apinotes)
 endif()
 
 add_subdirectory(include)

--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -28,10 +28,6 @@ add_custom_target("copy_apinotes"
     COMMENT "Copying API notes to ${output_dir}"
     SOURCES "${sources}")
 
-# This is treated as an OPTIONAL target because if we don't build the SDK
-# overlay, the files will be missing anyway. It also allows us to build
-# single overlays without installing the API notes.
 swift_install_in_component(DIRECTORY "${output_dir}"
                            DESTINATION "lib/swift/"
-                           COMPONENT sdk-overlay
-                           OPTIONAL)
+                           COMPONENT compiler)

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -4,6 +4,13 @@ set(swift_platform_sources
 set(swift_platform_gyb_sources
     tgmath.swift.gyb)
 
+set(darwin_depends)
+if(NOT BUILD_STANDALONE)
+  # This is overly conservative, but we have so few API notes files that
+  # haven't migrated to the Swift repo that it's probably fine in practice.
+  list(APPEND darwin_depends copy_apinotes)
+endif()
+
 add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     ${swift_platform_sources}
     POSIXError.swift
@@ -19,9 +26,7 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
     TARGET_SDKS ALL_APPLE_PLATFORMS
 
-    # This is overly conservative, but we have so few API notes files that
-    # haven't migrated to the Swift repo that it's probably fine in practice.
-    DEPENDS copy_apinotes)
+    DEPENDS ${darwin_depends})
 
 add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     ${swift_platform_sources}


### PR DESCRIPTION
We should always install the remaining `apinotes` when building and installing the `compiler` component. That way they'll always end up in the toolchain, even if you aren't building the standard library.

rdar://50390238