### PR TITLE
test: make portable to LLP64 targets

### DIFF
--- a/test/ParseableInterface/Inputs/enums-layout-helper.swift
+++ b/test/ParseableInterface/Inputs/enums-layout-helper.swift
@@ -18,8 +18,8 @@ public enum FutureproofEnum: Int {
   case c = 100
 }
 
-// CHECK-LABEL: public enum FutureproofObjCEnum : Int
-@objc public enum FutureproofObjCEnum: Int {
+// CHECK-LABEL: public enum FutureproofObjCEnum : Int32
+@objc public enum FutureproofObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
   // CHECK-NEXT: case b = 10{{$}}


### PR DESCRIPTION
`Int` is not usable for LLP64 targets, use an explicit `Int32` when
bridging an ObjC enumeration.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
