### PR TITLE
Fix TensorFlow module, sans tensorflow/swift-apis.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4646,7 +4646,9 @@ void ProtocolDecl::setRequirementSignature(ArrayRef<Requirement> requirements) {
 void ProtocolDecl::computeKnownProtocolKind() const {
   auto module = getModuleContext();
   if (module != module->getASTContext().getStdlibModule() &&
-      !module->getName().is("Foundation")) {
+      !module->getName().is("Foundation") &&
+      // SWIFT_ENABLE_TENSORFLOW
+      !module->getName().is("TensorFlow")) {
     const_cast<ProtocolDecl *>(this)->Bits.ProtocolDecl.KnownProtocol = 1;
     return;
   }

--- a/lib/Sema/DerivedConformanceTensorArrayProtocol.cpp
+++ b/lib/Sema/DerivedConformanceTensorArrayProtocol.cpp
@@ -39,8 +39,7 @@ bool DerivedConformance::canDeriveTensorArrayProtocol(NominalTypeDecl *nominal,
     return false;
   // All stored properties must conform to `TensorGroup`.
   auto &C = nominal->getASTContext();
-  auto *tensorGroupProto =
-      C.getProtocol(KnownProtocolKind::TensorGroup);
+  auto *tensorGroupProto = C.getProtocol(KnownProtocolKind::TensorGroup);
   return llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
     if (!v->hasInterfaceType())
       C.getLazyResolver()->resolveDeclSignature(v);
@@ -500,7 +499,7 @@ deriveBodyTensorArrayProtocol_init(AbstractFunctionDecl *funcDecl, void *) {
   Type intType = C.getIntDecl()->getDeclaredType();
   TypeExpr *intTE = TypeExpr::createImplicit(intType, C);
 
-  // Iterate over members and call `self.t = T(_owning:)`.
+  // Iterate over members and call `self.member = MemberType(_owning:)`.
   llvm::SmallVector<ASTNode, 2> thenMemberExprs;
   llvm::SmallVector<ASTNode, 2> elseMemberExprs;
   for (auto member : nominal->getStoredProperties()) {

--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND swift_stdlib_compile_flags "-Onone")
 list(APPEND swift_stdlib_compile_flags "-DCOMPILING_TENSORFLOW_MODULE")
 
 set(SOURCES
+  ArrayOps.swift
   CompilerRuntime.swift
   CompositeMath.swift
   Dataset.swift
@@ -38,6 +39,8 @@ set(SOURCES
   Execution.swift
   Gradients.swift
   Ops.swift
+  # NumPy bridging for `ShapedArray` and `Tensor`.
+  PythonConversion.swift
   ShapedArray.swift
   StringOps.swift
   StringTensor.swift
@@ -46,12 +49,11 @@ set(SOURCES
   TensorHandle.swift
   TensorProtocol.swift
   TensorShape.swift
-  Utilities.swift
-  ArrayOps.swift
   Threading.swift
-  ExecuteOp.swift.gyb
-  # NumPy bridging for `ShapedArray` and `Tensor`.
-  PythonConversion.swift)
+  Utilities.swift)
+
+set(GYB_SOURCES
+  ExecuteOp.swift.gyb)
 
 # Copy TensorFlow bindings file, if it exists.
 if (TENSORFLOW_SWIFT_BINDINGS)
@@ -77,6 +79,7 @@ endif()
 
 add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   "${SOURCES}"
+  GYB_SOURCES "${GYB_SOURCES}"
 
   INCORPORATE_OBJECT_LIBRARIES swiftCTensorFlow
   TARGET_SDKS OSX LINUX

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1922,8 +1922,9 @@ public extension Tensor {
 internal extension Tensor.IndexPath {
   @inlinable
   init(_ ranges: [TensorRange]) {
-    precondition(!ranges.isEmpty, "The tensor range collection cannot be empty.")
-    precondition(ranges.count(where: { $0 == TensorRange.ellipsis }) < 2,
+    precondition(!ranges.isEmpty,
+                 "The tensor range collection cannot be empty.")
+    precondition(ranges.lazy.filter { $0 == TensorRange.ellipsis }.count < 2,
                  "Only one ellipsis is allowed per tensor range collection.")
 
     var begin = [Int32](repeating: 0, count: ranges.count)


### PR DESCRIPTION
- Fix `stdlib/public/TensorFlow/CMakeLists.txt`.
  - List `ExecuteOp.swift.gyb` under GYB_SOURCES.
- Replace `count(where:)` with `lazy.filter { ... }.count`.
  - `count(where:)` reverted in https://github.com/apple/swift/pull/22289.
- Fix `ProtocolDecl::computeKnownProtocolKind()`.
- Update `test/TensorFlow/sema_errors.swift`.
  - Unfortunately, diagnostics have regressed.