### PR TITLE
Disable Prototypes/TextFormatting everywhere

### DIFF
--- a/test/Prototypes/TextFormatting.swift
+++ b/test/Prototypes/TextFormatting.swift
@@ -1,8 +1,8 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
-// Temporary workaround; ImmutableAddressUseVerifier asserts in 32-bit. rdar://problem/50676315
-// UNSUPPORTED: CPU=i386
+// Temporary workaround; ImmutableAddressUseVerifier asserts nondeterministically. rdar://problem/50676315
+// REQUIRES: rdar50676315
 
 // Text Formatting Prototype
 //


### PR DESCRIPTION
I originally assumed these failures were 32-bit only because the macOS tests passed and the 32-bit simulator ones failed, but I'm now seeing failures in macOS tests too, so there must be something nondeterministic about this bug. Disabling the test in all configurations. rdar://problem/50676315