### PR TITLE
[AutoDiff] Print full differentiation parameters clause by default.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -291,17 +291,19 @@ static std::string getDifferentiationParametersClauseString(
       ->castTo<AnyFunctionType>();
   bool isInstanceMethod = function && function->isInstanceMember();
 
-  // If the number of specified parameters is equal to the number of inferred
-  // differentiation parameters, then return an empty string.
-  auto parameterCount =
-      indices ? indices->parameters.count() : parsedParams.size();
-  if (!prettyPrintInModule)
-    prettyPrintInModule = function->getModuleContext();
-  auto inferredParametersCount =
-      AutoDiffParameterIndicesBuilder::inferParameters(
-          functionType, prettyPrintInModule).count();
-  if (parameterCount == inferredParametersCount)
-    return "";
+  // If pretty-printing, and the number of specified parameters is equal to the
+  // number of inferred differentiation parameters, then return an empty
+  // string. Otherwise, return the explicit differentiation parameters clause
+  // string.
+  if (prettyPrintInModule) {
+    auto parameterCount =
+        indices ? indices->parameters.count() : parsedParams.size();
+    auto inferredParametersCount =
+        AutoDiffParameterIndicesBuilder::inferParameters(
+            functionType, prettyPrintInModule).count();
+    if (parameterCount == inferredParametersCount)
+      return "";
+  }
 
   std::string result;
   llvm::raw_string_ostream printer(result);

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -92,7 +92,7 @@ public struct ConditionallyDifferentiable<T> {
 extension ConditionallyDifferentiable : Differentiable where T : Differentiable {}
 
 // CHECK-AST-LABEL: @_fieldwiseDifferentiable public struct ConditionallyDifferentiable<T> {
-// CHECK-AST:         @differentiable(where T : Differentiable)
+// CHECK-AST:         @differentiable(wrt: self where T : Differentiable)
 // CHECK-AST:         public let x: T
 // CHECK-AST:         internal init(x: T)
 // CHECK-AST:       }

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -12,7 +12,7 @@ func jvpSimple(x: Float) -> Float {
   return x
 }
 
-// CHECK-DAG: @differentiable(jvp: jvpSimpleJVP)
+// CHECK-DAG: @differentiable(wrt: x, jvp: jvpSimpleJVP)
 // CHECK-DAG: func jvpSimpleJVP(x: Float) -> (Float, (Float) -> Float)
 func jvpSimpleJVP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
@@ -23,7 +23,7 @@ func vjpSimple(x: Float) -> Float {
   return x
 }
 
-// CHECK-DAG: @differentiable(vjp: vjpSimpleVJP)
+// CHECK-DAG: @differentiable(wrt: x, vjp: vjpSimpleVJP)
 // CHECK-DAG: func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float)
 func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { v in v })
@@ -45,14 +45,14 @@ struct InstanceMethod : Differentiable {
   }
 }
 
-// CHECK-DAG: @differentiable(where T : Differentiable)
+// CHECK-DAG: @differentiable(wrt: x where T : Differentiable)
 // CHECK-DAG: func testOnlyWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(where T : Differentiable)
 func testOnlyWhereClause<T : Numeric>(x: T) -> T {
   return x
 }
 
-// CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
+// CHECK-DAG: @differentiable(wrt: x, vjp: vjpTestWhereClause where T : Differentiable)
 // CHECK-DAG: func testWhereClause<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClause where T : Differentiable)
 func testWhereClause<T : Numeric>(x: T) -> T {
@@ -66,7 +66,7 @@ func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector
 
 protocol P {}
 extension P {
-  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClause where Self : Differentiable)
+  // CHECK-DAG: @differentiable(wrt: self, vjp: vjpTestWhereClause where Self : Differentiable)
   // CHECK-DAG: func testWhereClause() -> Self
   @differentiable(wrt: self, vjp: vjpTestWhereClause where Self : Differentiable)
   func testWhereClause() -> Self {
@@ -79,7 +79,7 @@ extension P where Self : Differentiable {
   }
 }
 
-// CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
+// CHECK-DAG: @differentiable(wrt: x, vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
 // CHECK-DAG: func testWhereClauseMemberTypeConstraint<T>(x: T) -> T where T : Numeric
 @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where T : Differentiable, T == T.CotangentVector)
 func testWhereClauseMemberTypeConstraint<T : Numeric>(x: T) -> T {
@@ -92,7 +92,7 @@ func vjpTestWhereClauseMemberTypeConstraint<T>(x: T) -> (T, (T) -> T)
 }
 
 extension P {
-  // CHECK-DAG: @differentiable(vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self == Self.CotangentVector)
+  // CHECK-DAG: @differentiable(wrt: self, vjp: vjpTestWhereClauseMemberTypeConstraint where Self : Differentiable, Self == Self.CotangentVector)
   // CHECK-DAG: func testWhereClauseMemberTypeConstraint() -> Self
   @differentiable(wrt: self, vjp: vjpTestWhereClauseMemberTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
   func testWhereClauseMemberTypeConstraint() -> Self {

--- a/test/Serialization/differentiating_attr.swift
+++ b/test/Serialization/differentiating_attr.swift
@@ -8,7 +8,7 @@
 // BCANALYZER-NOT: UnknownCode
 
 // CHECK: @differentiable(wrt: x, jvp: jvpAddWrtX)
-// CHECK-NEXT: @differentiable(vjp: vjpAdd)
+// CHECK-NEXT: @differentiable(wrt: (x, y), vjp: vjpAdd)
 func add(x: Float, y: Float) -> Float {
   return x + y
 }
@@ -21,7 +21,7 @@ func vjpAdd(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, F
   return (x + y, { ($0, $0) })
 }
 
-// CHECK: @differentiable(vjp: vjpGeneric where T : Differentiable)
+// CHECK: @differentiable(wrt: x, vjp: vjpGeneric where T : Differentiable)
 func generic<T : Numeric>(x: T) -> T {
   return x
 }
@@ -33,9 +33,9 @@ func vjpGeneric<T>(x: T) -> (value: T, pullback: (T.CotangentVector) -> T.Cotang
 }
 
 protocol InstanceMethod : Differentiable {
-  // CHECK: @differentiable(vjp: vjpFoo)
+  // CHECK: @differentiable(wrt: (self, x), vjp: vjpFoo)
   func foo(_ x: Self) -> Self
-  // CHECK: @differentiable(jvp: jvpBarWrt where T == T.TangentVector)
+  // CHECK: @differentiable(wrt: (self, x), jvp: jvpBarWrt where T == T.TangentVector)
   func bar<T : Differentiable>(_ x: T) -> Self
 }
 extension InstanceMethod {


### PR DESCRIPTION
Print full differentiation parameters clause by default, for
`@differentiable` and `@differentiating` attribute.

This facilitates debugging: printed AST shows canonical differentiation
parameters clauses. Clauses are pretty-printed only for diagnostics.