### PR TITLE
[5.1] Fixes for opaque return types on local functions.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1004,6 +1004,7 @@ public:
   llvm::SetVector<TypeDecl *> LocalTypeDecls;
   
   /// The set of validated opaque return type decls in the source file.
+  llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
   llvm::StringMap<OpaqueTypeDecl *> ValidatedOpaqueReturnTypes;
   /// The set of parsed decls with opaque return types that have not yet
   /// been validated.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1792,8 +1792,11 @@ SourceFile::lookupOpaqueResultType(StringRef MangledName,
 void SourceFile::markDeclWithOpaqueResultTypeAsValidated(ValueDecl *vd) {
   UnvalidatedDeclsWithOpaqueReturnTypes.erase(vd);
   if (auto opaqueDecl = vd->getOpaqueResultTypeDecl()) {
-    ValidatedOpaqueReturnTypes.insert(
+    auto inserted = ValidatedOpaqueReturnTypes.insert(
               {opaqueDecl->getOpaqueReturnTypeIdentifier().str(), opaqueDecl});
+    if (inserted.second) {
+      OpaqueReturnTypes.push_back(opaqueDecl);
+    }
   }
 }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -891,20 +891,6 @@ void IRGenModule::maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *opaque) {
   }
 }
 
-void IRGenModule::emitFuncDecl(FuncDecl *fd) {
-  // If there's an opaque return type for this function, emit its descriptor.
-  if (auto opaque = fd->getOpaqueResultTypeDecl()) {
-    maybeEmitOpaqueTypeDecl(opaque);
-  }
-}
-
-void IRGenModule::emitAbstractStorageDecl(AbstractStorageDecl *fd) {
-  // If there's an opaque return type for this function, emit its descriptor.
-  if (auto opaque = fd->getOpaqueResultTypeDecl()) {
-    maybeEmitOpaqueTypeDecl(opaque);
-  }
-}
-
 namespace {
   /// A type implementation for resilient struct types. This is not a
   /// StructTypeInfoBase at all, since we don't know anything about

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1205,8 +1205,6 @@ public:
   void emitStructDecl(StructDecl *D);
   void emitClassDecl(ClassDecl *D);
   void emitExtension(ExtensionDecl *D);
-  void emitFuncDecl(FuncDecl *D);
-  void emitAbstractStorageDecl(AbstractStorageDecl *D);
   void emitOpaqueTypeDecl(OpaqueTypeDecl *D);
   void emitSILGlobalVariable(SILGlobalVariable *gv);
   void emitCoverageMapping();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2372,6 +2372,11 @@ public:
 
     return {true, S};
   }
+  
+  // Don't descend into nested decls.
+  bool walkToDeclPre(Decl *D) override {
+    return false;
+  }
 };
 
 } // end anonymous namespace

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -132,6 +132,16 @@ func baz<T: P & Q>(z: T) -> some P & Q {
   return z
 }
 
+// Ensure the local type's opaque descriptor gets emitted.
+// CHECK-LABEL: @"$s18opaque_result_type11localOpaqueQryF0D0L_QryFQOMQ" = 
+func localOpaque() -> some P {
+  func local() -> some P {
+    return "local"
+  }
+
+  return local()
+}
+
 public func useFoo(x: String, y: C) {
   let p = foo(x: x)
   let pa = p.poo()
@@ -180,3 +190,4 @@ struct X<T: R, U: R>: R {
     return Wrapper(wrapped: u)
   }
 }
+


### PR DESCRIPTION
- In Sema, don't traverse nested declarations while deducing the opaque return type. This would
  cause returns inside nested functions to clobber the return type of the outer function.
- In IRGen, walk the list of opaque return types we keep in the SourceFile already for type
  reconstruction, instead of trying to visit them ad-hoc as part of walking the AST, since
  IRGen doesn't normally walk the bodies of function decls directly.

Fixes rdar://problem/50459091