### PR TITLE
Revert "Enable ExistentialSpecializer by default"

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -51,7 +51,7 @@ public:
   bool RemoveRuntimeAsserts = false;
 
   /// Enable existential specializer optimization.
-  bool ExistentialSpecializer = true;
+  bool ExistentialSpecializer = false;
 
   /// Controls whether the SIL ARC optimizations are run.
   bool EnableARCOptimizations = true;


### PR DESCRIPTION
Reverts apple/swift#19820

Unfortunately the existential specializer causes leaks: See https://bugs.swift.org/browse/SR-10649

rdar://problem/50595630