### PR TITLE
Add back lost optional unwrapping feature used in EagerExecution.swift.

### DIFF
--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -176,3 +176,17 @@ public func _addScalarTensorsWithShape<Scalar: TensorFlowNumeric>(
 ) -> Tensor<Scalar> {
   return Raw.add(x, y)
 }
+
+// TODO: Consider revising the call sites where this is necessary to only need
+// UnsafeMutablePointer to optional when it is the actual c-api call site.
+extension UnsafeMutablePointer where Pointee == CTensorHandle? {
+  @usableFromInline
+  init(_ other: UnsafeMutablePointer<CTensorHandle>) {
+    self.init(other._rawValue)
+  }
+  @usableFromInline
+  init?(_ other: UnsafeMutablePointer<CTensorHandle>?) {
+    guard let unwrapped = other else { return nil }
+    self.init(unwrapped)
+  }
+}

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -351,7 +351,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-05-02-a",
                 "libcxx": "swift-5.1-branch",
                 "tensorflow": "447e512d332ab86172a3b13119900b4d021d0c65",
-                "tensorflow-swift-bindings": "ee5ded283a32b6fb5a17d99af6dd34ef7278a405",
+                "tensorflow-swift-bindings": "330ea66bd06ad9df911673bd263a787c63a51597",
                 "tensorflow-swift-apis": "cfefd63fa60a55d1da1e2a412ed561eb3448e691",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "swift-5.1-branch"


### PR DESCRIPTION
This is needed to make the tensorflow-swift-bindings compile again.