### PR TITLE
[benchmark] Disable some new Set tests with overlong runtime

### DIFF
--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -212,13 +212,13 @@ public let SetTests = [
   BenchmarkInfo(
     name: "Set.isStrictSubset.Int100",
     runFunction: { n in run_SetIsStrictSubsetInt(setP, setQ, false, 5000 * n) },
-    tags: [.validation, .api, .Set],
+    tags: [.validation, .api, .Set, .skip],
     setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Empty.Int",
     runFunction: { n in run_SetIsStrictSubsetSeqInt(setE, arrayAB, true, 5000 * n) },
-    tags: [.validation, .api, .Set],
+    tags: [.validation, .api, .Set, .skip],
     setUpFunction: { blackHole([setE, arrayAB]) }),
   BenchmarkInfo(
     name: "Set.isStrictSubset.Seq.Int.Empty",
@@ -305,7 +305,7 @@ public let SetTests = [
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Int.Empty",
     runFunction: { n in run_SetIsStrictSupersetSeqInt(setE, arrayAB, false, 5000 * n) },
-    tags: [.validation, .api, .Set],
+    tags: [.validation, .api, .Set, .skip],
     setUpFunction: { blackHole([setE, arrayAB]) }),
   BenchmarkInfo(
     name: "Set.isStrictSuperset.Seq.Int0",


### PR DESCRIPTION
PRs #23690 and #24156 have improved the performance coverage of `Set` type. The workloads in #24156 have been tune in with #21300 in mind. This means that some larger multipliers were selected assuming the presence of optimizations from #23100. This PR temporarily disables following test where it currently results in runtimes over 30 ms (these are guaranteed to include a context switch and are therefore more susceptible to be noisy and case false performance change):
* `Set.isStrictSubset.Int100`
* `Set.isStrictSubset.Seq.Empty.Int`
* `Set.isStrictSuperset.Seq.Int.Empty`