### PR TITLE
[code-completion] Avoid invalid member substitution for keypath dynamic lookup

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1041,7 +1041,8 @@ ASTBuilder::findForeignTypeDecl(StringRef name,
 
     explicit Consumer(Demangle::Node::Kind kind) : ExpectedKind(kind) {}
 
-    void foundDecl(ValueDecl *decl, DeclVisibilityKind reason) override {
+    void foundDecl(ValueDecl *decl, DeclVisibilityKind reason,
+                   DynamicLookupInfo dynamicLookupInfo = {}) override {
       if (HadError) return;
       if (decl == Result) return;
       if (!Result) {

--- a/lib/AST/ExperimentalDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/ExperimentalDependenciesSourceFileDepGraphConstructor.cpp
@@ -278,7 +278,8 @@ private:
       ConstPtrVec<ValueDecl> &classMembers;
       Collector(ConstPtrVec<ValueDecl> &classMembers)
           : classMembers(classMembers) {}
-      void foundDecl(ValueDecl *VD, DeclVisibilityKind) override {
+      void foundDecl(ValueDecl *VD, DeclVisibilityKind,
+                     DynamicLookupInfo) override {
         classMembers.push_back(VD);
       }
     } collector{classMembers};

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -298,7 +298,8 @@ void SourceLookupCache::lookupClassMembers(AccessPathTy accessPath,
       for (ValueDecl *vd : member.second) {
         auto *nominal = vd->getDeclContext()->getSelfNominalTypeDecl();
         if (nominal && nominal->getName() == accessPath.front().first)
-          consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
+          consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup,
+                             DynamicLookupInfo::AnyObject);
       }
     }
     return;
@@ -311,7 +312,8 @@ void SourceLookupCache::lookupClassMembers(AccessPathTy accessPath,
       continue;
 
     for (ValueDecl *vd : member.second)
-      consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
+      consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup,
+                         DynamicLookupInfo::AnyObject);
   }
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -63,14 +63,15 @@ ValueDecl *LookupResultEntry::getBaseDecl() const {
 
 void DebuggerClient::anchor() {}
 
-void AccessFilteringDeclConsumer::foundDecl(ValueDecl *D,
-                                            DeclVisibilityKind reason) {
+void AccessFilteringDeclConsumer::foundDecl(
+    ValueDecl *D, DeclVisibilityKind reason,
+    DynamicLookupInfo dynamicLookupInfo) {
   if (D->isInvalid())
     return;
   if (!D->isAccessibleFrom(DC))
     return;
 
-  ChainedConsumer.foundDecl(D, reason);
+  ChainedConsumer.foundDecl(D, reason, dynamicLookupInfo);
 }
 
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2225,9 +2225,10 @@ public:
     assert(CMU);
   }
 
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                 DynamicLookupInfo dynamicLookupInfo) override {
     if (isVisibleFromModule(ModuleFilter, VD))
-      NextConsumer.foundDecl(VD, Reason);
+      NextConsumer.foundDecl(VD, Reason, dynamicLookupInfo);
   }
 };
 
@@ -2242,9 +2243,10 @@ public:
     assert(CMU);
   }
 
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                 DynamicLookupInfo dynamicLookupInfo) override {
     if (isDeclaredInModule(ModuleFilter, VD))
-      NextConsumer.foundDecl(VD, Reason);
+      NextConsumer.foundDecl(VD, Reason, dynamicLookupInfo);
   }
 };
 
@@ -2307,9 +2309,10 @@ public:
                               topLevelModule->Name == "CoreServices");
   }
 
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                 DynamicLookupInfo dynamicLookupInfo) override {
     if (!shouldDiscard(VD))
-      NextConsumer.foundDecl(VD, Reason);
+      NextConsumer.foundDecl(VD, Reason, dynamicLookupInfo);
   }
 };
 
@@ -2551,7 +2554,8 @@ public:
   explicit VectorDeclPtrConsumer(SmallVectorImpl<Decl *> &Decls)
     : Results(Decls) {}
 
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                 DynamicLookupInfo) override {
     Results.push_back(VD);
   }
 };
@@ -3526,14 +3530,16 @@ void ClangImporter::Implementation::lookupObjCMembers(
       // FIXME: If we didn't need to check alternate decls here, we could avoid
       // importing the member at all by checking importedName ahead of time.
       if (decl->getFullName().matchesRef(name)) {
-        consumer.foundDecl(decl, DeclVisibilityKind::DynamicLookup);
+        consumer.foundDecl(decl, DeclVisibilityKind::DynamicLookup,
+                           DynamicLookupInfo::AnyObject);
       }
 
       // Check for an alternate declaration; if its name matches,
       // report it.
       for (auto alternate : getAlternateDecls(decl)) {
         if (alternate->getFullName().matchesRef(name)) {
-          consumer.foundDecl(alternate, DeclVisibilityKind::DynamicLookup);
+          consumer.foundDecl(alternate, DeclVisibilityKind::DynamicLookup,
+                             DynamicLookupInfo::AnyObject);
         }
       }
       return true;

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -437,7 +437,8 @@ void ProvidesEmitter::emitDynamicLookupMembers() const {
       SmallVector<DeclBaseName, 16> names;
 
     public:
-      void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+      void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                     DynamicLookupInfo) override {
         names.push_back(VD->getBaseName());
       }
       ArrayRef<DeclBaseName> getNames() {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1799,7 +1799,8 @@ public:
   }
 
   SemanticContextKind getSemanticContext(const Decl *D,
-                                         DeclVisibilityKind Reason) {
+                                         DeclVisibilityKind Reason,
+                                         DynamicLookupInfo dynamicLookupInfo) {
     if (ForcedSemanticContext)
       return *ForcedSemanticContext;
 
@@ -1845,12 +1846,27 @@ public:
       }
 
     case DeclVisibilityKind::DynamicLookup:
-      // AnyObject results can come from different modules, including the
-      // current module, but we always assign them the OtherModule semantic
-      // context.  These declarations are uniqued by signature, so it is
-      // totally random (determined by the hash function) which of the
-      // equivalent declarations (across multiple modules) we will get.
-      return SemanticContextKind::OtherModule;
+      switch (dynamicLookupInfo.getKind()) {
+      case DynamicLookupInfo::None:
+        llvm_unreachable("invalid DynamicLookupInfo::Kind for dynamic lookup");
+
+      case DynamicLookupInfo::AnyObject:
+        // AnyObject results can come from different modules, including the
+        // current module, but we always assign them the OtherModule semantic
+        // context.  These declarations are uniqued by signature, so it is
+        // totally random (determined by the hash function) which of the
+        // equivalent declarations (across multiple modules) we will get.
+        return SemanticContextKind::OtherModule;
+
+      case DynamicLookupInfo::KeyPathDynamicMember:
+        // Use the visibility of the underlying declaration.
+        // FIXME: KeyPath<AnyObject, U> !?!?
+        assert(dynamicLookupInfo.getKeyPathDynamicMember().originalVisibility !=
+               DeclVisibilityKind::DynamicLookup);
+        return getSemanticContext(
+            D, dynamicLookupInfo.getKeyPathDynamicMember().originalVisibility,
+            {});
+      }
     }
     llvm_unreachable("unhandled kind");
   }
