### PR TITLE
[5.1] CastOptimizer: Fix for opaque archetypes

### DIFF
--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -307,6 +307,10 @@ swift::classifyDynamicCast(ModuleDecl *M,
                            bool isWholeModuleOpts) {
   if (source == target) return DynamicCastFeasibility::WillSucceed;
 
+  // Return a conservative answer for opaque archetypes for now.
+  if (source->hasOpaqueArchetype() || target->hasOpaqueArchetype())
+    return DynamicCastFeasibility::MaySucceed;
+
   auto sourceObject = source.getOptionalObjectType();
   auto targetObject = target.getOptionalObjectType();
 

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
 // We want to check two things here:
 // - Correctness
 // - That certain "is" checks are eliminated based on static analysis at compile-time
@@ -1063,6 +1064,24 @@ public func testCastToPForOptionalSuccess() -> Bool {
 public func testCastToPForOptionalFailure() -> Bool {
   let t: Int = 42
   return testCastToPForOptional(t)
+}
+
+struct Underlying : P {
+}
+
+func returnOpaque() -> some P {
+  return Underlying()
+}
+
+// MANDATORY-LABEL: sil{{.*}} @$s12cast_folding23testCastOpaqueArchetypeyyF
+// MANDATORY:   [[O:%.*]] = alloc_stack $@_opaqueReturnTypeOf("$s12cast_folding12returnOpaqueQryF", 0)
+// MANDATORY:   [[F:%.*]] = function_ref @$s12cast_folding12returnOpaqueQryF
+// MANDATORY:   apply [[F]]([[O]])
+// MANDATORY:   [[U:%.*]] = alloc_stack $Underlying
+// MANDATORY:   unconditional_checked_cast_addr @_opaqueReturnTypeOf{{.*}}in [[O]] : $*@_opaqueReturnTypeOf{{.*}}to Underlying in [[U]] : $*Underlying
+// MANDATORY:   load [[U]] : $*Underlying
+public func testCastOpaqueArchetype() {
+  let o = returnOpaque() as! Underlying
 }
 
 print("test0=\(test0())")


### PR DESCRIPTION
The fallthrough path of this function assumes failure :(.

rdar://50544445