### PR TITLE
[5.1] Use the Swift runtime's (faster) class check in the stdlib instead of shimming object_getClass()

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -318,6 +318,11 @@ func _uncheckedUnsafeAssume(_ condition: Bool) {
 @usableFromInline
 @_silgen_name("_swift_objcClassUsesNativeSwiftReferenceCounting")
 internal func _usesNativeSwiftReferenceCounting(_ theClass: AnyClass) -> Bool
+
+/// Returns the class of a non-tagged-pointer Objective-C object
+@_effects(readonly)
+@_silgen_name("_swift_classOfObjCHeapObject")
+internal func _swift_classOfObjCHeapObject(_ object: AnyObject) -> AnyClass
 #else
 @inlinable
 @inline(__always)

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -125,11 +125,6 @@ private var kCFStringEncodingUTF8 : _swift_shims_CFStringEncoding {
   @inline(__always) get { return 0x8000100 }
 }
 
-@_effects(readonly)
-private func _unsafeAddressOfCocoaStringClass(_ str: _CocoaString) -> UInt {
-  return _swift_stdlib_unsafeAddressOfClass(str)
-}
-
 internal enum _KnownCocoaString {
   case storage
   case shared
@@ -148,7 +143,7 @@ internal enum _KnownCocoaString {
     }
 #endif
     
-    switch _unsafeAddressOfCocoaStringClass(str) {
+    switch unsafeBitCast(_swift_classOfObjCHeapObject(str), to: UInt.self) {
     case unsafeBitCast(__StringStorage.self, to: UInt.self):
       self = .storage
     case unsafeBitCast(__SharedStringStorage.self, to: UInt.self):

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -178,6 +178,11 @@ static SwiftObject *_allocHelper(Class cls) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+Class _swift_classOfObjCHeapObject(OpaqueValue *value) {
+  return _swift_getObjCClassOfAllocated(value);
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 NSString *swift_stdlib_getDescription(OpaqueValue *value,
                                       const Metadata *type);
 


### PR DESCRIPTION
Cherry-picking this speedup to 5.1 from #23732