### PR TITLE
Add a Diagnostic for .init calls which should be transformed into assignments (SR-10297)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -857,6 +857,10 @@ ERROR(did_not_call_method,none,
       "method %0 was used as a property; add () to call it",
       (Identifier))
 
+ERROR(init_not_instance_member_use_assignment,none,
+      "'init' is a member of the type; use assignment "
+      "to initalize the value instead", ())
+
 ERROR(init_not_instance_member,none,
       "'init' is a member of the type; use 'type(of: ...)' to initialize "
       "a new object of the same dynamic type", ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -101,6 +101,35 @@ Expr *FailureDiagnostic::getArgumentExprFor(Expr *anchor) const {
   return nullptr;
 }
 
+// TODO: Replace duplications of this logic with calls to this.
+Optional<SelectedOverload> FailureDiagnostic::getChoiceFor(Expr *expr) {
+  auto &cs = getConstraintSystem();
+  ConstraintLocator *locator = nullptr;
+
+  if (auto *call = dyn_cast<CallExpr>(expr)) {
+    auto *fnExpr = call->getFn();
+    return getChoiceFor(fnExpr);
+  } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
+    locator = cs.getConstraintLocator(UDE, ConstraintLocator::Member);
+  } else if (auto *UME = dyn_cast<UnresolvedMemberExpr>(expr)) {
+    locator = cs.getConstraintLocator(UME, ConstraintLocator::UnresolvedMember);
+  } else if (auto *TE = dyn_cast<TypeExpr>(expr)) {
+    locator = cs.getConstraintLocator(call,
+                                      {ConstraintLocator::ApplyFunction,
+                                        ConstraintLocator::ConstructorMember},
+                                      /*summaryFlags=*/0);
+  } else if (auto *SE = dyn_cast<SubscriptExpr>(expr)) {
+    locator = cs.getConstraintLocator(SE, ConstraintLocator::SubscriptMember);
+  } else {
+    locator = cs.getConstraintLocator(expr);
+  }
+  
+  if(!locator)
+    return None;
+
+  return getOverloadChoiceIfAvailable(locator);
+}
+
 Type RequirementFailure::getOwnerType() const {
   return getType(getRawAnchor())
       ->getInOutObjectType()
@@ -2042,42 +2071,43 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         emitDiagnostic(loc, diag::super_initializer_not_in_initializer);
         return true;
       }
+      
+      auto isInsideCall = [this](Expr *expr) {
+        auto &cs = getConstraintSystem();
+        auto argExpr = cs.getParentExpr(expr);
+        if (!argExpr)
+          return false;
+        auto possibleCallExpr = cs.getParentExpr(expr);
+        return possibleCallExpr && isa<CallExpr>(possibleCallExpr);
+      };
 
-      // Dig through the chain of member accesses until we find the last
-      // UnresolvedDotExpr.
-      auto *lastUnresolved = ctorRef;
-      while (auto *nextMember =
-                 dyn_cast_or_null<UnresolvedDotExpr>(lastUnresolved->getBase()))
-        lastUnresolved = nextMember;
+      auto *initCall = cs.getParentExpr(cs.getParentExpr(ctorRef));
 
