### PR TITLE
[5.1] Avoid the overhead of looking up the current CFAllocator in String bridging

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -80,7 +80,7 @@ _swift_shims_CFIndex _swift_stdlib_CFStringGetLength(
 SWIFT_RUNTIME_STDLIB_API
 __attribute__((ns_returns_retained))
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateWithSubstring(
-    _swift_shims_CFAllocatorRef _Nullable alloc,
+    const void * _Nullable unused,
     _swift_shims_CFStringRef _Nonnull str, _swift_shims_CFRange range);
 
 SWIFT_RUNTIME_STDLIB_API
@@ -90,13 +90,13 @@ _swift_shims_UniChar _swift_stdlib_CFStringGetCharacterAtIndex(
 SWIFT_RUNTIME_STDLIB_API
 __attribute__((ns_returns_retained))
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateCopy(
-    _swift_shims_CFAllocatorRef _Nullable alloc,
+    const void * _Nullable unused,
     _swift_shims_CFStringRef _Nonnull theString);
 
 SWIFT_RUNTIME_STDLIB_API
 __attribute__((ns_returns_retained))
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateWithBytes(
-    _swift_shims_CFAllocatorRef _Nullable alloc,
+    const void * _Nullable unused,
     const __swift_uint8_t *_Nonnull bytes, _swift_shims_CFIndex numBytes,
     _swift_shims_CFStringEncoding encoding,
     _swift_shims_Boolean isExternalRepresentation);

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -77,10 +77,13 @@ swift::_swift_stdlib_CFStringGetLength(_swift_shims_CFStringRef theString) {
 
 _swift_shims_CFStringRef
 swift::_swift_stdlib_CFStringCreateWithSubstring(
-                                         _swift_shims_CFAllocatorRef alloc,
+                                         const void *unused,
                                          _swift_shims_CFStringRef str,
                                          _swift_shims_CFRange range) {
-  return cast(CFStringCreateWithSubstring(cast(alloc), cast(str), cast(range)));
+  assert(unused == NULL);
+  return cast(CFStringCreateWithSubstring(kCFAllocatorSystemDefault,
+                                          cast(str),
+                                          cast(range)));
 }
 
 _swift_shims_CFComparisonResult
@@ -108,17 +111,19 @@ swift::_swift_stdlib_CFStringGetCharacterAtIndex(_swift_shims_CFStringRef theStr
 }
 
 _swift_shims_CFStringRef
-swift::_swift_stdlib_CFStringCreateCopy(_swift_shims_CFAllocatorRef alloc,
+swift::_swift_stdlib_CFStringCreateCopy(const void *unused,
                                         _swift_shims_CFStringRef theString) {
-  return cast(CFStringCreateCopy(cast(alloc), cast(theString)));
+  assert(unused == NULL);
+  return cast(CFStringCreateCopy(kCFAllocatorSystemDefault, cast(theString)));
 }
 
 _swift_shims_CFStringRef
 swift::_swift_stdlib_CFStringCreateWithBytes(
-    _swift_shims_CFAllocatorRef _Nullable alloc, const uint8_t *bytes,
+    const void *unused, const uint8_t *bytes,
     _swift_shims_CFIndex numBytes, _swift_shims_CFStringEncoding encoding,
     _swift_shims_Boolean isExternalRepresentation) {
-  return cast(CFStringCreateWithBytes(cast(alloc), bytes, numBytes,
+  assert(unused == NULL);
+  return cast(CFStringCreateWithBytes(kCFAllocatorSystemDefault, bytes, numBytes,
                                       cast(encoding),
                                       isExternalRepresentation));
 }


### PR DESCRIPTION
Cherry pick