### PR TITLE
[ConstraintSystem] Tighten "missing call" fix conditions by checking …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2032,7 +2032,8 @@ bool ConstraintSystem::repairFailures(
         // If left-hand side is a function type but right-hand
         // side isn't, let's check it would be possible to fix
         // this by forming an explicit call.
-        if (!rhs->is<FunctionType>() && !rhs->isVoid() &&
+        auto convertTo = rhs->lookThroughAllOptionalTypes();
+        if (!convertTo->is<FunctionType>() && !convertTo->isVoid() &&
             fnType->getNumParams() == 0 &&
             matchTypes(fnType->getResult(), rhs, ConstraintKind::Conversion,
                        TypeMatchFlags::TMF_ApplyingFix, locator)

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -345,3 +345,15 @@ func rdar47776586() {
   dict[1] += 1 // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
   // expected-note@-1 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{10-10=!}}
 }
+
+struct S {
+  var foo: Optional<() -> Int?> = nil
+  var bar: Optional<() -> Int?> = nil
+
+  mutating func test(_ clj: @escaping () -> Int) {
+    if let fn = foo {
+      bar = fn  // Ok
+      bar = clj // Ok
+    }
+  }
+}


### PR DESCRIPTION
…whether other side is an optional

If "convertTo" type is an optional let's look through it to see
whether it contains another function type which, if so, would
rule out possibility of missing explicit call.

Resolves: rdar://problem/50438071

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
