### PR TITLE
[Serialization] Retire "shadowed module" in favor of "underlying"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -625,7 +625,7 @@ ERROR(serialization_missing_dependencies,Fatal,
 ERROR(serialization_circular_dependency,Fatal,
       "circular dependency between modules '%0' and %1",
       (StringRef, Identifier))
-ERROR(serialization_missing_shadowed_module,Fatal,
+ERROR(serialization_missing_underlying_module,Fatal,
       "cannot load underlying module for %0", (Identifier))
 ERROR(serialization_name_mismatch,Fatal,
       "cannot load module '%0' as '%1'", (StringRef, StringRef))

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -57,8 +57,8 @@ class ModuleFile
   /// A reference back to the AST representation of the file.
   FileUnit *FileContext = nullptr;
 
-  /// The module shadowed by this module, if any.
-  ModuleDecl *ShadowedModule = nullptr;
+  /// The module that this module is an overlay of, if any.
+  ModuleDecl *UnderlyingModule = nullptr;
 
   /// The module file data.
   std::unique_ptr<llvm::MemoryBuffer> ModuleInputBuffer;
@@ -702,8 +702,8 @@ public:
     return Dependencies;
   }
 
-  /// The module shadowed by this module, if any.
-  ModuleDecl *getShadowedModule() const { return ShadowedModule; }
+  /// The module that this module is an overlay for, if any.
+  ModuleDecl *getUnderlyingModule() const { return UnderlyingModule; }
 
   /// Searches the module's top-level decls for the given identifier.
   void lookupValue(DeclName name, SmallVectorImpl<ValueDecl*> &results);

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -43,7 +43,7 @@ enum class Status {
   MissingDependency,
 
   /// The module file is an overlay for a Clang module, which can't be found.
-  MissingShadowedModule,
+  MissingUnderlyingModule,
 
   /// The module file depends on a module that is still being loaded, i.e.
   /// there is a circular dependency.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2010,14 +2010,14 @@ ModuleDecl *ModuleFile::getModule(ArrayRef<Identifier> name,
   // FIXME: duplicated from NameBinder::getModule
   if (name.size() == 1 &&
       name.front() == FileContext->getParentModule()->getName()) {
-    if (!ShadowedModule && allowLoading) {
+    if (!UnderlyingModule && allowLoading) {
       auto importer = getContext().getClangModuleLoader();
       assert(importer && "no way to import shadowed module");
-      ShadowedModule = importer->loadModule(SourceLoc(),
-                                            { { name.front(), SourceLoc() } });
+      UnderlyingModule = importer->loadModule(SourceLoc(),
+                                              {{name.front(), SourceLoc()}});
     }
 
-    return ShadowedModule;
+    return UnderlyingModule;
   }
 
   SmallVector<ImportDecl::AccessPathElement, 4> importPath;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1570,10 +1570,10 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
     }
     auto module = getModule(modulePath, /*allowLoading*/true);
     if (!module || module->failedToLoad()) {
-      // If we're missing the module we're shadowing, treat that specially.
+      // If we're missing the module we're an overlay for, treat that specially.
       if (modulePath.size() == 1 &&
           modulePath.front() == file->getParentModule()->getName()) {
-        return error(Status::MissingShadowedModule);
+        return error(Status::MissingUnderlyingModule);
       }
 
       // Otherwise, continue trying to load dependencies, so that we can list
@@ -1720,10 +1720,10 @@ TypeDecl *ModuleFile::lookupNestedType(Identifier name,
     }
   }
 
-  if (!ShadowedModule)
+  if (!UnderlyingModule)
     return nullptr;
 
-  for (FileUnit *file : ShadowedModule->getFiles())
+  for (FileUnit *file : UnderlyingModule->getFiles())
     if (auto *nestedType = file->lookupNestedType(name, parent))
       return nestedType;
 
@@ -2195,8 +2195,8 @@ ModuleFile::getOpaqueReturnTypeDecls(SmallVectorImpl<OpaqueTypeDecl *> &results)
 }
 
 void ModuleFile::getDisplayDecls(SmallVectorImpl<Decl *> &results) {
-  if (ShadowedModule)
-    ShadowedModule->getDisplayDecls(results);
+  if (UnderlyingModule)
+    UnderlyingModule->getDisplayDecls(results);
 
   PrettyStackTraceModuleFile stackEntry(*this);
   getImportDecls(results);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -562,7 +562,7 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
     // necessarily mean it's "system" module. User can make their own overlay
     // in non-system directory.
     // Remove this block after we fix the test suite.
-    if (auto shadowed = loadedModuleFile->getShadowedModule())
+    if (auto shadowed = loadedModuleFile->getUnderlyingModule())
       if (shadowed->isSystemModule())
         M.setIsSystemModule(true);
 
@@ -704,8 +704,8 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     break;
   }
 
-  case serialization::Status::MissingShadowedModule: {
-    Ctx.Diags.diagnose(diagLoc, diag::serialization_missing_shadowed_module,
+  case serialization::Status::MissingUnderlyingModule: {
+    Ctx.Diags.diagnose(diagLoc, diag::serialization_missing_underlying_module,
                        ModuleName);
     if (Ctx.SearchPathOpts.SDKPath.empty() &&
         llvm::Triple(llvm::sys::getProcessTriple()).isMacOSX()) {
@@ -938,7 +938,7 @@ void SerializedASTFile::collectLinkLibraries(
 }
 
 bool SerializedASTFile::isSystemModule() const {
-  if (auto Mod = File.getShadowedModule()) {
+  if (auto Mod = File.getUnderlyingModule()) {
     return Mod->isSystemModule();
   }
   return false;
@@ -1065,8 +1065,8 @@ StringRef SerializedASTFile::getFilename() const {
 }
 
 const clang::Module *SerializedASTFile::getUnderlyingClangModule() const {
-  if (auto *ShadowedModule = File.getShadowedModule())
-    return ShadowedModule->findUnderlyingClangModule();
+  if (auto *UnderlyingModule = File.getUnderlyingModule())
+    return UnderlyingModule->findUnderlyingClangModule();
   return nullptr;
 }
 


### PR DESCRIPTION
Similar to #24427, the "shadowed" terminology didn't end up describing the most common use of the feature; there is pretty much no intended case where a Swift module shadows a Clang module without also re-exporting it. Switch to "underlying", which was already in use in a few places, and which better parallels "overlay".

No intended functionality change.