### PR TITLE
[CodeCompletion] Complete Swift only module name after 'import'

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -860,6 +860,10 @@ public:
   /// not necessarily loaded.
   void getVisibleTopLevelClangModules(SmallVectorImpl<clang::Module*> &Modules) const;
 
+  /// Populate \p names with visible top level module names.
+  /// This guarantees that resulted \p names doesn't have duplicated names.
+  void getVisibleTopLevelModuleNames(SmallVectorImpl<Identifier> &names) const;
+
 private:
   /// Register the given generic signature builder to be used as the canonical
   /// generic signature builder for the given signature, if we don't already

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -856,10 +856,6 @@ public:
     return getIdentifier(getSwiftName(kind));
   }
 
-  /// Collect visible clang modules from the ClangModuleLoader. These modules are
-  /// not necessarily loaded.
-  void getVisibleTopLevelClangModules(SmallVectorImpl<clang::Module*> &Modules) const;
-
   /// Populate \p names with visible top level module names.
   /// This guarantees that resulted \p names doesn't have duplicated names.
   void getVisibleTopLevelModuleNames(SmallVectorImpl<Identifier> &names) const;

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -82,6 +82,13 @@ protected:
 public:
   virtual ~ModuleLoader() = default;
 
+  /// Collect visible module names.
+  ///
+  /// Append visible module names to \p names. Note that names are possibly
+  /// duplicated, and not guaranteed to be ordered in any way.
+  virtual void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const = 0;
+
   /// Check whether the module with a given name can be imported without
   /// importing it.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -119,6 +119,11 @@ public:
   static std::shared_ptr<clang::DependencyCollector>
   createDependencyCollector(bool TrackSystemDeps);
 
+  /// Append visible module names to \p names. Note that names are possibly
+  /// duplicated, and not guaranteed to be ordered in any way.
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override;
+
   /// Check whether the module with a given name can be imported without
   /// importing it.
   ///
@@ -336,7 +341,7 @@ public:
   /// Calling this function does not load the module.
   void collectSubModuleNames(
       ArrayRef<std::pair<Identifier, SourceLoc>> path,
-      std::vector<std::string> &names);
+      std::vector<std::string> &names) const;
 
   /// Given a Clang module, decide whether this module is imported already.
   static bool isModuleImported(const clang::Module *M);

--- a/include/swift/DWARFImporter/DWARFImporter.h
+++ b/include/swift/DWARFImporter/DWARFImporter.h
@@ -66,6 +66,9 @@ public:
 
   ~DWARFImporter();
 
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override;
+
   /// Check whether the module with a given name can be imported without
   /// importing it.
   ///

--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -154,6 +154,11 @@ public:
                                          RemarkOnRebuildFromInterface));
   }
 
+  /// Append visible module names to \p names. Note that names are possibly
+  /// duplicated, and not guaranteed to be ordered in any way.
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override;
+
   /// Unconditionally build \p InPath (a swiftinterface file) to \p OutPath (as
   /// a swiftmodule file).
   ///

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -48,6 +48,11 @@ public:
   SourceLoader &operator=(const SourceLoader &) = delete;
   SourceLoader &operator=(SourceLoader &&) = delete;
 
+  /// Append visible module names to \p names. Note that names are possibly
+  /// duplicated, and not guaranteed to be ordered in any way.
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override;
+
   /// Check whether the module with a given name can be imported without
   /// importing it.
   ///

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -44,6 +44,9 @@ protected:
   SerializedModuleLoaderBase(ASTContext &ctx, DependencyTracker *tracker,
                              ModuleLoadingMode LoadMode);
 
