### PR TITLE
Remove need for legacy-impl flag

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2023,7 +2023,6 @@ darwin-toolchain-application-cert=lldb_codesign
 # Instead, options are copied here individually.
 [preset: tensorflow_osx_base]
 mixin-preset=mixin_lightweight_assertions
-legacy-impl
 
 ### From: mixin_osx_package_base
 lldb
@@ -2119,19 +2118,11 @@ darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 
 [preset: tensorflow_linux]
 mixin-preset=buildbot_linux
-legacy-impl
-indexstore-db=0
-sourcekit-lsp=0
-toolchain-benchmarks=0
 enable-tensorflow
 install-tensorflow
 
 [preset: tensorflow_linux,no_test]
 mixin-preset=buildbot_linux,no_test
-legacy-impl
-indexstore-db=0
-sourcekit-lsp=0
-toolchain-benchmarks=0
 enable-tensorflow
 install-tensorflow
 
@@ -2181,7 +2172,6 @@ mixin-preset=mixin_lightweight_assertions
 enable-tensorflow
 release
 test
-legacy-impl
 test-optimized
 validation-test
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2551,6 +2551,20 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 if [[ "${ENABLE_TENSORFLOW}" ]] ; then
                     # Verify TensorFlow include/library directories.
+                    if [[ ! "${TENSORFLOW_HOST_INCLUDE_DIR}" ]] ; then
+                       TENSORFLOW_HOST_INCLUDE_DIR="$TENSORFLOW_SOURCE_DIR"
+                    fi
+                    if [[ ! "${TENSORFLOW_HOST_LIB_DIR}" ]] ; then
+                       TENSORFLOW_HOST_LIB_DIR="$TENSORFLOW_SOURCE_DIR/bazel-bin/tensorflow"
+                    fi
+
+                    if [[ ! "${TENSORFLOW_TARGET_LIB_DIR}" ]] ; then
+                        TENSORFLOW_TARGET_LIB_DIR="${TENSORFLOW_HOST_LIB_DIR}"
+                    fi
+                    if [[ ! "${TENSORFLOW_TARGET_INCLUDE_DIR}" ]] ; then
+                        TENSORFLOW_TARGET_INCLUDE_DIR="${TENSORFLOW_HOST_INCLUDE_DIR}"
+                    fi
+
                     verify_tensorflow_directories
 
                     # Copy TensorFlow libraries to correct destination.
@@ -2569,12 +2583,6 @@ for host in "${ALL_HOSTS[@]}"; do
                         find "${TENSORFLOW_HOST_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec cp -p {} "${TF_LIB_DIR}" \;
                     done
 
-                    if [[ ! "${TENSORFLOW_TARGET_LIB_DIR}" ]] ; then
-                        TENSORFLOW_TARGET_LIB_DIR="${TENSORFLOW_HOST_LIB_DIR}"
-                    fi
-                    if [[ ! "${TENSORFLOW_TARGET_INCLUDE_DIR}" ]] ; then
-                        TENSORFLOW_TARGET_INCLUDE_DIR="${TENSORFLOW_HOST_INCLUDE_DIR}"
-                    fi
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_ENABLE_TENSORFLOW:BOOL=TRUE
@@ -3027,12 +3035,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 echo yes "" | "${source_dir}/configure"
                 with_pushd "${source_dir}" \
                     call bazel build -c opt "${TENSORFLOW_BAZEL_OPTIONS[@]}" --define framework_shared_object=false //tensorflow:libtensorflow.so //tensorflow:libtensorflow_framework.so
-
-                # Set TensorFlow include/lib directories.
-                TENSORFLOW_HOST_INCLUDE_DIR="${source_dir}"
-                TENSORFLOW_HOST_LIB_DIR="${source_dir}/bazel-bin/tensorflow"
-                TENSORFLOW_TARGET_INCLUDE_DIR="${source_dir}"
-                TENSORFLOW_TARGET_LIB_DIR="${source_dir}/bazel-bin/tensorflow"
 
                 # TensorFlow builds itself and doesn't use CMake.
                 continue


### PR DESCRIPTION
The build script now runs in multiple passes. This means that the vars set in one pass will not show up in another. Just move the needed vars to the right place.