### PR TITLE
Improve diagnostic for throw in function type AND wrong position

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -724,9 +724,8 @@ ERROR(rethrows_in_wrong_position,none,
       "'rethrows' may only occur before '->'", ())
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())
-ERROR(throw_in_function_type_and_wrong_position,none,
-      "expected throwing specifier; did you mean 'throws'? "
-      "'throws' may only occur before '->'", ())
+NOTE(throw_in_function_type_and_wrong_position_note,none,
+      "expected throwing specifier; did you mean 'throws'?", ())
 ERROR(expected_type_before_arrow,none,
       "expected type before '->'", ())
 ERROR(expected_type_after_arrow,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -724,6 +724,9 @@ ERROR(rethrows_in_wrong_position,none,
       "'rethrows' may only occur before '->'", ())
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())
+ERROR(throw_in_function_type_and_wrong_position,none,
+      "expected throwing specifier; did you mean 'throws'? "
+      "'throws' may only occur before '->'", ())
 ERROR(expected_type_before_arrow,none,
       "expected type before '->'", ())
 ERROR(expected_type_after_arrow,none,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -789,9 +789,10 @@ Parser::parseFunctionSignature(Identifier SimpleName,
       throwsLoc = consumeToken();
       rethrows = true;
     } else if (Tok.is(tok::kw_throw)) {
-        throwsLoc = consumeToken();
-        isThrow = true;
-        return diagnose(throwsLoc, diag::throw_in_function_type_and_wrong_position);
+      throwsLoc = consumeToken();
+      isThrow = true;
+      return diagnose(throwsLoc,
+                      diag::throw_in_function_type_and_wrong_position);
     }
 
     if (!throwsLoc.isValid())
@@ -819,13 +820,12 @@ Parser::parseFunctionSignature(Identifier SimpleName,
       assert(arrowLoc.isValid());
       assert(throwsLoc.isValid());
       if (isThrow) {
-          (*diagOpt)
-          .fixItInsert(arrowLoc, "throws ")
-          .fixItRemove(SourceRange(throwsLoc));
+        (*diagOpt)
+            .fixItInsert(arrowLoc, "throws ")
+            .fixItRemove(SourceRange(throwsLoc));
       } else {
-          (*diagOpt).fixItExchange(SourceRange(arrowLoc),
-                                   SourceRange(throwsLoc));
-      } 
+        (*diagOpt).fixItExchange(SourceRange(arrowLoc), SourceRange(throwsLoc));
+      }
     }
 
     ParserResult<TypeRepr> ResultType =

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -110,6 +110,13 @@ func postRethrows2(_ f: () throws -> Int) -> rethrows Int { // expected-error{{'
   return try f()
 }
 
+func postThrow1() -> throw Int { // expected-error {{expected throwing specifier; did you mean 'throws'? 'throws' may only occur before '->'}} {{19-19=throws }} {{22-28=}}
+    return 0
+}
+func postThrow2() -> Int throw { // expected-error {{expected throwing specifier; did you mean 'throws'? 'throws' may only occur before '->'}} {{19-19=throws }} {{25-31=}}
+    return 0
+}
+
 func incompleteThrowType() {
   // FIXME: Bad recovery for incomplete function type.
   let _: () throws

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -110,10 +110,12 @@ func postRethrows2(_ f: () throws -> Int) -> rethrows Int { // expected-error{{'
   return try f()
 }
 
-func postThrow1() -> throw Int { // expected-error {{expected throwing specifier; did you mean 'throws'? 'throws' may only occur before '->'}} {{19-19=throws }} {{22-28=}}
+func postThrow1() -> throw Int { // expected-error {{'throws' may only occur before '->'}}
+                                 // expected-note@-1 {{expected throwing specifier; did you mean 'throws'?}} {{19-19=throws }} {{22-28=}}
     return 0
 }
-func postThrow2() -> Int throw { // expected-error {{expected throwing specifier; did you mean 'throws'? 'throws' may only occur before '->'}} {{19-19=throws }} {{25-31=}}
+func postThrow2() -> Int throw { // expected-error {{'throws' may only occur before '->'}}
+                                 // expected-note@-1 {{expected throwing specifier; did you mean 'throws'?}} {{19-19=throws }} {{25-31=}}
     return 0
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR improves the diagnostic when `throw` is used in a function type **and** in the wrong position.

Swift currently has specific diagnostics for the following cases:

- using `throw` instead of `throws` in function type. The compiler correctly detects and suggests the proper change. 

![image (4)](https://user-images.githubusercontent.com/750912/57181462-003d3980-6e8c-11e9-8cd9-e82a9df03aa5.png)

- `throws` in the wrong position. The compiler correctly detects the wrong position and is able to move it. 

![image (4)](https://user-images.githubusercontent.com/750912/57181482-4a261f80-6e8c-11e9-84c5-d134c80cf383.png)

Both of these scenarios are really useful, but when you use `throw` in the function type and in the wrong position the error is not really useful. Furthermore executing the fixit just makes things worse. 

![image (3)](https://user-images.githubusercontent.com/750912/57181445-cb30e700-6e8b-11e9-9e40-cd39d92412e1.png)

This is not a rare mistake. I've seen it happen to newcomers to the language or even experienced programmers that just mistyped throws and moved it in the wrong place before letting the fix-it appear. 

With this changes the compiler is now able to detect the combination of both cases and give a better error. It also able to provide an appropriate fixit that will rename `throw` to `throws` and move it to the correct position. 

> expected throwing specifier; did you mean 'throws'? 
> 'throws' may only occur before '->'

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->