### PR TITLE
[test] Mark stored-properties-client as executable.

### DIFF
--- a/test/ParseableInterface/stored-properties-client.swift
+++ b/test/ParseableInterface/stored-properties-client.swift
@@ -1,5 +1,7 @@
 // RUN: %empty-directory(%t)
 
+// REQUIRES: executable_test
+
 // 1. Build ../stored-properties.swift to a dylib and emit its interface in %t
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(StoredProperties)) -emit-module-interface-path %t/StoredProperties.swiftinterface %S/stored-properties.swift -module-name StoredProperties -swift-version 5


### PR DESCRIPTION
Test was enabled in #21426, but it was not marked as executable, and the Android CI has been trying to run it in the builder, and failing.

