### PR TITLE
[5.1][CMake] Split overlay list to multiple lines (NFC)

### DIFF
--- a/stdlib/public/Darwin/CMakeLists.txt
+++ b/stdlib/public/Darwin/CMakeLists.txt
@@ -8,7 +8,53 @@ if(SWIFT_BUILD_STATIC_SDK_OVERLAY)
   list(APPEND SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES STATIC)
 endif()
 
-set(all_overlays "Accelerate;AppKit;ARKit;AssetsLibrary;AVFoundation;CallKit;CloudKit;Compression;Contacts;CoreAudio;CoreData;CoreFoundation;CoreGraphics;CoreImage;CoreLocation;CoreMedia;CryptoTokenKit;Dispatch;Foundation;GameplayKit;GLKit;HomeKit;IOKit;Intents;MapKit;MediaPlayer;Metal;MetalKit;ModelIO;NaturalLanguage;Network;ObjectiveC;OpenCL;os;Photos;QuartzCore;SafariServices;SceneKit;simd;SpriteKit;UIKit;Vision;WatchKit;XCTest;XPC")
+set(all_overlays
+  Accelerate
+  AppKit
+  ARKit
+  AssetsLibrary
+  AVFoundation
+  CallKit
+  CloudKit
+  Compression
+  Contacts
+  CoreAudio
+  CoreData
+  CoreFoundation
+  CoreGraphics
+  CoreImage
+  CoreLocation
+  CoreMedia
+  CryptoTokenKit
+  Dispatch
+  Foundation
+  GameplayKit
+  GLKit
+  HomeKit
+  IOKit
+  Intents
+  MapKit
+  MediaPlayer
+  Metal
+  MetalKit
+  ModelIO
+  NaturalLanguage
+  Network
+  ObjectiveC
+  OpenCL
+  os
+  Photos
+  QuartzCore
+  SafariServices
+  SceneKit
+  simd
+  SpriteKit
+  UIKit
+  Vision
+  WatchKit
+  XCTest
+  XPC
+)
 
 if(DEFINED SWIFT_OVERLAY_TARGETS)
   set(overlays_to_build ${SWIFT_OVERLAY_TARGETS})


### PR DESCRIPTION
(cherry picked from commit 1dbb4830c5ca465b4ee2de334f78f96db31f41b6 in #24421)

Split `all_overlays` into a newline-separated list for easier reading/diffing. NFC