### PR TITLE
AD bug fixes for builtins and vectorspace lookup.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4436,7 +4436,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
 
   // Unwrap curry levels.
   SmallVector<AnyFunctionType *, 2> curryLevels;
-  auto *currentLevel = this;
+  auto *currentLevel = this->eraseDynamicSelfType()->castTo<AnyFunctionType>();
   while (currentLevel != nullptr) {
     curryLevels.push_back(currentLevel);
     currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2023,6 +2023,7 @@ darwin-toolchain-application-cert=lldb_codesign
 # Instead, options are copied here individually.
 [preset: tensorflow_osx_base]
 mixin-preset=mixin_lightweight_assertions
+legacy-impl
 
 ### From: mixin_osx_package_base
 lldb
@@ -2118,6 +2119,7 @@ darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 
 [preset: tensorflow_linux]
 mixin-preset=buildbot_linux
+legacy-impl
 enable-tensorflow
 install-tensorflow
 
@@ -2172,6 +2174,7 @@ mixin-preset=mixin_lightweight_assertions
 enable-tensorflow
 release
 test
+legacy-impl
 test-optimized
 validation-test
 


### PR DESCRIPTION
- lib/AST/Type.cpp -> Brittle Vector type lookup leads to Self type not
getting erased.
- lib/SILGen/SILGenBuiltin.cpp -> builtin apply macro switched from Expr to
[ManagedValue]. Need to remove all custom freeing logic.
- utils/build-presets.ini -> importing tensorflow means we cannot use
the new build-script impl.
