### PR TITLE
[5.1] [TypeChecker] Rephrase platforms in availability diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3981,8 +3981,9 @@ ERROR(dynamic_replacement_replaced_constructor_is_not_convenience, none,
 //------------------------------------------------------------------------------
 
 ERROR(availability_decl_unavailable, none,
-      "%select{getter for |setter for |}0%1 is unavailable",
-      (unsigned, DeclName))
+      "%select{getter for |setter for |}0%1 is unavailable"
+      "%select{ in %3|}2",
+      (unsigned, DeclName, bool, StringRef))
 
 #define REPLACEMENT_DECL_KIND_SELECT "select{| instance method| property}"
 ERROR(availability_decl_unavailable_rename, none,
@@ -3998,16 +3999,9 @@ ERROR(availability_decl_unavailable_rename_msg, none,
       (unsigned, DeclName, bool, unsigned, StringRef, StringRef))
 
 ERROR(availability_decl_unavailable_msg, none,
-      "%select{getter for |setter for |}0%1 is unavailable: %2",
-      (unsigned, DeclName, StringRef))
-
-ERROR(availability_decl_unavailable_in_swift, none,
-      "%select{getter for |setter for |}0%1 is unavailable in Swift",
-      (unsigned, DeclName))
-
-ERROR(availability_decl_unavailable_in_swift_msg, none,
-      "%select{getter for |setter for |}0%1 is unavailable in Swift: %2",
-      (unsigned, DeclName, StringRef))
+      "%select{getter for |setter for |}0%1 is unavailable"
+      "%select{ in %3|}2: %4",
+      (unsigned, DeclName, bool, StringRef, StringRef))
 
 NOTE(availability_marked_unavailable, none,
      "%select{getter for |setter for |}0%1 has been explicitly marked "
@@ -4023,18 +4017,18 @@ NOTE(availability_obsoleted, none,
 
 WARNING(availability_deprecated, none,
         "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
-        "deprecated%select{| %select{on|in}4 %3%select{| %5}4}2",
+        "deprecated%select{| in %3%select{| %5}4}2",
         (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple))
 
 WARNING(availability_deprecated_msg, none,
         "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
-        "deprecated%select{| %select{on|in}4 %3%select{| %5}4}2: %6",
+        "deprecated%select{| in %3%select{| %5}4}2: %6",
         (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple,
          StringRef))
 
 WARNING(availability_deprecated_rename, none,
         "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
-        "deprecated%select{| %select{on|in}4 %3%select{| %5}4}2: "
+        "deprecated%select{| in %3%select{| %5}4}2: "
         "%select{renamed to|replaced by}6%" REPLACEMENT_DECL_KIND_SELECT "7 "
         "'%8'",
         (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple, bool,
@@ -4051,7 +4045,7 @@ NOTE(availability_decl_more_than_enclosing_enclosing_here, none,
      "enclosing scope here", ())
 
 ERROR(availability_decl_only_version_newer, none,
-      "%0 is only available on %1 %2 or newer",
+      "%0 is only available in %1 %2 or newer",
       (DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_guard_with_version_check, none,
@@ -4061,13 +4055,13 @@ NOTE(availability_add_attribute, none,
      "add @available attribute to enclosing %0", (DescriptiveDeclKind))
 
 ERROR(availability_accessor_only_version_newer, none,
-      "%select{getter|setter}0 for %1 is only available on %2 %3"
+      "%select{getter|setter}0 for %1 is only available in %2 %3"
       " or newer",
       (/*AccessorKind*/unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 ERROR(availability_inout_accessor_only_version_newer, none,
       "cannot pass as inout because %select{getter|setter}0 for %1 is only "
-      "available on %2 %3 or newer",
+      "available in %2 %3 or newer",
       (/*AccessorKind*/unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 ERROR(availability_query_required_for_platform, none,
@@ -4089,7 +4083,7 @@ ERROR(availability_stored_property_no_potential,
       "'@available'", ())
 
 ERROR(availability_protocol_requires_version,
-      none, "protocol %0 requires %1 to be available on %2 %3 and newer",
+      none, "protocol %0 requires %1 to be available in %2 %3 and newer",
       (DeclName, DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_protocol_requirement_here, none,

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -41,7 +41,7 @@ StringRef platformString(PlatformKind platform);
 Optional<PlatformKind> platformFromString(StringRef Name);
 
 /// Returns a human-readable version of the platform name as a string, suitable
-/// for emission in diagnostics (e.g., "OS X").
+/// for emission in diagnostics (e.g., "macOS").
 StringRef prettyPlatformString(PlatformKind platform);
 
 /// Returns whether the passed-in platform is active, given the language

--- a/include/swift/AST/PlatformKinds.def
+++ b/include/swift/AST/PlatformKinds.def
@@ -25,10 +25,10 @@
 AVAILABILITY_PLATFORM(iOS, "iOS")
 AVAILABILITY_PLATFORM(tvOS, "tvOS")
 AVAILABILITY_PLATFORM(watchOS, "watchOS")
-AVAILABILITY_PLATFORM(OSX, "OS X")
-AVAILABILITY_PLATFORM(iOSApplicationExtension, "iOS application extension")
-AVAILABILITY_PLATFORM(tvOSApplicationExtension, "tvOS application extension")
-AVAILABILITY_PLATFORM(watchOSApplicationExtension, "watchOS application extension")
-AVAILABILITY_PLATFORM(OSXApplicationExtension, "OS X application extension")
+AVAILABILITY_PLATFORM(OSX, "macOS")
+AVAILABILITY_PLATFORM(iOSApplicationExtension, "application extensions for iOS")
+AVAILABILITY_PLATFORM(tvOSApplicationExtension, "application extensions for tvOS")
+AVAILABILITY_PLATFORM(watchOSApplicationExtension, "application extensions for watchOS")
+AVAILABILITY_PLATFORM(OSXApplicationExtension, "application extensions for macOS")
 
 #undef AVAILABILITY_PLATFORM

--- a/test/ClangImporter/availability_app_extension.swift
+++ b/test/ClangImporter/availability_app_extension.swift
@@ -1,9 +1,13 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -application-extension %s
 
+// Check the exact error message, which requires a regex match
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -application-extension %s 2>&1 | %FileCheck %s
+
 // REQUIRES: objc_interop
 
 import Foundation
 
 func test_unavailable_app_extension() {
-  _ = SomeCrazyAppExtensionForbiddenAPI() // expected-error {{'SomeCrazyAppExtensionForbiddenAPI()' is unavailable: Not available in App Extensions}}
+  _ = SomeCrazyAppExtensionForbiddenAPI() // expected-error {{unavailable}}
+// CHECK: error: 'SomeCrazyAppExtensionForbiddenAPI()' is unavailable in application extensions for {{[a-z]+}}OS: Not available in App Extensions
 }

--- a/test/ClangImporter/availability_implicit_macosx.swift
+++ b/test/ClangImporter/availability_implicit_macosx.swift
@@ -29,11 +29,11 @@ func useClassThatTriggersImportOfPotentiallyUnavailableOptions() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in OS X 10.51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 10.51: Use a different API}}
 }
 
-func useInSignature(_ options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
+func useInSignature(_ options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
 }
 
 class SuperClassWithDeprecatedInitializer {
@@ -49,7 +49,7 @@ class SubClassWithSynthesizedDesignedInitializerOverride : SuperClassWithDepreca
 }
 
 func callImplicitInitializerOnSubClassWithSynthesizedDesignedInitializerOverride() {
-  _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in OS X 10.51}}
+  _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.9, deprecated: 10.51)
@@ -57,7 +57,7 @@ class NSDeprecatedSuperClass {
   var i : Int = 7 // Causes initializer to be synthesized
 }
 
-class NotDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass { // expected-warning {{'NSDeprecatedSuperClass' was deprecated in OS X 10.51}}
+class NotDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass { // expected-warning {{'NSDeprecatedSuperClass' was deprecated in macOS 10.51}}
 }
 
 func callImplicitInitializerOnNotDeprecatedSubClassOfDeprecatedSuperClass() {

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -42,27 +42,27 @@ func testFactoryWithLaterIntroducedInit() {
 
   // Don't prefer more available convenience factory initializer over less
   // available designated initializer
-  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flim:5) // expected-error {{'init(flim:)' is only available on OS X 10.52 or newer}} 
+  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flim:5) // expected-error {{'init(flim:)' is only available in macOS 10.52 or newer}}
     // expected-note @-1 {{add 'if #available' version check}}
   
-  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5) // expected-error {{'init(flam:)' is only available on OS X 10.52 or newer}}
+  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5) // expected-error {{'init(flam:)' is only available in macOS 10.52 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}  {{3-63=if #available(OSX 10.52, *) {\n      _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5)\n  \} else {\n      // Fallback on earlier versions\n  \}}}
 
   
   // Don't prefer more available factory initializer over less
   // available designated initializer
-  _ = NSHavingFactoryAndLaterConvenienceInit(flim:5) // expected-error {{'init(flim:)' is only available on OS X 10.52 or newer}} 
+  _ = NSHavingFactoryAndLaterConvenienceInit(flim:5) // expected-error {{'init(flim:)' is only available in macOS 10.52 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}
   
 
-  _ = NSHavingFactoryAndLaterConvenienceInit(flam:5) // expected-error {{'init(flam:)' is only available on OS X 10.52 or newer}} 
+  _ = NSHavingFactoryAndLaterConvenienceInit(flam:5) // expected-error {{'init(flam:)' is only available in macOS 10.52 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}
 
 
   // When both a convenience factory and a convenience initializer have the
   // same availability, choose the convenience initializer.
-  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flim:5) // expected-warning {{'init(flim:)' was deprecated in OS X 10.51: ConvenienceInit}}
-  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flam:5) // expected-warning {{'init(flam:)' was deprecated in OS X 10.51: ConvenienceInit}}
+  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flim:5) // expected-warning {{'init(flim:)' was deprecated in macOS 10.51: ConvenienceInit}}
+  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flam:5) // expected-warning {{'init(flam:)' was deprecated in macOS 10.51: ConvenienceInit}}
 
   _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flotsam:5) // expected-warning {{'init(flotsam:)' is deprecated: ConvenienceInit}}
   _ = NSHavingConvenienceFactoryAndSameConvenienceInit(jetsam:5) // expected-warning {{'init(jetsam:)' is deprecated: ConvenienceInit}}

--- a/test/Interpreter/availability_host_os.swift
+++ b/test/Interpreter/availability_host_os.swift
@@ -13,6 +13,6 @@ print(mavericks()) // CHECK: {{^9$}}
 print(yosemite()) // CHECK-NEXT: {{^10$}}
 
 #if FAIL
-print(todosSantos()) // expected-error {{'todosSantos()' is only available on OS X 10.99 or newer}}
+print(todosSantos()) // expected-error {{'todosSantos()' is only available in macOS 10.99 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
 #endif

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -20,7 +20,7 @@ class OtherIntroduced10_51 {
 
   // This method uses a 10_52 only type in its signature, so validating
   // the declaration should produce an availability error
-  func returns10_52() -> OtherIntroduced10_52 { // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+  func returns10_52() -> OtherIntroduced10_52 { // expected-error {{'OtherIntroduced10_52' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     // Body is not type checked (by design) so no error is expected for unavailable type used in return.
@@ -86,5 +86,5 @@ extension OtherIntroduced10_51 {
 class OtherIntroduced10_53 {
 }
 
-var globalFromOtherOn10_52 : OtherIntroduced10_52? = nil // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+var globalFromOtherOn10_52 : OtherIntroduced10_52? = nil // expected-error {{'OtherIntroduced10_52' is only available in macOS 10.52 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing var}}

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -20,10 +20,10 @@ func globalFuncAvailableOn10_52() -> Int { return 11 }
 // Top level should reflect the minimum deployment target.
 let ignored1: Int = globalFuncAvailableOn10_9()
 
-let ignored2: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+let ignored2: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let ignored3: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+let ignored3: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Functions without annotations should reflect the minimum deployment target.
@@ -32,10 +32,10 @@ func functionWithoutAvailability() {
 
   let _: Int = globalFuncAvailableOn10_9()
 
-  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -53,7 +53,7 @@ func functionAvailableOn10_51() {
     let _: Int = globalFuncAvailableOn10_52()
   }
 
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -68,17 +68,17 @@ var deprecatedGlobalInScriptMode: Int = 5
 
 if #available(OSX 10.51, *) {
   let _: Int = globalFuncAvailableOn10_51()
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 if #available(OSX 10.51, *) {
   let _: Int = globalFuncAvailableOn10_51()
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 } else {
   let _: Int = globalFuncAvailableOn10_9()
-  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -91,22 +91,22 @@ if #available(OSX 10.51, iOS 8.0, *) {
 }
 
 if #available(iOS 9.0, *) {
-  let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0() // expected-error {{'globalFuncAvailableOnOSX10_51AndiOS8_0()' is only available on OS X 10.51 or newer}}
+  let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0() // expected-error {{'globalFuncAvailableOnOSX10_51AndiOS8_0()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Multiple unavailable references in a single statement
 
-let ignored4: (Int, Int) = (globalFuncAvailableOn10_51(), globalFuncAvailableOn10_52()) // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}  expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+let ignored4: (Int, Int) = (globalFuncAvailableOn10_51(), globalFuncAvailableOn10_52()) // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}  expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
     // expected-note@-1 2{{add 'if #available' version check}}
 
 
 _ = globalFuncAvailableOn10_9()
 
-let ignored5 = globalFuncAvailableOn10_51 // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+let ignored5 = globalFuncAvailableOn10_51 // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-_ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+_ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Overloaded global functions
@@ -117,7 +117,7 @@ func overloadedFunction() {}
 func overloadedFunction(_ on1010: Int) {}
 
 overloadedFunction()
-overloadedFunction(0) // expected-error {{'overloadedFunction' is only available on OS X 10.51 or newer}}
+overloadedFunction(0) // expected-error {{'overloadedFunction' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Unavailable methods
@@ -138,7 +138,7 @@ class ClassWithUnavailableMethod {
     // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     methAvailableOn10_9()
-    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -149,13 +149,13 @@ func callUnavailableMethods(_ o: ClassWithUnavailableMethod) {
   let m10_9 = o.methAvailableOn10_9
   m10_9()
   
-  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   m10_51()
   
   o.methAvailableOn10_9()
-  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -165,24 +165,24 @@ func callUnavailableMethodsViaIUO(_ o: ClassWithUnavailableMethod!) {
   let m10_9 = o.methAvailableOn10_9
   m10_9()
   
-  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       
       // expected-note@-2 {{add 'if #available' version check}}
 
   m10_51()
   
   o.methAvailableOn10_9()
-  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func callUnavailableClassMethod() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
-  ClassWithUnavailableMethod.classMethAvailableOn10_51() // expected-error {{'classMethAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  ClassWithUnavailableMethod.classMethAvailableOn10_51() // expected-error {{'classMethAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  let m10_51 = ClassWithUnavailableMethod.classMethAvailableOn10_51 // expected-error {{'classMethAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let m10_51 = ClassWithUnavailableMethod.classMethAvailableOn10_51 // expected-error {{'classMethAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   m10_51()
@@ -194,7 +194,7 @@ class SubClassWithUnavailableMethod : ClassWithUnavailableMethod {
         // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     methAvailableOn10_9()
-    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -205,13 +205,13 @@ class SubClassOverridingUnavailableMethod : ClassWithUnavailableMethod {
   override func methAvailableOn10_51() {
         // expected-note@-1 2{{add @available attribute to enclosing instance method}}
     methAvailableOn10_9()
-    super.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    super.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     let m10_9 = super.methAvailableOn10_9
     m10_9()
     
-    let m10_51 = super.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    let m10_51 = super.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     m10_51()
   }
@@ -235,7 +235,7 @@ func callUnavailableOverloadedMethod(_ o: ClassWithUnavailableOverloadedMethod) 
       // expected-note@-1 {{add @available attribute to enclosing global function}}
 
   o.overloadedMethod()
-  o.overloadedMethod(0) // expected-error {{'overloadedMethod' is only available on OS X 10.51 or newer}}
+  o.overloadedMethod(0) // expected-error {{'overloadedMethod' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -253,7 +253,7 @@ class ClassWithUnavailableInitializer {
   convenience init(s: String) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
     
-    self.init(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
+    self.init(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -267,12 +267,12 @@ func callUnavailableInitializer() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
   _ = ClassWithUnavailableInitializer()
-  _ = ClassWithUnavailableInitializer(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
+  _ = ClassWithUnavailableInitializer(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let i = ClassWithUnavailableInitializer.self 
   _ = i.init()
-  _ = i.init(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
+  _ = i.init(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -290,7 +290,7 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
   override init(_ val: Int) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
 
-    super.init(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
+    super.init(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -320,7 +320,7 @@ class ClassWithUnavailableProperties {
 
   // Make sure that we don't emit a Fix-It to mark a stored property as potentially unavailable.
   // We don't support potentially unavailable stored properties yet.
-  var storedPropertyOfUnavailableType: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  var storedPropertyOfUnavailableType: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
 
   @available(OSX, introduced: 10.9)
   lazy var availableOn10_9Stored: Int = 9
@@ -331,7 +331,7 @@ class ClassWithUnavailableProperties {
   @available(OSX, introduced: 10.9)
   var availableOn10_9Computed: Int {
     get {
-      let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
+      let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       
       if #available(OSX 10.51, *) {
@@ -358,7 +358,7 @@ class ClassWithUnavailableProperties {
   var propWithSetterOnlyAvailableOn10_51 : Int {
       // expected-note@-1 {{add @available attribute to enclosing property}}
     get {
-      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       return 0
     }
@@ -376,7 +376,7 @@ class ClassWithUnavailableProperties {
       return 0
     }
     set(newVal) {
-      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
     }
   }
@@ -414,11 +414,11 @@ class ClassWithUnavailableProperties {
 class ClassWithReferencesInInitializers {
   var propWithInitializer10_51: Int = globalFuncAvailableOn10_51()
 
-  var propWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  var propWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
 
   lazy var lazyPropWithInitializer10_51: Int = globalFuncAvailableOn10_51()
 
-  lazy var lazyPropWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  lazy var lazyPropWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing property}}
 }
 
@@ -426,25 +426,25 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
       // expected-note@-1 17{{add @available attribute to enclosing global function}}
   // Stored properties
   let _: Int = o.availableOn10_9Stored
-  let _: Int = o.availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
+  let _: Int = o.availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o.availableOn10_9Stored = 9
-  o.availableOn10_51Stored = 10 // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
+  o.availableOn10_51Stored = 10 // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Computed Properties
   let _: Int = o.availableOn10_9Computed
-  let _: Int = o.availableOn10_51Computed // expected-error {{'availableOn10_51Computed' is only available on OS X 10.51 or newer}}
+  let _: Int = o.availableOn10_51Computed // expected-error {{'availableOn10_51Computed' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o.availableOn10_9Computed = 9
-  o.availableOn10_51Computed = 10 // expected-error {{'availableOn10_51Computed' is only available on OS X 10.51 or newer}}
+  o.availableOn10_51Computed = 10 // expected-error {{'availableOn10_51Computed' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   // Getter allowed on 10.9 but setter is not
   let _: Int = o.propWithSetterOnlyAvailableOn10_51
-  o.propWithSetterOnlyAvailableOn10_51 = 5 // expected-error {{setter for 'propWithSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  o.propWithSetterOnlyAvailableOn10_51 = 5 // expected-error {{setter for 'propWithSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   if #available(OSX 10.51, *) {
@@ -454,7 +454,7 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
   
   // Setter allowed on 10.9 but getter is not
   o.propWithGetterOnlyAvailableOn10_51 = 5
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) {
@@ -465,15 +465,15 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
   // Tests for nested member refs
   
   // Both getters are potentially unavailable.
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on OS X 10.51 or newer}} expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available in macOS 10.51 or newer}} expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
   // Nested getter is potentially unavailable, outer getter is available
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithSetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithSetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Nested getter is available, outer getter is potentially unavailable
-  let _:Int = o.propWithSetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _:Int = o.propWithSetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Both getters are always available.
@@ -483,27 +483,27 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
   // Nesting in source of assignment
   var v: Int
   
-  v = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  v = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  v = (o.propWithGetterOnlyAvailableOn10_51) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  v = (o.propWithGetterOnlyAvailableOn10_51) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   // Inout requires access to both getter and setter
   
   func takesInout(_ i : inout Int) { }
   
-  takesInout(&o.propWithGetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithGetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  takesInout(&o.propWithSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because setter for 'propWithSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because setter for 'propWithSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  takesInout(&o.propWithGetterAndSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}} expected-error {{cannot pass as inout because setter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithGetterAndSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}} expected-error {{cannot pass as inout because setter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
   takesInout(&o.availableOn10_9Computed)
-  takesInout(&o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.availableOn10_9Computed) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.availableOn10_9Computed) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -542,10 +542,10 @@ enum CompassPoint {
   @available(OSX, introduced: 10.52)
   case WithAvailableByEnumElementPayload1(p : EnumIntroducedOn10_52), WithAvailableByEnumElementPayload2(p : EnumIntroducedOn10_52)
 
-  case WithUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
+  case WithUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing case}}
 
-    case WithUnavailablePayload1(p : EnumIntroducedOn10_52), WithUnavailablePayload2(p : EnumIntroducedOn10_52) // expected-error 2{{'EnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
+    case WithUnavailablePayload1(p : EnumIntroducedOn10_52), WithUnavailablePayload2(p : EnumIntroducedOn10_52) // expected-error 2{{'EnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
       // expected-note@-1 2{{add @available attribute to enclosing case}}
 }
 
@@ -554,13 +554,13 @@ func functionTakingEnumIntroducedOn10_52(_ e: EnumIntroducedOn10_52) { }
 
 func useEnums() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available on OS X 10.51 or newer}}
+  let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) {
     let _: CompassPoint = .North
 
-    let _: CompassPoint = .West // expected-error {{'West' is only available on OS X 10.52 or newer}}
+    let _: CompassPoint = .West // expected-error {{'West' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 
@@ -595,7 +595,7 @@ func useEnums() {
 
         // For the moment, we do not incorporate enum element availability into 
         // TRC construction. Perhaps we should?
-        functionTakingEnumIntroducedOn10_52(p)  // expected-error {{'functionTakingEnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
+        functionTakingEnumIntroducedOn10_52(p)  // expected-error {{'functionTakingEnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
           
           // expected-note@-2 {{add 'if #available' version check}}
     }
@@ -632,15 +632,15 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
 func classAvailability() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
   ClassAvailableOn10_9.someClassMethod()
-  ClassAvailableOn10_51.someClassMethod() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  ClassAvailableOn10_51.someClassMethod() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   _ = ClassAvailableOn10_9.self
-  _ = ClassAvailableOn10_51.self // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = ClassAvailableOn10_51.self // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let o10_9 = ClassAvailableOn10_9()
-  let o10_51 = ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let o10_51 = ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o10_9.someMethod()
@@ -652,13 +652,13 @@ func classAvailability() {
 
 func castingUnavailableClass(_ o : AnyObject) {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  let _ = o as! ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o as! ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o as? ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o as? ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o is ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o is ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -681,30 +681,30 @@ class ClassWithTwoGenericTypeParameter<T, S> { }
 
 func classViaTypeParameter() {
   // expected-note@-1 9{{add @available attribute to enclosing global function}}
-  let _ : ClassAvailableOn10_51_Creatable = // expected-error {{'ClassAvailableOn10_51_Creatable' is only available on OS X 10.51 or newer}}
+  let _ : ClassAvailableOn10_51_Creatable = // expected-error {{'ClassAvailableOn10_51_Creatable' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
       create()
       
   let _ = create() as
-      ClassAvailableOn10_51_Creatable // expected-error {{'ClassAvailableOn10_51_Creatable' is only available on OS X 10.51 or newer}}
+      ClassAvailableOn10_51_Creatable // expected-error {{'ClassAvailableOn10_51_Creatable' is only available in macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = [ClassAvailableOn10_51]() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = [ClassAvailableOn10_51]() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithGenericTypeParameter<ClassAvailableOn10_51> = ClassWithGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithGenericTypeParameter<ClassAvailableOn10_51> = ClassWithGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, String> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, String> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<String, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<String, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error 2{{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error 2{{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
-  let _: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
 }
@@ -720,7 +720,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
     unavailablePropertyOfUnavailableType = ClassAvailableOn10_51()
   }
 
-  var propertyOfUnavailableType: ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  var propertyOfUnavailableType: ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
 
   @available(OSX, introduced: 10.51)
   lazy var unavailablePropertyOfUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
@@ -737,7 +737,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
   @available(OSX, introduced: 10.51)
   static var unavailableStaticPropertyOfOptionalUnavailableType: ClassAvailableOn10_51?
 
-  func methodWithUnavailableParameterType(_ o : ClassAvailableOn10_51) { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func methodWithUnavailableParameterType(_ o : ClassAvailableOn10_51) { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
   }
   
@@ -745,10 +745,10 @@ class ClassWithDeclarationsOfUnavailableClasses {
   func unavailableMethodWithUnavailableParameterType(_ o : ClassAvailableOn10_51) {
   }
   
-  func methodWithUnavailableReturnType() -> ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func methodWithUnavailableReturnType() -> ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 2{{add @available attribute to enclosing instance method}}
 
-    return ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+    return ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -759,7 +759,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
 
   func methodWithUnavailableLocalDeclaration() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
-    let _ : ClassAvailableOn10_51 = methodWithUnavailableReturnType() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+    let _ : ClassAvailableOn10_51 = methodWithUnavailableReturnType() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -771,11 +771,11 @@ class ClassWithDeclarationsOfUnavailableClasses {
 
 func referToUnavailableStaticProperty() {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = ClassWithDeclarationsOfUnavailableClasses.unavailableStaticPropertyOfUnavailableType // expected-error {{'unavailableStaticPropertyOfUnavailableType' is only available on OS X 10.51 or newer}}
+  let _ = ClassWithDeclarationsOfUnavailableClasses.unavailableStaticPropertyOfUnavailableType // expected-error {{'unavailableStaticPropertyOfUnavailableType' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-class ClassExtendingUnavailableClass : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class ClassExtendingUnavailableClass : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 
@@ -846,7 +846,7 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
         // expected-note@-1 2{{add @available attribute to enclosing class}}
   @available(OSX, introduced: 10.9)
   override func someMethod() {
-    super.someMethod() // expected-error {{'someMethod()' is only available on OS X 10.51 or newer}}
+    super.someMethod() // expected-error {{'someMethod()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     if #available(OSX 10.51, *) {
@@ -857,7 +857,7 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
   @available(OSX, introduced: 10.9)
   override var someProperty: Int {
     get { 
-      let _ = super.someProperty // expected-error {{'someProperty' is only available on OS X 10.51 or newer}}
+      let _ = super.someProperty // expected-error {{'someProperty' is only available in macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       
       if #available(OSX 10.51, *) {
@@ -889,7 +889,7 @@ protocol ProtocolAvailableOn10_51InheritingFromProtocolAvailableOn10_9 : Protoco
 }
 
 @available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
 }
 
 // We allow nominal types to conform to protocols that are less available than the types themselves.
@@ -901,34 +901,34 @@ func castToUnavailableProtocol() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
   let o: ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51 = ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51()
 
-  let _: ProtocolAvailableOn10_51 = o // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ProtocolAvailableOn10_51 = o // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o as ProtocolAvailableOn10_51 // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o as ProtocolAvailableOn10_51 // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 @available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
 }
 
 class SomeGenericClass<T> { }
 
 @available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
 }
 
-func GenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn10_51 { // expected-error * {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+func GenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn10_51 { // expected-error * {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing global function}}
 }
 
-func GenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) { // expected-error * {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+func GenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) { // expected-error * {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing global function}}
 }
 
 // Extensions
 
-extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing extension}}
 
 @available(OSX, introduced: 10.51)
@@ -936,7 +936,7 @@ extension ClassAvailableOn10_51 {
   func m() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
     let _ = globalFuncAvailableOn10_51()
-    let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+    let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -975,13 +975,13 @@ func useUnavailableExtension() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
   let o = ClassToExtend()
 
-  o.extensionMethod() // expected-error {{'extensionMethod()' is only available on OS X 10.51 or newer}}
+  o.extensionMethod() // expected-error {{'extensionMethod()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = ClassToExtend.ExtensionClass() // expected-error {{'ExtensionClass' is only available on OS X 10.51 or newer}}
+  let _ = ClassToExtend.ExtensionClass() // expected-error {{'ExtensionClass' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  o.extensionMethod10_52() // expected-error {{'extensionMethod10_52()' is only available on OS X 10.52 or newer}}
+  o.extensionMethod10_52() // expected-error {{'extensionMethod10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1100,27 +1100,27 @@ if let _ = injectToOptional(5), #available(OSX 10.52, *) {}  // ok
 
 if #available(OSX 10.51, *),
    let _ = injectToOptional(globalFuncAvailableOn10_51()),
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   let _ = globalFuncAvailableOn10_51()
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
 if let _ = injectToOptional(5), #available(OSX 10.51, *),
    let _ = injectToOptional(globalFuncAvailableOn10_51()),
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   let _ = globalFuncAvailableOn10_51()
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
-if let _ = injectToOptional(globalFuncAvailableOn10_51()), #available(OSX 10.51, *), // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+if let _ = injectToOptional(globalFuncAvailableOn10_51()), #available(OSX 10.51, *), // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
 }
@@ -1136,14 +1136,14 @@ func useGuardAvailable() {
         // expected-note@-1 3{{add @available attribute to enclosing global function}}
   // Guard fallthrough should refine context
   guard #available(OSX 10.51, *) else { // expected-note {{enclosing scope here}}
-    let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     return
   }
 
   let _ = globalFuncAvailableOn10_51()
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
@@ -1155,7 +1155,7 @@ func useGuardAvailable() {
     _ = x
   }
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1171,13 +1171,13 @@ func twoGuardsInSameBlock(_ p: Int) {
     let _ = globalFuncAvailableOn10_52()
   }
 
-  let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Refining while loops
 
-while globalFuncAvailableOn10_51() > 10 { } // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+while globalFuncAvailableOn10_51() > 10 { } // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
 while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
@@ -1185,7 +1185,7 @@ while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
 
   let _ = globalFuncAvailableOn10_51()
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   while globalFuncAvailableOn10_51() > 11,
@@ -1205,17 +1205,17 @@ while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
 // take whatever indentation was there before and add 4 spaces to it).
 
 functionAvailableOn10_51()
-    // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
     // expected-note@-2 {{add 'if #available' version check}} {{1-27=if #available(OSX 10.51, *) {\n    functionAvailableOn10_51()\n} else {\n    // Fallback on earlier versions\n}}}
 
 let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{1-57=if #available(OSX 10.51, *) {\n    let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil\n} else {\n    // Fallback on earlier versions\n}}}
 
 func fixitForReferenceInGlobalFunction() {
       // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.51, *)\n}}
   functionAvailableOn10_51()
-      // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(OSX 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
@@ -1223,7 +1223,7 @@ func fixitForReferenceInGlobalFunction() {
 public func fixitForReferenceInGlobalFunctionWithDeclModifier() {
       // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.51, *)\n}}
   functionAvailableOn10_51()
-      // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(OSX 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
@@ -1232,7 +1232,7 @@ func fixitForReferenceInGlobalFunctionWithAttribute() -> Never {
     // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.51, *)\n}}
   _ = 0 // Avoid treating the call to functionAvailableOn10_51 as an implicit return
   functionAvailableOn10_51()
-    // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
     // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(OSX 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
     
 }
@@ -1245,7 +1245,7 @@ class ClassForFixit {
   func fixitForReferenceInMethod() {
         // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
     functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+        // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(OSX 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 
@@ -1253,18 +1253,18 @@ class ClassForFixit {
           // expected-note@-1 3{{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
     func inner() {
       functionAvailableOn10_51()
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+          // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
           // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(OSX 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
     }
 
     let _: () -> () = { () in
       functionAvailableOn10_51()
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+          // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
           // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(OSX 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
     }
 
     takesAutoclosure(functionAvailableOn10_51())
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+          // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
           // expected-note@-2 {{add 'if #available' version check}} {{5-49=if #available(OSX 10.51, *) {\n        takesAutoclosure(functionAvailableOn10_51())\n    } else {\n        // Fallback on earlier versions\n    }}}
           
   }
@@ -1273,7 +1273,7 @@ class ClassForFixit {
         // expected-note@-1 {{add @available attribute to enclosing property}} {{3-3=@available(OSX 10.51, *)\n  }}
     get {
       functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+        // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(OSX 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
         
       return 5
@@ -1281,26 +1281,26 @@ class ClassForFixit {
   }
 
   var fixitForReferenceInPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
 
   lazy var fixitForReferenceInLazyPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing property}} {{3-3=@available(OSX 10.51, *)\n  }}
 
   private lazy var fixitForReferenceInPrivateLazyPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing property}} {{3-3=@available(OSX 10.51, *)\n  }}
 
   lazy private var fixitForReferenceInLazyPrivatePropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing property}} {{3-3=@available(OSX 10.51, *)\n  }}
 
   static var fixitForReferenceInStaticPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing static property}} {{3-3=@available(OSX 10.51, *)\n  }}
 
   var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn10_51? = nil, other: Int = 7
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
 
   func fixitForRefInGuardOfIf() {
         // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
@@ -1308,7 +1308,7 @@ class ClassForFixit {
       let _ = 5
       let _ = 6
     }
-        // expected-error@-4 {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+        // expected-error@-4 {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-5 {{add 'if #available' version check}} {{5-6=if #available(OSX 10.51, *) {\n        if (globalFuncAvailableOn10_51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
@@ -1318,7 +1318,7 @@ extension ClassToExtend {
   func fixitForReferenceInExtensionMethod() {
         // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
     functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+        // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
         // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(OSX 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
@@ -1326,11 +1326,11 @@ extension ClassToExtend {
 enum EnumForFixit {
       // expected-note@-1 2{{add @available attribute to enclosing enum}} {{1-1=@available(OSX 10.51, *)\n}}
   case CaseWithUnavailablePayload(p: ClassAvailableOn10_51)
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing case}} {{3-3=@available(OSX 10.51, *)\n  }}
 
   case CaseWithUnavailablePayload2(p: ClassAvailableOn10_51), WithoutPayload
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing case}} {{3-3=@available(OSX 10.51, *)\n  }}
       
 }
@@ -1350,13 +1350,13 @@ func testForFixitWithNestedMemberRefExpr() {
   let x = X()
 
   x.y.z = globalFuncAvailableOn10_52()
-      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{3-39=if #available(OSX 10.52, *) {\n      x.y.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
 
   // Access via dynamic member reference
   let anyX: AnyObject = x
   anyX.y?.z = globalFuncAvailableOn10_52()
-      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{3-43=if #available(OSX 10.52, *) {\n      anyX.y?.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
@@ -1365,11 +1365,11 @@ func testForFixitWithNestedMemberRefExpr() {
 
 protocol ProtocolWithRequirementMentioningUnavailable {
       // expected-note@-1 2{{add @available attribute to enclosing protocol}}
-  func hasUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func hasUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
       
 
-  func hasUnavailableReturn() -> ClassAvailableOn10_51 // expected-error * {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func hasUnavailableReturn() -> ClassAvailableOn10_51 // expected-error * {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
 
   @available(OSX 10.51, *)
@@ -1383,7 +1383,7 @@ protocol HasMethodF {
 
 class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF {
   @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
 }
 
 
@@ -1399,7 +1399,7 @@ class SuperHasMethodF {
     func f(_ p: Int) { } // expected-note {{'f' declared here}}
 }
 
-class TriesToConformWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+class TriesToConformWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
   // The conformance here is generating an error on f in the super class.
 }
 
@@ -1423,13 +1423,13 @@ class ConformsByOverridingFunctionInSuperClass : SuperHasMethodF, HasMethodF {
 class HasNoMethodF1 { }
 extension HasNoMethodF1 : HasMethodF {
   @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
 }
 
 class HasNoMethodF2 { }
 @available(OSX, introduced: 10.51)
 extension HasNoMethodF2 : HasMethodF {
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
 }
 
 @available(OSX, introduced: 10.51)
@@ -1455,7 +1455,7 @@ class ConformsToUnavailableProtocolWithUnavailableWitness : HasMethodFOn10_51 {
 class HasNoMethodF4 { }
 @available(OSX, introduced: 10.52)
 extension HasNoMethodF4 : HasMethodFOn10_51 {
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available on OS X 10.51 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available in macOS 10.51 and newer}}
 }
 
 @available(OSX, introduced: 10.51)
@@ -1465,7 +1465,7 @@ protocol HasTakesClassAvailableOn10_51 {
 
 class AttemptsToConformToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
   @available(OSX, introduced: 10.52)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
+  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available in macOS 10.51 and newer}}
   }
 }
 
@@ -1478,7 +1478,7 @@ class ConformsToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
 class TakesClassAvailableOn10_51_A { }
 extension TakesClassAvailableOn10_51_A : HasTakesClassAvailableOn10_51 {
   @available(OSX, introduced: 10.52)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
+  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available in macOS 10.51 and newer}}
   }
 }
 
@@ -1500,7 +1500,7 @@ class TestAvailabilityDoesNotAffectWitnessCandidacy : HasMethodF {
   // witness that has suitable availability.
 
   @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
 
   func f<T>(_ p: T) { }
 }
@@ -1517,13 +1517,13 @@ class ConformsWithUnavailableFunction : HasUnavailableMethodF {
 
 func useUnavailableProtocolMethod(_ h: HasUnavailableMethodF) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  h.f("Foo") // expected-error {{'f' is only available on OS X 10.51 or newer}}
+  h.f("Foo") // expected-error {{'f' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func useUnavailableProtocolMethod<H : HasUnavailableMethodF> (_ h: H) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  h.f("Foo") // expected-error {{'f' is only available on OS X 10.51 or newer}}
+  h.f("Foo") // expected-error {{'f' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1544,7 +1544,7 @@ class ClassWithShortFormAvailableOn10_54 {
 
 @available(OSX 10.9, *)
 func funcWithShortFormAvailableOn10_9() {
-  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1556,7 +1556,7 @@ func funcWithShortFormAvailableOn10_51() {
 @available(iOS 14.0, *)
 func funcWithShortFormAvailableOniOS14() {
   // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1578,7 +1578,7 @@ func funcWithMultipleShortFormAnnotationsForDifferentPlatforms() {
 func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
   let _ = ClassWithShortFormAvailableOn10_53()
 
-  let _ = ClassWithShortFormAvailableOn10_54() // expected-error {{'ClassWithShortFormAvailableOn10_54' is only available on OS X 10.54 or newer}}
+  let _ = ClassWithShortFormAvailableOn10_54() // expected-error {{'ClassWithShortFormAvailableOn10_54' is only available in macOS 10.54 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1591,18 +1591,18 @@ func useShortFormAvailable() {
 
   funcWithShortFormAvailableOn10_9()
 
-  funcWithShortFormAvailableOn10_51() // expected-error {{'funcWithShortFormAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  funcWithShortFormAvailableOn10_51() // expected-error {{'funcWithShortFormAvailableOn10_51()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   funcWithShortFormAvailableOniOS14()
 
-  funcWithShortFormAvailableOniOS14AndOSX10_53() // expected-error {{'funcWithShortFormAvailableOniOS14AndOSX10_53()' is only available on OS X 10.53 or newer}}
+  funcWithShortFormAvailableOniOS14AndOSX10_53() // expected-error {{'funcWithShortFormAvailableOniOS14AndOSX10_53()' is only available in macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  funcWithMultipleShortFormAnnotationsForDifferentPlatforms() // expected-error {{'funcWithMultipleShortFormAnnotationsForDifferentPlatforms()' is only available on OS X 10.51 or newer}}
+  funcWithMultipleShortFormAnnotationsForDifferentPlatforms() // expected-error {{'funcWithMultipleShortFormAnnotationsForDifferentPlatforms()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available on OS X 10.53 or newer}}
+  funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available in macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   unavailableWins() // expected-error {{'unavailableWins()' is unavailable}}

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -17,10 +17,10 @@ var globalAvailableOn10_52: Int = 11
 // Top level should reflect the minimum deployment target.
 let ignored1: Int = globalAvailableOn10_9
 
-let ignored2: Int = globalAvailableOn10_51 // expected-error {{'globalAvailableOn10_51' is only available on OS X 10.51 or newer}}
+let ignored2: Int = globalAvailableOn10_51 // expected-error {{'globalAvailableOn10_51' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing let}}
 
-let ignored3: Int = globalAvailableOn10_52 // expected-error {{'globalAvailableOn10_52' is only available on OS X 10.52 or newer}}
+let ignored3: Int = globalAvailableOn10_52 // expected-error {{'globalAvailableOn10_52' is only available in macOS 10.52 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing let}}
 
 @available(OSX, introduced: 10.51)
@@ -32,18 +32,18 @@ func useFromOtherOn10_51() {
 
   let o10_9 = OtherIntroduced10_9()
   o10_9.extensionMethodOnOtherIntroduced10_9AvailableOn10_51(o10_51)
-  _ = o10_51.returns10_52Introduced10_52() // expected-error {{'returns10_52Introduced10_52()' is only available on OS X 10.52 or newer}}
+  _ = o10_51.returns10_52Introduced10_52() // expected-error {{'returns10_52Introduced10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   _ = OtherIntroduced10_52()
-      // expected-error@-1 {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+      // expected-error@-1 {{'OtherIntroduced10_52' is only available in macOS 10.52 or newer}}
       // expected-note@-2 {{add 'if #available' version check}}
 
-  o10_51.extensionMethodOnOtherIntroduced10_51AvailableOn10_52() // expected-error {{'extensionMethodOnOtherIntroduced10_51AvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  o10_51.extensionMethodOnOtherIntroduced10_51AvailableOn10_52() // expected-error {{'extensionMethodOnOtherIntroduced10_51AvailableOn10_52()' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   _ = OtherIntroduced10_51.NestedIntroduced10_52()
-      // expected-error@-1 {{'NestedIntroduced10_52' is only available on OS X 10.52 or newer}}
+      // expected-error@-1 {{'NestedIntroduced10_52' is only available in macOS 10.52 or newer}}
       // expected-note@-2 {{add 'if #available' version check}}
 }
 
@@ -53,7 +53,7 @@ func useFromOtherOn10_52() {
 
   let n10_52 = OtherIntroduced10_51.NestedIntroduced10_52()
   _ = n10_52.returns10_52()
-  _ = n10_52.returns10_53() // expected-error {{'returns10_53()' is only available on OS X 10.53 or newer}}
+  _ = n10_52.returns10_53() // expected-error {{'returns10_53()' is only available in macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // This will trigger validation of the global in availability_in_multi_other.swift

--- a/test/Sema/availability_versions_objc_api.swift
+++ b/test/Sema/availability_versions_objc_api.swift
@@ -9,7 +9,7 @@ import Foundation
 // Tests for uses of version-based potential unavailability imported from ObjC APIs.
 func callUnavailableObjC() {
       // expected-note@-1 5{{add @available attribute to enclosing global function}}
-  _ = NSAvailableOn10_51() // expected-error {{'NSAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = NSAvailableOn10_51() // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   
@@ -17,30 +17,30 @@ func callUnavailableObjC() {
     let o = NSAvailableOn10_51()!
     
     // Properties
-    _ = o.propertyOn10_52 // expected-error {{'propertyOn10_52' is only available on OS X 10.52 or newer}}
+    _ = o.propertyOn10_52 // expected-error {{'propertyOn10_52' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    o.propertyOn10_52 = 22 // expected-error {{'propertyOn10_52' is only available on OS X 10.52 or newer}}
+    o.propertyOn10_52 = 22 // expected-error {{'propertyOn10_52' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     // Methods
-    o.methodAvailableOn10_52() // expected-error {{'methodAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+    o.methodAvailableOn10_52() // expected-error {{'methodAvailableOn10_52()' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     // Initializers
     
-    _ = NSAvailableOn10_51(stringOn10_52:"Hi") // expected-error {{'init(stringOn10_52:)' is only available on OS X 10.52 or newer}}
+    _ = NSAvailableOn10_51(stringOn10_52:"Hi") // expected-error {{'init(stringOn10_52:)' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
 
 // Declarations with Objective-C-originated potentially unavailable APIs
 
-func functionWithObjCParam(o: NSAvailableOn10_51) { // expected-error {{'NSAvailableOn10_51' is only available on OS X 10.51 or newer}}
+func functionWithObjCParam(o: NSAvailableOn10_51) { // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing global function}}
 }
 
-class ClassExtendingUnvailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class ClassExtendingUnvailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 
@@ -55,42 +55,42 @@ extension SomeSoonToBeConformingClass : NSProtocolAvailableOn10_51 {
 
 // Enums from Objective-C
 
-let _: NSPotentiallyUnavailableOptions = .first // expected-error {{'NSPotentiallyUnavailableOptions' is only available on OS X 10.51 or newer}}
+let _: NSPotentiallyUnavailableOptions = .first // expected-error {{'NSPotentiallyUnavailableOptions' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSOptionsWithUnavailableElement = .third // expected-error {{'third' is only available on OS X 10.51 or newer}}
+let _: NSOptionsWithUnavailableElement = .third // expected-error {{'third' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSUnavailableEnum = .first // expected-error {{'NSUnavailableEnum' is only available on OS X 10.51 or newer}}
+let _: NSUnavailableEnum = .first // expected-error {{'NSUnavailableEnum' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSEnumWithUnavailableElement = .third // expected-error {{'third' is only available on OS X 10.51 or newer}}
+let _: NSEnumWithUnavailableElement = .third // expected-error {{'third' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Differing availability on getters and setters imported from ObjC.
 
 func gettersAndSettersFromObjC(o: NSAvailableOn10_9) {
       // expected-note@-1 6{{add @available attribute to enclosing global function}}
-  let _: Int = o.propertyOn10_51WithSetterOn10_52After  // expected-error {{'propertyOn10_51WithSetterOn10_52After' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propertyOn10_51WithSetterOn10_52After  // expected-error {{'propertyOn10_51WithSetterOn10_52After' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) {
     // Properties with unavailable accessors declared before property in Objective-C header
-    o.propertyOn10_51WithSetterOn10_52Before = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52Before' is only available on OS X 10.52 or newer}}
+    o.propertyOn10_51WithSetterOn10_52Before = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52Before' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    let _: Int = o.propertyOn10_51WithGetterOn10_52Before // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52Before' is only available on OS X 10.52 or newer}}
+    let _: Int = o.propertyOn10_51WithGetterOn10_52Before // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52Before' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
     // Properties with unavailable accessors declared after property in Objective-C header
-    o.propertyOn10_51WithSetterOn10_52After = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52After' is only available on OS X 10.52 or newer}}
+    o.propertyOn10_51WithSetterOn10_52After = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52After' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    let _: Int = o.propertyOn10_51WithGetterOn10_52After // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52After' is only available on OS X 10.52 or newer}}
+    let _: Int = o.propertyOn10_51WithGetterOn10_52After // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52After' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
     // Property with unavailable setter redeclared in Objective-C category
-    o.readOnlyRedeclaredWithSetterInCategory = 5 // expected-error {{setter for 'readOnlyRedeclaredWithSetterInCategory' is only available on OS X 10.52 or newer}}
+    o.readOnlyRedeclaredWithSetterInCategory = 5 // expected-error {{setter for 'readOnlyRedeclaredWithSetterInCategory' is only available in macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -99,13 +99,13 @@ func gettersAndSettersFromObjC(o: NSAvailableOn10_9) {
 
 func useGlobalsFromObjectiveC() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  _ = globalStringAvailableOn10_51 // expected-error {{'globalStringAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = globalStringAvailableOn10_51 // expected-error {{'globalStringAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = globalStringAvailableOn10_52 // expected-error {{'globalStringAvailableOn10_52' is only available on OS X 10.52 or newer}}
+  _ = globalStringAvailableOn10_52 // expected-error {{'globalStringAvailableOn10_52' is only available in macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = globalClassInstanceAvailableOn10_51 // expected-error {{'globalClassInstanceAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = globalClassInstanceAvailableOn10_51 // expected-error {{'globalClassInstanceAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) {
@@ -167,7 +167,7 @@ class UserClass : UnannotatedFrameworkProtocol {
 
 func callViaUnannotatedFrameworkProtocol(p: UnannotatedFrameworkProtocol) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = p.returnSomething() // expected-error {{'returnSomething()' is only available on OS X 10.51 or newer}}
+  let _ = p.returnSomething() // expected-error {{'returnSomething()' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -26,11 +26,11 @@ func useClassThatTriggersImportOfDeprecatedEnum() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in OS X 10.51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 10.51: Use a different API}}
 }
 
-func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
+func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
 }
 
 
@@ -83,20 +83,20 @@ class ClassWithComputedPropertyDeprecatedIn10_51 {
     }
   }
 
-  var unannotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  var unannotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
     get {
-      return ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+      return ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
     }
     set(newValue) {
-      _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+      _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
     }
   }
 
-  var unannotatedStoredPropertyOfTypeDeprecatedIn10_51 : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  var unannotatedStoredPropertyOfTypeDeprecatedIn10_51 : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 func usesFunctionDeprecatedIn10_51() {
-  _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
@@ -104,34 +104,34 @@ func annotatedUsesFunctionDeprecatedIn10_51() {
   _ = ClassDeprecatedIn10_51()
 }
 
-func hasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+func hasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedHasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) {
 }
 
-func hasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+func hasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedHasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 {
 }
 
-var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
 var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51?
 
 
 enum EnumWithDeprecatedCasePayload {
-  case WithDeprecatedPayload(p: ClassDeprecatedIn10_51) // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  case WithDeprecatedPayload(p: ClassDeprecatedIn10_51) // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
   @available(OSX, introduced: 10.8, deprecated: 10.51)
   case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn10_51)
 }
 
-extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
 }
 
@@ -142,9 +142,9 @@ extension ClassDeprecatedIn10_51 {
 }
 
 func callMethodInDeprecatedExtension() {
-  let o = ClassDeprecatedIn10_51() // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  let o = ClassDeprecatedIn10_51() // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
-  o.methodInExtensionOfClassDeprecatedIn10_51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn10_51()' was deprecated in OS X 10.51}}
+  o.methodInExtensionOfClassDeprecatedIn10_51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn10_51()' was deprecated in macOS 10.51}}
 }
 
 func functionWithDeprecatedMethodInDeadElseBranch() {

--- a/test/Serialization/target-too-new.swift
+++ b/test/Serialization/target-too-new.swift
@@ -15,5 +15,5 @@
 
 // REQUIRES: OS=macosx
 
-// CHECK: :[[@LINE+1]]:8: error: compiling for OS X 10.9, but module 'empty' has a minimum deployment target of OS X 10.50: {{.*}}empty.swiftmodule{{$}}
+// CHECK: :[[@LINE+1]]:8: error: compiling for macOS 10.9, but module 'empty' has a minimum deployment target of macOS 10.50: {{.*}}empty.swiftmodule{{$}}
 import empty

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -9,13 +9,13 @@ func foo() { }
 
 func useFoo() {
   if #available(macOS 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{23-30=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{23-30=10.50.2}}
   }
 }
 
 func useFooDifferentSpelling() {
   if #available(OSX 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{21-28=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{21-28=10.50.2}}
   }
 }
 
@@ -27,14 +27,14 @@ func useFooAlreadyOkRange() {
 
 func useFooUnaffectedSimilarText() {
   if #available(iOS 10.50.10, OSX 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{35-42=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{35-42=10.50.2}}
   }
 }
 
 func useFooWayOff() {
     // expected-note@-1{{add @available attribute to enclosing global function}}
   if #available(OSX 10.10, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}}
     // expected-note@-1{{add 'if #available' version check}}
   }
 }
@@ -42,14 +42,14 @@ func useFooWayOff() {
 @available(OSX 10.50, *)
 class FooUser {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{16-21=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{16-21=10.50.2}}
   }
 }
 
 @available(OSX, introduced: 10.50, obsoleted: 10.50.4)
 class FooUser2 {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{29-34=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{29-34=10.50.2}}
   }
 }
 
@@ -57,7 +57,7 @@ class FooUser2 {
 @objc
 class FooUser3 : NSObject {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{29-34=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{29-34=10.50.2}}
   }
 }
 

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -11,24 +11,24 @@ enum Optional<T> {
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9,
               message: "you don't want to do that anyway")
 func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in OS X 10.9}}
+// expected-note @-1{{'doSomething()' was obsoleted in macOS 10.9}}
 
-doSomething() // expected-error{{'doSomething()' is unavailable: you don't want to do that anyway}}
+doSomething() // expected-error{{'doSomething()' is unavailable in macOS: you don't want to do that anyway}}
 
 
 // Preservation of major.minor.micro
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9.1)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in OS X 10.9.1}}
+// expected-note @-1{{'doSomethingElse()' was obsoleted in macOS 10.9.1}}
 
-doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
+doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in macOS}}
 
 // Preservation of minor-only version
 @available(OSX, introduced: 8.0, deprecated: 8.5, obsoleted: 10)
 func doSomethingReallyOld() { }
-// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in OS X 10}}
+// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in macOS 10}}
 
-doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable}}
+doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in macOS}}
 
 // Test deprecations in 10.10 and later
 
@@ -36,19 +36,19 @@ doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailabl
               message: "Use another function")
 func deprecatedFunctionWithMessage() { }
 
-deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in OS X 10.10: Use another function}}
+deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in macOS 10.10: Use another function}}
 
 
 @available(OSX, introduced: 10.5, deprecated: 10.10)
 func deprecatedFunctionWithoutMessage() { }
 
-deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in OS X 10.10}}
+deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in macOS 10.10}}
 
 @available(OSX, introduced: 10.5, deprecated: 10.10,
               message: "Use BetterClass instead")
 class DeprecatedClass { }
 
-func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in OS X 10.10: Use BetterClass instead}}
+func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in macOS 10.10: Use BetterClass instead}}
 
 @available(OSX, introduced: 10.5, deprecated: 10.11,
               message: "Use BetterClass instead")
@@ -62,7 +62,7 @@ func functionWithDeprecatedLaterParameter(p: DeprecatedClassIn10_11) { }
 func doSomethingNotOnOSX() { }
 // expected-note @-1{{'doSomethingNotOnOSX()' has been explicitly marked unavailable here}}
 
-doSomethingNotOnOSX() // expected-error{{'doSomethingNotOnOSX()' is unavailable}}
+doSomethingNotOnOSX() // expected-error{{'doSomethingNotOnOSX()' is unavailable in macOS}}
 
 @available(iOS, unavailable)
 func doSomethingNotOniOS() { }
@@ -73,7 +73,7 @@ doSomethingNotOniOS() // okay
 @available(OSX, deprecated)
 func doSomethingDeprecatedOnOSX() { }
 
-doSomethingDeprecatedOnOSX() // expected-warning{{'doSomethingDeprecatedOnOSX()' is deprecated on OS X}}
+doSomethingDeprecatedOnOSX() // expected-warning{{'doSomethingDeprecatedOnOSX()' is deprecated in macOS}}
 
 @available(iOS, deprecated)
 func doSomethingDeprecatedOniOS() { }
