### PR TITLE
Properly Iterate Through RequestedCachedResults

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5568,8 +5568,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
         TheModule->forAllVisibleModules(AccessPath, handleImport);
       }
     }
-    Lookup.RequestedCachedResults.clear();
   }
+  Lookup.RequestedCachedResults.clear();
 
   CompletionContext.typeContextKind = Lookup.typeContextKind();
 


### PR DESCRIPTION
Clearing the cache and the end of the for loop invalidates the interator
and prevents iterating through the rest of the vector. This should be
cleared after we're done iterating.

I've moved the clear outside of the loop which I think was the original intent.