### PR TITLE
IRGen: mangle conformance access paths with opaque result type as a root

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -694,6 +694,7 @@ Property behaviors are implemented using private protocol conformances.
       dependent-associated-conformance 'HA' DEPENDENT-CONFORMANCE-INDEX
 
   dependent-associated-conformance ::= type protocol
+  dependent-protocol-conformance ::= dependent-protocol-conformance opaque-type 'HO'
 
 A compact representation used to represent mangled protocol conformance witness
 arguments at runtime. The ``module`` is only specified for conformances that

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2613,6 +2613,20 @@ void ASTMangler::appendConcreteProtocolConformance(
         auto conformanceAccessPath =
           CurGenericSignature->getConformanceAccessPath(type, proto);
         appendDependentProtocolConformance(conformanceAccessPath);
+      } else if (auto opaqueType = canType->getAs<OpaqueTypeArchetypeType>()) {
+        GenericSignature *opaqueSignature = opaqueType->getBoundSignature();
+        GenericTypeParamType *opaqueTypeParam = opaqueSignature->getGenericParams().back();
+        ConformanceAccessPath conformanceAccessPath =
+            opaqueSignature->getConformanceAccessPath(opaqueTypeParam, proto);
+
+        // Append the conformance access path with the signature of the opaque type.
+        CanGenericSignature savedSignature = CurGenericSignature;
+        CurGenericSignature = opaqueSignature->getCanonicalSignature();
+        appendDependentProtocolConformance(conformanceAccessPath);
+        CurGenericSignature = savedSignature;
+
+        appendType(canType);
+        appendOperator("HO");
       } else {
         auto conditionalConf = module->lookupConformance(canType, proto);
         appendConcreteProtocolConformance(conditionalConf->getConcrete());

--- a/test/IRGen/opaque_result_type_access_path.swift
+++ b/test/IRGen/opaque_result_type_access_path.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
+// Check that the IRGenMangler does not crashq when mangling a conformance
+// access path with an opaque result type as root.
+// As a bonus, also do a runtime test to check that there is no miscompile.
+
+protocol P {
+  func get() -> Int
+}
+
+extension Int : P {
+  func get() -> Int {
+    return self
+  }
+}
+
+struct X<T> {
+  let tt: T
+  init(_ t: T) {
+    tt = t
+  }
+}
+
+extension X : P where T : P {
+  func get() -> Int {
+    return tt.get()
+  }
+}
+
+func bar() -> some P {
+  return 27
+}
+
+func foo() -> some P {
+  return X(bar())
+}
+
+// CHECK: 27
+print(foo().get())
+


### PR DESCRIPTION
Fixes a crash in IRGen

TODO: also fix the demangler/remangler part of this mangling change.
Currently it's not a problem because we never demangle such a symbol (it's even not round-trip checked in Mangler::verify).

rdar://problem/50405691
