### PR TITLE
[5.1][Stdlib] Make the SwiftNativeNSXXXBase classes gracefully handle being decoded with NSKeyedUnarchiver.

### DIFF
--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -62,6 +62,9 @@ SWIFT_RUNTIME_STDLIB_API
 
 @implementation __SwiftNativeNS${Class}Base
 
+- (id)initWithCoder: (NSCoder *)coder {
+  return [self init];
+}
 - (id)retain {
   auto SELF = reinterpret_cast<HeapObject *>(self);
   swift_retain(SELF);

--- a/test/Interpreter/SDK/SwiftNativeNSXXXCoding.swift
+++ b/test/Interpreter/SDK/SwiftNativeNSXXXCoding.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+let testSuite = TestSuite("SwiftNativeNSXXXCoding")
+
+// Ensure that T gracefully handles being decoded. It doesn't have to
+// work, just not crash.
+private func test<T: NSObject & NSCoding>(type: T.Type) {
+  if #available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+    let swiftClassName = "__SwiftNative\(type)Base"
+    print(swiftClassName)
+    let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+    archiver.setClassName(swiftClassName, for: T.self)
+    archiver.encode(T(), forKey: "key")
+    archiver.finishEncoding()
+    let d = archiver.encodedData
+  
+    let unarchiver = try! NSKeyedUnarchiver(forReadingFrom: d)
+    _ = unarchiver.decodeObject(of: T.self, forKey: "key")
+  }
+}
+
+
+// Test all the classes listed in SwiftNativeNSXXXBase.mm.gyb except for
+// NSEnumerator (which doesn't conform to NSCoding).
+
+testSuite.test("NSArray") {
+  test(type: NSArray.self)
+}
+
+testSuite.test("NSDictionary") {
+  test(type: NSDictionary.self)
+}
+
+testSuite.test("NSSet") {
+  test(type: NSSet.self)
+}
+
+testSuite.test("NSString") {
+  test(type: NSString.self)
+}
+
+testSuite.test("NSData") {
+  test(type: NSData.self)
+}
+
+testSuite.test("NSIndexSet") {
+  test(type: NSIndexSet.self)
+}
+
+runAllTests()


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24394 to 5.1.

These would never be decoded in normal use, but it's possible to construct an archive that will attempt to decode them. Without this override, that throws an exception or worse.

rdar://problem/48429185