### PR TITLE
[5.1] XFAIL ParsableInterface/verify_all_overlays.py

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -12,6 +12,9 @@
 
 # REQUIRES: nonexecutable_test
 
+# rdar://problem/50648519
+# XFAIL: asan
+
 # Expected failures by platform
 # -----------------------------
 # macosx: XCTest


### PR DESCRIPTION
Cherry-picks #24669 from master to match #24650.

> #24641 seems to have [exposed some sort of bug ASAN can detect](https://ci.swift.org/job/oss-swift-incremental-ASAN-RA-osx/3322/). Rather than revert the PR, I'm temporarily disabling the test in ASAN mode.
> 
> rdar://problem/50648519