### PR TITLE
Re-enable disabled Driver tests.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2206,16 +2206,12 @@ function(_add_swift_executable_single name)
   # SWIFT_ENABLE_TENSORFLOW
   set(swift_relative_library_path "../lib/swift/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
   is_darwin_based_sdk("${SWIFTEXE_SINGLE_SDK}" IS_DARWIN)
-  # NOTE: Adding "${SWIFTLIB_DIR}/linux" to the rpath is a hack solely for
-  # working around tests like Driver/linker.swift which copy/hard link Swift
-  # executables to different directories without also copying the "libs"
-  # directory. A more robust solution should be found.
   # NOTE: Adding "${SWIFTLIB_DIR}/.." to the rpath was necessary to fix linker
   # errors for Syntax/Parser tests on Linux.
   if("${SWIFTEXE_SINGLE_SDK}" STREQUAL "LINUX" AND NOT "${SWIFTEXE_SINGLE_SDK}" STREQUAL "ANDROID")
-    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/linux:${SWIFTLIB_DIR}/..:/usr/lib/swift/linux")
+    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/..:/usr/lib/swift/linux")
   elseif("${SWIFTEXE_SINGLE_SDK}" STREQUAL "CYGWIN")
-    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/cygwin:${SWIFTLIB_DIR}/..:/usr/lib/swift/cygwin")
+    set(local_rpath "$ORIGIN:$ORIGIN/${swift_relative_library_path}:${SWIFTLIB_DIR}/..:/usr/lib/swift/cygwin")
   endif()
   # END SWIFT_ENABLE_TENSORFLOW
 

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -1,6 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because moving Swift executables without the TensorFlow libraries causes dynamic linking to fail.
-// UNSUPPORTED: tensorflow
-
 // RUN: %empty-directory(%t)
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>&1 > %t.simple.txt

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -1,6 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because moving Swift executables without the TensorFlow libraries causes dynamic linking to fail.
-// UNSUPPORTED: tensorflow
-
 // Make sure that the platform-appropriate clang_rt library (found relative to
 // the compiler) is included when using Swift as a linker (with Apple targets).
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -1,8 +1,5 @@
 // Must be able to run xcrun-return-self.sh
 // REQUIRES: shell
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because moving Swift executables without the TensorFlow libraries causes dynamic linking to fail.
-// UNSUPPORTED: tensorflow
-
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck %s < %t.simple.txt
 // RUN: %FileCheck -check-prefix SIMPLE %s < %t.simple.txt

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -1,6 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because moving Swift executables without the TensorFlow libraries causes dynamic linking to fail.
-// UNSUPPORTED: tensorflow
-
 // REQUIRES: OS=macosx
 
 // Test LLDB detection, first in a clean environment, then in one that looks

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -1,6 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because moving Swift executables without the TensorFlow libraries causes dynamic linking to fail.
-// UNSUPPORTED: tensorflow
-
 // RUN: not %swift -repl %s 2>&1 | %FileCheck -check-prefix=REPL_NO_FILES %s
 // RUN: not %swift_driver -sdk "" -repl %s 2>&1 | %FileCheck -check-prefix=REPL_NO_FILES %s
 // RUN: not %swift_driver -sdk "" -lldb-repl %s 2>&1 | %FileCheck -check-prefix=REPL_NO_FILES %s

--- a/test/Driver/static-stdlib.swift
+++ b/test/Driver/static-stdlib.swift
@@ -1,6 +1,4 @@
 // Statically link a "hello world" program
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because TensorFlow currently doesn't work with static-stdlib.
-// UNSUPPORTED: tensorflow
 // XFAIL: linux, win32
 // REQUIRES: static_stdlib
 // REQUIRES: executable_test

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -1,7 +1,4 @@
 // REQUIRES: shell
-// SWIFT_ENABLE_TENSORFLOW: This test is unsupported because moving Swift executables without the TensorFlow libraries causes dynamic linking to fail.
-// UNSUPPORTED: tensorflow
-
 // Check that 'swift' and 'swift repl' invoke the REPL.
 
 // RUN: rm -rf %t.dir


### PR DESCRIPTION
These tests were previously disabled on tensorflow branch, but now pass.