### PR TITLE
[android] Allow skipping adb_clean.py

### DIFF
--- a/utils/android/adb_clean.py
+++ b/utils/android/adb_clean.py
@@ -9,9 +9,12 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import os
+
 from adb.commands import DEVICE_TEMP_DIR, reboot, rmdir
 
 
 if __name__ == '__main__':
-    reboot()
-    rmdir(DEVICE_TEMP_DIR)
+    if 'SKIP_ANDROID_CLEAN' not in os.environ:
+        reboot()
+        rmdir(DEVICE_TEMP_DIR)


### PR DESCRIPTION
In normal cases, adb_clean.py cleaning the temporary directory is a good
idea because all the tests run in a clean state, and previous executions
do not influence the current one.

However, when iterating and running only one or two tests with
utils/run-test, removing all the artifacts and uploading them to the
device can turn each iteration into waiting a couple of minutes. Since
the changes in between tests should only touch a couple of libraries (or
none at all, if the test itself is the modification), avoiding a full
clean is beneficial.

The commit modifies `adb_clean.py` to allow providing the environment
variable `SKIP_ANDROID_CLEAN`, which will simply not execute the script.

Since the introduction of #24146, only the modified
artifacts will be uploaded, and the test iteration can be very fast
(including no time, if there are no changes).
