### PR TITLE
[5.1] Fix generic specialization that can result in noreturn apply without unreachable

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -193,6 +193,13 @@ protected:
                                  Helper.getArguments(), Inst->isNonThrowing(),
                                  GenericSpecializationInformation::create(
                                    Inst, getBuilder()));
+    // Specialization can return noreturn applies that were not identified as
+    // such before.
+    if (N->isCalleeNoReturn() &&
+        !isa<UnreachableInst>(*std::next(SILBasicBlock::iterator(Inst)))) {
+      noReturnApplies.push_back(N);
+    }
+
     recordClonedInstruction(Inst, N);
   }
 
@@ -381,6 +388,9 @@ protected:
   SILFunction &Original;
   /// True, if used for inlining.
   bool Inlining;
+  // Generic specialization can create noreturn applications that where
+  // previously not identifiable as such.
+  SmallVector<ApplyInst *, 16> noReturnApplies;
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -74,6 +74,8 @@ public:
     return SC.getCloned();
   }
 
+  void fixUp(SILFunction *calleeFunction);
+
 protected:
   void visitTerminator(SILBasicBlock *BB);
 

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -191,3 +191,12 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
   RemappedScopeCache.insert({DS, RemappedScope});
   return RemappedScope;
 }
+
+void GenericCloner::fixUp(SILFunction *f) {
+  for (auto *apply : noReturnApplies) {
+    auto applyBlock = apply->getParent();
+    applyBlock->split(std::next(SILBasicBlock::iterator(apply)));
+    getBuilder().setInsertionPoint(applyBlock);
+    getBuilder().createUnreachable(apply->getLoc());
+  }
+}

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -692,3 +692,37 @@ bb0(%0 : $*T):
   %13 = tuple ()
   return %13 : $()
 } // end sil function 'testSelfRecursiveFunction'
+
+sil @id : $@convention(thin) <T> (@in T) -> @out T {
+bb0(%0 : $*T, %1 :$*T):
+  copy_addr [take] %1 to [initialization] %0 : $*T
+  %t = tuple ()
+  return %t : $()
+}
+
+// This should not assert.
+// CHECK-LABEL: sil shared @$s26specialize_no_return_applys5NeverO_Tg5
+// CHECK:      apply
+// CHECK-NEXT: unreachable
+
+sil @specialize_no_return_apply: $@convention(thin) <T> (@thick T.Type) -> () {
+bb0(%0 : $@thick T.Type):
+  %in = alloc_stack $T
+  %out = alloc_stack $T
+  %f = function_ref @id : $@convention(thin) <T> (@in T) -> @out T
+  %r = apply %f<T>(%out, %in) : $@convention(thin) <T> (@in T) -> @out T
+  dealloc_stack %out : $*T
+  dealloc_stack %in : $*T
+  %t = tuple ()
+  return %t : $()
+}
+
+sil @test_specialize_noreturn_apply : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @specialize_no_return_apply : $@convention(thin) <T> (@thick T.Type) -> ()
+  %m = metatype $@thick Never.Type
+  %r = apply %f<Never>(%m) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %t = tuple ()
+  return %t : $()
+
+}


### PR DESCRIPTION

rdar://50393169