### PR TITLE
[api-digester] Serialize protocol USRs in conformances

### DIFF
--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -64,12 +64,14 @@
         {
           "kind": "Conformance",
           "name": "P2",
-          "printedName": "P2"
+          "printedName": "P2",
+          "usr": "s:4cake2P2P"
         },
         {
           "kind": "Conformance",
           "name": "P1",
-          "printedName": "P1"
+          "printedName": "P1",
+          "usr": "s:4cake2P1P"
         }
       ]
     },
@@ -138,12 +140,14 @@
         {
           "kind": "Conformance",
           "name": "P1",
-          "printedName": "P1"
+          "printedName": "P1",
+          "usr": "s:4cake2P1P"
         },
         {
           "kind": "Conformance",
           "name": "P2",
-          "printedName": "P2"
+          "printedName": "P2",
+          "usr": "s:4cake2P2P"
         }
       ]
     },
@@ -555,12 +559,14 @@
         {
           "kind": "Conformance",
           "name": "Equatable",
-          "printedName": "Equatable"
+          "printedName": "Equatable",
+          "usr": "s:SQ"
         },
         {
           "kind": "Conformance",
           "name": "Hashable",
-          "printedName": "Hashable"
+          "printedName": "Hashable",
+          "usr": "s:SH"
         },
         {
           "kind": "Conformance",
@@ -580,7 +586,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:SY"
         }
       ]
     },
@@ -1081,7 +1088,8 @@
         {
           "kind": "Conformance",
           "name": "PSuper",
-          "printedName": "PSuper"
+          "printedName": "PSuper",
+          "usr": "s:4cake6PSuperP"
         }
       ]
     },
@@ -1231,12 +1239,14 @@
           "kind": "Conformance",
           "name": "P1",
           "printedName": "P1",
+          "usr": "s:4cake2P1P",
           "isABIPlaceholder": true
         },
         {
           "kind": "Conformance",
           "name": "P2",
-          "printedName": "P2"
+          "printedName": "P2",
+          "usr": "s:4cake2P2P"
         }
       ]
     },