-      if (auto *DRE = dyn_cast<DeclRefExpr>(lastUnresolved->getBase())) {
-        auto isInsideCall = [this](Expr *expr) {
-          auto &cs = getConstraintSystem();
-          auto argExpr = cs.getParentExpr(expr);
-          if (!argExpr)
-            return false;
-          auto possibleCallExpr = cs.getParentExpr(expr);
-          return possibleCallExpr && isa<CallExpr>(possibleCallExpr);
-        };
+      auto isImmutable = [&DC](ValueDecl *decl) {
+        if (auto *storage = dyn_cast<AbstractStorageDecl>(decl))
+          return !storage->isSettable(DC) ||
+                !storage->isSetterAccessibleFrom(DC);
 
-        auto *initCall = cs.getParentExpr(cs.getParentExpr(ctorRef));
-
-        // We can only check if the base is settable here so provide the
-        // assignment diagnostic as it's our best guess.
-        if (DRE->getDecl()->isSettable(DC, DRE) && !isInsideCall(initCall) &&
+        return false;
+      };
+      
+      auto selection = getChoiceFor(ctorRef->getBase());
+      if (selection) {
+        OverloadChoice choice = selection.getValue().choice;
+        if (choice.isDecl() && !isImmutable(choice.getDecl()) && !isInsideCall(initCall) &&
             cs.getContextualTypePurpose() == CTP_Unused) {
           auto fixItLoc = ctorRef->getBase()->getSourceRange().End;
           emitDiagnostic(loc, diag::init_not_instance_member_use_assignment)
               .fixItInsertAfter(fixItLoc, " = ");
           return true;
         }
-      }
 
-      SourceRange fixItRng = ctorRef->getNameLoc().getSourceRange();
-      emitDiagnostic(loc, diag::init_not_instance_member)
-          .fixItInsert(fixItRng.Start, "type(of: ")
-          .fixItInsertAfter(fixItRng.End, ")");
-      return true;
+        SourceRange fixItRng = ctorRef->getNameLoc().getSourceRange();
+        emitDiagnostic(loc, diag::init_not_instance_member)
+            .fixItInsert(fixItRng.Start, "type(of: ")
+            .fixItInsertAfter(fixItRng.End, ")");
+        return true;
+      }
     }
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2083,18 +2083,17 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
 
       auto *initCall = cs.getParentExpr(cs.getParentExpr(ctorRef));
 
