### PR TITLE
[5.1] .init called on value diagnostic fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -858,6 +858,10 @@ ERROR(did_not_call_method,none,
       "method %0 was used as a property; add () to call it",
       (Identifier))
 
+ERROR(init_not_instance_member_use_assignment,none,
+      "'init' is a member of the type; use assignment "
+      "to initalize the value instead", ())
+
 ERROR(init_not_instance_member,none,
       "'init' is a member of the type; use 'type(of: ...)' to initialize "
       "a new object of the same dynamic type", ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -101,6 +101,35 @@ Expr *FailureDiagnostic::getArgumentExprFor(Expr *anchor) const {
   return nullptr;
 }
 
+// TODO: Replace duplications of this logic with calls to this.
+Optional<SelectedOverload> FailureDiagnostic::getChoiceFor(Expr *expr) {
+  auto &cs = getConstraintSystem();
+  ConstraintLocator *locator = nullptr;
+
+  if (auto *AE = dyn_cast<ApplyExpr>(expr)) {
+    if (auto *TE = dyn_cast<TypeExpr>(AE->getFn())) {
+      locator = cs.getConstraintLocator(AE,
+                                        {ConstraintLocator::ApplyFunction,
+                                         ConstraintLocator::ConstructorMember},
+                                        /*summaryFlags=*/0);
+    }
+    return getChoiceFor(AE->getFn());
+  } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
+    locator = cs.getConstraintLocator(UDE, ConstraintLocator::Member);
+  } else if (auto *UME = dyn_cast<UnresolvedMemberExpr>(expr)) {
+    locator = cs.getConstraintLocator(UME, ConstraintLocator::UnresolvedMember);
+  } else if (auto *SE = dyn_cast<SubscriptExpr>(expr)) {
+    locator = cs.getConstraintLocator(SE, ConstraintLocator::SubscriptMember);
+  } else {
+    locator = cs.getConstraintLocator(expr);
+  }
+
+  if (!locator)
+    return None;
+
+  return getOverloadChoiceIfAvailable(locator);
+}
+
 Type RequirementFailure::getOwnerType() const {
   return getType(getRawAnchor())
       ->getInOutObjectType()
@@ -1954,6 +1983,7 @@ bool MissingMemberFailure::diagnoseAsError() {
 bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   auto loc = getAnchor()->getLoc();
   auto &cs = getConstraintSystem();
+  auto *DC = getDC();
   auto locator = getLocator();
 
   if (loc.isInvalid()) {
@@ -2011,11 +2041,43 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         emitDiagnostic(loc, diag::super_initializer_not_in_initializer);
         return true;
       }
-      SourceRange fixItRng = ctorRef->getNameLoc().getSourceRange();
-      emitDiagnostic(loc, diag::init_not_instance_member)
-          .fixItInsert(fixItRng.Start, "type(of: ")
-          .fixItInsertAfter(fixItRng.End, ")");
-      return true;
+
+      auto isCallArgument = [this](Expr *expr) {
+        auto &cs = getConstraintSystem();
+        auto argExpr = cs.getParentExpr(expr);
+        if (!argExpr)
+          return false;
+        auto possibleApplyExpr = cs.getParentExpr(expr);
+        return possibleApplyExpr && isa<ApplyExpr>(possibleApplyExpr);
+      };
+
+      auto *initCall = cs.getParentExpr(cs.getParentExpr(ctorRef));
+
+      auto isMutable = [&DC](ValueDecl *decl) {
+        if (auto *storage = dyn_cast<AbstractStorageDecl>(decl))
+          return storage->isSettable(DC) && storage->isSetterAccessibleFrom(DC);
+
+        return true;
+      };
+
+      auto selection = getChoiceFor(ctorRef->getBase());
+      if (selection) {
+        OverloadChoice choice = selection->choice;
+        if (choice.isDecl() && isMutable(choice.getDecl()) &&
+            !isCallArgument(initCall) &&
+            cs.getContextualTypePurpose() == CTP_Unused) {
+          auto fixItLoc = ctorRef->getBase()->getSourceRange().End;
+          emitDiagnostic(loc, diag::init_not_instance_member_use_assignment)
+              .fixItInsertAfter(fixItLoc, " = ");
+          return true;
+        }
+
+        SourceRange fixItRng = ctorRef->getBase()->getSourceRange();
+        emitDiagnostic(loc, diag::init_not_instance_member)
+            .fixItInsert(fixItRng.Start, "type(of: ")
+            .fixItInsertAfter(fixItRng.End, ")");
+        return true;
+      }
     }
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -155,6 +155,8 @@ protected:
   /// reference or subscript, nullptr otherwise.
   Expr *getArgumentExprFor(Expr *anchor) const;
 
+  Optional<SelectedOverload> getChoiceFor(Expr *);
+
 private:
   /// Compute anchor expression associated with current diagnostic.
   std::pair<Expr *, bool> computeAnchor() const;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2528,9 +2528,12 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   auto contextualPurpose = CTP_Unused;
   TypeCheckExprOptions flags = TypeCheckExprFlags::ConvertTypeIsOnlyAHint;
 
+  // Set the contextual purpose even if the pattern doesn't have a type so
+  // if there's an error we can use that information to inform diagnostics.
+  contextualPurpose = CTP_Initialization;
+
   if (pattern->hasType()) {
     contextualType = TypeLoc::withoutLoc(pattern->getType());
-    contextualPurpose = CTP_Initialization;
 
     // If we already had an error, don't repeat the problem.
     if (contextualType.getType()->hasError())

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -101,7 +101,7 @@ enum Z2 {
 // Ill-formed initialization: wrong context.
 class Z3 {
   func f() {
-    self.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{10-10=type(of: }} {{14-14=)}}
+    self.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{9-9=)}}
   }
 
   init() { }
@@ -112,7 +112,7 @@ class Z4 {
   init() {} // expected-note{{selected non-required initializer}}
 
   convenience init(other: Z4) {
-    other.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{11-11=type(of: }} {{15-15=)}}
+    other.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{10-10=)}}
     type(of: other).init() // expected-error{{must use a 'required' initializer}}
   }
 }
