### PR TITLE
Revamp TensorFlowRuntime tests after GPE removal.

### DIFF
--- a/test/TensorFlowRuntime/accelerator_only.swift
+++ b/test/TensorFlowRuntime/accelerator_only.swift
@@ -1,7 +1,6 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-swift-frontend -emit-sil -O %s -verify | %FileCheck %s
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 // REQUIRES: deprecated_gpe_mode
 
 import TensorFlow

--- a/test/TensorFlowRuntime/codable.swift
+++ b/test/TensorFlowRuntime/codable.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 // REQUIRES: objc_interop
 
 import TensorFlow

--- a/test/TensorFlowRuntime/collective.swift
+++ b/test/TensorFlowRuntime/collective.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 // Tests on collective ops, as a building block for data/model parallel programs.
 

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,10 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-
-// SR-9737: hanging tests in GPE GPU mode
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
-
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Control flow related tests.
 

--- a/test/TensorFlowRuntime/control_flow_objc.swift
+++ b/test/TensorFlowRuntime/control_flow_objc.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 // REQUIRES: OS=macosx
 
 // Control flow related tests.

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Compiler-only testing for TPU graph lowering (e.g. shape requirements by XLA).
 

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Dataset API tests.
 

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 // This file contains testing over a dataset as a global variable. This requires
 // sends/recvs support for variant handles.

--- a/test/TensorFlowRuntime/device_placement.swift
+++ b/test/TensorFlowRuntime/device_placement.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 // Test device placement API.
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,8 +1,4 @@
-// FIXME: TFPartition fails in `GraphFunctionDeviceInfo::finalizeUsedDevices()`
-// because used device set includes RUNTIME device.
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
-
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,5 +1,4 @@
-// TODO: Revert to %target-run-gpe-swift once we fold dynamic compilation into -Onone.
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import CTensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
@@ -1,5 +1,4 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import TensorFlow

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 // XFAIL: *
 
 // This test suite contains expected failure tests for GPU execution.

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,10 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-
-// SR-9737: hanging tests in GPE GPU mode
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
-
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Compiler-only testing for TPU graph lowering (e.g. shape requirements by XLA).
 // TODO: enable this after https://github.com/apple/swift/pull/18458 is submitted.

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Loop tests.
 

--- a/test/TensorFlowRuntime/model_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/model_autodiff_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-eager-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
 // Machine learning API AD runtime tests.

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Trivial model tests.
 

--- a/test/TensorFlowRuntime/python_conversion.swift
+++ b/test/TensorFlowRuntime/python_conversion.swift
@@ -1,5 +1,4 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 //

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings
 //
 // TensorFlow Raw Ops API tests.

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Retain/release tests.
 

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,10 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-
-// SR-9737: hanging tests in GPE GPU mode
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
-
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 import CTensorFlow
 import TensorFlow

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 import TensorFlow
 #if TPU

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -1,7 +1,6 @@
 // This test has various test cases to check that SESE regions are computed correctly.
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 import TensorFlow
 #if TPU

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // ShapedArray and ShapedArraySlice API tests.
 

--- a/test/TensorFlowRuntime/string.swift
+++ b/test/TensorFlowRuntime/string.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // String Tensor tests.
 

--- a/test/TensorFlowRuntime/string_description.swift
+++ b/test/TensorFlowRuntime/string_description.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // `Tensor` string description tests.
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,8 +1,5 @@
-// FIXME: TFPartition fails in `GraphFunctionDeviceInfo::finalizeUsedDevices()`
-
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Tensor API tests.
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -466,36 +466,6 @@ TensorTests.testAllBackends("Concatenation") {
               concatenated1.array)
 }
 
