### PR TITLE
[test] Disable test/Interpreter/subclass_existentials.swift to unblock CI

### DIFF
--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -16,6 +16,9 @@
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
+// SR-10641 rdar://problem/50553481
+// REQUIRES: swift_test_mode_optimize_none
+
 import StdlibUnittest
 
 protocol P {


### PR DESCRIPTION
It's been failing in CI since enabling the existential specializer by default:
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/2043/