@@ -2057,7 +2073,8 @@ public:
     return Type();
   }
 
-  void addVarDeclRef(const VarDecl *VD, DeclVisibilityKind Reason) {
+  void addVarDeclRef(const VarDecl *VD, DeclVisibilityKind Reason,
+                     DynamicLookupInfo dynamicLookupInfo) {
     if (!VD->hasName() ||
         !VD->isAccessibleFrom(CurrDeclContext) ||
         VD->shouldHideFromEditor())
@@ -2068,9 +2085,8 @@ public:
 
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink,
-        CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(VD, Reason), expectedTypeContext);
+        Sink, CodeCompletionResult::ResultKind::Declaration,
+        getSemanticContext(VD, Reason, dynamicLookupInfo), expectedTypeContext);
     Builder.setAssociatedDecl(VD);
     addLeadingDot(Builder);
     addValueBaseName(Builder, Name);
@@ -2412,7 +2428,8 @@ public:
     llvm_unreachable("Unhandled LookupKind in switch.");
   }
 
-  void addMethodCall(const FuncDecl *FD, DeclVisibilityKind Reason) {
+  void addMethodCall(const FuncDecl *FD, DeclVisibilityKind Reason,
+                     DynamicLookupInfo dynamicLookupInfo) {
     if (FD->getName().empty())
       return;
     foundFunction(FD);
@@ -2444,7 +2461,8 @@ public:
       CommandWordsPairs Pairs;
       CodeCompletionResultBuilder Builder(
           Sink, CodeCompletionResult::ResultKind::Declaration,
-          getSemanticContext(FD, Reason), expectedTypeContext);
+          getSemanticContext(FD, Reason, dynamicLookupInfo),
+          expectedTypeContext);
       setClangDeclKeywords(FD, Pairs, Builder);
       Builder.setAssociatedDecl(FD);
       addLeadingDot(Builder);
@@ -2526,6 +2544,7 @@ public:
   }
 
   void addConstructorCall(const ConstructorDecl *CD, DeclVisibilityKind Reason,
+                          DynamicLookupInfo dynamicLookupInfo,
                           Optional<Type> BaseType, Optional<Type> Result,
                           bool IsOnType = true,
                           Identifier addName = Identifier()) {
@@ -2553,7 +2572,8 @@ public:
       CommandWordsPairs Pairs;
       CodeCompletionResultBuilder Builder(
           Sink, CodeCompletionResult::ResultKind::Declaration,
-          getSemanticContext(CD, Reason), expectedTypeContext);
+          getSemanticContext(CD, Reason, dynamicLookupInfo),
+          expectedTypeContext);
       setClangDeclKeywords(CD, Pairs, Builder);
       Builder.setAssociatedDecl(CD);
       if (needInit) {
@@ -2604,7 +2624,8 @@ public:
   }
 
   void addConstructorCallsForType(Type type, Identifier name,
-                                  DeclVisibilityKind Reason) {
+                                  DeclVisibilityKind Reason,
+                                  DynamicLookupInfo dynamicLookupInfo) {
     if (!Ctx.LangOpts.CodeCompleteInitsInPostfixExpr && !IsUnresolvedMember)
       return;
 
@@ -2620,13 +2641,15 @@ public:
             cast<ConstructorDecl>(init)->getFailability() == OTK_Optional) {
           continue;
         }
-        addConstructorCall(cast<ConstructorDecl>(init), Reason, type, None,
+        addConstructorCall(cast<ConstructorDecl>(init), Reason,
+                           dynamicLookupInfo, type, None,
                            /*IsOnType=*/true, name);
       }
     }
   }
 
-  void addSubscriptCall(const SubscriptDecl *SD, DeclVisibilityKind Reason) {
+  void addSubscriptCall(const SubscriptDecl *SD, DeclVisibilityKind Reason,
+                        DynamicLookupInfo dynamicLookupInfo) {
     // Don't add subscript call to unqualified completion.
     if (!ExprType)
       return;
@@ -2642,9 +2665,8 @@ public:
 
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink,
-        CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(SD, Reason), expectedTypeContext);
+        Sink, CodeCompletionResult::ResultKind::Declaration,
+        getSemanticContext(SD, Reason, dynamicLookupInfo), expectedTypeContext);
     Builder.setAssociatedDecl(SD);
     setClangDeclKeywords(SD, Pairs, Builder);
 