+  void collectVisibleTopLevelModuleNamesImpl(SmallVectorImpl<Identifier> &names,
+                                             StringRef extension) const;
+
   using AccessPathElem = std::pair<Identifier, SourceLoc>;
   bool findModule(AccessPathElem moduleID,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
@@ -169,6 +172,11 @@ class SerializedModuleLoader : public SerializedModuleLoaderBase {
 public:
   virtual ~SerializedModuleLoader();
 
+  /// Append visible module names to \p names. Note that names are possibly
+  /// duplicated, and not guaranteed to be ordered in any way.
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override;
+
   /// Create a new importer that can load serialized Swift modules
   /// into the given ASTContext.
   static std::unique_ptr<SerializedModuleLoader>
@@ -219,6 +227,9 @@ public:
                             std::unique_ptr<llvm::MemoryBuffer> input) {
     MemoryBuffers[AccessPath] = std::move(input);
   }
+
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override {}
 
   /// Create a new importer that can load serialized Swift modules
   /// into the given ASTContext.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1670,6 +1670,19 @@ void ProtocolDecl::setDefaultAssociatedConformanceWitness(
   (void)pair;
 }
 
+void ASTContext::getVisibleTopLevelModuleNames(
+    SmallVectorImpl<Identifier> &names) const {
+  names.clear();
+  for (auto &importer : getImpl().ModuleLoaders)
+    importer->collectVisibleTopLevelModuleNames(names);
+
+  // Sort and unique.
+  std::sort(names.begin(), names.end(), [](Identifier LHS, Identifier RHS) {
+    return LHS.str().compare_lower(RHS.str()) < 0;
+  });
+  names.erase(std::unique(names.begin(), names.end()), names.end());
+}
+
 bool ASTContext::canImportModule(std::pair<Identifier, SourceLoc> ModulePath) {
   // If this module has already been successfully imported, it is importable.
   if (getLoadedModule(ModulePath) != nullptr)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -47,10 +47,6 @@
 #include "swift/Syntax/SyntaxArena.h"
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
-#include "clang/AST/Attr.h"
-#include "clang/AST/DeclObjC.h"
-#include "clang/Lex/HeaderSearch.h"
-#include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
@@ -1421,12 +1417,6 @@ ModuleDecl *ASTContext::getLoadedModule(
 
 ModuleDecl *ASTContext::getLoadedModule(Identifier ModuleName) const {
   return LoadedModules.lookup(ModuleName);
-}
-
-void ASTContext::getVisibleTopLevelClangModules(
-    SmallVectorImpl<clang::Module*> &Modules) const {
-  getClangModuleLoader()->getClangPreprocessor().getHeaderSearchInfo().
-    collectAllModules(Modules);
 }
 
 static AllocationArena getArena(GenericSignature *genericSig) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1494,9 +1494,22 @@ ClangImporter::emitBridgingPCH(StringRef headerPath,
   return false;
 }
 
+void ClangImporter::collectVisibleTopLevelModuleNames(
+    SmallVectorImpl<Identifier> &names) const {
+  SmallVector<clang::Module *, 32> Modules;
+  Impl.getClangPreprocessor().getHeaderSearchInfo().collectAllModules(Modules);
+  for (auto &M : Modules) {
+    if (!M->isAvailable())
+      continue;
+
+    names.push_back(
+        Impl.SwiftContext.getIdentifier(M->getTopLevelModuleName()));
+  }
+}
+
 void ClangImporter::collectSubModuleNames(
     ArrayRef<std::pair<Identifier, SourceLoc>> path,
-    std::vector<std::string> &names) {
+    std::vector<std::string> &names) const {
   auto &clangHeaderSearch = Impl.getClangPreprocessor().getHeaderSearchInfo();
 
   // Look up the top-level module first.

--- a/lib/DWARFImporter/DWARFImporter.cpp
+++ b/lib/DWARFImporter/DWARFImporter.cpp
@@ -142,6 +142,9 @@ DWARFImporter::DWARFImporter(ASTContext &ctx,
 
 DWARFImporter::~DWARFImporter() { delete &Impl; }
 
+void DWARFImporter::collectVisibleTopLevelModuleNames(
+    SmallVectorImpl<Identifier> &names) const {}
+
 bool DWARFImporter::canImportModule(std::pair<Identifier, SourceLoc> named) {
   return false;
 }

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -1377,3 +1377,10 @@ bool ParseableInterfaceModuleLoader::buildSwiftModuleFromSwiftInterface(
   return builder.buildSwiftModule(OutPath, /*shouldSerializeDeps*/true,
                                   /*ModuleBuffer*/nullptr);
 }
+
+void ParseableInterfaceModuleLoader::collectVisibleTopLevelModuleNames(
+    SmallVectorImpl<Identifier> &names) const {
+  collectVisibleTopLevelModuleNamesImpl(
+      names,
+      file_types::getExtension(file_types::TY_SwiftParseableInterfaceFile));
+}

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -33,6 +33,7 @@
 #include "swift/Parse/CodeCompletionCallbacks.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Syntax/SyntaxKind.h"
+#include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -1761,11 +1762,10 @@ public:
 
     auto mainModuleName = CurrDeclContext->getParentModule()->getName();
     for (auto ModuleName : ModuleNames) {
-      if (ModuleName == mainModuleName)
-        continue;
-      if (ModuleName.str().startswith("_"))
-        continue;
-      if (ModuleName == Ctx.SwiftShimsModuleName)
+      if (ModuleName.str().startswith("_") ||
+          ModuleName == mainModuleName ||
+          ModuleName == Ctx.SwiftShimsModuleName ||
+          ModuleName.str() == SWIFT_ONONE_SUPPORT)
         continue;
 
       auto MD = ModuleDecl::create(ModuleName, Ctx);

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -70,6 +70,11 @@ class SkipNonTransparentFunctions : public DelayedParsingCallbacks {
 
 } // unnamed namespace
 
+void SourceLoader::collectVisibleTopLevelModuleNames(
+    SmallVectorImpl<Identifier> &names) const {
+  // TODO: Implement?
+}
+
 bool SourceLoader::canImportModule(std::pair<Identifier, SourceLoc> ID) {
   // Search the memory buffers to see if we can find this file on disk.
   FileOrError inputFileOrError = findModule(Ctx, ID.first.str(),

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -72,8 +72,7 @@ Optional<bool> forEachModuleSearchPath(
       return result;
 
   // Apple platforms have extra implicit framework search paths:
-  // $SDKROOT/System/Library/Frameworks/ ; and
-  // $SDKROOT/Library/Frameworks/
+  // $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
   if (Ctx.LangOpts.Target.isOSDarwin()) {
     SmallString<128> scratch;
     scratch = Ctx.SearchPathOpts.SDKPath;
@@ -154,7 +153,7 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
     switch (Kind) {
     case SearchPathKind::Import: {
       // Look for:
-      // $PATH/{name}.swiftmodule/{arch}.{extension} ; Or
+      // $PATH/{name}.swiftmodule/{arch}.{extension} or
       // $PATH/{name}.{extension}
       forEachDirectoryEntryPath(searchPath, [&](StringRef path) {
         auto pathExt = llvm::sys::path::extension(path);

--- a/test/IDE/complete_import_swiftmodule.swift
+++ b/test/IDE/complete_import_swiftmodule.swift
@@ -67,18 +67,22 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE -F %t/Frameworks -sdk %t -I %t/Modules | %FileCheck %s
 
-// CHECK-NOT: IosInterfaceFW
-// CHECK-NOT: NonTargetInterfaceFW
-// CHECK-NOT: NonTargetSerializedFW
-// CHECK-NOT: IosInterfaceMod
-// CHECK-NOT: DirInterfaceMod
-// CHECK-NOT: EmptyDirInterfaceMod
-// CHECK-NOT: EmptyDirSerializedMod
-// CHECK-NOT: UnrelatedFile
-// CHECK-NOT: ModuleInFrameworkDir
-// CHECK-NOT: FrameworkInModuleDir
-// CHECK-NOT: NameMismatchFW
-// CHECK-NOT: MismatchNameFW
+// CHECK: Begin completion
+// CHECK-NOT: IosInterfaceFW[#Module#]
+// CHECK-NOT: NonTargetInterfaceFW[#Module#]
+// CHECK-NOT: NonTargetSerializedFW[#Module#]
+// CHECK-NOT: IosInterfaceMod[#Module#]
+// CHECK-NOT: DirInterfaceMod[#Module#]
+// CHECK-NOT: EmptyDirInterfaceMod[#Module#]
+// CHECK-NOT: EmptyDirSerializedMod[#Module#]
+// CHECK-NOT: UnrelatedFile[#Module#]
+// CHECK-NOT: ModuleInFrameworkDir[#Module#]
+// CHECK-NOT: FrameworkInModuleDir[#Module#]
+// CHECK-NOT: NameMismatchFW[#Module#]
+// CHECK-NOT: MismatchNameFW[#Module#]
+// CHECK-NOT: SwiftOnoneSupport[#Module#]
+// CHECK-NOT: Builtin[#Module#]
+// CHECK-NOT: Module[_
 
 // CHECK-DAG: MacAndLinuxInterfaceFW[#Module#]
 // CHECK-DAG: MacAndLinuxSerializedFW[#Module#]
@@ -88,5 +92,6 @@
 // CHECK-DAG: NonTargetSerializedMod[#Module#]
 
 // CHECK-DAG: Swift[#Module#]
+// CHECK: End completion
 
 import #^COMPLETE^#

--- a/test/IDE/complete_import_swiftmodule.swift
+++ b/test/IDE/complete_import_swiftmodule.swift
@@ -1,0 +1,92 @@
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: CPU=x86_64
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/Frameworks
+// RUN: mkdir -p %t/Modules
+
+// RUN: mkdir -p %t/Frameworks/MacAndLinuxInterfaceFW.framework/Modules/MacAndLinuxInterfaceFW.swiftmodule/
+// RUN: touch    %t/Frameworks/MacAndLinuxInterfaceFW.framework/Modules/MacAndLinuxInterfaceFW.swiftmodule/x86_64-apple-macos.swiftinterface
+// RUN: touch    %t/Frameworks/MacAndLinuxInterfaceFW.framework/Modules/MacAndLinuxInterfaceFW.swiftmodule/x86_64-unknown-linux-gnu.swiftinterface
+
+// RUN: mkdir -p %t/Frameworks/MacAndLinuxSerializedFW.framework/Modules/MacAndLinuxSerializedFW.swiftmodule/
+// RUN: touch    %t/Frameworks/MacAndLinuxSerializedFW.framework/Modules/MacAndLinuxSerializedFW.swiftmodule/x86_64-apple-macos.swiftmodule
+// RUN: touch    %t/Frameworks/MacAndLinuxSerializedFW.framework/Modules/MacAndLinuxSerializedFW.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule
+
+// Not-matching target.
+// RUN: mkdir -p %t/Frameworks/IosInterfaceFW.framework/Modules/IosInterfaceFW.swiftmodule/
+// RUN: touch    %t/Frameworks/IosInterfaceFW.framework/Modules/IosInterfaceFW.swiftmodule/arm64-apple-ios.swiftinterface
+
+// Invalid - Framework must be target specific.
+// RUN: mkdir -p %t/Frameworks/NonTargetInterfaceFW.framework/Modules/
+// RUN: touch    %t/Frameworks/NonTargetInterfaceFW.framework/Modules/NonTargetInterfaceFW.swiftinterface
+
+// Invalid - Framework must be target specific.
+// RUN: mkdir -p %t/Frameworks/NonTargetSerializedFW.framework/Modules/
+// RUN: touch    %t/Frameworks/NonTargetSerializedFW.framework/Modules/NonTargetSerializedFW.swiftmodule
+
+// RUN: mkdir -p %t/Modules/MacAndLinuxInterfaceMod.swiftmodule/
+// RUN: touch    %t/Modules/MacAndLinuxInterfaceMod.swiftmodule/x86_64-apple-macos.swiftinterface
+// RUN: touch    %t/Modules/MacAndLinuxInterfaceMod.swiftmodule/x86_64-unknown-linux-gnu.swiftinterface
+
+// RUN: mkdir -p %t/Modules/MacAndLinuxSerializedMod.swiftmodule/
+// RUN: touch    %t/Modules/MacAndLinuxSerializedMod.swiftmodule/x86_64-apple-macos.swiftmodule
+// RUN: touch    %t/Modules/MacAndLinuxSerializedMod.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule
+
+// Non-matching target.
+// RUN: mkdir -p %t/Modules/IosInterfaceMod.swiftmodule
+// RUN: touch    %t/Modules/IosInterfaceMod.swiftmodule/arm64-apple-ios.swiftinterface
+
+// RUN: touch %t/Modules/NonTargetInterfaceMod.swiftinterface
+// RUN: touch %t/Modules/NonTargetSerializedMod.swiftmodule
+
+// Invalid - '.swiftinterface' directory.
+// RUN: mkdir -p %t/Modules/DirInterfaceMod.swiftinterface
+// RUN: touch    %t/Modules/DirInterfaceMod.swiftinterface/x86_64-apple-macos.swiftinterface
+// RUN: touch    %t/Modules/DirInterfaceMod.swiftinterface/x86_64-unknown-linux-gnu.swiftinterface
+
+// Invalid - Empty directory.
+// RUN: mkdir -p %t/Modules/EmptyDirInterfaceMod.swiftinterface
+// RUN: mkdir -p %t/Modules/EmptyDirSerializedMod.swiftmodule
+
+// Invalid - Not a module.
+// RUN: touch %t/Modules/UnrelatedFile.dat
+
+// Invalid - Serialized in -F directory.
+// RUN: touch %t/Frameworks/ModuleInFrameworkDir.swiftmodule
+
+// Invalid - Framework in -I directory.
+// RUN: mkdir -p %t/Modules/FrameworkInModuleDir.framework/Modules/FrameworkInModuleDir.swiftmodule/
+// RUN: touch    %t/Modules/FrameworkInModuleDir.framework/Modules/FrameworkInModuleDir.swiftmodule/x86_64-apple-macos.swiftinterface
+// RUN: touch    %t/Modules/FrameworkInModuleDir.framework/Modules/FrameworkInModuleDir.swiftmodule/x86_64-unknown-linux-gnu.swiftinterface
+
+// Invalid - FrameworkName/SerializedName mismatch
+// RUN: mkdir -p %t/Frameworks/NameMismatchFW.framework/Modules/MismatchNameFW.swiftmodule/
+// RUN: touch    %t/Frameworks/NameMismatchFW.framework/Modules/MismatchNameFW.swiftmodule/x86_64-apple-macos.swiftinterface
+// RUN: touch    %t/Frameworks/NameMismatchFW.framework/Modules/MismatchNameFW.swiftmodule/x86_64-unknown-linux-gnu.swiftinterface
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE -F %t/Frameworks -sdk %t -I %t/Modules | %FileCheck %s
+
+// CHECK-NOT: IosInterfaceFW
+// CHECK-NOT: NonTargetInterfaceFW
+// CHECK-NOT: NonTargetSerializedFW
+// CHECK-NOT: IosInterfaceMod
+// CHECK-NOT: DirInterfaceMod
+// CHECK-NOT: EmptyDirInterfaceMod
+// CHECK-NOT: EmptyDirSerializedMod
+// CHECK-NOT: UnrelatedFile
+// CHECK-NOT: ModuleInFrameworkDir
+// CHECK-NOT: FrameworkInModuleDir
+// CHECK-NOT: NameMismatchFW
+// CHECK-NOT: MismatchNameFW
+
+// CHECK-DAG: MacAndLinuxInterfaceFW[#Module#]
+// CHECK-DAG: MacAndLinuxSerializedFW[#Module#]
+// CHECK-DAG: MacAndLinuxInterfaceMod[#Module#]
+// CHECK-DAG: MacAndLinuxSerializedMod[#Module#]
+// CHECK-DAG: NonTargetInterfaceMod[#Module#]
+// CHECK-DAG: NonTargetSerializedMod[#Module#]
+
+// CHECK-DAG: Swift[#Module#]
+
+import #^COMPLETE^#


### PR DESCRIPTION
For each `ModuleLoader`, newly implement `collectVisibleTopLevelModuleNames()` which collects *visible* module names. It doesn't care about the actual content of the file though. So it doesn't guarantee the module is *loadable*.

rdar://problem/39392446