### PR TITLE
[Parse][Sema] Improve interpolation parsing and construction

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2377,14 +2377,30 @@ public:
                                                  : FunctionRefKind::Unapplied);
   }
   
-  SourceLoc getLoc() const { return NameLoc.getBaseNameLoc(); }
+  SourceLoc getLoc() const {
+    if (NameLoc.isValid())
+      return NameLoc.getBaseNameLoc();
+    else if (DotLoc.isValid())
+      return DotLoc;
+    else
+      return SubExpr->getEndLoc();
+  }
 
   SourceLoc getStartLoc() const {
-    return (DotLoc.isInvalid() ? NameLoc.getSourceRange().End 
-                               : SubExpr->getStartLoc());
+    if (SubExpr->getStartLoc().isValid())
+      return SubExpr->getStartLoc();
+    else if (DotLoc.isValid())
+      return DotLoc;
+    else
+      return NameLoc.getSourceRange().Start;
   }
   SourceLoc getEndLoc() const {
-    return NameLoc.getSourceRange().End;
+    if (NameLoc.isValid())
+      return NameLoc.getSourceRange().End;
+    else if (DotLoc.isValid())
+      return DotLoc;
+    else
+      return SubExpr->getEndLoc();
   }
 
   SourceLoc getDotLoc() const { return DotLoc; }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1863,8 +1863,8 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
                                        SyntaxKind::ExpressionSegment);
 
       // Backslash is part of an expression segment.
-      Token BackSlash(tok::backslash,
-                      CharSourceRange(Segment.Loc.getAdvancedLoc(-1), 1).str());
+      SourceLoc BackSlashLoc = Segment.Loc.getAdvancedLoc(-1);
+      Token BackSlash(tok::backslash, CharSourceRange(BackSlashLoc, 1).str());
       ExprContext.addToken(BackSlash, EmptyTrivia, EmptyTrivia);
       // Create a temporary lexer that lexes from the body of the string.
       LexerState BeginState =
@@ -1889,7 +1889,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
                                            tok::string_interpolation_anchor);
 
       auto callee = new (Context) UnresolvedDotExpr(InterpolationVarRef,
-                                                    /*dotloc=*/SourceLoc(),
+                                                    /*dotloc=*/BackSlashLoc,
                                                     appendInterpolation,
                                                     /*nameloc=*/DeclNameLoc(),
                                                     /*Implicit=*/true);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1927,37 +1927,6 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
 
       InterpolationCount += 1;
       
