### PR TITLE
[IRGen] Remove unused static applyFixedSpareBitsMask function

### DIFF
--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -213,19 +213,10 @@ public:
   ///   SpareBitVector spareBits;
   ///   for (EnumElementDecl *elt : u->getAllElements())
   ///     getFragileTypeInfo(elt->getArgumentType())
-  ///       .applyFixedSpareBitsMask(spareBits, 0);
+  ///       .applyFixedSpareBitsMask(spareBits);
   ///
   /// and end up with a spare bits mask for the entire enum.
   void applyFixedSpareBitsMask(SpareBitVector &mask) const;
-  
-  /// Applies a fixed spare bits mask to the given BitVector,
-  /// clearing any bits used by valid representations of the type.
-  ///
-  /// If the bitvector is empty or smaller than this type, it is grown and
-  /// filled with bits direct from the spare bits mask. If the bitvector is
-  /// larger than this type, the trailing bits are untouched.
-  static void applyFixedSpareBitsMask(SpareBitVector &mask,
-                                      const SpareBitVector &spareBits);
 
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -254,26 +254,21 @@ unsigned FixedTypeInfo::getSpareBitExtraInhabitantCount() const {
                   unsigned(ValueWitnessFlags::MaxNumExtraInhabitants));
 }
 
-void FixedTypeInfo::applyFixedSpareBitsMask(SpareBitVector &mask,
-                                            const SpareBitVector &spareBits) {
+void FixedTypeInfo::applyFixedSpareBitsMask(SpareBitVector &mask) const {
   // If the mask is no longer than the stored spare bits, we can just
   // apply the stored spare bits.
-  if (mask.size() <= spareBits.size()) {
+  if (mask.size() <= SpareBits.size()) {
     // Grow the mask out if necessary; the tail padding is all spare bits.
-    mask.extendWithSetBits(spareBits.size());
-    mask &= spareBits;
+    mask.extendWithSetBits(SpareBits.size());
+    mask &= SpareBits;
+    return;
+  }
 
   // Otherwise, we have to grow out the stored spare bits before we
   // can intersect.
-  } else {
-    auto paddedSpareBits = spareBits;
-    paddedSpareBits.extendWithSetBits(mask.size());
-    mask &= paddedSpareBits;
-  }
-}
-
-void FixedTypeInfo::applyFixedSpareBitsMask(SpareBitVector &mask) const {
-  return applyFixedSpareBitsMask(mask, SpareBits);
+  auto paddedSpareBits = SpareBits;
+  paddedSpareBits.extendWithSetBits(mask.size());
+  mask &= paddedSpareBits;
 }
 
 APInt


### PR DESCRIPTION
The function was only used in the non-static function of the same name. Inline it into that function and remove it.