@@ -1288,17 +1298,20 @@
         {
           "kind": "Conformance",
           "name": "FixedWidthInteger",
-          "printedName": "FixedWidthInteger"
+          "printedName": "FixedWidthInteger",
+          "usr": "s:s17FixedWidthIntegerP"
         },
         {
           "kind": "Conformance",
           "name": "SignedInteger",
-          "printedName": "SignedInteger"
+          "printedName": "SignedInteger",
+          "usr": "s:SZ"
         },
         {
           "kind": "Conformance",
           "name": "_ExpressibleByBuiltinIntegerLiteral",
-          "printedName": "_ExpressibleByBuiltinIntegerLiteral"
+          "printedName": "_ExpressibleByBuiltinIntegerLiteral",
+          "usr": "s:s35_ExpressibleByBuiltinIntegerLiteralP"
         },
         {
           "kind": "Conformance",
@@ -1318,17 +1331,20 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:Sz"
         },
         {
           "kind": "Conformance",
           "name": "LosslessStringConvertible",
-          "printedName": "LosslessStringConvertible"
+          "printedName": "LosslessStringConvertible",
+          "usr": "s:s25LosslessStringConvertibleP"
         },
         {
           "kind": "Conformance",
           "name": "SignedNumeric",
-          "printedName": "SignedNumeric"
+          "printedName": "SignedNumeric",
+          "usr": "s:s13SignedNumericP"
         },
         {
           "kind": "Conformance",
@@ -1348,12 +1364,14 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:Sj"
         },
         {
           "kind": "Conformance",
           "name": "CustomStringConvertible",
-          "printedName": "CustomStringConvertible"
+          "printedName": "CustomStringConvertible",
+          "usr": "s:s23CustomStringConvertibleP"
         },
         {
           "kind": "Conformance",
@@ -1373,12 +1391,14 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:Sx"
         },
         {
           "kind": "Conformance",
           "name": "AdditiveArithmetic",
-          "printedName": "AdditiveArithmetic"
+          "printedName": "AdditiveArithmetic",
+          "usr": "s:s18AdditiveArithmeticP"
         },
         {
           "kind": "Conformance",
@@ -1398,62 +1418,74 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:s27ExpressibleByIntegerLiteralP"
         },
         {
           "kind": "Conformance",
           "name": "Comparable",
-          "printedName": "Comparable"
+          "printedName": "Comparable",
+          "usr": "s:SL"
         },
         {
           "kind": "Conformance",
           "name": "P1",
-          "printedName": "P1"
+          "printedName": "P1",
+          "usr": "s:4cake2P1P"
         },
         {
           "kind": "Conformance",
           "name": "MirrorPath",
-          "printedName": "MirrorPath"
+          "printedName": "MirrorPath",
+          "usr": "s:s10MirrorPathP"
         },
         {
           "kind": "Conformance",
           "name": "CVarArg",
-          "printedName": "CVarArg"
+          "printedName": "CVarArg",
+          "usr": "s:s7CVarArgP"
         },
         {
           "kind": "Conformance",
           "name": "Encodable",
-          "printedName": "Encodable"
+          "printedName": "Encodable",
+          "usr": "s:SE"
         },
         {
           "kind": "Conformance",
           "name": "Decodable",
-          "printedName": "Decodable"
+          "printedName": "Decodable",
+          "usr": "s:Se"
         },
         {
           "kind": "Conformance",
           "name": "Hashable",
-          "printedName": "Hashable"
+          "printedName": "Hashable",
+          "usr": "s:SH"
         },
         {
           "kind": "Conformance",
           "name": "Equatable",
-          "printedName": "Equatable"
+          "printedName": "Equatable",
+          "usr": "s:SQ"
         },
         {
           "kind": "Conformance",
           "name": "_HasCustomAnyHashableRepresentation",
-          "printedName": "_HasCustomAnyHashableRepresentation"
+          "printedName": "_HasCustomAnyHashableRepresentation",
+          "usr": "s:s35_HasCustomAnyHashableRepresentationP"
         },
         {
           "kind": "Conformance",
           "name": "CustomReflectable",
-          "printedName": "CustomReflectable"
+          "printedName": "CustomReflectable",
+          "usr": "s:s17CustomReflectableP"
         },
         {
           "kind": "Conformance",
           "name": "_CustomPlaygroundQuickLookable",
-          "printedName": "_CustomPlaygroundQuickLookable"
+          "printedName": "_CustomPlaygroundQuickLookable",
+          "usr": "s:s30_CustomPlaygroundQuickLookableP"
         },
         {
           "kind": "Conformance",
@@ -1551,7 +1583,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:s10SIMDScalarP"
         }
       ]
     }

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -64,12 +64,14 @@
         {
           "kind": "Conformance",
           "name": "P2",
-          "printedName": "P2"
+          "printedName": "P2",
+          "usr": "s:4cake2P2P"
         },
         {
           "kind": "Conformance",
           "name": "P1",
-          "printedName": "P1"
+          "printedName": "P1",
+          "usr": "s:4cake2P1P"
         }
       ]
     },
@@ -145,12 +147,14 @@
         {
           "kind": "Conformance",
           "name": "P1",
-          "printedName": "P1"
+          "printedName": "P1",
+          "usr": "s:4cake2P1P"
         },
         {
           "kind": "Conformance",
           "name": "P2",
-          "printedName": "P2"
+          "printedName": "P2",
+          "usr": "s:4cake2P2P"
         }
       ]
     },
@@ -620,12 +624,14 @@
         {
           "kind": "Conformance",
           "name": "Equatable",
-          "printedName": "Equatable"
+          "printedName": "Equatable",
+          "usr": "s:SQ"
         },
         {
           "kind": "Conformance",
           "name": "Hashable",
-          "printedName": "Hashable"
+          "printedName": "Hashable",
+          "usr": "s:SH"
         },
         {
           "kind": "Conformance",
@@ -645,7 +651,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:SY"
         }
       ]
     },