-TensorTests.testAllBackends("VJPConcatenation") {
-  let a1 = Tensor<Float>([1,2,3,4])
-  let b1 = Tensor<Float>([5,6,7,8,9,10])
-
-  let a2 = Tensor<Float>([1,1,1,1])
-  let b2 = Tensor<Float>([1,1,1,1,1,1])
-
-  let grads = gradient(at: a2, b2) { a, b in
-    return ((a1 * a) ++ (b1 * b)).sum()
-  }
-
-  expectEqual(a1, grads.0)
-  expectEqual(b1, grads.1)
-}
-
-TensorTests.testAllBackends("VJPConcatenationNegativeAxis") {
-  let a1 = Tensor<Float>([1,2,3,4])
-  let b1 = Tensor<Float>([5,6,7,8,9,10])
-
-  let a2 = Tensor<Float>([1,1,1,1])
-  let b2 = Tensor<Float>([1,1,1,1,1,1])
-
-  let grads = gradient(at: a2, b2) { a, b in
-    return (a1 * a).concatenated(with: b1 * b, alongAxis: -1).sum()
-  }
-
-  expectEqual(a1, grads.0)
-  expectEqual(b1, grads.1)
-}
-
 TensorTests.test("EwiseComparison") {
   let x = Tensor<Float>([0, 1, 2])
   let y = Tensor<Float>([2, 1, 3])

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // This test suite is for tensor API and has been created because tensor.swift
 // has static shape restrictions for TPU send/receive. Until the restriction is

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -1,8 +1,4 @@
-// RUN: %target-run-eager-swift
-//
-// Note: GPE testing is disabled because GPE does not interact well with
-// VJP-based AD. See SR-9638.
-//
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
 // Tensor indirect passing AD runtime tests.

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect_crasher.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect_crasher.swift
@@ -1,8 +1,4 @@
-// RUN: %target-run-eager-swift
-//
-// Note: GPE testing is disabled because GPE does not interact well with
-// VJP-based AD. See SR-9638.
-//
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
 // FIXME(TF-326): Re-enable `-O` after deserialization failure fix.

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -159,6 +159,36 @@ TensorADTests.testAllBackends("reshaped") {
   expectEqual(input, reshapedPullback(reshaped))
 }
 
+TensorADTests.testAllBackends("concatenation (++)") {
+  let a1 = Tensor<Float>([1,2,3,4])
+  let b1 = Tensor<Float>([5,6,7,8,9,10])
+
+  let a2 = Tensor<Float>([1,1,1,1])
+  let b2 = Tensor<Float>([1,1,1,1,1,1])
+
+  let grads = gradient(at: a2, b2) { a, b in
+    return ((a1 * a) ++ (b1 * b)).sum()
+  }
+
+  expectEqual(a1, grads.0)
+  expectEqual(b1, grads.1)
+}
+
+TensorADTests.testAllBackends("concatenated") {
+  let a1 = Tensor<Float>([1,2,3,4])
+  let b1 = Tensor<Float>([5,6,7,8,9,10])
+
+  let a2 = Tensor<Float>([1,1,1,1])
+  let b2 = Tensor<Float>([1,1,1,1,1,1])
+
+  let grads = gradient(at: a2, b2) { a, b in
+    return (a1 * a).concatenated(with: b1 * b, alongAxis: -1).sum()
+  }
+
+  expectEqual(a1, grads.0)
+  expectEqual(b1, grads.1)
+}
+
 TensorADTests.testAllBackends("transposed") {
   let input = Tensor<Float>(ones: [2, 3])
   let transposed = Tensor<Float>(ones: [3, 2])

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,8 +1,4 @@
-// RUN: %target-run-eager-swift
-//
-// Note: GPE testing is disabled because GPE does not interact well with
-// VJP-based AD. See SR-9638.
-//
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
 // Tensor AD runtime tests.

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Tensor API tests, with debug logging enabled.
 

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,10 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-
-// SR-9737: hanging tests in GPE GPU mode
-// UN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
-
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // XLA tests, with debug logging enabled.
 

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 // This tests various issues with top level code, ensuring deabstraction and
 // other things work here.  This is not intended to be a place to test device

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,7 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
-// RUN: %target-run-gpe-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 // This file contains stubs for functions that the playground transform in
 // lib/Sema/PlaygroundTransform.cpp generates calls into.

--- a/test/TensorFlowRuntime/tracer.swift
+++ b/test/TensorFlowRuntime/tracer.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Tracer tests.
 

--- a/test/TensorFlowRuntime/tracer_tffunc.swift
+++ b/test/TensorFlowRuntime/tracer_tffunc.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 //
 // Tracer tests.
 

--- a/test/TensorFlowRuntime/with_device_1.swift
+++ b/test/TensorFlowRuntime/with_device_1.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-eager-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 
 // Tests on collective ops, as a building block for data/model parallel programs.
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -628,10 +628,6 @@ def use_interpreter_for_simple_runs():
     # SWIFT_ENABLE_TENSORFLOW
     # TODO: remove this flag once we migrate all device placement infra and
     # tests to the new code path (when the flag is true).
-    config.target_run_swift_eager = (
-        "%s %%s " % (target_run_base))
-    config.target_run_swift_gpe = (
-        "%s %%s " % (target_run_base))
     config.target_run_simple_swiftgyb = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1131,18 +1127,6 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     # SWIFT_ENABLE_TENSORFLOW
-    config.target_run_swift_eager = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main %s && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
-    config.target_run_swift_gpe = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -DTF_NODYNAMIC_COMPILATION -O -o %%t/a.out -module-name main %s && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_parse_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -parse-stdlib -o %%t/a.out -module-name main %s && '
@@ -1261,8 +1245,6 @@ config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_si
 config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.target_run_simple_swift_parameterized))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 # SWIFT_ENABLE_TENSORFLOW
-config.substitutions.append(('%target-run-eager-swift', config.target_run_swift_eager))
-config.substitutions.append(('%target-run-gpe-swift', config.target_run_swift_gpe))
 config.substitutions.append(('%target-run-simple-parse-stdlib-swift', config.target_run_simple_parse_stdlib_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))
 config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdlib_swift))


### PR DESCRIPTION
- Remove `%target-run-eager-swift` and `%target-run-gpe-swift`.
- Use `%target-run-simple-swift` in RUN lines.
- Remove `REQUIRES: swift_test_mode_optimize`.