### PR TITLE
[TF] Remove stale GPE documentation and diagnostics.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5555,36 +5555,6 @@ Extracts the original function or an associated function from the given
 ``@differentiable`` function at a specific differentiation order. It must be
 provided with an extractee: ``[original]``, ``[jvp]`` or ``[vjp]``.
 
-.. SWIFT_ENABLE_TENSORFLOW
-
-Graph Program Extraction
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-graph_op
-````````
-::
-
-  sil-instruction ::= 'graph_op' string-literal
-                      '(' (sil-operand (',' sil-operand)*)? ')'
-                      ('{' (sil-graph-op-attr (',' sil-graph-op-attr)*)? '}')?
-                      ':' sil-type (',' sil-type)*
-  sil-graph-op-attr ::= sil-identifier ':' sil-symbolic-value
-  sil-symbolic-value ::= i[0-9]+ int-literal |
-                         f(32|64) float-literal |
-                         sil-type |
-                         '[' (sil-symbolic-value (',' sil-symbolic-value)*)? ']'
-
-  %add = graph_op "tf.Add"(%x : $Tensor<Float>, %y : $Tensor<Float>) \
-    {T: $Float} : $Tensor<Float>
-
-Represents a graph program operation.
-
-``graph_op`` instructions have a name, zero or more operands, zero or more
-attributes (an identifier and SIL constant value), and one or more result
-types.
-
-This instruction is only valid in raw SIL and is rewritten and extracted by the
-graph program extraction passes (debastraction, partitioning, graph lowering).
 
 Assertion configuration
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -248,52 +248,6 @@ NOTE(constexpr_called_from, none, "when called from here", ())
 NOTE(constexpr_not_evaluable, none,
      "expression not evaluable as constant here", ())
 
-// SWIFT_ENABLE_TENSORFLOW
-// TensorFlow Support Diagnostics.
-ERROR(tf_internal_error, none,
-      "internal error: %0", (StringRef))
-ERROR(tf_multiple_device, none,
-      "device configuration specified multiple times", ())
-NOTE(tf_multiple_device_prev, none,
-      "previous configuration is specified here", ())
-ERROR(tf_lowering_error, none,
-      "internal error generating TensorFlow graph:\n%0", (StringRef))
-ERROR(tf_lowering_unknown_op, none,
-      "op named '%0' is not registered in TensorFlow", (StringRef))
-ERROR(tf_convention_tf_host_code_not_allowed, none,
-      "host code is not allowed in a TensorFlow function", ())
-ERROR(tf_no_captures_in_tf_functions, none,
-      "TensorFlow functions cannot capture values", ())
-
-WARNING(tf_value_implicitly_copied_to_accel, none,
-        "%0 implicitly copied to the accelerator, use .toAccelerator() to make "
-        "transfer explicit",
-        (StringRef))
-WARNING(tf_value_implicitly_copied_to_accel_always, none,
-        "%0 always cause a copy to the accelerator, use .toAccelerator() to make "
-        "transfer explicit",
-        (StringRef))
-
-WARNING(tf_value_implicitly_copied_to_host, none,
-        "value implicitly copied to the host, use .toHost() to make "
-        "transfer explicit",
-        ())
-
-NOTE(tf_value_used_here, none,
-     "value used here", ())
-ERROR(tf_op_misuse, none,
-      "%0", (StringRef))
-NOTE(tf_op_misuse_note, none,
-     "%0", (StringRef))
-
-ERROR(tf_op_result_generic,none,
-      "cannot extract TensorFlow result into type %0, because %0 contains "
-      "unbound generic parameters", (Type))
-ERROR(tf_op_result_not_value_or_aggregate,none,
-      "cannot extract TensorFlow result into type %0, because %0 is not a "
-      "TensorFlow value type or an aggregate of TensorFlow value types",
-      (Type))
-
 // Control flow diagnostics.
 ERROR(missing_return,none,
       "missing return in a %select{function|closure}1 expected to return %0",

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -15,21 +15,8 @@
 // This file should only contain internal details: runtime-related public APIs
 // should be defined in `Execution.swift`.
 //
-// Design notes on TF eager based runtime:
-//
-// 1. A global context (`_ExecutionContext.global`) is used to manage all tensor
+// A global context (`_ExecutionContext.global`) is used to manage all tensor
 // computation and transfers.
-//
-// 2. When the tensor computation involves N device functions, run them in N
-// threads (but with the same execution/eager context). In addition, run the
-// host-side of sends/recvs in the main thread. These N + 1 threads form
-// "coroutines", and use sends/recvs mechanisms to communicate and unblock each
-// other's progress.
-// 2a) The sends/recvs mechanism between host and TF is the enqueue / dequeue
-// operations on TF (CPU-based) Fifo queues. Only tensor handles are transferred
-// in these enqueue / dequeue operations. For host to consume the content of the
-// tensor sent from TF, it uses TFE_TensorHandleResolve().
-// 2b) The sends/recvs mechanism between TF devices is the _Send / _Recv TF ops.
 //
 // Potential TODOs:
 // - Support async on platforms other than Linux and FreeBSD.


### PR DESCRIPTION
* Remove `graph_op` instruction documentation from SIL.rst.
* Remove all GPE-related diagnostics.
* Remove stale info from the comment header of `CompilerRuntime.swift`.