### PR TITLE
stubs: configure flags based on SDK target

### DIFF
--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -41,7 +41,7 @@ add_swift_target_library(swiftStdlibStubs
                   INSTALL_IN_COMPONENT
                     stdlib)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if("${SWIFT_PRIMARY_VARIANT_SDK}" IN_LIST SWIFT_APPLE_PLATFORMS)
   set_property(SOURCE
                  SwiftNativeNSXXXBaseARC.m
                APPEND_STRING PROPERTY COMPILE_FLAGS


### PR DESCRIPTION
Due to the custom build system implemented in CMake for Swift, we cannot
properly detect the target and set flags appropriately.  Instead, assume
that if the primary variant is an Apple target, that all targets are
Apple variants.  This fixes cross-compilation on macOS.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
