### PR TITLE
[Serialization] Support Swift only system module

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -602,7 +602,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1,
     /// If the module was or is being compiled with `-enable-testing`.
     TestingEnabled : 1,
 
@@ -621,7 +621,10 @@ protected:
     PrivateImportsEnabled : 1,
 
     // If the module is compiled with `-enable-implicit-dynamic`.
-    ImplicitDynamicEnabled : 1
+    ImplicitDynamicEnabled : 1,
+
+    // Whether the module is a system module.
+    IsSystemModule : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -325,6 +325,15 @@ public:
     Bits.ModuleDecl.RawResilienceStrategy = unsigned(strategy);
   }
 
+  /// \returns true if this module is a system module; note that the StdLib is
+  /// considered a system module.
+  bool isSystemModule() const {
+    return Bits.ModuleDecl.IsSystemModule;
+  }
+  void setIsSystemModule(bool flag = true) {
+    Bits.ModuleDecl.IsSystemModule = flag;
+  }
+
   bool isResilient() const {
     return getResilienceStrategy() != ResilienceStrategy::Default;
   }
@@ -552,10 +561,6 @@ public:
 
   /// \returns true if this module is the "SwiftOnoneSupport" module;
   bool isOnoneSupportModule() const;
-
-  /// \returns true if this module is a system module; note that the StdLib is
-  /// considered a system module.
-  bool isSystemModule() const;
 
   /// \returns true if traversal was aborted, false otherwise.
   bool walk(ASTWalker &Walker);

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -51,7 +51,7 @@ protected:
   bool findModule(AccessPathElem moduleID,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
-                  bool &isFramework);
+                  bool &isFramework, bool &isSystemModule);
 
   /// Attempts to search the provided directory for a loadable serialized
   /// .swiftmodule with the provided `ModuleFilename`. Subclasses must

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1283,16 +1283,6 @@ bool ModuleDecl::registerEntryPointFile(FileUnit *file, SourceLoc diagLoc,
   return true;
 }
 
