### PR TITLE
[Build System: CMake] Install the apinotes in the 'compiler' install component (5.1 04-24-2019 branch).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,15 @@ option(SWIFT_INCLUDE_DOCS
     "Create targets for building docs."
     TRUE)
 
+set(_swift_include_apinotes_default FALSE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(_swift_include_apinotes_default TRUE)
+endif()
+
+option(SWIFT_INCLUDE_APINOTES
+  "Create targets for installing the remaining apinotes in the built toolchain."
+  ${_swift_include_apinotes_default})
+
 #
 # Miscellaneous User-configurable options.
 #
@@ -1052,12 +1061,8 @@ endif()
 # https://bugs.swift.org/browse/SR-5975
 add_subdirectory(stdlib)
 
-if(SWIFT_BUILD_SDK_OVERLAY)
-  list_intersect("${SWIFT_APPLE_PLATFORMS}" "${SWIFT_SDKS}"
-                 building_darwin_sdks)
-  if(building_darwin_sdks)
-    add_subdirectory(apinotes)
-  endif()
+if(SWIFT_INCLUDE_APINOTES)
+  add_subdirectory(apinotes)
 endif()
 
 add_subdirectory(include)

--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -31,7 +31,6 @@ add_custom_target("copy_apinotes"
 # This is treated as an OPTIONAL target because if we don't build the SDK
 # overlay, the files will be missing anyway. It also allows us to build
 # single overlays without installing the API notes.
-swift_install_in_component(sdk-overlay
+swift_install_in_component(compiler
     DIRECTORY "${output_dir}"
-    DESTINATION "lib/swift/"
-    OPTIONAL)
+    DESTINATION "lib/swift/")

--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -23,7 +23,7 @@ add_custom_command(
     COMMAND
       "${CMAKE_COMMAND}" "-E" "copy_if_different" ${inputs} "${output_dir}/")
 
-add_custom_target("copy_apinotes"
+add_custom_target("copy_apinotes" ALL
     DEPENDS "${outputs}" "${output_dir}"
     COMMENT "Copying API notes to ${output_dir}"
     SOURCES "${sources}")

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -3,6 +3,13 @@ set(swift_platform_sources
     TiocConstants.swift
     tgmath.swift.gyb)
 
+set(darwin_depends)
+if(NOT BUILD_STANDALONE)
+  # This is overly conservative, but we have so few API notes files that
+  # haven't migrated to the Swift repo that it's probably fine in practice.
+  list(APPEND darwin_depends copy_apinotes)
+endif()
+
 add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Darwin.swift.gyb
     ${swift_platform_sources}
@@ -13,9 +20,7 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
     TARGET_SDKS ALL_APPLE_PLATFORMS
 
-    # This is overly conservative, but we have so few API notes files that
-    # haven't migrated to the Swift repo that it's probably fine in practice.
-    DEPENDS copy_apinotes)
+    DEPENDS ${darwin_depends})
 
 add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Glibc.swift.gyb


### PR DESCRIPTION
Copy of #24419 for the 5.1 branch.

rdar://50390238