-      // In Swift 4.2 and earlier, a single argument with a label would ignore
-      // the label (at best), and multiple arguments would form a tuple.
-      if (!Context.isSwiftVersionAtLeast(5)) {
-        if (args.size() > 1) {
-          diagnose(args[1]->getLoc(), diag::string_interpolation_list_changing)
-            .highlightChars(args[1]->getLoc(), rParen);
-          diagnose(args[1]->getLoc(),
-                   diag::string_interpolation_list_insert_parens)
-            .fixItInsertAfter(lParen, "(")
-            .fixItInsert(rParen, ")");
-          
-          args = {
-            TupleExpr::create(Context,
-                              lParen, args, argLabels, argLabelLocs, rParen,
-                              /*hasTrailingClosure=*/false,
-                              /*Implicit=*/false)
-          };
-          argLabels = { Identifier() };
-          argLabelLocs = { SourceLoc() };
-        }
-        else if (args.size() == 1 && argLabels[0] != Identifier()) {
-          diagnose(argLabelLocs[0], diag::string_interpolation_label_changing)
-            .highlightChars(argLabelLocs[0], args[0]->getStartLoc());
-          diagnose(argLabelLocs[0], diag::string_interpolation_remove_label,
-                   argLabels[0])
-            .fixItRemoveChars(argLabelLocs[0], args[0]->getStartLoc());
-          
-          argLabels[0] = Identifier();
-        }
-      }
-      
       auto AppendInterpolationRef =
         new (Context) UnresolvedDotExpr(InterpolationVarRef,
                                         /*dotloc=*/SourceLoc(),

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -952,6 +952,107 @@ namespace {
     /// the type conforms to the expected literal protocol.
     Expr *simplifyTypeConstructionWithLiteralArg(Expr *E);
 
+    /// In Swift < 5, diagnose and correct invalid multi-argument or
+    /// argument-labeled interpolations.
+    void correctInterpolationIfStrange(InterpolatedStringLiteralExpr *ISLE) {
+      // These expressions are valid in Swift 5+.
+      if (TC.Context.isSwiftVersionAtLeast(5))
+        return;
+
+      /// Diagnoses appendInterpolation(...) calls with multiple
+      /// arguments or argument labels and corrects them.
+      class StrangeInterpolationRewriter : public ASTWalker {
+        TypeChecker &TC;
+
+      public:
+        StrangeInterpolationRewriter(TypeChecker &TC) : TC(TC) { }
+
+        virtual bool walkToDeclPre(Decl *D) {
+          // We don't want to look inside decls.
+          return false;
+        }
+
+        virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+          // One InterpolatedStringLiteralExpr should never be nested inside
+          // another except as a child of a CallExpr, and we don't recurse into
+          // the children of CallExprs.
+          assert(!isa<InterpolatedStringLiteralExpr>(E) &&
+                 "StrangeInterpolationRewriter found nested interpolation?");
+
+          // We only care about CallExprs.
+          if (!isa<CallExpr>(E))
+            return { true, E };
+
+          auto call = cast<CallExpr>(E);
+          if (auto callee = dyn_cast<UnresolvedDotExpr>(call->getFn())) {
+            if (callee->getName().getBaseName() ==
+                    TC.Context.Id_appendInterpolation) {
+              Expr *newArg = nullptr;
+              SourceLoc lParen, rParen;
+
+              if (call->getNumArguments() > 1) {
+                auto *args = cast<TupleExpr>(call->getArg());
+
+                lParen = args->getLParenLoc();
+                rParen = args->getRParenLoc();
+                Expr *secondArg = args->getElement(1);
+
+                TC.diagnose(secondArg->getLoc(),
+                            diag::string_interpolation_list_changing)
+                  .highlightChars(secondArg->getLoc(), rParen);
+                TC.diagnose(secondArg->getLoc(),
+                            diag::string_interpolation_list_insert_parens)
+                  .fixItInsertAfter(lParen, "(")
+                  .fixItInsert(rParen, ")");
+
+                newArg = args;
+              }
+              else if(call->getNumArguments() == 1 &&
+                      call->getArgumentLabels().front() != Identifier()) {
+                auto *args = cast<TupleExpr>(call->getArg());
+                newArg = args->getElement(0);
+
+                lParen = args->getLParenLoc();
+                rParen = args->getRParenLoc();
+
+                SourceLoc argLabelLoc = call->getArgumentLabelLoc(0),
+                          argLoc = newArg->getStartLoc();
+
+                TC.diagnose(argLabelLoc,
+                            diag::string_interpolation_label_changing)
+                  .highlightChars(argLabelLoc, argLoc);
+                TC.diagnose(argLabelLoc,
+                            diag::string_interpolation_remove_label,
+                            call->getArgumentLabels().front())
+                  .fixItRemoveChars(argLabelLoc, argLoc);
+              }
+
+              // If newArg is no longer null, we need to build a new
+              // appendInterpolation(_:) call that takes it to replace the bad
+              // appendInterpolation(...) call.
+              if (newArg) {
+                auto newCallee = new (TC.Context) UnresolvedDotExpr(
+                    callee->getBase(), /*dotloc=*/SourceLoc(),
+                    DeclName(TC.Context.Id_appendInterpolation),
+                    /*nameloc=*/DeclNameLoc(), /*Implicit=*/true);
+
+                E = CallExpr::create(TC.Context, newCallee, lParen,
+                    { newArg }, { Identifier() }, { SourceLoc() },
+                    rParen, /*trailingClosure=*/nullptr, /*implicit=*/false);
+              }
+            }
+          }
+
+          // There is never a CallExpr between an InterpolatedStringLiteralExpr
+          // and an un-typechecked appendInterpolation(...) call, so whether we
+          // changed E or not, we don't need to recurse any deeper.
+          return { false, E };
+        }
+      };
+      
+      ISLE->getAppendingExpr()->walk(StrangeInterpolationRewriter(TC));
+    }
+
   public:
     PreCheckExpression(TypeChecker &tc, DeclContext *dc, Expr *parent)
         : TC(tc), DC(dc), ParentExpr(parent) {}
@@ -1085,6 +1186,9 @@ namespace {
         TC.diagnose(expr->getStartLoc(), diag::extraneous_address_of);
         return finish(false, nullptr);
       }
+
+      if (auto *ISLE = dyn_cast<InterpolatedStringLiteralExpr>(expr))
+        correctInterpolationIfStrange(ISLE);
 
       return finish(true, expr);
     }

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -470,10 +470,9 @@ func resyncParserB14() {}
 var stringInterp = "\(#^STRING_INTERP_3^#)"
 _ = "" + "\(#^STRING_INTERP_4^#)" + ""
 // STRING_INTERP: Begin completions
