### PR TITLE
[sil] Change the immutable address use verifier to ignore br/cond_br …

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -512,6 +512,14 @@ struct ImmutableAddressUseVerifier {
         //
         // TODO: Can we do better?
         break;
+      case SILInstructionKind::BranchInst:
+      case SILInstructionKind::CondBranchInst:
+        // We do not analyze through branches and cond_br instructions and just
+        // assume correctness. This is so that we can avoid having to analyze
+        // through phi loops and since we want to remove address phis (meaning
+        // that this eventually would never be able to happen). Once that
+        // changes happens, we should remove this code and just error below.
+        break;
       case SILInstructionKind::ApplyInst:
       case SILInstructionKind::TryApplyInst:
       case SILInstructionKind::PartialApplyInst:

--- a/test/Prototypes/TextFormatting.swift
+++ b/test/Prototypes/TextFormatting.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
-// Temporary workaround; ImmutableAddressUseVerifier asserts nondeterministically. rdar://problem/50676315
-// REQUIRES: rdar50676315
-
 // Text Formatting Prototype
 //
 // This file demonstrates the concepts proposed in TextFormatting.rst


### PR DESCRIPTION
…uses that introduce address phis and re-enable the test that shows this behavior.

We want to eventually remove address phi arguments from SIL. This will enable
all sorts of nice IRGen optimizations and in general make life better. We are
not there yet, but given that is the direction we are going in, I don't think
there is much use in having to implement this sort of checking for SIL phi
arguments.

rdar://50676315
