### PR TITLE
[Runtime] Don't check objc_debug_isa_class_mask when back deploying.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -195,11 +195,15 @@ static NSString *_getClassDescription(Class cls) {
 
 @implementation SwiftObject
 + (void)initialize {
-#if SWIFT_HAS_ISA_MASKING
-  // Really old ObjC runtimes don't have this symbol, which is OK. If
-  // the symbol exists, then our value must match.
-  assert(&objc_debug_isa_class_mask == NULL ||
-         objc_debug_isa_class_mask == SWIFT_ISA_MASK);
+#if SWIFT_HAS_ISA_MASKING && !NDEBUG
+  // Older OSes may not have this variable, or it may not match. This code only
+  // runs on older OSes in certain testing scenarios, so that doesn't matter.
+  // Only perform the check on newer OSes where the value should definitely
+  // match.
+  if (!_swift_isBackDeploying()) {
+    assert(&objc_debug_isa_class_mask);
+    assert(objc_debug_isa_class_mask == SWIFT_ISA_MASK);
+  }
 #endif
 }
 


### PR DESCRIPTION
Older OSes may not have this value or may have a different value. We only want to check going forward, because newer runtimes don't run on older OSes except in certain testing scenarios.

rdar://problem/50700856