### PR TITLE
[CodeCompletion] Allow ErrorType in constructor

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2559,7 +2559,7 @@ public:
     }
 
     // If we won't be able to provide a result, bail out.
-    if (MemberType->hasError() && addName.empty() && !needInit)
+    if (!ConstructorType && addName.empty() && !needInit)
       return;
 
     // Add the constructor, possibly including any default arguments.
@@ -2577,8 +2577,6 @@ public:
         Builder.addTextChunk("init");
       } else if (!addName.empty()) {
         Builder.addTextChunk(addName.str());
-      } else {
-        assert(!MemberType->hasError() && "will insert empty result");
       }
 
       if (!ConstructorType) {

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -50,6 +50,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AVAILABLE_1 | %FileCheck %s -check-prefix=AVAILABLE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AVAILABLE_2 | %FileCheck %s -check-prefix=AVAILABLE_1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPENDENT_IN_CLOSURE_1 | %FileCheck %s -check-prefix=DEPENDENT_IN_CLOSURE_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPENDENT_IN_CLOSURE_2 | %FileCheck %s -check-prefix=DEPENDENT_IN_CLOSURE_2
+
 func freeFunc() {}
 
 //===---
@@ -368,4 +371,28 @@ func testAvailable() {
 // AVAILABLE_1: End completions
 
   let _ = AvailableTest.init(#^AVAILABLE_2^#
+}
+
+protocol DataType {
+  associatedtype Content
+}
+class DependentTypeInClosure<Data: DataType> {
+  init(_ arg: Data, fn: (Data.Content) -> Void) {}
+  init(arg: Data, fn: () -> Data.Content) {}
+}
+func testDependentTypeInClosure() {
+  let _: DependentTypeInClosure = .#^DEPENDENT_IN_CLOSURE_3^#
+  let _ = DependentTypeInClosure(#^DEPENDENT_IN_CLOSURE_1^#)
+// DEPENDENT_IN_CLOSURE_1: Begin completions
+// DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#(arg): _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#}[')'][#DependentTypeInClosure<_>#];
+// DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg: _#}, {#fn: () -> _.Content##() -> _.Content#}[')'][#DependentTypeInClosure<_>#];
+// DEPENDENT_IN_CLOSURE_1: End completions
+
+  let _ = DependentTypeInClosure.#^DEPENDENT_IN_CLOSURE_2^#
+// DEPENDENT_IN_CLOSURE_2: Begin completions, 4 items
+// DEPENDENT_IN_CLOSURE_2-DAG: Keyword[self]/CurrNominal:          self[#DependentTypeInClosure<_>.Type#]; name=self
+// DEPENDENT_IN_CLOSURE_2-DAG: Keyword/CurrNominal:                Type[#DependentTypeInClosure<_>.Type#]; name=Type
+// DEPENDENT_IN_CLOSURE_2-DAG: Decl[Constructor]/CurrNominal:      init({#(arg): _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#})[#DependentTypeInClosure<_>#]; name=init(arg: _, fn: (_.Content) -> Void)
+// DEPENDENT_IN_CLOSURE_2-DAG: Decl[Constructor]/CurrNominal:      init({#arg: _#}, {#fn: () -> _.Content##() -> _.Content#})[#DependentTypeInClosure<_>#]; name=init(arg: _, fn: () -> _.Content)
+// DEPENDENT_IN_CLOSURE_2: End completions
 }

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -154,7 +154,7 @@ func rdar22835966() {
   }
 }
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_22834017 | %FileCheck %s -check-prefix=INVALID_TYPE_INIT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_22834017 | %FileCheck %s -check-prefix=RDAR_22834017
 struct Foo {
   let a: Anosuchtype
   let b: Bnosuchtype
@@ -164,8 +164,9 @@ struct Foo {
 func rdar22834017() {
   Foo(#^RDAR_22834017^#)
 }
-// FIXME: We could provide a useful completion here. rdar://problem/22846558
-// INVALID_TYPE_INIT-NOT: Begin completions
+// RDAR_22834017: Begin completions, 1 items
+// RDAR_22834017: Decl[Constructor]/CurrNominal:      ['(']{#a: <<error type>>#}, {#b: <<error type>>#}, {#c: <<error type>>#}[')'][#Foo#];
+// RDAR_22834017: End completions
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_23173692 | %FileCheck %s -check-prefix=RDAR_23173692
 func rdar23173692() {


### PR DESCRIPTION
Even if the constructor has `ErrorType` we can suggest it as long as it's `FunctionType`.

rdar://problem/49480808