### PR TITLE
Remove '-enable-sil-ownership' flag.

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -25,7 +25,6 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
-list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-sil-ownership")
 list(APPEND swift_stdlib_compile_flags "-force-single-frontend-invocation")
 # FIXME(SR-7972): Some tests fail when TensorFlow is optimized.
 list(APPEND swift_stdlib_compile_flags "-Onone")


### PR DESCRIPTION
'-enable-sil-ownership' was renamed: 0dfaa19f9f637fc43fd3d7ae0388f1687b55385f.
Then removed: f854547c55567381891e44f352692de5ee1ab3f5.