### PR TITLE
[5.1][ConstraintSystem] Diagnose missing explicit calls in assignment 

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1585,6 +1585,17 @@ bool MissingCallFailure::diagnoseAsError() {
     }
   }
 
+  if (auto *AE = dyn_cast<AssignExpr>(baseExpr)) {
+    auto *srcExpr = AE->getSrc();
+    if (auto *fnType = getType(srcExpr)->getAs<FunctionType>()) {
+      emitDiagnostic(srcExpr->getLoc(), diag::missing_nullary_call,
+                     fnType->getResult())
+          .highlight(srcExpr->getSourceRange())
+          .fixItInsertAfter(srcExpr->getEndLoc(), "()");
+      return true;
+    }
+  }
+
   emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function_value)
       .fixItInsertAfter(insertLoc, "()");
   return true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1990,7 +1990,8 @@ bool ConstraintSystem::repairFailures(
         // If left-hand side is a function type but right-hand
         // side isn't, let's check it would be possible to fix
         // this by forming an explicit call.
-        if (!rhs->is<FunctionType>() && !rhs->isVoid() &&
+        auto convertTo = rhs->lookThroughAllOptionalTypes();
+        if (!convertTo->is<FunctionType>() && !convertTo->isVoid() &&
             fnType->getNumParams() == 0 &&
             matchTypes(fnType->getResult(), rhs, ConstraintKind::Conversion,
                        TypeMatchFlags::TMF_ApplyingFix, locator)

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2556,6 +2556,13 @@ public:
     TypeMatchResult(SolutionKind result) : Kind(result) {}
   };
 
+  /// Attempt to repair typing failures and record fixes if needed.
+  /// \return true if at least some of the failures has been repaired
+  /// successfully, which allows type matcher to continue.
+  bool repairFailures(Type lhs, Type rhs,
+                      SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
+                      ConstraintLocatorBuilder locator);
+
   /// Subroutine of \c matchTypes(), which matches up two tuple types.
   ///
   /// \returns the result of performing the tuple-to-tuple conversion.

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -14,8 +14,8 @@ func f4() -> B { }
 func f5(_ a: A) { }
 func f6(_ a: A, _: Int) { }
 
-func createB() -> B { }  // expected-note {{found this candidate}}
-func createB(_ i: Int) -> B { } // expected-note {{found this candidate}}
+func createB() -> B { }
+func createB(_ i: Int) -> B { }
 
 func f7(_ a: A, _: @escaping () -> Int) -> B { }
 func f7(_ a: A, _: Int) -> Int { }
@@ -37,7 +37,7 @@ func forgotCall() {
   f6(f4, f2) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
 
   // With overloading: only one succeeds.
-  a = createB // expected-error{{ambiguous reference to member 'createB()'}}
+  a = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
 
   // With overloading, pick the fewest number of fixes.
   var b = f7(f4, f1) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -345,3 +345,15 @@ func rdar47776586() {
   dict[1] += 1 // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
   // expected-note@-1 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{10-10=!}}
 }
+
+struct S {
+  var foo: Optional<() -> Int?> = nil
+  var bar: Optional<() -> Int?> = nil
+
+  mutating func test(_ clj: @escaping () -> Int) {
+    if let fn = foo {
+      bar = fn  // Ok
+      bar = clj // Ok
+    }
+  }
+}


### PR DESCRIPTION
If the source of the assignment is a function type which has
a result that could be converted to expected destination type,
let's diagnose that as missing call if such function doesn't
have any parameters.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
