### PR TITLE
 [AutoDiff] Improve non-differentiability diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -364,8 +364,12 @@ ERROR(pound_assert_failure,none,
 // Automatic differentiation diagnostics
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
-ERROR(autodiff_function_not_differentiable,none,
+ERROR(autodiff_function_not_differentiable_error,none,
       "function is not differentiable", ())
+ERROR(autodiff_expression_not_differentiable_error,none,
+      "expression is not differentiable", ())
+NOTE(autodiff_expression_not_differentiable_note,none,
+     "expression is not differentiable", ())
 NOTE(autodiff_external_nondifferentiable_function,none,
      "cannot differentiate an external function that has not been marked "
      "'@differentiable'", ())
@@ -411,14 +415,12 @@ NOTE(autodiff_when_differentiating_function_call,none,
      "when differentiating this function call", ())
 NOTE(autodiff_when_differentiating_function_definition,none,
      "when differentiating this function definition", ())
-NOTE(autodiff_expression_is_not_differentiable,none,
-     "expression is not differentiable", ())
 NOTE(autodiff_cannot_differentiate_through_inout_arguments,none,
      "cannot differentiate through 'inout' arguments", ())
 NOTE(autodiff_control_flow_not_supported,none,
-     "differentiating control flow is not supported yet", ())
+     "differentiating control flow is not yet supported", ())
 NOTE(autodiff_class_member_not_supported,none,
-     "differentiating class members is not supported yet", ())
+     "differentiating class members is not yet supported", ())
 NOTE(autodiff_missing_return,none,
      "missing return for differentiation", ())
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -277,6 +277,14 @@ static ReturnInst *getSingleReturn(SILFunction *f) {
   return cast<ReturnInst>(f->findReturnBB()->getTerminator());
 }
 
+/// Given an `autodiff_function` instruction, find the corresponding
+/// differential operator used in the AST. If no differential operator is found,
+/// return nullptr.
+static AutoDiffFunctionExpr *
+findDifferentialOperator(AutoDiffFunctionInst *inst) {
+  return inst->getLoc().getAsASTNode<AutoDiffFunctionExpr>();
+}
+
 //===----------------------------------------------------------------------===//
 // Auxiliary data structures
 //===----------------------------------------------------------------------===//