@@ -2671,15 +2693,15 @@ public:
     addTypeAnnotation(Builder, resultTy);
   }
 
-  void addNominalTypeRef(const NominalTypeDecl *NTD,
-                         DeclVisibilityKind Reason) {
+  void addNominalTypeRef(const NominalTypeDecl *NTD, DeclVisibilityKind Reason,
+                         DynamicLookupInfo dynamicLookupInfo) {
     if (IsUnresolvedMember)
       return;
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink,
-        CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(NTD, Reason), expectedTypeContext);
+        Sink, CodeCompletionResult::ResultKind::Declaration,
+        getSemanticContext(NTD, Reason, dynamicLookupInfo),
+        expectedTypeContext);
     Builder.setAssociatedDecl(NTD);
     setClangDeclKeywords(NTD, Pairs, Builder);
     addLeadingDot(Builder);
@@ -2687,14 +2709,15 @@ public:
     addTypeAnnotation(Builder, NTD->getDeclaredType());
   }
 
-  void addTypeAliasRef(const TypeAliasDecl *TAD, DeclVisibilityKind Reason) {
+  void addTypeAliasRef(const TypeAliasDecl *TAD, DeclVisibilityKind Reason,
+                       DynamicLookupInfo dynamicLookupInfo) {
     if (IsUnresolvedMember)
       return;
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink,
-        CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(TAD, Reason), expectedTypeContext);
+        Sink, CodeCompletionResult::ResultKind::Declaration,
+        getSemanticContext(TAD, Reason, dynamicLookupInfo),
+        expectedTypeContext);
     Builder.setAssociatedDecl(TAD);
     setClangDeclKeywords(TAD, Pairs, Builder);
     addLeadingDot(Builder);
@@ -2719,12 +2742,12 @@ public:
   }
 
   void addGenericTypeParamRef(const GenericTypeParamDecl *GP,
-                              DeclVisibilityKind Reason) {
+                              DeclVisibilityKind Reason,
+                              DynamicLookupInfo dynamicLookupInfo) {
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink,
-        CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(GP, Reason), expectedTypeContext);
+        Sink, CodeCompletionResult::ResultKind::Declaration,
+        getSemanticContext(GP, Reason, dynamicLookupInfo), expectedTypeContext);
     setClangDeclKeywords(GP, Pairs, Builder);
     Builder.setAssociatedDecl(GP);
     addLeadingDot(Builder);
@@ -2733,12 +2756,12 @@ public:
   }
 
   void addAssociatedTypeRef(const AssociatedTypeDecl *AT,
-                            DeclVisibilityKind Reason) {
+                            DeclVisibilityKind Reason,
+                            DynamicLookupInfo dynamicLookupInfo) {
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink,
-        CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(AT, Reason), expectedTypeContext);
+        Sink, CodeCompletionResult::ResultKind::Declaration,
+        getSemanticContext(AT, Reason, dynamicLookupInfo), expectedTypeContext);
     setClangDeclKeywords(AT, Pairs, Builder);
     Builder.setAssociatedDecl(AT);
     addLeadingDot(Builder);
@@ -2749,7 +2772,7 @@ public:
 
   void addPrecedenceGroupRef(PrecedenceGroupDecl *PGD) {
     auto semanticContext =
-      getSemanticContext(PGD, DeclVisibilityKind::VisibleAtTopLevel);
+        getSemanticContext(PGD, DeclVisibilityKind::VisibleAtTopLevel, {});
     CodeCompletionResultBuilder builder(
       Sink, CodeCompletionResult::ResultKind::Declaration,
       semanticContext, {});
@@ -2758,8 +2781,8 @@ public:
     builder.setAssociatedDecl(PGD);
   };
 
-  void addEnumElementRef(const EnumElementDecl *EED,
-                         DeclVisibilityKind Reason,
+  void addEnumElementRef(const EnumElementDecl *EED, DeclVisibilityKind Reason,
+                         DynamicLookupInfo dynamicLookupInfo,
                          bool HasTypeContext) {
     if (!EED->hasName() ||
         !EED->isAccessibleFrom(CurrDeclContext) ||
@@ -2770,7 +2793,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         HasTypeContext ? SemanticContextKind::ExpressionSpecific
-                       : getSemanticContext(EED, Reason),
+                       : getSemanticContext(EED, Reason, dynamicLookupInfo),
         expectedTypeContext);
     Builder.setAssociatedDecl(EED);
     setClangDeclKeywords(EED, Pairs, Builder);
@@ -2846,11 +2869,13 @@ public:
 
   /// Add the compound function name for the given function.
   void addCompoundFunctionName(AbstractFunctionDecl *AFD,
-                               DeclVisibilityKind Reason) {
+                               DeclVisibilityKind Reason,
+                               DynamicLookupInfo dynamicLookupInfo) {
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
-        getSemanticContext(AFD, Reason), expectedTypeContext);
+        getSemanticContext(AFD, Reason, dynamicLookupInfo),
+        expectedTypeContext);
     setClangDeclKeywords(AFD, Pairs, Builder);
     Builder.setAssociatedDecl(AFD);
 
@@ -2879,7 +2904,8 @@ public:
   }
 
   // Implement swift::VisibleDeclConsumer.