@@ -109,7 +109,7 @@ func testMemberAvailability() {
   TestStruct().doTheThing() // expected-error {{'doTheThing()' is unavailable}}
   TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
   TestStruct().doThirdThing() // expected-error {{'doThirdThing()' is unavailable}}
-  TestStruct().doFourthThing() // expected-error {{'doFourthThing()' is only available on OS X 10.12 or newer}} expected-note {{'if #available'}}
+  TestStruct().doFourthThing() // expected-error {{'doFourthThing()' is only available in macOS 10.12 or newer}} expected-note {{'if #available'}}
   TestStruct().doDeprecatedThing() // expected-warning {{'doDeprecatedThing()' is deprecated}}
 }
 
@@ -127,17 +127,17 @@ extension TestStruct {
   var unavailableSetter: Data {
     get { return Data() }
     @available(macOS, obsoleted: 10.5, message: "bad setter")
-    set {} // expected-note 2 {{setter for 'unavailableSetter' was obsoleted in OS X 10.5}}
+    set {} // expected-note 2 {{setter for 'unavailableSetter' was obsoleted in macOS 10.5}}
   }
 }
 
 func testAccessors() {
   var t = TestStruct()
-  _ = t.unavailableGetter // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = t.unavailableGetter // expected-error {{getter for 'unavailableGetter' is unavailable in macOS}}
   t.unavailableGetter = .init()
-  t.unavailableGetter.mutate() // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  t.unavailableGetter.mutate() // expected-error {{getter for 'unavailableGetter' is unavailable in macOS}}
 
   _ = t.unavailableSetter
-  t.unavailableSetter = .init() // expected-error {{setter for 'unavailableSetter' is unavailable: bad setter}}
-  t.unavailableSetter.mutate() // expected-error {{setter for 'unavailableSetter' is unavailable: bad setter}}
+  t.unavailableSetter = .init() // expected-error {{setter for 'unavailableSetter' is unavailable in macOS: bad setter}}
+  t.unavailableSetter.mutate() // expected-error {{setter for 'unavailableSetter' is unavailable in macOS: bad setter}}
 }

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -5,21 +5,21 @@
 func doSomething() { }
 // expected-note @-1{{'doSomething()' was obsoleted in tvOS 9.0}}
 
