### PR TITLE
make @differentiable propagate into AST function types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2258,7 +2258,9 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
 
       // Resolve the function type directly with these attributes.
       FunctionType::ExtInfo extInfo(rep, /*noescape=*/false,
-                                    fnRepr->throws(), false);
+                                    // SWIFT_ENABLE_TENSORFLOW
+                                    fnRepr->throws(),
+                                    attrs.has(TAK_autodiff) || attrs.has(TAK_differentiable));
 
       ty = resolveASTFunctionType(fnRepr, options, extInfo);
       if (!ty || ty->hasError())


### PR DESCRIPTION
The merge made AST function types stop picking up the @differentiable bit.

When the workarounds in https://github.com/dan-zheng/swift/commit/de90f39aa84bff1f1abc2b42ee0a28b70f52f6a0 are also applied, stdlib compilation no longer has the error mentioned in https://github.com/dan-zheng/swift/commit/de90f39aa84bff1f1abc2b42ee0a28b70f52f6a0. It gets all the way to IRGen, and crashes: https://gist.github.com/marcrasi/6e9f08f881347e9f012149b05e554adb