@@ -121,7 +121,7 @@ class Z5 : Z4 {
   override init() { }
 
   convenience init(other: Z5) {
-    other.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{11-11=type(of: }} {{15-15=)}}
+    other.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{10-10=)}}
   }
 }
 
@@ -150,7 +150,7 @@ struct RDar16603812 {
    var i = 42
    init() {}
    func foo() {
-      self.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{12-12=type(of: }} {{16-16=)}}
+      self.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{7-7=type(of: }} {{11-11=)}}
       type(of: self).init() // expected-warning{{result of 'RDar16603812' initializer is unused}}
    }
 }
@@ -199,7 +199,7 @@ class D: C {
   }
 
   func foo() {
-    self.init(x: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{10-10=type(of: }} {{14-14=)}}
+    self.init(x: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{9-9=)}}
   }
   func bar() {
     super.init(x: 0) // expected-error{{'super.init' cannot be called outside of an initializer}}
@@ -270,15 +270,26 @@ func foo<T: C>(_ x: T, y: T.Type) where T: P {
   var c3a = type(of: x).init() // expected-error{{'required' initializer}}
   var c4a = type(of: x).init(proto: "")
 
-  var ci1 = x.init(required: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
-  var ci2 = x.init(x: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
-  var ci3 = x.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}}
-  var ci4 = x.init(proto: "") // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{15-15=type(of: }} {{19-19=)}} 
-
-  var ci1a = x(required: 0) // expected-error{{cannot call value of non-function type 'T'}}
-  var ci2a = x(x: 0) // expected-error{{cannot call value of non-function type 'T'}}
-  var ci3a = x() // expected-error{{cannot call value of non-function type 'T'}}{{15-17=}}
-  var ci4a = x(proto: "") // expected-error{{cannot call value of non-function type 'T'}}
+  var ci1 = x.init(required: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{13-13=type(of: }} {{14-14=)}}
+  var ci2 = x.init(x: 0) // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{13-13=type(of: }} {{14-14=)}}
+  var ci3 = x.init() // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{13-13=type(of: }} {{14-14=)}}
+  var ci4 = x.init(proto: "") // expected-error{{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{13-13=type(of: }} {{14-14=)}}
+  
+  var z = x
+  z.init(required: 0) // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  z.init(x: 0) // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  z.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  z.init(proto: "") // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{4-4= = }}
+  
+  var ci1a = z.init(required: 0) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{15-15=)}}
+  var ci2a = z.init(x: 0) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{15-15=)}}
+  var ci3a = z.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{15-15=)}}
+  var ci4a = z.init(proto: "") // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{15-15=)}}
+  
+  var ci1b = x(required: 0) // expected-error{{cannot call value of non-function type 'T'}}
+  var ci2b = x(x: 0) // expected-error{{cannot call value of non-function type 'T'}}
+  var ci3b = x() // expected-error{{cannot call value of non-function type 'T'}}{{15-17=}}
+  var ci4b = x(proto: "") // expected-error{{cannot call value of non-function type 'T'}}
 
   var cm1 = y.init(required: 0)
   var cm2 = y.init(x: 0) // expected-error{{'required' initializer}}
@@ -497,5 +508,42 @@ class TestOptionalTrySub : TestOptionalTry {
   init(a: Int) { // expected-note {{propagate the failure with 'init?'}} {{7-7=?}}
     try? super.init() // expected-error {{a non-failable initializer cannot use 'try?' to chain to another initializer}}
     // expected-note@-1 {{force potentially-failing result with 'try!'}} {{5-9=try!}}
+  }
+}
+
+struct X { init() {} }
+
+func +(lhs: X, rhs: X) -> X { return lhs }
+func testInsideOperator(x: X) {
+  x.init() + x // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{3-3=type(of: }} {{4-4=)}}
+  x + x.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{7-7=type(of: }} {{8-8=)}}
+  x.init() + x.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{3-3=type(of: }} {{4-4=)}}
+  // expected-error@-1 {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{14-14=type(of: }} {{15-15=)}}
+}
+
+struct Y {
+  var x: X
+  let x2: X
+  
+  init() {
+    x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{6-6= = }}
+    foo(x.init()) // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{9-9=type(of: }} {{10-10=)}}
+  }
+  
+  func foo(_: X) {}
+  func asFunctionReturn() -> X {
+    var a = X()
+    return a.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{12-12=type(of: }} {{13-13=)}}
+  }
+}
+
+struct MultipleMemberAccesses {
+  var y: Y
+  let y2: Y
+  init() {
+    y = Y()
+    y2 = Y()
+    y.x.init() // expected-error {{'init' is a member of the type; use assignment to initalize the value instead}} {{8-8= = }}
+    y2.x2.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}} {{5-5=type(of: }} {{10-10=)}}
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cherry-pick #24617, and #24660.

Fixes outstanding bugs with the init_not_instance_member diagnostic.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3245](https://bugs.swift.org/browse/SR-3245).
Resolves [SR-10297](https://bugs.swift.org/browse/SR-10297).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
