### PR TITLE
[android] Remove uuid.h from Android's Glibc.

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -528,8 +528,10 @@ module SwiftGlibc [system] {
   }
 }
 
+% if CMAKE_SDK != "ANDROID":
 module CUUID [system] {
   header "${GLIBC_INCLUDE_PATH}/uuid/uuid.h"
   link "uuid"
   export *
 }
+% end


### PR DESCRIPTION
Android doesn't ship with uuid.h, so having a module pointing to that
header is an error.