### PR TITLE
[TF] Remove all of #tfop.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -252,13 +252,6 @@ NOTE(constexpr_not_evaluable, none,
 // TensorFlow Support Diagnostics.
 ERROR(tf_internal_error, none,
       "internal error: %0", (StringRef))
-ERROR(tfop_invalid_tfop, none,
-      "#tfop invalid: %0", (StringRef))
-ERROR(tfop_incorrect_definition, none,
-      "tfop function doesn't align with TensorFlow op definition:\n%0",
-      (StringRef))
-ERROR(tfop_value_no_send_receive, none,
-      "value cannot be used by non-TensorFlow API", ())
 ERROR(tf_multiple_device, none,
       "device configuration specified multiple times", ())
 NOTE(tf_multiple_device_prev, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -736,10 +736,6 @@ NOTE(object_literal_resolve_import,none,
      "import %0 to use '%1' as the default %2 literal type",
      (StringRef, StringRef, StringRef))
 
-// SWIFT_ENABLE_TENSORFLOW
-// TensorFlow op literal
-ERROR(invalid_tfop,none, "%0", (StringRef))
-
 ERROR(use_local_before_declaration,none,
       "use of local variable %0 before its declaration", (DeclName))
 ERROR(unsupported_existential_type,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1154,13 +1154,6 @@ public:
     return static_cast<LiteralKind>(Bits.ObjectLiteralExpr.LitKind);
   }
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// Return true if this object literal is the #tfop(...) op descriptor for
-  /// TensorFlow.
-  bool isTFOp() const {
-    return getLiteralKind() == LiteralKind::tfop;
-  }
-
   Expr *getArg() const { return Arg; }
   void setArg(Expr *arg) { Arg = arg; }
 

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -110,8 +110,6 @@ EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByUnicodeScalarLiteral, "UnicodeScala
 EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByColorLiteral, "_ColorLiteralType", true)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByImageLiteral, "_ImageLiteralType", true)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByFileReferenceLiteral, "_FileReferenceLiteralType", true)
-// SWIFT_ENABLE_TENSORFLOW
-EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByTensorFlowOp, "_ExpressibleByTensorFlowOp", true)
 
 BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByBuiltinBooleanLiteral)
 BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByBuiltinExtendedGraphemeClusterLiteral)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4167,7 +4167,6 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::ExpressibleByImageLiteral:
   case KnownProtocolKind::ExpressibleByFileReferenceLiteral:
   // SWIFT_ENABLE_TENSORFLOW
-  case KnownProtocolKind::ExpressibleByTensorFlowOp:
   case KnownProtocolKind::ExpressibleByBuiltinBooleanLiteral:
   case KnownProtocolKind::ExpressibleByBuiltinExtendedGraphemeClusterLiteral:
   case KnownProtocolKind::ExpressibleByBuiltinFloatLiteral:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2319,12 +2319,6 @@ namespace {
       llvm_unreachable("Unhandled MagicIdentifierLiteralExpr in switch.");
     }
 
