### PR TITLE
[5.1] Opaque types require the next Swift runtime

### DIFF
--- a/validation-test/Evolution/Inputs/opaque_archetypes_change_underlying_type.swift
+++ b/validation-test/Evolution/Inputs/opaque_archetypes_change_underlying_type.swift
@@ -19,6 +19,7 @@ public struct Pair : P {
 }
 #endif
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 public func resilientFunction() -> some P {
 #if BEFORE
   return Int(5)
@@ -27,10 +28,12 @@ public func resilientFunction() -> some P {
 #endif
 }
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 public func expectedResult() -> Int {
   return resilientFunction().getValue()
 }
 
+@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 public func expectedSize() -> Int {
   return MemoryLayout.size(ofValue: resilientFunction())
 }
@@ -39,6 +42,7 @@ public func expectedSize() -> Int {
 public struct Container {
   public init() {}
 
+  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
   public var property : some P {
     get {
 #if BEFORE
@@ -49,10 +53,12 @@ public struct Container {
     }
   }
 
+  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
   public func expectedResult() -> Int {
     return property.getValue()
   }
 
+  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
   public func expectedSize() -> Int {
     return MemoryLayout.size(ofValue: property)
   }

--- a/validation-test/Evolution/test_opaque_archetypes_change_underlying_type.swift
+++ b/validation-test/Evolution/test_opaque_archetypes_change_underlying_type.swift
@@ -10,13 +10,15 @@ import StdlibUnittest
 var OpaqueArchetypes = TestSuite("OpaqueArchetypes")
 
 OpaqueArchetypes.test("test1") {
-  let o = resilientFunction()
-  expectEqual(o.getValue(), expectedResult())
-  expectEqual(MemoryLayout.size(ofValue: o), expectedSize())
+  if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+    let o = resilientFunction()
+    expectEqual(o.getValue(), expectedResult())
+    expectEqual(MemoryLayout.size(ofValue: o), expectedSize())
 
-  let c = Container()
-  expectEqual(c.property.getValue(), c.expectedResult())
-  expectEqual(MemoryLayout.size(ofValue: c.property), c.expectedSize())
+    let c = Container()
+    expectEqual(c.property.getValue(), c.expectedResult())
+    expectEqual(MemoryLayout.size(ofValue: c.property), c.expectedSize())
+  }
 }
 
 runAllTests()


### PR DESCRIPTION
rdar://50503909