-  void foundDecl(ValueDecl *D, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
+                 DynamicLookupInfo dynamicLookupInfo) override {
     if (D->shouldHideFromEditor())
       return;
 
@@ -2901,7 +2927,7 @@ public:
       if (auto *CD = dyn_cast<ConstructorDecl>(D)) {
         // Do we want compound function names here?
         if (shouldUseFunctionReference(CD)) {
-          addCompoundFunctionName(CD, Reason);
+          addCompoundFunctionName(CD, Reason, dynamicLookupInfo);
           return;
         }
 
@@ -2924,10 +2950,12 @@ public:
           // the initializer is required, the base type's instance type is not a class,
           // or this is a 'self' or 'super' reference.
           if (IsStaticMetatype || IsUnresolvedMember || Ty->is<ArchetypeType>())
-            addConstructorCall(CD, Reason, None, Result, /*isOnType*/true);
+            addConstructorCall(CD, Reason, dynamicLookupInfo, None, Result,
+                               /*isOnType*/ true);
           else if ((IsSelfRefExpr || IsSuperRefExpr || !Ty->is<ClassType>() ||
                     CD->isRequired()) && !HaveLParen)
-            addConstructorCall(CD, Reason, None, Result, /*isOnType*/false);
+            addConstructorCall(CD, Reason, dynamicLookupInfo, None, Result,
+                               /*isOnType*/ false);
           return;
         }
         if (!HaveLParen) {
@@ -2938,7 +2966,8 @@ public:
           // initializers and for 'super' in convenience initializers.
           if ((IsSelfRefExpr && CDC->isConvenienceInit()) ||
               ((IsSuperRefExpr && !CDC->isConvenienceInit())))
-            addConstructorCall(CD, Reason, None, None, /*IsOnType=*/false);
+            addConstructorCall(CD, Reason, dynamicLookupInfo, None, None,
+                               /*IsOnType=*/false);
         }
         return;
       }
@@ -2951,7 +2980,7 @@ public:
     case LookupKind::ValueInDeclContext:
     case LookupKind::ImportFromModule:
       if (auto *VD = dyn_cast<VarDecl>(D)) {
-        addVarDeclRef(VD, Reason);
+        addVarDeclRef(VD, Reason, dynamicLookupInfo);
         return;
       }
 
@@ -2967,77 +2996,79 @@ public:
 
         // Do we want compound function names here?
         if (shouldUseFunctionReference(FD)) {
-          addCompoundFunctionName(FD, Reason);
+          addCompoundFunctionName(FD, Reason, dynamicLookupInfo);
           return;
         }
 
-        addMethodCall(FD, Reason);
+        addMethodCall(FD, Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
-        addNominalTypeRef(NTD, Reason);
+        addNominalTypeRef(NTD, Reason, dynamicLookupInfo);
         addConstructorCallsForType(NTD->getDeclaredInterfaceType(),
-                                   NTD->getName(), Reason);
+                                   NTD->getName(), Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
-        addTypeAliasRef(TAD, Reason);
+        addTypeAliasRef(TAD, Reason, dynamicLookupInfo);
         auto type = TAD->mapTypeIntoContext(TAD->getDeclaredInterfaceType());
         if (type->mayHaveMembers())
-          addConstructorCallsForType(type, TAD->getName(), Reason);
+          addConstructorCallsForType(type, TAD->getName(), Reason,
+                                     dynamicLookupInfo);
         return;
       }
 
       if (auto *GP = dyn_cast<GenericTypeParamDecl>(D)) {
-        addGenericTypeParamRef(GP, Reason);
+        addGenericTypeParamRef(GP, Reason, dynamicLookupInfo);
         for (auto *protocol : GP->getConformingProtocols())
           addConstructorCallsForType(protocol->getDeclaredInterfaceType(),
-                                     GP->getName(), Reason);
+                                     GP->getName(), Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *AT = dyn_cast<AssociatedTypeDecl>(D)) {
-        addAssociatedTypeRef(AT, Reason);
+        addAssociatedTypeRef(AT, Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *EED = dyn_cast<EnumElementDecl>(D)) {
-        addEnumElementRef(EED, Reason, /*HasTypeContext=*/false);
+        addEnumElementRef(EED, Reason, dynamicLookupInfo,
+                          /*HasTypeContext=*/false);
         return;
       }
 
       // Swift key path allows .[0]
       if (auto *SD = dyn_cast<SubscriptDecl>(D)) {
-        addSubscriptCall(SD, Reason);
+        addSubscriptCall(SD, Reason, dynamicLookupInfo);
         return;
       }
       return;
 
     case LookupKind::EnumElement:
-      handleEnumElement(D, Reason);
+      handleEnumElement(D, Reason, dynamicLookupInfo);
       return;
 
     case LookupKind::Type:
     case LookupKind::TypeInDeclContext:
       if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
-        addNominalTypeRef(NTD, Reason);
+        addNominalTypeRef(NTD, Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
-        addTypeAliasRef(TAD, Reason);
+        addTypeAliasRef(TAD, Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *GP = dyn_cast<GenericTypeParamDecl>(D)) {
-        addGenericTypeParamRef(GP, Reason);
+        addGenericTypeParamRef(GP, Reason, dynamicLookupInfo);
         return;
       }
 
       if (auto *AT = dyn_cast<AssociatedTypeDecl>(D)) {
-        addAssociatedTypeRef(AT, Reason);
+        addAssociatedTypeRef(AT, Reason, dynamicLookupInfo);
         return;
       }
 
@@ -3045,12 +3076,14 @@ public:
     }
   }
 
