### PR TITLE
[5.1][ConstraintSystem] Allow arguments to be passed by value to `@autoclo…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1703,6 +1703,14 @@ bool MissingCallFailure::diagnoseAsError() {
       return true;
     }
 
+    case ConstraintLocator::FunctionResult: {
+      path = path.drop_back();
+      if (path.back().getKind() != ConstraintLocator::AutoclosureResult)
+        break;
+
+      LLVM_FALLTHROUGH;
+    }
+
     case ConstraintLocator::AutoclosureResult: {
       auto &cs = getConstraintSystem();
       auto loc = cs.getConstraintLocator(getRawAnchor(), path.drop_back(),

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2664,6 +2664,18 @@ Expr *constraints::getArgumentExpr(Expr *expr, unsigned index) {
   return cast<TupleExpr>(argExpr)->getElement(index);
 }
 
+bool constraints::isAutoClosureArgument(Expr *argExpr) {
+  if (!argExpr)
+    return false;
+
+  if (auto *DRE = dyn_cast<DeclRefExpr>(argExpr)) {
+    if (auto *param = dyn_cast<ParamDecl>(DRE->getDecl()))
+      return param->isAutoClosure();
+  }
+
+  return false;
+}
+
 void ConstraintSystem::generateConstraints(
     SmallVectorImpl<Constraint *> &constraints, Type type,
     ArrayRef<OverloadChoice> choices, DeclContext *useDC,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3723,6 +3723,17 @@ Expr *simplifyLocatorToAnchor(ConstraintSystem &cs, ConstraintLocator *locator);
 /// wasn't of one of the kinds listed above.
 Expr *getArgumentExpr(Expr *expr, unsigned index);
 
+// Check whether argument of the call at given position refers to
+// parameter marked as `@autoclosure`. This function is used to
+// maintain source compatibility with Swift versions < 5,
+// previously examples like following used to type-check:
+//
+// func foo(_ x: @autoclosure () -> Int) {}
+// func bar(_ y: @autoclosure () -> Int) {
+//   foo(y)
+// }
+bool isAutoClosureArgument(Expr *argExpr);
+
 class DisjunctionChoice {
   unsigned Index;
   Constraint *Choice;

--- a/test/Compatibility/attr_autoclosure.swift
+++ b/test/Compatibility/attr_autoclosure.swift
@@ -62,3 +62,10 @@ func passAutoClosureToEnumCase(_ fn: @escaping @autoclosure () -> Int) {
   //        somewhere SILGen if `fn` doesn't have `@escaping`.
   let _: E = .baz(fn) // Ok
 }
+
+do {
+  func bar(_ fn: @autoclosure () -> (() -> Int)) {}
+  func foo(_ fn: @autoclosure @escaping () -> (() -> Int)) {
+    bar(fn) // Ok
+  }
+}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -245,3 +245,32 @@ protocol P_47586626 {
   func foo(_: @autoclosure F)
   func bar<T>(_: @autoclosure G<T>)
 }
+
+func overloaded_autoclj<T>(_: @autoclosure () -> T) {}
+func overloaded_autoclj(_: @autoclosure () -> Int) {}
+
+func autoclosure_param_returning_func_type() {
+  func foo(_ fn: @autoclosure () -> (() -> Int)) {}
+  func generic_foo<T>(_ fn: @autoclosure () -> T) {}
+
+  func bar_1(_ fn: @autoclosure @escaping () -> Int) { foo(fn) } // Ok
+  func bar_2(_ fn: @autoclosure () -> Int) { foo(fn) } // expected-note {{parameter 'fn' is implicitly non-escaping}}
+  // expected-error@-1 {{using non-escaping parameter 'fn' in a context expecting an @escaping closure}}
+  func baz_1(_ fn: @autoclosure @escaping () -> Int) { generic_foo(fn) }   // Ok (T is inferred as () -> Int)
+  func baz_2(_ fn: @autoclosure @escaping () -> Int) { generic_foo(fn()) } // Ok (T is inferred as Int)
+  func baz_3(_ fn: @autoclosure () -> Int) { generic_foo(fn) } // Fails because fn is not marked as @escaping
+  // expected-error@-1 {{converting non-escaping value to 'T' may allow it to escape}}
+
+  // Let's make sure using `fn` as value works fine in presence of overloading
+  func biz_1(_ fn: @autoclosure @escaping () -> Int) { overloaded_autoclj(fn) }   // Ok
+  func biz_2(_ fn: @autoclosure @escaping () -> Int) { overloaded_autoclj(fn()) } // Ok
+  func biz_3(_ fn: @autoclosure () -> Int) { overloaded_autoclj(fn) } // Fails because fn is not marked as @escaping
+  // expected-error@-1 {{add () to forward @autoclosure parameter}} {{67-67=()}}
+
+  func fiz(_: @autoclosure () -> (() -> Int)) {}
+
+  func biz_4(_ fn: @autoclosure @escaping () -> (() -> Int)) { fiz(fn) } // Can't forward in Swift >= 5 mode
+  // expected-error@-1 {{add () to forward @autoclosure parameter}} {{70-70=()}}
+  func biz_5(_ fn: @escaping () -> (() -> Int)) { fiz(fn) } // Can't forward in Swift >= 5 mode
+  // expected-error@-1 {{add () to forward @autoclosure parameter}} {{57-57=()}}
+}


### PR DESCRIPTION
…sure` parameters

Instead of always requiring a call to be made to pass argument
to `@autoclosure` parameter, it should be allowed to pass argument
by value to `@autoclosure` parameter which can return a function
type.

```swift
func foo<T>(_ fn: @autoclosure () -> T) {}
func bar(_ fn: @autoclosure @escaping () -> Int) { foo(fn) }
```

(cherry picked from commit 860cddfd348842d5027915d4fab317e5ef653ce7)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