-bool ModuleDecl::isSystemModule() const {
-  if (isStdlibModule())
-    return true;
-  for (auto F : getFiles()) {
-    if (auto LF = dyn_cast<LoadedFile>(F))
-      return LF->isSystemModule();
-  }
-  return false;
-}
-
 template<bool respectVisibility>
 static bool
 forAllImportedModules(ModuleDecl *topLevel, ModuleDecl::AccessPathTy thisPath,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1669,6 +1669,7 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     // but that's not correct for submodules.
     Identifier name = SwiftContext.getIdentifier((*clangModule).Name);
     result = ModuleDecl::create(name, SwiftContext);
+    result->setIsSystemModule(clangModule->IsSystem);
     // Silence error messages about testably importing a Clang module.
     result->setTestingEnabled();
     result->setHasResolvedImports();
@@ -1835,6 +1836,7 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   // FIXME: Handle hierarchical names better.
   Identifier name = SwiftContext.getIdentifier(underlying->Name);
   auto wrapper = ModuleDecl::create(name, SwiftContext);
+  wrapper->setIsSystemModule(underlying->IsSystem);
   // Silence error messages about testably importing a Clang module.
   wrapper->setTestingEnabled();
   wrapper->setHasResolvedImports();

--- a/test/IDE/complete_from_swiftonly_systemmodule.swift
+++ b/test/IDE/complete_from_swiftonly_systemmodule.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name SomeModule \
+// RUN:     -o %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     %t/SomeModule.swift
+
+// RUN: %target-swift-ide-test -code-completion -sdk %t/SDK -iframework %t/SDK/Frameworks -source-filename %t/main.swift -code-completion-token=GLOBAL | %FileCheck --check-prefix GLOBAL %s
+// RUN: %target-swift-ide-test -code-completion -sdk %t/SDK -iframework %t/SDK/Frameworks -source-filename %t/main.swift -code-completion-token=INSTANCE | %FileCheck --check-prefix INSTANCE %s
+// RUN: %target-swift-ide-test -code-completion -sdk %t/SDK -iframework %t/SDK/Frameworks -source-filename %t/main.swift -code-completion-token=INITIALIZER | %FileCheck --check-prefix INITIALIZER %s
+
+// Test that declarations starting with '_' from system module doesn't apper in
+// code completion.
+
+// BEGIN SomeModule.swift
+
+public struct SomeValue {
+  internal var internalValue: Int { return 1 }
+  public var _secretValue: Int { return 1 }
+  public var publicValue: Int { return 1 }
+
+  internal func internalMethod() -> Int { return 1 }
+  public func _secretMethod() -> Int { return 1 }
+  public func publicMethod() -> Int { return 1 }
+
+  internal init(internal: Int) {}
+  public init(_secret: Int) {}
+  public init(public: Int) {}
+}
+
+internal func internalFunc() {}
+public func _secretFunc() {}
+public func publicFunc() {}
+
+// BEGIN main.swift
+import SomeModule
+
+func test(value: SomeValue) {
+  let _ = #^GLOBAL^#
+// GLOBAL: Begin completions
+// GLOBAL-NOT: _secretFunc
+// GLOBAL-NOT: internalFunc
+// GLOBAL-DAG: Decl[Struct]/OtherModule[SomeModule]: SomeValue[#SomeValue#];
+// GLOBAL-DAG: Decl[FreeFunction]/OtherModule[SomeModule]: publicFunc()[#Void#];
+// GLOBAL: End completions
+
+  let _ = value.#^INSTANCE^#
+// INSTANCE: Begin completions, 3 items
+// INSTANCE-DAG: Keyword[self]/CurrNominal:          self[#SomeValue#];
+// INSTANCE-DAG: Decl[InstanceVar]/CurrNominal:      publicValue[#Int#];
+// INSTANCE-DAG: Decl[InstanceMethod]/CurrNominal:   publicMethod()[#Int#];
+// INSTANCE: End completions
+
+  let _ = SomeValue(#^INITIALIZER^#
+// INITIALIZER: Begin completions, 1 items
+// INITIALIZER-DAG: Decl[Constructor]/CurrNominal:      ['(']{#public: Int#}[')'][#SomeValue#];
+// INITIALIZER: End completions
+}

--- a/test/Index/index_swift_only_systemmodule.swift
+++ b/test/Index/index_swift_only_systemmodule.swift
@@ -1,0 +1,134 @@
+import SomeModule
+print(someFunc())
+
+// UNIT: Record | system | SomeModule |
+
+// RUN: %empty-directory(%t)
+//
+// RUN: echo 'public func someFunc() -> Int { return 42; }' >%t/some-module.swift
+// RUN: echo 'public struct XWrapper {' >>%t/some-module.swift
+// RUN: echo '  public let x: Int' >>%t/some-module.swift
+// RUN: echo '  public init(x: Int) {' >>%t/some-module.swift
+// RUN: echo '    self.x = x' >>%t/some-module.swift
+// RUN: echo '  }' >>%t/some-module.swift
+// RUN: echo '}' >>%t/some-module.swift
+//
+// -----------------------------------------------------------------------------
+// --- Prepare SDK (.swiftmodule).
+// RUN: %empty-directory(%t/SDK)
+// RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name SomeModule \
+// RUN:     -o %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     %t/some-module.swift
+
+// -----------------------------------------------------------------------------
+// Test-1 - '.swiftmodule' - Normal index-while-building.
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+//
+// --- Built with indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %s
+//
+// --- Check the index.
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+
+// -----------------------------------------------------------------------------
+// --- Prepare SDK (.swiftinterface).
+// RUN: %empty-directory(%t/SDK)
+// RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name SomeModule \
+// RUN:     -emit-parseable-module-interface-path %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule/%module-target-triple.swiftinterface \
+// RUN:     -o /dev/null \
+// RUN:     -swift-version 5 \
+// RUN:     -enable-library-evolution \
+// RUN:     %t/some-module.swift
+
+// -----------------------------------------------------------------------------
+// Test-2 - '.swiftinterface' - Normal index-while-building.
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+//
+// --- Built with indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %s
+//
+// --- Check the index.
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+
+// -----------------------------------------------------------------------------
+// Test-3 - '.swiftinterface' - Build once to populate modulecache, then index-while-building.
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+//
+// --- Build without indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %s
+//
+// --- Ensure module cache is populated.
+// RUN: find %t/modulecache -maxdepth 1 -name 'SomeModule-*.swiftmodule' | grep .
+//
+// --- Built with indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %s
+//
+// --- Check the index.
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+
+// -----------------------------------------------------------------------------
+// Test-4 - '.swiftinterface' - Prebuild module in prebuilt-module-cache-path
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+// RUN: %empty-directory(%t/prebuiltcache)
+//
+// --- Prebuild SDK module.
+// RUN: mkdir -p %t/prebuiltcache/SomeModule.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -build-module-from-parseable-interface \
+// RUN:     -module-name SomeModule \
+// RUN:     -o %t/prebuiltcache/SomeModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule/%module-target-triple.swiftinterface
+//
+// --- Build main file with indexing.
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     -prebuilt-module-cache-path %t/prebuiltcache \
+// RUN:     %s
+//
+// --- Check the index.
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s

--- a/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
+++ b/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
@@ -1,0 +1,40 @@
+// BEGIN SomeModule.swift
+
+/// Doc comment for 'someFunc()'
+public func someFunc() {}
+
+// BEGIN main.swift
+import SomeModule
+
+func test() {
+  someFunc()
+}
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name SomeModule \
+// RUN:     -o %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     %t/SomeModule.swift
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:3 %t/main.swift -- \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -target %target-triple \
+// RUN:     %t/main.swift \
+// RUN: | %FileCheck %s
+
+// CHECK: source.lang.swift.ref.function.free ()
+// CHECK-NEXT: someFunc()
+// CHECK-NEXT: s:10SomeModule8someFuncyyF
+// CHECK-NEXT: () -> ()
+// CHECK-NEXT: $syycD
+// CHECK-NEXT: SomeModule
+// CHECK-NEXT: SYSTEM
+// CHECK-NEXT: <Declaration>func someFunc()</Declaration>
+// CHECK-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>someFunc</decl.name>()</decl.function.free>
+// CHECK-NEXT: </LocalizationKey>

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -13,6 +13,7 @@
       key.name: "SwiftOnoneSupport",
       key.filepath: SwiftOnoneSupport.swiftmodule,
       key.hash: <hash>,
+      key.is_system: 1,
       key.dependencies: [
         {
           key.kind: source.lang.swift.import.module.swift,

--- a/test/SourceKit/Indexing/index_bad_modulename.swift.response
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift.response
@@ -33,6 +33,7 @@
           key.name: "SwiftOnoneSupport",
           key.filepath: SwiftOnoneSupport.swiftmodule,
           key.hash: <hash>,
+          key.is_system: 1,
           key.dependencies: [
             {
               key.kind: source.lang.swift.import.module.swift,

--- a/test/SourceKit/Indexing/index_func_import.swift.response
+++ b/test/SourceKit/Indexing/index_func_import.swift.response
@@ -26,6 +26,7 @@
           key.name: "SwiftOnoneSupport",
           key.filepath: SwiftOnoneSupport.swiftmodule,
           key.hash: <hash>,
+          key.is_system: 1,
           key.dependencies: [
             {
               key.kind: source.lang.swift.import.module.swift,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -3604,7 +3604,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 53,
-    key.length: 17
+    key.length: 17,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -264,7 +264,8 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 35,
-    key.length: 17
+    key.length: 17,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
@@ -69,7 +69,8 @@ public func pub_function()
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 7,
-    key.length: 17
+    key.length: 17,
+    key.is_system: 1
   }
 ]
 [

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -335,7 +335,8 @@ internal enum Colors {
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 94,
-    key.length: 6
+    key.length: 6,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,


### PR DESCRIPTION
Previously `ModuleDecl::isSystemModule()` returns true only if the module is:
- Standard library
- Clang module and that is `IsSystem`
- Swift overlay for clang `IsSystem` module

With this patch, now:
- Clang module and that is `IsSystem`; or
- Swift overlay for clang `IsSystem` module
- Swift module found in either of these directories:
  - Runtime library directoris (including stdlib)
  - Frameworks in `-Fsystem` directories
  - Frameworks in `$SDKROOT/System/Library/Frameworks/` (Darwin)
  - Frameworks in `$SDKROOT/Library/Frameworks/` (Darwin)

rdar://problem/50516314