-      auto isImmutable = [&DC](ValueDecl *decl) {
+      auto isMutable = [&DC](ValueDecl *decl) {
         if (auto *storage = dyn_cast<AbstractStorageDecl>(decl))
-          return !storage->isSettable(DC) ||
-                 !storage->isSetterAccessibleFrom(DC);
+          return storage->isSettable(DC) && storage->isSetterAccessibleFrom(DC);
 
-        return false;
+        return true;
       };
 
       auto selection = getChoiceFor(ctorRef->getBase());
       if (selection) {
         OverloadChoice choice = selection.getValue().choice;
-        if (choice.isDecl() && !isImmutable(choice.getDecl()) &&
+        if (choice.isDecl() && isMutable(choice.getDecl()) &&
             !isCallArgument(initCall) &&
             cs.getContextualTypePurpose() == CTP_Unused) {
           auto fixItLoc = ctorRef->getBase()->getSourceRange().End;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -154,7 +154,7 @@ protected:
   /// \returns An argument expression if given anchor is a call, member
   /// reference or subscript, nullptr otherwise.
   Expr *getArgumentExprFor(Expr *anchor) const;
-  
+
   Optional<SelectedOverload> getChoiceFor(Expr *);
 
 private:

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -154,6 +154,8 @@ protected:
   /// \returns An argument expression if given anchor is a call, member
   /// reference or subscript, nullptr otherwise.
   Expr *getArgumentExprFor(Expr *anchor) const;
+  
+  Optional<SelectedOverload> getChoiceFor(Expr *);
 
 private:
   /// Compute anchor expression associated with current diagnostic.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2646,6 +2646,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   auto contextualPurpose = CTP_Unused;
   TypeCheckExprOptions flags = TypeCheckExprFlags::ConvertTypeIsOnlyAHint;
 
+  // Set the contextual purpose even if the pattern doesn't have a type so
+  // if there's an error we can use that information to inform diagnostics.
   contextualPurpose = CTP_Initialization;
 
   if (pattern->hasType()) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2646,9 +2646,10 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   auto contextualPurpose = CTP_Unused;
   TypeCheckExprOptions flags = TypeCheckExprFlags::ConvertTypeIsOnlyAHint;
 
+  contextualPurpose = CTP_Initialization;
+
   if (pattern->hasType()) {
     contextualType = TypeLoc::withoutLoc(pattern->getType());
-    contextualPurpose = CTP_Initialization;
 
     // If we already had an error, don't repeat the problem.
     if (contextualType.getType()->hasError())

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -513,6 +513,14 @@ class TestOptionalTrySub : TestOptionalTry {
 
 struct X { init() {} }
 
+func +(lhs: X, rhs: X) -> X { return lhs }
+func testInsideOperator(x: X) {
+  x.init() + x // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{9-9=)}}
+  x + x.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{9-9=type(of: }} {{13-13=)}}
+  x.init() + x.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{9-9=)}}
+  // expected-error@-1 {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{16-16=type(of: }} {{20-20=)}}
+}
+
 struct Y {
   var x: X
   let x2: X

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -273,12 +273,23 @@ func foo<T: C>(_ x: T, y: T.Type) where T: P {
   var ci1 = x.init(required: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
   var ci2 = x.init(x: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
   var ci3 = x.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
-  var ci4 = x.init(proto: "") // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}} 
-
-  var ci1a = x(required: 0) // expected-error{{cannot call value of non-function type 'T'}}
-  var ci2a = x(x: 0) // expected-error{{cannot call value of non-function type 'T'}}
-  var ci3a = x() // expected-error{{cannot call value of non-function type 'T'}}{{15-17=}}
-  var ci4a = x(proto: "") // expected-error{{cannot call value of non-function type 'T'}}
+  var ci4 = x.init(proto: "") // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
+  
+  var z = x
+  z.init(required: 0) // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  z.init(x: 0) // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  z.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  z.init(proto: "") // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  
+  var ci1a = z.init(required: 0) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{16-16=type(of: }} {{20-20=)}}
+  var ci2a = z.init(x: 0) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{16-16=type(of: }} {{20-20=)}}
+  var ci3a = z.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{16-16=type(of: }} {{20-20=)}}
+  var ci4a = z.init(proto: "") // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{16-16=type(of: }} {{20-20=)}}
+  
+  var ci1b = x(required: 0) // expected-error{{cannot call value of non-function type 'T'}}
+  var ci2b = x(x: 0) // expected-error{{cannot call value of non-function type 'T'}}
+  var ci3b = x() // expected-error{{cannot call value of non-function type 'T'}}{{15-17=}}
+  var ci4b = x(proto: "") // expected-error{{cannot call value of non-function type 'T'}}
 
   var cm1 = y.init(required: 0)
   var cm2 = y.init(x: 0) // expected-error{{'required' initializer}}
@@ -497,5 +508,35 @@ class TestOptionalTrySub : TestOptionalTry {
   init(a: Int) { // expected-note {{propagate the failure with 'init?'}} {{7-7=?}}
     try? super.init() // expected-error {{a non-failable initializer cannot use 'try?' to chain to another initializer}}
     // expected-note@-1 {{force potentially-failing result with 'try!'}} {{5-9=try!}}
+  }
+}
+
+struct X { init() {} }
+
+struct Y {
+  func foo(_: X) {}
+  func asFunctionReturn() -> X {
+    var a = X()
+    return a.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{18-18=)}}
+  }
+  var x: X
+  init() {
+    x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{6-6= = }}
+    foo(x.init()) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{11-11=type(of: }} {{15-15=)}}
+  }
+}
+
+struct Y2 {
+  var x: X
+  init() {
+    x = X()
+  }
+}
+
+struct MultipleMemberAccesses {
+  var y: Y
+  init() {
+    y = Y()
+    y.x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{8-8= = }}
   }
 }

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -514,29 +514,28 @@ class TestOptionalTrySub : TestOptionalTry {
 struct X { init() {} }
 
 struct Y {
+  var x: X
+  let x2: X
+  
+  init() {
+    x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{6-6= = }}
+    foo(x.init()) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{11-11=type(of: }} {{15-15=)}}
+  }
+  
   func foo(_: X) {}
   func asFunctionReturn() -> X {
     var a = X()
     return a.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{18-18=)}}
   }
-  var x: X
-  init() {
-    x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{6-6= = }}
-    foo(x.init()) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{11-11=type(of: }} {{15-15=)}}
-  }
-}
-
-struct Y2 {
-  var x: X
-  init() {
-    x = X()
-  }
 }
 
 struct MultipleMemberAccesses {
   var y: Y
+  let y2: Y
   init() {
     y = Y()
+    y2 = Y()
     y.x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{8-8= = }}
+    y2.x2.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{11-11=type(of: }} {{15-15=)}}
   }
 }


### PR DESCRIPTION
This pull request adds a diagnostic for .init calls that should be transformed into assignments. It provides this diagnostic in the same place as the existing `init_not_instance_member` diagnostic if the base of the expression being modified is settable.

Additionally, this pull request changes typeCheckBinding so that it sets the contextual purpose regardless of if the pattern has a type.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10297](https://bugs.swift.org/browse/SR-10297).
Resolves: rdar://problem/36036244
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