@@ -1028,7 +1035,8 @@
         {
           "kind": "Conformance",
           "name": "PSuper",
-          "printedName": "PSuper"
+          "printedName": "PSuper",
+          "usr": "s:4cake6PSuperP"
         }
       ]
     },
@@ -1120,12 +1128,14 @@
           "kind": "Conformance",
           "name": "P1",
           "printedName": "P1",
+          "usr": "s:4cake2P1P",
           "isABIPlaceholder": true
         },
         {
           "kind": "Conformance",
           "name": "P2",
-          "printedName": "P2"
+          "printedName": "P2",
+          "usr": "s:4cake2P2P"
         }
       ]
     },
@@ -1177,12 +1187,14 @@
         {
           "kind": "Conformance",
           "name": "FixedWidthInteger",
-          "printedName": "FixedWidthInteger"
+          "printedName": "FixedWidthInteger",
+          "usr": "s:s17FixedWidthIntegerP"
         },
         {
           "kind": "Conformance",
           "name": "SignedInteger",
-          "printedName": "SignedInteger"
+          "printedName": "SignedInteger",
+          "usr": "s:SZ"
         },
         {
           "kind": "Conformance",
@@ -1202,17 +1214,20 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:Sz"
         },
         {
           "kind": "Conformance",
           "name": "LosslessStringConvertible",
-          "printedName": "LosslessStringConvertible"
+          "printedName": "LosslessStringConvertible",
+          "usr": "s:s25LosslessStringConvertibleP"
         },
         {
           "kind": "Conformance",
           "name": "SignedNumeric",
-          "printedName": "SignedNumeric"
+          "printedName": "SignedNumeric",
+          "usr": "s:s13SignedNumericP"
         },
         {
           "kind": "Conformance",
@@ -1239,12 +1254,14 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:Sj"
         },
         {
           "kind": "Conformance",
           "name": "CustomStringConvertible",
-          "printedName": "CustomStringConvertible"
+          "printedName": "CustomStringConvertible",
+          "usr": "s:s23CustomStringConvertibleP"
         },
         {
           "kind": "Conformance",
@@ -1264,12 +1281,14 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:Sx"
         },
         {
           "kind": "Conformance",
           "name": "AdditiveArithmetic",
-          "printedName": "AdditiveArithmetic"
+          "printedName": "AdditiveArithmetic",
+          "usr": "s:s18AdditiveArithmeticP"
         },
         {
           "kind": "Conformance",
@@ -1296,52 +1315,62 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:s27ExpressibleByIntegerLiteralP"
         },
         {
           "kind": "Conformance",
           "name": "Comparable",
-          "printedName": "Comparable"
+          "printedName": "Comparable",
+          "usr": "s:SL"
         },
         {
           "kind": "Conformance",
           "name": "P1",
-          "printedName": "P1"
+          "printedName": "P1",
+          "usr": "s:4cake2P1P"
         },
         {
           "kind": "Conformance",
           "name": "MirrorPath",
-          "printedName": "MirrorPath"
+          "printedName": "MirrorPath",
+          "usr": "s:s10MirrorPathP"
         },
         {
           "kind": "Conformance",
           "name": "CVarArg",
-          "printedName": "CVarArg"
+          "printedName": "CVarArg",
+          "usr": "s:s7CVarArgP"
         },
         {
           "kind": "Conformance",
           "name": "Encodable",
-          "printedName": "Encodable"
+          "printedName": "Encodable",
+          "usr": "s:SE"
         },
         {
           "kind": "Conformance",
           "name": "Decodable",
-          "printedName": "Decodable"
+          "printedName": "Decodable",
+          "usr": "s:Se"
         },
         {
           "kind": "Conformance",
           "name": "Hashable",
-          "printedName": "Hashable"
+          "printedName": "Hashable",
+          "usr": "s:SH"
         },
         {
           "kind": "Conformance",
           "name": "Equatable",
-          "printedName": "Equatable"
+          "printedName": "Equatable",
+          "usr": "s:SQ"
         },
         {
           "kind": "Conformance",
           "name": "CustomReflectable",
-          "printedName": "CustomReflectable"
+          "printedName": "CustomReflectable",
+          "usr": "s:s17CustomReflectableP"
         },
         {
           "kind": "Conformance",
@@ -1446,7 +1475,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "usr": "s:s10SIMDScalarP"
         }
       ]
     }

