### PR TITLE
[5.1][Runtime] Avoid +class overrides when initializing an ObjC class.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1269,7 +1269,11 @@ Class swift::swift_getInitializedObjCClass(Class c) {
   // Used when we have class metadata and we want to ensure a class has been
   // initialized by the Objective-C runtime. We need to do this because the
   // class "c" might be valid metadata, but it hasn't been initialized yet.
-  return [c class];
+  // Send a message that's likely not to be overridden to minimize potential
+  // side effects. Ignore the return value in case it is overridden to
+  // return something different. See SR-10463 for an example.
+  [c self];
+  return c;
 }
 
 static const ClassMetadata *

--- a/test/stdlib/Inputs/ObjCEvilClassInitialization/EvilClass.h
+++ b/test/stdlib/Inputs/ObjCEvilClassInitialization/EvilClass.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+// A class that overrides +class and +self to return nil.
+@interface EvilClass: NSObject
+@end

--- a/test/stdlib/Inputs/ObjCEvilClassInitialization/EvilClass.m
+++ b/test/stdlib/Inputs/ObjCEvilClassInitialization/EvilClass.m
@@ -1,0 +1,8 @@
+#import "EvilClass.h"
+
+@implementation EvilClass
+
++ (Class)class { return nil; }
++ (id)self { return nil; }
+
+@end

--- a/test/stdlib/Inputs/ObjCEvilClassInitialization/module.map
+++ b/test/stdlib/Inputs/ObjCEvilClassInitialization/module.map
@@ -1,0 +1,3 @@
+module EvilClass {
+  header "EvilClass.h"
+}

--- a/test/stdlib/ObjCEvilClassInitialization.swift
+++ b/test/stdlib/ObjCEvilClassInitialization.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -fobjc-arc %S/Inputs/ObjCEvilClassInitialization/EvilClass.m -c -o %t/EvilClass.o
+// RUN: %target-build-swift -I %S/Inputs/ObjCEvilClassInitialization/ %t/EvilClass.o %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import EvilClass
+
+import StdlibUnittest
+
+let tests = TestSuite("ObjCEvilClassInitialization")
+
+tests.test("GenericOnEvilClass") {
+  struct Generic<T> {
+    var type: T.Type { return T.self }
+  }
+  let g = Generic<EvilClass>()
+  expectEqual("\(type(of: g))", "Generic<EvilClass>")
+  expectEqual(g.type, EvilClass.self)
+}
+
+runAllTests()


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24618 to 5.1.

swift_getInitializedObjCClass called [c class] to trigger class initialization, and returned the value. This wreaked havoc when the class in question overrides +class. Instead, ignore the return value and return c. Switch from +class to +self, which is much less likely to be overridden. Calling an overridden method could have performance downsides or even cause unwanted side effects.

rdar://problem/49853091