### PR TITLE
[benchmark] Fix Existential.Array.Mutating Setup Overhead

### DIFF
--- a/benchmark/single-source/ExistentialPerformance.swift
+++ b/benchmark/single-source/ExistentialPerformance.swift
@@ -264,17 +264,6 @@ func caRef1() { ca(Ref1.self) }
 func caRef2() { ca(Ref2.self) }
 func caRef3() { ca(Ref3.self) }
 func caRef4() { ca(Ref4.self) }
-@inline(never)
-func grabArray() -> [Existential] { // transfer array ownership to caller
-  // FIXME: This is causing Illegal Instruction: 4 crash
-  // defer { array = nil }
-  // return array
-  // This doesn't work either:
-  // let a = array!
-  // array = nil
-  // return a
-  return array!
-}
 
 // `setUpFunctions` that determine which existential type will be tested
 var existentialType: Existential.Type!
@@ -540,7 +529,7 @@ func run_Array_init(_ N: Int) {
 }
 
 func run_Array_method1x(_ N: Int) {
-  let existentialArray = grabArray()
+  let existentialArray = array!
   for _ in 0 ..< N * 100 {
     for elt in existentialArray {
       if !elt.doIt()  {
@@ -551,7 +540,7 @@ func run_Array_method1x(_ N: Int) {
 }
 
 func run_Array_method2x(_ N: Int) {
-  let existentialArray = grabArray()
+  let existentialArray = array!
   for _ in 0 ..< N * 100 {
     for elt in existentialArray {
       if !elt.doIt() || !elt.reallyDoIt() {
@@ -562,8 +551,8 @@ func run_Array_method2x(_ N: Int) {
 }
 
 func run_ArrayMutating(_ N: Int) {
-  var existentialArray = grabArray()
-  for _ in 0 ..< N * 100 {
+  var existentialArray = array!
+  for _ in 0 ..< N * 500 {
     for i in 0 ..< existentialArray.count {
       if !existentialArray[i].mutateIt()  {
         fatalError("expected true")
@@ -573,7 +562,7 @@ func run_ArrayMutating(_ N: Int) {
 }
 
 func run_ArrayShift(_ N: Int) {
-  var existentialArray = grabArray()
+  var existentialArray = array!
   for _ in 0 ..< N * 25 {
     for i in 0 ..< existentialArray.count-1 {
       existentialArray.swapAt(i, i+1)
@@ -582,7 +571,7 @@ func run_ArrayShift(_ N: Int) {
 }
 
 func run_ArrayConditionalShift(_ N: Int) {
-  var existentialArray = grabArray()
+  var existentialArray = array!
   for _ in 0 ..< N * 25 {
     for i in 0 ..< existentialArray.count-1 {
       let curr = existentialArray[i]

--- a/benchmark/single-source/ExistentialPerformance.swift.gyb
+++ b/benchmark/single-source/ExistentialPerformance.swift.gyb
@@ -36,8 +36,8 @@ Setup = """
   let existential = existentialType.init()
   let existential2 = existentialType.init()
   var existential = existentialType.init()
-  let existentialArray = grabArray()
-  var existentialArray = grabArray()
+  let existentialArray = array!
+  var existentialArray = array!
 """.splitlines()
 Setup = [Setup[0], Setup[1], '\n'.join(Setup[1:3]), Setup[3], Setup[4], Setup[5]]
 
@@ -90,7 +90,7 @@ Workloads = [
       }
     }
 """),
-  ('Array.Mutating', Setup[5], '100', """
+  ('Array.Mutating', Setup[5], '500', """
     for i in 0 ..< existentialArray.count {
       if !existentialArray[i].mutateIt()  {
         fatalError("expected true")
@@ -151,17 +151,6 @@ func ca<T: Existential>(_: T.Type) {
 % for Variant in Vals + Refs:
 func ca${Variant}() { ca(${Variant}.self) }
 % end
-@inline(never)
-func grabArray() -> [Existential] { // transfer array ownership to caller
-  // FIXME: This is causing Illegal Instruction: 4 crash
-  // defer { array = nil }
-  // return array
-  // This doesn't work either:
-  // let a = array!
-  // array = nil
-  // return a
-  return array!
-}
 
 // `setUpFunctions` that determine which existential type will be tested
 var existentialType: Existential.Type!


### PR DESCRIPTION
Mask the setup overhead from copying of existential array in `Existential.Array.Mutating` by increasing the workload (5x). This way the overhead of copying is less than 5%.

Remove the misguided attempt at solving this problem with `grabArray` method - there is no way to avoid this overhead because every sample should start from a fresh copy.

Note: these benchmarks are tagged `.skip`, so they will not show up in the report.