### PR TITLE
[TF] Change java installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You will also need [CMake](https://cmake.org), [Ninja](https://ninja-build.org),
 
 ```shell
 brew install cmake ninja
-brew cask install caskroom/versions/java8 # required for Bazel
+brew cask install java # required for Bazel
 ```
 
 Additionally, [Bazel](https://www.bazel.build) v0.22.0 is required to build with TensorFlow support. Instructions to download Bazel directly can be found [below](###bazel). You can find instructions for installing CMake, and Ninja directly [below](#build-dependencies) as well.


### PR DESCRIPTION
`java8` is not available anymore, you can use the latest version of `java` with no problem.