### PR TITLE
test: remove extraneous macro definitions

### DIFF
--- a/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target arm64-apple-tvos9.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target arm64-apple-tvos9.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-tvos9.0
 
 #if os(iOS)

--- a/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target arm64-apple-ios7.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target arm64-apple-ios7.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)

--- a/test/Parse/ConditionalCompilation/armAndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/armAndroidTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target armv7-none-linux-androideabi -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target armv7-none-linux-androideabi -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target armv7-none-linux-androideabi
 
 #if os(Linux)

--- a/test/Parse/ConditionalCompilation/armIOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armIOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target arm-apple-ios7.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target arm-apple-ios7.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)

--- a/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target arm-apple-watchos2.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target arm-apple-watchos2.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm-apple-watchos2.0
 
 #if os(iOS)

--- a/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target i386-apple-tvos9.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target i386-apple-tvos9.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target i386-apple-tvos9.0
 
 #if os(iOS)

--- a/test/Parse/ConditionalCompilation/i386IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386IOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target i386-apple-ios7.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target i386-apple-ios7.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target i386-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)

--- a/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target i386-apple-watchos2.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target i386-apple-watchos2.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target i386-apple-watchos2.0
 
 #if os(iOS)

--- a/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target powerpc64-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64-unknown-linux-gnu
 
 #if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big)

--- a/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64le-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target powerpc64le-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64le-unknown-linux-gnu
 
 #if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little)

--- a/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target s390x-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target s390x-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target s390x-unknown-linux-gnu
 
 #if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big)

--- a/test/Parse/ConditionalCompilation/trailingClosureOnTargetConfig.swift
+++ b/test/Parse/ConditionalCompilation/trailingClosureOnTargetConfig.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAZ -target x86_64-apple-macosx10.9 -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-apple-macosx10.9 -parse-stdlib
 
 struct Foo {}
 

--- a/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-apple-tvos9.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-apple-tvos9.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-tvos9.0
 
 #if os(iOS)

--- a/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-windows-cygnus -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-unknown-windows-cygnus -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-cygnus
 
 #if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _endian(little)

--- a/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-freebsd10 -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-unknown-freebsd10 -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-freebsd10
 
 #if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little)

--- a/test/Parse/ConditionalCompilation/x64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64IOSTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-apple-ios7.0 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-apple-ios7.0 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)

--- a/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-linux-gnu
 
 #if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little)

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-apple-macosx10.9 -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-apple-macosx10.9 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-macosx10.9
 
 #if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little)

--- a/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-windows-msvc -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-unknown-windows-msvc -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-msvc
 
 #if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little)


### PR DESCRIPTION
These tests were defining an unused macro for no clear reason.  Remove
them to simplify the tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
