### PR TITLE
NFC opaque type cleanups

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1160,18 +1160,19 @@ void IRGenerator::addLazyFunction(SILFunction *f) {
 }
 
 bool IRGenerator::hasLazyMetadata(TypeDecl *type) {
+  assert(isa<NominalTypeDecl>(type) ||
+         isa<OpaqueTypeDecl>(type));
   auto found = HasLazyMetadata.find(type);
   if (found != HasLazyMetadata.end())
     return found->second;
 
   auto canBeLazy = [&]() -> bool {
-    if (isa<ClangModuleUnit>(type->getInnermostDeclContext()
-                                 ->getModuleScopeContext())) {
+    auto *dc = type->getDeclContext();
+    if (isa<ClangModuleUnit>(dc->getModuleScopeContext())) {
       if (auto nominal = dyn_cast<NominalTypeDecl>(type)) {
         return requiresForeignTypeMetadata(nominal);
       }
-    } else if (type->getInnermostDeclContext()->getParentModule()
-                                                     == SIL.getSwiftModule()) {
+    } else if (dc->getParentModule() == SIL.getSwiftModule()) {
       // When compiling with -Onone keep all metadata for the debugger. Even if
       // it is not used by the program itself.
       if (!Opts.shouldOptimize())

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -243,7 +243,6 @@ private:
   /// queued up.
   llvm::SmallPtrSet<NominalTypeDecl *, 4> LazilyEmittedFieldMetadata;
   struct LazyOpaqueInfo {
-    bool IsLazy = false;
     bool IsDescriptorUsed = false;
     bool IsDescriptorEmitted = false;
   };

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1049,6 +1049,7 @@ public:
   UNINTERESTING(Var) // Handled at the PatternBinding level.
   UNINTERESTING(Destructor) // Always correct.
   UNINTERESTING(Accessor) // Handled by the Var or Subscript.
+  UNINTERESTING(OpaqueType) // Handled by the Var or Subscript.
 
   /// If \p PBD declared stored instance properties in a fixed-contents struct,
   /// return said struct.
@@ -1191,11 +1192,6 @@ public:
       auto diag = TC.diagnose(TAD, diagID);
       highlightOffendingType(TC, diag, complainRepr);
     });
-  }
-
-  void visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
-    // TODO(opaque): The constraint class/protocols on the opaque interface, as
-    // well as the naming decl for the opaque type, need to be accessible.
   }
 
   void visitAssociatedTypeDecl(AssociatedTypeDecl *assocType) {


### PR DESCRIPTION
- Add some assertions, and avoid an unnecessary asserting cast
- Replace a no-op access visitor with UNINTERESTING