### PR TITLE
Fix validation-test/SIL/verify_all_overlays.py on macOS.

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# TODO(TF-491): reenable
+# TODO(TF-491): Re-enable.
 # RUN: echo "disabled"
 # UN: ${python} %s %target-swiftmodule-name %platform-sdk-overlay-dir \
 # UN:     %target-sil-opt -sdk %sdk -enable-sil-verify-all \
@@ -9,7 +9,8 @@
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test
 
-# XFAIL: OS=macosx
+# TODO(TF-491): Re-enable XFAIL.
+# XFAI: OS=macosx
 # https://bugs.swift.org/browse/SR-9847
 
 from __future__ import print_function


### PR DESCRIPTION
This test was originally XFAIL on macOS, but now passes since it's been disabled.
Re-enable XFAIL as part of [TF-491](https://bugs.swift.org/projects/TF/issues/TF-491).