### PR TITLE
[stdlib] Fix and Improve Unit Tests for Set

### DIFF
--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2861,7 +2861,9 @@ SetTestSuite.test("isSubsetOf.Set.Set") {
   let s2 = Set([1010, 2020, 3030])
   expectTrue(Set<Int>().isSubset(of: s1))
   expectFalse(s1.isSubset(of: Set<Int>()))
+  expectTrue(Set<Int>().isSubset(of: Set<Int>()))
   expectTrue(s1.isSubset(of: s1))
+  expectFalse(s1.isSubset(of: s2))
   expectTrue(s2.isSubset(of: s1))
 }
 
@@ -2874,9 +2876,13 @@ SetTestSuite.test("isSubsetOf.Set.Sequence") {
 
 SetTestSuite.test("isStrictSubsetOf.Set.Set") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
+  let s2 = Set([1010, 2020, 3030])
   expectTrue(Set<Int>().isStrictSubset(of: s1))
   expectFalse(s1.isStrictSubset(of: Set<Int>()))
+  expectFalse(Set<Int>().isStrictSubset(of: Set<Int>()))
   expectFalse(s1.isStrictSubset(of: s1))
+  expectFalse(s1.isStrictSubset(of: s2))
+  expectTrue(s2.isStrictSubset(of: s1))
 }
 
 SetTestSuite.test("isStrictSubsetOf.Set.Sequence") {
@@ -2891,9 +2897,10 @@ SetTestSuite.test("isSupersetOf.Set.Set") {
   let s2 = Set([1010, 2020, 3030])
   expectTrue(s1.isSuperset(of: Set<Int>()))
   expectFalse(Set<Int>().isSuperset(of: s1))
+  expectTrue(Set<Int>().isSuperset(of: Set<Int>()))
   expectTrue(s1.isSuperset(of: s1))
   expectTrue(s1.isSuperset(of: s2))
-  expectFalse(Set<Int>().isSuperset(of: s1))
+  expectFalse(s2.isSuperset(of: s1))
 }
 
 SetTestSuite.test("isSupersetOf.Set.Sequence") {
@@ -2906,13 +2913,15 @@ SetTestSuite.test("isSupersetOf.Set.Sequence") {
   expectFalse(Set<Int>().isSuperset(of: s1))
 }
 
-SetTestSuite.test("strictSuperset.Set.Set") {
+SetTestSuite.test("isStrictSuperset.Set.Set") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
   let s2 = Set([1010, 2020, 3030])
   expectTrue(s1.isStrictSuperset(of: Set<Int>()))
   expectFalse(Set<Int>().isStrictSuperset(of: s1))
+  expectFalse(Set<Int>().isStrictSuperset(of: Set<Int>()))
   expectFalse(s1.isStrictSuperset(of: s1))
   expectTrue(s1.isStrictSuperset(of: s2))
+  expectFalse(s2.isStrictSuperset(of: s1))
 }
 
 SetTestSuite.test("strictSuperset.Set.Sequence") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2868,10 +2868,13 @@ SetTestSuite.test("isSubsetOf.Set.Set") {
 }
 
 SetTestSuite.test("isSubsetOf.Set.Sequence") {
-  let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  expectTrue(Set<Int>().isSubset(of: s1))
-  expectFalse(s1.isSubset(of: Set<Int>()))
-  expectTrue(s1.isSubset(of: s1))
+  let s1 = Set([1010, 2020, 3030])
+  expectTrue(Set<Int>().isSubset(of: [1010]))
+  expectFalse(s1.isSubset(of: []))
+  expectTrue(Set<Int>().isSubset(of: []))
+  expectTrue(s1.isSubset(of: [1010, 2020, 3030]))
+  expectFalse(s1.isSubset(of: [1010, 2020]))
+  expectTrue(s1.isSubset(of: [1010, 2020, 3030, 4040]))
 }
 
 SetTestSuite.test("isStrictSubsetOf.Set.Set") {
@@ -2886,10 +2889,13 @@ SetTestSuite.test("isStrictSubsetOf.Set.Set") {
 }
 
 SetTestSuite.test("isStrictSubsetOf.Set.Sequence") {
-  let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  expectTrue(Set<Int>().isStrictSubset(of: s1))
-  expectFalse(s1.isStrictSubset(of: Set<Int>()))
-  expectFalse(s1.isStrictSubset(of: s1))
+  let s1 = Set([1010, 2020, 3030])
+  expectTrue(Set<Int>().isStrictSubset(of: [1010]))
+  expectFalse(s1.isStrictSubset(of: []))
+  expectFalse(Set<Int>().isStrictSubset(of: []))
+  expectFalse(s1.isStrictSubset(of: [1010, 2020, 3030]))
+  expectFalse(s1.isStrictSubset(of: [1010, 2020]))
+  expectTrue(s1.isStrictSubset(of: [1010, 2020, 3030, 4040]))
 }
 
 SetTestSuite.test("isSupersetOf.Set.Set") {
@@ -2904,13 +2910,13 @@ SetTestSuite.test("isSupersetOf.Set.Set") {
 }
 
 SetTestSuite.test("isSupersetOf.Set.Sequence") {
-  let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let s2 = AnySequence([1010, 2020, 3030])
+  let s1 = Set([1010, 2020, 3030])
   expectTrue(s1.isSuperset(of: Set<Int>()))
-  expectFalse(Set<Int>().isSuperset(of: s1))
-  expectTrue(s1.isSuperset(of: s1))
-  expectTrue(s1.isSuperset(of: s2))
-  expectFalse(Set<Int>().isSuperset(of: s1))
+  expectFalse(Set<Int>().isSuperset(of: [1010]))
+  expectTrue(Set<Int>().isSuperset(of: []))
+  expectTrue(s1.isSuperset(of: [1010, 2020, 3030]))
+  expectTrue(s1.isSuperset(of: [1010, 2020]))
+  expectFalse(s1.isSuperset(of: [1010, 2020, 3030, 4040]))
 }
 
 SetTestSuite.test("isStrictSuperset.Set.Set") {
@@ -2924,13 +2930,14 @@ SetTestSuite.test("isStrictSuperset.Set.Set") {
   expectFalse(s2.isStrictSuperset(of: s1))
 }
 
-SetTestSuite.test("strictSuperset.Set.Sequence") {
-  let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let s2 = AnySequence([1010, 2020, 3030])
-  expectTrue(s1.isStrictSuperset(of: Set<Int>()))
-  expectFalse(Set<Int>().isStrictSuperset(of: s1))
-  expectFalse(s1.isStrictSuperset(of: s1))
-  expectTrue(s1.isStrictSuperset(of: s2))
+SetTestSuite.test("isStrictSuperset.Set.Sequence") {
+  let s1 = Set([1010, 2020, 3030])
+  expectTrue(s1.isStrictSuperset(of: []))
+  expectFalse(Set<Int>().isStrictSuperset(of: [1010]))
+  expectFalse(Set<Int>().isStrictSuperset(of: []))
+  expectFalse(s1.isStrictSuperset(of: [1010, 2020, 3030]))
+  expectTrue(s1.isStrictSuperset(of: [1010, 2020]))
+  expectFalse(s1.isStrictSuperset(of: [1010, 2020, 3030, 4040]))
 }
 
 SetTestSuite.test("Equatable.Native.Native") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2868,13 +2868,14 @@ SetTestSuite.test("isSubsetOf.Set.Set") {
 }
 
 SetTestSuite.test("isSubsetOf.Set.Sequence") {
+  typealias Seq = Array<Int>
   let s1 = Set([1010, 2020, 3030])
-  expectTrue(Set<Int>().isSubset(of: [1010]))
-  expectFalse(s1.isSubset(of: []))
-  expectTrue(Set<Int>().isSubset(of: []))
-  expectTrue(s1.isSubset(of: [1010, 2020, 3030]))
-  expectFalse(s1.isSubset(of: [1010, 2020]))
-  expectTrue(s1.isSubset(of: [1010, 2020, 3030, 4040]))
+  expectTrue(Set<Int>().isSubset(of: [1010] as Seq))
+  expectFalse(s1.isSubset(of: [] as Seq))
+  expectTrue(Set<Int>().isSubset(of: [] as Seq))
+  expectTrue(s1.isSubset(of: [1010, 2020, 3030] as Seq))
+  expectFalse(s1.isSubset(of: [1010, 2020] as Seq))
+  expectTrue(s1.isSubset(of: [1010, 2020, 3030, 4040] as Seq))
 }
 
 SetTestSuite.test("isStrictSubsetOf.Set.Set") {
@@ -2889,13 +2890,14 @@ SetTestSuite.test("isStrictSubsetOf.Set.Set") {
 }
 
 SetTestSuite.test("isStrictSubsetOf.Set.Sequence") {
+  typealias Seq = Array<Int>
   let s1 = Set([1010, 2020, 3030])
-  expectTrue(Set<Int>().isStrictSubset(of: [1010]))
-  expectFalse(s1.isStrictSubset(of: []))
-  expectFalse(Set<Int>().isStrictSubset(of: []))
-  expectFalse(s1.isStrictSubset(of: [1010, 2020, 3030]))
-  expectFalse(s1.isStrictSubset(of: [1010, 2020]))
-  expectTrue(s1.isStrictSubset(of: [1010, 2020, 3030, 4040]))
+  expectTrue(Set<Int>().isStrictSubset(of: [1010] as Seq))
+  expectFalse(s1.isStrictSubset(of: [] as Seq))
+  expectFalse(Set<Int>().isStrictSubset(of: [] as Seq))
+  expectFalse(s1.isStrictSubset(of: [1010, 2020, 3030] as Seq))
+  expectFalse(s1.isStrictSubset(of: [1010, 2020] as Seq))
+  expectTrue(s1.isStrictSubset(of: [1010, 2020, 3030, 4040] as Seq))
 }
 
 SetTestSuite.test("isSupersetOf.Set.Set") {
@@ -2910,13 +2912,14 @@ SetTestSuite.test("isSupersetOf.Set.Set") {
 }
 
 SetTestSuite.test("isSupersetOf.Set.Sequence") {
+  typealias Seq = Array<Int>
   let s1 = Set([1010, 2020, 3030])
-  expectTrue(s1.isSuperset(of: Set<Int>()))
-  expectFalse(Set<Int>().isSuperset(of: [1010]))
-  expectTrue(Set<Int>().isSuperset(of: []))
-  expectTrue(s1.isSuperset(of: [1010, 2020, 3030]))
-  expectTrue(s1.isSuperset(of: [1010, 2020]))
-  expectFalse(s1.isSuperset(of: [1010, 2020, 3030, 4040]))
+  expectTrue(s1.isSuperset(of: [] as Seq))
+  expectFalse(Set<Int>().isSuperset(of: [1010] as Seq))
+  expectTrue(Set<Int>().isSuperset(of: [] as Seq))
+  expectTrue(s1.isSuperset(of: [1010, 2020, 3030] as Seq))
+  expectTrue(s1.isSuperset(of: [1010, 2020] as Seq))
+  expectFalse(s1.isSuperset(of: [1010, 2020, 3030, 4040] as Seq))
 }
 
 SetTestSuite.test("isStrictSuperset.Set.Set") {
@@ -2931,13 +2934,14 @@ SetTestSuite.test("isStrictSuperset.Set.Set") {
 }
 
 SetTestSuite.test("isStrictSuperset.Set.Sequence") {
+  typealias Seq = Array<Int>
   let s1 = Set([1010, 2020, 3030])
-  expectTrue(s1.isStrictSuperset(of: []))
-  expectFalse(Set<Int>().isStrictSuperset(of: [1010]))
-  expectFalse(Set<Int>().isStrictSuperset(of: []))
-  expectFalse(s1.isStrictSuperset(of: [1010, 2020, 3030]))
-  expectTrue(s1.isStrictSuperset(of: [1010, 2020]))
-  expectFalse(s1.isStrictSuperset(of: [1010, 2020, 3030, 4040]))
+  expectTrue(s1.isStrictSuperset(of: [] as Seq))
+  expectFalse(Set<Int>().isStrictSuperset(of: [1010] as Seq))
+  expectFalse(Set<Int>().isStrictSuperset(of: [] as Seq))
+  expectFalse(s1.isStrictSuperset(of: [1010, 2020, 3030] as Seq))
+  expectTrue(s1.isStrictSuperset(of: [1010, 2020] as Seq))
+  expectFalse(s1.isStrictSuperset(of: [1010, 2020, 3030, 4040] as Seq))
 }
 
 SetTestSuite.test("Equatable.Native.Native") {


### PR DESCRIPTION
Analyzing how well the #21300 handles `isEmpty` cases, I've noticed that the unit test that should be testing `Set.Sequence` variants of methods:
* `isSubset`
* `isSuperSet`
* `isStrictSubset`
* `isStrictSuperSet`

contained errors (sometimes testing `Set.Set` variants) and the tests did not fully cover the potential edge cases which might arise when implementing performance optimizations for the empty cases.

This PR fixes these errors and adds equivalent coverage for both `Set.Set` and `Set.Sequence` variants.