### PR TITLE
Reduce the Stack Size of ConstraintSystem

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -229,7 +229,8 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   }
 
   // Register the defaulted type variables.
-  DefaultedConstraints.append(solution.DefaultedConstraints.begin(),
+  DefaultedConstraints.insert(DefaultedConstraints.end(),
+                              solution.DefaultedConstraints.begin(),
                               solution.DefaultedConstraints.end());
 
   // Register the conformances checked along the way to arrive to solution.
@@ -309,6 +310,12 @@ bool ConstraintSystem::simplify(bool ContinueAfterFailures) {
 }
 
 namespace {
+
+template<typename T>
+void truncate(std::vector<T> &vec, unsigned newSize) {
+  assert(newSize <= vec.size() && "Not a truncation!");
+  vec.erase(vec.begin() + newSize, vec.end());
+}
 
 /// Truncate the given small vector to the given new size.
 template<typename T>

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -99,8 +99,8 @@ void SplitterStep::computeFollowupSteps(
   // FIXME: We're seeding typeVars with TypeVariables so that the
   // connected-components algorithm only considers those type variables within
   // our component. There are clearly better ways to do this.
-  SmallVector<TypeVariableType *, 16> typeVars(CS.TypeVariables);
-  SmallVector<unsigned, 16> components;
+  std::vector<TypeVariableType *> typeVars(CS.TypeVariables);
+  std::vector<unsigned> components;
   unsigned numComponents = CG.computeConnectedComponents(typeVars, components);
   if (numComponents < 2) {
     componentSteps.push_back(llvm::make_unique<ComponentStep>(

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -291,7 +291,7 @@ class ComponentStep final : public SolverStep {
     ConstraintSystem &CS;
     ConstraintSystem::SolverScope *SolverScope;
 
-    SmallVector<TypeVariableType *, 16> TypeVars;
+    std::vector<TypeVariableType *> TypeVars;
     ConstraintSystem::SolverScope *PrevPartialScope = nullptr;
 
     // The component this scope is associated with.
@@ -336,7 +336,7 @@ class ComponentStep final : public SolverStep {
   std::unique_ptr<Scope> ComponentScope = nullptr;
 
   /// Type variables and constraints "in scope" of this step.
-  SmallVector<TypeVariableType *, 16> TypeVars;
+  std::vector<TypeVariableType *> TypeVars;
   /// Constraints "in scope" of this step.
   ConstraintList *Constraints;
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -528,7 +528,7 @@ void ConstraintGraph::gatherConstraints(
 static void connectedComponentsDFS(ConstraintGraph &cg,
                                    ConstraintGraphNode &node,
                                    unsigned component,
-                                   SmallVectorImpl<unsigned> &components) {
+                                   std::vector<unsigned> &components) {
   // Local function that recurses on the given set of type variables.
   auto visitAdjacencies = [&](ArrayRef<TypeVariableType *> typeVars) {
     for (auto adj : typeVars) {
@@ -562,8 +562,8 @@ static void connectedComponentsDFS(ConstraintGraph &cg,
 }
 
 unsigned ConstraintGraph::computeConnectedComponents(
-           SmallVectorImpl<TypeVariableType *> &typeVars,
-           SmallVectorImpl<unsigned> &components) {
+           std::vector<TypeVariableType *> &typeVars,
+           std::vector<unsigned> &components) {
   // Track those type variables that the caller cares about.
   llvm::SmallPtrSet<TypeVariableType *, 4> typeVarSubset(typeVars.begin(),
                                                          typeVars.end());
@@ -871,9 +871,9 @@ void ConstraintGraph::dump() {
 }
 
 void ConstraintGraph::printConnectedComponents(llvm::raw_ostream &out) {
-  SmallVector<TypeVariableType *, 16> typeVars;
-  typeVars.append(TypeVariables.begin(), TypeVariables.end());
-  SmallVector<unsigned, 16> components;
+  std::vector<TypeVariableType *> typeVars;
+  typeVars.insert(typeVars.end(), TypeVariables.begin(), TypeVariables.end());
+  std::vector<unsigned> components;
   unsigned numComponents = computeConnectedComponents(typeVars, components);
   for (unsigned component = 0; component != numComponents; ++component) {
     out.indent(2);

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -249,8 +249,8 @@ public:
   /// one component for each of the constraints produced by
   /// \c getOrphanedConstraints().
   unsigned computeConnectedComponents(
-             SmallVectorImpl<TypeVariableType *> &typeVars,
-             SmallVectorImpl<unsigned> &components);
+             std::vector<TypeVariableType *> &typeVars,
+             std::vector<unsigned> &components);
 
   /// Retrieve the set of "orphaned" constraints, which are known to the
   /// constraint graph but have no type variables to anchor them.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2254,7 +2254,7 @@ size_t Solution::getTotalMemory() const {
          llvm::capacity_in_bytes(Fixes) + DisjunctionChoices.getMemorySize() +
          OpenedTypes.getMemorySize() + OpenedExistentialTypes.getMemorySize() +
          (DefaultedConstraints.size() * sizeof(void *)) +
-         llvm::capacity_in_bytes(Conformances);
+         Conformances.size() * sizeof(std::pair<ConstraintLocator *, ProtocolConformanceRef>);
 }
 
 DeclName OverloadChoice::getName() const {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -609,14 +609,14 @@ public:
   ConstraintSystem &getConstraintSystem() const { return *constraintSystem; }
 
   /// The set of type bindings.
-  llvm::SmallDenseMap<TypeVariableType *, Type> typeBindings;
+  llvm::DenseMap<TypeVariableType *, Type> typeBindings;
   
   /// The set of overload choices along with their types.
-  llvm::SmallDenseMap<ConstraintLocator *, SelectedOverload> overloadChoices;
+  llvm::DenseMap<ConstraintLocator *, SelectedOverload> overloadChoices;
 
   /// The set of constraint restrictions used to arrive at this restriction,
   /// which informs constraint application.
-  llvm::SmallDenseMap<std::pair<CanType, CanType>, ConversionRestrictionKind>
+  llvm::DenseMap<std::pair<CanType, CanType>, ConversionRestrictionKind>
     ConstraintRestrictions;
 
   /// The list of fixes that need to be applied to the initial expression
@@ -628,19 +628,19 @@ public:
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.
-  llvm::SmallDenseMap<ConstraintLocator *, unsigned> DisjunctionChoices;
+  llvm::DenseMap<ConstraintLocator *, unsigned> DisjunctionChoices;
 
   /// The set of opened types for a given locator.
-  llvm::SmallDenseMap<ConstraintLocator *, ArrayRef<OpenedType>> OpenedTypes;
+  llvm::DenseMap<ConstraintLocator *, ArrayRef<OpenedType>> OpenedTypes;
 
   /// The opened existential type for a given locator.
-  llvm::SmallDenseMap<ConstraintLocator *, OpenedArchetypeType *>
+  llvm::DenseMap<ConstraintLocator *, OpenedArchetypeType *>
     OpenedExistentialTypes;
 
   /// The locators of \c Defaultable constraints whose defaults were used.
-  llvm::SmallPtrSet<ConstraintLocator *, 8> DefaultedConstraints;
+  llvm::SmallPtrSet<ConstraintLocator *, 2> DefaultedConstraints;
 
-  llvm::SmallVector<std::pair<ConstraintLocator *, ProtocolConformanceRef>, 8>
+  std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       Conformances;
 
   /// Simplify the given type by substituting all occurrences of
@@ -1055,7 +1055,7 @@ private:
   /// solution it represents.
   Score CurrentScore;
 
-  SmallVector<TypeVariableType *, 16> TypeVariables;
+  std::vector<TypeVariableType *> TypeVariables;
 
   /// Maps expressions to types for choosing a favored overload
   /// type in a disjunction constraint.
@@ -1090,7 +1090,7 @@ private:
   /// there are multiple ways in which one type could convert to another, e.g.,
   /// given class types A and B, the solver might choose either a superclass
   /// conversion or a user-defined conversion.
-  SmallVector<std::tuple<Type, Type, ConversionRestrictionKind>, 32>
+  std::vector<std::tuple<Type, Type, ConversionRestrictionKind>>
       ConstraintRestrictions;
 
   /// The set of fixes applied to make the solution work.
@@ -1100,7 +1100,7 @@ private:
 
   /// The set of remembered disjunction choices used to reach
   /// the current constraint system.
-  SmallVector<std::pair<ConstraintLocator*, unsigned>, 32>
+  std::vector<std::pair<ConstraintLocator*, unsigned>>
       DisjunctionChoices;
 
   /// The worklist of "active" constraints that should be revisited
@@ -1124,12 +1124,12 @@ private:
   SmallVector<std::pair<ConstraintLocator *, OpenedArchetypeType *>, 4>
     OpenedExistentialTypes;
 
-  SmallVector<std::pair<ConstraintLocator *, ProtocolConformanceRef>, 8>
+  std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       CheckedConformances;
 
 public:
   /// The locators of \c Defaultable constraints whose defaults were used.
-  SmallVector<ConstraintLocator *, 8> DefaultedConstraints;
+  std::vector<ConstraintLocator *> DefaultedConstraints;
 
   /// A cache that stores the @dynamicCallable required methods implemented by
   /// types.


### PR DESCRIPTION
I've been looking at the sourcekit tests on Windows and have been running into stack overflows. The issue is not too much recursion, but rather one of huge stack frames in normal operation. For example, the ConstraintSystem class is on the order of 1000s of bytes in size on the stack. This becomes a problem with sourcekit which runs dispatch threads that have a hard coded 64k stack limit.

I don't see a single spot that's causing all the problems, I've seen it stack overflow so far with two entirely different stack traces. (Though one of them was probably caused because swift::Lexer::kindOfIdentifier uses 9992 bytes of stack on Windows and 12736 on Darwin.) I think most of this will be finding large classes and functions and either making them smaller, or instantiating them on the heap instead of the stack. 

This commit changes ConstraintSystem from using Small data types which store data on the stack to non small heap based data types.

As numbers go, this reduces the stack frame size of `ResolvedMemberResult swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name)` from 4824 bytes to 2584 bytes (measured on a Windows Release build). The numbers are taken from looking at the `sub rsp` instruction in the function's dissassembly. e.g:

```
    sourcekitdInProc!swift::resolveValueMember:
00007ff8`b66cc160 4157               push    r15
00007ff8`b66cc162 4156               push    r14
00007ff8`b66cc164 4155               push    r13
00007ff8`b66cc166 4154               push    r12
00007ff8`b66cc168 56                 push    rsi
00007ff8`b66cc169 57                 push    rdi
00007ff8`b66cc16a 55                 push    rbp
00007ff8`b66cc16b 53                 push    rbx
00007ff8`b66cc16c 4881ec180a0000     sub     rsp, 0A18h
```

I've only noticed the stack overflows on Windows so far. Windows in general does seem to allocate slightly more stack space than Darwin and I'm not sure why that is yet. For example, for one stack overflow I traced through, I counted up 48440 of used stack space on Windows and 41288 on Darwin at the same (non crashed) point.

