### PR TITLE
[5.1] Update “unable to load standard library” test

### DIFF
--- a/test/Misc/fatal_error.swift
+++ b/test/Misc/fatal_error.swift
@@ -1,5 +1,7 @@
-// RUN: not %target-swift-frontend -typecheck %s -sdk "" 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-MODULE %s
-// RUN: not %target-swift-frontend -typecheck %s -resource-dir / 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-STDLIB %s
+// RUN: %empty-directory(%t)
+
+// RUN: not %target-swift-frontend -typecheck %s -sdk %t 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-MODULE %s
+// RUN: not %target-swift-frontend -typecheck %s -resource-dir %t -sdk %t 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-STDLIB %s
 
 // NO-MODULE: error: no such module 'NonExistent'
 


### PR DESCRIPTION
Cherry-picks #23990 to swift-5.1-branch.

> One of the subtests of Misc/fatal_error.swift assumes that Swift.swiftmodule is located purely based on the resource directory. It can now also be located in the SDK, so the test needs to be updated. Fixes rdar://problem/49665477.

Original reviewed by @jrose-apple.