### PR TITLE
Property delegates serialization

### DIFF
--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -285,6 +285,24 @@ public:
       (*this)(requests)...);
   }
 
+  /// Cache a precomputed value for the given request, so that it will not
+  /// be computed.
+  template<typename Request,
+           typename std::enable_if<Request::hasExternalCache>::type* = nullptr>
+  void cacheOutput(const Request &request,
+                   typename Request::OutputType &&output) {
+    request.cacheResult(std::move(output));
+  }
+
+  /// Cache a precomputed value for the given request, so that it will not
+  /// be computed.
+  template<typename Request,
+           typename std::enable_if<!Request::hasExternalCache>::type* = nullptr>
+  void cacheOutput(const Request &request,
+                   typename Request::OutputType &&output) {
+    cache.insert({getCanonicalRequest(request), std::move(output)});
+  }
+
   /// Clear the cache stored within this evaluator.
   ///
   /// Note that this does not clear the caches of requests that use external

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 488; // assign_by_delegate
+const uint16_t SWIFTMODULE_VERSION_MINOR = 489; // backing variables
 
 using DeclIDField = BCFixed<31>;
 
@@ -1047,7 +1047,8 @@ namespace decls_block {
     AccessLevelField, // access level
     AccessLevelField, // setter access, if applicable
     DeclIDField, // opaque return type decl
-    BCArray<TypeIDField> // accessors and dependencies
+    BCFixed<2>,  // # of property delegate backing properties
+    BCArray<TypeIDField> // accessors, backing properties, and dependencies
   >;
 
   using ParamLayout = BCRecordLayout<

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1771,11 +1771,14 @@ static void maybeAddAccessorsForPropertyDelegate(VarDecl *var,
   auto valueVar = var->getAttachedPropertyDelegateTypeInfo().valueVar;
   assert(valueVar && "Cannot fail when the backing var is valid");
 
+  auto parentSF = var->getDeclContext()->getParentSourceFile();
   bool delegateSetterIsUsable =
     var->getSetter() ||
-    (!var->isLet() &&
-       valueVar->isSettable(nullptr) &&
-       valueVar->isSetterAccessibleFrom(var->getInnermostDeclContext()));
+    (parentSF &&
+     parentSF->Kind != SourceFileKind::Interface &&
+     !var->isLet() &&
+     valueVar->isSettable(nullptr) &&
+     valueVar->isSetterAccessibleFrom(var->getInnermostDeclContext()));
 
   if (!var->getGetter()) {
     addGetterToStorage(var, ctx);

--- a/lib/Sema/TypeCheckPropertyDelegate.cpp
+++ b/lib/Sema/TypeCheckPropertyDelegate.cpp
@@ -263,6 +263,11 @@ AttachedPropertyDelegateRequest::evaluate(Evaluator &evaluator,
     if (!nominal || !nominal->getAttrs().hasAttribute<PropertyDelegateAttr>())
       continue;
 
+    // If the declaration came from a module file, we've already done all of
+    // the semantic checking required.
+    if (!dc->getParentSourceFile())
+      return mutableAttr;
+
     // Check various restrictions on which properties can have delegates
     // attached to them.
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -22,7 +22,9 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/PropertyDelegates.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Serialization/BCReadingExtras.h"
@@ -2664,13 +2666,13 @@ public:
     DeclContextID contextID;
     bool isImplicit, isObjC, isStatic, hasNonPatternBindingInit;
     bool isGetterMutating, isSetterMutating;
-    unsigned rawSpecifier, numAccessors;
+    unsigned rawSpecifier, numAccessors, numBackingProperties;
     uint8_t readImpl, writeImpl, readWriteImpl, opaqueReadOwnership;
     uint8_t rawAccessLevel, rawSetterAccessLevel;
     TypeID interfaceTypeID;
     ModuleFile::AccessorRecord accessors;
     DeclID overriddenID, opaqueReturnTypeID;
-    ArrayRef<uint64_t> accessorAndDependencyIDs;
+    ArrayRef<uint64_t> arrayFieldIDs;
 
     decls_block::VarLayout::readRecord(scratch, nameID, contextID,
                                        isImplicit, isObjC, isStatic, rawSpecifier,
@@ -2683,7 +2685,8 @@ public:
                                        overriddenID,
                                        rawAccessLevel, rawSetterAccessLevel,
                                        opaqueReturnTypeID,
-                                       accessorAndDependencyIDs);
+                                       numBackingProperties,
+                                       arrayFieldIDs);
 
     Identifier name = MF.getIdentifier(nameID);
 
@@ -2693,13 +2696,17 @@ public:
       return llvm::make_error<OverrideError>(name);
     }
 
-    // Exctract the accessor IDs.
-    for (DeclID accessorID : accessorAndDependencyIDs.slice(0, numAccessors)) {
+    // Extract the accessor IDs.
+    for (DeclID accessorID : arrayFieldIDs.slice(0, numAccessors)) {
       accessors.IDs.push_back(accessorID);
     }
-    accessorAndDependencyIDs = accessorAndDependencyIDs.slice(numAccessors);
+    arrayFieldIDs = arrayFieldIDs.slice(numAccessors);
 
-    for (TypeID dependencyID : accessorAndDependencyIDs) {
+    // Extract the backing property IDs.
+    auto backingPropertyIDs = arrayFieldIDs.slice(0, numBackingProperties);
+    arrayFieldIDs = arrayFieldIDs.slice(numBackingProperties);
+
+    for (TypeID dependencyID : arrayFieldIDs) {
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
         // Stored properties in classes still impact class object layout because
@@ -2787,7 +2794,28 @@ public:
       var->setOpaqueResultTypeDecl(
                          cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
     }
-    
+
+    // If there are any backing properties, record the
+    if (numBackingProperties > 0) {
+      VarDecl *backingVar = cast<VarDecl>(MF.getDecl(backingPropertyIDs[0]));
+      VarDecl *storageDelegateVar = nullptr;
+      if (numBackingProperties > 1) {
+        storageDelegateVar = cast<VarDecl>(MF.getDecl(backingPropertyIDs[1]));
+      }
+
+      PropertyDelegateBackingPropertyInfo info(
+          backingVar, storageDelegateVar, nullptr, nullptr, nullptr);
+      ctx.evaluator.cacheOutput(
+          PropertyDelegateBackingPropertyInfoRequest{var}, std::move(info));
+      ctx.evaluator.cacheOutput(
+          PropertyDelegateBackingPropertyTypeRequest{var},
+          backingVar->getInterfaceType());
+      backingVar->setOriginalDelegatedProperty(var);
+
+      if (storageDelegateVar)
+        storageDelegateVar->setOriginalDelegatedProperty(var);
+    }
+
     return var;
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/PropertyDelegates.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/RawComment.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -3291,12 +3292,23 @@ void Serializer::writeDecl(const Decl *D) {
       rawSetterAccessLevel =
         getRawStableAccessLevel(var->getSetterFormalAccess());
 
+    unsigned numBackingProperties = 0;
     Type ty = var->getInterfaceType();
-    SmallVector<TypeID, 2> accessorsAndDependencies;
+    SmallVector<TypeID, 2> arrayFields;
     for (auto accessor : accessors.Decls)
-      accessorsAndDependencies.push_back(addDeclRef(accessor));
+      arrayFields.push_back(addDeclRef(accessor));
+    if (auto backingInfo = var->getPropertyDelegateBackingPropertyInfo()) {
+      if (backingInfo.backingVar) {
+        ++numBackingProperties;
+        arrayFields.push_back(addDeclRef(backingInfo.backingVar));
+      }
+      if (backingInfo.storageDelegateVar) {
+        ++numBackingProperties;
+        arrayFields.push_back(addDeclRef(backingInfo.storageDelegateVar));
+      }
+    }
     for (Type dependency : collectDependenciesFromType(ty->getCanonicalType()))
-      accessorsAndDependencies.push_back(addTypeRef(dependency));
+      arrayFields.push_back(addTypeRef(dependency));
 
     unsigned abbrCode = DeclTypeAbbrCodes[VarLayout::Code];
     VarLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -3318,7 +3330,8 @@ void Serializer::writeDecl(const Decl *D) {
                           addDeclRef(var->getOverriddenDecl()),
                           rawAccessLevel, rawSetterAccessLevel,
                           addDeclRef(var->getOpaqueResultTypeDecl()),
-                          accessorsAndDependencies);
+                          numBackingProperties,
+                          arrayFields);
     break;
   }
 

--- a/test/ParseableInterface/property-delegates.swift
+++ b/test/ParseableInterface/property-delegates.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -module-name TestResilient -emit-parseable-module-interface-path %t/TestResilient.swiftinterface -enable-library-evolution %s
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface --check-prefix CHECK --check-prefix RESILIENT
+
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-parseable-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s --check-prefix CHECK --check-prefix RESILIENT
+
+@_propertyDelegate
+public struct Wrapper<T> {
+  public var value: T
+}
+
+@_propertyDelegate
+public struct WrapperWithInitialValue<T> {
+  public var value: T
+
+  public init(initialValue: T) {
+    self.value = initialValue
+  }
+
+  public init(alternate value: T) {
+    self.value = value
+  }
+}
+
+// CHECK: public struct HasDelegates {
+public struct HasDelegates {
+  // CHECK: @TestResilient.Wrapper public var x: {{(Swift.)?}}Int {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: set
+  // CHECK-NEXT: }  
+  @Wrapper public var x: Int
+
+  // CHECK: @TestResilient.WrapperWithInitialValue public var y: Swift.Int {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }  
+  @WrapperWithInitialValue public private(set) var y = 17
+
+  // CHECK: @TestResilient.WrapperWithInitialValue public var z: Swift.Bool {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: set
+  // CHECK-NEXT: }  
+  @WrapperWithInitialValue(alternate: false) public var z
+}

--- a/test/Serialization/Inputs/def_property_delegates.swift
+++ b/test/Serialization/Inputs/def_property_delegates.swift
@@ -1,0 +1,12 @@
+@_propertyDelegate
+public struct SomeDelegate<T> {
+  public var value: T
+
+  public init(initialValue: T) {
+    self.value = initialValue
+  }
+}
+
+public struct HasDelegates {
+  @SomeDelegate public var x: Int = 17
+}

--- a/test/Serialization/property_delegates.swift
+++ b/test/Serialization/property_delegates.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_property_delegates.swift
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown
+
+// Same test, but with -enable-testing so we can see the backing properties
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_property_delegates.swift -enable-testing
+// RUN: %target-swift-frontend -DTESTING -typecheck -I%t %s
+
+#if TESTING
+@testable import def_property_delegates
+#else
+import def_property_delegates
+#endif
+
+func useDelegates(hd: HasDelegates) {
+  // Access the original properties
+  let _: Int = hd.x
+
+  let _: SomeDelegate<Int> = hd.$x // expected-error{{'$x' is inaccessible due to 'internal' protection level}}
+
+  var mutableHD = hd
+  mutableHD.x = 17
+
+  mutableHD.$x = SomeDelegate(initialValue: 42) // expected-error{{'$x' is inaccessible due to 'internal' protection level}}
+}


### PR DESCRIPTION
Serialize the relationship between a property that has an attached delegate
and its backing variable, so deserialization can reestablish that link. While here, fix a bug involving `private(set)` properties that have attached delegates when used with textual interfaces.

Fixes rdar://problem/50447022.