### PR TITLE
[5.1 04-24] [ModuleInterface] Include the raw values of @objc enums

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -170,8 +170,15 @@ struct PrintOptions {
   /// Whether to print variable initializers.
   bool VarInitializers = false;
 
+  /// Choices for how to print enum raw values.
+  enum class EnumRawValueMode {
+    Skip,
+    PrintObjCOnly,
+    Print
+  };
+
   /// Whether to print enum raw value expressions.
-  bool EnumRawValues = false;
+  EnumRawValueMode EnumRawValues = EnumRawValueMode::Skip;
 
   /// Whether to prefer printing TypeReprs instead of Types,
   /// if a TypeRepr is available.  This allows us to print the original
@@ -565,7 +572,7 @@ struct PrintOptions {
   static PrintOptions printQuickHelpDeclaration() {
     PrintOptions PO;
     PO.SkipUnderscoredKeywords = true;
-    PO.EnumRawValues = true;
+    PO.EnumRawValues = EnumRawValueMode::Print;
     PO.PrintImplicitAttrs = false;
     PO.PrintFunctionRepresentationAttrs = false;
     PO.PrintDocumentationComments = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -107,6 +107,7 @@ PrintOptions PrintOptions::printParseableInterfaceFile() {
   result.FunctionDefinitions = true;
   result.CollapseSingleGetterProperty = false;
   result.VarInitializers = true;
+  result.EnumRawValues = EnumRawValueMode::PrintObjCOnly;
   result.OpaqueReturnTypePrinting =
       OpaqueReturnTypePrintingMode::StableReference;
 
@@ -2858,8 +2859,19 @@ void PrintAST::printEnumElement(EnumElementDecl *elt) {
     Options.ExcludeAttrList.pop_back();
   }
 
+  switch (Options.EnumRawValues) {
+  case PrintOptions::EnumRawValueMode::Skip:
+    return;
+  case PrintOptions::EnumRawValueMode::PrintObjCOnly:
+    if (!elt->isObjC())
+      return;
+    break;
+  case PrintOptions::EnumRawValueMode::Print:
+    break;
+  }
+
   auto *raw = elt->getRawValueExpr();
-  if (!Options.EnumRawValues || !raw || raw->isImplicit())
+  if (!raw || raw->isImplicit())
     return;
 
   // Print the explicit raw value expression.

--- a/test/ParseableInterface/Inputs/enums-layout-helper.swift
+++ b/test/ParseableInterface/Inputs/enums-layout-helper.swift
@@ -1,0 +1,40 @@
+// CHECK-LABEL: public enum FutureproofEnum : Int
+public enum FutureproofEnum: Int {
+  // CHECK-NEXT: case a{{$}}
+  case a = 1
+  // CHECK-NEXT: case b{{$}}
+  case b = 10
+  // CHECK-NEXT: case c{{$}}
+  case c = 100
+}
+
+// CHECK-LABEL: public enum FrozenEnum : Int
+@_frozen public enum FrozenEnum: Int {
+  // CHECK-NEXT: case a{{$}}
+  case a = 1
+  // CHECK-NEXT: case b{{$}}
+  case b = 10
+  // CHECK-NEXT: case c{{$}}
+  case c = 100
+}
+
+// CHECK-LABEL: public enum FutureproofObjCEnum : Int
+@objc public enum FutureproofObjCEnum: Int {
+  // CHECK-NEXT: case a = 1{{$}}
+  case a = 1
+  // CHECK-NEXT: case b = 10{{$}}
+  case b = 10
+  // CHECK-NEXT: case c = 100{{$}}
+  case c = 100
+}
+
+// CHECK-LABEL: public enum FrozenObjCEnum : Int
+@_frozen @objc public enum FrozenObjCEnum: Int {
+  // CHECK-NEXT: case a = 1{{$}}
+  case a = 1
+  // CHECK-NEXT: case b = 10{{$}}
+  case b = 10
+  // CHECK-NEXT: case c = 100{{$}}
+  case c = 100
+}
+

--- a/test/ParseableInterface/enums-layout.swift
+++ b/test/ParseableInterface/enums-layout.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-interface-path %t/Lib.swiftinterface -typecheck -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift
+// RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
+// RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t | %FileCheck %s
+
+import Lib
+
+// CHECK-LABEL: define{{.+}}testFutureproofEnum
+func testFutureproofEnum() -> FutureproofEnum {
+  // Check a few things in the function to make sure it's getting the case
+  // representation dynamically.
+  // CHECK: [[CASE:%.+]] = load i32, i32* @"$s3Lib15FutureproofEnumO1byA2CmFWC"
+  // CHECK: [[METADATA_RESPONSE:%.+]] = tail call swiftcc %swift.metadata_response @"$s3Lib15FutureproofEnumOMa"
+  // CHECK: [[METADATA:%.+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+  // CHECK: tail call void {{%.+}}(%swift.opaque* noalias %0, i32 [[CASE]], %swift.type* [[METADATA]])
+  // CHECK-NEXT: ret void
+  return .b
+} // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: define{{.+}}testFrozenEnum
+func testFrozenEnum() -> FrozenEnum {
+  // CHECK: ret i8 1
+  return .b
+} // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: define{{.+}}testFutureproofObjCEnum
+func testFutureproofObjCEnum() -> FutureproofObjCEnum {
+  // CHECK: ret i{{32|64}} 10
+  return .b
+} // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: define{{.+}}testFrozenObjCEnum
+func testFrozenObjCEnum() -> FrozenObjCEnum {
+  // CHECK: ret i{{32|64}} 10
+  return .b
+} // CHECK-NEXT: {{^}$}}

--- a/test/ParseableInterface/synthesized.swift
+++ b/test/ParseableInterface/synthesized.swift
@@ -16,7 +16,7 @@ public enum HasRawValue: Int {
 }
 
 // CHECK-LABEL: @objc public enum ObjCEnum : Int32 {
-// CHECK-NEXT: case a, b, c
+// CHECK-NEXT: case a, b = 5, c
 // CHECK-DAG: public typealias RawValue = Swift.Int32
 // CHECK-DAG: @inlinable public init?(rawValue: Swift.Int32)
 // CHECK-DAG: public var rawValue: Swift.Int32 {


### PR DESCRIPTION
Cherry-pick of #24487 to the 04-24 5.1 branch, for Apple-internal clients. Reviewed by @harlanhaskins and @nathawes.

rdar://problem/50410541
