### PR TITLE
[5.1] Drop @inline(__always) from Accelerate overlay

### DIFF
--- a/stdlib/public/Darwin/Accelerate/AccelerateBuffer.swift
+++ b/stdlib/public/Darwin/Accelerate/AccelerateBuffer.swift
@@ -26,7 +26,7 @@ public protocol AccelerateBuffer {
     /// Calls a closure with a pointer to the object's contiguous storage.
     func withUnsafeBufferPointer<R>(
         _ body: (UnsafeBufferPointer<Element>) throws -> R
-        ) rethrows -> R
+    ) rethrows -> R
 }
 
 /// A mutable object composed of count elements that are stored contiguously
@@ -40,23 +40,25 @@ public protocol AccelerateMutableBuffer: AccelerateBuffer {
     /// contiguous storage.
     mutating func withUnsafeMutableBufferPointer<R>(
         _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-        ) rethrows -> R
+    ) rethrows -> R
 }
 
 @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 public extension AccelerateBuffer where Self: Collection {
+    @inlinable
     func withUnsafeBufferPointer<R>(
         _ body: (UnsafeBufferPointer<Element>) throws -> R
-        ) rethrows -> R {
+    ) rethrows -> R {
         return try withContiguousStorageIfAvailable(body)!
     }
 }
 
 @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
 extension AccelerateMutableBuffer where Self: MutableCollection {
+    @inlinable
     public mutating func withUnsafeMutableBufferPointer<R>(
         _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-        ) rethrows -> R {
+    ) rethrows -> R {
         return try withContiguousMutableStorageIfAvailable(body)!
     }
 }

--- a/stdlib/public/Darwin/Accelerate/vDSP_Arithmetic.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Arithmetic.swift
@@ -22,7 +22,7 @@ extension vDSP {
     /// - Parameter scalar: the `b` in `c[i] = a[i] + b`.
     /// - Parameter vector: the `a` in `c[i] = a[i] + b`.
     /// - Returns: The `c` in `c[i] = a[i] + b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U>(_ scalar: Float,
                               _ vector: U) -> [Float]
@@ -49,7 +49,7 @@ extension vDSP {
     /// - Parameter scalar: the `b` in `c[i] = a[i] + b`.
     /// - Parameter vector: the `a` in `c[i] = a[i] + b`.
     /// - Parameter result: The `c` in `c[i] = a[i] + b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U, V>(_ scalar: Float,
                                  _ vector: U,
@@ -79,7 +79,7 @@ extension vDSP {
     /// - Parameter scalar: the `b` in `c[i] = a[i] + b`.
     /// - Parameter vector: the `a` in `c[i] = a[i] + b`.
     /// - Returns: The `c` in `c[i] = a[i] + b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U>(_ scalar: Double,
                               _ vector: U) -> [Double]
@@ -106,7 +106,7 @@ extension vDSP {
     /// - Parameter scalar: the `b` in `c[i] = a[i] + b`.
     /// - Parameter vector: the `a` in `c[i] = a[i] + b`.
     /// - Parameter result: The `c` in `c[i] = a[i] + b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U, V>(_ scalar: Double,
                                  _ vector: U,
@@ -138,7 +138,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] + b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] + b[i]`.
     /// - Returns: The `c` in `c[i] = a[i] + b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(_ vectorA: T,
                                  _ vectorB: U) -> [Float]
@@ -166,7 +166,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] + b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] + b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] + b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(_ vectorA: T,
                                     _ vectorB: U,
@@ -198,7 +198,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] + b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] + b[i]`.
     /// - Returns: The `c` in `c[i] = a[i] + b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(_ vectorA: T,
                                  _ vectorB: U) -> [Double]
@@ -226,7 +226,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] + b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] + b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] + b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(_ vectorA: T,
                                     _ vectorB: U,
@@ -260,7 +260,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] - b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] - b[i]`.
     /// - Returns: The `c` in `c[i] = a[i] - b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U>(_ vectorA: U,
                                       _ vectorB: T) -> [Float]
@@ -288,7 +288,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] - b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] - b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] - b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U, V>(_ vectorA: U,
                                          _ vectorB: T,
@@ -320,7 +320,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] - b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] - b[i]`.
     /// - Returns: The `c` in `c[i] = a[i] - b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U>(_ vectorA: U,
                                       _ vectorB: T) -> [Double]
@@ -348,7 +348,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] - b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] - b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] - b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U, V>(_ vectorA: U,
                                          _ vectorB: T,
@@ -382,7 +382,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] * b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] * b`.
     /// - Returns: The `c` in `c[i] = a[i] * b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<U>(_ scalar: Float,
                                    _ vector: U) -> [Float]
@@ -409,7 +409,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] * b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] * b`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<U, V>(_ scalar: Float,
                                       _ vector: U,
@@ -439,7 +439,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] * b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] * b`.
     /// - Returns: The `c` in `c[i] = a[i] * b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<U>(_ scalar: Double,
                                    _ vector: U) -> [Double]
@@ -466,7 +466,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] * b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] * b`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<U, V>(_ scalar: Double,
                                       _ vector: U,
@@ -498,7 +498,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] * b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] * b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U>(_ vectorA: T,
                                       _ vectorB: U) -> [Float]
@@ -526,7 +526,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] * b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] * b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U, V>(_ vectorA: T,
                                          _ vectorB: U,
@@ -557,7 +557,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] * b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] * b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U>(_ vectorA: T,
                                       _ vectorB: U) -> [Double]
@@ -585,7 +585,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] * b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] * b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U, V>(_ vectorA: T,
                                          _ vectorB: U,
@@ -618,7 +618,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] / b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] / b`.
     /// - Returns: The `c` in `c[i] = a[i] / b`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U>(_ vector: U,
                                  _ scalar: Float) -> [Float]
@@ -645,7 +645,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] / b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] / b`.
     /// - Parameter result: The `c` in `c[i] = a[i] / b`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U, V>(_ vector: U,
                                     _ scalar: Float,
@@ -675,7 +675,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] / b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] / b`.
     /// - Returns: The `c` in `c[i] = a[i] / b`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U>(_ vector: U,
                                  _ scalar: Double) -> [Double]
@@ -702,7 +702,7 @@ extension vDSP {
     /// - Parameter vector: the `a` in `c[i] = a[i] / b`.
     /// - Parameter scalar: the `b` in `c[i] = a[i] / b`.
     /// - Parameter result: The `c` in `c[i] = a[i] / b`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U, V>(_ vector: U,
                                     _ scalar: Double,
@@ -734,7 +734,7 @@ extension vDSP {
     /// - Parameter scalar: the `a` in `c[i] = a / b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a / b[i]`.
     /// - Returns: The `c` in `c[i] = a / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U>(_ scalar: Float,
                                  _ vector: U) -> [Float]
@@ -761,7 +761,7 @@ extension vDSP {
     /// - Parameter scalar: the `a` in `c[i] = a / b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a / b[i]`.
     /// - Parameter result: The `c` in `c[i] = a / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U, V>(_ scalar: Float,
                                     _ vector: U,
@@ -791,7 +791,7 @@ extension vDSP {
     /// - Parameter scalar: the `a` in `c[i] = a / b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a / b[i]`.
     /// - Returns: The `c` in `c[i] = a / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U>(_ scalar: Double,
                                  _ vector: U) -> [Double]
@@ -818,7 +818,7 @@ extension vDSP {
     /// - Parameter scalar: the `a` in `c[i] = a / b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a / b[i]`.
     /// - Parameter result: The `c` in `c[i] = a / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U, V>(_ scalar: Double,
                                     _ vector: U,
@@ -850,7 +850,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] / b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] / b[i]`.
     /// - Returns: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<T, U>(_ vectorA: T,
                                     _ vectorB: U) -> [Float]
@@ -878,7 +878,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] / b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] / b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<T, U, V>(_ vectorA: T,
                                        _ vectorB: U,
@@ -909,7 +909,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] / b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] / b[i]`.
     /// - Returns: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<T, U>(_ vectorA: T,
                                     _ vectorB: U) -> [Double]
@@ -937,7 +937,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] / b[i]`.
     /// - Parameter vectorB: the `b` in `c[i] = a[i] / b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<T, U, V>(_ vectorA: T,
                                        _ vectorB: U,
@@ -971,7 +971,7 @@ extension vDSP {
     /// - Parameter vectorB: the `i0` in o0[i] = i1[i] + i0[i]; o1[i] = i1[i] - i0[i]`.
     /// - Parameter addResult: The `o0` in o0[i] = i1[i] + i0[i]; o1[i] = i1[i] - i0[i]`.
     /// - Parameter subtractResult: The `o1` in o0[i] = i1[i] + i0[i]; o1[i] = i1[i] - i0[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func addSubtract<S, T, U, V>(_ vectorA: S,
                                                _ vectorB: T,
@@ -1012,7 +1012,7 @@ extension vDSP {
     /// - Parameter vectorB: the `i0` in o0[i] = i1[i] + i0[i]; o1[i] = i1[i] - i0[i]`.
     /// - Parameter addResult: The `o0` in o0[i] = i1[i] + i0[i]; o1[i] = i1[i] - i0[i]`.
     /// - Parameter subtractResult: The `o1` in o0[i] = i1[i] + i0[i]; o1[i] = i1[i] - i0[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func addSubtract<S, T, U, V>(_ vectorA: S,
                                                _ vectorB: T,
@@ -1054,7 +1054,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] + b[i]) * c`.
     /// - Returns: The `d` in `d[i] = `(a[i] + b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U>(addition: (a: T, b: U),
                                       _ scalar: Float) -> [Float]
@@ -1082,7 +1082,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] + b[i]) * c`.
     /// - Parameter result: The `d` in `d[i] = `(a[i] + b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U, V>(addition: (a: T, b: U),
                                          _ scalar: Float,
@@ -1118,7 +1118,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] + b[i]) * c`.
     /// - Returns: The `d` in `d[i] = `(a[i] + b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U>(addition: (a: T, b: U),
                                       _ scalar: Double) -> [Double]
@@ -1146,7 +1146,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] + b[i]) * c`.
     /// - Parameter result: The `d` in `d[i] = `(a[i] + b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U, V>(addition: (a: T, b: U),
                                          _ scalar: Double,
@@ -1184,7 +1184,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Returns: The `d` in `d[i] = (a[i] + b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U>(addition: (a: S, b: T),
                                          _ vector: U) -> [Float]
@@ -1214,7 +1214,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Parameter result: The `d` in `d[i] = (a[i] + b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U, V>(addition: (a: S, b: T),
                                             _ vector: U,
@@ -1252,7 +1252,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Returns: The `d` in `d[i] = (a[i] + b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U>(addition: (a: S, b: T),
                                          _ vector: U) -> [Double]
@@ -1282,7 +1282,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] + b[i]) * c[i]`.
     /// - Parameter result: The `d` in `d[i] = (a[i] + b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U, V>(addition: (a: S, b: T),
                                             _ vector: U,
@@ -1322,7 +1322,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] - b[i]) * c`.
     /// - Returns: The `d` in `d[i] = `(a[i] - b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U>(subtraction: (a: T, b: U),
                                       _ scalar: Float) -> [Float]
@@ -1350,7 +1350,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] - b[i]) * c`.
     /// - Parameter result: The `d` in `d[i] = `(a[i] - b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U, V>(subtraction: (a: T, b: U),
                                          _ scalar: Float,
@@ -1386,7 +1386,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] - b[i]) * c`.
     /// - Returns: The `d` in `d[i] = `(a[i] - b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U>(subtraction: (a: T, b: U),
                                       _ scalar: Double) -> [Double]
@@ -1414,7 +1414,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c`.
     /// - Parameter scalar: the `c` in `d[i] = `(a[i] - b[i]) * c`.
     /// - Parameter result: The `d` in `d[i] = `(a[i] - b[i]) * c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<T, U, V>(subtraction: (a: T, b: U),
                                          _ scalar: Double,
@@ -1452,7 +1452,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = `(a[i] - b[i]) * c[i]`.
     /// - Returns: The `d` in `d[i] = `(a[i] - b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U>(subtraction: (a: S, b: T),
                                          _ vector: U) -> [Float]
@@ -1482,7 +1482,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = `(a[i] - b[i]) * c[i]`.
     /// - Parameter result: The `d` in `d[i] = `(a[i] - b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U, V>(subtraction: (a: S, b: T),
                                             _ vector: U,
@@ -1520,7 +1520,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = `(a[i] - b[i]) * c[i]`.
     /// - Returns: The `d` in `d[i] = `(a[i] - b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U>(subtraction: (a: S, b: T),
                                          _ vector: U) -> [Double]
