### PR TITLE
[5.1] [test] Remove debug flag from module cache rebuild test

### DIFF
--- a/test/ParseableInterface/ModuleCache/RebuildRemarks/out-of-date-cached-module.swift
+++ b/test/ParseableInterface/ModuleCache/RebuildRemarks/out-of-date-cached-module.swift
@@ -14,7 +14,7 @@
 // RUN: touch %t/Build/TestModule.swiftinterface
 
 // 5. Try to import the now out-of-date cached module
-// RUN: %target-swift-frontend -typecheck -verify %s -I %t/Build -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache -Xllvm -debug-only=textual-module-interface
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t/Build -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
 
 import TestModule // expected-remark {{rebuilding module 'TestModule' from interface}}
 // expected-note @-1 {{cached module is out of date}}


### PR DESCRIPTION
This debug flag shouldn't have been included in the test, and it doesn't
exist when built without asserts.

rdar://50447378 (Cherry-picked from #24479)