### PR TITLE
[CMake] Workaround circular linkage dependency

### DIFF
--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -13,4 +13,5 @@ target_link_libraries(SwiftASTTests
    # FIXME: Circular dependencies.
    swiftParse
    swiftSema
+   swiftSIL
 )

--- a/unittests/ClangImporter/CMakeLists.txt
+++ b/unittests/ClangImporter/CMakeLists.txt
@@ -3,8 +3,10 @@ add_swift_unittest(SwiftClangImporterTests
 )
 
 target_link_libraries(SwiftClangImporterTests
-    PRIVATE
-    swiftClangImporter
-    swiftParse
-    swiftAST
+  PRIVATE
+  swiftClangImporter
+  swiftParse
+  swiftAST
+  # FIXME: Circular dependencies.
+  swiftSIL
 )


### PR DESCRIPTION
As of cec1a5268e4028fd6a7246dfd7f5661198aad52d (GitHub #24224), the AST now depends on SIL.