### PR TITLE
[Sema] Disallow derived conformances in disallowed contexts.

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorNumeric.cpp
@@ -449,32 +449,36 @@ static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
 
 ValueDecl *
 DerivedConformance::deriveAdditiveArithmetic(ValueDecl *requirement) {
-  if (requirement->getBaseName() == TC.Context.getIdentifier("+")) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.getIdentifier("+"))
     return deriveMathOperator(*this, Add);
-  }
-  if (requirement->getBaseName() == TC.Context.getIdentifier("-")) {
+  if (requirement->getBaseName() == TC.Context.getIdentifier("-"))
     return deriveMathOperator(*this, Subtract);
-  }
-  if (requirement->getBaseName() == TC.Context.Id_zero) {
+  if (requirement->getBaseName() == TC.Context.Id_zero)
     return deriveAdditiveArithmetic_zero(*this);
-  }
   TC.diagnose(requirement->getLoc(),
               diag::broken_additive_arithmetic_requirement);
   return nullptr;
 }
 
 ValueDecl *DerivedConformance::deriveVectorNumeric(ValueDecl *requirement) {
-  if (requirement->getBaseName() == TC.Context.getIdentifier("*")) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.getIdentifier("*"))
     return deriveMathOperator(*this, ScalarMultiply);
-  }
   TC.diagnose(requirement->getLoc(), diag::broken_vector_numeric_requirement);
   return nullptr;
 }
 
 Type DerivedConformance::deriveVectorNumeric(AssociatedTypeDecl *requirement) {
-  if (requirement->getBaseName() == TC.Context.Id_Scalar) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.Id_Scalar)
     return deriveVectorNumeric_Scalar(Nominal, getConformanceContext());
-  }
   TC.diagnose(requirement->getLoc(), diag::broken_vector_numeric_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -705,7 +705,7 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   // members conform to `VectorNumeric` and share the same scalar type.
   Type sameScalarType;
   bool canDeriveVectorNumeric =
-      canDeriveAdditiveArithmetic && !diffProperties.empty() && 
+      canDeriveAdditiveArithmetic && !diffProperties.empty() &&
       llvm::all_of(diffProperties, [&](VarDecl *vd) {
         auto conf = TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
                                           vecNumProto, nominal,
@@ -1136,6 +1136,9 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
 }
 
 ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
   if (requirement->getBaseName() == TC.Context.Id_moved)
     return deriveDifferentiable_moved(*this);
   if (requirement->getBaseName() == TC.Context.Id_tangentVector)
@@ -1147,6 +1150,9 @@ ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
 }
 
 Type DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
   if (requirement->getBaseName() == TC.Context.Id_TangentVector)
     return deriveDifferentiable_AssociatedStruct(
         *this, TC.Context.Id_TangentVector);

--- a/lib/Sema/DerivedConformanceKeyPathIterable.cpp
+++ b/lib/Sema/DerivedConformanceKeyPathIterable.cpp
@@ -129,9 +129,11 @@ static Type deriveKeyPathIterable_AllKeyPaths(DerivedConformance &derived) {
 }
 
 ValueDecl *DerivedConformance::deriveKeyPathIterable(ValueDecl *requirement) {
-  if (requirement->getBaseName() == TC.Context.Id_allKeyPaths) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.Id_allKeyPaths)
     return deriveKeyPathIterable_allKeyPaths(*this);
-  }
   TC.diagnose(requirement->getLoc(),
               diag::broken_key_path_iterable_requirement);
   return nullptr;
@@ -139,9 +141,11 @@ ValueDecl *DerivedConformance::deriveKeyPathIterable(ValueDecl *requirement) {
 
 Type DerivedConformance::deriveKeyPathIterable(
     AssociatedTypeDecl *requirement) {
-  if (requirement->getBaseName() == TC.Context.Id_AllKeyPaths) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.Id_AllKeyPaths)
     return deriveKeyPathIterable_AllKeyPaths(*this);
-  }
   TC.diagnose(requirement->getLoc(),
               diag::broken_key_path_iterable_requirement);
   return nullptr;

