### PR TITLE
[benchmark] Add integer parsing benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -92,6 +92,7 @@ set(SWIFT_BENCH_MODULES
     single-source/Hash
     single-source/Histogram
     single-source/InsertCharacter  
+    single-source/IntegerParsing
     single-source/Integrate
     single-source/IterateData
     single-source/Join

--- a/benchmark/single-source/IntegerParsing.swift
+++ b/benchmark/single-source/IntegerParsing.swift
@@ -13,19 +13,19 @@
 import TestsUtils
 
 public let IntegerParsing = [
-  BenchmarkInfo(name: "ParseIntFromDecimal",
+  BenchmarkInfo(name: "ParseInt.Decimal",
     runFunction: run_ParseIntFromDecimal,
     tags: [.validation, .api],
     setUpFunction: { blackHole(decimalStrings) }),
-  BenchmarkInfo(name: "ParseIntFromBinary",
+  BenchmarkInfo(name: "ParseInt.Binary",
     runFunction: run_ParseIntFromBinary,
     tags: [.validation, .api],
     setUpFunction: { blackHole(binaryStrings) }),
-  BenchmarkInfo(name: "ParseIntFromHex",
+  BenchmarkInfo(name: "ParseInt.Hex",
     runFunction: run_ParseIntFromHex,
     tags: [.validation, .api],
     setUpFunction: { blackHole(hexStrings) }),
-  BenchmarkInfo(name: "ParseIntFromUncommonRadix",
+  BenchmarkInfo(name: "ParseInt.UncommonRadix",
     runFunction: run_ParseIntFromUncommonRadix,
     tags: [.validation, .api],
     setUpFunction: { blackHole(uncommonRadixStrings) }),

--- a/benchmark/single-source/IntegerParsing.swift
+++ b/benchmark/single-source/IntegerParsing.swift
@@ -77,45 +77,49 @@ private let largeUncommonRadixStrings: [String]
 @inline(never)
 public func run_ParseIntFromSmallDecimal(N: Int) {
   var result = 0
-  for _ in 0..<N {
+  let count = N*10
+  for _ in 0..<count {
     for string in smallDecimalStrings {
       result &+= Int(string, radix: 10)!
     }
   }
-  CheckResults(result == smallValuesSum &* N)
+  CheckResults(result == smallValuesSum &* count)
 }
 
 @inline(never)
 public func run_ParseIntFromSmallBinary(N: Int) {
   var result = 0
-  for _ in 0..<N {
+  let count = N*10
+  for _ in 0..<count {
     for string in smallBinaryStrings {
       result &+= Int(string, radix: 2)!
     }
   }
-  CheckResults(result == smallValuesSum &* N)
+  CheckResults(result == smallValuesSum &* count)
 }
 
 @inline(never)
 public func run_ParseIntFromSmallHex(N: Int) {
   var result = 0
-  for _ in 0..<N {
+  let count = N*10
+  for _ in 0..<count {
     for string in smallHexStrings {
       result &+= Int(string, radix: 16)!
     }
   }
-  CheckResults(result == smallValuesSum &* N)
+  CheckResults(result == smallValuesSum &* count)
 }
 
 @inline(never)
 public func run_ParseIntFromSmallUncommonRadix(N: Int) {
   var result = 0
-  for _ in 0..<N {
+  let count = N*10
+  for _ in 0..<count {
     for string in smallUncommonRadixStrings {
       result &+= Int(string, radix: uncommonRadix)!
     }
   }
-  CheckResults(result == smallValuesSum &* N)
+  CheckResults(result == smallValuesSum &* count)
 }
 
 @inline(never)

--- a/benchmark/single-source/IntegerParsing.swift
+++ b/benchmark/single-source/IntegerParsing.swift
@@ -13,73 +13,151 @@
 import TestsUtils
 
 public let IntegerParsing = [
-  BenchmarkInfo(name: "ParseInt.Decimal",
-    runFunction: run_ParseIntFromDecimal,
+  BenchmarkInfo(name: "ParseInt.Small.Decimal",
+    runFunction: run_ParseIntFromSmallDecimal,
     tags: [.validation, .api],
-    setUpFunction: { blackHole(decimalStrings) }),
-  BenchmarkInfo(name: "ParseInt.Binary",
-    runFunction: run_ParseIntFromBinary,
+    setUpFunction: { blackHole(smallDecimalStrings) }),
+  BenchmarkInfo(name: "ParseInt.Small.Binary",
+    runFunction: run_ParseIntFromSmallBinary,
     tags: [.validation, .api],
-    setUpFunction: { blackHole(binaryStrings) }),
-  BenchmarkInfo(name: "ParseInt.Hex",
-    runFunction: run_ParseIntFromHex,
+    setUpFunction: { blackHole(smallBinaryStrings) }),
+  BenchmarkInfo(name: "ParseInt.Small.Hex",
+    runFunction: run_ParseIntFromSmallHex,
     tags: [.validation, .api],
-    setUpFunction: { blackHole(hexStrings) }),
-  BenchmarkInfo(name: "ParseInt.UncommonRadix",
-    runFunction: run_ParseIntFromUncommonRadix,
+    setUpFunction: { blackHole(smallHexStrings) }),
+  BenchmarkInfo(name: "ParseInt.Small.UncommonRadix",
+    runFunction: run_ParseIntFromSmallUncommonRadix,
     tags: [.validation, .api],
-    setUpFunction: { blackHole(uncommonRadixStrings) }),
+    setUpFunction: { blackHole(smallUncommonRadixStrings) }),
+  BenchmarkInfo(name: "ParseInt.Large.Decimal",
+    runFunction: run_ParseIntFromLargeDecimal,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(largeDecimalStrings) }),
+  BenchmarkInfo(name: "ParseInt.Large.Binary",
+    runFunction: run_ParseIntFromLargeBinary,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(largeBinaryStrings) }),
+  BenchmarkInfo(name: "ParseInt.Large.Hex",
+    runFunction: run_ParseIntFromLargeHex,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(largeHexStrings) }),
+  BenchmarkInfo(name: "ParseInt.Large.UncommonRadix",
+    runFunction: run_ParseIntFromLargeUncommonRadix,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(largeUncommonRadixStrings) }),
 ]
 
-private let values: [Int] = Array(-1000...1000) // Give extra weight to low ints
-  + (0..<2000).map { _ in Int.random(in: .min ... .max) }
 private let uncommonRadix: Int = 7
-private let decimalStrings: [String] = values.map { String($0, radix: 10) }
-private let binaryStrings: [String] = values.map { String($0, radix: 2) }
-private let hexStrings: [String] = values.map { String($0, radix: 16) }
-private let uncommonRadixStrings: [String]
-  = values.map { String($0, radix: uncommonRadix) }
+private let smallValuesSum: Int = 0
+private let largeValuesSum: Int64 = 4790606764485943206
+// Values
+private let smallValues: [Int] = Array(-1000...1000)
+private let largeValues: [Int64] = {
+  var rng = SplitMix64(seed: 42)
+  return (0..<2000).map { _ in Int64.random(in: .min ... .max, using: &rng) }
+}()
+// Strings
+private let smallDecimalStrings: [String]
+  = smallValues.map { String($0, radix: 10) }
+private let smallBinaryStrings: [String]
+  = smallValues.map { String($0, radix: 2) }
+private let smallHexStrings: [String]
+  = smallValues.map { String($0, radix: 16) }
+private let smallUncommonRadixStrings: [String]
+  = smallValues.map { String($0, radix: uncommonRadix) }
+private let largeDecimalStrings: [String]
+  = largeValues.map { String($0, radix: 10) }
+private let largeBinaryStrings: [String]
+  = largeValues.map { String($0, radix: 2) }
+private let largeHexStrings: [String]
+  = largeValues.map { String($0, radix: 16) }
+private let largeUncommonRadixStrings: [String]
+  = largeValues.map { String($0, radix: uncommonRadix) }
 
 @inline(never)
-public func run_ParseIntFromDecimal(N: Int) {
+public func run_ParseIntFromSmallDecimal(N: Int) {
   var result = 0
   for _ in 0..<N {
-    for string in decimalStrings {
+    for string in smallDecimalStrings {
       result &+= Int(string, radix: 10)!
     }
   }
-  blackHole(result)
+  CheckResults(result == smallValuesSum &* N)
 }
 
 @inline(never)
-public func run_ParseIntFromBinary(N: Int) {
+public func run_ParseIntFromSmallBinary(N: Int) {
   var result = 0
   for _ in 0..<N {
-    for string in binaryStrings {
+    for string in smallBinaryStrings {
       result &+= Int(string, radix: 2)!
     }
   }
-  blackHole(result)
+  CheckResults(result == smallValuesSum &* N)
 }
 
 @inline(never)
-public func run_ParseIntFromHex(N: Int) {
+public func run_ParseIntFromSmallHex(N: Int) {
   var result = 0
   for _ in 0..<N {
-    for string in hexStrings {
+    for string in smallHexStrings {
       result &+= Int(string, radix: 16)!
     }
   }
-  blackHole(result)
+  CheckResults(result == smallValuesSum &* N)
 }
 
 @inline(never)
-public func run_ParseIntFromUncommonRadix(N: Int) {
+public func run_ParseIntFromSmallUncommonRadix(N: Int) {
   var result = 0
   for _ in 0..<N {
-    for string in uncommonRadixStrings {
+    for string in smallUncommonRadixStrings {
       result &+= Int(string, radix: uncommonRadix)!
     }
   }
-  blackHole(result)
+  CheckResults(result == smallValuesSum &* N)
+}
+
+@inline(never)
+public func run_ParseIntFromLargeDecimal(N: Int) {
+  var result: Int64 = 0
+  for _ in 0..<N {
+    for string in largeDecimalStrings {
+      result &+= Int64(string, radix: 10)!
+    }
+  }
+  CheckResults(result == largeValuesSum &* Int64(N))
+}
+
+@inline(never)
+public func run_ParseIntFromLargeBinary(N: Int) {
+  var result: Int64 = 0
+  for _ in 0..<N {
+    for string in largeBinaryStrings {
+      result &+= Int64(string, radix: 2)!
+    }
+  }
+  CheckResults(result == largeValuesSum &* Int64(N))
+}
+
+@inline(never)
+public func run_ParseIntFromLargeHex(N: Int) {
+  var result: Int64 = 0
+  for _ in 0..<N {
+    for string in largeHexStrings {
+      result &+= Int64(string, radix: 16)!
+    }
+  }
+  CheckResults(result == largeValuesSum &* Int64(N))
+}
+
+@inline(never)
+public func run_ParseIntFromLargeUncommonRadix(N: Int) {
+  var result: Int64 = 0
+  for _ in 0..<N {
+    for string in largeUncommonRadixStrings {
+      result &+= Int64(string, radix: uncommonRadix)!
+    }
+  }
+  CheckResults(result == largeValuesSum &* Int64(N))
 }

--- a/benchmark/single-source/IntegerParsing.swift
+++ b/benchmark/single-source/IntegerParsing.swift
@@ -1,0 +1,85 @@
+//===--- IntegerParsing.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let IntegerParsing = [
+  BenchmarkInfo(name: "ParseIntFromDecimal",
+    runFunction: run_ParseIntFromDecimal,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(decimalStrings) }),
+  BenchmarkInfo(name: "ParseIntFromBinary",
+    runFunction: run_ParseIntFromBinary,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(binaryStrings) }),
+  BenchmarkInfo(name: "ParseIntFromHex",
+    runFunction: run_ParseIntFromHex,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(hexStrings) }),
+  BenchmarkInfo(name: "ParseIntFromUncommonRadix",
+    runFunction: run_ParseIntFromUncommonRadix,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(uncommonRadixStrings) }),
+]
+
+private let values: [Int] = Array(-1000...1000) // Give extra weight to low ints
+  + (0..<2000).map { _ in Int.random(in: .min ... .max) }
+private let uncommonRadix: Int = 7
+private let decimalStrings: [String] = values.map { String($0, radix: 10) }
+private let binaryStrings: [String] = values.map { String($0, radix: 2) }
+private let hexStrings: [String] = values.map { String($0, radix: 16) }
+private let uncommonRadixStrings: [String]
+  = values.map { String($0, radix: uncommonRadix) }
+
+@inline(never)
+public func run_ParseIntFromDecimal(N: Int) {
+  var result = 0
+  for _ in 0..<N {
+    for string in decimalStrings {
+      result &+= Int(string, radix: 10)!
+    }
+  }
+  blackHole(result)
+}
+
+@inline(never)
+public func run_ParseIntFromBinary(N: Int) {
+  var result = 0
+  for _ in 0..<N {
+    for string in binaryStrings {
+      result &+= Int(string, radix: 2)!
+    }
+  }
+  blackHole(result)
+}
+
+@inline(never)
+public func run_ParseIntFromHex(N: Int) {
+  var result = 0
+  for _ in 0..<N {
+    for string in hexStrings {
+      result &+= Int(string, radix: 16)!
+    }
+  }
+  blackHole(result)
+}
+
+@inline(never)
+public func run_ParseIntFromUncommonRadix(N: Int) {
+  var result = 0
+  for _ in 0..<N {
+    for string in uncommonRadixStrings {
+      result &+= Int(string, radix: uncommonRadix)!
+    }
+  }
+  blackHole(result)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -80,6 +80,7 @@ import Hanoi
 import Hash
 import Histogram
 import InsertCharacter
+import IntegerParsing
 import Integrate
 import IterateData
 import Join
@@ -253,6 +254,7 @@ registerBenchmark(Hanoi)
 registerBenchmark(HashTest)
 registerBenchmark(Histogram)
 registerBenchmark(InsertCharacter)
+registerBenchmark(IntegerParsing)
 registerBenchmark(IntegrateTest)
 registerBenchmark(IterateData)
 registerBenchmark(Join)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds integer parsing benchmarks for an integer parsing rewrite I have coming up.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