-  bool handleEnumElement(ValueDecl *D, DeclVisibilityKind Reason) {
+  bool handleEnumElement(ValueDecl *D, DeclVisibilityKind Reason,
+                         DynamicLookupInfo dynamicLookupInfo) {
     if (!D->hasInterfaceType())
       TypeResolver->resolveDeclSignature(D);
 
     if (auto *EED = dyn_cast<EnumElementDecl>(D)) {
-      addEnumElementRef(EED, Reason, /*HasTypeContext=*/true);
+      addEnumElementRef(EED, Reason, dynamicLookupInfo,
+                        /*HasTypeContext=*/true);
       return true;
     } else if (auto *ED = dyn_cast<EnumDecl>(D)) {
       llvm::DenseSet<EnumElementDecl *> Elements;
@@ -3058,7 +3091,8 @@ public:
       for (auto *Ele : Elements) {
         if (!Ele->hasInterfaceType())
           TypeResolver->resolveDeclSignature(Ele);
-        addEnumElementRef(Ele, Reason, /*HasTypeContext=*/true);
+        addEnumElementRef(Ele, Reason, dynamicLookupInfo,
+                          /*HasTypeContext=*/true);
       }
       return true;
     }
@@ -3292,7 +3326,7 @@ public:
     // FIXME: we should get the semantic context of the function, not the
     // operator decl.
     auto semanticContext =
-        getSemanticContext(op, DeclVisibilityKind::VisibleAtTopLevel);
+        getSemanticContext(op, DeclVisibilityKind::VisibleAtTopLevel, {});
     CodeCompletionResultBuilder builder(
         Sink, CodeCompletionResult::ResultKind::Declaration, semanticContext,
         {});
@@ -3341,7 +3375,7 @@ public:
     // FIXME: we should get the semantic context of the function, not the
     // operator decl.
     auto semanticContext =
-        getSemanticContext(op, DeclVisibilityKind::VisibleAtTopLevel);
+        getSemanticContext(op, DeclVisibilityKind::VisibleAtTopLevel, {});
     CodeCompletionResultBuilder builder(
         Sink, CodeCompletionResult::ResultKind::Declaration, semanticContext,
         {});
@@ -3593,9 +3627,10 @@ public:
     DeclFilter Filter;
     FilteredDeclConsumer(swift::VisibleDeclConsumer &Consumer,
                          DeclFilter Filter) : Consumer(Consumer), Filter(Filter) {}
-    void foundDecl(ValueDecl *VD, DeclVisibilityKind Kind) override {
+    void foundDecl(ValueDecl *VD, DeclVisibilityKind Kind,
+                   DynamicLookupInfo dynamicLookupInfo) override {
       if (Filter(VD, Kind))
-        Consumer.foundDecl(VD, Kind);
+        Consumer.foundDecl(VD, Kind, dynamicLookupInfo);
     }
   };
 
@@ -3624,7 +3659,7 @@ public:
           if (!isa<ProtocolDecl>(NTD) &&
               NTD->getModuleContext() != CurrDeclContext->getParentModule()) {
             addNominalTypeRef(NT->getDecl(),
-                              DeclVisibilityKind::VisibleAtTopLevel);
+                              DeclVisibilityKind::VisibleAtTopLevel, {});
           }
         }
       }
