### PR TITLE
Add tests for weak-linked class stubs

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -322,6 +322,13 @@ private:
   void visitClassDecl(ClassDecl *CD) {
     printDocumentationComment(CD);
 
+    // This is just for testing, so we check explicitly for the attribute instead
+    // of asking if the class is weak imported. If the class has availablility,
+    // we'll print a SWIFT_AVAIALBLE() which implies __attribute__((weak_imported))
+    // already.
+    if (CD->getAttrs().hasAttribute<WeakLinkedAttr>())
+      os << "SWIFT_WEAK_IMPORT\n";
+
     bool hasResilientAncestry =
       CD->checkAncestry().contains(AncestryFlags::ResilientOther);
     if (hasResilientAncestry) {
@@ -2716,6 +2723,9 @@ public:
            "#endif\n"
            "#if !defined(SWIFT_AVAILABILITY)\n"
            "# define SWIFT_AVAILABILITY(plat, ...) __attribute__((availability(plat, __VA_ARGS__)))\n"
+           "#endif\n"
+           "#if !defined(SWIFT_WEAK_IMPORT)\n"
+           "# define SWIFT_WEAK_IMPORT __attribute__((weak_import))\n"
            "#endif\n"
            "#if !defined(SWIFT_DEPRECATED)\n"
            "# define SWIFT_DEPRECATED __attribute__((deprecated))\n"

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -805,3 +805,9 @@ public class NonObjCClass { }
   @objc func referenceSingleGenericClass(_: SingleImportedObjCGeneric<AnyObject>?) {}
 }
 // CHECK: @end
+
+// CHECK: SWIFT_WEAK_IMPORT
+// CHECK-NEXT: SWIFT_CLASS("_TtC7classes17WeakImportedClass")
+// CHECK-NEXT: @interface WeakImportedClass
+// CHECK-NEXT: @end
+@_weakLinked @objc class WeakImportedClass {}

--- a/validation-test/Runtime/Inputs/class-stubs-weak/first.swift
+++ b/validation-test/Runtime/Inputs/class-stubs-weak/first.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+open class BaseClass : NSObject {
+  @objc dynamic open func instanceMethod() -> Int {
+    return 42
+  }
+
+  @objc dynamic open class func classMethod() -> Int {
+    return 31337
+  }
+}

--- a/validation-test/Runtime/Inputs/class-stubs-weak/module.map
+++ b/validation-test/Runtime/Inputs/class-stubs-weak/module.map
@@ -1,0 +1,3 @@
+module first {
+  header "first.h"
+}

--- a/validation-test/Runtime/Inputs/class-stubs-weak/second.swift
+++ b/validation-test/Runtime/Inputs/class-stubs-weak/second.swift
@@ -1,0 +1,5 @@
+import first
+
+#if BEFORE
+@_weakLinked public class DerivedClass : BaseClass {}
+#endif

--- a/validation-test/Runtime/class_stubs.m
+++ b/validation-test/Runtime/class_stubs.m
@@ -5,14 +5,12 @@
 // RUN: %target-build-swift -emit-library -emit-module -o %t/libfirst.dylib -emit-objc-header-path %t/first.h %S/Inputs/class-stubs-from-objc/first.swift -Xlinker -install_name -Xlinker @executable_path/libfirst.dylib -enable-library-evolution
 // RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -emit-objc-header-path %t/second.h -I %t %S/Inputs/class-stubs-from-objc/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -Xfrontend -enable-resilient-objc-class-stubs
 // RUN: cp %S/Inputs/class-stubs-from-objc/module.map %t/
-// RUN: xcrun %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond
+// RUN: xcrun %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -Wl,-U,_objc_loadClassref
 // RUN: %target-codesign %t/main %t/libfirst.dylib %t/libsecond.dylib
-// RUN: %target-run %t/main %t/libfirst.dylib %t/libsecond.dylib | %FileCheck %s
+// RUN: %target-run %t/main %t/libfirst.dylib %t/libsecond.dylib
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-
-// XFAIL: *
 
 #import <dlfcn.h>
 #import <stdio.h>
@@ -39,9 +37,17 @@ int main(int argc, const char * const argv[]) {
 
   DerivedClass *obj = [[DerivedClass alloc] init];
 
-  // CHECK: Result is 43
-  printf("Result is %ld\n", [obj instanceMethod]); 
+  {
+    long result = [obj instanceMethod];
+    printf("[obj instanceMethod] == %ld\n", result);
+    if (result != 43)
+      exit(EXIT_FAILURE);
+  }
 
-  // CHECK: Result is 31338
-  printf("Result is %ld\n", [DerivedClass classMethod]); 
+  {
+    long result = [DerivedClass classMethod];
+    printf("[obj classMethod] == %ld\n", result);
+    if (result != 31338)
+      exit(EXIT_FAILURE);
+  }
 }

--- a/validation-test/Runtime/class_stubs_weak.m
+++ b/validation-test/Runtime/class_stubs_weak.m
@@ -1,0 +1,50 @@
+// Check that Objective-C is able to use a resilient class stub emitted
+// by the Swift compiler.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -emit-module -o %t/libfirst.dylib -emit-objc-header-path %t/first.h %S/Inputs/class-stubs-weak/first.swift -Xlinker -install_name -Xlinker @executable_path/libfirst.dylib -enable-library-evolution
+// RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -emit-objc-header-path %t/second.h -I %t %S/Inputs/class-stubs-weak/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -Xfrontend -enable-resilient-objc-class-stubs -DBEFORE
+// RUN: cp %S/Inputs/class-stubs-weak/module.map %t/
+// RUN: xcrun %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -Wl,-U,_objc_loadClassref
+
+// Now rebuild the library, omitting the weak-exported class
+// RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -I %t %S/Inputs/class-stubs-weak/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -Xfrontend -enable-resilient-objc-class-stubs
+
+// RUN: %target-codesign %t/main %t/libfirst.dylib %t/libsecond.dylib
+// RUN: %target-run %t/main %t/libfirst.dylib %t/libsecond.dylib
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+#import <dlfcn.h>
+#import <stdio.h>
+#import "second.h"
+
+@implementation DerivedClass (MyCategory)
+
+- (int)instanceMethod {
+  return [super instanceMethod] + 1;
+}
+
++ (int)classMethod {
+  return [super classMethod] + 1;
+}
+
+@end
+
+int main(int argc, const char * const argv[]) {
+  // Only test the new behavior on a new enough libobjc.
+  if (!dlsym(RTLD_NEXT, "_objc_loadClassref")) {
+    fprintf(stderr, "skipping evolution tests; OS too old\n");
+    return EXIT_SUCCESS;
+  }
+
+  Class cls = [DerivedClass class];
+  if (cls) {
+    printf("Class is not null");
+    return EXIT_FAILURE;
+  }
+
+  printf("Class is null");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
We want to make sure libobjc doesn't crash when Clang references a weak-exported class stub from a Swift dylib.