### PR TITLE
[AST] NFC: Add `ValueDecl::getOpaqueResultTypeRepr` accessor

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -90,6 +90,7 @@ namespace swift {
   class UnboundGenericType;
   class ValueDecl;
   class VarDecl;
+  class OpaqueReturnTypeRepr;
 
 enum class DeclKind : uint8_t {
 #define DECL(Id, Parent) Id,
@@ -2692,7 +2693,10 @@ public:
   
   /// Get the decl for this value's opaque result type, if it has one.
   OpaqueTypeDecl *getOpaqueResultTypeDecl() const;
-  
+
+  /// Get the representative for this value's opaque result type, if it has one.
+  OpaqueReturnTypeRepr *getOpaqueResultTypeRepr() const;
+
   /// Set the opaque return type decl for this decl.
   ///
   /// `this` must be of a decl type that supports opaque return types, and

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2454,6 +2454,19 @@ void ValueDecl::setOverriddenDecls(ArrayRef<ValueDecl *> overridden) {
   request.cacheResult(overriddenVec);
 }
 
+OpaqueReturnTypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
+  TypeLoc returnLoc;
+  if (auto *VD = dyn_cast<VarDecl>(this)) {
+    returnLoc = VD->getTypeLoc();
+  } else if (auto *FD = dyn_cast<FuncDecl>(this)) {
+    returnLoc = FD->getBodyResultTypeLoc();
+  } else if (auto *SD = dyn_cast<SubscriptDecl>(this)) {
+    returnLoc = SD->getElementTypeLoc();
+  }
+
+  return dyn_cast_or_null<OpaqueReturnTypeRepr>(returnLoc.getTypeRepr());
+}
+
 OpaqueTypeDecl *ValueDecl::getOpaqueResultTypeDecl() const {
   if (auto func = dyn_cast<FuncDecl>(this)) {
     return func->getOpaqueResultTypeDecl();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -278,18 +278,9 @@ bool RequirementFailure::diagnoseAsError() {
         anchor->getLoc(), diag::type_does_not_conform_in_opaque_return,
         namingDecl->getDescriptiveKind(), namingDecl->getFullName(), lhs, rhs);
 
-    TypeLoc returnLoc;
-    if (auto *VD = dyn_cast<VarDecl>(namingDecl)) {
-      returnLoc = VD->getTypeLoc();
-    } else if (auto *FD = dyn_cast<FuncDecl>(namingDecl)) {
-      returnLoc = FD->getBodyResultTypeLoc();
-    } else if (auto *SD = dyn_cast<SubscriptDecl>(namingDecl)) {
-      returnLoc = SD->getElementTypeLoc();
-    }
-
-    if (returnLoc.hasLocation()) {
-      emitDiagnostic(returnLoc.getLoc(), diag::opaque_return_type_declared_here)
-          .highlight(returnLoc.getSourceRange());
+    if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {
+      emitDiagnostic(repr->getLoc(), diag::opaque_return_type_declared_here)
+          .highlight(repr->getSourceRange());
     }
     return true;
   }


### PR DESCRIPTION
Follow-up cleanup to simplify code related to diagnosing of
opaque return type conformance mismatches.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
