### PR TITLE
build: make `SWIFT_BUILD_STDLIB` control the stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1049,7 +1049,9 @@ endif()
 # created. This then will cause SwiftSyntax to fail to build.
 #
 # https://bugs.swift.org/browse/SR-5975
-add_subdirectory(stdlib)
+if(SWIFT_BUILD_STDLIB)
+  add_subdirectory(stdlib)
+endif()
 
 if(SWIFT_INCLUDE_APINOTES)
   add_subdirectory(apinotes)


### PR DESCRIPTION
Permit disabling the standard library build.  This will allow a
toolchain to be built without the standard library now that it is
possible to build just the standard library without the toolchain.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
