### PR TITLE
Sema: Use GSB to build the signature for opaque result type decls.

### DIFF
--- a/test/type/opaque_constraint_order.swift
+++ b/test/type/opaque_constraint_order.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir -verify %s
+
+// rdar://problem/50309983, make sure that the generic signature built for
+// an opaque return type is correct when there are associated type constraints
+// on the enclosing generic context
+
+protocol Bort {}
+
+extension Int: Bort {}
+
+struct Butt<T: RandomAccessCollection>
+  where T.Element: Bort, T.Index: Hashable
+{
+  func foo() -> some Bort {
+    return 0
+  }
+}


### PR DESCRIPTION
Our ad-hoc mechanism for building the signature did not always produce requirements in the order
expected by the rest of the system; using the GSB should ensure we build a valid generic signature.
Fixes rdar://problem/50309983.