### PR TITLE
[IRGen]: Remove unused explosion schema from enum payload schema

### DIFF
--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -26,54 +26,38 @@ namespace swift {
 namespace irgen {
   
 /// A description of how to represent an enum payload as a value.
-/// A payload can either use a generic word-chunked representation, or attempt
-/// to follow the explosion schema of one of its payload types.
+/// A payload can either use a generic word-chunked representation,
+/// or attempt to follow the explosion schema of one of its payload
+/// types.
+/// TODO: the current code only ever uses the generic word-chunked
+/// representation, it might be better if it used an appropriate
+/// explosion schema instead.
 class EnumPayloadSchema {
-  using BitSizeTy = llvm::PointerEmbeddedInt<unsigned, 31>;
-
-  const llvm::PointerUnion<ExplosionSchema *, BitSizeTy> Value;
-
+  // A size in bits less than 0 indicates that the payload size is
+  // dynamic.
+  const int64_t BitSize;
 public:
-  EnumPayloadSchema() : Value((ExplosionSchema *)nullptr) {}
+  /// Create a new schema with a dynamic size.
+  EnumPayloadSchema() : BitSize(-1) {}
 
-  explicit operator bool() {
-    return Value.getOpaqueValue() != nullptr;
-  }
-
+  /// Create a new schema with the given fixed size in bits.
   explicit EnumPayloadSchema(unsigned bits)
-    : Value(BitSizeTy(bits)) {}
+    : BitSize(static_cast<int64_t>(bits)) {}
 
-  EnumPayloadSchema(ExplosionSchema &s)
-    : Value(&s) {}
+  /// Report whether the schema has a fixed size.
+  explicit operator bool() const {
+    return BitSize >= 0;
+  }
 
-  static EnumPayloadSchema withBitSize(unsigned bits) {
-    return EnumPayloadSchema(bits);
-  }
-  
-  ExplosionSchema *getSchema() const {
-    return Value.dyn_cast<ExplosionSchema*>();
-  }
-  
   /// Invoke a functor for each element type in the schema.
   template<typename TypeFn /* void(llvm::Type *schemaType) */>
   void forEachType(IRGenModule &IGM, TypeFn &&fn) const {
-    // Follow an explosion schema if we have one.
-    if (auto *explosion = Value.dyn_cast<ExplosionSchema *>()) {
-      for (auto &element : *explosion) {
-        auto type = element.getScalarType();
-        assert(IGM.DataLayout.getTypeSizeInBits(type)
-                 == IGM.DataLayout.getTypeAllocSizeInBits(type)
-               && "enum payload schema elements should use full alloc size");
-        (void) type;
-        fn(element.getScalarType());
-      }
-      return;
-    }
-    
-    // Otherwise, chunk into pointer-sized integer values by default.
-    unsigned bitSize = Value.get<BitSizeTy>();
-    unsigned pointerSize = IGM.getPointerSize().getValueInBits();
-    
+    assert(BitSize >= 0 && "payload size must not be dynamic");
+
+    // Chunk into pointer-sized integer values.
+    int64_t bitSize = BitSize;
+    int64_t pointerSize = IGM.getPointerSize().getValueInBits();
+
     while (bitSize >= pointerSize) {
       fn(IGM.SizeTy);
       bitSize -= pointerSize;

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1334,11 +1334,6 @@ namespace {
         PayloadBitCount = ~0u;
       }
     }
-    
-    ~PayloadEnumImplStrategyBase() override {
-      if (auto schema = PayloadSchema.getSchema())
-        delete schema;
-    }
 
     void getSchema(ExplosionSchema &schema) const override {
       if (TIK < Loadable) {

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -115,7 +115,7 @@ IRGenTypeVerifierFunction::emit(ArrayRef<CanType> formalTypes) {
         auto fixedXIOpaque = Builder.CreateBitCast(fixedXIBuf,
                                                        IGM.OpaquePtrTy);
         auto xiMask = fixedTI->getFixedExtraInhabitantMask(IGM);
-        auto xiSchema = EnumPayloadSchema::withBitSize(xiMask.getBitWidth());
+        auto xiSchema = EnumPayloadSchema(xiMask.getBitWidth());
 
         auto maxXiCount = std::min(xiCount, 256u);
         auto numCases = llvm::ConstantInt::get(IGM.Int32Ty, maxXiCount);


### PR DESCRIPTION
At some point it might be useful to be able to use an appropriate
explosion schema to explode payloads but currently the code that
handles this is unused. There are lots of different ways we might
add this functionality in the future and it isn't clear that the
existing code will be the best way to use explosion schemas in the
future.

For now remove this dead code so that its presence doesn't obscure
the code that is actually in use.
