### PR TITLE
[android] Enable some tests that should pass on Android.

### DIFF
--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -7,7 +7,7 @@
 
 // REQUIRES: executable_test
 // FIXME: seems to fail on 32-bit simulator?
-// REQUIRES: OS=macosx || OS=linux
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=linux-androideabi || OS=linux-android
 
 import Basic
 import WithAssoc

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -13,10 +13,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// FIXME: The Android test runner is incapable of running this test, which
-//        relies on stdin input.
-// UNSUPPORTED: OS=linux-androideabi
-
 import StdlibUnittest
 
 

--- a/validation-test/stdlib/Glibc.swift
+++ b/validation-test/stdlib/Glibc.swift
@@ -5,9 +5,8 @@
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
-// UNSUPPORTED: OS=linux-androideabi
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES-ANY: OS=linux-gnu, OS=linux-androideabi, OS=linux-android
 
 import Swift
 import StdlibUnittest

--- a/validation-test/stdlib/StringLowercasedUppercased.swift
+++ b/validation-test/stdlib/StringLowercasedUppercased.swift
@@ -5,7 +5,7 @@
 // directly.  It is not specific to Linux, it is just that on
 // Apple platforms we are using the NSString bridge right now.
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES-ANY: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
 
 import StdlibUnittest
 


### PR DESCRIPTION
Some tests are limited to only Linux, when they should also pass for
Android.

Additionally, InputStream.swift.gyb was disabled for Android ARMv7, but
wasn't for Android AArch64, which allow me to find the error on it and
fix it on #24521.

Finally, StringLowercasedUppercased is interesting in Android because it
checks the used ICU is correct for performing the tasks that the stdlib
needs.