@@ -1030,47 +1038,64 @@ InFlightDiagnostic
 ADContext::emitNondifferentiabilityError(SILValue value,
                                          const DifferentiationTask *task,
                                          Optional<Diag<>> diag) {
-  auto *inst = value->getDefiningInstruction();
-  if (!inst) {
-    return diagnose(value.getLoc().getSourceLoc(),
-        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
-  }
-  return emitNondifferentiabilityError(inst, task, diag);
+  LLVM_DEBUG({
+    auto &s = getADDebugStream()
+        << "Diagnosing non-differentiability for value \n\t" << value
+        << "\nwhile performing differentiation task\n\t";
+    task->print(s);
+    s << '\n';
+  });
+  auto valueLoc = value.getLoc().getSourceLoc();
+  return emitNondifferentiabilityError(valueLoc, task, diag);
 }
 
 InFlightDiagnostic
 ADContext::emitNondifferentiabilityError(SILInstruction *inst,
                                          const DifferentiationTask *task,
                                          Optional<Diag<>> diag) {
-  // Location of the instruction.
-  auto opLoc = inst->getLoc().getSourceLoc();
-  if (!task) {
-    return diagnose(opLoc,
-        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
-  }
   LLVM_DEBUG({
     auto &s = getADDebugStream()
-        << "Diagnosing non-differentiability for inst \n\t" << *inst
+        << "Diagnosing non-differentiability for inst \n\t" << inst
         << "\nwhile performing differentiation task\n\t";
     task->print(s);
     s << '\n';
   });
-  return emitNondifferentiabilityError(opLoc, task, diag);
+  auto instLoc = inst->getLoc().getSourceLoc();
+  return emitNondifferentiabilityError(instLoc, task, diag);
 }
 
 InFlightDiagnostic
 ADContext::emitNondifferentiabilityError(SourceLoc loc,
                                          const DifferentiationTask *task,
                                          Optional<Diag<>> diag) {
+  if (!task) {
+    diagnose(loc, diag::autodiff_expression_not_differentiable_error);
+    return diagnose(loc,
+        diag.getValueOr(diag::autodiff_expression_not_differentiable_note));
+  }
   auto invoker = task->getInvoker();
   switch (invoker.getKind()) {
-  // For a `autodiff_function` instruction or a `[differentiable]` attribute
-  // that is not associated with any source location, we emit a diagnostic at
-  // the instruction source location.
-  case DifferentiationInvoker::Kind::AutoDiffFunctionInst:
-    // FIXME: This will not report an error to the user.
+  // For `autodiff_function` instructions: if the `autodiff_function`
+  // instruction comes from a differential operator, emit an error on the
+  // expression and a note on the non-differentiable operation. Otherwise, emit
+  // both an error and note on the non-differentiation operation.
+  case DifferentiationInvoker::Kind::AutoDiffFunctionInst: {
+    auto *inst = invoker.getAutoDiffFunctionInst();
+    if (auto *expr = findDifferentialOperator(inst)) {
+      diagnose(expr->getLoc(), diag::autodiff_function_not_differentiable_error)
+          .highlight(expr->getSubExpr()->getSourceRange());
+      return diagnose(loc,
+          diag.getValueOr(diag::autodiff_expression_not_differentiable_note));
+    }
+    diagnose(loc, diag::autodiff_expression_not_differentiable_error);
     return diagnose(loc,
-        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
+        diag.getValueOr(diag::autodiff_expression_not_differentiable_note));
+  }
+
+  // For `[differentiable]` attributes, try to find an AST function declaration
+  // and `@differentiable` attribute. If they are found, emit an error on the
+  // `@differentiable` attribute; otherwise, emit an error on the SIL function.
+  // Emit a note at the non-differentiable operation.
   case DifferentiationInvoker::Kind::SILDifferentiableAttribute: {
     auto attr = invoker.getSILDifferentiableAttribute();
     bool foundAttr = false;
@@ -1079,7 +1104,7 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
         if (auto *diffAttr =
                 fnDecl->getAttrs().getAttribute<DifferentiableAttr>()) {
           diagnose(diffAttr->getLocation(),
-                   diag::autodiff_function_not_differentiable)
+                   diag::autodiff_function_not_differentiable_error)
               .highlight(diffAttr->getRangeWithAt());
           diagnose(attr.second->getLocation().getSourceLoc(),
                    diag::autodiff_when_differentiating_function_definition);
@@ -1087,13 +1112,12 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
         }
       }
     }
-    if (!foundAttr) {
-      // Fallback if we cannot find the expected attribute.
+    // Fallback if we cannot find the expected attribute.
+    if (!foundAttr)
       diagnose(attr.second->getLocation().getSourceLoc(),
-               diag::autodiff_function_not_differentiable);
-    }
+               diag::autodiff_function_not_differentiable_error);
     return diagnose(loc,
-        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
+        diag.getValueOr(diag::autodiff_expression_not_differentiable_note));
   }
 
   // For indirect differentiation, emit a "not differentiable" note on the
@@ -1112,10 +1136,10 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
   // attribute first and a note on the non-differentiable operation.
   case DifferentiationInvoker::Kind::FunctionConversion: {
     auto *expr = invoker.getFunctionConversion();
-    diagnose(expr->getLoc(), diag::autodiff_function_not_differentiable)
+    diagnose(expr->getLoc(), diag::autodiff_function_not_differentiable_error)
         .highlight(expr->getSubExpr()->getSourceRange());
     return diagnose(loc,
-        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
+        diag.getValueOr(diag::autodiff_expression_not_differentiable_note));
   }
   }
 }
