### PR TITLE
[docs] Update `trailingZeroBitCount` documentation

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -717,8 +717,7 @@ public protocol BinaryInteger :
   ///     // x == -8
   ///     // x.trailingZeroBitCount == 3
   ///
-  /// If there are no bits equal to 1 in this value's binary representation,
-  /// then `trailingZeroBitCount` is equal to `bitWidth`.
+  /// If the value is zero, then `trailingZeroBitCount` is equal to `bitWidth`.
   var trailingZeroBitCount: Int { get }
 
   /// Returns the quotient of dividing the first value by the second.
@@ -2084,6 +2083,8 @@ where Magnitude : FixedWidthInteger & UnsignedInteger,
   ///     let x: Int8 = 0b0001_1111
   ///     // x == 31
   ///     // x.leadingZeroBitCount == 3
+  ///
+  /// If the value is zero, then `leadingZeroBitCount` is equal to `bitWidth`.
   var leadingZeroBitCount: Int { get }
 
   /// Creates an integer from its big-endian representation, changing the byte

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -716,6 +716,9 @@ public protocol BinaryInteger :
   ///     let x = Int8(bitPattern: 0b1111_1000)
   ///     // x == -8
   ///     // x.trailingZeroBitCount == 3
+  ///
+  /// If there are no bits equal to 1 in this value's binary representation,
+  /// then `trailingZeroBitCount` is equal to `bitWidth`.
   var trailingZeroBitCount: Int { get }
 
   /// Returns the quotient of dividing the first value by the second.


### PR DESCRIPTION
Document the required behavior for `trailingZeroBitCount` when the value is zero. Namely, in that scenario, `trailingZeroBitCount` should be equal to `bitWidth`.

Resolves [SR-10657](https://bugs.swift.org/browse/SR-10657).