### PR TITLE
Fix `test/AutoDiff/deserialization_crashers.swift`.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -767,6 +767,7 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     newMember->setType(memberAssocContextualType);
     Pattern *memberPattern =
         new (C) NamedPattern(newMember, /*implicit*/ true);
+    memberPattern->setType(memberAssocContextualType);
     memberPattern = TypedPattern::createImplicit(
         C, memberPattern, memberAssocContextualType);
     memberPattern->setType(memberAssocContextualType);


### PR DESCRIPTION
Set type for implicit `NamedPattern`.

---

All `AutoDiff` tests pass!