@@ -3686,7 +3721,8 @@ public:
     // type and has the same type (or if the member is a function, then the
     // same result type) as the contextual type.
     FilteredDeclConsumer consumer(*this, [=](ValueDecl *VD,
-                                             DeclVisibilityKind reason) {
+                                             DeclVisibilityKind Reason) {
+
       if (VD->isOperator())
         return false;
 
@@ -3713,11 +3749,11 @@ public:
       // Only non-failable constructors are implicitly referenceable.
       if (auto CD = dyn_cast<ConstructorDecl>(VD)) {
         switch (CD->getFailability()) {
-          case OTK_None:
-          case OTK_ImplicitlyUnwrappedOptional:
-            return true;
-          case OTK_Optional:
-            return false;
+        case OTK_None:
+        case OTK_ImplicitlyUnwrappedOptional:
+          return true;
+        case OTK_Optional:
+          return false;
         }
       }
 
@@ -3816,7 +3852,7 @@ public:
     if (!TheEnumDecl)
       return;
     for (auto Element : TheEnumDecl->getAllElements()) {
-      foundDecl(Element, DeclVisibilityKind::MemberOfCurrentNominal);
+      foundDecl(Element, DeclVisibilityKind::MemberOfCurrentNominal, {});
     }
   }
 
@@ -4058,7 +4094,8 @@ public:
 
   /// Return type if the result type if \p VD should be represented as opaque
   /// result type.
-  TypeLoc getOpaqueResultTypeLoc(const ValueDecl *VD, DeclVisibilityKind Reason) {
+  TypeLoc getOpaqueResultTypeLoc(const ValueDecl *VD, DeclVisibilityKind Reason,
+                                 DynamicLookupInfo dynamicLookupInfo) {
     if (Reason !=
         DeclVisibilityKind::MemberOfProtocolImplementedByCurrentNominal)
       return nullptr;
@@ -4100,6 +4137,7 @@ public:
   }
 
   void addValueOverride(const ValueDecl *VD, DeclVisibilityKind Reason,
+                        DynamicLookupInfo dynamicLookupInfo,
                         CodeCompletionResultBuilder &Builder,
                         bool hasDeclIntroducer) {
     class DeclPrinter : public StreamPrinter {
@@ -4131,7 +4169,8 @@ public:
     unsigned NameOffset = 0;
     {
       llvm::raw_svector_ostream OS(DeclStr);
-      DeclPrinter Printer(OS, getOpaqueResultTypeLoc(VD, Reason));
+      DeclPrinter Printer(
+          OS, getOpaqueResultTypeLoc(VD, Reason, dynamicLookupInfo));
       PrintOptions Options;
       if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
         Options.setBaseType(transformType);
@@ -4167,16 +4206,18 @@ public:
     Builder.addTextChunk(DeclStr.str().substr(NameOffset));
   }
 
-  void addMethodOverride(const FuncDecl *FD, DeclVisibilityKind Reason) {
+  void addMethodOverride(const FuncDecl *FD, DeclVisibilityKind Reason,
+                         DynamicLookupInfo dynamicLookupInfo) {
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
     Builder.setAssociatedDecl(FD);
-    addValueOverride(FD, Reason, Builder, hasFuncIntroducer);
+    addValueOverride(FD, Reason, dynamicLookupInfo, Builder, hasFuncIntroducer);
     Builder.addBraceStmtWithCursor();
   }
 
-  void addVarOverride(const VarDecl *VD, DeclVisibilityKind Reason) {
+  void addVarOverride(const VarDecl *VD, DeclVisibilityKind Reason,
+                      DynamicLookupInfo dynamicLookupInfo) {
     // Overrides cannot use 'let', but if the 'override' keyword is specified
     // then the intention is clear, so provide the results anyway.  The compiler
     // can then provide an error telling you to use 'var' instead.
@@ -4189,19 +4230,21 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
     Builder.setAssociatedDecl(VD);
-    addValueOverride(VD, Reason, Builder, hasVarIntroducer);
+    addValueOverride(VD, Reason, dynamicLookupInfo, Builder, hasVarIntroducer);
   }
 
-  void addSubscriptOverride(const SubscriptDecl *SD, DeclVisibilityKind Reason) {
+  void addSubscriptOverride(const SubscriptDecl *SD, DeclVisibilityKind Reason,
+                            DynamicLookupInfo dynamicLookupInfo) {
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
     Builder.setAssociatedDecl(SD);
-    addValueOverride(SD, Reason, Builder, false);
+    addValueOverride(SD, Reason, dynamicLookupInfo, Builder, false);
     Builder.addBraceStmtWithCursor();
   }
 
-  void addTypeAlias(const AssociatedTypeDecl *ATD, DeclVisibilityKind Reason) {
+  void addTypeAlias(const AssociatedTypeDecl *ATD, DeclVisibilityKind Reason,
+                    DynamicLookupInfo dynamicLookupInfo) {
     CodeCompletionResultBuilder Builder(Sink,
       CodeCompletionResult::ResultKind::Declaration,
       SemanticContextKind::Super, {});
@@ -4215,7 +4258,8 @@ public:
     Builder.addSimpleNamedParameter("Type");
   }
 
-  void addConstructor(const ConstructorDecl *CD, DeclVisibilityKind Reason) {
+  void addConstructor(const ConstructorDecl *CD, DeclVisibilityKind Reason,
+                      DynamicLookupInfo dynamicLookupInfo) {
     CodeCompletionResultBuilder Builder(
         Sink,
         CodeCompletionResult::ResultKind::Declaration,
@@ -4257,7 +4301,8 @@ public:
   }
 
   // Implement swift::VisibleDeclConsumer.
-  void foundDecl(ValueDecl *D, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
+                 DynamicLookupInfo dynamicLookupInfo) override {
     if (Reason == DeclVisibilityKind::MemberOfCurrentNominal)
       return;
 
@@ -4295,19 +4340,19 @@ public:
         return;
 
       if (hasFuncIntroducer || (!hasIntroducer && !hasInitializerModifier))
-        addMethodOverride(FD, Reason);
+        addMethodOverride(FD, Reason, dynamicLookupInfo);
       return;
     }
 
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (hasVarIntroducer || (!hasIntroducer && !hasInitializerModifier))
-        addVarOverride(VD, Reason);
+        addVarOverride(VD, Reason, dynamicLookupInfo);
       return;
     }
 
     if (auto *SD = dyn_cast<SubscriptDecl>(D)) {
       if (!hasIntroducer && !hasInitializerModifier)
-        addSubscriptOverride(SD, Reason);
+        addSubscriptOverride(SD, Reason, dynamicLookupInfo);
     }
 
     if (auto *CD = dyn_cast<ConstructorDecl>(D)) {
@@ -4317,7 +4362,7 @@ public:
           hasStaticOrClass)
         return;
       if (CD->isRequired() || CD->isDesignatedInit())
-        addConstructor(CD, Reason);
+        addConstructor(CD, Reason, dynamicLookupInfo);
       return;
     }
   }
@@ -4340,7 +4385,7 @@ public:
       if (Constructor->hasStubImplementation())
         continue;
       if (Constructor->isDesignatedInit())
-        addConstructor(Constructor, DeclVisibilityKind::MemberOfSuper);
+        addConstructor(Constructor, DeclVisibilityKind::MemberOfSuper, {});
     }
   }
 
@@ -4362,8 +4407,10 @@ public:
         if (!Conformance->hasTypeWitness(ATD) ||
             ATD->hasDefaultDefinitionType())
           continue;
-        addTypeAlias(ATD,
-          DeclVisibilityKind::MemberOfProtocolImplementedByCurrentNominal);
+        addTypeAlias(
+            ATD,
+            DeclVisibilityKind::MemberOfProtocolImplementedByCurrentNominal,
+            {});
       }
     }
   }
@@ -5423,8 +5470,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (auto GT = ParsedTypeLoc.getType()->getAnyGeneric()) {
       if (auto Params = GT->getGenericParams()) {
         for (auto GP : Params->getParams()) {
-          Lookup.addGenericTypeParamRef(GP,
-                                        DeclVisibilityKind::GenericParameter);
+          Lookup.addGenericTypeParamRef(
+              GP, DeclVisibilityKind::GenericParameter, {});
         }
       }
     }

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -147,7 +147,8 @@ void ConformingMethodListCallbacks::getMatchingMethods(
         : CurModule(DC->getParentModule()), T(T), ExpectedTypes(expectedTypes),
           Result(result) {}
 
-    void foundDecl(ValueDecl *VD, DeclVisibilityKind reason) {
+    void foundDecl(ValueDecl *VD, DeclVisibilityKind reason,
+                   DynamicLookupInfo) {
       if (isMatchingMethod(VD) && !VD->shouldHideFromEditor())
         Result.push_back(VD);
     }

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -163,7 +163,8 @@ void ContextInfoCallbacks::getImplicitMembers(
         : DC(DC), TypeResolver(DC->getASTContext().getLazyResolver()),
           CurModule(DC->getParentModule()), T(T), Result(Result) {}
 
-    void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) {
+    void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                   DynamicLookupInfo) {
       if (canBeImplictMember(VD) && !VD->shouldHideFromEditor())
         Result.push_back(VD);
     }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2086,7 +2086,8 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
           dc = dc->getParent();
         if (auto nominal = dc->getSelfNominalTypeDecl())
           if (nominal->getName() == accessPath.front().first)
-            consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
+            consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup,
+                               DynamicLookupInfo::AnyObject);
       }
     }
     return;
@@ -2095,7 +2096,8 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
   for (const auto &list : ClassMembersForDynamicLookup->data()) {
     for (auto item : list)
       consumer.foundDecl(cast<ValueDecl>(getDecl(item.second)),
-                         DeclVisibilityKind::DynamicLookup);
+                         DeclVisibilityKind::DynamicLookup,
+                         DynamicLookupInfo::AnyObject);
   }
 }
 

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -169,7 +169,7 @@ protocol Bar { func bar() }
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[baz_clang_module]:   .baz_Class_ClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[baz_clang_module]: .baz_Class_InstanceFunc1({#(self): Baz_Class#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[baz_clang_module]:   .baz_Protocol_ClassFunc1()[#Void#]{{; name=.+$}}
-// DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[baz_clang_module]: .baz_Protocol_InstanceFunc1({#(self): Self#})[#() -> Void#]{{; name=.+$}}
+// DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[baz_clang_module]: .baz_Protocol_InstanceFunc1({#(self): Baz_Protocol#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   .foo_Nested1_ObjcClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: .foo_Nested1_ObjcInstanceFunc1({#(self): Foo_ContainerForNestedClass1.Foo_Nested1#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   .foo_Nested2_ObjcClassFunc1()[#Void#]{{; name=.+$}}
@@ -179,7 +179,7 @@ protocol Bar { func bar() }
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   .foo_TopLevelObjcClass_ClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: .foo_TopLevelObjcClass_InstanceFunc1({#(self): Foo_TopLevelObjcClass#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   .foo_TopLevelObjcProtocol_ClassFunc1()[#Void#]{{; name=.+$}}
-// DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: .foo_TopLevelObjcProtocol_InstanceFunc1({#(self): Self#})[#() -> Void#]{{; name=.+$}}
+// DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: .foo_TopLevelObjcProtocol_InstanceFunc1({#(self): Foo_TopLevelObjcProtocol#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     .nested1_ObjcClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .nested1_ObjcInstanceFunc1({#(self): ContainerForNestedClass1.Nested1#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     .nested2_ObjcClassFunc1()[#Void#]{{; name=.+$}}
@@ -190,7 +190,7 @@ protocol Bar { func bar() }
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     .topLevelObjcClass_ClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .topLevelObjcClass_InstanceFunc1({#(self): TopLevelObjcClass#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     .topLevelObjcProtocol_ClassFunc1()[#Void#]{{; name=.+$}}
-// DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .topLevelObjcProtocol_InstanceFunc1({#(self): Self#})[#() -> Void#]{{; name=.+$}}
+// DL_CLASS_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .topLevelObjcProtocol_InstanceFunc1({#(self): TopLevelObjcProtocol#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_NO_DOT: End completions
 
 // DL_CLASS_DOT: Begin completions
@@ -203,7 +203,7 @@ protocol Bar { func bar() }
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[baz_clang_module]:   baz_Class_ClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[baz_clang_module]: baz_Class_InstanceFunc1({#(self): Baz_Class#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[baz_clang_module]:   baz_Protocol_ClassFunc1()[#Void#]{{; name=.+$}}
-// DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[baz_clang_module]: baz_Protocol_InstanceFunc1({#(self): Self#})[#() -> Void#]{{; name=.+$}}
+// DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[baz_clang_module]: baz_Protocol_InstanceFunc1({#(self): Baz_Protocol#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   foo_Nested1_ObjcClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: foo_Nested1_ObjcInstanceFunc1({#(self): Foo_ContainerForNestedClass1.Foo_Nested1#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   foo_Nested2_ObjcClassFunc1()[#Void#]{{; name=.+$}}
@@ -213,7 +213,7 @@ protocol Bar { func bar() }
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   foo_TopLevelObjcClass_ClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: foo_TopLevelObjcClass_InstanceFunc1({#(self): Foo_TopLevelObjcClass#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[foo_swift_module]:   foo_TopLevelObjcProtocol_ClassFunc1()[#Void#]{{; name=.+$}}
-// DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: foo_TopLevelObjcProtocol_InstanceFunc1({#(self): Self#})[#() -> Void#]{{; name=.+$}}
+// DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[foo_swift_module]: foo_TopLevelObjcProtocol_InstanceFunc1({#(self): Foo_TopLevelObjcProtocol#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     nested1_ObjcClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   nested1_ObjcInstanceFunc1({#(self): ContainerForNestedClass1.Nested1#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     nested2_ObjcClassFunc1()[#Void#]{{; name=.+$}}
@@ -224,7 +224,7 @@ protocol Bar { func bar() }
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     topLevelObjcClass_ClassFunc1()[#Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   topLevelObjcClass_InstanceFunc1({#(self): TopLevelObjcClass#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT-DAG: Decl[StaticMethod]/OtherModule[swift_ide_test]:     topLevelObjcProtocol_ClassFunc1()[#Void#]{{; name=.+$}}
-// DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   topLevelObjcProtocol_InstanceFunc1({#(self): Self#})[#() -> Void#]{{; name=.+$}}
+// DL_CLASS_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   topLevelObjcProtocol_InstanceFunc1({#(self): TopLevelObjcProtocol#})[#() -> Void#]{{; name=.+$}}
 // DL_CLASS_DOT: End completions
 
 // TLOC_MEMBERS_NO_DOT: Begin completions

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -16,6 +16,12 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid2 | %FileCheck %s -check-prefix=testInvalid2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid3 | %FileCheck %s -check-prefix=testInvalid3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testInvalid4 | %FileCheck %s -check-prefix=testInvalid4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testGenericRoot1 | %FileCheck %s -check-prefix=testGenericRoot1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testAnyObjectRoot1 | %FileCheck %s -check-prefix=testAnyObjectRoot1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testNested1 | %FileCheck %s -check-prefix=testNested1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testNested2 | %FileCheck %s -check-prefix=testNested2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testCycle1 | %FileCheck %s -check-prefix=testCycle1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testCycle2 | %FileCheck %s -check-prefix=testCycle2
 
 struct Point {
   var x: Int
@@ -268,3 +274,96 @@ func testInvalid4(r: Invalid4) {
   r.#^testInvalid4^#
 }
 // testInvalid4-NOT: topLeft
+
+struct Gen1<T> {
+  var foo: T
+}
+
+@dynamicMemberLookup
+struct GenericRoot<T> {
+  subscript<U>(dynamicMember member: KeyPath<Gen1<T>, U>) -> Int {
+    return 1
+  }
+}
+
+func testGenericRoot1(r: GenericRoot<Point>) {
+  r.#^testGenericRoot1^#
+}
+// FIXME: Type should be substituted to Point.
+// testGenericRoot1: Decl[InstanceVar]/CurrNominal:      foo[#T#];
+
+class C {
+  var someUniqueName: Int = 0
+}
+
+@dynamicMemberLookup
+struct AnyObjectRoot {
+  subscript<U>(dynamicMember member: KeyPath<AnyObject, U>) -> Int {
+    return 1
+  }
+}
+
+func testAnyObjectRoot1(r: AnyObjectRoot) {
+  r.#^testAnyObjectRoot1^#
+}
+// Do not do find via AnyObject dynamic lookup.
+// testAnyObjectRoot1-NOT: someUniqueName
+
+func testNested1(r: Lens<Lens<Point>>) {
+  r.#^testNested1^#
+// testNested1: Begin completions
+// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testNested1: End completions
+}
+
+func testNested2(r: Lens<Lens<Lens<Point>>>) {
+  r.#^testNested2^#
+// testNested2: Begin completions
+// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testNested2: End completions
+}
+
+@dynamicMemberLookup
+struct Recurse<T> {
+  var obj: T
+  init(_ obj: T) { self.obj = obj }
+
+  subscript<U>(dynamicMember member: KeyPath<Recurse<T>, U>) -> Int {
+    return 1
+  }
+}
+
+func testCycle1(r: Recurse<Point>) {
+  r.#^testCycle1^#
+// testCycle1: Begin completions
+// testCycle1-NOT: x[#Int#]
+}
+
+@dynamicMemberLookup
+struct CycleA<T> {
+  var fromA: Int
+  subscript<U>(dynamicMember member: KeyPath<CycleB<T>, U>) -> Int {
+    return 1
+  }
+}
+@dynamicMemberLookup
+struct CycleB<T> {
+  var fromB: Int
+  subscript<U>(dynamicMember member: KeyPath<CycleC<T>, U>) -> Int {
+    return 1
+  }
+}
+@dynamicMemberLookup
+struct CycleC<T> {
+  var fromC: Int
+  subscript<U>(dynamicMember member: KeyPath<CycleA<T>, U>) -> Int {
+    return 1
+  }
+}
+
+func testCycle2(r: CycleA<Point>) {
+  r.#^testCycle2^#
+// testCycle2: Begin completions
+}

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -289,7 +289,7 @@ struct GenericRoot<T> {
 func testGenericRoot1(r: GenericRoot<Point>) {
   r.#^testGenericRoot1^#
 }
-// FIXME: Type should be substituted to Point.
+// FIXME: Type should be substituted to Int.
 // testGenericRoot1: Decl[InstanceVar]/CurrNominal:      foo[#T#];
 
 class C {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1613,7 +1613,8 @@ void SwiftDeclCollector::lookupVisibleDecls(ArrayRef<ModuleDecl *> Modules) {
         continue;
       KnownDecls.insert(D);
       if (auto VD = dyn_cast<ValueDecl>(D))
-        foundDecl(VD, DeclVisibilityKind::DynamicLookup);
+        foundDecl(VD, DeclVisibilityKind::DynamicLookup,
+                  DynamicLookupInfo::AnyObject);
       else
         processDecl(D);
     }
@@ -1676,7 +1677,8 @@ void SwiftDeclCollector::processValueDecl(ValueDecl *VD) {
   }
 }
 
-void SwiftDeclCollector::foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) {
+void SwiftDeclCollector::foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                                   DynamicLookupInfo) {
   if (VD->getClangMacro()) {
     // Collect macros, we will sort them afterwards.
     ClangMacros.push_back(VD);

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -690,7 +690,8 @@ public:
   std::vector<SDKNode*> createParameterNodes(ParameterList *PL);
   SDKNode *constructTypeNode(Type T, TypeInitInfo Info = TypeInitInfo());
   void processValueDecl(ValueDecl *VD);
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override;
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                 DynamicLookupInfo dynamicLookupInfo = {}) override;
   void processDecl(Decl *D);
 public:
   void lookupVisibleDecls(ArrayRef<ModuleDecl *> Modules);


### PR DESCRIPTION
When performing keypath dynamic member lookup, avoid substituting the base type in override detection and completion, as the base type of the lookup is not the base type of the member. For now, we just avoid the substitution entirely to fix potential crashes; in a future commit we will change to using the subscript return type and substituting with the base type of the subscript instead of the base type of the lookup.
    
rdar://50449788