### PR TITLE
[test] Add availability guards for tests checking behavioral changes in 5.1

### DIFF
--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -572,6 +572,11 @@ ${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/validCount") 
 }
 
 ${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/reassignBuffer") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+    // When back-deployed to 5.0, this coding error does not get detected.
+    return
+  }
+
   expectCrashLater()
   let otherBuffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: 1)
   let array = ${ArrayType}<Int>(unsafeUninitializedCapacity: 10) { buffer, _ in

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -77,6 +77,8 @@ StringBridgeTests.test("Tagged NSString") {
 
 func returnOne<T>(_ t: T) -> Int { return 1 }
 StringBridgeTests.test("Character from NSString") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+
   // NOTE: Using hard-coded literals to directly construct NSStrings
   let ns1 = "A" as NSString
   let ns2 = "A\u{301}" as NSString

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -316,6 +316,8 @@ class TestAffineTransform : TestAffineTransformSuper {
     }
     
     func test_hashing() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+
         // the transforms are made up and the values don't matter
         let a = AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7)
         let b = AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33)

--- a/test/stdlib/TestDateInterval.swift
+++ b/test/stdlib/TestDateInterval.swift
@@ -66,7 +66,7 @@ class TestDateInterval : TestDateIntervalSuper {
     }
 
     func test_hashing() {
-        guard #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) else { return }
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
 
         let start1a = dateWithString("2019-04-04 17:09:23 -0700")
         let start1b = dateWithString("2019-04-04 17:09:23 -0700")

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -222,6 +222,7 @@ class TestIndexPath: TestIndexPathSuper {
     }
     
     func testHashing() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
         let samples: [IndexPath] = [
             [],
             [1],

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -155,6 +155,7 @@ class TestMeasurement : TestMeasurementSuper {
     }
 
     func testHashing() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
         let lengths: [[Measurement<UnitLength>]] = [
             [
                 Measurement(value: 5, unit: UnitLength.kilometers),

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -85,6 +85,7 @@ class TestUUID : TestUUIDSuper {
     }
     
     func test_hash() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
         let values: [UUID] = [
             // This list takes a UUID and tweaks every byte while
             // leaving the version/variant intact.

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3004,7 +3004,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
-  do {
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    // Identity of empty dictionaries changed in
+    // https://github.com/apple/swift/pull/22527
     var d = getBridgedNonverbatimDictionary([:])
     assert(isNativeDictionary(d))
     assert(d.count == 0)
@@ -3087,7 +3089,6 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }
 }
-
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Count") {
   let d = getBridgedVerbatimDictionary()
@@ -3298,6 +3299,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+    // Identity of empty dictionaries changed in
+    // https://github.com/apple/swift/pull/22527
+    return
+  }
+
   let d1 = getBridgedNonverbatimEquatableDictionary([:])
   let identity1 = d1._rawIdentifier()
   assert(isNativeDictionary(d1))
@@ -3319,7 +3326,6 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
   assert(identity1 == d1._rawIdentifier())
   assert(identity2 != d2._rawIdentifier())
 }
-
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
   func helper(_ nd1: Dictionary<Int, Int>, _ nd2: Dictionary<Int, Int>, _ expectedEq: Bool) {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1983,7 +1983,8 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
-  do {
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    // Identity of empty sets changed in https://github.com/apple/swift/pull/22527
     var s = getBridgedNonverbatimSet([])
     expectTrue(isNativeSet(s))
     expectEqual(0, s.count)
@@ -2174,6 +2175,10 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+    // Identity of empty sets changed in https://github.com/apple/swift/pull/22527
+    return
+  }
   let s1 = getBridgedNonverbatimSet([])
   let identity1 = s1._rawIdentifier()
   expectTrue(isNativeSet(s1))
@@ -4649,45 +4654,49 @@ SetTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
 }
 
 #if _runtime(_ObjC)
-SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // https://github.com/apple/swift/pull/23174
+  SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
   .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+      { _isFastAssertConfiguration() },
+      reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches("Could not cast value of type")
   .code {
+    let s1: NSSet = [
+      "Gordon" as NSString,
+      "William" as NSString,
+      "Katherine" as NSString,
+      "Lynn" as NSString,
+      "Brian" as NSString,
+      1756 as NSNumber]
 
-  let s1: NSSet = [
-    "Gordon" as NSString,
-    "William" as NSString,
-    "Katherine" as NSString,
-    "Lynn" as NSString,
-    "Brian" as NSString,
-    1756 as NSNumber]
-
-  expectCrashLater()
-  _ = s1 as! Set<String>
+    expectCrashLater()
+    _ = s1 as! Set<String>
+  }
 }
 #endif
 
 #if _runtime(_ObjC)
-SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // https://github.com/apple/swift/pull/23174
+  SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches("Could not cast value of type")
   .code {
+    let s1: NSSet = [
+      4 as NSNumber,
+      8 as NSNumber,
+      15 as NSNumber,
+      16 as NSNumber,
+      23 as NSNumber,
+      42 as NSNumber,
+      "John" as NSString]
 
-  let s1: NSSet = [
-    4 as NSNumber,
-    8 as NSNumber,
-    15 as NSNumber,
-    16 as NSNumber,
-    23 as NSNumber,
-    42 as NSNumber,
-    "John" as NSString]
-
-  expectCrashLater()
-  _ = s1 as! Set<Int>
+    expectCrashLater()
+    _ = s1 as! Set<Int>
+  }
 }
 #endif
 