-// FIXME: Why is this TypeRelation[Invalid] in STRING_INTERP_4?
-// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal{{(/NotRecommended/TypeRelation\[Invalid\])?}}:   ['(']{#(value): _#}[')'][#Void#]; name=value: _
+// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(value): _#}[')'][#Void#]; name=value: _
 // STRING_INTERP-DAG: Decl[Struct]/CurrModule: FooStruct[#FooStruct#];
-// STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: fooFunc1()[#Void#];
+// STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule/NotRecommended/TypeRelation[Invalid]: fooFunc1()[#Void#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: optStr()[#String?#];
 // STRING_INTERP-DAG: Decl[GlobalVar]/Local: fooObject[#FooStruct#];
 // STRING_INTERP: End completions

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -167,6 +167,11 @@ func fooFunc2(_ a: Int, _ b: Double) {}
 
 func erroneous1(_ x: Undeclared) {}
 
+// FIXME: Hides all other string interpolation completion.
+//extension DefaultStringInterpolation {
+//  mutating func appendInterpolation(interpolate: Double) {}
+//}
+
 //===--- Test code completions of expressions that can be typechecked.
 
 // Although the parser can recover in most of these test cases, we resync it
@@ -465,8 +470,10 @@ func resyncParserB14() {}
 var stringInterp = "\(#^STRING_INTERP_3^#)"
 _ = "" + "\(#^STRING_INTERP_4^#)" + ""
 // STRING_INTERP: Begin completions
+// FIXME: Why is this TypeRelation[Invalid] in STRING_INTERP_4?
+// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal{{(/NotRecommended/TypeRelation\[Invalid\])?}}:   ['(']{#(value): _#}[')'][#Void#]; name=value: _
 // STRING_INTERP-DAG: Decl[Struct]/CurrModule: FooStruct[#FooStruct#];
-// STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule/NotRecommended/TypeRelation[Invalid]: fooFunc1()[#Void#];
+// STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: fooFunc1()[#Void#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: optStr()[#String?#];
 // STRING_INTERP-DAG: Decl[GlobalVar]/Local: fooObject[#FooStruct#];
 // STRING_INTERP: End completions

--- a/test/Parse/strange_interpolation.swift
+++ b/test/Parse/strange_interpolation.swift
@@ -54,5 +54,12 @@ print("[\(stringInterpolationSegment: x)]")
 // expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
 // expected-note@-3{{remove 'stringInterpolationSegment' label to keep current behavior}} {{11-39=}}
 
+print("[ \(foo: "[\(bar: x)]") ]")
+// CHECK-NEXT: [ [1] ]
+// expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
+// expected-note@-3{{remove 'foo' label to keep current behavior}} {{12-17=}}
+// expected-warning@-4{{labeled interpolations will not be ignored in Swift 5}}
+// expected-note@-5{{remove 'bar' label to keep current behavior}} {{21-26=}}
+
 print("End")
 // CHECK-NEXT: End

--- a/test/Parse/strange_interpolation.swift
+++ b/test/Parse/strange_interpolation.swift
@@ -6,47 +6,53 @@
 
 // REQUIRES: executable_test
 
- let x = 1
+print("Begin")
+// CHECK: Begin
 
- print("[\(x)]")
- // CHECK: [1]
+let x = 1
 
- print("[\(foo: x)]")
- // CHECK: [1]
- // expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
- // expected-note@-3{{remove 'foo' label to keep current behavior}} {{12-17=}}
+print("[\(x)]")
+// CHECK-NEXT: [1]
 
