### PR TITLE
tests: Win32 ParseableInterface.ModuleCache.SystemDependencies

### DIFF
--- a/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -43,11 +43,12 @@
 // NEGATIVE-NOT: SomeCModule.h
 // CHECK: SomeCModule.h
 
-// CHECK-DUMP-NOT: usr/include
-// CHECK-DUMP: DEPENDENCY_DIRECTORY{{.+}}'usr/include'
+// CHECK-DUMP-NOT: usr{{[/\\]}}include
+// CHECK-DUMP: DEPENDENCY_DIRECTORY{{.+}}'usr{{[/\\]}}include'
 // CHECK-DUMP-NEXT: FILE_DEPENDENCY{{.+}}'module.modulemap'
-// CHECK-DUMP-NEXT: FILE_DEPENDENCY{{.+}}'SomeCModule.h'
-// CHECK-DUMP-NOT: usr/include
+// CHECK-DUMP-NOT: FILE_DEPENDENCY{{.+}}'SomeCModule.h'
+// CHECK-DUMP: FILE_DEPENDENCY{{.+}}'SomeCModule.h'
+// CHECK-DUMP-NOT: usr{{[/\\]}}include
 
 // MODULECACHE-COUNT-2: SystemDependencies-{{[^ ]+}}.swiftmodule
 


### PR DESCRIPTION
Fix the path separator.  On Windows, there is an extra search path which
makes the strict next check fail.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
