### PR TITLE
Sema: Tweak test/decl/protocol/conforms/nscoding.swift a bit [5.1]

### DIFF
--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -1,10 +1,16 @@
+// RUN: %empty-directory(%t)
+
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -disable-nskeyedarchiver-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-NO-DIAGS %s
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast > %t.ast
-// RUN: %FileCheck %s < %t.ast
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast -target x86_64-apple-macosx10.14.3 > %t/old.ast
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast -target x86_64-apple-macosx10.14.4 > %t/new.ast
 
-// REQUIRES: objc_interop
+// RUN: %FileCheck --check-prefix=CHECK-OLD %s < %t/old.ast
+// RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/old.ast
+// RUN: %FileCheck --check-prefix=NEGATIVE --check-prefix=NEGATIVE-NEW %s < %t/new.ast
+
+// REQUIRES: OS=macosx
 
 // CHECK-NO-DIAGS-NOT: NSCoding
 // CHECK-NO-DIAGS-NOT: unstable
@@ -12,7 +18,7 @@
 import Foundation
 
 // Top-level classes
-// CHECK-NOT: class_decl{{.*}}"CodingA"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NOT: class_decl{{.*}}"CodingA"{{.*}}@_staticInitializeObjCMetadata
 class CodingA : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
@@ -21,7 +27,7 @@ class CodingA : NSObject, NSCoding {
 
 // Nested classes
 extension CodingA {
-  // CHECK-NOT: class_decl{{.*}}"NestedA"{{.*}}@_staticInitializeObjCMetadata
+  // NEGATIVE-NOT: class_decl{{.*}}"NestedA"{{.*}}@_staticInitializeObjCMetadata
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
     // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{3-3=@objc(_TtCC8nscoding7CodingA7NestedA)}}
     // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#prefixed Objective-C class name#>)}}
@@ -36,14 +42,14 @@ extension CodingA {
     func encode(coder: NSCoder) { }
   }
 
-  // CHECK-NOT: class_decl{{.*}}"NestedC"{{.*}}@_staticInitializeObjCMetadata
+  // NEGATIVE-NOT: class_decl{{.*}}"NestedC"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedC)
   class NestedC : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
-  // CHECK-NOT: class_decl{{.*}}"NestedD"{{.*}}@_staticInitializeObjCMetadata
+  // NEGATIVE-NOT: class_decl{{.*}}"NestedD"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedD)
   class NestedD : NSObject {
     required init(coder: NSCoder) { }
@@ -58,7 +64,7 @@ extension CodingA.NestedD: NSCoding { // okay
 }
 
 // Generic classes
-// CHECK-NOT: class_decl{{.*}}"CodingB"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NOT: class_decl{{.*}}"CodingB"{{.*}}@_staticInitializeObjCMetadata
 class CodingB<T> : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
@@ -72,7 +78,7 @@ extension CodingB {
 }
 
 // Fileprivate classes.
-// CHECK-NOT: class_decl{{.*}}"CodingC"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NOT: class_decl{{.*}}"CodingC"{{.*}}@_staticInitializeObjCMetadata
 fileprivate class CodingC : NSObject, NSCoding { // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
   // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{1-1=@objc(_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingC)}}
   // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#prefixed Objective-C class name#>)}}
@@ -99,7 +105,7 @@ func someFunction() {
 }
 
 // Inherited conformances.
-// CHECK-NOT: class_decl{{.*}}"CodingE"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NOT: class_decl{{.*}}"CodingE"{{.*}}@_staticInitializeObjCMetadata
 class CodingE<T> : CodingB<T> {
   required init(coder: NSCoder) { super.init(coder: coder) }
   override func encode(coder: NSCoder) { }
@@ -119,24 +125,26 @@ private class CodingG : NSObject, NSCoding {
 }
 
 extension CodingB {
-  // CHECK-NOT: class_decl{{.*}}"GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
+  // NEGATIVE-NOT: class_decl{{.*}}"GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
   @objc(GenericViaScope) // expected-error {{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}}
   class GenericViaScope : NSObject { }
 }
 
 // Inference of @_staticInitializeObjCMetadata.
-// CHECK-NOT: class_decl{{.*}}"SubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NOT: class_decl{{.*}}"SubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
 class SubclassOfCodingA : CodingA { }
 
-// CHECK: class_decl{{.*}}"SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-OLD: class_decl{{.*}}"SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NEW-NOT: class_decl{{.*}}"SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
 class SubclassOfCodingE : CodingE<Int> { }
 
 // Do not warn when simply inheriting from classes that conform to NSCoding.
 // The subclass may never be serialized. But do still infer static
 // initialization, just in case.
-// CHECK-NOT: class_decl{{.*}}"PrivateSubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NOT: class_decl{{.*}}"PrivateSubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
 private class PrivateSubclassOfCodingA : CodingA { }
-// CHECK: class_decl{{.*}}"PrivateSubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-OLD: class_decl{{.*}}"PrivateSubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+// NEGATIVE-NEW-NOT: class_decl{{.*}}"PrivateSubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
 private class PrivateSubclassOfCodingE : CodingE<Int> { }
 
 // But do warn when inherited through a protocol.


### PR DESCRIPTION
Fixes <rdar://problem/50432525>.

Make sure we test on both an "old" and "new" deployment target.