- print("[\(x, x)]")
- // CHECK: [(1, 1)]
- // expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
- // expected-note@-3{{insert parentheses to keep current behavior}} {{12-12=(}} {{16-16=)}}
+print("[\(foo: x)]")
+// CHECK-NEXT: [1]
+// expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
+// expected-note@-3{{remove 'foo' label to keep current behavior}} {{11-16=}}
 
- print("[\(foo: x, x)]")
- // CHECK: [(foo: 1, 1)]
- // expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
- // expected-note@-3{{insert parentheses to keep current behavior}} {{12-12=(}} {{21-21=)}}
+print("[\(x, x)]")
+// CHECK-NEXT: [(1, 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{15-15=)}}
 
- print("[\(x, foo: x)]")
- // CHECK: [(1, foo: 1)]
- // expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
- // expected-note@-3{{insert parentheses to keep current behavior}} {11-11(}} {{20-20=)}}
+print("[\(foo: x, x)]")
+// CHECK-NEXT: [(foo: 1, 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{20-20=)}}
 
- print("[\(foo: x, foo: x)]")
- // CHECK: [(foo: 1, foo: 1)]
- // expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
- // expected-note@-3{{insert parentheses to keep current behavior}} {11-11(}} {{25-25=)}}
+print("[\(x, foo: x)]")
+// CHECK-NEXT: [(1, foo: 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{20-20=)}}
 
- print("[\(describing: x)]")
- // CHECK: [1]
- // expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
- // expected-note@-3{{remove 'describing' label to keep current behavior}} {{12-24=}}
+print("[\(foo: x, foo: x)]")
+// CHECK-NEXT: [(foo: 1, foo: 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{25-25=)}}
 
- print("[\(x, radix: x)]")
- // CHECK: [(1, radix: 1)]
- // expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
- // expected-note@-3{{insert parentheses to keep current behavior}} {11-11(}} {{25-25=)}}
+print("[\(describing: x)]")
+// CHECK-NEXT: [1]
+// expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
+// expected-note@-3{{remove 'describing' label to keep current behavior}} {{11-23=}}
 
- print("[\(stringInterpolationSegment: x)]")
- // CHECK: [1]
- // expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
- // expected-note@-3{{remove 'stringInterpolationSegment' label to keep current behavior}} {{12-40=}}
+print("[\(x, radix: x)]")
+// CHECK-NEXT: [(1, radix: 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in Swift 5}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{22-22=)}}
+
+print("[\(stringInterpolationSegment: x)]")
+// CHECK-NEXT: [1]
+// expected-warning@-2{{labeled interpolations will not be ignored in Swift 5}}
+// expected-note@-3{{remove 'stringInterpolationSegment' label to keep current behavior}} {{11-39=}}
+
+print("End")
+// CHECK-NEXT: End

--- a/test/SourceKit/Misc/strange_interpolation.swift
+++ b/test/SourceKit/Misc/strange_interpolation.swift
@@ -1,0 +1,19 @@
+// Parse-only modes, like swift -parse and SourceKit, should not emit strange
+// interpolation errors in `#if swift(>=5)` blocks. (SR-9937)
+//
+// Even though this is in the test/SourceKit directory, it also tests
+// -frontend -parse behavior because the test cases are exactly the same.
+
+// RUN: %sourcekitd-test -req=open %s -- -swift-version 4.2 %s == -req=print-diags %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse -verify -swift-version 4.2 %s
+
+let x = 1
+
+// We should not warn in blocks that can only run when `swift(>=5.0)`.
+
+#if swift(>=5.0)
+  print("[\(foo: x)]")
+  print("[\(x, x)]")
+#endif
+
+// CHECK: <<NULL>>


### PR DESCRIPTION
In Swift 4.2 mode, we currently diagnose and correct multi-argument and labeled interpolations during parsing. This isn't great because there are various modes where we parse code that won't actually compile in Swift 4.2 mode, like code in `#if swift(>=5)` blocks.

This PR moves this diagnosis to Sema, specifically to `PreCheckExpression`. This then allows us to parse string interpolations *literally* as argument lists, which (with another small fix) is enough to let code completion offer `appendInterpolation` overload signatures in a string interpolation segment.

While I was there, I also cleaned up some issues with the strange interpolation warning test, such as fixits that weren't being checked properly and accidental indentation. It's best to review the commits separately so you can see which parts of the test changed.

Resolves [SR-9937](https://bugs.swift.org/browse/SR-9937).

