### PR TITLE
[AutoDiff] Fix `@differentiable` and `@differentiating` type-checking.

### DIFF
--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -505,6 +505,41 @@ func vjpWhere1<T : Differentiable>(x: T) -> (T, (T.CotangentVector) -> T.Cotange
   return (x, { v in v })
 }
 
+// Test derivative functions with result tuple type labels.
+@differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
+func derivativeResultLabels(_ x: Float) -> Float {
+  return x
+}
+func jvpResultLabels(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+  return (x, { $0 })
+}
+func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (x, { $0 })
+}
+struct ResultLabelTest {
+  @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
+  static func derivativeResultLabels(_ x: Float) -> Float {
+    return x
+  }
+  static func jvpResultLabels(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (x, { $0 })
+  }
+  static func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (x, { $0 })
+  }
+
+  @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
+  func derivativeResultLabels(_ x: Float) -> Float {
+    return x
+  }
+  func jvpResultLabels(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (x, { $0 })
+  }
+  func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (x, { $0 })
+  }
+}
+
 struct Tensor<Scalar> : AdditiveArithmetic {}
 extension Tensor : Differentiable where Scalar : Differentiable {
   typealias TangentVector = Tensor

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -579,7 +579,6 @@ extension FloatingPoint {
 }
 
 protocol MethodDiffReq {
-  // expected-error @+1 {{'vjpFoo' does not have expected type '<Self where Self : Differentiable, Self : MethodDiffReq> (Self) -> () -> (Self, (Self.CotangentVector) -> Self.CotangentVector)'}}
   @differentiable(wrt: self, vjp: vjpFoo where Self : Differentiable)
   func foo() -> Self
 }

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -280,3 +280,16 @@ extension InstanceMethodProto where Self : Differentiable {
     return (bar(), { _ in .zero })
   }
 }
+
+// Test consistent usages of `@differentiable` and `@differentiating` where
+// derivative functions are specified in both attributes.
+@differentiable(jvp: jvpConsistent, vjp: vjpConsistent)
+func consistentSpecifiedDerivatives(_ x: Float) -> Float {
+  return x
+}
+func jvpConsistent(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+  return (x, { $0 })
+}
+func vjpConsistent(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (x, { $0 })
+}

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -287,9 +287,11 @@ extension InstanceMethodProto where Self : Differentiable {
 func consistentSpecifiedDerivatives(_ x: Float) -> Float {
   return x
 }
+@differentiating(consistentSpecifiedDerivatives)
 func jvpConsistent(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
   return (x, { $0 })
 }
+@differentiating(consistentSpecifiedDerivatives(_:))
 func vjpConsistent(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   return (x, { $0 })
 }


### PR DESCRIPTION
- `@differentiable`: Ignore derivative function result tuple type labels.
  - This enables JVP/VJPs that return labeled tuple results (e.g. `(value:pullback:)`).
- `@differentiating`: Fix duplicate `@differentiable` attribute diagnostic.
  - Emit an error only when the original function has a `@differentiable` attribute
    with the same differentiation parameters and a *different* registered derivative.

---

These changes are a step towards fixing `validation-test/ParseableInterface/verify_stdlib.swift` on the `tensorflow-merge` branch (merging to `swift-DEVELOPMENT-SNAPSHOT-2019-05-02-a`).