-doSomething() // expected-error{{'doSomething()' is unavailable: you don't want to do that anyway}}
+doSomething() // expected-error{{'doSomething()' is unavailable in tvOS: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
 @available(tvOS, introduced: 1.0, deprecated: 2.0, obsoleted: 8.0)
 func doSomethingElse() { }
 // expected-note @-1{{'doSomethingElse()' was obsoleted in tvOS 8.0}}
 
-doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
+doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in tvOS}}
 
 // Preservation of minor-only version
 @available(tvOS, introduced: 1.0, deprecated: 1.5, obsoleted: 9)
 func doSomethingReallyOld() { }
 // expected-note @-1{{'doSomethingReallyOld()' was obsoleted in tvOS 9}}
 
-doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable}}
+doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in tvOS}}
 
 // Test deprecations in 9.0 and later
 
@@ -54,12 +54,12 @@ func functionWithDeprecatedLaterParameter(p: DeprecatedClassIn8_0) { }
 func functionIntroducedOntvOS9_2() { }
 
 if #available(iOS 9.3, *) {
-  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available on tvOS 9.2 or newer}}
+  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available in tvOS 9.2 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 if #available(iOS 9.3, tvOS 9.1, *) {
-  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available on tvOS 9.2 or newer}} {{29-32=9.2}}
+  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available in tvOS 9.2 or newer}} {{29-32=9.2}}
 }
 
 if #available(iOS 9.1, tvOS 9.2, *) {

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -5,21 +5,21 @@
 func doSomething() { }
 // expected-note @-1{{'doSomething()' was obsoleted in watchOS 2.0}}
 
