### PR TITLE
[benchmark] Fix: Set.*.Box use identity everywhere

### DIFF
--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -517,7 +517,7 @@ func run_SetIntersectionBox(
   _ r: Int,
   _ n: Int) {
   for _ in 0 ..< n {
-    let and = a.intersection(b)
+    let and = a.intersection(identity(b))
     CheckResults(and.count == r)
   }
 }
@@ -529,7 +529,7 @@ func run_SetSubtractingBox(
   _ r: Int,
   _ n: Int) {
   for _ in 0 ..< n {
-    let and = a.subtracting(b)
+    let and = a.subtracting(identity(b))
     CheckResults(and.count == r)
   }
 }


### PR DESCRIPTION
Consistently apply the `identity` in `Box` variants of benchmarks for `subtracting` and `intersection` to guard against future sufficiently smart compiler that could hoist the constant expression out of the loop. This pattern is used in all other variants and was explained by @lorentey in https://github.com/apple/swift/pull/18928#discussion_r212722518.

