### PR TITLE
[test] Modify lit replacements for Android ARMv7

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -944,6 +944,12 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         (config.variant_triple, clang_mcp_opt))
     config.target_ld = "ld -L%r" % (make_path(test_resource_dir, config.target_sdk_name))
 elif run_os == 'linux-androideabi' or run_os == 'linux-android':
+    # The module triple for Android ARMv7 seems to be canonicalized in LLVM
+    # to be armv7-none-linux-android, without the "eabi" bit. Let's remove the
+    # same bit from the substitutions so the tests pass correctly.
+    target_specific_module_triple = re.sub(r'androideabi', 'android',
+                                           target_specific_module_triple)
+    config.variant_triple = re.sub(r'androideabi', 'android', config.variant_triple)
     def get_architecture_value(**kwargs):
         result = kwargs[run_cpu]
         if result is None:


### PR DESCRIPTION
Android ARMv7 has an LLVM triple of armv7-none-linux-androideabi, but
the Swift module triple is just armv7-none-linux-android. The change
removes the "eabi" bit for the %module-target-triple substitution of lit
to avoid an error in the test
test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift.

Android AArch64 wasn't affected because the LLVM triple for it is just
aarch64-none-linux-android.

This should fix the Android ARMv7 CI (https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/)

/cc @rintaro 