### PR TITLE
Disable Prototypes/TextFormatting in 32-bit

### DIFF
--- a/test/Prototypes/TextFormatting.swift
+++ b/test/Prototypes/TextFormatting.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
+// Temporary workaround; ImmutableAddressUseVerifier asserts in 32-bit. rdar://problem/50676315
+// UNSUPPORTED: CPU=i386
+
 // Text Formatting Prototype
 //
 // This file demonstrates the concepts proposed in TextFormatting.rst


### PR DESCRIPTION
The new ImmutableAddressUseVerifier asserts when it tries to compile this test. Disable it in i386 while @gottesmm investigates. rdar://problem/50676315