@@ -4800,61 +4809,70 @@ SetTestSuite.test("ForcedVerbatimDowncast.Trap.Int")
 #endif
 
 #if _runtime(_ObjC)
-SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // https://github.com/apple/swift/pull/23174
+  SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches("Could not cast value of type")
   .code {
-  let s1: Set<NSObject> = [
-    "Gordon" as NSString,
-    "William" as NSString,
-    "Katherine" as NSString,
-    "Lynn" as NSString,
-    "Brian" as NSString,
-    1756 as NSNumber]
-  expectCrashLater()
-  // Nonverbatim downcasts are greedy and they trap immediately.
-  let s2 = s1 as! Set<String>
-  _ = s2.contains("Gordon")
+    let s1: Set<NSObject> = [
+      "Gordon" as NSString,
+      "William" as NSString,
+      "Katherine" as NSString,
+      "Lynn" as NSString,
+      "Brian" as NSString,
+      1756 as NSNumber]
+    expectCrashLater()
+    // Nonverbatim downcasts are greedy and they trap immediately.
+    let s2 = s1 as! Set<String>
+    _ = s2.contains("Gordon")
+  }
 }
 #endif
 
 #if _runtime(_ObjC)
-SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // https://github.com/apple/swift/pull/23174
+  SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches("Could not cast value of type")
   .code {
-  let s1: Set<NSObject> = [
-    4 as NSNumber,
-    8 as NSNumber,
-    15 as NSNumber,
-    16 as NSNumber,
-    23 as NSNumber,
-    42 as NSNumber,
-    "John" as NSString]
-  expectCrashLater()
-  // Nonverbatim downcasts are greedy and they trap immediately.
-  let s2 = s1 as! Set<Int>
-  _ = s2.contains(23)
+    let s1: Set<NSObject> = [
+      4 as NSNumber,
+      8 as NSNumber,
+      15 as NSNumber,
+      16 as NSNumber,
+      23 as NSNumber,
+      42 as NSNumber,
+      "John" as NSString]
+    expectCrashLater()
+    // Nonverbatim downcasts are greedy and they trap immediately.
+    let s2 = s1 as! Set<Int>
+    _ = s2.contains(23)
+  }
 }
 #endif
 
 #if _runtime(_ObjC)
-SetTestSuite.test("Upcast.StringEqualityMismatch") {
-  // Upcasting from NSString to String keys changes their concept of equality,
-  // resulting in two equal keys, one of which should be discarded by the
-  // downcast. (Along with its associated value.)
-  // rdar://problem/35995647
-  let s: Set<NSString> = [
-    "cafe\u{301}",
-    "café"
-  ]
-  expectEqual(s.count, 2)
-  let s2 = s as Set<String>
-  expectEqual(s2.count, 1)
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // https://github.com/apple/swift/pull/23683
+  SetTestSuite.test("Upcast.StringEqualityMismatch") {
+    // Upcasting from NSString to String keys changes their concept of equality,
+    // resulting in two equal keys, one of which should be discarded by the
+    // downcast. (Along with its associated value.)
+    // rdar://problem/35995647
+    let s: Set<NSString> = [
+      "cafe\u{301}",
+      "café"
+    ]
+    expectEqual(s.count, 2)
+    let s2 = s as Set<String>
+    expectEqual(s2.count, 1)
+  }
 }
 #endif
 


### PR DESCRIPTION
Add runtime 9999-availability guards around tests checking for behavioral changes since 5.0.

This is useful in case these tests are deployed with the 5.0 stdlib.

rdar://problem/50150948