### PR TITLE
Fix remaining trivially-fixable tests.

### DIFF
--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -45,7 +45,6 @@ bb0:
   %diffFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
   %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@differentiable @convention(thin) (Float) -> Float
   %extractedOriginal = autodiff_function_extract [original] %diffFunc : $@differentiable @convention(thin) (Float) -> Float
-  %copied = copy_value %extractedOriginal : $@convention(thin) (Float) -> Float
   return %undiffedFunc : $@differentiable @convention(thin) (Float) -> Float
 }
 
@@ -56,5 +55,4 @@ bb0:
 // CHECK:   [[DIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), [[FOO_VJP]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
 // CHECK:   [[EXTRACTED_VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED_FOO]] : $@differentiable @convention(thin) (Float) -> Float
 // CHECK:   [[EXTRACTED_ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_FOO]] : $@differentiable @convention(thin) (Float) -> Float
-// CHECK:   copy_value [[EXTRACTED_ORIG]] : $@convention(thin) (Float) -> Float
 // CHECK:   return [[UNDIFFED_FOO]] : $@differentiable @convention(thin) (Float) -> Float

--- a/test/AutoDiff/core_builtins.swift
+++ b/test/AutoDiff/core_builtins.swift
@@ -9,14 +9,11 @@ func evaldiff<T: Differentiable, U: Differentiable>(_ f: @differentiable (T) -> 
 }
 
 // CHECK-SIL-LABEL: @{{.*}}evaldiff{{.*}}
-// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : @trivial $*U, [[ORIG_FN:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @out U, [[ORIG_FN_ARG:%.*]] : @trivial $*T):
-// CHECK-SIL:   [[ORIG_FN_ARG_COPY:%.*]] = alloc_stack $T
-// CHECK-SIL:   copy_addr [[ORIG_FN_ARG]] to [initialization] [[ORIG_FN_ARG_COPY]] : $*T
+// CHECK-SIL: bb0([[ORIG_RES_BUF:%.*]] : $*U, [[ORIG_FN:%.*]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @out U, [[ORIG_FN_ARG:%.*]] : $*T):
 // CHECK-SIL:   [[JVP_FN:%.*]] = autodiff_function_extract [jvp] [order 1] [[ORIG_FN]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T) -> @out U
 // CHECK-SIL:   [[JVP_RES_BUF:%.*]] = alloc_stack $(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector)
 // CHECK-SIL:   [[JVP_RES_BUF_0:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector), 0
-// CHECK-SIL:   [[DIFFERENTIAL:%.*]] = apply [[JVP_FN]]([[JVP_RES_BUF_0]], [[ORIG_FN_ARG_COPY]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector)
-// CHECK-SIL:   destroy_addr [[ORIG_FN_ARG_COPY]] : $*T
+// CHECK-SIL:   [[DIFFERENTIAL:%.*]] = apply [[JVP_FN]]([[JVP_RES_BUF_0]], [[ORIG_FN_ARG]]) : $@noescape @callee_guaranteed (@in_guaranteed T) -> (@out U, @owned @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector)
 // CHECK-SIL:   [[JVP_RES_BUF_1:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector), 1
 // CHECK-SIL:   store [[DIFFERENTIAL]] to [init] [[JVP_RES_BUF_1]] : $*@callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector
 // CHECK-SIL:   [[JVP_RES_BUF_0:%.*]] = tuple_element_addr [[JVP_RES_BUF]] : $*(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector), 0