--- a/test/api-digester/Outputs/clang-module-dump.txt
+++ b/test/api-digester/Outputs/clang-module-dump.txt
@@ -115,12 +115,14 @@
         {
           "kind": "Conformance",
           "name": "ObjcProt",
-          "printedName": "ObjcProt"
+          "printedName": "ObjcProt",
+          "usr": "c:objc(pl)ObjcProt"
         },
         {
           "kind": "Conformance",
           "name": "NSObjectProtocol",
-          "printedName": "NSObjectProtocol"
+          "printedName": "NSObjectProtocol",
+          "usr": "c:objc(pl)NSObject"
         }
       ]
     },

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -28,7 +28,8 @@ internal extension S1 {
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "kind": "Conformance",
 // CHECK-NEXT:     "name": "PublicProto",
-// CHECK-NEXT:     "printedName": "PublicProto"
+// CHECK-NEXT:     "printedName": "PublicProto",
+// CHECK-NEXT:     "usr": "s:4main11PublicProtoP"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]
 extension C0: InternalProto {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -112,7 +112,7 @@ SDKNodeDeclType::SDKNodeDeclType(SDKNodeInitInfo Info):
 
 SDKNodeConformance::SDKNodeConformance(SDKNodeInitInfo Info):
   SDKNode(Info, SDKNodeKind::Conformance),
-  IsABIPlaceholder(Info.IsABIPlaceholder) {}
+  Usr(Info.Usr), IsABIPlaceholder(Info.IsABIPlaceholder) {}
 
 SDKNodeTypeWitness::SDKNodeTypeWitness(SDKNodeInitInfo Info):
   SDKNode(Info, SDKNodeKind::TypeWitness) {}
@@ -123,7 +123,7 @@ SDKNodeDeclOperator::SDKNodeDeclOperator(SDKNodeInitInfo Info):
 SDKNodeDeclTypeAlias::SDKNodeDeclTypeAlias(SDKNodeInitInfo Info):
   SDKNodeDecl(Info, SDKNodeKind::DeclTypeAlias) {}
 
-SDKNodeDeclVar::SDKNodeDeclVar(SDKNodeInitInfo Info): 
+SDKNodeDeclVar::SDKNodeDeclVar(SDKNodeInitInfo Info):
   SDKNodeDecl(Info, SDKNodeKind::DeclVar), IsLet(Info.IsLet),
   HasStorage(Info.HasStorage), HasDidSet(Info.HasDidset),
   HasWillSet(Info.HasWillset) {}
@@ -140,7 +140,7 @@ SDKNodeDeclFunction::SDKNodeDeclFunction(SDKNodeInitInfo Info):
 SDKNodeDeclConstructor::SDKNodeDeclConstructor(SDKNodeInitInfo Info):
   SDKNodeDeclAbstractFunc(Info, SDKNodeKind::DeclConstructor) {}
 
-SDKNodeDeclGetter::SDKNodeDeclGetter(SDKNodeInitInfo Info): 
+SDKNodeDeclGetter::SDKNodeDeclGetter(SDKNodeInitInfo Info):
   SDKNodeDeclAbstractFunc(Info, SDKNodeKind::DeclGetter) {}
 
 SDKNodeDeclSetter::SDKNodeDeclSetter(SDKNodeInitInfo Info):
@@ -552,7 +552,7 @@ SDKNode* SDKNode::constructSDKNode(SDKContext &Ctx,
   NodeVector Conformances;
 
   for (auto &Pair : *Node) {
-    auto keyString = GetScalarString(Pair.getKey()); 
+    auto keyString = GetScalarString(Pair.getKey());
     if (auto keyKind = parseKeyKind(keyString)) {
       switch(*keyKind) {
       case KeyKind::KK_kind:
@@ -1708,6 +1708,7 @@ void SDKNode::jsonize(json::Output &out) {
 
 void SDKNodeConformance::jsonize(json::Output &out) {
   SDKNode::jsonize(out);
+  output(out, KeyKind::KK_usr, Usr);
   output(out, KeyKind::KK_isABIPlaceholder, IsABIPlaceholder);
 }
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -123,7 +123,7 @@ SDKNodeDeclOperator::SDKNodeDeclOperator(SDKNodeInitInfo Info):
 SDKNodeDeclTypeAlias::SDKNodeDeclTypeAlias(SDKNodeInitInfo Info):
   SDKNodeDecl(Info, SDKNodeKind::DeclTypeAlias) {}
 
-SDKNodeDeclVar::SDKNodeDeclVar(SDKNodeInitInfo Info):
+SDKNodeDeclVar::SDKNodeDeclVar(SDKNodeInitInfo Info): 
   SDKNodeDecl(Info, SDKNodeKind::DeclVar), IsLet(Info.IsLet),
   HasStorage(Info.HasStorage), HasDidSet(Info.HasDidset),
   HasWillSet(Info.HasWillset) {}
@@ -140,7 +140,7 @@ SDKNodeDeclFunction::SDKNodeDeclFunction(SDKNodeInitInfo Info):
 SDKNodeDeclConstructor::SDKNodeDeclConstructor(SDKNodeInitInfo Info):
   SDKNodeDeclAbstractFunc(Info, SDKNodeKind::DeclConstructor) {}
 
-SDKNodeDeclGetter::SDKNodeDeclGetter(SDKNodeInitInfo Info):
+SDKNodeDeclGetter::SDKNodeDeclGetter(SDKNodeInitInfo Info): 
   SDKNodeDeclAbstractFunc(Info, SDKNodeKind::DeclGetter) {}
 
 SDKNodeDeclSetter::SDKNodeDeclSetter(SDKNodeInitInfo Info):
@@ -552,7 +552,7 @@ SDKNode* SDKNode::constructSDKNode(SDKContext &Ctx,
   NodeVector Conformances;
 
   for (auto &Pair : *Node) {
-    auto keyString = GetScalarString(Pair.getKey());
+    auto keyString = GetScalarString(Pair.getKey()); 
     if (auto keyKind = parseKeyKind(keyString)) {
       switch(*keyKind) {
       case KeyKind::KK_kind:

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -499,11 +499,13 @@ public:
 /// The SDKNode part of the conformance node is constructed using the protocol
 /// in the conformance, thus getName() will give us the name of the protocol.
 class SDKNodeConformance: public SDKNode {
+  StringRef Usr;
   SDKNodeDeclType *TypeDecl;
   friend class SDKNodeDeclType;
   bool IsABIPlaceholder;
 public:
   SDKNodeConformance(SDKNodeInitInfo Info);
+  StringRef getUsr() const { return Usr; }
   ArrayRef<SDKNode*> getTypeWitnesses() const { return Children; }
   SDKNodeDeclType *getNominalTypeDecl() const { return TypeDecl; }
   bool isABIPlaceholder() const { return IsABIPlaceholder; }


### PR DESCRIPTION
Currently SDK conformance nodes include protocol `name` and `printedName` keys, where both are equal, demangled names. Seems like this is sufficient for changes analysis, but its not possible to uniquely identify the protocols.
For my use case including USR would be very useful, as then protocols can be identified across module boundaries. Currently I can't be certain about this even with some intermediate analysis, as there could be a collision in protocol names between modules.

The information is already there, it only has to be serialised.

Tests for stdlib are passing on my local machine without any changes. 
I tried to update them as well, but there were other changes as well, so I guess the file stdlib inputs are not totally up to date?

@nkcsgexi do you think this is relevant for upstreaming?