-doSomething() // expected-error{{'doSomething()' is unavailable: you don't want to do that anyway}}
+doSomething() // expected-error{{'doSomething()' is unavailable in watchOS: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
 @available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 1.5.3)
 func doSomethingElse() { }
 // expected-note @-1{{'doSomethingElse()' was obsoleted in watchOS 1.5.3}}
 
-doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
+doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in watchOS}}
 
 // Preservation of minor-only version
 @available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2)
 func doSomethingReallyOld() { }
 // expected-note @-1{{'doSomethingReallyOld()' was obsoleted in watchOS 2}}
 
-doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable}}
+doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in watchOS}}
 
 // Test deprecations in 2.0 and later
 
@@ -54,12 +54,12 @@ func functionWithDeprecatedLaterParameter(p: DeprecatedClassIn3_0) { }
 func functionIntroducedOnwatchOS2_2() { }
 
 if #available(iOS 9.3, *) {
-  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available on watchOS 2.2 or newer}}
+  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available in watchOS 2.2 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 if #available(iOS 9.3, watchOS 2.1, *) {
-  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available on watchOS 2.2 or newer}} {{32-35=2.2}}
+  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available in watchOS 2.2 or newer}} {{32-35=2.2}}
 }
 
 if #available(iOS 9.1, watchOS 2.2, *) {

