### PR TITLE
[5.1] Sema: Use GSB to build the signature for opaque result type decls.

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -203,49 +203,52 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   // Create a generic signature for the opaque environment. This is the outer
   // generic signature with an added generic parameter representing the opaque
   // type and its interface constraints.
-  SmallVector<GenericTypeParamType *, 4> interfaceGenericParams;
-  SmallVector<Requirement, 4> interfaceRequirements;
+  GenericSignatureBuilder builder(Context);
 
   auto originatingDC = originatingDecl->getInnermostDeclContext();
-  auto outerGenericSignature = originatingDC->getGenericSignatureOfContext();
-  if (outerGenericSignature) {
-    std::copy(outerGenericSignature->getGenericParams().begin(),
-              outerGenericSignature->getGenericParams().end(),
-              std::back_inserter(interfaceGenericParams));
-    std::copy(outerGenericSignature->getRequirements().begin(),
-              outerGenericSignature->getRequirements().end(),
-              std::back_inserter(interfaceRequirements));
-  }
-
   unsigned returnTypeDepth = 0;
-  if (!interfaceGenericParams.empty())
-    returnTypeDepth = interfaceGenericParams.back()->getDepth() + 1;
+  auto outerGenericSignature = originatingDC->getGenericSignatureOfContext();
+  
+  if (outerGenericSignature) {
+    builder.addGenericSignature(outerGenericSignature);
+    returnTypeDepth =
+               outerGenericSignature->getGenericParams().back()->getDepth() + 1;
+  }
+  
   auto returnTypeParam = GenericTypeParamType::get(returnTypeDepth, 0,
                                                    Context);
-  interfaceGenericParams.push_back(returnTypeParam);
+
+  builder.addGenericParameter(returnTypeParam);
 
   if (constraintType->getClassOrBoundGenericClass()) {
-    // Use the type as a superclass constraint.
-    interfaceRequirements.push_back(Requirement(RequirementKind::Superclass,
-                                              returnTypeParam, constraintType));
+    builder.addRequirement(Requirement(RequirementKind::Superclass,
+                                       returnTypeParam, constraintType),
+             GenericSignatureBuilder::FloatingRequirementSource::forAbstract(),
+             originatingDC->getParentModule());
   } else {
     auto constraints = constraintType->getExistentialLayout();
     if (auto superclass = constraints.getSuperclass()) {
-      interfaceRequirements.push_back(Requirement(RequirementKind::Superclass,
-                                                  returnTypeParam, superclass));
+      builder.addRequirement(Requirement(RequirementKind::Superclass,
+                                         returnTypeParam, superclass),
+             GenericSignatureBuilder::FloatingRequirementSource::forAbstract(),
+             originatingDC->getParentModule());
     }
     for (auto protocol : constraints.getProtocols()) {
-      interfaceRequirements.push_back(Requirement(RequirementKind::Conformance,
-                                                  returnTypeParam, protocol));
+      builder.addRequirement(Requirement(RequirementKind::Conformance,
+                                         returnTypeParam, protocol),
+             GenericSignatureBuilder::FloatingRequirementSource::forAbstract(),
+             originatingDC->getParentModule());
     }
     if (auto layout = constraints.getLayoutConstraint()) {
-      interfaceRequirements.push_back(Requirement(RequirementKind::Layout,
-                                                  returnTypeParam, layout));
+      builder.addRequirement(Requirement(RequirementKind::Layout,
+                                         returnTypeParam, layout),
+             GenericSignatureBuilder::FloatingRequirementSource::forAbstract(),
+             originatingDC->getParentModule());
     }
   }
   
-  auto interfaceSignature = GenericSignature::get(interfaceGenericParams,
-                                                  interfaceRequirements);
+  auto interfaceSignature = std::move(builder)
+                                          .computeGenericSignature(SourceLoc());
   
   // Create the OpaqueTypeDecl for the result type.
   // It has the same parent context and generic environment as the originating

--- a/test/type/opaque_constraint_order.swift
+++ b/test/type/opaque_constraint_order.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir -verify %s
+
+// rdar://problem/50309983, make sure that the generic signature built for
+// an opaque return type is correct when there are associated type constraints
+// on the enclosing generic context
+
+protocol Bort {}
+
+extension Int: Bort {}
+
+struct Butt<T: RandomAccessCollection>
+  where T.Element: Bort, T.Index: Hashable
+{
+  func foo() -> some Bort {
+    return 0
+  }
+}


### PR DESCRIPTION
Our ad-hoc mechanism for building the signature did not always produce requirements in the order
expected by the rest of the system; using the GSB should ensure we build a valid generic signature.
Fixes rdar://problem/50309983.