### PR TITLE
Fix archive_attributes test to work on macOS 10.9

### DIFF
--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -6,7 +6,7 @@
 // RUN: %target-build-swift %s -module-name=test -o %t/decode
 // RUN: %target-run %t/decode %t/test.arc --stdlib-unittest-in-process
 
-// RUN: %target-build-swift %s -module-name=test -o %t/decode -target x86_64-apple-macosx10.14.4
+// RUN: %target-build-swift %s -module-name=test -o %t/decode -target x86_64-apple-macosx10.14.4 -link-objc-runtime
 // RUN: %target-run %t/decode %t/test.arc NEW --stdlib-unittest-in-process
 
 // REQUIRES: executable_test


### PR DESCRIPTION
That OS doesn't have objc_readClassPair(). This test uses -target to
explicitly select a newer deployment target and then runs the binary
on an old OS to test the behavior. However this means arclite won't
get linked in unless we also pass in -link-objc-runtime.

Fixes <rdar://problem/50610877>.