### PR TITLE
Add useful diagnostic when trying to write through key path on private(set) var

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1008,7 +1008,7 @@ bool AssignmentFailure::diagnoseAsError() {
     // Otherwise, we cannot resolve this because the available setter candidates
     // are all mutating and the base must be mutating.  If we dug out a
     // problematic decl, we can produce a nice tailored diagnostic.
-    if (auto *VD = dyn_cast_or_null<VarDecl>(choice->getDecl())) {
+    if (auto *VD = dyn_cast<VarDecl>(choice->getDecl())) {
       std::string message = "'";
       message += VD->getName().str().str();
       message += "'";

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -989,16 +989,16 @@ bool AssignmentFailure::diagnoseAsError() {
     if (!choice->isDecl()) {
       if (choice->getKind() == OverloadChoiceKind::KeyPathApplication &&
           !isa<ApplyExpr>(immInfo.first)) {
-        std::string message = "the key path";
+        std::string message = "";
         if (auto *SE = dyn_cast<SubscriptExpr>(immInfo.first)) {
           if (auto *tupleExpr = dyn_cast<TupleExpr>(SE->getIndex())) {
             if (auto *DRE = dyn_cast<DeclRefExpr>(tupleExpr->getElement(0))) {
               auto identifier = DRE->getDecl()->getBaseName().getIdentifier();
-              message = "'" + identifier.str().str() + "'";
+              message = "'" + identifier.str().str() + "' ";
             }
           }
         }
-        emitDiagnostic(Loc, DeclDiagnostic, message + " is a read-only key path")
+        emitDiagnostic(Loc, DeclDiagnostic, message + "is read-only")
             .highlight(immInfo.first->getSourceRange());
         return true;
       }
@@ -1016,7 +1016,7 @@ bool AssignmentFailure::diagnoseAsError() {
       auto type = getType(immInfo.first);
 
       if (isKnownKeyPathType(type))
-        message += " is a read-only key path";
+        message += " is read-only";
       else if (VD->isCaptureList())
         message += " is an immutable capture";
       else if (VD->isImplicit())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -989,6 +989,7 @@ bool AssignmentFailure::diagnoseAsError() {
     auto getKeyPathArgument = [](SubscriptExpr *expr) {
       auto *TE = dyn_cast<TupleExpr>(expr->getIndex());
       assert(TE->getNumElements() == 1);
+      assert(TE->getElementName(0).str() == "keyPath");
       return TE->getElement(0);
     };
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -633,8 +633,10 @@ private:
   /// to complain about "x" being a let property if "v.v" are both mutable.
   ///
   /// \returns The base subexpression that looks immutable (or that can't be
-  /// analyzed any further) along with a decl extracted from it if we could.
-  std::pair<Expr *, ValueDecl *> resolveImmutableBase(Expr *expr) const;
+  /// analyzed any further) along with an OverloadChoice extracted from it if we
+  /// could.
+  std::pair<Expr *, Optional<OverloadChoice>>
+  resolveImmutableBase(Expr *expr) const;
 
   static Diag<StringRef> findDeclDiagonstic(ASTContext &ctx, Expr *destExpr);
 
@@ -650,7 +652,7 @@ private:
 
   /// Retrive an member reference associated with given member
   /// looking through dynamic member lookup on the way.
-  ValueDecl *getMemberRef(ConstraintLocator *locator) const;
+  Optional<OverloadChoice> getMemberRef(ConstraintLocator *locator) const;
 };
 
 /// Intended to diagnose any possible contextual failure

--- a/test/Constraints/keypath_swift_5.swift
+++ b/test/Constraints/keypath_swift_5.swift
@@ -7,7 +7,7 @@ struct S {
     let _: WritableKeyPath<S, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type 'WritableKeyPath<S, Int>'}}
 
     S()[keyPath: \.i] = 1
-    // expected-error@-1 {{cannot assign through subscript: the key path is a read-only key path}}
+    // expected-error@-1 {{cannot assign through subscript: is read-only}}
   }
 }
 
@@ -15,7 +15,7 @@ func test() {
   let _: WritableKeyPath<C, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<C, Int>' to specified type 'WritableKeyPath<C, Int>'}}
 
   C()[keyPath: \.i] = 1
-  // expected-error@-1 {{cannot assign through subscript: the key path is a read-only key path}}
+  // expected-error@-1 {{cannot assign through subscript: is read-only}}
 
   let _ = C()[keyPath: \.i] // no warning for a read
 }
@@ -31,6 +31,6 @@ struct T {
 func testReadOnlyKeyPathDiagnostics() {
   let path = \T.a
   var t = T(a: 3)
-  t[keyPath: path] = 4 // expected-error {{cannot assign through subscript: 'path' is a read-only key path}}
-  t[keyPath: \T.a] = 4 // expected-error {{cannot assign through subscript: the key path is a read-only key path}}
+  t[keyPath: path] = 4 // expected-error {{cannot assign through subscript: 'path' is read-only}}
+  t[keyPath: \T.a] = 4 // expected-error {{cannot assign through subscript: is read-only}}
 }

--- a/test/Constraints/keypath_swift_5.swift
+++ b/test/Constraints/keypath_swift_5.swift
@@ -7,7 +7,7 @@ struct S {
     let _: WritableKeyPath<S, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type 'WritableKeyPath<S, Int>'}}
 
     S()[keyPath: \.i] = 1
-    // expected-error@-1 {{cannot assign through subscript: is read-only}}
+    // expected-error@-1 {{cannot assign through subscript: key path is read-only}}
   }
 }
 
@@ -15,22 +15,22 @@ func test() {
   let _: WritableKeyPath<C, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<C, Int>' to specified type 'WritableKeyPath<C, Int>'}}
 
   C()[keyPath: \.i] = 1
-  // expected-error@-1 {{cannot assign through subscript: is read-only}}
+  // expected-error@-1 {{cannot assign through subscript: key path is read-only}}
 
   let _ = C()[keyPath: \.i] // no warning for a read
 }
 
 
 struct T {
-    private(set) var a: Int
-    init(a: Int) {
-        self.a = a
-    }
+  private(set) var a: Int
+  init(a: Int) {
+    self.a = a
+  }
 }
 
 func testReadOnlyKeyPathDiagnostics() {
   let path = \T.a
   var t = T(a: 3)
-  t[keyPath: path] = 4 // expected-error {{cannot assign through subscript: 'path' is read-only}}
-  t[keyPath: \T.a] = 4 // expected-error {{cannot assign through subscript: is read-only}}
+  t[keyPath: path] = 4 // expected-error {{cannot assign through subscript: 'path' is a read-only key path}}
+  t[keyPath: \T.a] = 4 // expected-error {{cannot assign through subscript: key path is read-only}}
 }

--- a/test/Constraints/keypath_swift_5.swift
+++ b/test/Constraints/keypath_swift_5.swift
@@ -7,7 +7,7 @@ struct S {
     let _: WritableKeyPath<S, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type 'WritableKeyPath<S, Int>'}}
 
     S()[keyPath: \.i] = 1
