### PR TITLE
[Sema] Fix `Differentiable` member type usage crasher.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -996,7 +996,7 @@ static void addOpaqueAccessorToStorage(AbstractStorageDecl *storage,
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// Made public so that DerivedConformanceParameterized can call it.
+/// Made public so that DerivedConformanceDifferentiable.cpp can call it.
 void swift::addExpectedOpaqueAccessorsToStorage(AbstractStorageDecl *storage,
                                                 ASTContext &ctx) {
   // Nameless vars from interface files should not have any accessors.

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -780,6 +780,7 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     newMember->copyFormalAccessFrom(member, /*sourceIsParentContext*/ true);
     newMember->setValidationToChecked();
     newMember->setSetterAccess(member->getFormalAccess());
+    addExpectedOpaqueAccessorsToStorage(newMember, C);
     C.addSynthesizedDecl(newMember);
     C.addSynthesizedDecl(memberBinding);
 

--- a/test/Sema/struct_differentiable_member_types.swift
+++ b/test/Sema/struct_differentiable_member_types.swift
@@ -1,0 +1,19 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-typecheck-verify-swift
+
+// Test usages of synthesized `Differentiable` member struct types.
+
+// TF-466: Test conforming a synthesized member type to a protocol with
+// property requirements.
+protocol Proto {
+  var weight: Float { get }
+}
+struct Foo : Differentiable {
+  var weight: Float
+}
+// Note: the global variable here is necessary for type-checking to pass
+// when extending a synthesized member type. Enabling general extensions of
+// synthesized member types require extra non-trivial work, due to the
+// current type-checker design.
+let randomGlobal = 1
+extension Foo.CotangentVector : Proto {}


### PR DESCRIPTION
Fix crasher when conforming a synthesized member type (e.g. `CotangentVector`) to a protocol with property requirements.

Resolves [TF-466](https://bugs.swift.org/browse/TF-466). Enabling general extensions of synthesized member types requires extra work.