### PR TITLE
build: don't always load clang/cmark

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -196,13 +196,12 @@ endmacro()
 #   product
 #     The product name, e.g. Swift or SourceKit. Used as prefix for some
 #     cmake variables.
-#
-#   is_cross_compiling
-#     Whether this is cross-compiling host tools.
 macro(swift_common_standalone_build_config product)
   swift_common_standalone_build_config_llvm(${product})
-  swift_common_standalone_build_config_clang(${product})
-  swift_common_standalone_build_config_cmark(${product})
+  if(SWIFT_INCLUDE_TOOLS)
+    swift_common_standalone_build_config_clang(${product})
+    swift_common_standalone_build_config_cmark(${product})
+  endif()
 
   # Enable groups for IDE generators (Xcode and MSVC).
   set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
clang/cmark are only needed for the tools, not for the runtime/SDK
overlay.  Do not attempt to configure clang and CMark in the case we do
not build the tools.  This is needed to enable the standalone standard
library only builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
