### PR TITLE
[NFC] Add LoadBorrow::getEndBorrows() and minor cleanup.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -126,27 +126,6 @@ private:
   }
 };
 
-struct UseToEndBorrow {
-  Optional<EndBorrowInst *> operator()(Operand *use) const {
-    if (auto *ebi = dyn_cast<EndBorrowInst>(use->getUser())) {
-      return ebi;
-    }
-    return None;
-  }
-};
-
-using EndBorrowRange =
-    OptionalTransformRange<ValueBase::use_range, UseToEndBorrow,
-                           ValueBase::use_iterator>;
-
-/// Given a value \p v that is a "borrow" introducer, return its associated
-/// end_borrow users.
-inline auto makeEndBorrowRange(SILValue v) -> EndBorrowRange {
-  assert((isa<BeginBorrowInst>(v) || isa<LoadBorrowInst>(v)) &&
-         "Unhandled borrow introducer");
-  return EndBorrowRange(v->getUses(), UseToEndBorrow());
-}
-
 /// Returns true if:
 ///
 /// 1. No consuming uses are reachable from any other consuming use, from any

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -331,7 +331,7 @@ bool SILValueOwnershipChecker::gatherUsers(
         for (unsigned i : indices(nonLifetimeEndingUsers)) {
           if (auto *bbi = dyn_cast<BeginBorrowInst>(
                   nonLifetimeEndingUsers[i].getInst())) {
-            copy(makeEndBorrowRange(bbi),
+            copy(bbi->getEndBorrows(),
                  std::back_inserter(implicitRegularUsers));
           }
         }


### PR DESCRIPTION
Instructions that start a scope should have a (discoverable) method
that retrieves the end of scope. This is a basic structural property
of the instruction.

I removed the makeEndBorrowRange helper because it adds overall
complexity and doesn't provide any value. If some code wants to be
generic over BeginBorrow/LoadBorrow, then that code should have it's
own trivial generic helper:

EndBorrowRange getEndBorrows<T>(T *beginBorrow) {
  return beginBorrow->getEndBorrows()
}