### PR TITLE
Fix differentiation of nested functions inside `@inlinable` functions.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -114,7 +114,8 @@ static SILLinkage getAutoDiffFunctionLinkage(SILLinkage originalLinkage,
   // associated function. Make the associated function public unless
   // differentiation is not explicitly requested.
   if (originalLinkage == SILLinkage::Public ||
-      originalLinkage == SILLinkage::PublicNonABI)
+      originalLinkage == SILLinkage::PublicNonABI ||
+      originalLinkage == SILLinkage::Shared)
     return isExported ? originalLinkage : SILLinkage::Hidden;
 
   // Otherwise, the original function is defined and used only in the current

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -140,6 +140,7 @@ public extension Differentiable {
 //===----------------------------------------------------------------------===//
 
 /// Create a differentiable function from a vector-Jacobian products function.
+@inlinable
 public func differentiableFunction<T : Differentiable, R : Differentiable>(
   from vjp: @escaping (T)
            -> (value: R, pullback: (R.CotangentVector) -> T.CotangentVector)
@@ -156,6 +157,7 @@ public func differentiableFunction<T : Differentiable, R : Differentiable>(
 }
 
 /// Create a differentiable function from a vector-Jacobian products function.
+@inlinable
 public func differentiableFunction<T, U, R>(
   from vjp: @escaping (T, U)
            -> (value: R, pullback: (R.CotangentVector)


### PR DESCRIPTION
Fix differentiation of `@inlinable public func differentiationFunction(from:)`.
Todo: add a test.