### PR TITLE
[Build System: CMake] Always copy the apinotes into the build directory when the apinotes directory is included via SWIFT_INCLUDE_APINOTES (5.1 branch).

### DIFF
--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -23,7 +23,7 @@ add_custom_command(
     COMMAND
       "${CMAKE_COMMAND}" "-E" "copy_if_different" ${inputs} "${output_dir}/")
 
-add_custom_target("copy_apinotes"
+add_custom_target("copy_apinotes" ALL
     DEPENDS "${outputs}" "${output_dir}"
     COMMENT "Copying API notes to ${output_dir}"
     SOURCES "${sources}")


### PR DESCRIPTION
Copy of #24527 for the 5.1 branch.