-    // SWIFT_ENABLE_TENSORFLOW
-    Expr *visitTFOp(ObjectLiteralExpr *expr) {
-      cs.TC.diagnose(expr->getLoc(), diag::invalid_tfop, "all tfops are now invalid");
-      return nullptr;
-    }
-
     Expr *visitObjectLiteralExpr(ObjectLiteralExpr *expr) {
       if (cs.getType(expr) && !cs.getType(expr)->hasTypeVariable())
         return expr;
@@ -2336,12 +2330,6 @@ namespace {
       auto openedType = cs.getType(expr);
       auto type = simplifyType(openedType);
       cs.setType(expr, type);
-
-      // SWIFT_ENABLE_TENSORFLOW
-      // #tfop() declarations are not like normal object literals, so we use
-      // special checking logic.
-      if (expr->isTFOp())
-        return visitTFOp(expr);
 
       if (type->is<UnresolvedType>()) return expr;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6417,11 +6417,6 @@ bool FailureDiagnosis::visitDictionaryExpr(DictionaryExpr *E) {
 bool FailureDiagnosis::visitObjectLiteralExpr(ObjectLiteralExpr *E) {
   auto &TC = CS.getTypeChecker();
 
-  // SWIFT_ENABLE_TENSORFLOW
-  // TensorFlow ops don't act like other literals.
-  if (E->isTFOp())
-    return false;
-
   // Type check the argument first.
   auto protocol = TC.getLiteralProtocol(E);
   if (!protocol)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1251,10 +1251,6 @@ namespace {
       if (expr->getType())
         return expr->getType();
 
-      // SWIFT_ENABLE_TENSORFLOW
-      if (expr->isTFOp())
-        return visitTFOpExpr(expr);
-
       auto &tc = CS.getTypeChecker();
       auto protocol = tc.getLiteralProtocol(expr);
       if (!protocol) {
@@ -1304,17 +1300,6 @@ namespace {
         result = OptionalType::get(result);
 
       return result;
-    }
-
-    // SWIFT_ENABLE_TENSORFLOW
-    // #tfop is type checked and SILGen'd differently than the rest of the
-    // literals.
-    Type visitTFOpExpr(ObjectLiteralExpr *expr) {
-      assert(expr->isTFOp() && "Unexpected expression");
-      auto &tc = CS.getTypeChecker();
-      tc.diagnose(expr->getLoc(), diag::invalid_tfop,
-                  "#tfop() is deprecated and cannot be used");
-      return nullptr;
     }
 
     Type visitDeclRefExpr(DeclRefExpr *E) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -325,8 +325,6 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
   case KnownProtocolKind::ExpressibleByColorLiteral: index = 10; break;
   case KnownProtocolKind::ExpressibleByImageLiteral: index = 11; break;
   case KnownProtocolKind::ExpressibleByFileReferenceLiteral: index = 12; break;
-  // SWIFT_ENABLE_TENSORFLOW
-  case KnownProtocolKind::ExpressibleByTensorFlowOp: return ArrayRef<Type>();
   }
   static_assert(NumAlternativeLiteralTypes == 13, "Wrong # of literal types");
 
@@ -372,8 +370,6 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
   case KnownProtocolKind::ExpressibleByColorLiteral:
   case KnownProtocolKind::ExpressibleByImageLiteral:
   case KnownProtocolKind::ExpressibleByFileReferenceLiteral:
-  // SWIFT_ENABLE_TENSORFLOW
-  case KnownProtocolKind::ExpressibleByTensorFlowOp:
     break;
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -178,8 +178,6 @@ DeclName TypeChecker::getObjectLiteralConstructorName(ObjectLiteralExpr *expr) {
     return DeclName(Context, DeclBaseName::createConstructor(),
             { Context.getIdentifier("fileReferenceLiteralResourceName") });
   }
-  // SWIFT_ENABLE_TENSORFLOW
-  case ObjectLiteralExpr::tfop: return DeclName();
   }
   llvm_unreachable("unknown literal constructor");
 }
@@ -215,9 +213,6 @@ Type TypeChecker::getObjectLiteralParameterType(ObjectLiteralExpr *expr,
   case ObjectLiteralExpr::fileLiteral:
   case ObjectLiteralExpr::imageLiteral:
     return replace("resourceName");
-  // SWIFT_ENABLE_TENSORFLOW
-  case ObjectLiteralExpr::tfop:
-    llvm_unreachable("#tfop gets special type checking");
   }
   llvm_unreachable("unknown literal constructor");
 }

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -561,8 +561,6 @@ EXPR_NODES = [
                        'PoundColorLiteralToken',
                        'PoundFileLiteralToken',
                        'PoundImageLiteralToken',
-                       # SWIFT_ENABLE_TENSORFLOW
-                       'PoundTensorFlowOpToken',
                    ]),
              Child('LeftParen', kind='LeftParenToken'),
              Child('Arguments', kind='FunctionCallArgumentList',

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -330,12 +330,6 @@ SYNTAX_TOKENS = [
          text=')', classification='StringInterpolationAnchor',
          serialization_code=101),
     Misc('Yield', 'kw_yield', serialization_code=116, text='yield'),
-
-    # SWIFT_ENABLE_TENSORFLOW
-    PoundObjectLiteral('PoundTensorFlowOp', 'tfop', text='#tfop',
-                       serialization_code=119,
-                       description='TensorFlow operation',
-                       protocol='ExpressibleByTensorFlowOp'),
 ]
 
 SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}


### PR DESCRIPTION
Remove all of `#tfop` including its token kind, type checking logic, and stale diagnostics.