### PR TITLE
[Windows] Fix resolvePathSymlinks

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -861,17 +861,17 @@ std::string SwiftLangSupport::resolvePathSymlinks(StringRef FilePath) {
   if (fileHandle == INVALID_HANDLE_VALUE)
     return InputPath;
 
-  bool success = GetFinalPathNameByHandleW(fileHandle, full_path, MAX_PATH,
+  DWORD numChars = GetFinalPathNameByHandleW(fileHandle, full_path, MAX_PATH,
                                             FILE_NAME_NORMALIZED);
   CloseHandle(fileHandle);
   std::string utf8Path;
-  if (success) {
+  if (numChars > 0 && numChars <= MAX_PATH) {
     llvm::ArrayRef<char> pathRef((const char *)full_path,
-                                 (const char *)(full_path + MAX_PATH));
-    success &= llvm::convertUTF16ToUTF8String(pathRef, utf8Path);
+                                 (const char *)(full_path + numChars));
+    return llvm::convertUTF16ToUTF8String(pathRef, utf8Path) ? utf8Path
+                                                             : InputPath;
   }
-
-  return (success ? utf8Path : InputPath);
+  return InputPath;
 #endif
 }
 


### PR DESCRIPTION
The llvm::ArrayRef constructor should be passed the actual length of the
resulting string, not MAX_PATH, else the StringRef that results has an
incorrect length of MAX_PATH.