@@ -24,7 +21,6 @@ func evaldiff<T: Differentiable, U: Differentiable>(_ f: @differentiable (T) -> 
 // CHECK-SIL:   [[DIFFERENTIAL:%.*]] = load [take] [[JVP_RES_BUF_1]] : $*@callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector
 // CHECK-SIL:   copy_addr [take] [[JVP_RES_BUF_0]] to [initialization] [[ORIG_RES_BUF]] : $*U
 // CHECK-SIL:   dealloc_stack [[JVP_RES_BUF]] : $*(U, @callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector)
-// CHECK-SIL:   dealloc_stack [[ORIG_FN_ARG_COPY]] : $*T
 // CHECK-SIL:   return [[DIFFERENTIAL]] : $@callee_guaranteed (@in_guaranteed T) -> @out U.TangentVector
 
 func evaldiff2<T: Differentiable, U: Differentiable, V: Differentiable>(_ f: @differentiable (T, U) -> V, _ x: T, _ y: U) -> (V, (T.TangentVector, U.TangentVector) -> V.TangentVector)
@@ -33,5 +29,5 @@ func evaldiff2<T: Differentiable, U: Differentiable, V: Differentiable>(_ f: @di
 }
 
 // CHECK-LABEL: @{{.*}}evaldiff2{{.*}}
-// CHECK: bb0({{.*}} : @trivial $*V, [[DIFFED:%.*]] : @trivial $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V, {{.*}} : @trivial $*T, {{.*}} : @trivial $*U):
+// CHECK: bb0({{.*}} : $*V, [[DIFFED:%.*]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V, {{.*}} : $*T, {{.*}} : $*U):
 // CHECK:   autodiff_function_extract [jvp] [order 1] [[DIFFED]] : $@differentiable @noescape @callee_guaranteed (@in_guaranteed T, @in_guaranteed U) -> @out V // user: %14

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -33,7 +33,7 @@ func testOwnedVector(_ x: Vector) -> Vector {
 _ = pullback(at: Vector.zero, in: testOwnedVector)
 
 // CHECK-LABEL: struct {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 {
-// CHECK-NEXT:   @_hasStorage var pullback_0: (Vector) -> (Vector, Vector)
+// CHECK-NEXT:   @_hasStorage var pullback_0: (Vector) -> (Vector, Vector) { get set }
 // CHECK-NEXT: }
 
 // The primal should not release primal values.

--- a/test/AutoDiff/tape_builtins.sil
+++ b/test/AutoDiff/tape_builtins.sil
@@ -6,7 +6,7 @@ import Swift
 import Builtin
 
 sil @foo : $@convention(thin) (Float, Float) -> Float {
-bb0(%0 : @trivial $Float, %1 : @trivial $Float):
+bb0(%0 : $Float, %1 : $Float):
   %tape = builtin "autodiffCreateTape"<Float>() : $_AutoDiffTape<Float>
   %id = integer_literal $Builtin.Word, 0
   builtin "autodiffPushToTape"<Float>(%tape : $_AutoDiffTape<Float>, %0 : $Float, %id : $Builtin.Word) : $()
@@ -16,7 +16,7 @@ bb0(%0 : @trivial $Float, %1 : @trivial $Float):
 }
 
 // CHECK-LABEL: @foo
-// CHECK: bb0(%0 : @trivial $Float, %1 : @trivial $Float):
+// CHECK: bb0(%0 : $Float, %1 : $Float):
 // CHECK:  [[tape:%.*]] = builtin "autodiffCreateTape"<Float>() : $_AutoDiffTape<Float>
 // CHECK:  [[id:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:  builtin "autodiffPushToTape"<Float>([[tape]] : $_AutoDiffTape<Float>, %0 : $Float, [[id]] : $Builtin.Word) : $()

--- a/test/AutoDiff/tape_builtins_irgen.sil
+++ b/test/AutoDiff/tape_builtins_irgen.sil
@@ -6,7 +6,7 @@ import Swift
 import Builtin
 
 sil @foo : $@convention(thin) (Float, Float) -> Float {
-bb0(%0 : @trivial $Float, %1 : @trivial $Float):
+bb0(%0 : $Float, %1 : $Float):
   %tape = builtin "autodiffCreateTape"<Float>() : $_AutoDiffTape<Float>
   %id = integer_literal $Builtin.Word, 0
   builtin "autodiffPushToTape"<Float>(%tape : $_AutoDiffTape<Float>, %0 : $Float, %id : $Builtin.Word) : $()


### PR DESCRIPTION
- Remove `@trivial` type annotations.
- Update SIL FileCheck based on changes in generated code.