### PR TITLE
[Serialization] Reduce file size by splitting dep dirnames from basenames

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 488; // assign_by_delegate
+const uint16_t SWIFTMODULE_VERSION_MINOR = 489; // dependency directories
 
 using DeclIDField = BCFixed<31>;
 
@@ -644,6 +644,7 @@ namespace input_block {
     MODULE_FLAGS, // [unused]
     SEARCH_PATH,
     FILE_DEPENDENCY,
+    DEPENDENCY_DIRECTORY,
     PARSEABLE_INTERFACE_PATH
   };
 
@@ -689,7 +690,13 @@ namespace input_block {
     FileModTimeOrContentHashField, // mtime or content hash (for validation)
     BCFixed<1>,                    // are we reading mtime (0) or hash (1)?
     BCFixed<1>,                    // SDK-relative?
+    BCVBR<8>,                      // subpath-relative index (0=none)
     BCBlob                         // path
+  >;
+
+  using DependencyDirectoryLayout = BCRecordLayout<
+    DEPENDENCY_DIRECTORY,
+    BCBlob
   >;
 
   using ParseableInterfaceLayout = BCRecordLayout<

--- a/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -22,6 +22,7 @@
 // RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
 // RUN: test -f %t/MCP-system/SystemDependencies*.swiftmodule
 // RUN: %FileCheck -check-prefix CHECK %s < %t/dummy.d
+// RUN: llvm-bcanalyzer -dump %t/MCP-system/SystemDependencies*.swiftmodule | %FileCheck -check-prefix CHECK-DUMP %s
 // RUN: %{python} %S/Inputs/make-old.py %t/MCP-system/SystemDependencies*.swiftmodule
 
 // Baseline: running the same command again doesn't rebuild the cached module.
@@ -41,6 +42,13 @@
 
 // NEGATIVE-NOT: SomeCModule.h
 // CHECK: SomeCModule.h
+
+// CHECK-DUMP-NOT: usr/include
+// CHECK-DUMP: DEPENDENCY_DIRECTORY{{.+}}'usr/include'
+// CHECK-DUMP-NEXT: FILE_DEPENDENCY{{.+}}'module.modulemap'
+// CHECK-DUMP-NEXT: FILE_DEPENDENCY{{.+}}'SomeCModule.h'
+// CHECK-DUMP-NOT: usr/include
+
 // MODULECACHE-COUNT-2: SystemDependencies-{{[^ ]+}}.swiftmodule
 
 import SomeCModule


### PR DESCRIPTION
Dependency tracking for cached compiled modules (compiled from swiftinterfaces) can lead to a high percentage of the module being SDK-relative paths when `-track-system-dependencies` is on. Cut down on this by storing directory names in a separate record that gets referenced from each file dependency. (Since a lot of per-file dependencies are header files in a common directory, this is a win.)

We can do something more clever in the future, but this is a reasonable start for, say, the overlays.

rdar://problem/50449802