--- a/lib/Sema/DerivedConformanceTensorGroup.cpp
+++ b/lib/Sema/DerivedConformanceTensorGroup.cpp
@@ -30,7 +30,7 @@
 
 using namespace swift;
 
-bool DerivedConformance::canDeriveTensorGroup(NominalTypeDecl *nominal, 
+bool DerivedConformance::canDeriveTensorGroup(NominalTypeDecl *nominal,
                                               DeclContext *DC) {
   // Nominal type must be a struct (zero stored properties is okay).
   // Note: we could extend synthesis to support classes.
@@ -77,13 +77,13 @@ deriveBodyTensorGroup_typeList(AbstractFunctionDecl *funcDecl) {
 
   // Concatenate all member `_typeList` arrays.
   Type arrayType = BoundGenericType::get(
-    C.getArrayDecl(), Type(), 
+    C.getArrayDecl(), Type(),
     {C.getTensorDataTypeDecl()->getDeclaredInterfaceType()});
   auto *arrayTypeExpr = TypeExpr::createImplicit(arrayType, C);
   auto plusOpLookup = C.getArrayDecl()->lookupDirect(C.getIdentifier("+"));
   assert(plusOpLookup.size() == 1 && "Ambiguous 'Array.+' operator.");
   ValueDecl *plusOpDecl = plusOpLookup.front();
-  auto plusOpDRE = new (C) 
+  auto plusOpDRE = new (C)
       DeclRefExpr(plusOpDecl, DeclNameLoc(), /*Implicit*/ true);
   auto plusOpExpr = new (C)
       DotSyntaxCallExpr(plusOpDRE, SourceLoc(), arrayTypeExpr);
@@ -92,15 +92,15 @@ deriveBodyTensorGroup_typeList(AbstractFunctionDecl *funcDecl) {
     auto memberType =
         parentDC->mapTypeIntoContext(member->getValueInterfaceType());
     auto *memberTypeExpr = TypeExpr::createImplicit(memberType, C);
-    auto *memberTypeListExpr = new (C) 
+    auto *memberTypeListExpr = new (C)
         MemberRefExpr(memberTypeExpr, SourceLoc(), typeListReq,
                       DeclNameLoc(), /*Implicit*/ true);
     // Create expression `lhsArg + rhsArg`.
     auto *plusOpArgs =
-        TupleExpr::create(C, SourceLoc(), {typeListExpr, memberTypeListExpr}, 
+        TupleExpr::create(C, SourceLoc(), {typeListExpr, memberTypeListExpr},
                           {}, {}, SourceLoc(), /*HasTrailingClosure*/ false,
                           /*Implicit*/ true);
-    typeListExpr = new (C) BinaryExpr(plusOpExpr, plusOpArgs, 
+    typeListExpr = new (C) BinaryExpr(plusOpExpr, plusOpArgs,
                                       /*Implicit*/ true);
   }
 
@@ -120,7 +120,7 @@ static ValueDecl *deriveTensorGroup_typeList(DerivedConformance &derived) {
 
   auto parentDC = derived.getConformanceContext();
   Type dataTypeArrayType = BoundGenericType::get(
-    C.getArrayDecl(), Type(), 
+    C.getArrayDecl(), Type(),
     {C.getTensorDataTypeDecl()->getDeclaredInterfaceType()});
   auto returnType = parentDC->mapTypeIntoContext(dataTypeArrayType);
 
@@ -147,7 +147,7 @@ static ValueDecl *deriveTensorGroup_typeList(DerivedConformance &derived) {
 }
 
 // Synthesize body for `init(_owning:)`.
-static void 
+static void
 deriveBodyTensorGroup_init(AbstractFunctionDecl *funcDecl) {
   auto *parentDC = funcDecl->getParent();
   auto *nominal = parentDC->getSelfNominalTypeDecl();
@@ -163,33 +163,33 @@ deriveBodyTensorGroup_init(AbstractFunctionDecl *funcDecl) {
 
   // Get references to `self` and parameter declarations.
   auto *selfDecl = funcDecl->getImplicitSelfDecl();
-  auto *selfDRE = new (C) 
+  auto *selfDRE = new (C)
       DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
   auto *paramDecl = funcDecl->getParameters()->get(0);
-  auto *paramDRE = new (C) 
+  auto *paramDRE = new (C)
       DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit*/ true);
 
   // Create an `if var` statement for the current address.
   VarDecl *currAddressDecl = new (C) VarDecl(
-      /*IsStatic*/ false, VarDecl::Specifier::Var, /*IsCaptureList*/ false, 
+      /*IsStatic*/ false, VarDecl::Specifier::Var, /*IsCaptureList*/ false,
       SourceLoc(), C.getIdentifier("currentAddress"), funcDecl);
   currAddressDecl->setImplicit();
   currAddressDecl->setHasNonPatternBindingInit(true);
   currAddressDecl->setInterfaceType(baseAddressType);
   currAddressDecl->setValidationToChecked();
 
-  Pattern *currAddressPat = new (C) 
+  Pattern *currAddressPat = new (C)
       NamedPattern(currAddressDecl, /*implicit*/ true);
-  currAddressPat = new (C) 
-      VarPattern(SourceLoc(), /*isLet*/ false, currAddressPat, 
+  currAddressPat = new (C)
+      VarPattern(SourceLoc(), /*isLet*/ false, currAddressPat,
                  /*implicit*/ true);
   currAddressPat = new (C)
-      OptionalSomePattern(currAddressPat, currAddressPat->getEndLoc(), 
+      OptionalSomePattern(currAddressPat, currAddressPat->getEndLoc(),
                           /*implicit*/ true);
   StmtConditionElement cond[] = {
       StmtConditionElement(SourceLoc(), currAddressPat, /*Init*/ paramDRE)};
 
-  // Get the necessary protocol requirements.  
+  // Get the necessary protocol requirements.
   auto *tensorGroupProto = C.getProtocol(KnownProtocolKind::TensorGroup);
   auto *tensorArrayProto = C.getProtocol(
       KnownProtocolKind::TensorArrayProtocol);
@@ -202,8 +202,8 @@ deriveBodyTensorGroup_init(AbstractFunctionDecl *funcDecl) {
   Type intType = C.getIntDecl()->getDeclaredType();
   TypeExpr *intTE = TypeExpr::createImplicit(intType, C);
 
-  // Goes through the member TensorGroups and call 
-  // `self.t = T(_owning:)`.
+  // Iterate through the `TensorGroup`-conforming members and call
+  // `self.member = MemberType(_owning:)`.
   llvm::SmallVector<ASTNode, 2> thenMemberExprs;
   llvm::SmallVector<ASTNode, 2> elseMemberExprs;
   for (auto member : nominal->getStoredProperties()) {
@@ -236,15 +236,15 @@ deriveBodyTensorGroup_init(AbstractFunctionDecl *funcDecl) {
     auto *addressDRE = new (C) DeclRefExpr(
         currAddressDecl, DeclNameLoc(), /*implicit*/ true);
     auto *loadExpr = new (C) LoadExpr(addressDRE, baseAddressType);
-    
-    // Initialize the member using its TensorGroup constructor.
-    // Note that, initialization is dependent on the branch of the 
+
+    // Initialize the member using its `TensorGroup` constructor.
+    // Note that, initialization is dependent on the branch of the
     // if-statement taken.
     auto *thenInitExpr = new (C) InjectIntoOptionalExpr(loadExpr, addressType);
     auto *thenInitCallExpr = CallExpr::createImplicit(
         C, memberInitExpr, {thenInitExpr}, {C.getIdentifier("_owning")});
-    
-    // Create a nil expression with type UnsafePointer<CTensorHandle>? for the 
+
+    // Create a nil expression with type `UnsafePointer<CTensorHandle>?` for the
     // `else` branch.
     auto *nilDecl = C.getOptionalNoneDecl();
     auto *nilDRE = new (C) DeclRefExpr(
@@ -253,7 +253,7 @@ deriveBodyTensorGroup_init(AbstractFunctionDecl *funcDecl) {
         nilDRE, SourceLoc(), addressTE);
     auto *elseInitCallExpr = CallExpr::createImplicit(
         C, memberInitExpr, {elseInitExpr}, {C.getIdentifier("_owning")});
-    
+
     // Assign the current member to the result of the initializer call.
     auto *memberDRE = new (C) MemberRefExpr(
         selfDRE, SourceLoc(), member, DeclNameLoc(), /*Implicit*/ true);
@@ -262,63 +262,62 @@ deriveBodyTensorGroup_init(AbstractFunctionDecl *funcDecl) {
         memberDRE, SourceLoc(), thenInitCallExpr, /*Implicit*/ true);
     auto *elseAssignMemberExpr = new (C) AssignExpr(
         memberDRE, SourceLoc(), elseInitCallExpr, /*Implicit*/ true);
-    
+
     thenMemberExprs.push_back(thenAssignMemberExpr);
     elseMemberExprs.push_back(elseAssignMemberExpr);
-    
+
     // Advance the current address.
-    DeclName advancedName(C, C.getIdentifier("advanced"), 
+    DeclName advancedName(C, C.getIdentifier("advanced"),
                           {C.getIdentifier("by")});
-    auto *advancedMethodExpr = 
+    auto *advancedMethodExpr =
         new (C) UnresolvedDotExpr(addressDRE, SourceLoc(),
-                                  advancedName, DeclNameLoc(), 
+                                  advancedName, DeclNameLoc(),
                                   /*Implicit*/ true);
-    
+
     // Obtain `MemberType._tensorHandleCount`.
     auto *memberCountMRE = new (C) MemberRefExpr(
         memberDRE, SourceLoc(), tensorHandleCountReq, DeclNameLoc(),
         /*Implicit*/ true);
-    
+
     // Cast the tensor handle count to Int.
-    auto intInitName = DeclName(C, DeclBaseName::createConstructor(), 
+    auto intInitName = DeclName(C, DeclBaseName::createConstructor(),
                                 {Identifier()});
-    auto *intInitExpr = 
-        new (C) UnresolvedDotExpr(intTE, SourceLoc(), intInitName, 
+    auto *intInitExpr =
+        new (C) UnresolvedDotExpr(intTE, SourceLoc(), intInitName,
                                   DeclNameLoc(), /*Implicit*/ true);
     auto *intInitCallExpr = CallExpr::createImplicit(
         C, intInitExpr, {memberCountMRE}, {Identifier()});
-    
+
     // Assign the new address.
     auto *assignAddrCallExpr = CallExpr::createImplicit(
         C, advancedMethodExpr, {intInitCallExpr}, {C.getIdentifier("by")});
-    auto *assignAddrExpr = new (C) AssignExpr(addressDRE, SourceLoc(), 
-                                              assignAddrCallExpr, 
+    auto *assignAddrExpr = new (C) AssignExpr(addressDRE, SourceLoc(),
+                                              assignAddrCallExpr,
                                               /*Implicit*/ true);
 
     thenMemberExprs.push_back(assignAddrExpr);
   }
 
   auto *thenBody = BraceStmt::create(
-    C, SourceLoc(), C.AllocateCopy(thenMemberExprs), SourceLoc(), 
+    C, SourceLoc(), C.AllocateCopy(thenMemberExprs), SourceLoc(),
     /*implicit*/ true);
 
   auto *elseBody = BraceStmt::create(
-    C, SourceLoc(), C.AllocateCopy(elseMemberExprs), SourceLoc(), 
+    C, SourceLoc(), C.AllocateCopy(elseMemberExprs), SourceLoc(),
     /*implicit*/ true);
 
   auto *ifStmt = new (C)
-      IfStmt(LabeledStmtInfo(), /*IfLoc*/ SourceLoc(), 
-             /*Cond*/ C.AllocateCopy(cond), /*Then*/ thenBody, 
+      IfStmt(LabeledStmtInfo(), /*IfLoc*/ SourceLoc(),
+             /*Cond*/ C.AllocateCopy(cond), /*Then*/ thenBody,
              /*ElseLoc*/ SourceLoc(), /*Else*/ elseBody, /*implicit*/ true);
-  
+
   funcDecl->setBody(BraceStmt::create(C, SourceLoc(), {ifStmt}, SourceLoc(),
                                       /*implicit*/ true));
 }
 
-// Synthesize a constructor declaration for a `TensorGroup` 
-// method requirement.
+// Synthesize a constructor declaration for a `TensorGroup` method requirement.
 static ValueDecl *deriveTensorGroup_constructor(
-    DerivedConformance &derived, Identifier argumentName, 
+    DerivedConformance &derived, Identifier argumentName,
     Identifier parameterName, Type parameterType, Type returnType,
     AbstractFunctionDecl::BodySynthesizer bodySynthesizer) {
   auto nominal = derived.Nominal;
@@ -353,7 +352,7 @@ static ValueDecl *deriveTensorGroup_constructor(
 }
 
 // Synthesize the `init(_owning:)` function declaration.
-static ValueDecl 
+static ValueDecl
 *deriveTensorGroup_init(DerivedConformance &derived) {
   auto &C = derived.TC.Context;
 
@@ -372,6 +371,9 @@ static ValueDecl
 }
 
 ValueDecl *DerivedConformance::deriveTensorGroup(ValueDecl *requirement) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
   if (requirement->getBaseName() == TC.Context.Id_typeList)
     return deriveTensorGroup_typeList(*this);
   if (requirement->getBaseName() == DeclBaseName::createConstructor())

--- a/test/AutoDiff/Inputs/differentiable_requirement_other_module.swift
+++ b/test/AutoDiff/Inputs/differentiable_requirement_other_module.swift
@@ -1,6 +1,4 @@
-public struct Empty {
-  public init() {}
-}
+public struct Empty : AdditiveArithmetic {}
 
 public protocol DifferentiableRequirement {
   @differentiable

--- a/test/AutoDiff/differentiable_requirement_cross_module.swift
+++ b/test/AutoDiff/differentiable_requirement_cross_module.swift
@@ -6,7 +6,15 @@ import differentiable_requirement_other_module
 
 // Conform `Empty` to `Differentiable`.
 // The `foo` protocol requirement is `@differentiable` and has an `Empty` parameter.
-extension Empty : Differentiable {}
+extension Empty : Differentiable {
+  public typealias TangentVector = Empty
+  public typealias CotangentVector = Empty
+  public typealias AllDifferentiableVariables = Empty
+
+  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
+    return cotangent
+  }
+}
 
 // expected-error @+1 {{type 'Conforming' does not conform to protocol 'DifferentiableRequirement'}}
 struct Conforming : DifferentiableRequirement {

--- a/test/Sema/Inputs/struct_additive_arithmetic_other_module.swift
+++ b/test/Sema/Inputs/struct_additive_arithmetic_other_module.swift
@@ -1,0 +1,14 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+// expected-note @+1 3 {{type declared here}}
+struct OtherFileNonconforming : Equatable {
+  var int: Int
+  var float: Float
+}
+
+// expected-note @+1 3 {{type declared here}}
+struct GenericOtherFileNonconforming<T : AdditiveArithmetic> : Equatable {
+  var x: T
+  var int: Int
+  var float: Float
+}

--- a/test/Sema/Inputs/struct_differentiable_other_module.swift
+++ b/test/Sema/Inputs/struct_differentiable_other_module.swift
@@ -1,0 +1,9 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+// expected-note @+1 {{type declared here}}
+struct OtherFileNonconforming {}
+
+// expected-note @+1 {{type declared here}}
+struct GenericOtherFileNonconforming<T : Differentiable> {
+  var x: T
+}

--- a/test/Sema/Inputs/struct_key_path_iterable_other_module.swift
+++ b/test/Sema/Inputs/struct_key_path_iterable_other_module.swift
@@ -1,0 +1,14 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+// expected-note @+1 {{type declared here}}
+struct OtherFileNonconforming {
+  var int: Int
+  var float: Float
+}
+
+// expected-note @+1 {{type declared here}}
+struct GenericOtherFileNonconforming<T : KeyPathIterable> {
+  var x: T
+  var int: Int
+  var float: Float
+}

--- a/test/Sema/Inputs/struct_tensor_array_protocol_other_module.swift
+++ b/test/Sema/Inputs/struct_tensor_array_protocol_other_module.swift
@@ -1,0 +1,16 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+import TensorFlow
+
+// expected-note @+1 4 {{type declared here}}
+struct OtherFileNonconforming {
+  var x: Tensor<Int32>
+  var y: Tensor<Float>
+}
+
+// expected-note @+1 4 {{type declared here}}
+struct GenericOtherFileNonconforming<T : TensorFlowScalar> {
+  var x: Tensor<Int32>
+  var y: Tensor<Float>
+  var z: Tensor<T>
+}

--- a/test/Sema/Inputs/struct_tensor_group_other_module.swift
+++ b/test/Sema/Inputs/struct_tensor_group_other_module.swift
@@ -1,0 +1,16 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+import TensorFlow
+
+// expected-note @+1 2 {{type declared here}}
+struct OtherFileNonconforming : TensorArrayProtocol {
+  var x: Tensor<Int32>
+  var y: Tensor<Float>
+}
+
+// expected-note @+1 2 {{type declared here}}
+struct GenericOtherFileNonconforming<T : TensorFlowScalar> : TensorArrayProtocol, Equatable {
+  var x: Tensor<Int32>
+  var y: Tensor<Float>
+  var z: Tensor<T>
+}

--- a/test/Sema/Inputs/struct_vector_numeric_other_module.swift
+++ b/test/Sema/Inputs/struct_vector_numeric_other_module.swift
@@ -1,0 +1,12 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+// expected-note @+1 {{type declared here}}
+struct OtherFileNonconforming : AdditiveArithmetic {
+  var float: Float
+}
+
+// expected-note @+1 {{type declared here}}
+struct GenericOtherFileNonconforming<T : VectorNumeric> : AdditiveArithmetic {
+  var x: T
+  var y: T
+}

--- a/test/Sema/struct_additive_arithmetic.swift
+++ b/test/Sema/struct_additive_arithmetic.swift
@@ -1,5 +1,5 @@
 // SWIFT_ENABLE_TENSORFLOW
-// RUN: %target-swift-frontend -typecheck -verify %s -verify-ignore-unknown
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_additive_arithmetic_other_module.swift
 
 func testAdditiveArithmetic<T : AdditiveArithmetic>(
   _ x: inout T
@@ -11,31 +11,39 @@ func testAdditiveArithmetic<T : AdditiveArithmetic>(
 }
 
 struct Empty : AdditiveArithmetic {}
-var empty = Empty()
-testAdditiveArithmetic(&empty)
+func testEmpty() {
+  var empty = Empty()
+  testAdditiveArithmetic(&empty)
+}
 
 struct Int2: AdditiveArithmetic {
   var a: Int
   var b: Int
 }
-var int2 = Int2(a: 1, b: 1)
-testAdditiveArithmetic(&int2)
+func testInt2() {
+  var int2 = Int2(a: 1, b: 1)
+  testAdditiveArithmetic(&int2)
+}
 
 // Test generic type.
 struct Vector2<T : AdditiveArithmetic>: AdditiveArithmetic {
   var x: T
   var y: T
 }
-var vec2 = Vector2<Double>(x: 1, y: 1)
-testAdditiveArithmetic(&vec2)
+func testVector2() {
+  var vec2 = Vector2<Double>(x: 1, y: 1)
+  testAdditiveArithmetic(&vec2)
+}
 
 // Test nested type.
 struct Nested: AdditiveArithmetic {
   var int2: Int2
   var int: Int
 }
-var nested = Nested(int2: int2, int: 1)
-testAdditiveArithmetic(&nested)
+func testNested(int2: Int2) {
+  var nested = Nested(int2: int2, int: 1)
+  testAdditiveArithmetic(&nested)
+}
 
 // Test mixed type.
 // Note: `Numeric` refines `AdditiveArithmetic`.
@@ -44,8 +52,10 @@ struct Mixed: AdditiveArithmetic {
   var float: Float
   var uint8: UInt8
 }
-var mixed = Mixed(nested: nested, float: 1, uint8: 1)
-testAdditiveArithmetic(&mixed)
+func testMixed(nested: Nested) {
+  var mixed = Mixed(nested: nested, float: 1, uint8: 1)
+  testAdditiveArithmetic(&mixed)
+}
 
 // Test type in generic context.
 struct A<T> {
@@ -57,7 +67,7 @@ struct A<T> {
     }
   }
 }
-func testGenericContext<T, U, V>() -> A<T>.B<U, V>.GenericContextNested {
+func testGenericContext<T, U, V>(nested: Nested) -> A<T>.B<U, V>.GenericContextNested {
   var genericNested =
     A<T>.B<U, V>.GenericContextNested(nested: nested, float: 1, uint8: 1)
   testAdditiveArithmetic(&genericNested)
@@ -81,3 +91,11 @@ struct HasCustomNonMemberwiseInitializer<T : AdditiveArithmetic>: AdditiveArithm
   var value: T
   init(randomLabel value: T) { self.value = value }
 }
+
+// Test derived conformances in disallowed contexts.
+
+// expected-error @+1 3 {{implementation of 'AdditiveArithmetic' cannot be automatically synthesized in an extension in a different file to the type}}
+extension OtherFileNonconforming : AdditiveArithmetic {}
+
+// expected-error @+1 3 {{implementation of 'AdditiveArithmetic' cannot be automatically synthesized in an extension in a different file to the type}}
+extension GenericOtherFileNonconforming : AdditiveArithmetic {}

--- a/test/Sema/struct_tensor_array_protocol.swift
+++ b/test/Sema/struct_tensor_array_protocol.swift
@@ -1,0 +1,30 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_tensor_array_protocol_other_module.swift
+
+import TensorFlow
+
+struct Empty : TensorArrayProtocol {}
+
+struct Simple : TensorArrayProtocol, Equatable {
+  var w, b: Tensor<Float>
+}
+
+struct Mixed : TensorArrayProtocol, Equatable {
+  // Mutable.
+  var float: Tensor<Float>
+  // Immutable.
+  let int: Tensor<Int32>
+}
+
+struct Generic<T: TensorGroup & Equatable, U: TensorGroup & Equatable> : TensorArrayProtocol, Equatable {
+  var t: T
+  var u: U
+}
+
+// Test derived conformances in disallowed contexts.
+
+// expected-error @+1 4 {{implementation of 'TensorArrayProtocol' cannot be automatically synthesized in an extension in a different file to the type}}
+extension OtherFileNonconforming : TensorArrayProtocol {}
+
+// expected-error @+1 4 {{implementation of 'TensorArrayProtocol' cannot be automatically synthesized in an extension in a different file to the type}}
+extension GenericOtherFileNonconforming : TensorArrayProtocol {}

--- a/test/Sema/struct_tensor_group.swift
+++ b/test/Sema/struct_tensor_group.swift
@@ -1,0 +1,37 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_tensor_group_other_module.swift
+
+import TensorFlow
+
+struct Empty : TensorGroup {}
+
+struct Simple : TensorGroup, Equatable {
+  var w, b: Tensor<Float>
+}
+
+struct Mixed : TensorGroup, Equatable {
+  // Mutable.
+  var float: Tensor<Float>
+  // Immutable.
+  let int: Tensor<Int32>
+}
+
+struct Nested : TensorGroup, Equatable {
+  // Immutable.
+  let simple: Simple
+  // Mutable.
+  var mixed: Mixed
+}
+
+struct Generic<T: TensorGroup & Equatable, U: TensorGroup & Equatable> : TensorGroup, Equatable {
+  var t: T
+  var u: U
+}
+
+// Test derived conformances in disallowed contexts.
+
+// expected-error @+1 2 {{implementation of 'TensorGroup' cannot be automatically synthesized in an extension in a different file to the type}}
+extension OtherFileNonconforming : TensorGroup {}
+
+// expected-error @+1 2 {{implementation of 'TensorGroup' cannot be automatically synthesized in an extension in a different file to the type}}
+extension GenericOtherFileNonconforming : TensorGroup {}


### PR DESCRIPTION
Disallow derived conformances in disallowed contexts for:
- `AdditiveArithmetic`
- `VectorNumeric`
- `KeyPathIterable`
- `Differentiable`
- `TensorArrayProtocol`
- `TensorGroup`

This is consistent with existing derived conformances for other protocols.
Remove `-verify-ignore-unknown` from various tests.