### PR TITLE
[test] Enable impossible to support test POSIXErrorCode.

### DIFF
--- a/validation-test/stdlib/POSIXErrorCode.swift
+++ b/validation-test/stdlib/POSIXErrorCode.swift
@@ -1,12 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
-// REQUIRES: OS=macosx
-// REQUIRES: OS=ios
-// REQUIRES: OS=tvos
-// REQUIRES: OS=watchos
-// REQUIRES: OS=linux-androideabi
-// REQUIRES: OS=linux-gnu
+// REQUIRES-ANY: OS=macosx, OS=ios, OS=tvos, OS=watchos, OS=linux-androideabi, OS=linux-android, OS=linux-gnu
 
 import Swift
 import StdlibUnittest
@@ -163,3 +158,5 @@ POSIXErrorCodeTestSuite.test("Linux POSIX error codes constants") {
 }
 
 #endif
+
+runAllTests()


### PR DESCRIPTION
The REQUIRES written one in each line were impossible to satisfy in any
platform, so the test wasn't running at all. This was changed to a
REQUIRE-ANY listing all the platforms (and adding Android). I also
needed to add runAllTest() at the end to make the test pass.

This was like this since back in #6707. It seems to work on Android and my Linux installation. I hope it works on Darwin too.