### PR TITLE
[ConstraintSystem] Extend use of missing explicit call fix

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1745,6 +1745,33 @@ bool MissingCallFailure::diagnoseAsError() {
   if (isa<KeyPathExpr>(baseExpr))
     return false;
 
+  auto path = getLocator()->getPath();
+  if (!path.empty()) {
+    const auto &last = path.back();
+
+    switch (last.getKind()) {
+    case ConstraintLocator::ContextualType:
+    case ConstraintLocator::ApplyArgToParam: {
+      auto fnType = getType(baseExpr)->castTo<FunctionType>();
+      assert(fnType->getNumParams() == 0);
+      emitDiagnostic(baseExpr->getLoc(), diag::missing_nullary_call,
+                     fnType->getResult())
+          .fixItInsertAfter(baseExpr->getEndLoc(), "()");
+      return true;
+    }
+
+    case ConstraintLocator::AutoclosureResult: {
+      auto &cs = getConstraintSystem();
+      auto loc = cs.getConstraintLocator(getRawAnchor(), path.drop_back(),
+                                         /*summaryFlags=*/0);
+      AutoClosureForwardingFailure failure(cs, loc);
+      return failure.diagnoseAsError();
+    }
+    default:
+      break;
+    }
+  }
+
   if (auto *DRE = dyn_cast<DeclRefExpr>(baseExpr)) {
     emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function,
                    DRE->getDecl()->getBaseName().getIdentifier())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2020,6 +2020,51 @@ bool ConstraintSystem::repairFailures(
   SmallVector<LocatorPathElt, 4> path;
   auto *anchor = locator.getLocatorParts(path);
 
+  // If there is a missing explicit call it could be:
+  //
+  // a). Contextual e.g. `let _: R = foo`
+  // b). Argument is a function value passed to parameter
+  //     which expects its result type e.g. `foo(bar)`
+  // c). Assigment destination type matches return type of
+  //     of the function value e.g. `foo = bar` or `foo = .bar`
+  auto repairByInsertingExplicitCall = [&](Type srcType, Type dstType) -> bool {
+    auto fnType = srcType->getAs<FunctionType>();
+    if (!fnType || fnType->getNumParams() > 0)
+      return false;
+
+    auto resultType = fnType->getResult();
+    // If this is situation like `x = { ... }` where closure results in
+    // `Void`, let's not suggest to call the closure, because it's most
+    // likely not intended.
+    if (anchor && isa<AssignExpr>(anchor)) {
+      auto *assignment = cast<AssignExpr>(anchor);
+      if (isa<ClosureExpr>(assignment->getSrc()) && resultType->isVoid())
+        return false;
+    }
+
+    // If left-hand side is a function type but right-hand
+    // side isn't, let's check it would be possible to fix
+    // this by forming an explicit call.
+    auto convertTo = dstType->lookThroughAllOptionalTypes();
+    // Right-hand side can't be - a function, a type variable or dependent
+    // member, or `Any` (if function conversion to `Any` didn't succeed there
+    // is something else going on e.g. problem with escapiness).
+    if (convertTo->is<FunctionType>() || convertTo->isTypeVariableOrMember() ||
+        convertTo->isAny())
+      return false;
+
+    auto result = matchTypes(resultType, dstType, ConstraintKind::Conversion,
+                             TypeMatchFlags::TMF_ApplyingFix, locator);
+
+    if (result.isSuccess()) {
+      conversionsOrFixes.push_back(
+          InsertExplicitCall::create(*this, getConstraintLocator(locator)));
+      return true;
+    }
+
+    return false;
+  };
+
   if (path.empty()) {
     if (!anchor)
       return false;
@@ -2036,21 +2081,8 @@ bool ConstraintSystem::repairFailures(
     }
 
     if (auto *AE = dyn_cast<AssignExpr>(anchor)) {
-      if (auto *fnType = lhs->getAs<FunctionType>()) {
-        // If left-hand side is a function type but right-hand
-        // side isn't, let's check it would be possible to fix
-        // this by forming an explicit call.
-        auto convertTo = rhs->lookThroughAllOptionalTypes();
-        if (!convertTo->is<FunctionType>() && !convertTo->isVoid() &&
-            fnType->getNumParams() == 0 &&
-            matchTypes(fnType->getResult(), rhs, ConstraintKind::Conversion,
-                       TypeMatchFlags::TMF_ApplyingFix, locator)
-                .isSuccess()) {
-          conversionsOrFixes.push_back(
-              InsertExplicitCall::create(*this, getConstraintLocator(locator)));
-          return true;
-        }
-      }
+      if (repairByInsertingExplicitCall(lhs, rhs))
+        return true;
 
       if (isa<InOutExpr>(AE->getSrc())) {
         conversionsOrFixes.push_back(
@@ -2066,6 +2098,9 @@ bool ConstraintSystem::repairFailures(
   switch (elt.getKind()) {
   case ConstraintLocator::LValueConversion:
   case ConstraintLocator::ApplyArgToParam: {
+    if (repairByInsertingExplicitCall(lhs, rhs))
+      return true;
+
     if (lhs->getOptionalObjectType() && !rhs->getOptionalObjectType()) {
       conversionsOrFixes.push_back(
           ForceOptional::create(*this, lhs, lhs->getOptionalObjectType(),
@@ -2137,6 +2172,9 @@ bool ConstraintSystem::repairFailures(
       return true;
     }
 
+    if (repairByInsertingExplicitCall(lhs, rhs))
+      return true;
+
     // If both types are key path, the only differences
     // between them are mutability and/or root, value type mismatch.
     if (isKnownKeyPathType(lhs) && isKnownKeyPathType(rhs)) {
@@ -2151,6 +2189,12 @@ bool ConstraintSystem::repairFailures(
                                              getConstraintLocator(locator));
       conversionsOrFixes.push_back(fix);
     }
+    break;
+  }
+
+  case ConstraintLocator::AutoclosureResult: {
+    if (repairByInsertingExplicitCall(lhs, rhs))
+      return true;
     break;
   }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -55,7 +55,7 @@ func inoutToSharedConversions() {
 // Autoclosure
 func f1(f: @autoclosure () -> Int) { }
 func f2() -> Int { }
-f1(f: f2) // expected-error{{function produces expected type 'Int'; did you mean to call it with '()'?}}{{9-9=()}}
+f1(f: f2) // expected-error{{add () to forward @autoclosure parameter}}{{9-9=()}}
 f1(f: 5)
 
 // Ternary in closure
@@ -268,7 +268,7 @@ func someFunc(_ foo: ((String) -> String)?,
 
 func verify_NotAC_to_AC_failure(_ arg: () -> ()) {
   func takesAC(_ arg: @autoclosure () -> ()) {}
-  takesAC(arg) // expected-error {{function produces expected type '()'; did you mean to call it with '()'?}}
+  takesAC(arg) // expected-error {{add () to forward @autoclosure parameter}} {{14-14=()}}
 }
 
 // SR-1069 - Error diagnostic refers to wrong argument

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -39,6 +39,9 @@ func forgotCall() {
   // With overloading: only one succeeds.
   a = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
 
+  let _: A = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}} {{21-21=()}}
+  let _: B = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}} {{21-21=()}}
+
   // With overloading, pick the fewest number of fixes.
   var b = f7(f4, f1) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
   b.iAmAB()

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -317,7 +317,7 @@ func testClosures() {
 
 func acceptAutoclosure(f: @autoclosure () -> Int) { }
 func produceInt() -> Int { }
-acceptAutoclosure(f: produceInt) // expected-error{{function produces expected type 'Int'; did you mean to call it with '()'?}} {{32-32=()}}
+acceptAutoclosure(f: produceInt) // expected-error{{add () to forward @autoclosure parameter}} {{32-32=()}}
 
 // -------------------------------------------
 // Trailing closures


### PR DESCRIPTION
Now covers following new areas (alongside simple assignments):

- Contextual type coercions:
  - In assignment e.g. `let _: X = foo`
  - In return type positions e.g. `func foo() -> A { return bar }`

- Argument-to-parameter applications (including @autoclosure)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
