### PR TITLE
[TF] Fix `Tensor.replacing(_:_:)` wrong semantics.

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -979,7 +979,7 @@ public extension Tensor {
                   vjp: _vjpReplacing where Scalar : TensorFlowFloatingPoint)
   func replacing(with other: Tensor,
                  where mask: Tensor<Bool>) -> Tensor {
-    return Raw.select(condition: mask, t: self, e: other)
+    return Raw.select(condition: mask, t: other, e: self)
   }
 }
 


### PR DESCRIPTION
Swapped `self` and `other`. Now values will be replaced if mask is `true`.

References:
https://bugs.swift.org/browse/TF-492
https://forums.fast.ai/t/tensor-replacing-with-replacing-on-false/45507