### PR TITLE
[AST] Allocate GenericSignature(Builders) in the arena

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -312,6 +312,12 @@ public:
   /// generic parameters to themselves.
   SubstitutionMap getIdentitySubstitutionMap() const;
 
+  /// Whether this generic signature involves a type variable.
+  bool hasTypeVariable() const;
+
+  /// Whether the given set of requirements involves a type variable.
+  static bool hasTypeVariable(ArrayRef<Requirement> requirements);
+
   static void Profile(llvm::FoldingSetNodeID &ID,
                       TypeArrayView<GenericTypeParamType> genericParams,
                       ArrayRef<Requirement> requirements);

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1042,3 +1042,28 @@ unsigned GenericSignature::getGenericParamOrdinal(GenericTypeParamType *param) {
     .findIndexIn(getGenericParams());
 }
 
+bool GenericSignature::hasTypeVariable() const {
+  return hasTypeVariable(getRequirements());
+}
+
+bool GenericSignature::hasTypeVariable(ArrayRef<Requirement> requirements) {
+  for (const auto &req : requirements) {
+    if (req.getFirstType()->hasTypeVariable())
+      return true;
+
+    switch (req.getKind()) {
+    case RequirementKind::Layout:
+      break;
+
+    case RequirementKind::Conformance:
+    case RequirementKind::SameType:
+    case RequirementKind::Superclass:
+      if (req.getSecondType()->hasTypeVariable())
+        return true;
+      break;
+    }
+  }
+
+  return false;
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0194-rdar50309503.swift
+++ b/validation-test/compiler_crashers_2_fixed/0194-rdar50309503.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %s
+
+protocol P {
+  associatedtype AT
+  func foo() -> AT
+}
+
+struct X<C1: Collection, C2: Collection, T>: P
+    where C1.Element == C2.Element
+{
+  func foo() -> some P {
+    return self
+  }
+}


### PR DESCRIPTION
Opaque result type archetypes can involve type variables, which
then get introduced into GenericSignatureBuilders and the
generated GenericSignatures. Allocate them in the proper arena
So we don’t end up with use-after-free errors.

Fixes rdar://problem/50309503.
