### PR TITLE
Fix Syntax/Parser tests on Linux.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2210,10 +2210,12 @@ function(_add_swift_executable_single name)
   # working around tests like Driver/linker.swift which copy/hard link Swift
   # executables to different directories without also copying the "libs"
   # directory. A more robust solution should be found.
+  # NOTE: Adding "${SWIFTLIB_DIR}/.." to the rpath was necessary to fix linker
+  # errors for Syntax/Parser tests on Linux.
   if("${SWIFTEXE_SINGLE_SDK}" STREQUAL "LINUX" AND NOT "${SWIFTEXE_SINGLE_SDK}" STREQUAL "ANDROID")
-    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/linux:/usr/lib/swift/linux")
+    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/linux:${SWIFTLIB_DIR}/..:/usr/lib/swift/linux")
   elseif("${SWIFTEXE_SINGLE_SDK}" STREQUAL "CYGWIN")
-    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/cygwin:/usr/lib/swift/cygwin")
+    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/cygwin:${SWIFTLIB_DIR}/..:/usr/lib/swift/cygwin")
   endif()
   # END SWIFT_ENABLE_TENSORFLOW
 


### PR DESCRIPTION
On Linux, adding an extra rpath fixes the following error:
"error while loading shared libraries: lib_InternalSwiftSyntaxParser.so".

Revisit - this change should not be necessary.