@@ -1780,13 +1804,10 @@ emitAssociatedFunctionReference(ADContext &context, SILBuilder &builder,
   // the given kind and desired differentiation parameter indices, simply
   // extract the associated function of its function operand, retain the
   // associated function, and return it.
-  if (auto *inst = original->getDefiningInstruction()) {
-    if (auto *adfei = dyn_cast<AutoDiffFunctionExtractInst>(inst)) {
-      if (adfei->getExtractee() == AutoDiffFunctionExtractee::Original) {
+  if (auto *inst = original->getDefiningInstruction())
+    if (auto *adfei = dyn_cast<AutoDiffFunctionExtractInst>(inst))
+      if (adfei->getExtractee() == AutoDiffFunctionExtractee::Original)
         functionSource = adfei->getFunctionOperand();
-      }
-    }
-  }
 
   // If functionSource is a @differentiable function, just extract it.
   if (auto diffableFnType = original->getType().castTo<SILFunctionType>()) {
@@ -2628,8 +2649,7 @@ public:
   }
 
   void visitSILInstruction(SILInstruction *inst) {
-    getContext().emitNondifferentiabilityError(inst, getDifferentiationTask(),
-        diag::autodiff_expression_is_not_differentiable);
+    getContext().emitNondifferentiabilityError(inst, getDifferentiationTask());
     errorOccurred = true;
   }
 
@@ -2966,7 +2986,6 @@ public:
           primalGen.schedulePrimalSynthesisIfNeeded(newTask);
         });
     if (!vjpAndVJPIndices) {
-      context.emitNondifferentiabilityError(ai, synthesis.task);
       errorOccurred = true;
       return;
     }
@@ -4025,8 +4044,7 @@ public:
   void visitSILInstruction(SILInstruction *inst) {
     LLVM_DEBUG(getADDebugStream()
                << "Unhandled instruction in adjoint emitter: " << *inst);
-    getContext().emitNondifferentiabilityError(inst, getDifferentiationTask(),
-        diag::autodiff_expression_is_not_differentiable);
+    getContext().emitNondifferentiabilityError(inst, getDifferentiationTask());
     errorOccurred = true;
   }
 