@@ -1550,7 +1550,7 @@ extension vDSP {
     /// - Parameter subtraction: the `a` and `b` in `d[i] = (a[i] - b[i]) * c[i]`.
     /// - Parameter vector: the `c` in `d[i] = `(a[i] - b[i]) * c[i]`.
     /// - Parameter result: The `d` in `d[i] = `(a[i] - b[i]) * c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U, V>(subtraction: (a: S, b: T),
                                             _ vector: U,
@@ -1591,7 +1591,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = a[i]*b[i] + c`.
     /// - Parameter scalar: the `c` in `d[i] = a[i]*b[i] + c`.
     /// - Returns: the `d` in `d[i] = a[i]*b[i] + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(multiplication: (a: T, b: U),
                                  _ scalar: Float) -> [Float]
@@ -1620,7 +1620,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = a[i]*b[i] + c`.
     /// - Parameter scalar: the `c` in `d[i] = a[i]*b[i] + c`.
     /// - Parameter result: the `d` in `d[i] = a[i]*b[i] + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(multiplication: (a: T, b: U),
                                     _ scalar: Float,
@@ -1657,7 +1657,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = a[i]*b[i] + c`.
     /// - Parameter scalar: the `c` in `d[i] = a[i]*b[i] + c`.
     /// - Returns: the `d` in `d[i] = a[i]*b[i] + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(multiplication: (a: T, b: U),
                                  _ scalar: Double) -> [Double]
@@ -1686,7 +1686,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = a[i]*b[i] + c`.
     /// - Parameter scalar: the `c` in `d[i] = a[i]*b[i] + c`.
     /// - Parameter result: the `d` in `d[i] = a[i]*b[i] + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(multiplication: (a: T, b: U),
                                     _ scalar: Double,
@@ -1725,7 +1725,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b) + c[i]`.
     /// - Returns: the `d` in `d[i] = (a[i] * b) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(multiplication: (a: T, b: Float),
                                  _ vector: U) -> [Float]
@@ -1754,7 +1754,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b) + c[i]`.
     /// - Parameter result: the `d` in `d[i] = (a[i] * b) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(multiplication: (a: T, b: Float),
                                     _ vector: U,
@@ -1790,7 +1790,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b) + c[i]`.
     /// - Returns: the `d` in `d[i] = (a[i] * b) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(multiplication: (a: T, b: Double),
                                  _ vector: U) -> [Double]
@@ -1819,7 +1819,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b) + c[i]`.
     /// - Parameter result: the `d` in `d[i] = (a[i] * b) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(multiplication: (a: T, b: Double),
                                     _ vector: U,
@@ -1857,7 +1857,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Returns: the `d` in `d[i] = (a[i] * b[i]) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<S, T, U>(multiplication: (a: S, b: T),
                                     _ vector: U) -> [Float]
@@ -1888,7 +1888,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Parameter result: the `d` in `d[i] = (a[i] * b[i]) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<S, T, U, V>(multiplication: (a: S, b: T),
                                        _ vector: U,
@@ -1927,7 +1927,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Returns: the `d` in `d[i] = (a[i] * b[i]) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<S, T, U>(multiplication: (a: S, b: T),
                                     _ vector: U) -> [Double]
@@ -1958,7 +1958,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) + c[i]`.
     /// - Parameter result: the `d` in `d[i] = (a[i] * b[i]) + c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<S, T, U, V>(multiplication: (a: S, b: T),
                                        _ vector: U,
@@ -1999,7 +1999,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Returns: the `d` in `d[i] = (a[i] * b[i]) - c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<S, T, U>(multiplication: (a: T, b: U),
                                          _ vector: S) -> [Float]
@@ -2030,7 +2030,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Parameter result: the `d` in `d[i] = (a[i] * b[i]) - c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<S, T, U, V>(multiplication: (a: T, b: U),
                                             _ vector: S,
@@ -2069,7 +2069,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Returns: the `d` in `d[i] = (a[i] * b[i]) - c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<S, T, U>(multiplication: (a: T, b: U),
                                          _ vector: S) -> [Double]
@@ -2100,7 +2100,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Parameter vector: the `c` in `d[i] = (a[i] * b[i]) - c[i]`.
     /// - Parameter result: the `d` in `d[i] = (a[i] * b[i]) - c[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<S, T, U, V>(multiplication: (a: T, b: U),
                                             _ vector: S,
@@ -2140,7 +2140,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Returns: the `e` in `e[i] = (a[i] * b) + (c[i] * d)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(multiplication multiplicationAB: (a: T, b: Float),
                                  multiplication multiplicationCD: (c: U, d: Float)) -> [Float]
@@ -2168,7 +2168,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Parameter result: the `e` in `e[i] = (a[i] * b) + (c[i] * d)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(multiplication multiplicationAB: (a: T, b: Float),
                                     multiplication multiplicationCD: (c: U, d: Float),
@@ -2207,7 +2207,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Returns: the `e` in `e[i] = (a[i] * b) + (c[i] * d)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U>(multiplication multiplicationAB: (a: T, b: Double),
                                  multiplication multiplicationCD: (c: U, d: Double)) -> [Double]
@@ -2235,7 +2235,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b) + (c[i] * d)`.
     /// - Parameter result: the `e` in `e[i] = (a[i] * b) + (c[i] * d)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<T, U, V>(multiplication multiplicationAB: (a: T, b: Double),
                                     multiplication multiplicationCD: (c: U, d: Double),
@@ -2276,7 +2276,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<R, S, T, U>(multiplication multiplicationAB: (a: R, b: S),
                                        multiplication multiplicationCD: (c: T, d: U)) -> [Float]
@@ -2308,7 +2308,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<R, S, T, U, V>(multiplication multiplicationAB: (a: R, b: S),
                                           multiplication multiplicationCD: (c: T, d: U),
@@ -2353,7 +2353,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<R, S, T, U>(multiplication multiplicationAB: (a: R, b: S),
                                        multiplication multiplicationCD: (c: T, d: U)) -> [Double]
@@ -2385,7 +2385,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] * b[i]) + (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<R, S, T, U, V>(multiplication multiplicationAB: (a: R, b: S),
                                           multiplication multiplicationCD: (c: T, d: U),
@@ -2432,7 +2432,7 @@ extension vDSP {
     /// - Parameter additionAB: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Parameter additionCD: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U>(addition additionAB: (a: S, b: T),
                                          addition additionCD: (c: U, d: U)) -> [Float]
@@ -2462,7 +2462,7 @@ extension vDSP {
     /// - Parameter additionAB: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Parameter additionCD: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U, V>(addition additionAB: (a: S, b: T),
                                             addition additionCD: (c: U, d: U),
@@ -2505,7 +2505,7 @@ extension vDSP {
     /// - Parameter additionAB: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Parameter additionCD: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U>(addition additionAB: (a: S, b: T),
                                          addition additionCD: (c: U, d: U)) -> [Double]
@@ -2535,7 +2535,7 @@ extension vDSP {
     /// - Parameter additionAB: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Parameter additionCD: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] + b[i]) * (c[i] + d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<S, T, U, V>(addition additionAB: (a: S, b: T),
                                             addition additionCD: (c: U, d: U),
@@ -2580,7 +2580,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<R, S, T, U>(multiplication multiplicationAB: (a: T, b: U),
                                             multiplication multiplicationCD: (c: R, d: S)) -> [Float]
@@ -2612,7 +2612,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<R, S, T, U, V>(multiplication multiplicationAB: (a: T, b: U),
                                                multiplication multiplicationCD: (c: R, d: S),
@@ -2657,7 +2657,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<R, S, T, U>(multiplication multiplicationAB: (a: T, b: U),
                                             multiplication multiplicationCD: (c: R, d: S)) -> [Double]
@@ -2689,7 +2689,7 @@ extension vDSP {
     /// - Parameter multiplicationAB: the `a` and `b` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Parameter multiplicationCD: the `c` and `d` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] * b[i]) - (c[i] * d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<R, S, T, U, V>(multiplication multiplicationAB: (a: T, b: U),
                                                multiplication multiplicationCD: (c: R, d: S),
@@ -2736,7 +2736,7 @@ extension vDSP {
     /// - Parameter subtractionAB: the `a` and `b` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Parameter subtractionCD: the `c` and `d` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U>(subtraction subtractionAB: (a: R, b: S),
                                             subtraction subtractionCD: (c: T, d: U)) -> [Float]
@@ -2768,7 +2768,7 @@ extension vDSP {
     /// - Parameter subtractionAB: the `a` and `b` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Parameter subtractionCD: the `c` and `d` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U, V>(subtraction subtractionAB: (a: R, b: S),
                                                subtraction subtractionCD: (c: T, d: U),
@@ -2813,7 +2813,7 @@ extension vDSP {
     /// - Parameter subtractionAB: the `a` and `b` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Parameter subtractionCD: the `c` and `d` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U>(subtraction subtractionAB: (a: R, b: S),
                                             subtraction subtractionCD: (c: T, d: U)) -> [Double]
@@ -2845,7 +2845,7 @@ extension vDSP {
     /// - Parameter subtractionAB: the `a` and `b` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Parameter subtractionCD: the `c` and `d` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] - b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U, V>(subtraction subtractionAB: (a: R, b: S),
                                                subtraction subtractionCD: (c: T, d: U),
@@ -2892,7 +2892,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Parameter subtraction: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U>(addition: (a: R, b: S),
                                             subtraction: (c: T, d: U)) -> [Float]
@@ -2924,7 +2924,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Parameter subtraction: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U, V>(addition: (a: R, b: S),
                                                subtraction: (c: T, d: U),
@@ -2969,7 +2969,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Parameter subtraction: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Returns: the `e` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U>(addition: (a: R, b: S),
                                             subtraction: (c: T, d: U)) -> [Double]
@@ -3001,7 +3001,7 @@ extension vDSP {
     /// - Parameter addition: the `a` and `b` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Parameter subtraction: the `c` and `d` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
     /// - Parameter result: the `e` in `e[i] = (a[i] + b[i]) * (c[i] - d[i])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<R, S, T, U, V>(addition: (a: R, b: S),
                                                subtraction: (c: T, d: U),
@@ -3048,7 +3048,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[n] = a[n]*b + c`.
     /// - Parameter scalar: the `c` in `d[n] = a[n]*b + c`.
     /// - Returns: the `e` in `d[n] = a[n]*b + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U>(multiplication: (a: U, b: Float),
                               _ scalar: Float) -> [Float]
@@ -3075,7 +3075,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[n] = a[n]*b + c`.
     /// - Parameter scalar: the `c` in `d[n] = a[n]*b + c`.
     /// - Parameter result: the `e` in `d[n] = a[n]*b + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U, V>(multiplication: (a: U, b: Float),
                                  _ scalar: Float,
@@ -3108,7 +3108,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[n] = a[n]*b + c`.
     /// - Parameter scalar: the `c` in `d[n] = a[n]*b + c`.
     /// - Returns: the `e` in `d[n] = a[n]*b + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U>(multiplication: (a: U, b: Double),
                               _ scalar: Double) -> [Double]
@@ -3135,7 +3135,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `d[n] = a[n]*b + c`.
     /// - Parameter scalar: the `c`in `d[n] = a[n]*b + c`.
     /// - Parameter result: the `e` in `d[n] = a[n]*b + c`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add<U, V>(multiplication: (a: U, b: Double),
                                  _ scalar: Double,
@@ -3171,7 +3171,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `D[n] = A[n]*B - C[n]`.
     /// - Parameter vector: the `c` in `D[n] = A[n]*B - C[n]`.
     /// - Returns: the `d` in `D[n] = A[n]*B - C[n]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U>(multiplication: (a: U, b: Float),
                                       _ vector: T) -> [Float]
@@ -3201,7 +3201,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `D[n] = A[n]*B - C[n]`.
     /// - Parameter vector: the `c` in `D[n] = A[n]*B - C[n]`.
     /// - Parameter result: the `d` in `D[n] = A[n]*B - C[n]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U, V>(multiplication: (a: U, b: Float),
                                          _ vector: T,
@@ -3239,7 +3239,7 @@ extension vDSP {
     /// - Parameter multiplication: the `a` and `b` in `D[n] = A[n]*B - C[n]`.
     /// - Parameter vector: the `c` in `D[n] = A[n]*B - C[n]`.
     /// - Returns: the `d` in `D[n] = A[n]*B - C[n]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U>(multiplication: (a: U, b: Double),
                                       _ vector: T) -> [Double]
@@ -3269,7 +3269,7 @@ extension vDSP {
     /// - Parameter vector: the `c` in `D[n] = A[n]*B - C[n]`.
     /// - Parameter multiplication: the `a` and `b` in `D[n] = A[n]*B - C[n]`.
     /// - Parameter result: the `d` in `D[n] = A[n]*B - C[n]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract<T, U, V>(multiplication: (a: U, b: Double),
                                          _ vector: T,

--- a/stdlib/public/Darwin/Accelerate/vDSP_Biquad.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Biquad.swift
@@ -163,7 +163,7 @@ extension vDSP {
     struct BiquadFunctions {
         
         @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-        @inline(__always)
+        @inlinable
         static func applyBiquadSingle<U, V, Scalar>(source: U,
                                                     destination: inout V,
                                                     delays: inout [Scalar],
@@ -186,7 +186,7 @@ extension vDSP {
         }
         
         @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-        @inline(__always)
+        @inlinable
         static func applyBiquadMulti<U, V>(source: U,
                                            destination: inout V,
                                            setup: OpaquePointer,
@@ -289,7 +289,7 @@ public protocol vDSP_BiquadFunctions {
 extension vDSP.VectorizableFloat: vDSP_BiquadFunctions {
     
     /// Returns a data structure that contains precalculated data for use by the cascaded biquad IIR filter function.
-    @inline(__always)
+    @inlinable
     public static func makeBiquadSetup(channelCount: UInt,
                                        coefficients: [Double],
                                        sectionCount: UInt) -> OpaquePointer? {
@@ -304,7 +304,7 @@ extension vDSP.VectorizableFloat: vDSP_BiquadFunctions {
     }
     
     /// Applies a single-channel biquad IIR filter.
-    @inline(__always)
+    @inlinable
     public static func applySingle<U, V>(source: U,
                                          destination: inout V,
                                          delays: UnsafeMutablePointer<Scalar>,
@@ -328,7 +328,7 @@ extension vDSP.VectorizableFloat: vDSP_BiquadFunctions {
     }
     
     /// Applies a multichannel biquad IIR filter.
-    @inline(__always)
+    @inlinable
     public static func applyMulti(setup: vDSP_biquadm_SetupD,
                                   pInputs: UnsafeMutablePointer<UnsafePointer<Scalar>>,
                                   pOutputs: UnsafeMutablePointer<UnsafeMutablePointer<Scalar>>,
@@ -340,7 +340,7 @@ extension vDSP.VectorizableFloat: vDSP_BiquadFunctions {
     }
     
     /// Destroys a setup object.
-    @inline(__always)
+    @inlinable
     public static func destroySetup(channelCount: UInt,
                                     biquadSetup: OpaquePointer) {
         if channelCount == 1 {
@@ -355,7 +355,7 @@ extension vDSP.VectorizableFloat: vDSP_BiquadFunctions {
 extension vDSP.VectorizableDouble: vDSP_BiquadFunctions {
     
     /// Returns a data structure that contains precalculated data for use by the cascaded biquad IIR filter function.
-    @inline(__always)
+    @inlinable
     public static func makeBiquadSetup(channelCount: vDSP_Length,
                                        coefficients: [Double],
                                        sectionCount: vDSP_Length) -> OpaquePointer? {
@@ -370,7 +370,7 @@ extension vDSP.VectorizableDouble: vDSP_BiquadFunctions {
     }
     
     /// Applies a single-channel biquad IIR filter.
-    @inline(__always)
+    @inlinable
     public static func applySingle<U, V>(source: U,
                                          destination: inout V,
                                          delays: UnsafeMutablePointer<Scalar>,
@@ -394,7 +394,7 @@ extension vDSP.VectorizableDouble: vDSP_BiquadFunctions {
     }
     
     /// Applies a multichannel biquad IIR filter.
-    @inline(__always)
+    @inlinable
     public static func applyMulti(setup: vDSP_biquadm_SetupD,
                                   pInputs: UnsafeMutablePointer<UnsafePointer<Scalar>>,
                                   pOutputs: UnsafeMutablePointer<UnsafeMutablePointer<Scalar>>,
@@ -406,7 +406,7 @@ extension vDSP.VectorizableDouble: vDSP_BiquadFunctions {
     }
     
     /// Destroys a setup object.
-    @inline(__always)
+    @inlinable
     public static func destroySetup(channelCount: UInt,
                                     biquadSetup: OpaquePointer) {
         if channelCount == 1 {

--- a/stdlib/public/Darwin/Accelerate/vDSP_ClippingLimitThreshold.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_ClippingLimitThreshold.swift
@@ -19,7 +19,7 @@ extension vDSP {
     /// - Parameter vector: Source vector.
     /// - Parameter bounds: Clipping threshold.
     /// - Returns: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func clip<U>(_ vector: U,
                                to bounds: ClosedRange<Float>) -> [Float]
@@ -45,7 +45,7 @@ extension vDSP {
     /// - Parameter vector: Source vector.
     /// - Parameter bounds: Clipping threshold.
     /// - Parameter result: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func clip<U, V>(_ vector: U,
                                   to bounds: ClosedRange<Float>,
@@ -78,7 +78,7 @@ extension vDSP {
     /// - Parameter vector: Source vector.
     /// - Parameter bounds: Clipping threshold.
     /// - Returns: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func clip<U>(_ vector: U,
                                to bounds: ClosedRange<Double>) -> [Double]
@@ -104,7 +104,7 @@ extension vDSP {
     /// - Parameter vector: Source vector.
     /// - Parameter bounds: Clipping threshold.
     /// - Parameter result: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func clip<U, V>(_ vector: U,
                                   to bounds: ClosedRange<Double>,
@@ -152,7 +152,7 @@ extension vDSP {
     ///         D[n] = *C;
     /// }
     /// ```
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func invertedClip<U>(_ vector: U,
                                        to bounds: ClosedRange<Float>) -> [Float]
@@ -191,7 +191,7 @@ extension vDSP {
     ///         D[n] = *C;
     /// }
     /// ```
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func invertedClip<U, V>(_ vector: U,
                                           to bounds: ClosedRange<Float>,
@@ -237,7 +237,7 @@ extension vDSP {
     ///         D[n] = *C;
     /// }
     /// ```
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func invertedClip<U>(_ vector: U,
                                        to bounds: ClosedRange<Double>) -> [Double]
@@ -276,7 +276,7 @@ extension vDSP {
     ///         D[n] = *C;
     /// }
     /// ```
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func invertedClip<U, V>(_ vector: U,
                                           to bounds: ClosedRange<Double>,
@@ -321,7 +321,7 @@ extension vDSP {
     /// - Parameter vector: Source vector.
     /// - Parameter bounds: Clipping threshold.
     /// - Returns: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func threshold<U>(_ vector: U,
                                     to lowerBound: Float,
@@ -356,7 +356,6 @@ extension vDSP {
     /// - Parameter lowerBound: Low clipping threshold.
     /// - Parameter rule: The thresholding rule.
     /// - Parameter result: The threshold result.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func threshold<U, V>(_ vector: U,
                                        to lowerBound: Float,
@@ -402,7 +401,7 @@ extension vDSP {
     /// - Parameter vector: Source vector.
     /// - Parameter bounds: Clipping threshold.
     /// - Returns: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func threshold<U>(_ vector: U,
                                     to lowerBound: Double,
@@ -437,7 +436,6 @@ extension vDSP {
     /// - Parameter lowerBound: Low clipping threshold.
     /// - Parameter rule: The thresholding rule.
     /// - Parameter result: The threshold result.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func threshold<U, V>(_ vector: U,
                                        to lowerBound: Double,
@@ -488,7 +486,7 @@ extension vDSP {
     /// - Parameter limit: Limit.
     /// - Parameter x: Value written to result.
     /// - Returns: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func limit<U>(_ vector: U,
                                 limit: Float,
@@ -519,7 +517,7 @@ extension vDSP {
     /// - Parameter limit: Limit.
     /// - Parameter x: Value written to result.
     /// - Parameter result: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func limit<U, V>(_ vector: U,
                                    limit: Float,
@@ -556,7 +554,7 @@ extension vDSP {
     /// - Parameter limit: Limit.
     /// - Parameter x: Value written to result.
     /// - Returns: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func limit<U>(_ vector: U,
                                 limit: Double,
@@ -587,7 +585,7 @@ extension vDSP {
     /// - Parameter limit: Limit.
     /// - Parameter x: Value written to result.
     /// - Parameter result: The clipped result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func limit<U, V>(_ vector: U,
                                    limit: Double,

--- a/stdlib/public/Darwin/Accelerate/vDSP_ComplexConversion.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_ComplexConversion.swift
@@ -16,7 +16,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplexVector: Source vector.
     /// - Parameter interleavedComplexVector: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert(splitComplexVector: DSPSplitComplex,
                                toInterleavedComplexVector interleavedComplexVector: inout [DSPComplex]) {
@@ -32,7 +32,7 @@ extension vDSP {
     ///
     /// - Parameter interleavedComplexVector: Source vector.
     /// - Parameter splitComplexVector: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert(interleavedComplexVector: [DSPComplex],
                                toSplitComplexVector splitComplexVector: inout DSPSplitComplex) {
@@ -46,7 +46,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplexVector: Source vector.
     /// - Parameter interleavedComplexVector: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert(splitComplexVector: DSPDoubleSplitComplex,
                                toInterleavedComplexVector interleavedComplexVector: inout [DSPDoubleComplex]) {
@@ -62,7 +62,7 @@ extension vDSP {
     ///
     /// - Parameter interleavedComplexVector: Source vector.
     /// - Parameter splitComplexVector: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert(interleavedComplexVector: [DSPDoubleComplex],
                                toSplitComplexVector splitComplexVector: inout DSPDoubleSplitComplex) {

--- a/stdlib/public/Darwin/Accelerate/vDSP_ComplexOperations.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_ComplexOperations.swift
@@ -22,7 +22,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplex: Single-precision complex input vector.
     /// - Parameter result: Single-precision real output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func phase<V>(_ splitComplex: DSPSplitComplex,
                                 result: inout V)
@@ -45,7 +45,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplex: Double-precision complex input vector.
     /// - Parameter result: Double-precision real output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func phase<V>(_ splitComplex: DSPDoubleSplitComplex,
                                 result: inout V)
@@ -74,7 +74,7 @@ extension vDSP {
     ///
     /// - Parameter source: Single-precision complex input vector.
     /// - Parameter destination: Single-precision real output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func copy(_ source: DSPSplitComplex,
                             to destination: inout DSPSplitComplex,
@@ -93,7 +93,7 @@ extension vDSP {
     ///
     /// - Parameter source: Double-precision complex input vector.
     /// - Parameter destination: Double-precision real output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func copy(_ source: DSPDoubleSplitComplex,
                             to destination: inout DSPDoubleSplitComplex,
@@ -118,7 +118,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplex: the `A` in `C[n] = conj(A[n])`.
     /// - Parameter result: The `C` in `C[n] = conj(A[n])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func conjugate(_ splitComplex: DSPSplitComplex,
                                  count: Int,
@@ -135,7 +135,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplex: the `A` in `C[n] = conj(A[n])`.
     /// - Parameter result: The `C` in `C[n] = conj(A[n])`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func conjugate(_ splitComplex: DSPDoubleSplitComplex,
                                  count: Int,
@@ -160,7 +160,7 @@ extension vDSP {
     /// - Parameter splitComplex: the `a` in `c[i] = a[i] / b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a[i] / b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U>(_ splitComplex: DSPSplitComplex,
                                  by vector: U,
@@ -185,7 +185,7 @@ extension vDSP {
     /// - Parameter splitComplex: the `a` in `c[i] = a[i] / b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a[i] / b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide<U>(_ splitComplex: DSPDoubleSplitComplex,
                                  by vector: U,
@@ -210,7 +210,7 @@ extension vDSP {
     /// - Parameter splitComplex: the `a` in `c[i] = a[i] * b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a[i] * b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<U>(_ splitComplex: DSPSplitComplex,
                                    by vector: U,
@@ -235,7 +235,7 @@ extension vDSP {
     /// - Parameter splitComplex: the `a` in `c[i] = a[i] * b[i]`.
     /// - Parameter vector: the `b` in `c[i] = a[i] * b[i]`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply<U>(_ splitComplex: DSPDoubleSplitComplex,
                                    by vector: U,
@@ -262,7 +262,7 @@ extension vDSP {
     /// - Parameter count: The number of elements to process.
     /// - Parameter useConjugate: Specifies whether to multiply the complex conjugates of `splitComplexA`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]` or `c[i] = conj(a[i]) * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply(_ splitComplexA: DSPSplitComplex,
                                 by splitComplexB: DSPSplitComplex,
@@ -291,7 +291,7 @@ extension vDSP {
     /// - Parameter count: The number of elements to process.
     /// - Parameter useConjugate: Specifies whether to multiply the complex conjugates of `splitComplexA`.
     /// - Parameter result: The `c` in `c[i] = a[i] * b[i]` or `c[i] = conj(a[i]) * b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func multiply(_ splitComplexA: DSPDoubleSplitComplex,
                                 by splitComplexB: DSPDoubleSplitComplex,
@@ -319,7 +319,7 @@ extension vDSP {
     /// - Parameter splitComplexB: the `b` in `c[i] = a[i] + b[i]`.
     /// - Parameter count: The number of elements to process.
     /// - Parameter result: The `c` in `c[i] = a[i] + b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add(_ splitComplexA: DSPSplitComplex,
                            to splitComplexB: DSPSplitComplex,
@@ -343,7 +343,7 @@ extension vDSP {
     /// - Parameter splitComplexB: the `b` in `c[i] = a[i] + b[i]`.
     /// - Parameter count: The number of elements to process.
     /// - Parameter result: The `c` in `c[i] = a[i] + b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func add(_ splitComplexA: DSPDoubleSplitComplex,
                            to splitComplexB: DSPDoubleSplitComplex,
@@ -367,7 +367,7 @@ extension vDSP {
     /// - Parameter splitComplexB: the `b` in `c[i] = a[i] / b[i]`.
     /// - Parameter count: The number of elements to process.
     /// - Parameter result: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide(_ splitComplexA: DSPSplitComplex,
                               by splitComplexB: DSPSplitComplex,
@@ -391,7 +391,7 @@ extension vDSP {
     /// - Parameter splitComplexB: the `b` in `c[i] = a[i] / b[i]`.
     /// - Parameter count: The number of elements to process.
     /// - Parameter result: The `c` in `c[i] = a[i] / b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func divide(_ splitComplexA: DSPDoubleSplitComplex,
                               by splitComplexB: DSPDoubleSplitComplex,
@@ -415,7 +415,7 @@ extension vDSP {
     /// - Parameter splitComplexB: the `b` in `c[i] = a[i] - b[i]`.
     /// - Parameter count: The number of elements to process.
     /// - Parameter result: The `c` in `c[i] = a[i] - b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract(_ splitComplexB: DSPSplitComplex,
                                 from splitComplexA: DSPSplitComplex,
@@ -439,7 +439,7 @@ extension vDSP {
     /// - Parameter splitComplexB: the `b` in `c[i] = a[i] - b[i]`.
     /// - Parameter count: The number of elements to process.
     /// - Parameter result: The `c` in `c[i] = a[i] - b[i]`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func subtract(_ splitComplexB: DSPDoubleSplitComplex,
                                 from splitComplexA: DSPDoubleSplitComplex,
@@ -467,7 +467,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func absolute<V>(_ vector: DSPSplitComplex,
                                    result: inout V)
@@ -491,7 +491,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func absolute<V>(_ vector: DSPDoubleSplitComplex,
                                    result: inout V)
@@ -520,7 +520,7 @@ extension vDSP {
     ///
     /// - Parameter splitComplex: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func squareMagnitudes<V>(_ splitComplex: DSPSplitComplex,
                                            result: inout V)
@@ -539,7 +539,7 @@ extension vDSP {
             }
     }
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     /// Calculates the squared magnitude of each element in `vector`, writing the result to `result`; double-precision.
     ///

--- a/stdlib/public/Darwin/Accelerate/vDSP_Conversion.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Conversion.swift
@@ -18,7 +18,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -45,7 +45,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -72,7 +72,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -99,7 +99,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -126,7 +126,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -153,7 +153,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -180,7 +180,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -207,7 +207,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -234,7 +234,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -261,7 +261,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -288,7 +288,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -315,7 +315,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -349,7 +349,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -382,7 +381,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -415,7 +413,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -448,7 +445,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -481,7 +477,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -514,7 +509,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -548,7 +542,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -581,7 +574,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -614,7 +606,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -647,7 +638,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -680,7 +670,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -713,7 +702,6 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V,
@@ -746,7 +734,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -771,7 +759,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Parameter destination: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convertElements<U, V>(of source: U,
                                              to destination: inout V)
@@ -821,7 +809,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integerToFloatingPoint<T, U>(_ vector: T,
                                                     floatingPointType: U.Type) -> [U]
@@ -863,7 +851,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integerToFloatingPoint<T, U>(_ vector: T,
                                                     floatingPointType: U.Type) -> [U]
@@ -905,7 +893,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integerToFloatingPoint<T, U>(_ vector: T,
                                                     floatingPointType: U.Type) -> [U]
@@ -947,7 +935,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integerToFloatingPoint<T, U>(_ vector: T,
                                                     floatingPointType: U.Type) -> [U]
@@ -989,7 +977,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integerToFloatingPoint<T, U>(_ vector: T,
                                                     floatingPointType: U.Type) -> [U]
@@ -1031,7 +1019,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integerToFloatingPoint<T, U>(_ vector: T,
                                                     floatingPointType: U.Type) -> [U]
@@ -1075,7 +1063,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floatingPointToInteger<T, U>(_ vector: T,
                                                     integerType: U.Type,
@@ -1167,7 +1155,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floatingPointToInteger<T, U>(_ vector: T,
                                                     integerType: U.Type,
@@ -1261,7 +1249,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floatToDouble<U>(_ source: U) -> [Double]
         where
@@ -1283,7 +1271,7 @@ extension vDSP {
     ///
     /// - Parameter source: Source vector.
     /// - Returns: Conversion result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func doubleToFloat<U>(_ source: U) -> [Float]
         where

--- a/stdlib/public/Darwin/Accelerate/vDSP_Convolution.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Convolution.swift
@@ -19,7 +19,7 @@ extension vDSP {
     /// - Parameter vector: The vector to convolve.
     /// - Parameter kernel: Single-precision convolution kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       withKernel kernel: U) -> [Float]
@@ -49,7 +49,7 @@ extension vDSP {
     /// - Parameter kernel: Single-precision convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          withKernel kernel: U,
@@ -82,7 +82,7 @@ extension vDSP {
     /// - Parameter vector: The vector to convolve.
     /// - Parameter kernel: Double-precision convolution kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       withKernel kernel: U) -> [Double]
@@ -112,7 +112,7 @@ extension vDSP {
     /// - Parameter kernel: Double-precision convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          withKernel kernel: U,
@@ -147,7 +147,7 @@ extension vDSP {
     /// - Parameter vector: The vector to correlate.
     /// - Parameter kernel: Single-precision convolution kernel.
     /// - Returns: Correlation result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func correlate<T, U>(_ vector: T,
                                        withKernel kernel: U) -> [Float]
@@ -177,7 +177,7 @@ extension vDSP {
     /// - Parameter kernel: Single-precision convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func correlate<T, U, V>(_ vector: T,
                                           withKernel kernel: U,
@@ -210,7 +210,7 @@ extension vDSP {
     /// - Parameter vector: The vector to correlate.
     /// - Parameter kernel: Single-precision convolution kernel.
     /// - Returns: Correlation result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func correlate<T, U>(_ vector: T,
                                        withKernel kernel: U) -> [Double]
@@ -240,7 +240,7 @@ extension vDSP {
     /// - Parameter kernel: Single-precision convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func correlate<T, U, V>(_ vector: T,
                                           withKernel kernel: U,
@@ -282,7 +282,7 @@ extension vDSP {
     /// - Parameter columnCount: The number of columns in the input vector.
     /// - Parameter kernel: Single-precision 3x3 convolution kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       rowCount: Int, columnCount: Int,
@@ -314,7 +314,7 @@ extension vDSP {
     /// - Parameter kernel: Single-precision 3x3 convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          rowCount: Int, columnCount: Int,
@@ -357,7 +357,7 @@ extension vDSP {
     /// - Parameter columnCount: The number of columns in the input vector.
     /// - Parameter kernel: Double-precision 3x3 convolution kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       rowCount: Int, columnCount: Int,
@@ -389,7 +389,7 @@ extension vDSP {
     /// - Parameter kernel: Double-precision 3x3 convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          rowCount: Int, columnCount: Int,
@@ -432,7 +432,7 @@ extension vDSP {
     /// - Parameter columnCount: The number of columns in the input vector.
     /// - Parameter kernel: Single-precision 5x5 convolution kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       rowCount: Int, columnCount: Int,
@@ -464,7 +464,7 @@ extension vDSP {
     /// - Parameter kernel: Single-precision 5x5 convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          rowCount: Int, columnCount: Int,
@@ -507,7 +507,7 @@ extension vDSP {
     /// - Parameter columnCount: The number of columns in the input vector.
     /// - Parameter kernel: Double-precision 3x3 convolution kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       rowCount: Int, columnCount: Int,
@@ -539,7 +539,7 @@ extension vDSP {
     /// - Parameter kernel: Double-precision 5x5 convolution kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          rowCount: Int, columnCount: Int,
@@ -584,7 +584,7 @@ extension vDSP {
     /// - Parameter kernelRowCount: The number of rows in the kernel.
     /// - Parameter kernelColumnCount: The number of columns in the kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       rowCount: Int, columnCount: Int,
@@ -619,7 +619,7 @@ extension vDSP {
     /// - Parameter kernelRowCount: The number of rows in the kernel.
     /// - Parameter kernelColumnCount: The number of columns in the kernel.
     /// - Parameter result: Destination vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          rowCount: Int, columnCount: Int,
@@ -669,7 +669,7 @@ extension vDSP {
     /// - Parameter kernelRowCount: The number of rows in the kernel.
     /// - Parameter kernelColumnCount: The number of columns in the kernel.
     /// - Returns: Convolution result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U>(_ vector: T,
                                       rowCount: Int, columnCount: Int,
@@ -705,7 +705,7 @@ extension vDSP {
     /// - Parameter kernelColumnCount: The number of columns in the kernel.
     /// - Parameter result: Destination vector.
     
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convolve<T, U, V>(_ vector: T,
                                          rowCount: Int, columnCount: Int,

--- a/stdlib/public/Darwin/Accelerate/vDSP_DCT.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_DCT.swift
@@ -60,7 +60,6 @@ extension vDSP {
         /// - Parameter input: Real input vector.
         /// - Returns: Real output vector.
         @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-        @inline(__always)
         public func transform<U>(_ vector: U) -> [Float]
             where
             U: AccelerateBuffer,
@@ -83,7 +82,6 @@ extension vDSP {
         /// - Parameter input: Real input vector.
         /// - Parameter output: Real output vector.
         @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-        @inline(__always)
         public func transform<U, V>(_ vector: U, result: inout V)
             where
             U: AccelerateBuffer,
@@ -115,12 +113,10 @@ extension Float: vDSP_FloatingPointDiscreteCosineTransformable {
 fileprivate protocol vDSP_DCTFunctions {
     associatedtype Scalar
     
-    @inline(__always)
     static func makeDCTSetup(previous: vDSP.DCT?,
                              count: Int,
                              transformType: vDSP.DCTTransformType) -> OpaquePointer?
     
-    @inline(__always)
     static func transform<U, V>(dctSetup: OpaquePointer,
                                 source: U,
                                 destination: inout V)
@@ -134,7 +130,6 @@ fileprivate protocol vDSP_DCTFunctions {
 extension vDSP.VectorizableFloat: vDSP_DCTFunctions {
     
     @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
     fileprivate static func makeDCTSetup(previous: vDSP.DCT? = nil,
                                     count: Int,
                                     transformType: vDSP.DCTTransformType) -> OpaquePointer? {
@@ -145,7 +140,6 @@ extension vDSP.VectorizableFloat: vDSP_DCTFunctions {
     }
     
     @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
     fileprivate static func transform<U, V>(dctSetup: OpaquePointer,
                                        source: U,
                                        destination: inout V)

--- a/stdlib/public/Darwin/Accelerate/vDSP_DFT.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_DFT.swift
@@ -159,7 +159,6 @@ extension Double: vDSP_FloatingPointDiscreteFourierTransformable {
 public protocol vDSP_DFTFunctions {
     associatedtype Scalar
     
-    @inline(__always)
     /// Returns a setup structure to perform a discrete Fourier transform
     ///
     /// - Parameter previous: a previous vDSP_DFT instance to share data with.
@@ -178,7 +177,6 @@ public protocol vDSP_DFTFunctions {
     /// - Parameter inputImaginary: Input vector - imaginary part.
     /// - Parameter outputReal: Output vector - real part.
     /// - Parameter outputImaginary: Output vector - imaginary part.
-    @inline(__always)
     static func transform<U, V>(dftSetup: OpaquePointer,
                                 inputReal: U,
                                 inputImaginary: U,
@@ -190,7 +188,6 @@ public protocol vDSP_DFTFunctions {
         U.Element == Scalar, V.Element == Scalar
     
     /// Releases a DFT setup object.
-    @inline(__always)
     static func destroySetup(_ setup: OpaquePointer)
 }
 
@@ -209,7 +206,6 @@ extension vDSP.VectorizableFloat: vDSP_DFTFunctions {
     /// - Parameter count: the number of real elements to be transformed.
     /// - Parameter direction: Specifies the transform direction.
     /// - Parameter transformType: Specficies whether to forward transform is real-to-complex or complex-to-complex.
-    @inline(__always)
     public static func makeDFTSetup<T>(previous: vDSP.DFT<T>? = nil,
                                        count: Int,
                                        direction: vDSP.FourierTransformDirection,
@@ -235,7 +231,6 @@ extension vDSP.VectorizableFloat: vDSP_DFTFunctions {
     /// - Parameter inputImaginary: Input vector - imaginary part.
     /// - Parameter outputReal: Output vector - real part.
     /// - Parameter outputImaginary: Output vector - imaginary part.
-    @inline(__always)
     public static func transform<U, V>(dftSetup: OpaquePointer,
                                        inputReal: U,
                                        inputImaginary: U,
@@ -263,7 +258,6 @@ extension vDSP.VectorizableFloat: vDSP_DFTFunctions {
     }
     
     /// Releases a DFT setup object.
-    @inline(__always)
     public static func destroySetup(_ setup: OpaquePointer) {
         vDSP_DFT_DestroySetup(setup)
     }
@@ -278,7 +272,6 @@ extension vDSP.VectorizableDouble: vDSP_DFTFunctions {
     /// - Parameter count: the number of real elements to be transformed.
     /// - Parameter direction: Specifies the transform direction.
     /// - Parameter transformType: Specficies whether to forward transform is real-to-complex or complex-to-complex.
-    @inline(__always)
     public static func makeDFTSetup<T>(previous: vDSP.DFT<T>? = nil,
                                        count: Int,
                                        direction: vDSP.FourierTransformDirection,
@@ -304,7 +297,6 @@ extension vDSP.VectorizableDouble: vDSP_DFTFunctions {
     /// - Parameter inputImaginary: Input vector - imaginary part.
     /// - Parameter outputReal: Output vector - real part.
     /// - Parameter outputImaginary: Output vector - imaginary part.
-    @inline(__always)
     public static func transform<U, V>(dftSetup: OpaquePointer,
                                        inputReal: U, inputImaginary: U,
                                        outputReal: inout V, outputImaginary: inout V)
@@ -330,7 +322,6 @@ extension vDSP.VectorizableDouble: vDSP_DFTFunctions {
     }
     
     /// Releases a DFT setup object.
-    @inline(__always)
     public static func destroySetup(_ setup: OpaquePointer) {
         vDSP_DFT_DestroySetupD(setup)
     }

--- a/stdlib/public/Darwin/Accelerate/vDSP_DecibelConversion.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_DecibelConversion.swift
@@ -17,7 +17,7 @@ extension vDSP {
     /// - Parameter power: Source vector.
     /// - Parameter zeroReference: Zero reference.
     /// - Returns: `power` converted to decibels.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func powerToDecibels<U>(_ power: U,
                                           zeroReference: Float) -> [Float]
@@ -43,7 +43,7 @@ extension vDSP {
     /// - Parameter power: Source vector.
     /// - Parameter decibels: Destination vector.
     /// - Parameter zeroReference: Zero reference.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(power: U,
                                      toDecibels decibels: inout V,
@@ -74,7 +74,7 @@ extension vDSP {
     /// - Parameter power: Source vector.
     /// - Parameter zeroReference: Zero reference.
     /// - Returns: `power` converted to decibels.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func powerToDecibels<U>(_ power: U,
                                           zeroReference: Double) -> [Double]
@@ -100,7 +100,7 @@ extension vDSP {
     /// - Parameter power: Source vector.
     /// - Parameter decibels: Destination vector.
     /// - Parameter zeroReference: Zero reference.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(power: U,
                                      toDecibels decibels: inout V,
@@ -131,7 +131,7 @@ extension vDSP {
     /// - Parameter amplitude: Source vector.
     /// - Parameter zeroReference: Zero reference.
     /// - Returns: `amplitude` converted to decibels.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func amplitudeToDecibels<U>(_ amplitude: U,
                                               zeroReference: Float) -> [Float]
@@ -157,7 +157,7 @@ extension vDSP {
     /// - Parameter amplitude: Source vector.
     /// - Parameter decibels: Destination vector.
     /// - Parameter zeroReference: Zero reference.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(amplitude: U,
                                      toDecibels decibels: inout V,
@@ -188,7 +188,7 @@ extension vDSP {
     /// - Parameter amplitude: Source vector.
     /// - Parameter zeroReference: Zero reference.
     /// - Returns: `amplitude` converted to decibels.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func amplitudeToDecibels<U>(_ amplitude: U,
                                               zeroReference: Double) -> [Double]
@@ -214,7 +214,7 @@ extension vDSP {
     /// - Parameter amplitude: Source vector.
     /// - Parameter decibels: Destination vector.
     /// - Parameter zeroReference: Zero reference.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(amplitude: U,
                                      toDecibels decibels: inout V,

--- a/stdlib/public/Darwin/Accelerate/vDSP_FFT.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_FFT.swift
@@ -51,7 +51,6 @@ extension vDSP {
         ///
         /// - Parameter log2n: The base-two logarithm of the maximum number of elements to be transformed.
         /// - Parameter radix: Specifies radix options.
-        @inline(__always)
         public init?(log2n: vDSP_Length,
                      radix: Radix,
                      ofType: T.Type) {
@@ -67,7 +66,6 @@ extension vDSP {
             fftSetup = setup
         }
         
-        @inline(__always)
         /// Computes an out-of-place single-precision real forward or inverse fast Fourier transform.
         ///
         /// - Parameter input: Complex input vector.
@@ -126,7 +124,6 @@ extension vDSP {
         /// - Parameter width: The width of the matrix to be transformed.
         /// - Parameter height: The width of the matrix to be transformed.
         @available(iOS 9999, OSX 9999, tvOS 9999, watchOS 9999, *)
-        @inline(__always)
         required public init?(width: Int,
                               height: Int,
                               ofType: T.Type) {
@@ -145,7 +142,6 @@ extension vDSP {
         /// - Parameter input: Complex input vector.
         /// - Parameter output: Complex output vector.
         /// - Parameter direction: Specifies transform direction.
-        @inline(__always)
         override public func transform<T: vDSP_FourierTransformable>(input: T,
                                                                      output: inout T,
                                                                      direction: vDSP.FourierTransformDirection) {
@@ -194,7 +190,6 @@ public struct vDSP_SplitComplexFloat: vDSP_FourierTransformFunctions {
     public typealias SplitComplex = DSPSplitComplex
     
     /// Returns a setup structure to perform a fast Fourier transform.
-    @inline(__always)
     public static func makeFFTSetup(log2n: vDSP_Length,
                                     radix: vDSP.Radix) -> OpaquePointer? {
         
@@ -204,7 +199,6 @@ public struct vDSP_SplitComplexFloat: vDSP_FourierTransformFunctions {
     }
     
     /// Performs a 1D fast Fourier transform.
-    @inline(__always)
     public static func transform(fftSetup: OpaquePointer,
                                  log2n: vDSP_Length,
                                  source: UnsafePointer<SplitComplex>,
@@ -233,7 +227,6 @@ public struct vDSP_SplitComplexFloat: vDSP_FourierTransformFunctions {
     }
     
     /// Releases an FFT setup object.
-    @inline(__always)
     public static func destroySetup(_ setup: OpaquePointer) {
         vDSP_destroy_fftsetup(setup)
     }
@@ -244,7 +237,6 @@ public struct vDSP_SplitComplexDouble: vDSP_FourierTransformFunctions {
     public typealias SplitComplex = DSPDoubleSplitComplex
     
     /// Returns a setup structure to perform a fast Fourier transform.
-    @inline(__always)
     public static func makeFFTSetup(log2n: vDSP_Length,
                                     radix: vDSP.Radix) -> OpaquePointer? {
         
@@ -254,7 +246,6 @@ public struct vDSP_SplitComplexDouble: vDSP_FourierTransformFunctions {
     }
     
     /// Performs a 1D fast Fourier transform.
-    @inline(__always)
     public static func transform(fftSetup: OpaquePointer,
                                  log2n: vDSP_Length,
                                  source: UnsafePointer<SplitComplex>,
@@ -283,7 +274,6 @@ public struct vDSP_SplitComplexDouble: vDSP_FourierTransformFunctions {
     }
     
     /// Releases an FFT setup object.
-    @inline(__always)
     public static func destroySetup(_ setup: OpaquePointer) {
         vDSP_destroy_fftsetupD(setup)
     }

--- a/stdlib/public/Darwin/Accelerate/vDSP_FIR.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_FIR.swift
@@ -18,7 +18,7 @@ extension vDSP {
     /// - Parameter decimationFactor: The integer factor by which to divide the sampling rate.
     /// - Parameter filter: Filter to use during the downsampling operation.
     /// - Returns: Single-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func downsample<T, U>(_ source: U,
                                         decimationFactor: Int,
@@ -51,7 +51,7 @@ extension vDSP {
     /// - Parameter decimationFactor: The integer factor by which to divide the sampling rate.
     /// - Parameter filter: Filter to use during the downsampling operation.
     /// - Parameter result: Single-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func downsample<T, U, V>(_ source: U,
                                            decimationFactor: Int,
@@ -91,7 +91,7 @@ extension vDSP {
     /// - Parameter decimationFactor: The integer factor by which to divide the sampling rate.
     /// - Parameter filter: Filter to use during the downsampling operation.
     /// - Returns: Double-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func downsample<T, U>(_ source: U,
                                         decimationFactor: Int,
@@ -123,7 +123,7 @@ extension vDSP {
     /// - Parameter decimationFactor: The integer factor by which to divide the sampling rate.
     /// - Parameter filter: Filter to use during the downsampling operation.
     /// - Parameter result: Double-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func downsample<T, U, V>(_ source: U,
                                            decimationFactor: Int,

--- a/stdlib/public/Darwin/Accelerate/vDSP_FillClearGenerate.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_FillClearGenerate.swift
@@ -23,7 +23,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The vector to fill.
     /// - Parameter value: The fill value.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func fill<V>(_ vector: inout V,
                                with value: Float)
@@ -45,7 +45,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The vector to fill.
     /// - Parameter value: The fill value.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func fill<V>(_ vector: inout V,
                                with value: Double)
@@ -66,7 +66,7 @@ extension vDSP {
     /// Fill vector with zeros, single-precision.
     ///
     /// - Parameter vector: The vector to fill.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func clear<V>(_ vector: inout V)
         where V: AccelerateMutableBuffer,
@@ -83,7 +83,7 @@ extension vDSP {
     /// Fill vector with zeros, double-precision.
     ///
     /// - Parameter vector: The vector to fill.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func clear<V>(_ vector: inout V)
         where V: AccelerateMutableBuffer,
@@ -120,7 +120,7 @@ extension vDSP {
     /// - Parameter count: The number of elements in the array.
     /// - Parameter isHalfWindow: When true, creates a window with only the first `(N+1)/2` points.
     /// - Returns: An array containing the specified window.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func window<T: vDSP_FloatingPointGeneratable>(ofType: T.Type,
                                                                 usingSequence sequence: WindowSequence,
@@ -165,7 +165,6 @@ extension vDSP {
     /// - Parameter sequence: Specifies the window sequence.
     /// - Parameter result: Output values.
     /// - Parameter isHalfWindow: When true, creates a window with only the first `(N+1)/2` points.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formWindow<V>(usingSequence sequence: WindowSequence,
                                      result: inout V,
@@ -204,7 +203,6 @@ extension vDSP {
     /// - Parameter sequence: Specifies the window sequence.
     /// - Parameter result: Output values.
     /// - Parameter isHalfWindow: When true, creates a window with only the first `(N+1)/2` points.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formWindow<V>(usingSequence sequence: WindowSequence,
                                      result: inout V,
@@ -250,7 +248,7 @@ extension vDSP {
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter count: The number of elements in the array.
     /// - Returns: An array containing the specified ramp.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ramp(withInitialValue initialValue: Float,
                             increment: Float,
@@ -276,7 +274,7 @@ extension vDSP {
     /// - Parameter initialValue: Specifies the initial value.
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formRamp<V>(withInitialValue initialValue: Float,
                                    increment: Float,
@@ -304,7 +302,7 @@ extension vDSP {
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter count: The number of elements in the array.
     /// - Returns: An array containing the specified ramp.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ramp(withInitialValue initialValue: Double,
                             increment: Double,
@@ -330,7 +328,7 @@ extension vDSP {
     /// - Parameter initialValue: Specifies the initial value.
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formRamp<V>(withInitialValue initialValue: Double,
                                    increment: Double,
@@ -361,7 +359,7 @@ extension vDSP {
     /// - Parameter range: Specifies range of the ramp..
     /// - Parameter count: The number of elements in the array.
     /// - Returns: An array containing the specified ramp.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ramp(in range: ClosedRange<Float>,
                             count: Int) -> [Float] {
@@ -384,7 +382,7 @@ extension vDSP {
     ///
     /// - Parameter range: Specifies range of the ramp.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formRamp<V>(in range: ClosedRange<Float>,
                                    result: inout V)
@@ -410,7 +408,7 @@ extension vDSP {
     /// - Parameter range: Specifies range of the ramp..
     /// - Parameter count: The number of elements in the array.
     /// - Returns: An array containing the specified ramp.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ramp(in range: ClosedRange<Double>,
                             count: Int) -> [Double] {
@@ -433,7 +431,7 @@ extension vDSP {
     ///
     /// - Parameter range: Specifies range of the ramp.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formRamp<V>(in range: ClosedRange<Double>,
                                    result: inout V)
@@ -465,7 +463,7 @@ extension vDSP {
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements
     /// - Parameter count: The number of elements in the array.
     /// - Returns: An array containing the specified ramp.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ramp<U>(withInitialValue initialValue: inout Float,
                                multiplyingBy vector: U,
@@ -494,7 +492,7 @@ extension vDSP {
     /// - Parameter multiplyingBy: Input values multiplied by the ramp function.
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formRamp<U,V>(withInitialValue initialValue: inout Float,
                                      multiplyingBy vector: U,
@@ -528,7 +526,7 @@ extension vDSP {
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements
     /// - Parameter count: The number of elements in the array.
     /// - Returns: An array containing the specified ramp.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ramp<U>(withInitialValue initialValue: inout Double,
                                multiplyingBy vector: U,
@@ -557,7 +555,7 @@ extension vDSP {
     /// - Parameter multiplyingBy: Input values multiplied by the ramp function.
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formRamp<U,V>(withInitialValue initialValue: inout Double,
                                      multiplyingBy vector: U,
@@ -595,7 +593,7 @@ extension vDSP {
     /// - Parameter multiplierTwo: Input values multiplied by the ramp function.
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Returns: A tuple of two arrays containing the specified ramps.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func stereoRamp<U>(withInitialValue initialValue: inout Float,
                                      multiplyingBy multiplierOne: U, _ multiplierTwo: U,
@@ -637,7 +635,7 @@ extension vDSP {
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter resultOne: Output values.
     /// - Parameter resultTwo: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formStereoRamp<U,V>(withInitialValue initialValue: inout Float,
                                            multiplyingBy multiplierOne: U, _ multiplierTwo: U,
@@ -679,7 +677,7 @@ extension vDSP {
     /// - Parameter multiplierTwo: Input values multiplied by the ramp function.
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Returns: A tuple of two arrays containing the specified ramps.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func stereoRamp<U>(withInitialValue initialValue: inout Double,
                                      multiplyingBy multiplierOne: U, _ multiplierTwo: U,
@@ -721,7 +719,7 @@ extension vDSP {
     /// - Parameter increment: The increment (or decrement if negative) between consecutive elements.
     /// - Parameter resultOne: Output values.
     /// - Parameter resultTwo: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func formStereoRamp<U,V>(withInitialValue initialValue: inout Double,
                                            multiplyingBy multiplierOne: U, _ multiplierTwo: U,

--- a/stdlib/public/Darwin/Accelerate/vDSP_Geometry.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Geometry.swift
@@ -19,7 +19,7 @@ extension vDSP {
     /// - Parameter vectorA: Single-precision real input vector A.
     /// - Parameter vectorB: Single-precision real input vector B.
     /// - Returns: The dot product of vectors A and B.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func dot<U>(_ vectorA: U,
                               _ vectorB: U) -> Float
@@ -50,7 +50,7 @@ extension vDSP {
     /// - Parameter vectorA: Double-precision real input vector A.
     /// - Parameter vectorB: Double-precision real input vector B.
     /// - Returns: The dot product of vectors A and B.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func dot<U>(_ vectorA: U,
                               _ vectorB: U) -> Double
@@ -84,7 +84,7 @@ extension vDSP {
     /// - Parameter x: The `x` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter y: The `y` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter result: The `z` in `z[i] = sqrt(x[i]² + y[i]²)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<U, V>(_ x: U,
                                    _ y: V) -> [Float]
@@ -113,7 +113,7 @@ extension vDSP {
     /// - Parameter x: The `x` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter y: The `y` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter result: The `z` in `z[i] = sqrt(x[i]² + y[i]²)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<T, U, V>(_ x: T,
                                       _ y: U,
@@ -145,7 +145,7 @@ extension vDSP {
     /// - Parameter x: The `x` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter y: The `y` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter result: The `z` in `z[i] = sqrt(x[i]² + y[i]²)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<U, V>(_ x: U,
                                    _ y: V) -> [Double]
@@ -174,7 +174,7 @@ extension vDSP {
     /// - Parameter x: The `x` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter y: The `y` in `z[i] = sqrt(x[i]² + y[i]²)`.
     /// - Parameter result: The `z` in `z[i] = sqrt(x[i]² + y[i]²)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<T, U, V>(_ x: T,
                                       _ y: U,
@@ -210,7 +210,7 @@ extension vDSP {
     /// - Parameter y0: The `y0` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter y1: The `y1` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter result: The `z` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<R, S, T, U>(x0: R, x1: S,
                                             y0: T, y1: U) -> [Float]
@@ -247,7 +247,7 @@ extension vDSP {
     /// - Parameter y0: The `y0` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter y1: The `y1` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter result: The `z` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<R, S, T, U, V>(x0: R, x1: S,
                                             y0: T, y1: U,
@@ -293,7 +293,7 @@ extension vDSP {
     /// - Parameter y0: The `y0` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter y1: The `y1` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter result: The `z` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<R, S, T, U>(x0: R, x1: S,
                                             y0: T, y1: U) -> [Double]
@@ -330,7 +330,7 @@ extension vDSP {
     /// - Parameter y0: The `y0` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter y1: The `y1` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
     /// - Parameter result: The `z` in `z[i] = sqrt( (x0[i] - x1[i])² + (y0[i] - y1[i])² )`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func hypot<R, S, T, U, V>(x0: R, x1: S,
                                             y0: T, y1: U,
@@ -375,7 +375,7 @@ extension vDSP {
     /// - Parameter pointA: First point in `n` dimensional space, where `n` is the collection count.
     /// - Parameter pointB: Second point in `n` dimensional space, where `n` is the collection count.
     /// - Returns: The distance squared between `pointA` and `pointB`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func distanceSquared<U, V>(_ pointA: U,
                                              _ pointB: V) -> Float
@@ -406,7 +406,7 @@ extension vDSP {
     /// - Parameter pointA: First point in `n` dimensional space, where `n` is the collection count.
     /// - Parameter pointB: Second point in `n` dimensional space, where `n` is the collection count.
     /// - Returns: The distance squared between `pointA` and `pointB`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func distanceSquared<U, V>(_ pointA: U,
                                              _ pointB: V) -> Double

--- a/stdlib/public/Darwin/Accelerate/vDSP_Integration.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Integration.swift
@@ -25,7 +25,7 @@ extension vDSP {
     /// - Parameter rule: The integration rule.
     /// - Parameter stepSize: The integration step size (weighting factor for running sum).
     /// - Returns: The integration result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integrate<U>(_ vector: U,
                                     using rule: IntegrationRule,
@@ -53,7 +53,6 @@ extension vDSP {
     /// - Parameter rule: The integration rule.
     /// - Parameter stepSize: The integration step size (weighting factor for running sum).
     /// - Parameter result: The destination vector to receive the result.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integrate<U, V>(_ vector: U,
                                        using rule: IntegrationRule,
@@ -96,7 +95,7 @@ extension vDSP {
     /// - Parameter rule: The integration rule.
     /// - Parameter stepSize: The integration step size (weighting factor for running sum).
     /// - Returns: The integration result.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integrate<U>(_ vector: U,
                                     using rule: IntegrationRule,
@@ -124,7 +123,6 @@ extension vDSP {
     /// - Parameter rule: The integration rule.
     /// - Parameter stepSize: The integration step size (weighting factor for running sum).
     /// - Parameter result: The destination vector to receive the result.
-    @inline(__always)
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func integrate<U, V>(_ vector: U,
                                        using rule: IntegrationRule,

--- a/stdlib/public/Darwin/Accelerate/vDSP_Interpolation.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Interpolation.swift
@@ -19,7 +19,7 @@ extension vDSP {
     /// - Parameter interpolationConstant: The `C` in `D[n] = A[n] + C * (B[n] - A[n])`.
     /// - Returns: The `D` in `D[n] = A[n] + C * (B[n] - A[n])`.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U>(_ vectorA: T,
                                                _ vectorB: U,
                                                using interpolationConstant: Float) -> [Float]
@@ -49,7 +49,7 @@ extension vDSP {
     /// - Parameter interpolationConstant: The `C` in `D[n] = A[n] + C * (B[n] - A[n])`.
     /// - Parameter result: The `D` in `D[n] = A[n] + C * (B[n] - A[n])`.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U, V>(_ vectorA: T,
                                                   _ vectorB: U,
                                                   using interpolationConstant: Float,
@@ -85,7 +85,7 @@ extension vDSP {
     /// - Parameter interpolationConstant: The `C` in `D[n] = A[n] + C * (B[n] - A[n])`.
     /// - Returns: The `D` in `D[n] = A[n] + C * (B[n] - A[n])`.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U>(_ vectorA: T,
                                                _ vectorB: U,
                                                using interpolationConstant: Double) -> [Double]
@@ -115,7 +115,7 @@ extension vDSP {
     /// - Parameter interpolationConstant: The `C` in `D[n] = A[n] + C * (B[n] - A[n])`.
     /// - Parameter result: The `D` in `D[n] = A[n] + C * (B[n] - A[n])`.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U, V>(_ vectorA: T,
                                                   _ vectorB: U,
                                                   using interpolationConstant: Double,
@@ -161,7 +161,7 @@ extension vDSP {
     /// - Parameter controlVector: Vector that controls interpolation.
     /// - Returns: Output values.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U>(elementsOf vector: T,
                                                using controlVector: U) -> [Float]
         where
@@ -199,7 +199,7 @@ extension vDSP {
     /// - Parameter controlVector: Vector that controls interpolation.
     /// - Parameter result: Output values.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U, V>(elementsOf vector: T,
                                                   using controlVector: U,
                                                   result: inout V)
@@ -243,7 +243,7 @@ extension vDSP {
     /// - Parameter controlVector: Vector that controls interpolation.
     /// - Returns: Output values.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U>(elementsOf vector: T,
                                                using controlVector: U) -> [Double]
         where
@@ -281,7 +281,7 @@ extension vDSP {
     /// - Parameter controlVector: Vector that controls interpolation.
     /// - Parameter result: Output values.
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
-    @inline(__always)
+    @inlinable
     public static func linearInterpolate<T, U, V>(elementsOf vector: T,
                                                   using controlVector: U,
                                                   result: inout V)

--- a/stdlib/public/Darwin/Accelerate/vDSP_PolarRectangularConversion.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_PolarRectangularConversion.swift
@@ -16,7 +16,7 @@ extension vDSP {
     ///
     /// - Parameter rectangularCoordinates: Source vector, represented as consecutive x, y pairs.
     /// - Returns: Polar coordinates, represented as consecutive rho, (radius) theta (angle in radians) pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rectangularToPolar<U>(_ rectangularCoordinates: U) -> [Float]
         where
@@ -39,7 +39,7 @@ extension vDSP {
     ///
     /// - Parameter rectangularCoordinates: Source vector, represented as consecutive x, y pairs.
     /// - Parameter polarCoordinates: Destination vector, represented as consecutive rho, (radius) theta (angle in radians) pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(rectangularCoordinates: U,
                                      toPolarCoordinates polarCoordinates: inout V)
@@ -65,7 +65,7 @@ extension vDSP {
     ///
     /// - Parameter rectangularCoordinates: Source vector, represented as consecutive x, y pairs.
     /// - Returns: Polar coordinates, represented as consecutive rho, (radius) theta (angle in radians) pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rectangularToPolar<U>(_ rectangularCoordinates: U) -> [Double]
         where
@@ -88,7 +88,7 @@ extension vDSP {
     ///
     /// - Parameter rectangularCoordinates: Source vector, represented as consecutive x, y pairs.
     /// - Parameter polarCoordinates: Destination vector, represented as consecutive rho, (radius) theta (angle in radians) pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(rectangularCoordinates: U,
                                      toPolarCoordinates polarCoordinates: inout V)
@@ -114,7 +114,7 @@ extension vDSP {
     ///
     /// - Parameter polarCoordinates: Source vector, represented as consecutive rho, (radius) theta (angle in radians) pairs.
     /// - Returns: Rectangular coordinates, represented as consecutive x, y pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func polarToRectangular<U>(_ polarCoordinates: U) -> [Float]
         where
@@ -137,7 +137,7 @@ extension vDSP {
     ///
     /// - Parameter polarCoordinates: Source vector, represented as consecutive rho, (radius) theta (angle in radians) pairs.
     /// - Parameter rectangularCoordinates: Destination vector, represented as consecutive x, y pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(polarCoordinates: U,
                                      toRectangularCoordinates rectangularCoordinates: inout V)
@@ -163,7 +163,7 @@ extension vDSP {
     ///
     /// - Parameter polarCoordinates: Source vector, represented as consecutive rho, (radius) theta (angle in radians) pairs.
     /// - Returns: Rectangular coordinates, represented as consecutive x, y pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func polarToRectangular<U>(_ polarCoordinates: U) -> [Double]
         where
@@ -186,7 +186,7 @@ extension vDSP {
     ///
     /// - Parameter polarCoordinates: Source vector, represented as consecutive rho, (radius) theta (angle in radians) pairs.
     /// - Parameter rectangularCoordinates: Destination vector, represented as consecutive x, y pairs.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func convert<U, V>(polarCoordinates: U,
                                      toRectangularCoordinates rectangularCoordinates: inout V)

--- a/stdlib/public/Darwin/Accelerate/vDSP_PolynomialEvaluation.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_PolynomialEvaluation.swift
@@ -24,7 +24,7 @@ extension vDSP {
     /// `result[0] = (10 * 2²) + (20 * 2¹) + (30 * 2⁰) // 110`
     ///
     /// `result[1] = (10 * 5²) + (20 * 5¹) + (30 * 5⁰) // 380`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func evaluatePolynomial<U>(usingCoefficients coefficients: [Float],
                                              withVariables variables: U) -> [Float]
@@ -57,7 +57,7 @@ extension vDSP {
     /// `result[0] = (10 * 2²) + (20 * 2¹) + (30 * 2⁰) // 110`
     ///
     /// `result[1] = (10 * 5²) + (20 * 5¹) + (30 * 5⁰) // 380`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func evaluatePolynomial<U, V>(usingCoefficients coefficients: [Float],
                                                 withVariables variables: U,
@@ -95,7 +95,7 @@ extension vDSP {
     /// `result[0] = (10 * 2²) + (20 * 2¹) + (30 * 2⁰) // 110`
     ///
     /// `result[1] = (10 * 5²) + (20 * 5¹) + (30 * 5⁰) // 380`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func evaluatePolynomial<U>(usingCoefficients coefficients: [Double],
                                              withVariables variables: U) -> [Double]
@@ -128,7 +128,7 @@ extension vDSP {
     /// `result[0] = (10 * 2²) + (20 * 2¹) + (30 * 2⁰) // 110`
     ///
     /// `result[1] = (10 * 5²) + (20 * 5¹) + (30 * 5⁰) // 380`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func evaluatePolynomial<U, V>(usingCoefficients coefficients: [Double],
                                                 withVariables variables: U,

--- a/stdlib/public/Darwin/Accelerate/vDSP_RecursiveFilters.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_RecursiveFilters.swift
@@ -30,7 +30,7 @@ extension vDSP {
     ///
     /// Where `A` is the input vector, `B` is the filter coefficients, and `C`
     /// is the output vector. Note that outputs start with C[2].
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func twoPoleTwoZeroFilter<U>(_ source: U,
                                                   coefficients: (Float, Float, Float, Float, Float)) -> [Float]
@@ -72,7 +72,7 @@ extension vDSP {
     ///
     /// Where `A` is the input vector, `B` is the filter coefficients, and `C`
     /// is the output vector. Note that outputs start with C[2].
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func twoPoleTwoZeroFilter<U, V>(_ source: U,
                                                   coefficients: (Float, Float, Float, Float, Float),
@@ -117,7 +117,7 @@ extension vDSP {
     ///
     /// Where `A` is the input vector, `B` is the filter coefficients, and `C`
     /// is the output vector. Note that outputs start with C[2].
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func twoPoleTwoZeroFilter<U>(_ source: U,
                                                   coefficients: (Double, Double, Double, Double, Double)) -> [Double]
@@ -159,7 +159,7 @@ extension vDSP {
     ///
     /// Where `A` is the input vector, `B` is the filter coefficients, and `C`
     /// is the output vector. Note that outputs start with C[2].
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func twoPoleTwoZeroFilter<U, V>(_ source: U,
                                                   coefficients: (Double, Double, Double, Double, Double),

--- a/stdlib/public/Darwin/Accelerate/vDSP_Reduction.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_Reduction.swift
@@ -18,7 +18,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The maximum value in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximum<U>(_ vector: U) -> Float
         where
@@ -41,7 +41,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The maximum value in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximum<U>(_ vector: U) -> Double
         where
@@ -66,7 +66,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The maximum magnitude in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximumMagnitude<U>(_ vector: U) -> Float
         where
@@ -89,7 +89,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The maximum magnitude in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximumMagnitude<U>(_ vector: U) -> Double
         where
@@ -114,7 +114,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The minimum value in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func minimum<U>(_ vector: U) -> Float
         where
@@ -137,7 +137,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The minimum value in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func minimum<U>(_ vector: U) -> Double
         where
@@ -162,7 +162,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of values in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sum<U>(_ vector: U) -> Float
         where
@@ -185,7 +185,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of values in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sum<U>(_ vector: U) -> Double
         where
@@ -208,7 +208,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of squares in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sumOfSquares<U>(_ vector: U) -> Float
         where
@@ -231,7 +231,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of squares in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sumOfSquares<U>(_ vector: U) -> Double
         where
@@ -254,7 +254,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of values and the sum of squares in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sumAndSumOfSquares<U>(_ vector: U) -> (elementsSum: Float, squaresSum: Float)
         where
@@ -279,7 +279,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of values and the sum of squares in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sumAndSumOfSquares<U>(_ vector: U) -> (elementsSum: Double, squaresSum: Double)
         where
@@ -304,7 +304,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of magnitudes in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sumOfMagnitudes<U>(_ vector: U) -> Float
         where
@@ -327,7 +327,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: The sum of magnitudes in `vector`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sumOfMagnitudes<U>(_ vector: U) -> Double
         where
@@ -355,7 +355,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: A tuple containing the maximum value and its index.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func indexOfMaximum<U>(_ vector: U) -> (UInt, Float)
         where
@@ -380,7 +380,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: A tuple containing the maximum value and its index.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func indexOfMaximum<U>(_ vector: U) -> (UInt, Double)
         where
@@ -407,7 +407,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: A tuple containing the maximum magnitude and its index.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func indexOfMaximumMagnitude<U>(_ vector: U) -> (UInt, Float)
         where
@@ -432,7 +432,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: A tuple containing the maximum magnitude and its index.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func indexOfMaximumMagnitude<U>(_ vector: U) -> (UInt, Double)
         where
@@ -459,7 +459,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: A tuple containing the minimum value and its index.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func indexOfMinimum<U>(_ vector: U) -> (UInt, Float)
         where
@@ -484,7 +484,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Returns: A tuple containing the minimum value and its index.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func indexOfMinimum<U>(_ vector: U) -> (UInt, Double)
         where
@@ -513,7 +513,7 @@ extension vDSP {
     /// Returns the mean square of the supplied single-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func meanSquare<U>(_ vector: U) -> Float
         where
@@ -535,7 +535,7 @@ extension vDSP {
     /// Returns the mean square of the supplied double-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func meanSquare<U>(_ vector: U) -> Double
         where
@@ -559,7 +559,7 @@ extension vDSP {
     /// Returns the mean magnitude of the supplied single-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func meanMagnitude<U>(_ vector: U) -> Float
         where
@@ -581,7 +581,7 @@ extension vDSP {
     /// Returns the mean magnitude of the supplied double-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func meanMagnitude<U>(_ vector: U) -> Double
         where
@@ -606,7 +606,7 @@ extension vDSP {
     /// Returns the mean magnitude of the supplied single-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func mean<U>(_ vector: U) -> Float
         where
@@ -628,7 +628,7 @@ extension vDSP {
     /// Returns the mean of the supplied double-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func mean<U>(_ vector: U) -> Double
         where
@@ -652,7 +652,7 @@ extension vDSP {
     /// Returns the root-mean-square of the supplied single-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rootMeanSquare<U>(_ vector: U) -> Float
         where
@@ -674,7 +674,7 @@ extension vDSP {
     /// Returns the root-mean-square of the supplied double-precision vector.
     ///
     /// - Parameter vector: The input vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rootMeanSquare<U>(_ vector: U) -> Double
         where

--- a/stdlib/public/Darwin/Accelerate/vDSP_SingleVectorOperations.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_SingleVectorOperations.swift
@@ -25,7 +25,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func minimum<U>(_ vectorA: U,
                                   _ vectorB: U) -> [Float]
@@ -52,7 +52,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter result: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func minimum<U, V>(_ vectorA: U,
                                      _ vectorB: U,
@@ -83,7 +83,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func minimum<U>(_ vectorA: U,
                                   _ vectorB: U) -> [Double]
@@ -110,7 +110,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter result: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func minimum<U, V>(_ vectorA: U,
                                      _ vectorB: U,
@@ -143,7 +143,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximum<U>(_ vectorA: U,
                                   _ vectorB: U) -> [Float]
@@ -170,7 +170,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Parameter result: the `c` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximum<U, V>(_ vectorA: U,
                                      _ vectorB: U,
@@ -201,7 +201,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = `c[i] = a[i] > b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximum<U>(_ vectorA: U,
                                   _ vectorB: U) -> [Double]
@@ -228,7 +228,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
     /// - Parameter result: the `c` in `c[i] = a[i] > b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func maximum<U, V>(_ vectorA: U,
                                      _ vectorB: U,
@@ -268,7 +268,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func absolute<U>(_ vector: U) -> [Float]
         where
@@ -292,7 +292,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func absolute<U, V>(_ vector: U,
                                       result: inout V)
@@ -318,7 +318,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func absolute<U>(_ vector: U) -> [Double]
         where
@@ -342,7 +342,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func absolute<U, V>(_ vector: U,
                                       result: inout V)
@@ -367,7 +367,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negativeAbsolute<U>(_ vector: U) -> [Float]
         where
@@ -391,7 +391,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negativeAbsolute<U, V>(_ vector: U,
                                               result: inout V)
@@ -416,7 +416,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negativeAbsolute<U>(_ vector: U) -> [Double]
         where
@@ -440,7 +440,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negativeAbsolute<U, V>(_ vector: U,
                                               result: inout V)
@@ -465,7 +465,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negative<U>(_ vector: U) -> [Float]
         where
@@ -489,7 +489,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negative<U, V>(_ vector: U,
                                       result: inout V)
@@ -514,7 +514,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negative<U>(_ vector: U) -> [Double]
         where
@@ -538,7 +538,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The input vector.
     /// - Parameter result: The output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func negative<U, V>(_ vector: U,
                                       result: inout V)
@@ -572,7 +572,7 @@ extension vDSP {
     /// Reverses an array of single-precision values in-place.
     ///
     /// - Parameter vector: The array to reverse.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func reverse<V>(_ vector: inout V)
         where
@@ -590,7 +590,7 @@ extension vDSP {
     /// Reverses an array of double-precision values in-place.
     ///
     /// - Parameter vector: The array to reverse.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func reverse<V>(_ vector: inout V)
         where
@@ -616,7 +616,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The array to sort.
     /// - Parameter sortOrder: The sort direction.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sort<V>(_ vector: inout V,
                                sortOrder: SortOrder)
@@ -637,7 +637,7 @@ extension vDSP {
     ///
     /// - Parameter vector: The array to sort.
     /// - Parameter sortOrder: The sort direction.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sort<V>(_ vector: inout V,
                                sortOrder: SortOrder)
@@ -670,7 +670,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func square<U>(_ vector: U) -> [Float]
         where
@@ -693,7 +693,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func square<U, V>(_ vector: U,
                                     result: inout V)
@@ -720,7 +720,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func square<U>(_ vector: U) -> [Double]
         where
@@ -743,7 +743,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func square<U, V>(_ vector: U,
                                     result: inout V)
@@ -772,7 +772,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func signedSquare<U>(_ vector: U) -> [Float]
         where
@@ -795,7 +795,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func signedSquare<U, V>(_ vector: U,
                                           result: inout V)
@@ -822,7 +822,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func signedSquare<U>(_ vector: U) -> [Double]
         where
@@ -845,7 +845,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func signedSquare<U, V>(_ vector: U,
                                           result: inout V)
@@ -874,7 +874,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U>(_ vector: U) -> [Float]
         where
@@ -897,7 +897,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U, V>(_ vector: U,
                                    result: inout V)
@@ -924,7 +924,7 @@ extension vDSP {
     /// - Parameter vectorA: the `a` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Parameter vectorB: the `b` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
     /// - Returns: the `c` in `c[i] = a[i] < b[i] ? a[i] : b[i]`
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U>(_ vector: U) -> [Double]
         where
@@ -947,7 +947,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U, V>(_ vector: U,
                                    result: inout V)
@@ -975,7 +975,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: The total number of transitions from positive to negative values and from negative to positive values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func countZeroCrossings<U>(_ vector: U) -> UInt
         where
@@ -1001,7 +1001,7 @@ extension vDSP {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: The total number of transitions from positive to negative values and from negative to positive values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func countZeroCrossings<U>(_ vector: U) -> UInt
         where

--- a/stdlib/public/Darwin/Accelerate/vDSP_SlidingWindow.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_SlidingWindow.swift
@@ -17,7 +17,7 @@ extension vDSP {
     /// - Parameter source: Single-precision input vector.
     /// - Parameter windowLength: The number of consecutive elements to sum.
     /// - Returns: Single-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func slidingWindowSum<U>(_ vector: U,
                                            usingWindowLength windowLength: Int) -> [Float]
@@ -45,7 +45,7 @@ extension vDSP {
     /// - Parameter source: Single-precision input vector.
     /// - Parameter windowLength: The number of consecutive elements to sum.
     /// - Parameter result: Single-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func slidingWindowSum<U, V>(_ vector: U,
                                               usingWindowLength windowLength: Int,
@@ -75,7 +75,7 @@ extension vDSP {
     /// - Parameter source: Single-precision input vector.
     /// - Parameter windowLength: The number of consecutive elements to sum.
     /// - Returns: Single-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func slidingWindowSum<U>(_ vector: U,
                                            usingWindowLength windowLength: Int) -> [Double]
@@ -103,7 +103,7 @@ extension vDSP {
     /// - Parameter source: Double-precision input vector.
     /// - Parameter windowLength: The number of consecutive elements to sum.
     /// - Parameter result: Double-precision output vector.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func slidingWindowSum<U, V>(_ vector: U,
                                               usingWindowLength windowLength: Int,

--- a/stdlib/public/Darwin/Accelerate/vForce_Operations.swift
+++ b/stdlib/public/Darwin/Accelerate/vForce_Operations.swift
@@ -23,7 +23,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ceil<U>(_ vector: U)  -> [Float]
         where
@@ -46,7 +46,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ceil<U, V>(_ vector: U,
                                   result: inout V)
@@ -72,7 +72,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ceil<U>(_ vector: U)  -> [Double]
         where
@@ -95,7 +95,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func ceil<U, V>(_ vector: U,
                                   result: inout V)
@@ -123,7 +123,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floor<U>(_ vector: U) -> [Float]
         where
@@ -146,7 +146,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floor<U, V>(_ vector: U,
                                    result: inout V)
@@ -172,7 +172,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floor<U>(_ vector: U) -> [Double]
         where
@@ -195,7 +195,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func floor<U, V>(_ vector: U,
                                    result: inout V)
@@ -224,7 +224,7 @@ extension vForce {
     /// - Parameter magnitudes: Input magnitudes.
     /// - Parameter signs: Input signs.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func copysign<U, V>(magnitudes: U,
                                       signs: V) -> [Float]
@@ -253,7 +253,7 @@ extension vForce {
     /// - Parameter magnitudes: Input magnitudes.
     /// - Parameter signs: Input signs.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func copysign<T, U, V>(magnitudes: T,
                                          signs: U,
@@ -285,7 +285,7 @@ extension vForce {
     /// - Parameter magnitudes: Input magnitudes.
     /// - Parameter signs: Input signs.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func copysign<U, V>(magnitudes: U,
                                       signs: V) -> [Double]
@@ -314,7 +314,7 @@ extension vForce {
     /// - Parameter magnitudes: Input magnitudes.
     /// - Parameter signs: Input signs.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func copysign<T, U, V>(magnitudes: T,
                                          signs: U,
@@ -355,7 +355,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is the integer formed by rounding `a/b` towards zero, so `abs(r) < abs(b)` and `r` has the same sign as `a`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func truncatingRemainder<U, V>(dividends: U,
                                                  divisors: V) -> [Float]
@@ -389,7 +389,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is the integer formed by rounding `a/b` towards zero, so `abs(r) < abs(b)` and `r` has the same sign as `a`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func truncatingRemainder<T, U, V>(dividends: T,
                                                     divisors: U,
@@ -425,7 +425,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is the integer formed by rounding `a/b` towards zero, so `abs(r) < abs(b)` and `r` has the same sign as `a`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func truncatingRemainder<U, V>(dividends: U,
                                                  divisors: V) -> [Double]
@@ -459,7 +459,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is the integer formed by rounding `a/b` towards zero, so `abs(r) < abs(b)` and `r` has the same sign as `a`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func truncatingRemainder<T, U, V>(dividends: T,
                                                     divisors: U,
@@ -497,7 +497,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is `a/b` rounded to the nearest integer, so `abs(r) <= abs(b/2)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func remainder<U, V>(dividends: U,
                                        divisors: V) -> [Float]
@@ -530,7 +530,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is `a/b` rounded to the nearest integer, so `abs(r) <= abs(b/2)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func remainder<T, U, V>(dividends: T,
                                           divisors: U,
@@ -566,7 +566,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is `a/b` rounded to the nearest integer, so `abs(r) <= abs(b/2)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func remainder<U, V>(dividends: U,
                                        divisors: V) -> [Double]
@@ -599,7 +599,7 @@ extension vForce {
     /// For each corresponding `a` from `dividends` and `b` from `divisors`, the result `r` satisfies:
     ///     a = bq + r
     /// where q is `a/b` rounded to the nearest integer, so `abs(r) <= abs(b/2)`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func remainder<T, U, V>(dividends: T,
                                           divisors: U,
@@ -632,7 +632,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U>(_ vector: U)  -> [Float]
         where
@@ -655,7 +655,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U, V>(_ vector: U,
                                    result: inout V)
@@ -681,7 +681,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U>(_ vector: U)  -> [Double]
         where
@@ -704,7 +704,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func trunc<U, V>(_ vector: U,
                                    result: inout V)
@@ -732,7 +732,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func nearestInteger<U>(_ vector: U)  -> [Float]
         where
@@ -755,7 +755,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func nearestInteger<U, V>(_ vector: U,
                                             result: inout V)
@@ -781,7 +781,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func nearestInteger<U>(_ vector: U)  -> [Double]
         where
@@ -804,7 +804,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func nearestInteger<U, V>(_ vector: U,
                                             result: inout V)
@@ -832,7 +832,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rsqrt<U>(_ vector: U)  -> [Float]
         where
@@ -855,7 +855,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rsqrt<U, V>(_ vector: U,
                                    result: inout V)
@@ -881,7 +881,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rsqrt<U>(_ vector: U)  -> [Double]
         where
@@ -904,7 +904,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func rsqrt<U, V>(_ vector: U,
                                    result: inout V)
@@ -932,7 +932,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sqrt<U>(_ vector: U)  -> [Float]
         where
@@ -955,7 +955,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sqrt<U, V>(_ vector: U,
                                   result: inout V)
@@ -982,7 +982,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sqrt<U>(_ vector: U)  -> [Double]
         where
@@ -1005,7 +1005,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sqrt<U, V>(_ vector: U,
                                   result: inout V)
@@ -1033,7 +1033,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func reciprocal<U>(_ vector: U)  -> [Float]
         where
@@ -1056,7 +1056,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func reciprocal<U, V>(_ vector: U,
                                         result: inout V)
@@ -1082,7 +1082,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func reciprocal<U>(_ vector: U)  -> [Double]
         where
@@ -1105,7 +1105,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func reciprocal<U, V>(_ vector: U,
                                         result: inout V)
@@ -1138,7 +1138,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp<U>(_ vector: U)  -> [Float]
         where
@@ -1161,7 +1161,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp<U, V>(_ vector: U,
                                  result: inout V)
@@ -1187,7 +1187,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func expm1<U>(_ vector: U)  -> [Float]
         where
@@ -1210,7 +1210,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func expm1<U, V>(_ vector: U,
                                    result: inout V)
@@ -1236,7 +1236,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp2<U>(_ vector: U)  -> [Float]
         where
@@ -1259,7 +1259,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp2<U, V>(_ vector: U,
                                   result: inout V)
@@ -1285,7 +1285,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp<U>(_ vector: U)  -> [Double]
         where
@@ -1308,7 +1308,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp<U, V>(_ vector: U,
                                  result: inout V)
@@ -1334,7 +1334,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func expm1<U>(_ vector: U)  -> [Double]
         where
@@ -1357,7 +1357,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func expm1<U, V>(_ vector: U,
                                    result: inout V)
@@ -1383,7 +1383,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp2<U>(_ vector: U)  -> [Double]
         where
@@ -1406,7 +1406,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func exp2<U, V>(_ vector: U,
                                   result: inout V)
@@ -1434,7 +1434,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log2<U>(_ vector: U)  -> [Float]
         where
@@ -1457,7 +1457,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log2<U, V>(_ vector: U,
                                   result: inout V)
@@ -1483,7 +1483,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log10<U>(_ vector: U)  -> [Float]
         where
@@ -1506,7 +1506,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log10<U, V>(_ vector: U,
                                    result: inout V)
@@ -1532,7 +1532,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log2<U>(_ vector: U)  -> [Double]
         where
@@ -1555,7 +1555,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log2<U, V>(_ vector: U,
                                   result: inout V)
@@ -1581,7 +1581,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log10<U>(_ vector: U)  -> [Double]
         where
@@ -1604,7 +1604,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func log10<U, V>(_ vector: U,
                                    result: inout V)
@@ -1632,7 +1632,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func logb<U>(_ vector: U)  -> [Float]
         where
@@ -1657,7 +1657,7 @@ extension vForce {
     /// - Parameter result: Output values.
     ///
     /// This function calculates `floor(log2(vector))`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func logb<U, V>(_ vector: U,
                                   result: inout V)
@@ -1683,7 +1683,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func logb<U>(_ vector: U)  -> [Double]
         where
@@ -1708,7 +1708,7 @@ extension vForce {
     /// - Parameter result: Output values.
     ///
     /// This function calculates `floor(log2(vector))`.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func logb<U, V>(_ vector: U,
                                   result: inout V)
@@ -1742,7 +1742,7 @@ extension vForce {
     /// - Parameter bases: Input base values.
     /// - Parameter exponents: Input exponents.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func pow<U, V>(bases: U,
                                  exponents: V) -> [Float]
@@ -1771,7 +1771,7 @@ extension vForce {
     /// - Parameter bases: Input base values.
     /// - Parameter exponents: Input exponents.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func pow<T, U, V>(bases: T,
                                     exponents: U,
@@ -1803,7 +1803,7 @@ extension vForce {
     /// - Parameter bases: Input base values.
     /// - Parameter exponents: Input exponents.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func pow<U, V>(bases: U,
                                  exponents: V) -> [Double]
@@ -1832,7 +1832,7 @@ extension vForce {
     /// - Parameter bases: Input base values.
     /// - Parameter exponents: Input exponents.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func pow<T, U, V>(bases: T,
                                     exponents: U,
@@ -1874,7 +1874,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sin<U>(_ vector: U)  -> [Float]
         where
@@ -1897,7 +1897,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sin<U, V>(_ vector: U,
                                  result: inout V)
@@ -1923,7 +1923,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sin<U>(_ vector: U)  -> [Double]
         where
@@ -1946,7 +1946,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sin<U, V>(_ vector: U,
                                  result: inout V)
@@ -1972,7 +1972,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinPi<U>(_ vector: U)  -> [Float]
         where
@@ -1995,7 +1995,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinPi<U, V>(_ vector: U,
                                    result: inout V)
@@ -2021,7 +2021,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinPi<U>(_ vector: U)  -> [Double]
         where
@@ -2044,7 +2044,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinPi<U, V>(_ vector: U,
                                    result: inout V)
@@ -2072,7 +2072,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cos<U>(_ vector: U)  -> [Float]
         where
@@ -2095,7 +2095,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cos<U, V>(_ vector: U,
                                  result: inout V)
@@ -2121,7 +2121,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cos<U>(_ vector: U)  -> [Double]
         where
@@ -2144,7 +2144,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cos<U, V>(_ vector: U,
                                  result: inout V)
@@ -2170,7 +2170,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosPi<U>(_ vector: U)  -> [Float]
         where
@@ -2193,7 +2193,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosPi<U, V>(_ vector: U,
                                    result: inout V)
@@ -2219,7 +2219,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosPi<U>(_ vector: U)  -> [Double]
         where
@@ -2242,7 +2242,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosPi<U, V>(_ vector: U,
                                    result: inout V)
@@ -2271,7 +2271,7 @@ extension vForce {
     /// - Parameter vector: Input values.
     /// - Parameter sinresult: Output sine values.
     /// - Parameter cosresult: Output cosine values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sincos<T, U, V>(_ vector: T,
                                        sinResult: inout U,
@@ -2303,7 +2303,7 @@ extension vForce {
     /// - Parameter vector: Input values.
     /// - Parameter sinresult: Output sine values.
     /// - Parameter cosresult: Output cosine values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sincos<T, U, V>(_ vector: T,
                                        sinResult: inout U,
@@ -2336,7 +2336,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tan<U>(_ vector: U)  -> [Float]
         where
@@ -2359,7 +2359,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tan<U, V>(_ vector: U,
                                  result: inout V)
@@ -2385,7 +2385,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tan<U>(_ vector: U)  -> [Double]
         where
@@ -2409,7 +2409,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tan<U, V>(_ vector: U,
                                  result: inout V)
@@ -2435,7 +2435,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanPi<U>(_ vector: U)  -> [Float]
         where
@@ -2458,7 +2458,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanPi<U, V>(_ vector: U,
                                    result: inout V)
@@ -2484,7 +2484,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanPi<U>(_ vector: U)  -> [Double]
         where
@@ -2507,7 +2507,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanPi<U, V>(_ vector: U,
                                    result: inout V)
@@ -2535,7 +2535,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asin<U>(_ vector: U)  -> [Float]
         where
@@ -2558,7 +2558,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asin<U, V>(_ vector: U,
                                   result: inout V)
@@ -2584,7 +2584,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asin<U>(_ vector: U)  -> [Double]
         where
@@ -2607,7 +2607,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asin<U, V>(_ vector: U,
                                   result: inout V)
@@ -2635,7 +2635,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acos<U>(_ vector: U)  -> [Float]
         where
@@ -2658,7 +2658,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acos<U, V>(_ vector: U,
                                   result: inout V)
@@ -2684,7 +2684,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acos<U>(_ vector: U)  -> [Double]
         where
@@ -2707,7 +2707,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acos<U, V>(_ vector: U,
                                   result: inout V)
@@ -2735,7 +2735,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atan<U>(_ vector: U)  -> [Float]
         where
@@ -2758,7 +2758,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atan<U, V>(_ vector: U,
                                   result: inout V)
@@ -2784,7 +2784,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atan<U>(_ vector: U)  -> [Double]
         where
@@ -2807,7 +2807,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atan<U, V>(_ vector: U,
                                   result: inout V)
@@ -2840,7 +2840,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinh<U>(_ vector: U)  -> [Float]
         where
@@ -2863,7 +2863,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinh<U, V>(_ vector: U,
                                   result: inout V)
@@ -2889,7 +2889,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinh<U>(_ vector: U)  -> [Double]
         where
@@ -2912,7 +2912,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func sinh<U, V>(_ vector: U,
                                   result: inout V)
@@ -2940,7 +2940,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosh<U>(_ vector: U)  -> [Float]
         where
@@ -2963,7 +2963,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosh<U, V>(_ vector: U,
                                   result: inout V)
@@ -2989,7 +2989,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosh<U>(_ vector: U)  -> [Double]
         where
@@ -3012,7 +3012,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func cosh<U, V>(_ vector: U,
                                   result: inout V)
@@ -3040,7 +3040,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanh<U>(_ vector: U)  -> [Float]
         where
@@ -3063,7 +3063,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanh<U, V>(_ vector: U,
                                   result: inout V)
@@ -3089,7 +3089,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanh<U>(_ vector: U)  -> [Double]
         where
@@ -3112,7 +3112,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func tanh<U, V>(_ vector: U,
                                   result: inout V)
@@ -3140,7 +3140,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asinh<U>(_ vector: U)  -> [Float]
         where
@@ -3163,7 +3163,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asinh<U, V>(_ vector: U,
                                    result: inout V)
@@ -3189,7 +3189,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asinh<U>(_ vector: U)  -> [Double]
         where
@@ -3212,7 +3212,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func asinh<U, V>(_ vector: U,
                                    result: inout V)
@@ -3240,7 +3240,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acosh<U>(_ vector: U)  -> [Float]
         where
@@ -3263,7 +3263,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acosh<U, V>(_ vector: U,
                                    result: inout V)
@@ -3289,7 +3289,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acosh<U>(_ vector: U)  -> [Double]
         where
@@ -3312,7 +3312,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func acosh<U, V>(_ vector: U,
                                    result: inout V)
@@ -3340,7 +3340,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atanh<U>(_ vector: U)  -> [Float]
         where
@@ -3363,7 +3363,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atanh<U, V>(_ vector: U,
                                    result: inout V)
@@ -3389,7 +3389,7 @@ extension vForce {
     ///
     /// - Parameter _ vector: Input values.
     /// - Returns: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atanh<U>(_ vector: U)  -> [Double]
         where
@@ -3412,7 +3412,7 @@ extension vForce {
     ///
     /// - Parameter vector: Input values.
     /// - Parameter result: Output values.
-    @inline(__always)
+    @inlinable
     @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
     public static func atanh<U, V>(_ vector: U,
                                    result: inout V)


### PR DESCRIPTION
@inline(__always) does not imply inlinable, which means that it effectively does nothing in the context of the Accelerate overlay. I have replaced all of these with @inlinable where that can be done as a one-line change. Functions that switch over open enums and more complex API (DCT, DFT, FFT) will require more sophisticated corrections, which we can undertake in later commits. For now, they have been rolled back to simply being normal public API.

(Cherry pick of https://github.com/apple/swift/pull/24641 for 5.1-branch)