### PR TITLE
[5.1] [Serialization] Reduce file size by splitting dep dirnames from basenames

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 487; // Last change: Opaque result types generic params
+const uint16_t SWIFTMODULE_VERSION_MINOR = 488; // Last change: dependency directories
 
 using DeclIDField = BCFixed<31>;
 
@@ -644,6 +644,7 @@ namespace input_block {
     MODULE_FLAGS, // [unused]
     SEARCH_PATH,
     FILE_DEPENDENCY,
+    DEPENDENCY_DIRECTORY,
     PARSEABLE_INTERFACE_PATH
   };
 
@@ -689,7 +690,13 @@ namespace input_block {
     FileModTimeOrContentHashField, // mtime or content hash (for validation)
     BCFixed<1>,                    // are we reading mtime (0) or hash (1)?
     BCFixed<1>,                    // SDK-relative?
+    BCVBR<8>,                      // subpath-relative index (0=none)
     BCBlob                         // path
+  >;
+
+  using DependencyDirectoryLayout = BCRecordLayout<
+    DEPENDENCY_DIRECTORY,
+    BCBlob
   >;
 
   using ParseableInterfaceLayout = BCRecordLayout<

--- a/test/ParseableInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies.swift
@@ -12,9 +12,9 @@
 // RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/SdkLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
 //
 // PREBUILT: MODULE_BLOCK
-// PREBUILT-NOT: FILE_DEPENDENCY {{.*}}/MCP/{{.*}}
-// PREBUILT-NOT: FILE_DEPENDENCY {{.*}}/prebuilt-cache/{{.*}}
-// PREBUILD-NOT: FILE_DEPENDENCY {{.*}}/lib/swift/{{.*}}
+// PREBUILT-NOT: FILE_DEPENDENCY {{.*[/\\]MCP[/\\]}}
+// PREBUILT-NOT: FILE_DEPENDENCY {{.*[/\\]prebuilt-cache[/\\]}}
+// PREBUILD-NOT: FILE_DEPENDENCY {{.*[/\\]lib[/\\]swift[/\\]}}
 //
 // Re-build them in the opposite order
 // RUN: %empty-directory(%t/prebuilt-cache)
@@ -50,8 +50,8 @@
 // RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE-NEGATIVE
 // RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
 //
-// DEPFILE-NEGATIVE-NOT: /MCP/
-// DEPFILE-NEGATIVE-NOT: /prebuilt-cache/
+// DEPFILE-NEGATIVE-NOT: {{[/\\]MCP[/\\]}}
+// DEPFILE-NEGATIVE-NOT: {{[/\\]prebuilt-cache[/\\]}}
 //
 // DEPFILE-DAG: SomeCModule.h
 // DEPFILE-DAG: SdkLib.swiftinterface
@@ -79,21 +79,21 @@
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=EXLIB,SDKLIB
 //
 // EXLIB: dependencies:
-// EXLIB-DAG: /my-sdk/usr/include/module.modulemap
-// EXLIB-DAG: /my-sdk/usr/include/SomeCModule.h
-// EXLIB-DAG: /my-sdk/ExportedLib.swiftinterface
-// SDKLIB-DAG: /my-sdk/SdkLib.swiftinterface
+// EXLIB-DAG: {{[/\\]my-sdk[/\\]usr[/\\]include[/\\]}}module.modulemap
+// EXLIB-DAG: {{[/\\]my-sdk[/\\]usr[/\\]include[/\\]}}SomeCModule.h
+// EXLIB-DAG: {{[/\\]my-sdk[/\\]}}ExportedLib.swiftinterface
+// SDKLIB-DAG: {{[/\\]my-sdk[/\\]}}SdkLib.swiftinterface
 //
 // Check they don't contain any dependencies from either cache other than themselves
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=ExportedLib
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=SdkLib
 //
 // NOCACHE: dependencies:
-// NOCACHE-NOT: /prebuilt-cache/
-// NOCACHE-NOT: /MCP/
-// NOCACHE: /prebuilt-cache/[[LIB_NAME]].swiftmodule
-// NOCACHE-NOT: /prebuilt-cache/
-// NOCACHE-NOT: /MCP/
+// NOCACHE-NOT: {{[/\\]prebuilt-cache[/\\]}}
+// NOCACHE-NOT: {{[/\\]MCP[/\\]}}
+// NOCACHE: {{[/\\]prebuilt-cache[/\\]}}[[LIB_NAME]].swiftmodule
+// NOCACHE-NOT: {{[/\\]prebuilt-cache[/\\]}}
+// NOCACHE-NOT: {{[/\\]MCP[/\\]}}
 //
 // Check we didn't emit anything from the cache in the .d file either
 // RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE-NEGATIVE
@@ -122,10 +122,10 @@
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NEW-EXLIB
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=NEW-EXLIB,NEW-SDKLIB
 //
-// NEW-EXLIB-DAG: /my-new-sdk/usr/include/module.modulemap
-// NEW-EXLIB-DAG: /my-new-sdk/usr/include/SomeCModule.h
-// NEW-EXLIB-DAG: /my-new-sdk/ExportedLib.swiftinterface
-// NEW-SDKLIB-DAG: /my-new-sdk/SdkLib.swiftinterface
+// NEW-EXLIB-DAG: {{[/\\]my-new-sdk[/\\]usr[/\\]include[/\\]}}module.modulemap
+// NEW-EXLIB-DAG: {{[/\\]my-new-sdk[/\\]usr[/\\]include[/\\]}}SomeCModule.h
+// NEW-EXLIB-DAG: {{[/\\]my-new-sdk[/\\]}}ExportedLib.swiftinterface
+// NEW-SDKLIB-DAG: {{[/\\]my-new-sdk[/\\]}}SdkLib.swiftinterface
 //
 // Check they don't contain dependencies from the module cache, old prebuilt
 // cache, or new prebuilt cache

--- a/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -22,6 +22,7 @@
 // RUN: echo 'import SystemDependencies' | %target-swift-frontend -typecheck - -I %S -sdk %t/mock-sdk -module-cache-path %t/MCP-system -emit-dependencies-path %t/dummy.d -track-system-dependencies
 // RUN: test -f %t/MCP-system/SystemDependencies*.swiftmodule
 // RUN: %FileCheck -check-prefix CHECK %s < %t/dummy.d
+// RUN: llvm-bcanalyzer -dump %t/MCP-system/SystemDependencies*.swiftmodule | %FileCheck -check-prefix CHECK-DUMP %s
 // RUN: %{python} %S/Inputs/make-old.py %t/MCP-system/SystemDependencies*.swiftmodule
 
 // Baseline: running the same command again doesn't rebuild the cached module.
@@ -41,6 +42,13 @@
 
 // NEGATIVE-NOT: SomeCModule.h
 // CHECK: SomeCModule.h
+
+// CHECK-DUMP-NOT: usr/include
+// CHECK-DUMP: DEPENDENCY_DIRECTORY{{.+}}'usr/include'
+// CHECK-DUMP-NEXT: FILE_DEPENDENCY{{.+}}'module.modulemap'
+// CHECK-DUMP-NEXT: FILE_DEPENDENCY{{.+}}'SomeCModule.h'
+// CHECK-DUMP-NOT: usr/include
+
 // MODULECACHE-COUNT-2: SystemDependencies-{{[^ ]+}}.swiftmodule
 
 import SomeCModule

--- a/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -35,10 +35,12 @@
 
 // Check that it picked a different cache key.
 // RUN: %empty-directory(%t/MCP-combined)
-// RUN: cp -n %t/MCP/SystemDependencies*.swiftmodule %t/MCP-combined
-// RUN: cp -n %t/MCP-system/SystemDependencies*.swiftmodule %t/MCP-combined
+// RUN: cp %t/MCP/SystemDependencies*.swiftmodule %t/MCP-combined
+// RUN: cp %t/MCP-system/SystemDependencies*.swiftmodule %t/MCP-combined
+// RUN: ls -1 %t/MCP-combined | %FileCheck %s -check-prefix=MODULECACHE
 
 // NEGATIVE-NOT: SomeCModule.h
 // CHECK: SomeCModule.h
+// MODULECACHE-COUNT-2: SystemDependencies-{{[^ ]+}}.swiftmodule
 
 import SomeCModule


### PR DESCRIPTION
Cherry-pick of #24503 to the 5.1 branch (plus #23773 to keep the tests in sync). Reviewed by @harlanhaskins.

rdar://problem/50449802