-    // expected-error@-1 {{cannot assign through subscript: immutable key path}}
+    // expected-error@-1 {{cannot assign through subscript: the key path is a read-only key path}}
   }
 }
 
@@ -15,7 +15,22 @@ func test() {
   let _: WritableKeyPath<C, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<C, Int>' to specified type 'WritableKeyPath<C, Int>'}}
 
   C()[keyPath: \.i] = 1
-  // expected-error@-1 {{cannot assign through subscript: immutable key path}}
+  // expected-error@-1 {{cannot assign through subscript: the key path is a read-only key path}}
 
   let _ = C()[keyPath: \.i] // no warning for a read
+}
+
+
+struct T {
+    private(set) var a: Int
+    init(a: Int) {
+        self.a = a
+    }
+}
+
+func testReadOnlyKeyPathDiagnostics() {
+  let path = \T.a
+  var t = T(a: 3)
+  t[keyPath: path] = 4 // expected-error {{cannot assign through subscript: 'path' is a read-only key path}}
+  t[keyPath: \T.a] = 4 // expected-error {{cannot assign through subscript: the key path is a read-only key path}}
 }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -301,8 +301,8 @@ func testKeyPathSubscript(readonly: Z, writable: inout Z,
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
 
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
   readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
   writable[keyPath: wkp] = sink
   readonly[keyPath: rkp] = sink
@@ -401,8 +401,8 @@ func testKeyPathSubscriptMetatype(readonly: Z.Type, writable: inout Z.Type,
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
 
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
   readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
   writable[keyPath: wkp] = sink
   readonly[keyPath: rkp] = sink
@@ -421,8 +421,8 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
 
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
   readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
   writable[keyPath: wkp] = sink
   readonly[keyPath: rkp] = sink

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -301,8 +301,8 @@ func testKeyPathSubscript(readonly: Z, writable: inout Z,
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
 
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
   readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
   writable[keyPath: wkp] = sink
   readonly[keyPath: rkp] = sink
@@ -401,8 +401,8 @@ func testKeyPathSubscriptMetatype(readonly: Z.Type, writable: inout Z.Type,
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
 
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
   readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
   writable[keyPath: wkp] = sink
   readonly[keyPath: rkp] = sink
@@ -421,8 +421,8 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
 
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is read-only}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
   readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
   writable[keyPath: wkp] = sink
   readonly[keyPath: rkp] = sink


### PR DESCRIPTION
This changes resolveImmutableBase so that instead of returning std::pair<Expr *, ValueDecl *>, it now returns std::pair<Expr*, Optional<OverloadChoice>>. It then uses this information to produce a better diagnostic.

Resolves [SR-10202](https://bugs.swift.org/browse/SR-10202).