@@ -5702,14 +5720,6 @@ void DifferentiationTask::createVJP(bool isExported) {
 // Differentiation pass implementation
 //===----------------------------------------------------------------------===//
 
-/// Given an `autodiff_function` instruction, find the corresponding
-/// differential operator used in the AST. If no differential operator is found,
-/// return nullptr.
-static AutoDiffFunctionExpr *findDifferentialOperator(
-    AutoDiffFunctionInst *inst) {
-  return inst->getLoc().getAsASTNode<AutoDiffFunctionExpr>();
-}
-
 /// The automatic differentiation pass.
 namespace {
 class Differentiation : public SILModuleTransform {
@@ -5794,13 +5804,10 @@ SILValue ADContext::promoteToDifferentiableFunction(
     auto assocFnAndIndices = emitAssociatedFunctionReference(
         *this, builder, /*parentTask*/ nullptr, desiredIndices, assocFnKind,
         origFnOperand, invoker, [](DifferentiationTask *newTask) {});
-    if (!assocFnAndIndices) {
-      // Show an error at the operator, highlight the argument, and show a note
-      // at the definition site of the argument.
-      auto loc = invoker.getLocation();
-      diagnose(loc, diag::autodiff_function_not_differentiable).highlight(loc);
+    // If `emitAssociatedFunctionReference` fails, it produces a diagnostic.
+    // Return nullptr.
+    if (!assocFnAndIndices)
       return nullptr;
-    }
     assert(assocFnAndIndices->second == desiredIndices &&
            "FIXME: We could emit a thunk that converts the VJP to have the "
            "desired indices.");

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -4,9 +4,9 @@
 // Top-level (before primal/adjoint synthesis)
 //===----------------------------------------------------------------------===//
 
-// expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
+// expected-note @+2 {{opaque non-'@differentiable' function is not differentiable}}
+// expected-error @+1 {{expression is not differentiable}}
 func foo(_ f: (Float) -> Float) -> Float {
-  // expected-error @+1 {{function is not differentiable}}
   return gradient(at: 0, in: f)
 }
 
@@ -74,7 +74,7 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
 func uses_optionals(_ x: Float) -> Float {
   var maybe: Float? = 10
   maybe = x
-  // xpected-note @+1 {{differentiating control flow is not supported yet}}
+  // xpected-note @+1 {{differentiating control flow is not yet supported}}
   return maybe!
 }
 
@@ -187,15 +187,15 @@ class Foo {
 }
 
 // Nested call case.
-@differentiable // expected-error 2 {{function is not differentiable}}
-// expected-note @+1 2 {{when differentiating this function definition}}
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
 func triesToDifferentiateClassMethod(x: Float) -> Float {
-  // expected-note @+2 {{expression is not differentiable}}
-  // expected-note @+1 {{differentiating class members is not supported yet}}
+  // expected-note @+1 {{differentiating class members is not yet supported}}
   return Foo().class_method(x)
 }
 
-// expected-error @+2 {{function is not differentiable}}
+// expected-error @+2 {{expression is not differentiable}}
 // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
 _ = gradient(at: .zero, in: Foo().class_method)
 
@@ -206,16 +206,15 @@ _ = gradient(at: .zero, in: Foo().class_method)
 // expected-error @+1 {{function is not differentiable}}
 let no_return: @differentiable (Float) -> Float = { x in
   let _ = x + 1
-// expected-note @+2 {{missing return for differentiation}}
-// expected-error @+1 {{missing return in a closure expected to return 'Float'}}
+// expected-error @+2 {{missing return in a closure expected to return 'Float'}}
+// expected-note @+1 {{missing return for differentiation}}
 }
 
-// expected-error @+1 2 {{function is not differentiable}}
+// expected-error @+1 {{function is not differentiable}}
 @differentiable
-// expected-note @+1 2 {{when differentiating this function definition}}
+// expected-note @+1 {{when differentiating this function definition}}
 func roundingGivesError(x: Float) -> Float {
-  // expected-note @+2 {{cannot differentiate through a non-differentiable result; do you want to add '.withoutDerivative()'?}}
-  // expected-note @+1 {{expression is not differentiable}}
+  // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to add '.withoutDerivative()'?}}
   return Float(Int(x))
 }
 
@@ -260,7 +259,6 @@ func nonVariedResult(_ x: Float) -> Float {
 //===----------------------------------------------------------------------===//
 
 func nondiff(_ f: @differentiable (Float, @nondiff Float) -> Float) -> Float {
-  // expected-note @+3 {{expression is not differentiable}}
   // expected-note @+2 {{cannot differentiate with respect to a '@nondiff' parameter}}
   // expected-error @+1 {{function is not differentiable}}
   return gradient(at: 2) { x in f(x * x, x) }

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -4,13 +4,11 @@
 // due to direct differentiation of reabstraction thunks, which emits errors
 // with unknown location.
 
-// expected-error @+1 2 {{function is not differentiable}}
-@differentiable()
-// expected-note @+2 {{when differentiating this function definition}}
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
 // expected-note @+1 {{when differentiating this function definition}}
 func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
-  // expected-note @+2 {{member is not differentiable because the corresponding protocol requirement is not '@differentiable'}}
-  // expected-note @+1 {{expression is not differentiable}}
+  // expected-note @+1 {{member is not differentiable because the corresponding protocol requirement is not '@differentiable'}}
   return x + 1
 }
 _ = gradient(at: 1.0, in: generic) // expected-error {{function is not differentiable}}


### PR DESCRIPTION
* Ensure that `emitNondifferentiabilityError` always produces an error and note.
* Ensure that diagnostics are not emitted twice.
  * `emitNondifferentiabilityError` emits diagnostics and callers should not.

---

This PR subsumes https://github.com/apple/swift/pull/23374, which additionally removed the `FunctionConversion` `DifferentiationInvoker` kind, merging it into the `AutoDiffFunctionInst` invoker kind. However, https://github.com/apple/swift/pull/23374 had some non-deterministic test failures.

Todo: re-attempt to remove the `FunctionConversion` invoker kind.