--- a/test/stdlib/DispatchDeprecationWatchOS.swift
+++ b/test/stdlib/DispatchDeprecationWatchOS.swift
@@ -6,9 +6,9 @@ import Foundation
 import Dispatch
 
 // These are deprecated on all versions of watchOS.
-_ = DispatchQueue.GlobalQueuePriority.high // expected-warning {{'high' is deprecated on watchOS: Use qos attributes instead}}
-_ = DispatchQueue.GlobalQueuePriority.default // expected-warning {{'default' is deprecated on watchOS: Use qos attributes instead}}
-_ = DispatchQueue.GlobalQueuePriority.low // expected-warning {{'low' is deprecated on watchOS: Use qos attributes instead}}
-let b = DispatchQueue.GlobalQueuePriority.background // expected-warning {{'background' is deprecated on watchOS: Use qos attributes instead}}
+_ = DispatchQueue.GlobalQueuePriority.high // expected-warning {{'high' is deprecated in watchOS: Use qos attributes instead}}
+_ = DispatchQueue.GlobalQueuePriority.default // expected-warning {{'default' is deprecated in watchOS: Use qos attributes instead}}
+_ = DispatchQueue.GlobalQueuePriority.low // expected-warning {{'low' is deprecated in watchOS: Use qos attributes instead}}
+let b = DispatchQueue.GlobalQueuePriority.background // expected-warning {{'background' is deprecated in watchOS: Use qos attributes instead}}
 
-_ = DispatchQueue.global(priority:b)   // expected-warning {{'global(priority:)' is deprecated on watchOS}}
+_ = DispatchQueue.global(priority:b)   // expected-warning {{'global(priority:)' is deprecated in watchOS}}


### PR DESCRIPTION
This PR cherry-picks #24334 to swift-5.1-branch. Master PR reviewed by @jrose-apple.

> This does several different things to improve how platforms are described in availability diagnostics:
> 
> • Mentions the platform in diagnostics for platform-specific @available(unavailable) attributes.
> • Replaces “OS X” with “macOS”.
> • Replaces “fooOS application extension” with “application extensions for fooOS”.
> • Replaces “on fooOS” with “in fooOS”.
> 
> Fixes <rdar://problem/49963341>.
> 
> (If you want to review this, turn on "Hide whitespace changes" in the diff settings—this PR reindents a lot more code than it actually rewrites.)