### PR TITLE
[5.1][test] TestNotification: Check availability before running hashing test

### DIFF
--- a/test/stdlib/TestNotification.swift
+++ b/test/stdlib/TestNotification.swift
@@ -34,6 +34,8 @@ class TestNotification : TestNotificationSuper {
     }
 
     func test_hashing() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+
         let o1 = NSObject()
         let o2 = NSObject()
         let values: [Notification] = [


### PR DESCRIPTION
Cherry-picked from #24555 to unblock CI testing.

The 5.0 Foundation overlay had a different hash encoding for TestNotification.

rdar://problem/50504038
