### PR TITLE
disable sized deallocation for TextOwner

### DIFF
--- a/include/swift/Basic/OwnedString.h
+++ b/include/swift/Basic/OwnedString.h
@@ -46,6 +46,10 @@ class OwnedString {
       return new (data) TextOwner(Text);
     }
 
+    /// Disable sized deallocation for TextOwner, because it has tail-allocated
+    /// data.
+    void operator delete(void *p) { ::operator delete(p); }
+
     const char *getText() const { return getTrailingObjects<char>(); }
   };
 


### PR DESCRIPTION
Deallocating strings fails when running with sized deallocation. This fixes it, by doing something similar to other places, e.g. https://github.com/apple/swift-llvm/blob/082dec2e222ca228125e187a726ee87c5b83ad54/lib/Support/MemoryBuffer.cpp#L92