### PR TITLE
[5.1] SR-10555 foreignCopyUTF8 should do bulk access

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -69,6 +69,27 @@ internal func _cocoaStringSubscript(
   return _swift_stdlib_CFStringGetCharacterAtIndex(cfSelf, position)
 }
 
+@_effects(releasenone)
+internal func _cocoaStringCopyUTF8(
+  _ target: _CocoaString,
+  into bufPtr: UnsafeMutableBufferPointer<UInt8>
+) -> Int? {
+  let ptr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
+  let len = _stdlib_binary_CFStringGetLength(target)
+  var count = 0
+  let converted = _swift_stdlib_CFStringGetBytes(
+    target,
+    _swift_shims_CFRange(location: 0, length: len),
+    kCFStringEncodingUTF8,
+    0,
+    0,
+    ptr,
+    bufPtr.count,
+    &count
+  )
+  return len == converted ? count : nil
+}
+
 @_effects(readonly)
 internal func _cocoaStringCompare(
   _ string: _CocoaString, _ other: _CocoaString

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -246,16 +246,12 @@ extension _StringGuts {
   internal func _foreignCopyUTF8(
     into mbp: UnsafeMutableBufferPointer<UInt8>
   ) -> Int? {
-    var ptr = mbp.baseAddress._unsafelyUnwrappedUnchecked
-    var numWritten = 0
-    for cu in String(self).utf8 {
-      guard numWritten < mbp.count else { return nil }
-      ptr.initialize(to: cu)
-      ptr += 1
-      numWritten += 1
-    }
-
-    return numWritten
+    #if _runtime(_ObjC)
+    // Currently, foreign  means NSString
+    return _cocoaStringCopyUTF8(_object.cocoaObject, into: mbp)
+    #else
+    fatalError("No foreign strings on Linux in this version of Swift")
+    #endif
   }
 
   @inline(__always)


### PR DESCRIPTION
Cherry picking this to 5.1, ~2.5x speedup for foreign strings

Fixes rdar://50220164